### PR TITLE
Implement a different escaping/quoting algorithm for arguments to System.Diagnostics.Process.

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -269,6 +269,8 @@ Change the architecture in the project's Mac Build options to 'x86_64' in order 
 
 #### MM0147: Unable to parse the cflags '{cflags} from pkg-config: {exception}
 
+#### MM0148: Unable to parse the linker flags '{linker_flags}' from the LinkWith attribute for the library {library} in {assembly} : {exception}
+
 ## MM1xxx: file copy / symlinks (project related)
 
 <a name="MM1034" />

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -267,6 +267,8 @@ Change the architecture in the project's Mac Build options to 'x86_64' in order 
 
 <!-- 0145 and 0146 used by mtouch -->
 
+#### MM0147: Unable to parse the cflags '{cflags} from pkg-config: {exception}
+
 ## MM1xxx: file copy / symlinks (project related)
 
 <a name="MM1034" />

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -990,6 +990,8 @@ This warning is shown when `--interpreter` isn't specified explicitly for ARM64_
 
 <!-- 0147 used by mmp -->
 
+#### MM0148: Unable to parse the linker flags '{linker_flags}' from the LinkWith attribute for the library {library} in {assembly} : {exception}
+
 # MT1xxx: Project related error messages
 
 ### MT10xx: Installer / mtouch

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -988,6 +988,8 @@ can build for both ARMv7k and ARM64_32 at the same time.
 
 This warning is shown when `--interpreter` isn't specified explicitly for ARM64_32 Debug builds. The AOT compiler can't be used because it doesn't support ARM64_32.
 
+<!-- 0147 used by mmp -->
+
 # MT1xxx: Project related error messages
 
 ### MT10xx: Installer / mtouch

--- a/msbuild/Xamarin.Mac.Tasks.Core/Xamarin.Mac.Tasks.Core.csproj
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Xamarin.Mac.Tasks.Core.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Xamarin.Mac.Tasks.Core</AssemblyName>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Mac.Tasks</RootNamespace>
     <AssemblyName>Xamarin.Mac.Tasks</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -136,21 +136,21 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <Target Name="ILRepack" AfterTargets="CoreCompile" DependsOnTargets="CoreCompile" Inputs="@(IntermediateAssembly -> '%(FullPath)')" Outputs="$(IntermediateOutputPath)ilrepack.txt" Returns="@(MergedAssemblies)" Condition="Exists(@(IntermediateAssembly -> '%(FullPath)')) And '$(ILRepack)' != 'false'">
+  <Target Name="ILRepack" AfterTargets="CoreCompile" DependsOnTargets="CoreCompile" Inputs="@(IntermediateAssembly -&gt; '%(FullPath)')" Outputs="$(IntermediateOutputPath)ilrepack.txt" Returns="@(MergedAssemblies)" Condition="Exists(@(IntermediateAssembly -&gt; '%(FullPath)')) And '$(ILRepack)' != 'false'">
     <GetReferenceAssemblyPaths BypassFrameworkInstallChecks="False" TargetFrameworkMoniker="$(TargetFrameworkMoniker)">
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FullFrameworkReferenceAssemblyPaths" />
     </GetReferenceAssemblyPaths>
     <ItemGroup>
       <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('Xamarin')) And '%(Extension)' == '.dll'" />
       <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('Mono')) And '%(Extension)' == '.dll'" />
-      <ReferenceCopyLocalDirs Include="@(ReferenceCopyLocalPaths -> '%(RootDir)%(Directory)')" />
+      <ReferenceCopyLocalDirs Include="@(ReferenceCopyLocalPaths -&gt; '%(RootDir)%(Directory)')" />
       <ReferenceCopyLocalPaths Remove="@(MergedAssemblies)" />
-      <LibDir Include="@(ReferenceCopyLocalDirs -> Distinct())" />
+      <LibDir Include="@(ReferenceCopyLocalDirs -&gt; Distinct())" />
     </ItemGroup>
     <PropertyGroup>
       <ILRepackArgs Condition="'$(AssemblyOriginatorKeyFile)' != ''">/keyfile:"$(AssemblyOriginatorKeyFile)"</ILRepackArgs>
     </PropertyGroup>
-    <Exec Command="&quot;$(ILRepack)&quot; @(LibDir -> '/lib:&quot;%(Identity).&quot;', ' ') $(ILRepackArgs) /out:&quot;@(IntermediateAssembly -> '%(FullPath)')&quot; &quot;@(IntermediateAssembly -> '%(FullPath)')&quot; @(MergedAssemblies -> '&quot;%(FullPath)&quot;', ' ')" WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
+    <Exec Command="&quot;$(ILRepack)&quot; @(LibDir -&gt; '/lib:&quot;%(Identity).&quot;', ' ') $(ILRepackArgs) /out:&quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot; &quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot; @(MergedAssemblies -&gt; '&quot;%(FullPath)&quot;', ' ')" WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput" />
       <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
     </Exec>
@@ -158,6 +158,6 @@
     <Delete Files="$(IntermediateOutputPath)ilrepack.txt" Condition="'$(ExitCode)' != '0'" />
     <Touch AlwaysCreate="true" Files="$(IntermediateOutputPath)ilrepack.txt" Condition="'$(ExitCode)' == '0'" />
     <Error Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0' And '$(ContinueOnError)' != 'true'" />
-    <Delete Files="@(MergedAssemblies -> '$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" />
+    <Delete Files="@(MergedAssemblies -&gt; '$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" />
   </Target>
 </Project>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.MacDev.Tasks</RootNamespace>
     <AssemblyName>Xamarin.MacDev.Tasks.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.MacDev.Tasks</RootNamespace>
     <AssemblyName>Xamarin.MacDev.Tasks</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Xamarin.iOS.Tasks.Core</AssemblyName>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Xamarin.iOS.Tasks</AssemblyName>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -114,21 +114,21 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <Target Name="ILRepack" AfterTargets="CoreCompile" DependsOnTargets="CoreCompile" Inputs="@(IntermediateAssembly -> '%(FullPath)')" Outputs="$(IntermediateOutputPath)ilrepack.txt" Returns="@(MergedAssemblies)" Condition="Exists(@(IntermediateAssembly -> '%(FullPath)')) And '$(ILRepack)' != 'false'">
+  <Target Name="ILRepack" AfterTargets="CoreCompile" DependsOnTargets="CoreCompile" Inputs="@(IntermediateAssembly -&gt; '%(FullPath)')" Outputs="$(IntermediateOutputPath)ilrepack.txt" Returns="@(MergedAssemblies)" Condition="Exists(@(IntermediateAssembly -&gt; '%(FullPath)')) And '$(ILRepack)' != 'false'">
     <GetReferenceAssemblyPaths BypassFrameworkInstallChecks="False" TargetFrameworkMoniker="$(TargetFrameworkMoniker)">
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FullFrameworkReferenceAssemblyPaths" />
     </GetReferenceAssemblyPaths>
     <ItemGroup>
       <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('Xamarin')) And '%(Extension)' == '.dll'" />
       <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('Mono')) And '%(Extension)' == '.dll'" />
-      <ReferenceCopyLocalDirs Include="@(ReferenceCopyLocalPaths -> '%(RootDir)%(Directory)')" />
+      <ReferenceCopyLocalDirs Include="@(ReferenceCopyLocalPaths -&gt; '%(RootDir)%(Directory)')" />
       <ReferenceCopyLocalPaths Remove="@(MergedAssemblies)" />
-      <LibDir Include="@(ReferenceCopyLocalDirs -> Distinct())" />
+      <LibDir Include="@(ReferenceCopyLocalDirs -&gt; Distinct())" />
     </ItemGroup>
     <PropertyGroup>
       <ILRepackArgs Condition="'$(AssemblyOriginatorKeyFile)' != ''">/keyfile:"$(AssemblyOriginatorKeyFile)"</ILRepackArgs>
     </PropertyGroup>
-    <Exec Command="&quot;$(ILRepack)&quot; @(LibDir -> '/lib:&quot;%(Identity).&quot;', ' ') $(ILRepackArgs) /out:&quot;@(IntermediateAssembly -> '%(FullPath)')&quot; &quot;@(IntermediateAssembly -> '%(FullPath)')&quot; @(MergedAssemblies -> '&quot;%(FullPath)&quot;', ' ')" WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
+    <Exec Command="&quot;$(ILRepack)&quot; @(LibDir -&gt; '/lib:&quot;%(Identity).&quot;', ' ') $(ILRepackArgs) /out:&quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot; &quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot; @(MergedAssemblies -&gt; '&quot;%(FullPath)&quot;', ' ')" WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput" />
       <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
     </Exec>
@@ -136,6 +136,6 @@
     <Delete Files="$(IntermediateOutputPath)ilrepack.txt" Condition="'$(ExitCode)' != '0'" />
     <Touch AlwaysCreate="true" Files="$(IntermediateOutputPath)ilrepack.txt" Condition="'$(ExitCode)' == '0'" />
     <Error Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0' And '$(ContinueOnError)' != 'true'" />
-    <Delete Files="@(MergedAssemblies -> '$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" />
+    <Delete Files="@(MergedAssemblies -&gt; '$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" />
   </Target>
 </Project>

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/NativeReferencesNoEmbedding.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/NativeReferencesNoEmbedding.cs
@@ -61,7 +61,7 @@ namespace Xamarin.iOS.Tasks
 			string libPath = Path.Combine (Directory.GetCurrentDirectory (), bindingApp.ProjectBinPath, "MyiOSBinding.dll");
 			Assert.True (File.Exists (libPath), $"Did not find expected library: {libPath}");
 
-			int returnValue = ExecutionHelper.Execute ("/Library/Frameworks/Mono.framework/Commands/monodis", new string[] { "--presources", libPath }, out string monoDisResults);
+			int returnValue = ExecutionHelper.Execute ("/Library/Frameworks/Mono.framework/Commands/monodis", new [] { "--presources", libPath }, out string monoDisResults);
 			Assert.AreEqual (0, returnValue);
 			Assert.IsFalse (monoDisResults.Contains ("XTest.framework"), $"Binding Library contained embedded resource: {monoDisResults}");
 

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/NativeReferencesNoEmbedding.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/NativeReferencesNoEmbedding.cs
@@ -61,7 +61,7 @@ namespace Xamarin.iOS.Tasks
 			string libPath = Path.Combine (Directory.GetCurrentDirectory (), bindingApp.ProjectBinPath, "MyiOSBinding.dll");
 			Assert.True (File.Exists (libPath), $"Did not find expected library: {libPath}");
 
-			int returnValue = ExecutionHelper.Execute ("/Library/Frameworks/Mono.framework/Commands/monodis", "--presources " + libPath, out string monoDisResults);
+			int returnValue = ExecutionHelper.Execute ("/Library/Frameworks/Mono.framework/Commands/monodis", new string[] { "--presources", libPath }, out string monoDisResults);
 			Assert.AreEqual (0, returnValue);
 			Assert.IsFalse (monoDisResults.Contains ("XTest.framework"), $"Binding Library contained embedded resource: {monoDisResults}");
 

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectReference.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectReference.cs
@@ -32,7 +32,7 @@ namespace Xamarin.iOS.Tasks
 				NugetRestore ("../MyExtensionWithPackageReference/MyExtensionWithPackageReference.csproj");
 
 				// Can't use the in-process MSBuild engine, because it complains that the project file is invalid (the attribute 'Version' in the element '<PackageReference>' is unrecognized)
-				var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, $"-- ../MyAppWithPackageReference/MyAppWithPackageReference.csproj /p:Platform={Platform} /p:Configuration=Debug", out var output);
+				var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, new string[] { "--", "../MyAppWithPackageReference/MyAppWithPackageReference.csproj", $"/p:Platform={Platform}", $"/p:Configuration=Debug" }, out var output);
 				if (rv != 0) {
 					Console.WriteLine ("Build failed:");
 					Console.WriteLine (output);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectReference.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectReference.cs
@@ -32,7 +32,7 @@ namespace Xamarin.iOS.Tasks
 				NugetRestore ("../MyExtensionWithPackageReference/MyExtensionWithPackageReference.csproj");
 
 				// Can't use the in-process MSBuild engine, because it complains that the project file is invalid (the attribute 'Version' in the element '<PackageReference>' is unrecognized)
-				var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, new string[] { "--", "../MyAppWithPackageReference/MyAppWithPackageReference.csproj", $"/p:Platform={Platform}", $"/p:Configuration=Debug" }, out var output);
+				var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, new string[] { "--", "../MyAppWithPackageReference/MyAppWithPackageReference.csproj", $"/p:Platform={Platform}", "/p:Configuration=Debug" }, out var output);
 				if (rv != 0) {
 					Console.WriteLine ("Build failed:");
 					Console.WriteLine (output);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectReference.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectReference.cs
@@ -32,7 +32,7 @@ namespace Xamarin.iOS.Tasks
 				NugetRestore ("../MyExtensionWithPackageReference/MyExtensionWithPackageReference.csproj");
 
 				// Can't use the in-process MSBuild engine, because it complains that the project file is invalid (the attribute 'Version' in the element '<PackageReference>' is unrecognized)
-				var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, new string[] { "--", "../MyAppWithPackageReference/MyAppWithPackageReference.csproj", $"/p:Platform={Platform}", "/p:Configuration=Debug" }, out var output);
+				var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, new [] { "--", "../MyAppWithPackageReference/MyAppWithPackageReference.csproj", $"/p:Platform={Platform}", "/p:Configuration=Debug" }, out var output);
 				if (rv != 0) {
 					Console.WriteLine ("Build failed:");
 					Console.WriteLine (output);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
@@ -341,7 +341,7 @@ namespace Xamarin.iOS.Tasks
 		public static bool IsAPFS {
 			get {
 				if (!is_apfs.HasValue) {
-					var exit_code = ExecutionHelper.Execute ("/bin/df", "-t apfs /", out var output, TimeSpan.FromSeconds (10));
+					var exit_code = ExecutionHelper.Execute ("/bin/df", new string[] { "-t", "apfs", "/" }, out var output, TimeSpan.FromSeconds (10));
 					is_apfs = exit_code == 0 && output.Trim ().Split ('\n').Length >= 2;
 				}
 				return is_apfs.Value;
@@ -391,7 +391,7 @@ namespace Xamarin.iOS.Tasks
 
 		public static void NugetRestore (string project)
 		{
-			var rv = ExecutionHelper.Execute ("nuget", $"restore {StringUtils.Quote (project)}", out var output);
+			var rv = ExecutionHelper.Execute ("nuget", new string[] { "restore", project }, out var output);
 			if (rv != 0) {
 				Console.WriteLine ("nuget restore failed:");
 				Console.WriteLine (output);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.iOS.Tasks</RootNamespace>
     <AssemblyName>Xamarin.iOS.Tasks.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -238,15 +238,15 @@ public class BindingTouch {
 			{ "unsafe", "Sets the unsafe flag for the build", v=> unsafef = true },
 			{ "core", "Use this to build product assemblies", v => BindThirdPartyLibrary = false },
 			{ "r=", "Adds a reference", v => references.Add (v) },
-			{ "lib=", "Adds the directory to the search path for the compiler", v => libs.Add (StringUtils.Quote (v)) },
+			{ "lib=", "Adds the directory to the search path for the compiler", v => libs.Add (v) },
 			{ "compiler=", "Sets the compiler to use (Obsolete) ", v => compiler = v, true },
 			{ "sdk=", "Sets the .NET SDK to use (Obsolete)", v => {}, true },
 			{ "new-style", "Build for Unified (Obsolete).", v => { Console.WriteLine ("The --new-style option is obsolete and ignored."); }, true},
 			{ "d=", "Defines a symbol", v => defines.Add (v) },
-			{ "api=", "Adds a API definition source file", v => api_sources.Add (StringUtils.Quote (v)) },
-			{ "s=", "Adds a source file required to build the API", v => core_sources.Add (StringUtils.Quote (v)) },
+			{ "api=", "Adds a API definition source file", v => api_sources.Add (v) },
+			{ "s=", "Adds a source file required to build the API", v => core_sources.Add (v) },
 			{ "v", "Sets verbose mode", v => verbose = true },
-			{ "x=", "Adds the specified file to the build, used after the core files are compiled", v => extra_sources.Add (StringUtils.Quote (v)) },
+			{ "x=", "Adds the specified file to the build, used after the core files are compiled", v => extra_sources.Add (v) },
 			{ "e", "Generates smaller classes that can not be subclassed (previously called 'external mode')", v => external = true },
 			{ "p", "Sets private mode", v => public_mode = false },
 			{ "baselib=", "Sets the base library", v => baselibdll = v },
@@ -379,9 +379,9 @@ public class BindingTouch {
 		}
 
 		if (sources.Count > 0) {
-			api_sources.Insert (0, StringUtils.Quote (sources [0]));
+			api_sources.Insert (0, sources [0]);
 			for (int i = 1; i < sources.Count; i++)
-				core_sources.Insert (i - 1, StringUtils.Quote (sources [i]));
+				core_sources.Insert (i - 1, sources [i]);
 		}
 
 		if (api_sources.Count == 0) {
@@ -393,48 +393,44 @@ public class BindingTouch {
 		if (tmpdir == null)
 			tmpdir = GetWorkDir ();
 
-		string firstApiDefinitionName = Path.GetFileNameWithoutExtension (StringUtils.Unquote (api_sources [0]));
+		string firstApiDefinitionName = Path.GetFileNameWithoutExtension (api_sources [0]);
 		firstApiDefinitionName = firstApiDefinitionName.Replace ('-', '_'); // This is not exhaustive, but common.
 		if (outfile == null)
 			outfile = firstApiDefinitionName + ".dll";
 
-		string refs = string.Empty;
-		foreach (var r in references) {
-			if (refs != string.Empty)
-				refs += " ";
-			refs += "-r:" + StringUtils.Quote (r);
-		}
-		string paths = (libs.Count > 0 ? "-lib:" + String.Join (" -lib:", libs.ToArray ()) : "");
+		var refs = references.Select ((v) => "-r:" + v);
+		var paths = libs.Select ((v) => "-lib:" + v);
 
 		try {
 			var tmpass = Path.Combine (tmpdir, "temp.dll");
 
 			// -nowarn:436 is to avoid conflicts in definitions between core.dll and the sources
 			// Keep source files at the end of the command line - csc will create TWO assemblies if any sources preceed the -out parameter
-			var cargs = new StringBuilder ();
+			var cargs = new List<string> ();
 
-			cargs.Append ("-debug -unsafe -target:library -nowarn:436").Append (' ');
-			cargs.Append ("-out:").Append (StringUtils.Quote (tmpass)).Append (' ');
-			cargs.Append ("-r:").Append (StringUtils.Quote (GetAttributeLibraryPath ())).Append (' ');
-			cargs.Append (refs).Append (' ');
+			cargs.Add ("-debug");
+			cargs.Add ("-unsafe");
+			cargs.Add ("-target:library");
+			cargs.Add ("-nowarn:436");
+			cargs.Add ("-out:" + tmpass);
+			cargs.Add ("-r:" + GetAttributeLibraryPath ());
+			cargs.AddRange (refs);
 			if (unsafef)
-				cargs.Append ("-unsafe ");
-			cargs.Append ("-r:").Append (StringUtils.Quote (baselibdll)).Append (' ');
+				cargs.Add ("-unsafe");
+			cargs.Add ("-r:" + baselibdll);
 			foreach (var def in defines)
-				cargs.Append ("-define:").Append (def).Append (' ');
-			cargs.Append (paths).Append (' ');
+				cargs.Add ("-define:" + def);
+			cargs.AddRange (paths);
 			if (nostdlib) {
-				cargs.Append ("-nostdlib ");
-				cargs.Append ("-noconfig ");
+				cargs.Add ("-nostdlib");
+				cargs.Add ("-noconfig");
 			}
-			foreach (var qs in api_sources)
-				cargs.Append (qs).Append (' ');
-			foreach (var cs in core_sources)
-				cargs.Append (cs).Append (' ');
+			cargs.AddRange (api_sources);
+			cargs.AddRange (core_sources);
 			if (!string.IsNullOrEmpty (Path.GetDirectoryName (baselibdll)))
-				cargs.Append ("-lib:").Append (Path.GetDirectoryName (baselibdll)).Append (' ');
+				cargs.Add ("-lib:" + Path.GetDirectoryName (baselibdll));
 
-			if (Driver.RunCommand (compiler, cargs.ToString (), null, out var compile_output, true, verbose ? 1 : 0) != 0)
+			if (Driver.RunCommand (compiler, cargs, null, out var compile_output, true, verbose ? 1 : 0) != 0)
 				throw ErrorHelper.CreateError (2, "Could not compile the API bindings.\n\t" + compile_output.ToString ().Replace ("\n", "\n\t"));
 
 			universe = new Universe (UniverseOptions.EnableFunctionPointers | UniverseOptions.ResolveMissingMembers | UniverseOptions.MetadataOnly);
@@ -524,29 +520,25 @@ public class BindingTouch {
 
 			cargs.Clear ();
 			if (unsafef)
-				cargs.Append ("-unsafe ");
-			cargs.Append ("-target:library ");
-			cargs.Append ("-out:").Append (StringUtils.Quote (outfile)).Append (' ');
+				cargs.Add ("-unsafe");
+			cargs.Add ("-target:library");
+			cargs.Add ("-out:" + outfile);
 			foreach (var def in defines)
-				cargs.Append ("-define:").Append (def).Append (' ');
-			foreach (var gf in g.GeneratedFiles)
-				cargs.Append (gf).Append (' ');
-			foreach (var cs in core_sources)
-				cargs.Append (cs).Append (' ');
-			foreach (var es in extra_sources)
-				cargs.Append (es).Append (' ');
-			cargs.Append (refs).Append (' ');
-			cargs.Append ("-r:").Append (StringUtils.Quote (baselibdll)).Append (' ');
-			foreach (var res in resources)
-				cargs.Append (res).Append (' ');
+				cargs.Add ("-define:" + def);
+			cargs.AddRange (g.GeneratedFiles);
+			cargs.AddRange (core_sources);
+			cargs.AddRange (extra_sources);
+			cargs.AddRange (refs);
+			cargs.Add ("-r:" + baselibdll);
+			cargs.AddRange (resources);
 			if (nostdlib) {
-				cargs.Append ("-nostdlib ");
-				cargs.Append ("-noconfig ");
+				cargs.Add ("-nostdlib");
+				cargs.Add ("-noconfig");
 			}
 			if (!string.IsNullOrEmpty (Path.GetDirectoryName (baselibdll)))
-				cargs.Append ("-lib:").Append (Path.GetDirectoryName (baselibdll)).Append (' ');
+				cargs.Add ("-lib:" + Path.GetDirectoryName (baselibdll));
 
-			if (Driver.RunCommand (compiler, cargs.ToString (), null, out var generated_compile_output, true, verbose ? 1 : 0) != 0)
+			if (Driver.RunCommand (compiler, cargs, null, out var generated_compile_output, true, verbose ? 1 : 0) != 0)
 				throw ErrorHelper.CreateError (1000, "Could not compile the generated API bindings.\n\t" + generated_compile_output.ToString ().Replace ("\n", "\n\t"));
 		} finally {
 			if (delete_temp)

--- a/tests/common/BundlerTest.cs
+++ b/tests/common/BundlerTest.cs
@@ -127,7 +127,7 @@ class T {
 ";
 				bundler.Profile = profile;
 				bundler.CreateTemporaryCacheDirectory ();
-				bundler.CreateTemporaryApp (profile, code: code, extraArg: "/debug:full");
+				bundler.CreateTemporaryApp (profile, code: code, extraArgs: new string [] { "/debug:full" });
 				bundler.Linker = LinkerOption.LinkAll;
 				bundler.Optimize = new string [] { "blockliteral-setupblock" };
 				bundler.AssertExecute ();
@@ -168,7 +168,7 @@ class T {
 ";
 				bundler.Profile = profile;
 				bundler.CreateTemporaryCacheDirectory ();
-				bundler.CreateTemporaryApp (profile, code: code, extraArg: "/debug:full");
+				bundler.CreateTemporaryApp (profile, code: code, extraArgs: new string [] { "/debug:full" });
 				bundler.Linker = LinkerOption.LinkSdk;
 				bundler.Registrar = RegistrarOption.Static;
 				bundler.Optimize = new string [] { "remove-dynamic-registrar" };
@@ -250,7 +250,7 @@ class D : NSObject {
 ";
 				bundler.Profile = profile;
 				bundler.CreateTemporaryCacheDirectory ();
-				bundler.CreateTemporaryApp (profile, code: code, extraArg: "/debug:full");
+				bundler.CreateTemporaryApp (profile, code: code, extraArgs: new string [] { "/debug:full" });
 				bundler.Optimize = new string [] { "blockliteral-setupblock" };
 				bundler.Registrar = RegistrarOption.Static;
 				bundler.AssertExecuteFailure ();
@@ -298,7 +298,7 @@ class Issue4072Session : NSUrlSession {
 			using (var bundler = new BundlerTool ()) {
 				bundler.Profile = profile;
 				bundler.CreateTemporaryCacheDirectory ();
-				bundler.CreateTemporaryApp (profile, code: code, extraArg: "/debug:full");
+				bundler.CreateTemporaryApp (profile, code: code, extraArgs: new string [] { "/debug:full" });
 				bundler.Registrar = RegistrarOption.Static;
 				bundler.Linker = LinkerOption.DontLink;
 				bundler.AssertExecute ();
@@ -314,7 +314,7 @@ class Issue4072Session : NSUrlSession {
 			using (var bundler = new BundlerTool ()) {
 				bundler.Profile = profile;
 				bundler.CreateTemporaryCacheDirectory ();
-				bundler.CreateTemporaryApp (profile, code: code, extraArg: "/debug-"); // Build without debug info so that the source code location isn't available.
+				bundler.CreateTemporaryApp (profile, code: code, extraArgs: new string [] { "/debug-" }); // Build without debug info so that the source code location isn't available.
 				bundler.Registrar = RegistrarOption.Static;
 #if !__MACOS__
 				bundler.Linker = LinkerOption.LinkAll; // This will remove the parameter name in Xamarin.iOS (the parameter name removal optimization (MetadataReducerSubStep) isn't implemented for Xamarin.Mac).

--- a/tests/common/BundlerTest.cs
+++ b/tests/common/BundlerTest.cs
@@ -127,7 +127,7 @@ class T {
 ";
 				bundler.Profile = profile;
 				bundler.CreateTemporaryCacheDirectory ();
-				bundler.CreateTemporaryApp (profile, code: code, extraArgs: new string [] { "/debug:full" });
+				bundler.CreateTemporaryApp (profile, code: code, extraArgs: new [] { "/debug:full" });
 				bundler.Linker = LinkerOption.LinkAll;
 				bundler.Optimize = new string [] { "blockliteral-setupblock" };
 				bundler.AssertExecute ();
@@ -168,7 +168,7 @@ class T {
 ";
 				bundler.Profile = profile;
 				bundler.CreateTemporaryCacheDirectory ();
-				bundler.CreateTemporaryApp (profile, code: code, extraArgs: new string [] { "/debug:full" });
+				bundler.CreateTemporaryApp (profile, code: code, extraArgs: new [] { "/debug:full" });
 				bundler.Linker = LinkerOption.LinkSdk;
 				bundler.Registrar = RegistrarOption.Static;
 				bundler.Optimize = new string [] { "remove-dynamic-registrar" };
@@ -250,7 +250,7 @@ class D : NSObject {
 ";
 				bundler.Profile = profile;
 				bundler.CreateTemporaryCacheDirectory ();
-				bundler.CreateTemporaryApp (profile, code: code, extraArgs: new string [] { "/debug:full" });
+				bundler.CreateTemporaryApp (profile, code: code, extraArgs: new [] { "/debug:full" });
 				bundler.Optimize = new string [] { "blockliteral-setupblock" };
 				bundler.Registrar = RegistrarOption.Static;
 				bundler.AssertExecuteFailure ();
@@ -298,7 +298,7 @@ class Issue4072Session : NSUrlSession {
 			using (var bundler = new BundlerTool ()) {
 				bundler.Profile = profile;
 				bundler.CreateTemporaryCacheDirectory ();
-				bundler.CreateTemporaryApp (profile, code: code, extraArgs: new string [] { "/debug:full" });
+				bundler.CreateTemporaryApp (profile, code: code, extraArgs: new [] { "/debug:full" });
 				bundler.Registrar = RegistrarOption.Static;
 				bundler.Linker = LinkerOption.DontLink;
 				bundler.AssertExecute ();
@@ -314,7 +314,7 @@ class Issue4072Session : NSUrlSession {
 			using (var bundler = new BundlerTool ()) {
 				bundler.Profile = profile;
 				bundler.CreateTemporaryCacheDirectory ();
-				bundler.CreateTemporaryApp (profile, code: code, extraArgs: new string [] { "/debug-" }); // Build without debug info so that the source code location isn't available.
+				bundler.CreateTemporaryApp (profile, code: code, extraArgs: new [] { "/debug-" }); // Build without debug info so that the source code location isn't available.
 				bundler.Registrar = RegistrarOption.Static;
 #if !__MACOS__
 				bundler.Linker = LinkerOption.LinkAll; // This will remove the parameter name in Xamarin.iOS (the parameter name removal optimization (MetadataReducerSubStep) isn't implemented for Xamarin.Mac).

--- a/tests/common/BundlerTool.cs
+++ b/tests/common/BundlerTool.cs
@@ -156,7 +156,6 @@ namespace Xamarin.Tests
 			if (I18N != I18N.None) {
 				sb.Add ("--i18n");
 				var i18n = new List<string> ();
-				int count = 0;
 				if ((I18N & I18N.CJK) == I18N.CJK)
 					i18n.Add ("cjk");
 				if ((I18N & I18N.MidEast) == I18N.MidEast)

--- a/tests/common/BundlerTool.cs
+++ b/tests/common/BundlerTool.cs
@@ -87,7 +87,7 @@ namespace Xamarin.Tests
 			}
 		}
 
-		protected void GetVerbosity (IList<string> args)
+		protected void AddVerbosity (IList<string> args)
 		{
 			if (Verbosity == 0) {
 				// do nothing
@@ -287,7 +287,7 @@ namespace Xamarin.Tests
 				sb.Add (TargetVer);
 			}
 
-			GetVerbosity (sb);
+			AddVerbosity (sb);
 
 			if (WarnAsError != null) {
 				if (WarnAsError.Length > 0) {

--- a/tests/common/BundlerTool.cs
+++ b/tests/common/BundlerTool.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -86,22 +87,22 @@ namespace Xamarin.Tests
 			}
 		}
 
-		protected string GetVerbosity ()
+		protected void GetVerbosity (IList<string> args)
 		{
 			if (Verbosity == 0) {
-				return string.Empty;
+				// do nothing
 			} else if (Verbosity > 0) {
-				return new string ('-', Verbosity).Replace ("-", "-v ");
+				args.Add ("-" + new string ('v', Verbosity));
 			} else {
-				return new string ('-', -Verbosity).Replace ("-", "-q ");
+				args.Add ("-" + new string ('q', -Verbosity));
 			}
 		}
 
-		protected string ToolArguments {
+		protected IList<string> ToolArguments {
 			get {
-				var sb = new StringBuilder ();
+				var sb = new List<string> ();
 				BuildArguments (sb);
-				return sb.ToString ();
+				return sb;
 			}
 		}
 
@@ -110,56 +111,63 @@ namespace Xamarin.Tests
 			return null;
 		}
 
-		protected virtual void BuildArguments (StringBuilder sb)
+		protected virtual void BuildArguments (IList<string> sb)
 		{
 			// Options are processed alphabetically
 
 			if (Abi == None) {
 				// add nothing
 			} else if (!string.IsNullOrEmpty (Abi)) {
-				sb.Append (IsMtouchTool ? " --abi " : " --arch ").Append (Abi);
+				sb.Add (IsMtouchTool ? "--abi" : "--arch");
+				sb.Add (Abi);
 			} else {
 				var a = GetDefaultAbi ();
 				if (!string.IsNullOrEmpty (a)) {
-					sb.Append (IsMtouchTool ? " --abi " : " --arch ");
-					sb.Append (a);
+					sb.Add (IsMtouchTool ? "--abi" : "--arch");
+					sb.Add (a);
 				}
 			}
 
-			if (!string.IsNullOrEmpty (Cache))
-				sb.Append (" --cache ").Append (StringUtils.Quote (Cache));
+			if (!string.IsNullOrEmpty (Cache)) {
+				sb.Add ("--cache");
+				sb.Add (Cache);
+			}
 
 			if (CustomArguments != null) {
 				foreach (var arg in CustomArguments) {
-					sb.Append (" ").Append (arg);
+					sb.Add (arg);
 				}
 			}
 
 			if (Debug.HasValue && Debug.Value)
-				sb.Append (" --debug");
+				sb.Add ("--debug");
 
 			if (Extension == true)
-				sb.Append (" --extension");
+				sb.Add ("--extension");
 
-			if (!string.IsNullOrEmpty (GccFlags))
-				sb.Append (IsMtouchTool ? " --gcc_flags " : " --link_flags ").Append (StringUtils.Quote (GccFlags));
+			if (!string.IsNullOrEmpty (GccFlags)) {
+				sb.Add (IsMtouchTool ? "--gcc_flags" : "--link_flags");
+				sb.Add (GccFlags);
+			}
 
 			if (!string.IsNullOrEmpty (HttpMessageHandler))
-				sb.Append (" --http-message-handler=").Append (StringUtils.Quote (HttpMessageHandler));
+				sb.Add ($"--http-message-handler={HttpMessageHandler}");
 
 			if (I18N != I18N.None) {
-				sb.Append (" --i18n ");
+				sb.Add ("--i18n");
+				var i18n = new List<string> ();
 				int count = 0;
 				if ((I18N & I18N.CJK) == I18N.CJK)
-					sb.Append (count++ == 0 ? string.Empty : ",").Append ("cjk");
+					i18n.Add ("cjk");
 				if ((I18N & I18N.MidEast) == I18N.MidEast)
-					sb.Append (count++ == 0 ? string.Empty : ",").Append ("mideast");
+					i18n.Add ("mideast");
 				if ((I18N & I18N.Other) == I18N.Other)
-					sb.Append (count++ == 0 ? string.Empty : ",").Append ("other");
+					i18n.Add ("other");
 				if ((I18N & I18N.Rare) == I18N.Rare)
-					sb.Append (count++ == 0 ? string.Empty : ",").Append ("rare");
+					i18n.Add ("rare");
 				if ((I18N & I18N.West) == I18N.West)
-					sb.Append (count++ == 0 ? string.Empty : ",").Append ("west");
+					i18n.Add ("west");
+				sb.Add (string.Join (",", i18n));
 			}
 
 			switch (Linker) {
@@ -167,13 +175,13 @@ namespace Xamarin.Tests
 			case LinkerOption.Unspecified:
 				break;
 			case LinkerOption.DontLink:
-				sb.Append (" --nolink");
+				sb.Add ("--nolink");
 				break;
 			case LinkerOption.LinkSdk:
-				sb.Append (" --linksdkonly");
+				sb.Add ("--linksdkonly");
 				break;
 			case LinkerOption.LinkPlatform:
-				sb.Append (" --linkplatform");
+				sb.Add ("--linkplatform");
 				break;
 			default:
 				throw new NotImplementedException ();
@@ -181,87 +189,91 @@ namespace Xamarin.Tests
 
 			if (LinkSkip?.Length > 0) {
 				foreach (var ls in LinkSkip)
-					sb.Append (" --linkskip:").Append (StringUtils.Quote (ls));
+					sb.Add ($"--linkskip:{ls}");
 			}
 
 			if (NoWarn != null) {
 				if (NoWarn.Length > 0) {
-					sb.Append (" --nowarn:");
-					foreach (var code in NoWarn)
-						sb.Append (code).Append (',');
-					sb.Length--;
+					sb.Add ($"--nowarn:{string.Join (",", NoWarn.Select ((v) => v.ToString ()))}");
 				} else {
-					sb.Append (" --nowarn");
+					sb.Add ("--nowarn");
 				}
 			}
 
 			if (Optimize != null) {
 				foreach (var opt in Optimize)
-					sb.Append (" --optimize:").Append (opt);
+					sb.Add ($"--optimize:{opt}");
 			}
 
 			if (Profiling.HasValue)
-				sb.Append (" --profiling:").Append (Profiling.Value ? "true" : "false");
+				sb.Add ($"--profiling:{(Profiling.Value ? "true" : "false")}");
 
 			if (References != null) {
 				foreach (var r in References)
-					sb.Append (IsMtouchTool ? " -r:" : " -a:").Append (StringUtils.Quote (r));
+					sb.Add ((IsMtouchTool ? "-r:" : "-a:") + r);
 			}
 
 			switch (Registrar) {
 			case RegistrarOption.Unspecified:
 				break;
 			case RegistrarOption.Dynamic:
-				sb.Append (" --registrar:dynamic");
+				sb.Add ("--registrar:dynamic");
 				break;
 			case RegistrarOption.Static:
-				sb.Append (" --registrar:static");
+				sb.Add ("--registrar:static");
 				break;
 			default:
 				throw new NotImplementedException ();
 			}
 
 			if (!string.IsNullOrEmpty (ResponseFile))
-				sb.Append (" @").Append (StringUtils.Quote (ResponseFile));
+				sb.Add ("@" + ResponseFile);
 
 			if (!string.IsNullOrEmpty (RootAssembly))
-				sb.Append (" ").Append (StringUtils.Quote (RootAssembly));
+				sb.Add (RootAssembly);
 
 			if (Sdk == None) {
 				// do nothing	
 			} else if (!string.IsNullOrEmpty (Sdk)) {
-				sb.Append (" --sdk ").Append (Sdk);
+				sb.Add ("--sdk");
+				sb.Add (Sdk);
 			} else {
-				sb.Append (" --sdk ").Append (Configuration.GetSdkVersion (Profile));
+				sb.Add ("--sdk");
+				sb.Add (Configuration.GetSdkVersion (Profile));
 			}
 
 			if (SdkRoot == None) {
 				// do nothing
 			} else if (!string.IsNullOrEmpty (SdkRoot)) {
-				sb.Append (" --sdkroot ").Append (StringUtils.Quote (SdkRoot));
+				sb.Add ("--sdkroot");
+				sb.Add (SdkRoot);
 			} else {
-				sb.Append (" --sdkroot ").Append (StringUtils.Quote (Configuration.xcode_root));
+				sb.Add ("--sdkroot");
+				sb.Add (Configuration.xcode_root);
 			}
 
 			if (TargetFramework == None) {
 				// do nothing
 			} else if (!string.IsNullOrEmpty (TargetFramework)) {
-				sb.Append (" --target-framework ").Append (TargetFramework);
+				sb.Add ("--target-framework");
+				sb.Add (TargetFramework);
 			} else if (!NoPlatformAssemblyReference) {
 				// make the implicit default the way tests have been running until now, and at the same time the very minimum to make apps build.
 				switch (Profile) {
 				case Profile.iOS:
-					sb.Append (" -r:").Append (StringUtils.Quote (Configuration.XamarinIOSDll));
+					sb.Add ($"-r:" + Configuration.XamarinIOSDll);
 					break;
 				case Profile.tvOS:
 				case Profile.watchOS:
-					sb.Append (" --target-framework ").Append (Configuration.GetTargetFramework (Profile));
-					sb.Append (" -r:").Append (StringUtils.Quote (Configuration.GetBaseLibrary (Profile)));
+					sb.Add ("--target-framework");
+					sb.Add (Configuration.GetTargetFramework (Profile));
+					sb.Add ("-r:" + Configuration.GetBaseLibrary (Profile));
 					break;
 				case Profile.macOSFull:
 				case Profile.macOSMobile:
 				case Profile.macOSSystem:
-					sb.Append (" --target-framework ").Append (Configuration.GetTargetFramework (Profile));
+					sb.Add ("--target-framework");
+					sb.Add (Configuration.GetTargetFramework (Profile));
 					break;
 				default:
 					throw new NotImplementedException ();
@@ -271,32 +283,30 @@ namespace Xamarin.Tests
 			if (TargetVer == None) {
 				// do nothing
 			} else if (!string.IsNullOrEmpty (TargetVer)) {
-				sb.Append (IsMtouchTool ? " --targetver " : " --minos ").Append (TargetVer);
+				sb.Add (IsMtouchTool ? "--targetver" : "--minos");
+				sb.Add (TargetVer);
 			}
 
-			sb.Append (" ").Append (GetVerbosity ());
+			GetVerbosity (sb);
 
 			if (WarnAsError != null) {
 				if (WarnAsError.Length > 0) {
-					sb.Append (" --warnaserror:");
-					foreach (var code in WarnAsError)
-						sb.Append (code).Append (',');
-					sb.Length--;
+					sb.Add ($"--warnaserror:{string.Join (",", WarnAsError.Select ((v) => v.ToString ()))}");
 				} else {
-					sb.Append (" --warnaserror");
+					sb.Add ("--warnaserror");
 				}
 			}
 
 			if (XmlDefinitions?.Length > 0) {
 				foreach (var xd in XmlDefinitions)
-					sb.Append (" --xml:").Append (StringUtils.Quote (xd));
+					sb.Add ($"--xml:{xd}");
 			}
 
 			if (Interpreter != null) {
 				if (Interpreter.Length == 0)
-					sb.Append (" --interpreter");
+					sb.Add ("--interpreter");
 				else
-					sb.Append (" --interpreter=").Append (Interpreter);
+					sb.Add ("--interpreter=" + Interpreter);
 			}
 		}
 
@@ -331,9 +341,9 @@ namespace Xamarin.Tests
 			Assert.AreEqual (1, Execute (), message);
 		}
 
-		public abstract void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, string extraArg = "", string extraCode = null, string usings = null, bool use_csc = true);
+		public abstract void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, IList<string> extraArgs = null, string extraCode = null, string usings = null, bool use_csc = true);
 
-		public static string CompileTestAppExecutable (string targetDirectory, string code = null, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp", string extraCode = null, string usings = null, bool use_csc = true)
+		public static string CompileTestAppExecutable (string targetDirectory, string code = null, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp", string extraCode = null, string usings = null, bool use_csc = true)
 		{
 			if (code == null)
 				code = "public class TestApp { static void Main () { System.Console.WriteLine (typeof (ObjCRuntime.Runtime).ToString ()); } }";
@@ -342,15 +352,15 @@ namespace Xamarin.Tests
 			if (extraCode != null)
 				code += extraCode;
 
-			return CompileTestAppCode ("exe", targetDirectory, code, extraArg, profile, appName, use_csc);
+			return CompileTestAppCode ("exe", targetDirectory, code, extraArgs, profile, appName, use_csc);
 		}
 
-		public static string CompileTestAppLibrary (string targetDirectory, string code, string extraArg = null, Profile profile = Profile.iOS, string appName = "testApp")
+		public static string CompileTestAppLibrary (string targetDirectory, string code, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp")
 		{
-			return CompileTestAppCode ("library", targetDirectory, code, extraArg, profile, appName);
+			return CompileTestAppCode ("library", targetDirectory, code, extraArgs, profile, appName);
 		}
 
-		public static string CompileTestAppCode (string target, string targetDirectory, string code, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp", bool use_csc = true)
+		public static string CompileTestAppCode (string target, string targetDirectory, string code, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp", bool use_csc = true)
 		{
 			var ext = target == "exe" ? "exe" : "dll";
 			var cs = Path.Combine (targetDirectory, "testApp.cs");
@@ -360,10 +370,17 @@ namespace Xamarin.Tests
 			File.WriteAllText (cs, code);
 
 			string output;
-			StringBuilder args = new StringBuilder ();
+			var args = new List<string> ();
 			string fileName = Configuration.GetCompiler (profile, args, use_csc);
-			args.AppendFormat ($" /noconfig /t:{target} /nologo /out:{StringUtils.Quote (assembly)} /r:{StringUtils.Quote (root_library)} {StringUtils.Quote (cs)} {extraArg}");
-			if (ExecutionHelper.Execute (fileName, args.ToString (), out output) != 0) {
+			args.Add ("/noconfig");
+			args.Add ($"/t:{target}");
+			args.Add ("/nologo");
+			args.Add ($"/out:{assembly}");
+			args.Add ($"/r:{root_library}");
+			args.Add (cs);
+			if (extraArgs != null)
+				args.AddRange (extraArgs);
+			if (ExecutionHelper.Execute (fileName, args, out output) != 0) {
 				Console.WriteLine ("{0} {1}", fileName, args);
 				Console.WriteLine (output);
 				throw new Exception (output);

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -155,7 +155,7 @@ namespace Xamarin.Tests
 				if (tests_dir == null)
 					throw new Exception ($"Could not find the directory 'tests'. Please run 'make' in the tests/ directory.");
 				// Run make
-				ExecutionHelper.Execute ("make", $"-C {StringUtils.Quote (tests_dir)} test.config");
+				ExecutionHelper.Execute ("make", new string[] { "-C", tests_dir }, "test.config");
 				test_config = FindConfigFiles ("test.config");
 			}
 			ParseConfigFiles (test_config);
@@ -224,7 +224,7 @@ namespace Xamarin.Tests
 				File.Copy (path, tmpfile, true);
 				using (var process = new System.Diagnostics.Process ()) {
 					process.StartInfo.FileName = "plutil";
-					process.StartInfo.Arguments = $"-convert xml1 {Xamarin.Utils.StringUtils.Quote (tmpfile)}";
+					process.StartInfo.Arguments = StringUtils.FormatArguments ("-convert", "xml1", tmpfile);
 					process.Start ();
 					process.WaitForExit ();
 					return File.ReadAllText (tmpfile);
@@ -535,9 +535,9 @@ namespace Xamarin.Tests
 			}
 		}
 
-		public static string GetCompiler (Profile profile, StringBuilder args, bool use_csc = true)
+		public static string GetCompiler (Profile profile, IList<string> args, bool use_csc = true)
 		{
-			args.Append (" -lib:").Append (Path.GetDirectoryName (GetBaseLibrary (profile))).Append (' ');
+			args.Add ($"-lib:{Path.GetDirectoryName (GetBaseLibrary (profile))}");
 			if (use_csc) {
 				return "/Library/Frameworks/Mono.framework/Commands/csc";
 			} else {

--- a/tests/common/ExecutionHelper.cs
+++ b/tests/common/ExecutionHelper.cs
@@ -435,7 +435,7 @@ namespace Xamarin.Tests
 	static class ExecutionHelper {
 		static int Execute (string fileName, string[] arguments, StringBuilder stdout, StringBuilder stderr, TimeSpan? timeout = null)
 		{
-			var psi = new ProcessStartInfo (fileName, string.Join (" ", arguments.Select ((v) => StringUtils.Quote (v))));
+			var psi = new ProcessStartInfo (fileName, string.Join (" ", arguments.Select ((v) => StringUtils.QuoteForProcess (v))));
 			return Execute (psi, (line) => {
 				lock (stdout)
 					stdout.AppendLine (line);
@@ -463,7 +463,7 @@ namespace Xamarin.Tests
 
 		public static int Execute (string fileName, string [] arguments, string working_directory = null, Action<string> stdout_callback = null, Action<string> stderr_callback = null, TimeSpan? timeout = null)
 		{
-			var psi = new ProcessStartInfo (fileName, string.Join (" ", arguments.Select ((v) => StringUtils.Quote (v))));
+			var psi = new ProcessStartInfo (fileName, string.Join (" ", arguments.Select ((v) => StringUtils.QuoteForProcess (v))));
 			psi.WorkingDirectory = working_directory;
 			return Execute (psi, stdout_callback, stderr_callback, timeout);
 		}
@@ -471,7 +471,7 @@ namespace Xamarin.Tests
 		public static int Execute (string fileName, string [] arguments, out StringBuilder output, string working_directory = null, TimeSpan? timeout = null)
 		{
 			output = new StringBuilder ();
-			var psi = new ProcessStartInfo (fileName, string.Join (" ", arguments.Select ((v) => StringUtils.Quote (v))));
+			var psi = new ProcessStartInfo (fileName, string.Join (" ", arguments.Select ((v) => StringUtils.QuoteForProcess (v))));
 			psi.WorkingDirectory = working_directory;
 			var capturedOutput = output;
 			var callback = new Action<string> ((v) => {
@@ -483,7 +483,7 @@ namespace Xamarin.Tests
 
 		public static int Execute (string fileName, string [] arguments, out bool timed_out, Dictionary<string, string> environment_variables = null, Action<string> stdout_callback = null, Action<string> stderr_callback = null, TimeSpan? timeout = null)
 		{
-			var psi = new ProcessStartInfo (fileName, string.Join (" ", StringUtils.Quote (arguments)));
+			var psi = new ProcessStartInfo (fileName, string.Join (" ", StringUtils.QuoteForProcess (arguments)));
 			if (environment_variables != null) {
 				foreach (var ev in environment_variables)
 					psi.EnvironmentVariables [ev.Key] = ev.Value;
@@ -493,7 +493,7 @@ namespace Xamarin.Tests
 
 		public static int Execute (string fileName, string [] arguments, out bool timed_out, string working_directory = null, Dictionary<string, string> environment_variables = null, Action<string> stdout_callback = null, Action<string> stderr_callback = null, TimeSpan? timeout = null)
 		{
-			var psi = new ProcessStartInfo (fileName, string.Join (" ", StringUtils.Quote (arguments)));
+			var psi = new ProcessStartInfo (fileName, string.Join (" ", StringUtils.QuoteForProcess (arguments)));
 			psi.WorkingDirectory = working_directory;
 			if (environment_variables != null) {
 				foreach (var ev in environment_variables)
@@ -597,7 +597,7 @@ namespace Xamarin.Tests
 		// The arguments are automatically quoted.
 		public static int Execute (string fileName, string[] arguments, Dictionary<string, string> environmentVariables, StringBuilder stdout, StringBuilder stderr, TimeSpan? timeout = null, string workingDirectory = null)
 		{
-			return Execute (fileName, string.Join (" ", Xamarin.Utils.StringUtils.Quote (arguments)), environmentVariables, stdout, stderr, timeout, workingDirectory);
+			return Execute (fileName, string.Join (" ", Xamarin.Utils.StringUtils.QuoteForProcess (arguments)), environmentVariables, stdout, stderr, timeout, workingDirectory);
 		}
 
 		public static int Execute (string fileName, string arguments, Dictionary<string, string> environmentVariables, StringBuilder stdout, StringBuilder stderr, TimeSpan? timeout = null, string workingDirectory = null)
@@ -626,7 +626,7 @@ namespace Xamarin.Tests
 		private static extern void kill (int pid, int sig);
 		public static string Execute (string fileName, string[] arguments, bool throwOnError = true, Dictionary<string, string> environmentVariables = null, bool hide_output = false, TimeSpan? timeout = null)
 		{
-			return Execute (fileName, string.Join (" ", StringUtils.Quote (arguments)), throwOnError, environmentVariables, hide_output, timeout);
+			return Execute (fileName, string.Join (" ", StringUtils.QuoteForProcess (arguments)), throwOnError, environmentVariables, hide_output, timeout);
 		}
 
 		public static string Execute (string fileName, string arguments, bool throwOnError = true, Dictionary<string, string> environmentVariables = null,

--- a/tests/common/mac/ProjectTestHelpers.cs
+++ b/tests/common/mac/ProjectTestHelpers.cs
@@ -96,18 +96,18 @@ namespace Xamarin.MMP.Tests
 			File.WriteAllText (f ("foo.c"), "int Answer () { return 42; }");
 			File.WriteAllText (f ("Info.plist"), PListText);
 
-			TI.RunAndAssert ($"clang -m32 -c -o {f ("foo_32.o")} {f ("foo.c")}");
-			TI.RunAndAssert ($"clang -m64 -c -o {f ("foo_64.o")} {f ("foo.c")}");
-			TI.RunAndAssert ($"clang -m32 -dynamiclib -o {f ("foo_32.dylib")} {f ("foo_32.o")}");
-			TI.RunAndAssert ($"clang -m64 -dynamiclib -o {f ("foo_64.dylib")} {f ("foo_64.o")}");
-			TI.RunAndAssert ($"lipo -create {f ("foo_32.dylib")} {f ("foo_64.dylib")} -output {f ("Foo")}");
-			TI.RunAndAssert ($"install_name_tool -id @rpath/Foo.framework/Foo {f ("Foo")}");
-			TI.RunAndAssert ($"mkdir -p {f ("Foo.framework/Versions/A/Resources")}");
-			TI.RunAndAssert ($"cp {f ("Foo")} {f ("Foo.framework/Versions/A/Foo")}");
-			TI.RunAndAssert ($"cp {f ("Info.plist")} {f ("Foo.framework/Versions/A/Resources/")}");
-			TI.RunAndAssert ($"ln -s Versions/A/Foo {f ("Foo.framework/Foo")}");
-			TI.RunAndAssert ($"ln -s Versions/A/Resources  {f ("Foo.framework/Resources")}");
-			TI.RunAndAssert ($"ln -s Versions/A  {f ("Foo.framework/Current")}");
+			TI.RunAndAssert ($"clang", "-m32", "-c", "-o", $"{f ("foo_32.o")}", $"{f ("foo.c")}");
+			TI.RunAndAssert ($"clang", "-m64", "-c", "-o", $"{f ("foo_64.o")}", $"{f ("foo.c")}");
+			TI.RunAndAssert ($"clang", "-m32", "-dynamiclib", "-o", $"{f ("foo_32.dylib")}", $"{f ("foo_32.o")}");
+			TI.RunAndAssert ($"clang", "-m64", "-dynamiclib", "-o", $"{f ("foo_64.dylib")}", $"{f ("foo_64.o")}");
+			TI.RunAndAssert ($"lipo", "-create", $"{f ("foo_32.dylib")}", $"{f ("foo_64.dylib")}", "-output", $"{f ("Foo")}");
+			TI.RunAndAssert ($"install_name_tool", "-id", "@rpath/Foo.framework/Foo", $"{f ("Foo")}");
+			TI.RunAndAssert ($"mkdir", "-p", $"{f ("Foo.framework/Versions/A/Resources")}");
+			TI.RunAndAssert ($"cp", $"{f ("Foo")}", $"{f ("Foo.framework/Versions/A/Foo")}");
+			TI.RunAndAssert ($"cp", $"{f ("Info.plist")}", $"{f ("Foo.framework/Versions/A/Resources/")}");
+			TI.RunAndAssert ($"ln", "-s", "Versions/A/Foo", $"{f ("Foo.framework/Foo")}");
+			TI.RunAndAssert ($"ln", "-s", "Versions/A/Resources", $"{f ("Foo.framework/Resources")}");
+			TI.RunAndAssert ($"ln", "-s", "Versions/A", $"{f ("Foo.framework/Current")}");
 			return f ("Foo.framework");
 		}
 
@@ -118,15 +118,15 @@ namespace Xamarin.MMP.Tests
 			File.WriteAllText (f ("Info.plist"), PListText);
 
 			string bitnessArg = sixtyFourBits ? "-m64" : "-m32";
-			TI.RunAndAssert ($"clang {bitnessArg} -c -o {f ("foo.o")} {f ("foo.c")}");
-			TI.RunAndAssert ($"clang {bitnessArg} -dynamiclib -o {f ("Foo")} {f ("foo.o")}");
-			TI.RunAndAssert ($"install_name_tool -id @rpath/Foo.framework/Foo {f ("Foo")}");
-			TI.RunAndAssert ($"mkdir -p {f ("Foo.framework/Versions/A/Resources")}");
-			TI.RunAndAssert ($"cp {f ("Foo")} {f ("Foo.framework/Versions/A/Foo")}");
-			TI.RunAndAssert ($"cp {f ("Info.plist")} {f ("Foo.framework/Versions/A/Resources/")}");
-			TI.RunAndAssert ($"ln -s Versions/A/Foo {f ("Foo.framework/Foo")}");
-			TI.RunAndAssert ($"ln -s Versions/A/Resources  {f ("Foo.framework/Resources")}");
-			TI.RunAndAssert ($"ln -s Versions/A  {f ("Foo.framework/Current")}");
+			TI.RunAndAssert ($"clang", bitnessArg, "-c", "-o", $"{f ("foo.o")}", $"{f ("foo.c")}");
+			TI.RunAndAssert ($"clang", bitnessArg, "-dynamiclib", "-o", $"{f ("Foo")}", $"{f ("foo.o")}");
+			TI.RunAndAssert ($"install_name_tool", "-id", "@rpath/Foo.framework/Foo", $"{f ("Foo")}");
+			TI.RunAndAssert ($"mkdir", "-p", $"{f ("Foo.framework/Versions/A/Resources")}");
+			TI.RunAndAssert ($"cp", $"{f ("Foo")}", $"{f ("Foo.framework/Versions/A/Foo")}");
+			TI.RunAndAssert ($"cp", $"{f ("Info.plist")}", $"{f ("Foo.framework/Versions/A/Resources/")}");
+			TI.RunAndAssert ($"ln", "-s", "Versions/A/Foo", $"{f ("Foo.framework/Foo")}");
+			TI.RunAndAssert ($"ln", "-s", "Versions/A/Resources", $"{f ("Foo.framework/Resources")}");
+			TI.RunAndAssert ($"ln", "-s", "Versions/A", $"{f ("Foo.framework/Current")}");
 			return f ("Foo.framework");
 		}
 	}
@@ -198,33 +198,29 @@ namespace Xamarin.MMP.Tests
 
 		public static Version FindMonoVersion ()
 		{
-			string output = RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono", new StringBuilder ("--version"), "FindMonoVersion");
+			string output = RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono", new string [] { "--version" }, "FindMonoVersion");
 
 			Regex versionRegex = new Regex("compiler version \\d+.\\d+.\\d+(.\\d+)?", RegexOptions.IgnoreCase);
 			return new Version (versionRegex.Match (output).Value.Split (' ')[2]);
 		}
 
-		public static string RunAndAssert (string exe)
+		public static string RunAndAssert (string exe, params string [] args)
 		{
-			var parts = exe.Split (new char [] { ' ' }, 2);
-			if (parts.Length == 1)
-				return RunAndAssert (exe, "", "Command: " + exe);
-			else
-				return RunAndAssert (parts[0], parts[1], "Command: " + exe);
+			return RunAndAssert (exe, args, "Command: " + exe);
 		}
 
-		public static string RunAndAssert (string exe, string args, string stepName, bool shouldFail = false, Func<string> getAdditionalFailInfo = null, string[] environment = null)
+		public static string RunAndAssert (string exe, IList<string> args, string stepName, bool shouldFail = false, Func<string> getAdditionalFailInfo = null, string[] environment = null)
 		{
 			StringBuilder output = new StringBuilder ();
 			Environment.SetEnvironmentVariable ("MONO_PATH", null);
-			int compileResult = Xamarin.Bundler.Driver.RunCommand (exe, args != null ? args.ToString () : string.Empty, environment, output, suppressPrintOnErrors: shouldFail);
+			int compileResult = Xamarin.Bundler.Driver.RunCommand (exe, args, environment, output, suppressPrintOnErrors: shouldFail);
 			if (!shouldFail && compileResult != 0 && Xamarin.Bundler.Driver.Verbosity < 1) {
 				Console.WriteLine ($"Execution failed; exit code: {compileResult}");
 			}
 			Func<string> getInfo = () => getAdditionalFailInfo != null ? getAdditionalFailInfo () : "";
 			bool passed = shouldFail ? compileResult != 0 : compileResult == 0;
 			if (!passed) {
-				string outputLine = PrintRedirectIfLong ($"{exe}{args} Output: {output} {getInfo ()}");
+				string outputLine = PrintRedirectIfLong ($"{exe} {StringUtils.FormatArguments (args)} Output: {output} {getInfo ()}");
 				Assert.Fail ($@"{stepName} {(shouldFail ? "passed" : "failed")} unexpectedly: {outputLine}");
 			}
 			return output.ToString ();
@@ -239,15 +235,10 @@ namespace Xamarin.MMP.Tests
 			return outputLine;
 		}
 
-		public static string RunAndAssert (string exe, StringBuilder args, string stepName, bool shouldFail = false, Func<string> getAdditionalFailInfo = null, string[] environment = null)
-		{
-			return RunAndAssert (exe, args.ToString (), stepName, shouldFail, getAdditionalFailInfo, environment);
-		}
-
 		// In most cases we generate projects in tmp and this is not needed. But nuget and test projects can make that hard
 		public static void CleanUnifiedProject (string csprojTarget)
 		{
-			RunAndAssert (Configuration.XIBuildPath, new StringBuilder ("-- " + csprojTarget + " /t:clean"), "Clean");
+			RunAndAssert (Configuration.XIBuildPath, new string [] { "--", csprojTarget, "/t:clean" }, "Clean");
 		}
 
 		public static string BuildClassicProject (string csprojTarget)
@@ -262,14 +253,14 @@ namespace Xamarin.MMP.Tests
 			Environment.SetEnvironmentVariable ("XamarinMacFrameworkRoot", rootDirectory + "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current");
 
 			// This is to force build to use our mmp and not system mmp
-			StringBuilder buildArgs = new StringBuilder ();
-			buildArgs.Append (" build ");
-			buildArgs.Append (StringUtils.Quote (csprojTarget));
+			var buildArgs = new List<string> ();
+			buildArgs.Add ("build");
+			buildArgs.Add (csprojTarget);
 
 			return RunAndAssert ("/Applications/Visual Studio.app/Contents/MacOS/vstool", buildArgs, "Compile", shouldFail: true);
 		}
 
-		public static string BuildProject (string csprojTarget, bool shouldFail = false, bool release = false, string[] environment = null, string extraArgs = "")
+		public static string BuildProject (string csprojTarget, bool shouldFail = false, bool release = false, string[] environment = null, IList<string> extraArgs = null)
 		{
 			string rootDirectory = FindRootDirectory ();
 
@@ -281,19 +272,19 @@ namespace Xamarin.MMP.Tests
 			Environment.SetEnvironmentVariable ("XamarinMacFrameworkRoot", rootDirectory + "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current");
 
 			// This is to force build to use our mmp and not system mmp
-			StringBuilder buildArgs = new StringBuilder ();
-			buildArgs.Append (" /verbosity:diagnostic ");
-			buildArgs.Append (" /property:XamarinMacFrameworkRoot=" + rootDirectory + "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current ");
+			var buildArgs = new List<string> ();
+			buildArgs.Add ("/verbosity:diagnostic");
+			buildArgs.Add ("/property:XamarinMacFrameworkRoot=" + rootDirectory + "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current");
 
 			if (release)
-				buildArgs.Append ("/property:Configuration=Release ");
+				buildArgs.Add ("/property:Configuration=Release");
 			else
-				buildArgs.Append ("/property:Configuration=Debug ");
+				buildArgs.Add ("/property:Configuration=Debug");
 
-			if (!string.IsNullOrEmpty (extraArgs))
-				buildArgs.Append (extraArgs);
+			if (extraArgs?.Count > 0)
+				buildArgs.AddRange (extraArgs);
 
-			buildArgs.Append (StringUtils.Quote (csprojTarget));
+			buildArgs.Add (csprojTarget);
 
 			Func <string> getBuildProjectErrorInfo = () => {
 				string csprojText = "\n\n\n\tCSProj: \n" + File.ReadAllText (csprojTarget);
@@ -302,7 +293,7 @@ namespace Xamarin.MMP.Tests
 				return csprojText + fileList;
 			};
 
-			buildArgs.Insert (0, " -- ");
+			buildArgs.Insert (0, "--");
 			return RunAndAssert (Configuration.XIBuildPath, buildArgs, "Compile", shouldFail, getBuildProjectErrorInfo, environment);
 		}
 
@@ -323,7 +314,7 @@ namespace Xamarin.MMP.Tests
 		{
 			// Assert that the program actually runs and returns our guid
 			Assert.IsTrue (File.Exists (path), string.Format ("{0} did not generate an exe?", path));
-			string output = RunAndAssert (path, (string)null, "Run");
+			string output = RunAndAssert (path, Array.Empty<string> (), "Run");
 
 			string guidPath = Path.Combine (tmpDir, guid.ToString ());
 			Assert.IsTrue(File.Exists (guidPath), "Generated program did not create expected guid file: " + output);
@@ -341,7 +332,7 @@ namespace Xamarin.MMP.Tests
 
 			if (config.AssetIcons) 
 			{
-				RunAndAssert ("/bin/cp", $"-R {Path.Combine (sourceDir, "Icons/Assets.xcassets")} {config.TmpDir}", "Copy Asset Icons");
+				RunAndAssert ("/bin/cp", new string [] { "-R", Path.Combine (sourceDir, "Icons/Assets.xcassets"), config.TmpDir }, "Copy Asset Icons");
 				config.ItemGroup += @"<ItemGroup>
     <ImageAsset Include=""Assets.xcassets\AppIcon.appiconset\Contents.json"" />
     <ImageAsset Include=""Assets.xcassets\AppIcon.appiconset\AppIcon-128.png"" />
@@ -524,7 +515,7 @@ namespace Xamarin.MMP.Tests
 
 		public static void CopyDirectory (string src, string target)
 		{
-			Xamarin.Bundler.Driver.RunCommand ("/bin/cp", $"-r {src} {target}");
+			Xamarin.Bundler.Driver.RunCommand ("/bin/cp", new string [] { "-r", src, target });
 		}
 
 		public static string CopyFileWithSubstitutions (string src, string target, Func<string, string > replacementAction)
@@ -597,7 +588,7 @@ namespace TestCase
 			Environment.SetEnvironmentVariable ("XAMMAC_FRAMEWORK_PATH", rootDirectory + "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current");
 			Environment.SetEnvironmentVariable ("XamarinMacFrameworkRoot", rootDirectory + "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current");
 
-			var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, $"-- /restore {StringUtils.Quote (project)}", out var output);
+			var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, new string [] { $"--", "/restore", project}, out var output);
 			if (rv != 0) {
 				Console.WriteLine ("nuget restore failed:");
 				Console.WriteLine (output);
@@ -646,10 +637,10 @@ namespace Xamarin.Bundler {
 	{
 		public static int verbose { get { return 0; } }
 		public static int Verbosity {  get { return verbose; }}
-		public static int RunCommand (string path, string args, string[] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
+		public static int RunCommand (string path, IList<string> args, string[] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
 		{
 			Exception stdin_exc = null;
-			var info = new ProcessStartInfo (path, args);
+			var info = new ProcessStartInfo (path, StringUtils.FormatArguments (args));
 			info.UseShellExecute = false;
 			info.RedirectStandardInput = false;
 			info.RedirectStandardOutput = true;
@@ -664,8 +655,13 @@ namespace Xamarin.Bundler {
 				if (env.Length % 2 != 0)
 					throw new Exception ("You passed an environment key without a value");
 
-				for (int i = 0; i < env.Length; i+= 2)
-					info.EnvironmentVariables [env[i]] = env[i+1];
+				for (int i = 0; i < env.Length; i += 2) {
+					if (env [i + 1] == null) {
+						info.EnvironmentVariables.Remove (env [i]);
+					} else {
+						info.EnvironmentVariables [env [i]] = env [i + 1];
+					}
+				}
 			}
 
 			if (verbose > 0)

--- a/tests/common/mac/ProjectTestHelpers.cs
+++ b/tests/common/mac/ProjectTestHelpers.cs
@@ -198,7 +198,7 @@ namespace Xamarin.MMP.Tests
 
 		public static Version FindMonoVersion ()
 		{
-			string output = RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono", new string [] { "--version" }, "FindMonoVersion");
+			string output = RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono", new [] { "--version" }, "FindMonoVersion");
 
 			Regex versionRegex = new Regex("compiler version \\d+.\\d+.\\d+(.\\d+)?", RegexOptions.IgnoreCase);
 			return new Version (versionRegex.Match (output).Value.Split (' ')[2]);
@@ -238,7 +238,7 @@ namespace Xamarin.MMP.Tests
 		// In most cases we generate projects in tmp and this is not needed. But nuget and test projects can make that hard
 		public static void CleanUnifiedProject (string csprojTarget)
 		{
-			RunAndAssert (Configuration.XIBuildPath, new string [] { "--", csprojTarget, "/t:clean" }, "Clean");
+			RunAndAssert (Configuration.XIBuildPath, new [] { "--", csprojTarget, "/t:clean" }, "Clean");
 		}
 
 		public static string BuildClassicProject (string csprojTarget)
@@ -332,7 +332,7 @@ namespace Xamarin.MMP.Tests
 
 			if (config.AssetIcons) 
 			{
-				RunAndAssert ("/bin/cp", new string [] { "-R", Path.Combine (sourceDir, "Icons/Assets.xcassets"), config.TmpDir }, "Copy Asset Icons");
+				RunAndAssert ("/bin/cp", new [] { "-R", Path.Combine (sourceDir, "Icons/Assets.xcassets"), config.TmpDir }, "Copy Asset Icons");
 				config.ItemGroup += @"<ItemGroup>
     <ImageAsset Include=""Assets.xcassets\AppIcon.appiconset\Contents.json"" />
     <ImageAsset Include=""Assets.xcassets\AppIcon.appiconset\AppIcon-128.png"" />
@@ -515,7 +515,7 @@ namespace Xamarin.MMP.Tests
 
 		public static void CopyDirectory (string src, string target)
 		{
-			Xamarin.Bundler.Driver.RunCommand ("/bin/cp", new string [] { "-r", src, target });
+			Xamarin.Bundler.Driver.RunCommand ("/bin/cp", new [] { "-r", src, target });
 		}
 
 		public static string CopyFileWithSubstitutions (string src, string target, Func<string, string > replacementAction)
@@ -588,7 +588,7 @@ namespace TestCase
 			Environment.SetEnvironmentVariable ("XAMMAC_FRAMEWORK_PATH", rootDirectory + "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current");
 			Environment.SetEnvironmentVariable ("XamarinMacFrameworkRoot", rootDirectory + "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current");
 
-			var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, new string [] { $"--", "/restore", project}, out var output);
+			var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, new [] { $"--", "/restore", project}, out var output);
 			if (rv != 0) {
 				Console.WriteLine ("nuget restore failed:");
 				Console.WriteLine (output);

--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -169,7 +169,7 @@ namespace Xamarin.Tests
 				ParseMessages ();
 				return rv;
 			}
-			return Execute (string.Join (" ", StringUtils.Quote (arguments)), always_show_output: true);
+			return Execute (arguments, always_show_output: true);
 		}
 
 		public void AssertApiCallsMethod (string caller_namespace, string caller_type, string caller_method, string @called_method, string message)

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -10,6 +10,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.MMP.Tests</RootNamespace>
     <AssemblyName>mmptest</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/mmptest/packages.config
+++ b/tests/mmptest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.11.0" targetFramework="net40" />
+  <package id="NUnit" version="3.11.0" targetFramework="net40" requireReinstallation="true" />
   <package id="NUnit.ConsoleRunner" version="3.9.0" targetFramework="net40" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net40" />
   <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net40" />

--- a/tests/mmptest/src/AOTTests.cs
+++ b/tests/mmptest/src/AOTTests.cs
@@ -78,7 +78,7 @@ namespace Xamarin.MMP.Tests
 
 				foreach (var file in GetOutputDirInfo (tmpDir).EnumerateFiles ()) {
 					if (IsFileManagedCode (file))
-						TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono-cil-strip", file.ToString (), "Manually strip IL");
+						TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono-cil-strip", new string [] { file.ToString () }, "Manually strip IL");
 
 				}
 
@@ -98,7 +98,7 @@ namespace Xamarin.MMP.Tests
 				};
 				string buildResults = TI.TestUnifiedExecutable (test).BuildOutput;
 
-				TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono-cil-strip", Path.Combine (GetOutputBundlePath (tmpDir), "UnifiedExample.exe"), "Manually strip IL");
+				TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono-cil-strip", new string [] { Path.Combine (GetOutputBundlePath (tmpDir), "UnifiedExample.exe") }, "Manually strip IL");
 
 				ValidateAOTStatus (tmpDir, IsFileManagedCode, buildResults);
 

--- a/tests/mmptest/src/AOTTests.cs
+++ b/tests/mmptest/src/AOTTests.cs
@@ -78,7 +78,7 @@ namespace Xamarin.MMP.Tests
 
 				foreach (var file in GetOutputDirInfo (tmpDir).EnumerateFiles ()) {
 					if (IsFileManagedCode (file))
-						TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono-cil-strip", new string [] { file.ToString () }, "Manually strip IL");
+						TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono-cil-strip", new [] { file.ToString () }, "Manually strip IL");
 
 				}
 
@@ -98,7 +98,7 @@ namespace Xamarin.MMP.Tests
 				};
 				string buildResults = TI.TestUnifiedExecutable (test).BuildOutput;
 
-				TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono-cil-strip", new string [] { Path.Combine (GetOutputBundlePath (tmpDir), "UnifiedExample.exe") }, "Manually strip IL");
+				TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono-cil-strip", new [] { Path.Combine (GetOutputBundlePath (tmpDir), "UnifiedExample.exe") }, "Manually strip IL");
 
 				ValidateAOTStatus (tmpDir, IsFileManagedCode, buildResults);
 

--- a/tests/mmptest/src/AssemblyReferencesTests.cs
+++ b/tests/mmptest/src/AssemblyReferencesTests.cs
@@ -44,17 +44,15 @@ namespace Xamarin.MMP.Tests
 		public void AllowsUnresolvableReferences ()
 		{
 			MMPTests.RunMMPTest (tmpDir => {
-				var sb = new StringBuilder ();
+				string [] sb;
 
 				// build b.dll
-				sb.Clear ();
-				sb.AppendFormat ("-target:library -out:{0}/b.dll {0}/b.cs", tmpDir);
+				sb = new string [] { "-target:library", $"-out:{tmpDir}/b.dll", $"{tmpDir}/b.cs" };
 				File.WriteAllText (Path.Combine (tmpDir, "b.cs"), "public class B { }");
 				TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/csc", sb, "b");
 
 				// build a.dll
-				sb.Clear ();
-				sb.AppendFormat ("-target:library -out:{0}/a.dll {0}/a.cs -r:{0}/b.dll", tmpDir);
+				sb = new string [] { "-target:library", $"-out:{tmpDir}/a.dll", $"{tmpDir}/a.cs", $"-r:{tmpDir}/b.dll" };
 				File.WriteAllText (Path.Combine (tmpDir, "a.cs"), "public class A { public A () { System.Console.WriteLine (typeof (B)); }}");
 				TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/csc", sb, "a");
 

--- a/tests/mmptest/src/AssemblyReferencesTests.cs
+++ b/tests/mmptest/src/AssemblyReferencesTests.cs
@@ -47,12 +47,12 @@ namespace Xamarin.MMP.Tests
 				string [] sb;
 
 				// build b.dll
-				sb = new string [] { "-target:library", $"-out:{tmpDir}/b.dll", $"{tmpDir}/b.cs" };
+				sb = new [] { "-target:library", $"-out:{tmpDir}/b.dll", $"{tmpDir}/b.cs" };
 				File.WriteAllText (Path.Combine (tmpDir, "b.cs"), "public class B { }");
 				TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/csc", sb, "b");
 
 				// build a.dll
-				sb = new string [] { "-target:library", $"-out:{tmpDir}/a.dll", $"{tmpDir}/a.cs", $"-r:{tmpDir}/b.dll" };
+				sb = new [] { "-target:library", $"-out:{tmpDir}/a.dll", $"{tmpDir}/a.cs", $"-r:{tmpDir}/b.dll" };
 				File.WriteAllText (Path.Combine (tmpDir, "a.cs"), "public class A { public A () { System.Console.WriteLine (typeof (B)); }}");
 				TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/csc", sb, "a");
 

--- a/tests/mmptest/src/BindingProjectNoEmbeddingTests.cs
+++ b/tests/mmptest/src/BindingProjectNoEmbeddingTests.cs
@@ -16,7 +16,7 @@ namespace Xamarin.MMP.Tests
 		{
 			string bindingName = BindingProjectTests.RemoveCSProj (projectName);
 			string bindingLibraryPath = Path.Combine (tmpDir, $"bin/Debug/{bindingName}.dll");
-			string resourceOutput = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monodis", new string [] { "--presources", bindingLibraryPath }, "monodis");
+			string resourceOutput = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monodis", new [] { "--presources", bindingLibraryPath }, "monodis");
 			Assert.False (resourceOutput.Contains (resourceName), "Binding project output contained embedded library");
 		}
 

--- a/tests/mmptest/src/BindingProjectNoEmbeddingTests.cs
+++ b/tests/mmptest/src/BindingProjectNoEmbeddingTests.cs
@@ -16,7 +16,7 @@ namespace Xamarin.MMP.Tests
 		{
 			string bindingName = BindingProjectTests.RemoveCSProj (projectName);
 			string bindingLibraryPath = Path.Combine (tmpDir, $"bin/Debug/{bindingName}.dll");
-			string resourceOutput = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monodis", "--presources " + bindingLibraryPath, "monodis");
+			string resourceOutput = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monodis", new string [] { "--presources", bindingLibraryPath }, "monodis");
 			Assert.False (resourceOutput.Contains (resourceName), "Binding project output contained embedded library");
 		}
 

--- a/tests/mmptest/src/BindingProjectTests.cs
+++ b/tests/mmptest/src/BindingProjectTests.cs
@@ -109,7 +109,7 @@ namespace Xamarin.MMP.Tests
 
 				string libPath = Path.Combine (tmpDir, $"bin/Debug/{appName}.app/Contents/MonoBundle/{bindingName}.dll");
 				Assert.True (File.Exists (libPath), $"Did not find expected library: {libPath}");
-				string monoDisResults = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monodis", new string [] { "--presources", libPath }, "monodis");
+				string monoDisResults = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monodis", new [] { "--presources", libPath }, "monodis");
 				Assert.IsFalse (monoDisResults.Contains ("SimpleClassDylib.dylib"));
 			});
 		}
@@ -161,7 +161,7 @@ namespace Xamarin.MMP.Tests
 				string libPath = Path.Combine (tmpDir, $"bin/Debug/{appName}.app/Contents/MonoBundle/{bindingName}.dll");
 
 				Assert.True (File.Exists (libPath));
-				string results = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monop", new string [] { "--refs", "-r:" + libPath }, "monop");
+				string results = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monop", new [] { "--refs", "-r:" + libPath }, "monop");
 				string mscorlibLine = results.Split (new char[] { '\n' }).First (x => x.Contains ("mscorlib"));
 
 				string expectedVersion = GetExpectedBCLVersion (type);

--- a/tests/mmptest/src/BindingProjectTests.cs
+++ b/tests/mmptest/src/BindingProjectTests.cs
@@ -109,7 +109,7 @@ namespace Xamarin.MMP.Tests
 
 				string libPath = Path.Combine (tmpDir, $"bin/Debug/{appName}.app/Contents/MonoBundle/{bindingName}.dll");
 				Assert.True (File.Exists (libPath), $"Did not find expected library: {libPath}");
-				string monoDisResults = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monodis", "--presources " + libPath, "monodis");
+				string monoDisResults = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monodis", new string [] { "--presources", libPath }, "monodis");
 				Assert.IsFalse (monoDisResults.Contains ("SimpleClassDylib.dylib"));
 			});
 		}
@@ -161,7 +161,7 @@ namespace Xamarin.MMP.Tests
 				string libPath = Path.Combine (tmpDir, $"bin/Debug/{appName}.app/Contents/MonoBundle/{bindingName}.dll");
 
 				Assert.True (File.Exists (libPath));
-				string results = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monop", "--refs -r:" + libPath, "monop");
+				string results = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monop", new string [] { "--refs", "-r:" + libPath }, "monop");
 				string mscorlibLine = results.Split (new char[] { '\n' }).First (x => x.Contains ("mscorlib"));
 
 				string expectedVersion = GetExpectedBCLVersion (type);

--- a/tests/mmptest/src/LinkerTests.cs
+++ b/tests/mmptest/src/LinkerTests.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MMP.Tests
 	{
 		int GetNumberOfTypesInLibrary (string path)
 		{
-			string output = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", new string [] { "-r:" + path }, "GetNumberOfTypesInLibrary");
+			string output = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", new [] { "-r:" + path }, "GetNumberOfTypesInLibrary");
 			string[] splitBuildOutput = output.Split (new string[] { Environment.NewLine }, StringSplitOptions.None);
 			string outputLine = splitBuildOutput.First (x => x.StartsWith ("Total:"));
 			string numberSize = outputLine.Split (':')[1];

--- a/tests/mmptest/src/LinkerTests.cs
+++ b/tests/mmptest/src/LinkerTests.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MMP.Tests
 	{
 		int GetNumberOfTypesInLibrary (string path)
 		{
-			string output = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", new StringBuilder ("-r:" + path), "GetNumberOfTypesInLibrary");
+			string output = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", new string [] { "-r:" + path }, "GetNumberOfTypesInLibrary");
 			string[] splitBuildOutput = output.Split (new string[] { Environment.NewLine }, StringSplitOptions.None);
 			string outputLine = splitBuildOutput.First (x => x.StartsWith ("Total:"));
 			string numberSize = outputLine.Split (':')[1];

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -188,13 +188,12 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void Dontlink_Allow_ReadonlyAssembly ()
 		{
-			var sb = new StringBuilder ();
+			string [] sb;
 			RunMMPTest (tmpDir =>
 			{
 				// build b.dll
-				sb.Clear ();
 				string assemblyPath = string.Format ("{0}/b.dll", tmpDir);
-				sb.AppendFormat ("-target:library -debug -out:{0} {1}/b.cs", assemblyPath, tmpDir);
+				sb = new string [] { "-target:library", "-debug", $"-out:{assemblyPath}", $"{tmpDir}/b.cs" };
 				File.WriteAllText (Path.Combine (tmpDir, "b.cs"), "public class B { }");
 				TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/csc", sb, "b");
 
@@ -373,7 +372,7 @@ namespace Xamarin.MMP.Tests
 
 				string libPath = Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/MonoBundle/UnifiedLibrary.dll");
 				Assert.True (File.Exists (libPath));
-				string monoDisResults = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monodis", new StringBuilder ("--presources " + libPath), "monodis");
+				string monoDisResults = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monodis", new string [] { "--presources", libPath }, "monodis");
 				Assert.IsFalse (monoDisResults.Contains ("foo.xml"));
 			});
 		}
@@ -386,7 +385,7 @@ namespace Xamarin.MMP.Tests
 				string testPath = Path.Combine (TI.FindSourceDirectory (), @"ConsoleXMApp.csproj");
 				TI.BuildProject (testPath);
 				string exePath = Path.Combine (TI.FindSourceDirectory (), @"bin/Debug/ConsoleXMApp.exe");
-				var output = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono64", new StringBuilder (exePath), "RunSideBySizeXamMac");
+				var output = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono64", new string [] { exePath }, "RunSideBySizeXamMac");
 				Assert.IsTrue (output.Split (Environment.NewLine.ToCharArray ()).Any (x => x.Contains ("True")), "Unified_SideBySideXamMac_ConsoleTest run"); 
 			});
 		}
@@ -671,7 +670,7 @@ namespace Xamarin.MMP.Tests
 				buildOutput = TI.BuildProject (project);
 				Assert.False (buildOutput.Contains ("actool execution started with arguments"), $"Second build should not run actool");
 
-				TI.RunAndAssert ("touch", Path.Combine (tmpDir, "Assets.xcassets/AppIcon.appiconset/AppIcon-256@2x.png"), "touch icon");
+				TI.RunAndAssert ("touch", new string [] { Path.Combine (tmpDir, "Assets.xcassets/AppIcon.appiconset/AppIcon-256@2x.png") }, "touch icon");
 
 				buildOutput = TI.BuildProject (project);
 				Assert.True (buildOutput.Contains ("actool execution started with arguments"), $"Build after touching icon must run actool");
@@ -732,7 +731,7 @@ namespace Xamarin.MMP.Tests
 					CSProjConfig = "<EnableCodeSigning>true</EnableCodeSigning>"
 				};
 				TI.TestUnifiedExecutable (test);
-				var output = TI.BuildProject (Path.Combine (tmpDir, full ? "XM45Example.csproj" : "UnifiedExample.csproj"), release: true, extraArgs: "/p:ArchiveOnBuild=true ");
+				var output = TI.BuildProject (Path.Combine (tmpDir, full ? "XM45Example.csproj" : "UnifiedExample.csproj"), release: true, extraArgs: new string [] { "/p:ArchiveOnBuild=true" });
 			});
 
 			// TODO: Add something to validate the archive is loadable by Xcode

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -193,7 +193,7 @@ namespace Xamarin.MMP.Tests
 			{
 				// build b.dll
 				string assemblyPath = string.Format ("{0}/b.dll", tmpDir);
-				sb = new string [] { "-target:library", "-debug", $"-out:{assemblyPath}", $"{tmpDir}/b.cs" };
+				sb = new [] { "-target:library", "-debug", $"-out:{assemblyPath}", $"{tmpDir}/b.cs" };
 				File.WriteAllText (Path.Combine (tmpDir, "b.cs"), "public class B { }");
 				TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/csc", sb, "b");
 
@@ -372,7 +372,7 @@ namespace Xamarin.MMP.Tests
 
 				string libPath = Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/MonoBundle/UnifiedLibrary.dll");
 				Assert.True (File.Exists (libPath));
-				string monoDisResults = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monodis", new string [] { "--presources", libPath }, "monodis");
+				string monoDisResults = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monodis", new [] { "--presources", libPath }, "monodis");
 				Assert.IsFalse (monoDisResults.Contains ("foo.xml"));
 			});
 		}
@@ -385,7 +385,7 @@ namespace Xamarin.MMP.Tests
 				string testPath = Path.Combine (TI.FindSourceDirectory (), @"ConsoleXMApp.csproj");
 				TI.BuildProject (testPath);
 				string exePath = Path.Combine (TI.FindSourceDirectory (), @"bin/Debug/ConsoleXMApp.exe");
-				var output = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono64", new string [] { exePath }, "RunSideBySizeXamMac");
+				var output = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono64", new [] { exePath }, "RunSideBySizeXamMac");
 				Assert.IsTrue (output.Split (Environment.NewLine.ToCharArray ()).Any (x => x.Contains ("True")), "Unified_SideBySideXamMac_ConsoleTest run"); 
 			});
 		}
@@ -548,7 +548,7 @@ namespace Xamarin.MMP.Tests
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
 					CSProjConfig = "<DebugSymbols>True</DebugSymbols>", // This makes the msbuild tasks pass /debug to mmp
 				};
-				TI.TestUnifiedExecutable (test, shouldFail: false, environment: new string [] { "MD_APPLE_SDK_ROOT", Path.GetDirectoryName (Path.GetDirectoryName (oldXcode)) });
+				TI.TestUnifiedExecutable (test, shouldFail: false, environment: new [] { "MD_APPLE_SDK_ROOT", Path.GetDirectoryName (Path.GetDirectoryName (oldXcode)) });
 			});
 		}
 
@@ -670,7 +670,7 @@ namespace Xamarin.MMP.Tests
 				buildOutput = TI.BuildProject (project);
 				Assert.False (buildOutput.Contains ("actool execution started with arguments"), $"Second build should not run actool");
 
-				TI.RunAndAssert ("touch", new string [] { Path.Combine (tmpDir, "Assets.xcassets/AppIcon.appiconset/AppIcon-256@2x.png") }, "touch icon");
+				TI.RunAndAssert ("touch", new [] { Path.Combine (tmpDir, "Assets.xcassets/AppIcon.appiconset/AppIcon-256@2x.png") }, "touch icon");
 
 				buildOutput = TI.BuildProject (project);
 				Assert.True (buildOutput.Contains ("actool execution started with arguments"), $"Build after touching icon must run actool");
@@ -731,7 +731,7 @@ namespace Xamarin.MMP.Tests
 					CSProjConfig = "<EnableCodeSigning>true</EnableCodeSigning>"
 				};
 				TI.TestUnifiedExecutable (test);
-				var output = TI.BuildProject (Path.Combine (tmpDir, full ? "XM45Example.csproj" : "UnifiedExample.csproj"), release: true, extraArgs: new string [] { "/p:ArchiveOnBuild=true" });
+				var output = TI.BuildProject (Path.Combine (tmpDir, full ? "XM45Example.csproj" : "UnifiedExample.csproj"), release: true, extraArgs: new [] { "/p:ArchiveOnBuild=true" });
 			});
 
 			// TODO: Add something to validate the archive is loadable by Xcode

--- a/tests/mmptest/src/MmpTool.cs
+++ b/tests/mmptest/src/MmpTool.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Xamarin.Tests;
@@ -25,32 +26,32 @@ namespace Xamarin
 			// Nothing to do here yet
 		}
 
-		protected override void BuildArguments (StringBuilder sb)
+		protected override void BuildArguments (IList<string> sb)
 		{
 			base.BuildArguments (sb);
 
 			if (!string.IsNullOrEmpty (ApplicationName))
-				sb.Append (" --name=").Append (StringUtils.Quote (ApplicationName));
+				sb.Add ($"--name={ApplicationName}");
 
 			if (!string.IsNullOrEmpty (OutputPath))
-				sb.Append (" --output=").Append (StringUtils.Quote (OutputPath));
+				sb.Add ($"--output={OutputPath}");
 
 			switch (Profile) {
 			case Profile.macOSMobile:
-				sb.Append (" --profile=Xamarin.Mac,Version=v2.0,Profile=Mobile");
+				sb.Add ("--profile=Xamarin.Mac,Version=v2.0,Profile=Mobile");
 				break;
 			case Profile.macOSFull:
-				sb.Append (" --profile=Xamarin.Mac,Version=v4.5,Profile=Full");
+				sb.Add ("--profile=Xamarin.Mac,Version=v4.5,Profile=Full");
 				break;
 			case Profile.macOSSystem:
-				sb.Append (" --profile=Xamarin.Mac,Version=v4.5,Profile=System");
+				sb.Add ("--profile=Xamarin.Mac,Version=v4.5,Profile=System");
 				break;
 			default:
 				throw new NotImplementedException (Profile.ToString ());
 			}
 		}
 
-		public override void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, string extraArg = "", string extraCode = null, string usings = null, bool use_csc = true)
+		public override void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, IList<string> extraArgs = null, string extraCode = null, string usings = null, bool use_csc = true)
 		{
 			if (RootAssembly == null) {
 				OutputPath = CreateTemporaryDirectory ();
@@ -61,7 +62,7 @@ namespace Xamarin
 			ApplicationName = appName;
 			var app = Path.Combine (OutputPath, appName + ".app");
 			Directory.CreateDirectory (app);
-			RootAssembly = CompileTestAppExecutable (OutputPath, code, extraArg, profile, appName, extraCode, usings, use_csc);
+			RootAssembly = CompileTestAppExecutable (OutputPath, code, extraArgs, profile, appName, extraCode, usings, use_csc);
 		}
 
 		public override string GetAppAssembliesDirectory()

--- a/tests/mmptest/src/NativeReferencesTests.cs
+++ b/tests/mmptest/src/NativeReferencesTests.cs
@@ -101,7 +101,7 @@ namespace Xamarin.MMP.Tests
 				Assert.True (Directory.Exists (Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/Frameworks/iTunesLibrary.framework")));
 
 				string binaryPath = Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/MacOS/UnifiedExample");
-				string otoolText = TI.RunAndAssert ("/usr/bin/otool", new StringBuilder ("-l " + binaryPath), "Unified_WithNativeReferences_InMainProjectWorks - rpath");
+				string otoolText = TI.RunAndAssert ("/usr/bin/otool", new string [] { "-l", binaryPath }, "Unified_WithNativeReferences_InMainProjectWorks - rpath");
 				Assert.True (otoolText.Contains ("path @loader_path/../Frameworks"));
 			});
 		}

--- a/tests/mmptest/src/NativeReferencesTests.cs
+++ b/tests/mmptest/src/NativeReferencesTests.cs
@@ -101,7 +101,7 @@ namespace Xamarin.MMP.Tests
 				Assert.True (Directory.Exists (Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/Frameworks/iTunesLibrary.framework")));
 
 				string binaryPath = Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/MacOS/UnifiedExample");
-				string otoolText = TI.RunAndAssert ("/usr/bin/otool", new string [] { "-l", binaryPath }, "Unified_WithNativeReferences_InMainProjectWorks - rpath");
+				string otoolText = TI.RunAndAssert ("/usr/bin/otool", new [] { "-l", binaryPath }, "Unified_WithNativeReferences_InMainProjectWorks - rpath");
 				Assert.True (otoolText.Contains ("path @loader_path/../Frameworks"));
 			});
 		}

--- a/tests/mmptest/src/NetStandardTests.cs
+++ b/tests/mmptest/src/NetStandardTests.cs
@@ -37,7 +37,7 @@ namespace Xamarin.MMP.Tests {
 				"MSBuildSDKsPath", null,
 			};
 
-			TI.RunAndAssert("/usr/local/share/dotnet/dotnet", new string [] { "restore", netStandardProject }, "Restore", environment: environment);
+			TI.RunAndAssert("/usr/local/share/dotnet/dotnet", new [] { "restore", netStandardProject }, "Restore", environment: environment);
 			TI.BuildProject(netStandardProject);
 
 			config.ItemGroup = $@"

--- a/tests/mmptest/src/NetStandardTests.cs
+++ b/tests/mmptest/src/NetStandardTests.cs
@@ -30,7 +30,14 @@ namespace Xamarin.MMP.Tests {
 			TI.UnifiedTestConfig config = new TI.UnifiedTestConfig (tmpDir);
 
 			string netStandardProject = TI.GenerateNetStandardProject (config);
-			TI.RunAndAssert("/usr/local/share/dotnet/dotnet", $"restore {netStandardProject}", "Restore");
+
+			var environment = new string [] {
+				"MSBUILD_EXE_PATH", null,
+				"MSBuildExtensionsPathFallbackPathsOverride", null,
+				"MSBuildSDKsPath", null,
+			};
+
+			TI.RunAndAssert("/usr/local/share/dotnet/dotnet", new string [] { "restore", netStandardProject }, "Restore", environment: environment);
 			TI.BuildProject(netStandardProject);
 
 			config.ItemGroup = $@"

--- a/tests/mmptest/src/System.ServiceModel/Net45.cs
+++ b/tests/mmptest/src/System.ServiceModel/Net45.cs
@@ -24,7 +24,7 @@ namespace MonoTouchFixtures.ServiceModel {
 		public void ShouldIncludeSystemServiceModel ()
 		{
 			StringBuilder output = new StringBuilder ();
-			int result = Driver.RunCommand ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", String.Format ("--refs -r:{0}/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/4.5/System.ServiceModel.dll", TI.FindRootDirectory ()), null, output);
+			int result = Driver.RunCommand ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", new string [] { "--refs", $"-r:{TI.FindRootDirectory ()}/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/4.5/System.ServiceModel.dll" }, null, output);
 			Assert.That (result, Is.EqualTo (0));
 			Assert.That (output.ToString (), Contains.Substring ("System.Web.Services, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"));
 		}
@@ -33,7 +33,7 @@ namespace MonoTouchFixtures.ServiceModel {
 		public void ShouldNotIncludeSystemDrawing ()
 		{
 			StringBuilder output = new StringBuilder ();
-			int result = Driver.RunCommand ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", String.Format ("--refs -r:{0}/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/4.5/System.ServiceModel.dll", TI.FindRootDirectory ()), null, output);
+			int result = Driver.RunCommand ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", new string [] { "--refs", $"-r:{TI.FindRootDirectory ()}/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/4.5/System.ServiceModel.dll" }, null, output);
 			Assert.That (result, Is.EqualTo (0));
 			Assert.That (output.ToString (), !Contains.Substring ("System.Drawing"));
 		}
@@ -48,7 +48,7 @@ namespace MonoTouchFixtures.ServiceModel {
 
 			TI.BuildProject (testFolder + "/ServiceModel_Test.csproj");
 
-			TI.RunAndAssert (testFolder + "/bin/Debug/ServiceModel_Test.app/Contents/MacOS/ServiceModel_Test", (string)null, "Run");
+			TI.RunAndAssert (testFolder + "/bin/Debug/ServiceModel_Test.app/Contents/MacOS/ServiceModel_Test", Array.Empty<string> (), "Run");
 			Assert.True (File.Exists (testResults));
 
 			using (TextReader reader = File.OpenText (testResults)) {

--- a/tests/mmptest/src/System.ServiceModel/Net45.cs
+++ b/tests/mmptest/src/System.ServiceModel/Net45.cs
@@ -24,7 +24,7 @@ namespace MonoTouchFixtures.ServiceModel {
 		public void ShouldIncludeSystemServiceModel ()
 		{
 			StringBuilder output = new StringBuilder ();
-			int result = Driver.RunCommand ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", new string [] { "--refs", $"-r:{TI.FindRootDirectory ()}/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/4.5/System.ServiceModel.dll" }, null, output);
+			int result = Driver.RunCommand ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", new [] { "--refs", $"-r:{TI.FindRootDirectory ()}/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/4.5/System.ServiceModel.dll" }, null, output);
 			Assert.That (result, Is.EqualTo (0));
 			Assert.That (output.ToString (), Contains.Substring ("System.Web.Services, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"));
 		}
@@ -33,7 +33,7 @@ namespace MonoTouchFixtures.ServiceModel {
 		public void ShouldNotIncludeSystemDrawing ()
 		{
 			StringBuilder output = new StringBuilder ();
-			int result = Driver.RunCommand ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", new string [] { "--refs", $"-r:{TI.FindRootDirectory ()}/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/4.5/System.ServiceModel.dll" }, null, output);
+			int result = Driver.RunCommand ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", new [] { "--refs", $"-r:{TI.FindRootDirectory ()}/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/4.5/System.ServiceModel.dll" }, null, output);
 			Assert.That (result, Is.EqualTo (0));
 			Assert.That (output.ToString (), !Contains.Substring ("System.Drawing"));
 		}

--- a/tests/mmptest/src/TargetFrameworkDetectionTests.cs
+++ b/tests/mmptest/src/TargetFrameworkDetectionTests.cs
@@ -17,14 +17,14 @@ namespace Xamarin.MMP.Tests
 		{
 			string path = Path.Combine (tmpDir, "b.exe");
 			File.WriteAllText (Path.Combine (tmpDir, "b.cs"), "public static class EntryPoint { public static void Main () {} }");
-			TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/csc", new string [] { $"-out:{path}", $"{tmpDir}/b.cs" }, "CreateTestExe");
+			TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/csc", new [] { $"-out:{path}", $"{tmpDir}/b.cs" }, "CreateTestExe");
 			return path;
 		}
 
 		IList<string> GetTestMMPInvocation (string tmpDir, string libPath, TargetFramework targetFramework, bool correctReference = true)
 		{
 			string xmReference = correctReference ? GetXMReference (targetFramework) : GetWrongXMReference (targetFramework);
-			return new string [] {
+			return new [] {
 				"-v", "-v", "-v", "-v", "-v",
 				$"--output={tmpDir}",
 				"--arch=x86_64","" +

--- a/tests/mmptest/src/Unified45.cs
+++ b/tests/mmptest/src/Unified45.cs
@@ -18,14 +18,14 @@ namespace MonoTouchFixtures.Net45 {
 				File.Delete (testResults);
 
 			StringBuilder restoreOutput = new StringBuilder ();
-			int code = Driver.RunCommand ("mono", String.Format ("/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore {0}/packages.config -PackagesDirectory {1}", testFolder, Configuration.NuGetPackagesDirectory), output: restoreOutput);
+			int code = Driver.RunCommand ("mono", new string [] { "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe", "restore", $"{testFolder}/packages.config", "-PackagesDirectory", Configuration.NuGetPackagesDirectory }, output: restoreOutput);
 
 			if (code != 0)
 				Assert.Fail ("ProtobufShouldSerializeAndDeserialize failed to restore nuget packages");
 
 			TI.BuildProject (testFolder + "/Protobuf_Test.csproj");
 
-			TI.RunAndAssert (testFolder + "/bin/Debug/Protobuf_Test.app/Contents/MacOS/Protobuf_Test", (string)null, "Run");
+			TI.RunAndAssert (testFolder + "/bin/Debug/Protobuf_Test.app/Contents/MacOS/Protobuf_Test", Array.Empty<string> (), "Run");
 			Assert.True (File.Exists (testResults));
 
 			using (TextReader reader = File.OpenText (testResults)) {
@@ -44,14 +44,14 @@ namespace MonoTouchFixtures.Net45 {
 
 			StringBuilder restoreOutput = new StringBuilder ();
 
-			int code = Driver.RunCommand ("mono", String.Format ("/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore {0}/packages.config -PackagesDirectory {1}", testFolder, Configuration.NuGetPackagesDirectory), output: restoreOutput);
+			int code = Driver.RunCommand ("mono", new string [] { "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe", "restore", $"{testFolder}/packages.config", "-PackagesDirectory", Configuration.NuGetPackagesDirectory }, output: restoreOutput);
 
 			if (code != 0)
 				Assert.Fail ("Net45ShouldUseImmutableCollection failed to restore nuget packages");
 
 			TI.BuildProject (testFolder + "/ImmutableCollection_Test.csproj");
 
-			TI.RunAndAssert (testFolder + "/bin/Debug/ImmutableCollection_Test.app/Contents/MacOS/ImmutableCollection_Test", (string)null, "Run");
+			TI.RunAndAssert (testFolder + "/bin/Debug/ImmutableCollection_Test.app/Contents/MacOS/ImmutableCollection_Test", Array.Empty<string> (), "Run");
 		}
 
 		[Test]
@@ -64,14 +64,14 @@ namespace MonoTouchFixtures.Net45 {
 
 			StringBuilder restoreOutput = new StringBuilder ();
 
-			int code = Driver.RunCommand ("mono", String.Format ("/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore {0}/../MyLibrary/packages.config -PackagesDirectory {1}", testFolder, Configuration.NuGetPackagesDirectory), output: restoreOutput);
+			int code = Driver.RunCommand ("mono", new string [] { "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe", "restore", $"{testFolder}/../MyLibrary/packages.config", "-PackagesDirectory", Configuration.NuGetPackagesDirectory }, output: restoreOutput);
 
 			if (code != 0)
 				Assert.Fail ("Net45ShouldUseImmutableCollection failed to restore nuget packages");
 
 			TI.BuildProject (testFolder + "/BasicPCLTest.csproj");
 
-			TI.RunAndAssert (testFolder + "/bin/Debug/BasicPCLTest.app/Contents/MacOS/BasicPCLTest", (string)null, "Run");
+			TI.RunAndAssert (testFolder + "/bin/Debug/BasicPCLTest.app/Contents/MacOS/BasicPCLTest", Array.Empty<string> (), "Run");
 			Assert.True (File.Exists (testResults));
 
 			using (TextReader reader = File.OpenText (testResults)) {

--- a/tests/mmptest/src/Unified45.cs
+++ b/tests/mmptest/src/Unified45.cs
@@ -18,7 +18,7 @@ namespace MonoTouchFixtures.Net45 {
 				File.Delete (testResults);
 
 			StringBuilder restoreOutput = new StringBuilder ();
-			int code = Driver.RunCommand ("mono", new string [] { "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe", "restore", $"{testFolder}/packages.config", "-PackagesDirectory", Configuration.NuGetPackagesDirectory }, output: restoreOutput);
+			int code = Driver.RunCommand ("mono", new [] { "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe", "restore", $"{testFolder}/packages.config", "-PackagesDirectory", Configuration.NuGetPackagesDirectory }, output: restoreOutput);
 
 			if (code != 0)
 				Assert.Fail ("ProtobufShouldSerializeAndDeserialize failed to restore nuget packages");
@@ -44,7 +44,7 @@ namespace MonoTouchFixtures.Net45 {
 
 			StringBuilder restoreOutput = new StringBuilder ();
 
-			int code = Driver.RunCommand ("mono", new string [] { "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe", "restore", $"{testFolder}/packages.config", "-PackagesDirectory", Configuration.NuGetPackagesDirectory }, output: restoreOutput);
+			int code = Driver.RunCommand ("mono", new [] { "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe", "restore", $"{testFolder}/packages.config", "-PackagesDirectory", Configuration.NuGetPackagesDirectory }, output: restoreOutput);
 
 			if (code != 0)
 				Assert.Fail ("Net45ShouldUseImmutableCollection failed to restore nuget packages");
@@ -64,7 +64,7 @@ namespace MonoTouchFixtures.Net45 {
 
 			StringBuilder restoreOutput = new StringBuilder ();
 
-			int code = Driver.RunCommand ("mono", new string [] { "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe", "restore", $"{testFolder}/../MyLibrary/packages.config", "-PackagesDirectory", Configuration.NuGetPackagesDirectory }, output: restoreOutput);
+			int code = Driver.RunCommand ("mono", new [] { "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe", "restore", $"{testFolder}/../MyLibrary/packages.config", "-PackagesDirectory", Configuration.NuGetPackagesDirectory }, output: restoreOutput);
 
 			if (code != 0)
 				Assert.Fail ("Net45ShouldUseImmutableCollection failed to restore nuget packages");

--- a/tests/msbuild-mac/msbuild-mac.csproj
+++ b/tests/msbuild-mac/msbuild-mac.csproj
@@ -10,6 +10,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>msbuildMac</RootNamespace>
     <AssemblyName>msbuild-mac</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/msbuild-mac/packages.config
+++ b/tests/msbuild-mac/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.11.0" targetFramework="net40" />
+  <package id="NUnit" version="3.11.0" targetFramework="net40" requireReinstallation="true" />
   <package id="NUnit.ConsoleRunner" version="3.9.0" targetFramework="net40" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net40" />
   <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net40" />

--- a/tests/msbuild-mac/src/MSBuild-Smoke.cs
+++ b/tests/msbuild-mac/src/MSBuild-Smoke.cs
@@ -135,7 +135,7 @@ namespace Xamarin.MMP.Tests
 				Assert.IsTrue (File.Exists (Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/MonoBundle/SimpleClassDylib.dylib")));
 
 				StringBuilder output = new StringBuilder ();
-				Xamarin.Bundler.Driver.RunCommand ("/usr/bin/otool", new string [] { "-L", Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/MacOS/UnifiedExample") }, null, output);
+				Xamarin.Bundler.Driver.RunCommand ("/usr/bin/otool", new [] { "-L", Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/MacOS/UnifiedExample") }, null, output);
 				Assert.IsTrue (output.ToString ().Contains ("SimpleClassDylib.dylib"));
 			});
 		}

--- a/tests/msbuild-mac/src/MSBuild-Smoke.cs
+++ b/tests/msbuild-mac/src/MSBuild-Smoke.cs
@@ -135,7 +135,7 @@ namespace Xamarin.MMP.Tests
 				Assert.IsTrue (File.Exists (Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/MonoBundle/SimpleClassDylib.dylib")));
 
 				StringBuilder output = new StringBuilder ();
-				Xamarin.Bundler.Driver.RunCommand ("/usr/bin/otool", "-L " + Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/MacOS/UnifiedExample"), null, output);
+				Xamarin.Bundler.Driver.RunCommand ("/usr/bin/otool", new string [] { "-L", Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/MacOS/UnifiedExample") }, null, output);
 				Assert.IsTrue (output.ToString ().Contains ("SimpleClassDylib.dylib"));
 			});
 		}

--- a/tests/msbuild-mac/src/RoslynSmokeTests.cs
+++ b/tests/msbuild-mac/src/RoslynSmokeTests.cs
@@ -12,7 +12,7 @@ namespace Xamarin.MMP.Tests
 
 		void RestoreRoslynNuget (string projectPath)
 		{
-			TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/nuget", new string [] { "restore", projectPath }, "Restore Nuget");
+			TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/nuget", new [] { "restore", projectPath }, "Restore Nuget");
 		}
 
 		[Test]

--- a/tests/msbuild-mac/src/RoslynSmokeTests.cs
+++ b/tests/msbuild-mac/src/RoslynSmokeTests.cs
@@ -12,7 +12,7 @@ namespace Xamarin.MMP.Tests
 
 		void RestoreRoslynNuget (string projectPath)
 		{
-			TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/nuget", "restore " + projectPath, "Restore Nuget");
+			TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/nuget", new string [] { "restore", projectPath }, "Restore Nuget");
 		}
 
 		[Test]
@@ -23,7 +23,7 @@ namespace Xamarin.MMP.Tests
 			TI.CleanUnifiedProject (projectPath);
 			RestoreRoslynNuget (projectPath);
 			TI.BuildProject (projectPath);
-			TI.RunAndAssert (Path.Combine (RoslynTestProjectRoot, "Modern/bin/Debug/RoslynTestApp.app/Contents/MacOS/RoslynTestApp"), new StringBuilder (), "Run");
+			TI.RunAndAssert (Path.Combine (RoslynTestProjectRoot, "Modern/bin/Debug/RoslynTestApp.app/Contents/MacOS/RoslynTestApp"), Array.Empty<string> (), "Run");
 		}
 
 		[Test]
@@ -34,7 +34,7 @@ namespace Xamarin.MMP.Tests
 			TI.CleanUnifiedProject (projectPath);
 			RestoreRoslynNuget (projectPath);
 			TI.BuildProject (projectPath);
-			TI.RunAndAssert (Path.Combine (RoslynTestProjectRoot, "Full/bin/Debug/RoslynTestApp.app/Contents/MacOS/RoslynTestApp"), new StringBuilder (), "Run");
+			TI.RunAndAssert (Path.Combine (RoslynTestProjectRoot, "Full/bin/Debug/RoslynTestApp.app/Contents/MacOS/RoslynTestApp"), Array.Empty<string> (), "Run");
 		}
 	}
 }

--- a/tests/msbuild-mac/src/RuntimeTests.cs
+++ b/tests/msbuild-mac/src/RuntimeTests.cs
@@ -19,7 +19,7 @@ namespace Xamarin.MMP.Tests
 
 			TI.CleanUnifiedProject (projectPath);
 			TI.BuildProject (projectPath);
-			TI.RunAndAssert (Path.Combine (Path.GetDirectoryName (projectPath), $"bin/Debug/{projectName}.app/Contents/MacOS/{projectName}"), new StringBuilder (), "Run");
+			TI.RunAndAssert (Path.Combine (Path.GetDirectoryName (projectPath), $"bin/Debug/{projectName}.app/Contents/MacOS/{projectName}"), Array.Empty<string> (), "Run");
 		}
 	}
 }

--- a/tests/mtouch/MLaunchTool.cs
+++ b/tests/mtouch/MLaunchTool.cs
@@ -28,7 +28,7 @@ namespace Xamarin
 		public MLaunchAction Action = MLaunchAction.Sim;
 		public Profile Profile = Profile.iOS;
 
-		void GetVerbosity (IList<string> args)
+		void AddVerbosity (IList<string> args)
 		{
 			if (Verbosity == 0) {
 				// do nothing
@@ -71,7 +71,7 @@ namespace Xamarin
 				sb.Add (Configuration.xcode_root);
 			}
 
-			GetVerbosity (sb);
+			AddVerbosity (sb);
 
 			if (Sdk == None) {
 				// do nothing

--- a/tests/mtouch/MLaunchTool.cs
+++ b/tests/mtouch/MLaunchTool.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using Xamarin.Utils;
 using Xamarin.Tests;
@@ -27,13 +28,15 @@ namespace Xamarin
 		public MLaunchAction Action = MLaunchAction.Sim;
 		public Profile Profile = Profile.iOS;
 
-		string GetVerbosity ()
+		void GetVerbosity (IList<string> args)
 		{
-			if (Verbosity == 0)
-				return string.Empty;
-			if (Verbosity > 0)
-				return new string ('-', Verbosity).Replace ("-", "-v ");
-			return new string ('-', -Verbosity).Replace ("-", "-q ");
+			if (Verbosity == 0) {
+				// do nothing
+			} else if (Verbosity > 0) {
+				args.Add ("-" + new string ('v', Verbosity));
+			} else {
+				args.Add ("-" + new string ('q', -Verbosity));
+			}
 		}
 
 		public int Execute ()
@@ -41,9 +44,9 @@ namespace Xamarin
 			return Execute (Configuration.MlaunchPath, BuildArguments ());
 		}
 
-		string BuildArguments ()
+		IList<string> BuildArguments ()
 		{
-			var sb = new StringBuilder ();
+			var sb = new List<string> ();
 
 			switch (Action) {
 			case MLaunchAction.None:
@@ -51,7 +54,8 @@ namespace Xamarin
 			case MLaunchAction.Sim:
 				if (AppPath == null)
 					throw new Exception ("No AppPath specified.");
-				sb.Append (" --launchsim ").Append (StringUtils.Quote (AppPath));
+				sb.Add ("--launchsim");
+				sb.Add (AppPath);
 				break;
 			default:
 				throw new Exception ("MLaunchAction not specified.");
@@ -60,19 +64,23 @@ namespace Xamarin
 			if (SdkRoot == None) {
 				// do nothing
 			} else if (!string.IsNullOrEmpty (SdkRoot)) {
-				sb.Append (" --sdkroot ").Append (StringUtils.Quote (SdkRoot));
+				sb.Add ("--sdkroot");
+				sb.Add (SdkRoot);
 			} else {
-				sb.Append (" --sdkroot ").Append (StringUtils.Quote (Configuration.xcode_root));
+				sb.Add ("--sdkroot");
+				sb.Add (Configuration.xcode_root);
 			}
 
-			sb.Append (" ").Append (GetVerbosity ());
+			GetVerbosity (sb);
 
 			if (Sdk == None) {
 				// do nothing
 			} else if (!string.IsNullOrEmpty (Sdk)) {
-				sb.Append (" --sdk ").Append (Sdk);
+				sb.Add ("--sdk");
+				sb.Add (Sdk);
 			} else {
-				sb.Append (" --sdk ").Append (MTouch.GetSdkVersion (Profile));
+				sb.Add ("--sdk");
+				sb.Add (Profile.ToString ());
 			}
 
 			string platformName = null;
@@ -93,10 +101,10 @@ namespace Xamarin
 
 			if (!string.IsNullOrEmpty (platformName) && !string.IsNullOrEmpty (simType)) {
 				var device = string.Format (":v2:runtime=com.apple.CoreSimulator.SimRuntime.{0}-{1},devicetype=com.apple.CoreSimulator.SimDeviceType.{2}", platformName, Configuration.sdk_version.Replace ('.', '-'), simType);
-				sb.Append (" --device:").Append (StringUtils.Quote (device));
+				sb.Add ($"--device:{device}");
 			}
 
-			return sb.ToString ();
+			return sb;
 		}
 
 		protected override string ToolPath {

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1861,6 +1861,36 @@ public class B
 		}
 
 		[Test]
+		public void MT0148 ()
+		{
+			using (var mtouch = new MTouchTool ()) {
+				var tmpdir = mtouch.CreateTemporaryDirectory ();
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryAppDirectory ();
+
+
+				mtouch.CreateTemporaryApp (code: @"
+using System.Runtime.InteropServices;
+using Foundation;
+using ObjCRuntime;
+
+[assembly: LinkWith (""dummylib.a"", LinkerFlags = ""'"")]
+
+[Preserve (AllMembers = true)]
+public class TestApp {
+	static void Main ()
+	{
+		System.Console.WriteLine (typeof (ObjCRuntime.Runtime).ToString ());
+	}
+}
+");
+				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
+				mtouch.AssertError (148, "Unable to parse the linker flags ''' from the LinkWith attribute for the library 'dummylib.a' in testApp.exe : No matching quote found.");
+				mtouch.AssertErrorCount (1);
+			}
+		}
+
+		[Test]
 		[TestCase ("all")]
 		[TestCase ("-all")]
 		[TestCase ("remove-uithread-checks,dead-code-elimination,inline-isdirectbinding,inline-intptr-size,inline-runtime-arch,register-protocols")]

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -163,7 +163,7 @@ public class B : A {}
 				var dllPath = CompileTestAppLibrary (tmpdir, codeDll, profile: Profile.iOS, appName: "A");
 
 				mtouch.References = new string [] { dllPath };
-				mtouch.CreateTemporaryApp (extraCode: codeExe, extraArgs: new string [] { $"-r:{dllPath}" });
+				mtouch.CreateTemporaryApp (extraCode: codeExe, extraArgs: new [] { $"-r:{dllPath}" });
 				mtouch.Linker = MTouchLinker.LinkSdk;
 				mtouch.Debug = false;
 				mtouch.CustomArguments = new string [] { "--dlsym:+A.dll", "--dlsym:-testApp.exe" };
@@ -841,7 +841,7 @@ public class B : A {}
 				var tmp = mtouch.CreateTemporaryDirectory ();
 				var dllA = CompileTestAppCode ("library", tmp, "public class X {}");
 
-				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArgs: new string [] { "-r:" + dllA });
+				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArgs: new [] { "-r:" + dllA });
 				mtouch.References = new string [] { dllA };
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
@@ -858,7 +858,7 @@ public class B : A {}
 				var dll = CompileTestAppCode ("library", tmp, "public class X {}", appName: "testApp");
 
 				extension.Linker = MTouchLinker.DontLink; // fastest.
-				extension.CreateTemporaryServiceExtension (extraArgs: new string [] { $"-r:{dll}" }, extraCode: "class Z { static void Y () { System.Console.WriteLine (typeof (X)); } }", appName: "testApp");
+				extension.CreateTemporaryServiceExtension (extraArgs: new [] { $"-r:{dll}" }, extraCode: "class Z { static void Y () { System.Console.WriteLine (typeof (X)); } }", appName: "testApp");
 				extension.CreateTemporaryCacheDirectory ();
 				extension.References = new [] { dll };
 				extension.AssertExecute (MTouchAction.BuildSim, "extension build");
@@ -930,13 +930,13 @@ public class B : A {}
 		{
 			if (Directory.Exists ("/Applications/Xcode44.app/Contents/Developer")) {
 				Asserts.ThrowsPattern<TestExecutionException> (() => {
-					ExecutionHelper.Execute (TestTarget.ToolPath, new string [] { "-sdkroot", "/Applications/Xcode44.app/Contents/Developer", "-sim", "/tmp/foo" });
+					ExecutionHelper.Execute (TestTarget.ToolPath, new [] { "-sdkroot", "/Applications/Xcode44.app/Contents/Developer", "-sim", "/tmp/foo" });
 				}, "error MT0051: Xamarin.iOS .* requires Xcode 6.0 or later. The current Xcode version [(]found in /Applications/Xcode44.app/Contents/Developer[)] is 4.*");
 			}
 
 			if (Directory.Exists (Configuration.xcode5_root)) {
 				Asserts.ThrowsPattern<TestExecutionException> (() => {
-					ExecutionHelper.Execute (TestTarget.ToolPath, new string [] { "-sdkroot", "/Applications/Xcode511.app/Contents/Developer", "-sim", "/tmp/foo" });
+					ExecutionHelper.Execute (TestTarget.ToolPath, new [] { "-sdkroot", "/Applications/Xcode511.app/Contents/Developer", "-sim", "/tmp/foo" });
 				}, "error MT0051: Xamarin.iOS .* requires Xcode 6.0 or later. The current Xcode version [(]found in " + Configuration.xcode5_root + "[)] is 6.0");
 			}
 		}
@@ -1572,7 +1572,7 @@ public class B : A {}
 			using (var extension = new MTouchTool ()) {
 				var ext_tmpdir = extension.CreateTemporaryDirectory ();
 				var ext_dll = CompileTestAppLibrary (ext_tmpdir, @"public class X { }", appName: "testLibrary");
-				extension.CreateTemporaryServiceExtension (extraCode: "class Y : X {}", extraArgs: new string [] { $"-r:{ext_dll}" });
+				extension.CreateTemporaryServiceExtension (extraCode: "class Y : X {}", extraArgs: new [] { $"-r:{ext_dll}" });
 				extension.CreateTemporaryCacheDirectory ();
 				extension.References = new string [] { ext_dll };
 				extension.AssertExecute (MTouchAction.BuildDev, "build extension");
@@ -1582,7 +1582,7 @@ public class B : A {}
 
 					var app_tmpdir = app.CreateTemporaryDirectory ();
 					var app_dll = CompileTestAppLibrary (app_tmpdir, @"public abstract class X { }", appName: "testLibrary");
-					app.CreateTemporaryApp (extraCode: "class Y : X {}", extraArgs: new string [] { $"-r:{app_dll}" });
+					app.CreateTemporaryApp (extraCode: "class Y : X {}", extraArgs: new [] { $"-r:{app_dll}" });
 					app.CreateTemporaryCacheDirectory ();
 					app.References = new string [] { app_dll };
 					app.WarnAsError = new int [] { 113 };
@@ -1647,7 +1647,7 @@ public class B : A {}
 			using (var extension = new MTouchTool ()) {
 				var ext_tmpdir = extension.CreateTemporaryDirectory ();
 				var ext_dll = CompileTestAppLibrary (ext_tmpdir, @"public class X { }", appName: "testLibrary");
-				extension.CreateTemporaryServiceExtension (extraCode: "class Y : X {}", extraArgs: new string [] { $"-r:{ext_dll}" });
+				extension.CreateTemporaryServiceExtension (extraCode: "class Y : X {}", extraArgs: new [] { $"-r:{ext_dll}" });
 				extension.CreateTemporaryCacheDirectory ();
 				extension.References = new string [] { ext_dll };
 				extension.AssertExecute (MTouchAction.BuildDev, "build extension");
@@ -1658,7 +1658,7 @@ public class B : A {}
 					var app_tmpdir = app.CreateTemporaryDirectory ();
 					var app_dll = Path.Combine (app_tmpdir, Path.GetFileName (ext_dll));
 					File.Copy (ext_dll, app_dll);
-					app.CreateTemporaryApp (extraCode: "class Y : X {}", extraArgs: new string [] { $"-r:{app_dll}" });
+					app.CreateTemporaryApp (extraCode: "class Y : X {}", extraArgs: new [] { $"-r:{app_dll}" });
 					app.CreateTemporaryCacheDirectory ();
 					app.References = new string [] { app_dll };
 					app.WarnAsError = new int [] { 113 };
@@ -1753,7 +1753,7 @@ public class TestApp {
 		System.Console.WriteLine (BindingAppB.getNumber ());
 	}
 }
-", new string [] { $"-r:{bindingLibA}", $"-r:{bindingLibB}" });
+", new [] { $"-r:{bindingLibA}", $"-r:{bindingLibB}" });
 
 				mtouch.RootAssembly = exe;
 				mtouch.References = new [] { bindingLibA, bindingLibB };
@@ -1789,7 +1789,7 @@ public class TestApp {
 
 				var dllPath = CompileTestAppLibrary (tmpdir, codeDll, profile: Profile.iOS, appName: "A");
 
-				mtouch.CreateTemporaryApp (extraCode: codeExe, extraArgs: new string [] { $"-r:{dllPath}" });
+				mtouch.CreateTemporaryApp (extraCode: codeExe, extraArgs: new [] { $"-r:{dllPath}" });
 				mtouch.Debug = false;
 				mtouch.Linker = MTouchLinker.DontLink;
 				File.Delete (dllPath);
@@ -1826,7 +1826,7 @@ public class B
 				File.WriteAllText (codeExeFile, codeExe);
 				var dllPath = CompileTestAppLibrary (tmpdir, codeDll, profile: Profile.iOS, appName: "A");
 
-				mtouch.CreateTemporaryApp (extraArgs: new string [] { $"-r:{dllPath}", codeExeFile });
+				mtouch.CreateTemporaryApp (extraArgs: new [] { $"-r:{dllPath}", codeExeFile });
 				mtouch.Debug = false;
 				mtouch.Linker = MTouchLinker.DontLink;
 				File.Delete (dllPath);
@@ -2132,7 +2132,7 @@ public class TestApp {
 				mtouch.CreateTemporaryCacheDirectory ();
 				mtouch.AssertExecute (MTouchAction.BuildSim);
 
-				var load_commands = ExecutionHelper.Execute ("otool", new string [] { "-l", mtouch.NativeExecutablePath }, hide_output: true);
+				var load_commands = ExecutionHelper.Execute ("otool", new [] { "-l", mtouch.NativeExecutablePath }, hide_output: true);
 				Asserts.DoesNotContain ("SafariServices", load_commands, "SafariServices");
 				Asserts.DoesNotContain ("GameController", load_commands, "GameController");
 				Asserts.DoesNotContain ("NewsstandKit", load_commands, "NewsstandKit");
@@ -2141,7 +2141,7 @@ public class TestApp {
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecute (MTouchAction.BuildSim);
 
-				load_commands = ExecutionHelper.Execute ("otool", new string [] { "-l", mtouch.NativeExecutablePath }, hide_output: true);
+				load_commands = ExecutionHelper.Execute ("otool", new [] { "-l", mtouch.NativeExecutablePath }, hide_output: true);
 				Asserts.DoesNotContain ("SafariServices", load_commands, "SafariServices");
 				Asserts.DoesNotContain ("GameController", load_commands, "GameController");
 				Asserts.DoesNotContain ("QuickLook", load_commands, "QuickLook");
@@ -2640,7 +2640,7 @@ public class TestApp {
 		{
 			AssertDeviceAvailable ();
 
-			ExecutionHelper.Execute ("make", new string [] { "-C", Path.Combine (Configuration.SourceRoot, "tests", "scripted") }, timeout: TimeSpan.FromMinutes (10));
+			ExecutionHelper.Execute ("make", new [] { "-C", Path.Combine (Configuration.SourceRoot, "tests", "scripted") }, timeout: TimeSpan.FromMinutes (10));
 		}
 
 		[Test]
@@ -2720,7 +2720,7 @@ public class TestApp {
 	}
 }
 ",
-					new string [] { "-r:" + bindingLib });
+					new [] { "-r:" + bindingLib });
 
 				mtouch.RootAssembly = exe;
 				mtouch.References = new [] { bindingLib };
@@ -2733,7 +2733,7 @@ public class TestApp {
 				Assert.That (symbols, Has.Some.EqualTo ("_dummy_field"), "Field not found in initial build");
 				Assert.That (symbols, Has.Some.EqualTo ("_DummyMethod"), "P/invoke not found in initial build");
 
-				ExecutionHelper.Execute ("touch", new string [] { bindingLib }); // This will make it so that the second identical variation won't skip the final link step.
+				ExecutionHelper.Execute ("touch", new [] { bindingLib }); // This will make it so that the second identical variation won't skip the final link step.
 				mtouch.AssertExecute (MTouchAction.BuildDev, "second build");
 				symbols = GetNativeSymbols (mtouch.NativeExecutablePath);
 				Assert.That (symbols, Has.Some.EqualTo ("_dummy_field"), "Field not found in second build");
@@ -2778,7 +2778,7 @@ public class TestApp {
 	}
 }
 ",
-					new string [] { "-r:" + bindingLib });
+					new [] { "-r:" + bindingLib });
 
 				mtouch.RootAssembly = exe;
 				mtouch.References = new [] { bindingLib };
@@ -2786,7 +2786,7 @@ public class TestApp {
 
 				// test twice so that we don't break when everything is found in the cache the second time around.
 				for (int iteration = 0; iteration < 2; iteration++) {
-					ExecutionHelper.Execute ("touch", new string [] { bindingLib }); // This will make it so that the second identical variation won't skip the final link step.
+					ExecutionHelper.Execute ("touch", new [] { bindingLib }); // This will make it so that the second identical variation won't skip the final link step.
 
 					mtouch.AssertExecute (MTouchAction.BuildDev, $"build #{iteration}");
 
@@ -2998,7 +2998,7 @@ public class TestApp {
 		public void MT1211 ()
 		{
 			Assert.Ignore ("There are no device types in the iOS 9 simulator that the 8.1 simulator (earliest simulator Xcode 7 can run) doesn't support, so there's no way to produce the MT1211 error");
-			Asserts.Throws<TestExecutionException> (() => ExecutionHelper.Execute (TestTarget.ToolPath, new string [] { "--sdkroot", Configuration.xcode_root, "--launchsim", "/path/to/somewhere", "--device=:v2;runtime=com.apple.CoreSimulator.SimRuntime.iOS-7-1,devicetype=com.apple.CoreSimulator.SimDeviceType.Apple-Watch-38mm" }),
+			Asserts.Throws<TestExecutionException> (() => ExecutionHelper.Execute (TestTarget.ToolPath, new [] { "--sdkroot", Configuration.xcode_root, "--launchsim", "/path/to/somewhere", "--device=:v2;runtime=com.apple.CoreSimulator.SimRuntime.iOS-7-1,devicetype=com.apple.CoreSimulator.SimDeviceType.Apple-Watch-38mm" }),
 				"error MT1211: The simulator version '7.1' does not support the simulator type 'Resizable iPhone'\n");
 		}
 
@@ -3059,7 +3059,7 @@ class TestClass {
 				ext.Profile = Profile.watchOS;
 				ext.Linker = MTouchLinker.LinkSdk;
 				ext.CreateTemporaryDirectory ();
-				ext.CreateTemporaryWatchKitExtension (extraCode: code, extraArgs: new string [] { "/debug" });
+				ext.CreateTemporaryWatchKitExtension (extraCode: code, extraArgs: new [] { "/debug" });
 				ext.WarnAsError = new int [] { 2105 };
 				ext.AssertExecuteFailure (MTouchAction.BuildDev);
 				ext.AssertError (2105, "The method TestClass.FilterClause contains a 'Filter' exception clause, which is currently not supported when compiling for bitcode. This method will throw an exception if called.", "testApp.cs", 9);
@@ -3161,7 +3161,7 @@ class Test {
 
 				File.WriteAllText (dllcs, "public class TestLib { public TestLib () { System.Console.WriteLine (typeof (UIKit.UIWindow).ToString ()); } }");
 
-				var args = new string [] { dllcs, "/debug:full", "/noconfig", "/t:library", "/nologo", $"/out:{dll}", "/r:" + Configuration.XamarinIOSDll };
+				var args = new [] { dllcs, "/debug:full", "/noconfig", "/t:library", "/nologo", $"/out:{dll}", "/r:" + Configuration.XamarinIOSDll };
 				File.WriteAllText (DLL + ".config", "");
 				if (ExecutionHelper.Execute (Configuration.SmcsPath, args, out output) != 0)
 					throw new Exception (output);
@@ -3178,7 +3178,7 @@ class Test {
 
 				File.WriteAllText (exeF, execs);
 
-				var cmds = new string [] { exeF, "/noconfig", "/t:exe", "/nologo", $"/out:{exe}", $"/r:{dll}", $"-r:{Configuration.XamarinIOSDll}" };
+				var cmds = new [] { exeF, "/noconfig", "/t:exe", "/nologo", $"/out:{exe}", $"/r:{dll}", $"-r:{Configuration.XamarinIOSDll}" };
 				if (ExecutionHelper.Execute (Configuration.SmcsPath, cmds, out output) != 0)
 					throw new Exception (output);
 
@@ -3254,7 +3254,7 @@ class Test {
 		{
 			Assert.Ignore ("This functionality has been migrated to mlaunch, and the test needs to be updated accordingly.");
 
-			ExecutionHelper.Execute (TestTarget.ToolPath, new string [] { "--listdev", "--sdkroot", Configuration.xcode_root });
+			ExecutionHelper.Execute (TestTarget.ToolPath, new [] { "--listdev", "--sdkroot", Configuration.xcode_root });
 		}
 
 		[Test]
@@ -3357,7 +3357,7 @@ class Test {
 
 				Assert.IsTrue (File.Exists (Path.Combine (tool.AppPath, "libpinvokes.dylib")), "libpinvokes.dylib existence");
 
-				var otool_output = ExecutionHelper.Execute ("otool", new string [] { "-l", Path.Combine (tool.AppPath, "libpinvokes.dylib") }, hide_output: true);
+				var otool_output = ExecutionHelper.Execute ("otool", new [] { "-l", Path.Combine (tool.AppPath, "libpinvokes.dylib") }, hide_output: true);
 				Assert.That (otool_output, Does.Contain ("LC_ID_DYLIB"), "output contains LC_ID_DYLIB");
 
 				var lines = otool_output.Split (new char [] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
@@ -3386,14 +3386,14 @@ class Test {
 				using (var ext1 = new MTouchTool ()) {
 					ext1.References = new string [] { dll };
 					ext1.CreateTemporaryCacheDirectory ();
-					ext1.CreateTemporaryTodayExtension (extraCode: "class E1 : L {}", extraArgs: new string [] { $"-r:{dll}" });
+					ext1.CreateTemporaryTodayExtension (extraCode: "class E1 : L {}", extraArgs: new [] { $"-r:{dll}" });
 					ext1.Linker = MTouchLinker.LinkSdk;
 					tool.AppExtensions.Add (ext1);
 
 					using (var ext2 = new MTouchTool ()) {
 						ext2.References = new string [] { dll };
 						ext2.CreateTemporaryCacheDirectory ();
-						ext2.CreateTemporaryServiceExtension (extraCode: "class E1 : L {}", extraArgs: new string [] { $"-r:{dll}" });
+						ext2.CreateTemporaryServiceExtension (extraCode: "class E1 : L {}", extraArgs: new [] { $"-r:{dll}" });
 						ext2.Linker = MTouchLinker.LinkSdk;
 						tool.AppExtensions.Add (ext2);
 
@@ -3508,7 +3508,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 	{
 		System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ());
 	}
-}", extraArgs: new string [] { "-r:" + exttool.References [0] });
+}", extraArgs: new [] { "-r:" + exttool.References [0] });
 				exttool.AssertExecute (MTouchAction.BuildSim, "build extension");
 
 				using (var apptool = new MTouchTool ()) {
@@ -3533,14 +3533,14 @@ public partial class NotificationService : UNNotificationServiceExtension
 				exttool.Linker = MTouchLinker.DontLink; // faster
 				exttool.References = new string [] { GetFrameworksBindingLibrary (exttool.Profile) };
 				exttool.CreateTemporaryCacheDirectory ();
-				exttool.CreateTemporaryServiceExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArgs: new string [] { $"-r:{exttool.References [0]}" });
+				exttool.CreateTemporaryServiceExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArgs: new [] { $"-r:{exttool.References [0]}" });
 				exttool.AssertExecute (MTouchAction.BuildSim, "build extension");
 
 				using (var apptool = new MTouchTool ()) {
 					apptool.Profile = Profile.iOS;
 					apptool.CreateTemporaryCacheDirectory ();
 					apptool.References = exttool.References;
-					apptool.CreateTemporaryApp (extraCode: @"[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } };", extraArgs: new string [] { $"-r:{apptool.References [0]}" });
+					apptool.CreateTemporaryApp (extraCode: @"[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } };", extraArgs: new [] { $"-r:{apptool.References [0]}" });
 					apptool.AppExtensions.Add (exttool);
 					apptool.AssertExecute (MTouchAction.BuildSim, "build app");
 
@@ -3562,7 +3562,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 				exttool.Linker = MTouchLinker.DontLink; // faster
 				exttool.References = new string [] { framework_binding_library };
 				exttool.CreateTemporaryCacheDirectory ();
-				exttool.CreateTemporaryServiceExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArgs: new string [] { $"-r:{exttool.References [0]}" });
+				exttool.CreateTemporaryServiceExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArgs: new [] { $"-r:{exttool.References [0]}" });
 				exttool.AssertExecute (MTouchAction.BuildSim, "build extension");
 
 				using (var apptool = new MTouchTool ()) {
@@ -3574,7 +3574,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 					var res = (Mono.Cecil.EmbeddedResource) ad.MainModule.Resources.Where ((v) => v.Name == "XTest.framework").First ();
 					File.WriteAllBytes (framework_zip, res.GetResourceData ());
 					File.WriteAllText (extra_content, "Hello world");
-					ExecutionHelper.Execute ("zip", new string [] { framework_zip, extra_content });
+					ExecutionHelper.Execute ("zip", new [] { framework_zip, extra_content });
 					ad.MainModule.Resources.Remove (res);
 					ad.MainModule.Resources.Add (new Mono.Cecil.EmbeddedResource (res.Name, res.Attributes, File.ReadAllBytes (framework_zip)));
 					ad.Write (modified_framework_binding_library);
@@ -3583,7 +3583,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 					apptool.Linker = MTouchLinker.DontLink; // faster
 					apptool.References = new string [] { modified_framework_binding_library };
 					apptool.CreateTemporaryCacheDirectory ();
-					apptool.CreateTemporaryApp (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArgs: new string [] { $"-r:{apptool.References [0]}" });
+					apptool.CreateTemporaryApp (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArgs: new [] { $"-r:{apptool.References [0]}" });
 					apptool.AppExtensions.Add (exttool);
 					apptool.AssertExecuteFailure (MTouchAction.BuildSim, "build app");
 					apptool.AssertError (1035, "Cannot include different versions of the framework 'XTest.framework'");
@@ -3603,7 +3603,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 				service_ext.Linker = MTouchLinker.DontLink; // faster
 				service_ext.References = new string [] { GetFrameworksBindingLibrary (service_ext.Profile) };
 				service_ext.CreateTemporaryCacheDirectory ();
-				service_ext.CreateTemporaryServiceExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArgs: new string [] { $"-r:{service_ext.References [0]}" });
+				service_ext.CreateTemporaryServiceExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArgs: new [] { $"-r:{service_ext.References [0]}" });
 				service_ext.AssertExecute (MTouchAction.BuildSim, "build service extension");
 
 				using (var today_ext = new MTouchTool ()) {
@@ -3611,7 +3611,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 					today_ext.Linker = MTouchLinker.DontLink; // faster
 					today_ext.References = service_ext.References;
 					today_ext.CreateTemporaryCacheDirectory ();
-					today_ext.CreateTemporaryTodayExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArgs: new string [] { $"-r:{today_ext.References [0]}" });
+					today_ext.CreateTemporaryTodayExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArgs: new [] { $"-r:{today_ext.References [0]}" });
 					today_ext.AssertExecute (MTouchAction.BuildSim, "build today extension");
 
 					using (var apptool = new MTouchTool ()) {
@@ -3644,7 +3644,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 
 				// Create a sample exe
 				var code = "public class TestApp { static void Main () { System.Console.WriteLine (typeof (ObjCRuntime.Runtime).ToString ()); } }";
-				var exe = MTouch.CompileTestAppExecutable (tmp, code, new string [] { "/debug:full" }, use_csc: false);
+				var exe = MTouch.CompileTestAppExecutable (tmp, code, new [] { "/debug:full" }, use_csc: false);
 
 				mtouch.AppPath = mtouch.CreateTemporaryDirectory ();
 				mtouch.RootAssembly = exe;
@@ -3661,7 +3661,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 
 				EnsureFilestampChange ();
 				// Recompile the exe, adding only whitespace. This will only change the debug files
-				MTouch.CompileTestAppExecutable (tmp, "\n\n" + code + "\n\n", new string [] { "/debug:full" }, use_csc: false);
+				MTouch.CompileTestAppExecutable (tmp, "\n\n" + code + "\n\n", new [] { "/debug:full" }, use_csc: false);
 
 				// Rebuild the app
 				mtouch.AssertExecute (MTouchAction.BuildSim);
@@ -3761,7 +3761,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 				var dllB = Path.Combine (tmpB, Path.GetFileName (dllA));
 				File.Copy (dllA, dllB);
 
-				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArgs: new string [] { "-r:" + dllA });
+				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArgs: new [] { "-r:" + dllA });
 				mtouch.References = new string [] { dllA, dllB };
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build");
@@ -3783,7 +3783,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 
 				var dllB = Path.Combine (Configuration.SdkRootXI, "lib", "mono", "Xamarin.iOS", Path.GetFileName (dllA));
 
-				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArgs: new string [] { "-r:" + dllA });
+				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArgs: new [] { "-r:" + dllA });
 				mtouch.References = new string [] { dllA, dllB };
 
 				// Without the linker we'll just copy the references, and not actually run into problems if we copy one that doesn't work
@@ -3812,7 +3812,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 
 				var dllB = Path.Combine (Configuration.SdkRootXI, "lib", "mono", "Xamarin.iOS", Path.GetFileName (dllA));
 
-				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArgs: new string [] { "-r:" + dllA });
+				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArgs: new [] { "-r:" + dllA });
 				mtouch.References = new string [] { dllB, dllA };
 
 				// Without the linker we'll just copy the references, and not actually run into problems if we copy one that doesn't work
@@ -3988,7 +3988,7 @@ public class HandlerTest
 				string libraryPath = Path.Combine (Configuration.SourceRoot, "tests", "common", "MixedClassLibrary.dll");
 
 				mtouch.CreateTemporaryApp (code: "public class TestApp { static void Main () { System.Console.WriteLine (typeof (MixedClassLibrary.Class1)); System.Console.WriteLine (typeof (ObjCRuntime.Runtime)); } }",
-										   extraArgs: new string [] { $"-r:Xamarin.iOS.dll", $"-r:{libraryPath}" });
+										   extraArgs: new [] { $"-r:Xamarin.iOS.dll", $"-r:{libraryPath}" });
 				mtouch.CreateTemporaryCacheDirectory ();
 				mtouch.References = new string [] { libraryPath };
 				if (nofastsim)
@@ -4018,7 +4018,7 @@ public class HandlerTest
 		{
 			using (var mtouch = new MTouchTool ()) {
 				// Compile the managed executable twice, the second time without debugging symbols, which will cause the debugging symbols to become stale
-				mtouch.CreateTemporaryApp (extraArgs: new string [] { "/debug:full" }, use_csc: use_csc);
+				mtouch.CreateTemporaryApp (extraArgs: new [] { "/debug:full" }, use_csc: use_csc);
 				mtouch.CreateTemporaryApp ();
 				mtouch.Linker = MTouchLinker.DontLink; // makes the test faster
 				mtouch.Debug = true; // makes the test faster because it makes simlauncher possible
@@ -4033,10 +4033,10 @@ public class HandlerTest
 		{
 			using (var mtouch = new MTouchTool ()) {
 				// Compile the managed executable twice, both times with debugging symbols, but restore the debugging symbols from the first build so that they're stale
-				mtouch.CreateTemporaryApp (extraArgs: new string [] { "/debug:full" }, use_csc: use_csc);
+				mtouch.CreateTemporaryApp (extraArgs: new [] { "/debug:full" }, use_csc: use_csc);
 				var symbol_file = use_csc ? Path.ChangeExtension (mtouch.RootAssembly, "pdb") : mtouch.RootAssembly + ".mdb";
 				var symbols = File.ReadAllBytes (symbol_file);
-				mtouch.CreateTemporaryApp (extraArgs: new string [] { "/debug:full" }, use_csc: use_csc);
+				mtouch.CreateTemporaryApp (extraArgs: new [] { "/debug:full" }, use_csc: use_csc);
 				File.WriteAllBytes (symbol_file, symbols);
 				mtouch.Linker = MTouchLinker.DontLink; // makes the test faster
 				mtouch.Debug = true; // makes the test faster because it makes simlauncher possible
@@ -4053,7 +4053,7 @@ public class HandlerTest
 		{
 			using (var mtouch = new MTouchTool ()) {
 				// (Over)write invalid data in the debug symbol file
-				mtouch.CreateTemporaryApp (use_csc, extraArgs: compile_with_debug_symbols ? new string [] { "/debug:full" } : Array.Empty<string> ());
+				mtouch.CreateTemporaryApp (use_csc, extraArgs: compile_with_debug_symbols ? new [] { "/debug:full" } : Array.Empty<string> ());
 				var symbol_file = use_csc ? Path.ChangeExtension (mtouch.RootAssembly, "pdb") : mtouch.RootAssembly + ".mdb";
 				File.WriteAllText (symbol_file, "invalid stuff");
 				mtouch.Linker = MTouchLinker.DontLink; // makes the test faster
@@ -4226,7 +4226,7 @@ public partial class KeyboardViewController : UIKit.UIInputViewController
 					apptool.AssertExecute (MTouchAction.BuildDev, "build app");
 
 					var sdk = Path.Combine (apptool.Cache, "arm64", "Xamarin.Sdk");
-					var shared_libraries = ExecutionHelper.Execute ("otool", new string [] { "-L", sdk }, hide_output: true);
+					var shared_libraries = ExecutionHelper.Execute ("otool", new [] { "-L", sdk }, hide_output: true);
 					Asserts.DoesNotContain ("Private", shared_libraries, "Private");
 
 					exttool.AssertNoWarnings();
@@ -4377,7 +4377,7 @@ public class Dummy {
 
 		public static string CompileTestAppCode (string target, string targetDirectory, string code, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp", bool use_csc = true)
 		{
-			return BundlerTool.CompileTestAppCode (target, targetDirectory, code, new string [] { extraArg }, profile, appName, use_csc);
+			return BundlerTool.CompileTestAppCode (target, targetDirectory, code, new [] { extraArg }, profile, appName, use_csc);
 		}
 
 		static string CreateBindingLibrary (string targetDirectory, string nativeCode, string bindingCode, string linkWith = null, string extraCode = "", string name = "binding", string[] references = null, string arch = "armv7")
@@ -4555,7 +4555,7 @@ public class TestApp {
 
 		public static IEnumerable<string> GetNativeSymbols (string file, string arch = null)
 		{
-			var arguments = new List<string> (new string [] { "-gUjA", file });
+			var arguments = new List<string> (new [] { "-gUjA", file });
 			if (!string.IsNullOrEmpty (arch)) {
 				arguments.Add ("-arch");
 				arguments.Add (arch);
@@ -4575,7 +4575,7 @@ public class TestApp {
 		public static bool IsAPFS {
 			get {
 				if (!is_apfs.HasValue) {
-					var exit_code = ExecutionHelper.Execute ("/bin/df", new string [] { "-t", "apfs", "/" }, out var output, TimeSpan.FromSeconds (10));
+					var exit_code = ExecutionHelper.Execute ("/bin/df", new [] { "-t", "apfs", "/" }, out var output, TimeSpan.FromSeconds (10));
 					is_apfs = exit_code == 0 && output.Trim ().Split ('\n').Length >= 2;
 				}
 				return is_apfs.Value;

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -163,7 +163,7 @@ public class B : A {}
 				var dllPath = CompileTestAppLibrary (tmpdir, codeDll, profile: Profile.iOS, appName: "A");
 
 				mtouch.References = new string [] { dllPath };
-				mtouch.CreateTemporaryApp (extraCode: codeExe, extraArg: $"-r:{StringUtils.Quote (dllPath)}");
+				mtouch.CreateTemporaryApp (extraCode: codeExe, extraArgs: new string [] { $"-r:{dllPath}" });
 				mtouch.Linker = MTouchLinker.LinkSdk;
 				mtouch.Debug = false;
 				mtouch.CustomArguments = new string [] { "--dlsym:+A.dll", "--dlsym:-testApp.exe" };
@@ -841,7 +841,7 @@ public class B : A {}
 				var tmp = mtouch.CreateTemporaryDirectory ();
 				var dllA = CompileTestAppCode ("library", tmp, "public class X {}");
 
-				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArg: "-r:" + StringUtils.Quote (dllA));
+				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArgs: new string [] { "-r:" + dllA });
 				mtouch.References = new string [] { dllA };
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
@@ -858,7 +858,7 @@ public class B : A {}
 				var dll = CompileTestAppCode ("library", tmp, "public class X {}", appName: "testApp");
 
 				extension.Linker = MTouchLinker.DontLink; // fastest.
-				extension.CreateTemporaryServiceExtension (extraArg: $"-r:{StringUtils.Quote (dll)}", extraCode: "class Z { static void Y () { System.Console.WriteLine (typeof (X)); } }", appName: "testApp");
+				extension.CreateTemporaryServiceExtension (extraArgs: new string [] { $"-r:{dll}" }, extraCode: "class Z { static void Y () { System.Console.WriteLine (typeof (X)); } }", appName: "testApp");
 				extension.CreateTemporaryCacheDirectory ();
 				extension.References = new [] { dll };
 				extension.AssertExecute (MTouchAction.BuildSim, "extension build");
@@ -902,20 +902,41 @@ public class B : A {}
 				mtouch.AssertExecuteFailure (MTouchAction.BuildDev, "build");
 				mtouch.AssertError (26, "Could not parse the command line argument '--llvm-opt=-O2': Both assembly and optimization must be specified (assembly=optimization)");
 			}
+
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryApp ();
+				mtouch.GccFlags = "-a'-b"; // 1 single quote
+				mtouch.AssertExecuteFailure (MTouchAction.BuildDev, "build");
+				mtouch.AssertError (26, "Could not parse the command line argument '--gcc-flags=-a'-b': No matching quote found.");
+			}
 		}
-			
+
+		[Test]
+		[TestCase ("'", "No matching quote found")] // 1 single quote
+		[TestCase ("\"", "No matching quote found")] // 1 double quote
+		[TestCase ("\\", "Incomplete escape sequence")] // 1 backslash
+		public void MT0026_GccFlags (string gcc_flags, string error)
+		{
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryApp ();
+				mtouch.GccFlags = gcc_flags;
+				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
+				mtouch.AssertError (26, $"Could not parse the command line argument '--gcc-flags={gcc_flags}': {error}.");
+			}
+		}
+
 		[Test]
 		public void MT0051 ()
 		{
 			if (Directory.Exists ("/Applications/Xcode44.app/Contents/Developer")) {
 				Asserts.ThrowsPattern<TestExecutionException> (() => {
-					ExecutionHelper.Execute (TestTarget.ToolPath, "-sdkroot /Applications/Xcode44.app/Contents/Developer -sim /tmp/foo");
+					ExecutionHelper.Execute (TestTarget.ToolPath, new string [] { "-sdkroot", "/Applications/Xcode44.app/Contents/Developer", "-sim", "/tmp/foo" });
 				}, "error MT0051: Xamarin.iOS .* requires Xcode 6.0 or later. The current Xcode version [(]found in /Applications/Xcode44.app/Contents/Developer[)] is 4.*");
 			}
 
 			if (Directory.Exists (Configuration.xcode5_root)) {
 				Asserts.ThrowsPattern<TestExecutionException> (() => {
-					ExecutionHelper.Execute (TestTarget.ToolPath, "-sdkroot /Applications/Xcode511.app/Contents/Developer -sim /tmp/foo");
+					ExecutionHelper.Execute (TestTarget.ToolPath, new string [] { "-sdkroot", "/Applications/Xcode511.app/Contents/Developer", "-sim", "/tmp/foo" });
 				}, "error MT0051: Xamarin.iOS .* requires Xcode 6.0 or later. The current Xcode version [(]found in " + Configuration.xcode5_root + "[)] is 6.0");
 			}
 		}
@@ -1395,7 +1416,7 @@ public class B : A {}
 					app.WarnAsError = new int [] { 113 };
 					app.AotOtherArguments = "--aot-options=-O=float32"; // doesn't matter exactly what, just that it's different from the extension.
 					app.AssertExecuteFailure (MTouchAction.BuildDev, "build app");
-					app.AssertError (113, "Native code sharing has been disabled for the extension 'testServiceExtension' because the other arguments to the AOT compiler are different between the container app (--aot-options=-O=float32 ) and the extension ().");
+					app.AssertError (113, "Native code sharing has been disabled for the extension 'testServiceExtension' because the other arguments to the AOT compiler are different between the container app (--aot-options=-O=float32) and the extension ().");
 				}
 			}
 		}
@@ -1551,7 +1572,7 @@ public class B : A {}
 			using (var extension = new MTouchTool ()) {
 				var ext_tmpdir = extension.CreateTemporaryDirectory ();
 				var ext_dll = CompileTestAppLibrary (ext_tmpdir, @"public class X { }", appName: "testLibrary");
-				extension.CreateTemporaryServiceExtension (extraCode: "class Y : X {}", extraArg: $"-r:{StringUtils.Quote (ext_dll)}");
+				extension.CreateTemporaryServiceExtension (extraCode: "class Y : X {}", extraArgs: new string [] { $"-r:{ext_dll}" });
 				extension.CreateTemporaryCacheDirectory ();
 				extension.References = new string [] { ext_dll };
 				extension.AssertExecute (MTouchAction.BuildDev, "build extension");
@@ -1561,7 +1582,7 @@ public class B : A {}
 
 					var app_tmpdir = app.CreateTemporaryDirectory ();
 					var app_dll = CompileTestAppLibrary (app_tmpdir, @"public abstract class X { }", appName: "testLibrary");
-					app.CreateTemporaryApp (extraCode: "class Y : X {}", extraArg: $"-r:{StringUtils.Quote (app_dll)}");
+					app.CreateTemporaryApp (extraCode: "class Y : X {}", extraArgs: new string [] { $"-r:{app_dll}" });
 					app.CreateTemporaryCacheDirectory ();
 					app.References = new string [] { app_dll };
 					app.WarnAsError = new int [] { 113 };
@@ -1626,7 +1647,7 @@ public class B : A {}
 			using (var extension = new MTouchTool ()) {
 				var ext_tmpdir = extension.CreateTemporaryDirectory ();
 				var ext_dll = CompileTestAppLibrary (ext_tmpdir, @"public class X { }", appName: "testLibrary");
-				extension.CreateTemporaryServiceExtension (extraCode: "class Y : X {}", extraArg: $"-r:{StringUtils.Quote (ext_dll)}");
+				extension.CreateTemporaryServiceExtension (extraCode: "class Y : X {}", extraArgs: new string [] { $"-r:{ext_dll}" });
 				extension.CreateTemporaryCacheDirectory ();
 				extension.References = new string [] { ext_dll };
 				extension.AssertExecute (MTouchAction.BuildDev, "build extension");
@@ -1637,7 +1658,7 @@ public class B : A {}
 					var app_tmpdir = app.CreateTemporaryDirectory ();
 					var app_dll = Path.Combine (app_tmpdir, Path.GetFileName (ext_dll));
 					File.Copy (ext_dll, app_dll);
-					app.CreateTemporaryApp (extraCode: "class Y : X {}", extraArg: $"-r:{StringUtils.Quote (app_dll)}");
+					app.CreateTemporaryApp (extraCode: "class Y : X {}", extraArgs: new string [] { $"-r:{app_dll}" });
 					app.CreateTemporaryCacheDirectory ();
 					app.References = new string [] { app_dll };
 					app.WarnAsError = new int [] { 113 };
@@ -1732,7 +1753,7 @@ public class TestApp {
 		System.Console.WriteLine (BindingAppB.getNumber ());
 	}
 }
-", $"-r:{StringUtils.Quote (bindingLibA)} -r:{StringUtils.Quote (bindingLibB)}");
+", new string [] { $"-r:{bindingLibA}", $"-r:{bindingLibB}" });
 
 				mtouch.RootAssembly = exe;
 				mtouch.References = new [] { bindingLibA, bindingLibB };
@@ -1768,7 +1789,7 @@ public class TestApp {
 
 				var dllPath = CompileTestAppLibrary (tmpdir, codeDll, profile: Profile.iOS, appName: "A");
 
-				mtouch.CreateTemporaryApp (extraCode: codeExe, extraArg: $"-r:{StringUtils.Quote (dllPath)}");
+				mtouch.CreateTemporaryApp (extraCode: codeExe, extraArgs: new string [] { $"-r:{dllPath}" });
 				mtouch.Debug = false;
 				mtouch.Linker = MTouchLinker.DontLink;
 				File.Delete (dllPath);
@@ -1805,7 +1826,7 @@ public class B
 				File.WriteAllText (codeExeFile, codeExe);
 				var dllPath = CompileTestAppLibrary (tmpdir, codeDll, profile: Profile.iOS, appName: "A");
 
-				mtouch.CreateTemporaryApp (extraArg: $"-r:{StringUtils.Quote (dllPath)} {StringUtils.Quote (codeExeFile)}");
+				mtouch.CreateTemporaryApp (extraArgs: new string [] { $"-r:{dllPath}", codeExeFile });
 				mtouch.Debug = false;
 				mtouch.Linker = MTouchLinker.DontLink;
 				File.Delete (dllPath);
@@ -1961,9 +1982,9 @@ public class B
 			return Configuration.GetBaseLibrary (profile);
 		}
 
-		public static string GetCompiler (Profile profile, StringBuilder args, bool use_csc = true)
+		public static string GetCompiler (Profile profile, IList<string> args, bool use_csc = true)
 		{
-			args.Append (" -lib:").Append (Path.GetDirectoryName (GetBaseLibrary (profile))).Append (' ');
+			args.Add ($"-lib:{Path.GetDirectoryName (GetBaseLibrary (profile))}");
 			if (use_csc) {
 				return "/Library/Frameworks/Mono.framework/Commands/csc";
 			} else {
@@ -2081,7 +2102,7 @@ public class B
 				mtouch.CreateTemporaryCacheDirectory ();
 				mtouch.AssertExecute (MTouchAction.BuildSim);
 
-				var load_commands = ExecutionHelper.Execute ("otool", $"-l {StringUtils.Quote (mtouch.NativeExecutablePath)}", hide_output: true);
+				var load_commands = ExecutionHelper.Execute ("otool", new string [] { "-l", mtouch.NativeExecutablePath }, hide_output: true);
 				Asserts.DoesNotContain ("SafariServices", load_commands, "SafariServices");
 				Asserts.DoesNotContain ("GameController", load_commands, "GameController");
 				Asserts.DoesNotContain ("NewsstandKit", load_commands, "NewsstandKit");
@@ -2090,7 +2111,7 @@ public class B
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecute (MTouchAction.BuildSim);
 
-				load_commands = ExecutionHelper.Execute ("otool", $"-l {StringUtils.Quote (mtouch.NativeExecutablePath)}", hide_output: true);
+				load_commands = ExecutionHelper.Execute ("otool", new string [] { "-l", mtouch.NativeExecutablePath }, hide_output: true);
 				Asserts.DoesNotContain ("SafariServices", load_commands, "SafariServices");
 				Asserts.DoesNotContain ("GameController", load_commands, "GameController");
 				Asserts.DoesNotContain ("QuickLook", load_commands, "QuickLook");
@@ -2589,7 +2610,7 @@ public class B
 		{
 			AssertDeviceAvailable ();
 
-			ExecutionHelper.Execute ("make", string.Format ("-C \"{0}\"", Path.Combine (Configuration.SourceRoot, "tests", "scripted")), timeout: TimeSpan.FromMinutes (10));
+			ExecutionHelper.Execute ("make", new string [] { "-C", Path.Combine (Configuration.SourceRoot, "tests", "scripted") }, timeout: TimeSpan.FromMinutes (10));
 		}
 
 		[Test]
@@ -2669,7 +2690,7 @@ public class TestApp {
 	}
 }
 ",
-					"-r:" + bindingLib);
+					new string [] { "-r:" + bindingLib });
 
 				mtouch.RootAssembly = exe;
 				mtouch.References = new [] { bindingLib };
@@ -2682,7 +2703,7 @@ public class TestApp {
 				Assert.That (symbols, Has.Some.EqualTo ("_dummy_field"), "Field not found in initial build");
 				Assert.That (symbols, Has.Some.EqualTo ("_DummyMethod"), "P/invoke not found in initial build");
 
-				ExecutionHelper.Execute ("touch", bindingLib); // This will make it so that the second identical variation won't skip the final link step.
+				ExecutionHelper.Execute ("touch", new string [] { bindingLib }); // This will make it so that the second identical variation won't skip the final link step.
 				mtouch.AssertExecute (MTouchAction.BuildDev, "second build");
 				symbols = GetNativeSymbols (mtouch.NativeExecutablePath);
 				Assert.That (symbols, Has.Some.EqualTo ("_dummy_field"), "Field not found in second build");
@@ -2727,7 +2748,7 @@ public class TestApp {
 	}
 }
 ",
-					"-r:" + bindingLib);
+					new string [] { "-r:" + bindingLib });
 
 				mtouch.RootAssembly = exe;
 				mtouch.References = new [] { bindingLib };
@@ -2735,7 +2756,7 @@ public class TestApp {
 
 				// test twice so that we don't break when everything is found in the cache the second time around.
 				for (int iteration = 0; iteration < 2; iteration++) {
-					ExecutionHelper.Execute ("touch", bindingLib); // This will make it so that the second identical variation won't skip the final link step.
+					ExecutionHelper.Execute ("touch", new string [] { bindingLib }); // This will make it so that the second identical variation won't skip the final link step.
 
 					mtouch.AssertExecute (MTouchAction.BuildDev, $"build #{iteration}");
 
@@ -2767,7 +2788,7 @@ public class TestApp {
 				mtouch.CreateTemporaryApp ();
 				mtouch.NoFastSim = true;
 				mtouch.Abi = "i386";
-				mtouch.GccFlags = StringUtils.Quote (lib);
+				mtouch.GccFlags = lib;
 				mtouch.TargetVer = "10.3"; // otherwise 32-bit build isn't possible
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build a");
 				if (Configuration.XcodeVersion.Major >= 11) {
@@ -2947,7 +2968,7 @@ public class TestApp {
 		public void MT1211 ()
 		{
 			Assert.Ignore ("There are no device types in the iOS 9 simulator that the 8.1 simulator (earliest simulator Xcode 7 can run) doesn't support, so there's no way to produce the MT1211 error");
-			Asserts.Throws<TestExecutionException> (() => ExecutionHelper.Execute (TestTarget.ToolPath,"--sdkroot " + Configuration.xcode_root +  " --launchsim /path/to/somewhere --device=:v2;runtime=com.apple.CoreSimulator.SimRuntime.iOS-7-1,devicetype=com.apple.CoreSimulator.SimDeviceType.Apple-Watch-38mm"),
+			Asserts.Throws<TestExecutionException> (() => ExecutionHelper.Execute (TestTarget.ToolPath, new string [] { "--sdkroot", Configuration.xcode_root, "--launchsim", "/path/to/somewhere", "--device=:v2;runtime=com.apple.CoreSimulator.SimRuntime.iOS-7-1,devicetype=com.apple.CoreSimulator.SimDeviceType.Apple-Watch-38mm" }),
 				"error MT1211: The simulator version '7.1' does not support the simulator type 'Resizable iPhone'\n");
 		}
 
@@ -3008,7 +3029,7 @@ class TestClass {
 				ext.Profile = Profile.watchOS;
 				ext.Linker = MTouchLinker.LinkSdk;
 				ext.CreateTemporaryDirectory ();
-				ext.CreateTemporaryWatchKitExtension (extraCode: code, extraArg: "/debug");
+				ext.CreateTemporaryWatchKitExtension (extraCode: code, extraArgs: new string [] { "/debug" });
 				ext.WarnAsError = new int [] { 2105 };
 				ext.AssertExecuteFailure (MTouchAction.BuildDev);
 				ext.AssertError (2105, "The method TestClass.FilterClause contains a 'Filter' exception clause, which is currently not supported when compiling for bitcode. This method will throw an exception if called.", "testApp.cs", 9);
@@ -3106,12 +3127,11 @@ class Test {
 				string exe = Path.Combine (testDir, "testApp.exe");
 				string dll = Path.Combine (testDir, "testLibrary.dll");
 				string DLL = Path.Combine (testDir, "TESTLIBRARY.dll");
-				string args;
 				string output;
 
 				File.WriteAllText (dllcs, "public class TestLib { public TestLib () { System.Console.WriteLine (typeof (UIKit.UIWindow).ToString ()); } }");
 
-				args = string.Format ("\"{0}\" /debug:full /noconfig /t:library /nologo /out:\"{1}\" /r:" + Configuration.XamarinIOSDll, dllcs, dll);
+				var args = new string [] { dllcs, "/debug:full", "/noconfig", "/t:library", "/nologo", $"/out:{dll}", "/r:" + Configuration.XamarinIOSDll };
 				File.WriteAllText (DLL + ".config", "");
 				if (ExecutionHelper.Execute (Configuration.SmcsPath, args, out output) != 0)
 					throw new Exception (output);
@@ -3128,7 +3148,7 @@ class Test {
 
 				File.WriteAllText (exeF, execs);
 
-				var cmds = string.Format ("\"{0}\" /noconfig /t:exe /nologo /out:\"{1}\" \"/r:{2}\" -r:{3}", exeF, exe, dll, Configuration.XamarinIOSDll);
+				var cmds = new string [] { exeF, "/noconfig", "/t:exe", "/nologo", $"/out:{exe}", $"/r:{dll}", $"-r:{Configuration.XamarinIOSDll}" };
 				if (ExecutionHelper.Execute (Configuration.SmcsPath, cmds, out output) != 0)
 					throw new Exception (output);
 
@@ -3204,7 +3224,7 @@ class Test {
 		{
 			Assert.Ignore ("This functionality has been migrated to mlaunch, and the test needs to be updated accordingly.");
 
-			ExecutionHelper.Execute (TestTarget.ToolPath, string.Format ("--listdev --sdkroot {0}", Configuration.xcode_root));
+			ExecutionHelper.Execute (TestTarget.ToolPath, new string [] { "--listdev", "--sdkroot", Configuration.xcode_root });
 		}
 
 		[Test]
@@ -3307,7 +3327,7 @@ class Test {
 
 				Assert.IsTrue (File.Exists (Path.Combine (tool.AppPath, "libpinvokes.dylib")), "libpinvokes.dylib existence");
 
-				var otool_output = ExecutionHelper.Execute ("otool", $"-l {StringUtils.Quote (Path.Combine (tool.AppPath, "libpinvokes.dylib"))}", hide_output: true);
+				var otool_output = ExecutionHelper.Execute ("otool", new string [] { "-l", Path.Combine (tool.AppPath, "libpinvokes.dylib") }, hide_output: true);
 				Assert.That (otool_output, Does.Contain ("LC_ID_DYLIB"), "output contains LC_ID_DYLIB");
 
 				var lines = otool_output.Split (new char [] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
@@ -3336,14 +3356,14 @@ class Test {
 				using (var ext1 = new MTouchTool ()) {
 					ext1.References = new string [] { dll };
 					ext1.CreateTemporaryCacheDirectory ();
-					ext1.CreateTemporaryTodayExtension (extraCode: "class E1 : L {}", extraArg: $"-r:{StringUtils.Quote (dll)}");
+					ext1.CreateTemporaryTodayExtension (extraCode: "class E1 : L {}", extraArgs: new string [] { $"-r:{dll}" });
 					ext1.Linker = MTouchLinker.LinkSdk;
 					tool.AppExtensions.Add (ext1);
 
 					using (var ext2 = new MTouchTool ()) {
 						ext2.References = new string [] { dll };
 						ext2.CreateTemporaryCacheDirectory ();
-						ext2.CreateTemporaryServiceExtension (extraCode: "class E1 : L {}", extraArg: $"-r:{StringUtils.Quote (dll)}");
+						ext2.CreateTemporaryServiceExtension (extraCode: "class E1 : L {}", extraArgs: new string [] { $"-r:{dll}" });
 						ext2.Linker = MTouchLinker.LinkSdk;
 						tool.AppExtensions.Add (ext2);
 
@@ -3458,7 +3478,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 	{
 		System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ());
 	}
-}", extraArg: StringUtils.Quote ("-r:" + exttool.References [0]));
+}", extraArgs: new string [] { "-r:" + exttool.References [0] });
 				exttool.AssertExecute (MTouchAction.BuildSim, "build extension");
 
 				using (var apptool = new MTouchTool ()) {
@@ -3483,14 +3503,14 @@ public partial class NotificationService : UNNotificationServiceExtension
 				exttool.Linker = MTouchLinker.DontLink; // faster
 				exttool.References = new string [] { GetFrameworksBindingLibrary (exttool.Profile) };
 				exttool.CreateTemporaryCacheDirectory ();
-				exttool.CreateTemporaryServiceExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArg: $"-r:{StringUtils.Quote (exttool.References [0])}");
+				exttool.CreateTemporaryServiceExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArgs: new string [] { $"-r:{exttool.References [0]}" });
 				exttool.AssertExecute (MTouchAction.BuildSim, "build extension");
 
 				using (var apptool = new MTouchTool ()) {
 					apptool.Profile = Profile.iOS;
 					apptool.CreateTemporaryCacheDirectory ();
 					apptool.References = exttool.References;
-					apptool.CreateTemporaryApp (extraCode: @"[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } };", extraArg: $"-r:{StringUtils.Quote (apptool.References [0])}");
+					apptool.CreateTemporaryApp (extraCode: @"[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } };", extraArgs: new string [] { $"-r:{apptool.References [0]}" });
 					apptool.AppExtensions.Add (exttool);
 					apptool.AssertExecute (MTouchAction.BuildSim, "build app");
 
@@ -3512,7 +3532,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 				exttool.Linker = MTouchLinker.DontLink; // faster
 				exttool.References = new string [] { framework_binding_library };
 				exttool.CreateTemporaryCacheDirectory ();
-				exttool.CreateTemporaryServiceExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArg: $"-r:{StringUtils.Quote (exttool.References [0])}");
+				exttool.CreateTemporaryServiceExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArgs: new string [] { $"-r:{exttool.References [0]}" });
 				exttool.AssertExecute (MTouchAction.BuildSim, "build extension");
 
 				using (var apptool = new MTouchTool ()) {
@@ -3524,7 +3544,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 					var res = (Mono.Cecil.EmbeddedResource) ad.MainModule.Resources.Where ((v) => v.Name == "XTest.framework").First ();
 					File.WriteAllBytes (framework_zip, res.GetResourceData ());
 					File.WriteAllText (extra_content, "Hello world");
-					ExecutionHelper.Execute ("zip", $"{StringUtils.Quote (framework_zip)} {StringUtils.Quote (extra_content)}");
+					ExecutionHelper.Execute ("zip", new string [] { framework_zip, extra_content });
 					ad.MainModule.Resources.Remove (res);
 					ad.MainModule.Resources.Add (new Mono.Cecil.EmbeddedResource (res.Name, res.Attributes, File.ReadAllBytes (framework_zip)));
 					ad.Write (modified_framework_binding_library);
@@ -3533,7 +3553,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 					apptool.Linker = MTouchLinker.DontLink; // faster
 					apptool.References = new string [] { modified_framework_binding_library };
 					apptool.CreateTemporaryCacheDirectory ();
-					apptool.CreateTemporaryApp (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArg: $"-r:{StringUtils.Quote (apptool.References [0])}");
+					apptool.CreateTemporaryApp (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArgs: new string [] { $"-r:{apptool.References [0]}" });
 					apptool.AppExtensions.Add (exttool);
 					apptool.AssertExecuteFailure (MTouchAction.BuildSim, "build app");
 					apptool.AssertError (1035, "Cannot include different versions of the framework 'XTest.framework'");
@@ -3553,7 +3573,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 				service_ext.Linker = MTouchLinker.DontLink; // faster
 				service_ext.References = new string [] { GetFrameworksBindingLibrary (service_ext.Profile) };
 				service_ext.CreateTemporaryCacheDirectory ();
-				service_ext.CreateTemporaryServiceExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArg: $"-r:{StringUtils.Quote (service_ext.References [0])}");
+				service_ext.CreateTemporaryServiceExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArgs: new string [] { $"-r:{service_ext.References [0]}" });
 				service_ext.AssertExecute (MTouchAction.BuildSim, "build service extension");
 
 				using (var today_ext = new MTouchTool ()) {
@@ -3561,7 +3581,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 					today_ext.Linker = MTouchLinker.DontLink; // faster
 					today_ext.References = service_ext.References;
 					today_ext.CreateTemporaryCacheDirectory ();
-					today_ext.CreateTemporaryTodayExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArg: $"-r:{StringUtils.Quote (today_ext.References [0])}");
+					today_ext.CreateTemporaryTodayExtension (extraCode: "\n\n[Foundation.Preserve] class X { public X () { System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ()); } }", extraArgs: new string [] { $"-r:{today_ext.References [0]}" });
 					today_ext.AssertExecute (MTouchAction.BuildSim, "build today extension");
 
 					using (var apptool = new MTouchTool ()) {
@@ -3594,7 +3614,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 
 				// Create a sample exe
 				var code = "public class TestApp { static void Main () { System.Console.WriteLine (typeof (ObjCRuntime.Runtime).ToString ()); } }";
-				var exe = MTouch.CompileTestAppExecutable (tmp, code, "/debug:full", use_csc: false);
+				var exe = MTouch.CompileTestAppExecutable (tmp, code, new string [] { "/debug:full" }, use_csc: false);
 
 				mtouch.AppPath = mtouch.CreateTemporaryDirectory ();
 				mtouch.RootAssembly = exe;
@@ -3611,7 +3631,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 
 				EnsureFilestampChange ();
 				// Recompile the exe, adding only whitespace. This will only change the debug files
-				MTouch.CompileTestAppExecutable (tmp, "\n\n" + code + "\n\n", "/debug:full", use_csc: false);
+				MTouch.CompileTestAppExecutable (tmp, "\n\n" + code + "\n\n", new string [] { "/debug:full" }, use_csc: false);
 
 				// Rebuild the app
 				mtouch.AssertExecute (MTouchAction.BuildSim);
@@ -3711,7 +3731,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 				var dllB = Path.Combine (tmpB, Path.GetFileName (dllA));
 				File.Copy (dllA, dllB);
 
-				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArg: "-r:" + StringUtils.Quote (dllA));
+				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArgs: new string [] { "-r:" + dllA });
 				mtouch.References = new string [] { dllA, dllB };
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build");
@@ -3733,7 +3753,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 
 				var dllB = Path.Combine (Configuration.SdkRootXI, "lib", "mono", "Xamarin.iOS", Path.GetFileName (dllA));
 
-				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArg: "-r:" + StringUtils.Quote (dllA));
+				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArgs: new string [] { "-r:" + dllA });
 				mtouch.References = new string [] { dllA, dllB };
 
 				// Without the linker we'll just copy the references, and not actually run into problems if we copy one that doesn't work
@@ -3762,7 +3782,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 
 				var dllB = Path.Combine (Configuration.SdkRootXI, "lib", "mono", "Xamarin.iOS", Path.GetFileName (dllA));
 
-				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArg: "-r:" + StringUtils.Quote (dllA));
+				mtouch.CreateTemporaryApp (code: "public class C { static void Main () { System.Console.WriteLine (typeof (X)); System.Console.WriteLine (typeof (UIKit.UIWindow)); } }", extraArgs: new string [] { "-r:" + dllA });
 				mtouch.References = new string [] { dllB, dllA };
 
 				// Without the linker we'll just copy the references, and not actually run into problems if we copy one that doesn't work
@@ -3938,7 +3958,7 @@ public class HandlerTest
 				string libraryPath = Path.Combine (Configuration.SourceRoot, "tests", "common", "MixedClassLibrary.dll");
 
 				mtouch.CreateTemporaryApp (code: "public class TestApp { static void Main () { System.Console.WriteLine (typeof (MixedClassLibrary.Class1)); System.Console.WriteLine (typeof (ObjCRuntime.Runtime)); } }",
-										   extraArg: $"-r:Xamarin.iOS.dll -r:{StringUtils.Quote (libraryPath)}");
+										   extraArgs: new string [] { $"-r:Xamarin.iOS.dll", $"-r:{libraryPath}" });
 				mtouch.CreateTemporaryCacheDirectory ();
 				mtouch.References = new string [] { libraryPath };
 				if (nofastsim)
@@ -3968,7 +3988,7 @@ public class HandlerTest
 		{
 			using (var mtouch = new MTouchTool ()) {
 				// Compile the managed executable twice, the second time without debugging symbols, which will cause the debugging symbols to become stale
-				mtouch.CreateTemporaryApp (extraArg: "/debug:full", use_csc: use_csc);
+				mtouch.CreateTemporaryApp (extraArgs: new string [] { "/debug:full" }, use_csc: use_csc);
 				mtouch.CreateTemporaryApp ();
 				mtouch.Linker = MTouchLinker.DontLink; // makes the test faster
 				mtouch.Debug = true; // makes the test faster because it makes simlauncher possible
@@ -3983,10 +4003,10 @@ public class HandlerTest
 		{
 			using (var mtouch = new MTouchTool ()) {
 				// Compile the managed executable twice, both times with debugging symbols, but restore the debugging symbols from the first build so that they're stale
-				mtouch.CreateTemporaryApp (extraArg: "/debug:full", use_csc: use_csc);
+				mtouch.CreateTemporaryApp (extraArgs: new string [] { "/debug:full" }, use_csc: use_csc);
 				var symbol_file = use_csc ? Path.ChangeExtension (mtouch.RootAssembly, "pdb") : mtouch.RootAssembly + ".mdb";
 				var symbols = File.ReadAllBytes (symbol_file);
-				mtouch.CreateTemporaryApp (extraArg: "/debug:full", use_csc: use_csc);
+				mtouch.CreateTemporaryApp (extraArgs: new string [] { "/debug:full" }, use_csc: use_csc);
 				File.WriteAllBytes (symbol_file, symbols);
 				mtouch.Linker = MTouchLinker.DontLink; // makes the test faster
 				mtouch.Debug = true; // makes the test faster because it makes simlauncher possible
@@ -4003,7 +4023,7 @@ public class HandlerTest
 		{
 			using (var mtouch = new MTouchTool ()) {
 				// (Over)write invalid data in the debug symbol file
-				mtouch.CreateTemporaryApp (use_csc, extraArg: compile_with_debug_symbols ? "/debug:full" : string.Empty);
+				mtouch.CreateTemporaryApp (use_csc, extraArgs: compile_with_debug_symbols ? new string [] { "/debug:full" } : Array.Empty<string> ());
 				var symbol_file = use_csc ? Path.ChangeExtension (mtouch.RootAssembly, "pdb") : mtouch.RootAssembly + ".mdb";
 				File.WriteAllText (symbol_file, "invalid stuff");
 				mtouch.Linker = MTouchLinker.DontLink; // makes the test faster
@@ -4175,8 +4195,8 @@ public partial class KeyboardViewController : UIKit.UIInputViewController
 					apptool.Linker = MTouchLinker.DontLink;
 					apptool.AssertExecute (MTouchAction.BuildDev, "build app");
 
-					var sdk = StringUtils.Quote (Path.Combine (apptool.Cache, "arm64", "Xamarin.Sdk"));
-					var shared_libraries = ExecutionHelper.Execute ("otool", $"-L {sdk}", hide_output: true);
+					var sdk = Path.Combine (apptool.Cache, "arm64", "Xamarin.Sdk");
+					var shared_libraries = ExecutionHelper.Execute ("otool", new string [] { "-L", sdk }, hide_output: true);
 					Asserts.DoesNotContain ("Private", shared_libraries, "Private");
 
 					exttool.AssertNoWarnings();
@@ -4299,22 +4319,35 @@ public class Dummy {
 			var environment_variables = new Dictionary<string, string> ();
 			if (!clean_simulator)
 				environment_variables ["SKIP_SIMULATOR_SETUP"] = "1";
-			ExecutionHelper.Execute ("mono", $"{StringUtils.Quote (Path.Combine (Configuration.RootPath, "tests", "xharness", "xharness.exe"))} --run {StringUtils.Quote (csprojpath)} --target ios-simulator-64 --sdkroot {Configuration.xcode_root} --logdirectory {StringUtils.Quote (Path.Combine (tmpdir, "log.txt"))} --configuration {configuration}", environmentVariables: environment_variables);
+
+			var args = new List<string> ();
+			args.Add (Path.Combine (Configuration.RootPath, "tests", "xharness", "xharness.exe"));
+			args.Add ("--run");
+			args.Add (csprojpath);
+			args.Add ("--target");
+			args.Add ("ios-simulator-64");
+			args.Add ("--sdkroot");
+			args.Add (Configuration.xcode_root);
+			args.Add ("--logdirectory");
+			args.Add (Path.Combine (tmpdir, "log.txt"));
+			args.Add ("--configuration");
+			args.Add (configuration);
+			ExecutionHelper.Execute ("mono", args, environmentVariables: environment_variables);
 		}
 
-		public static string CompileTestAppExecutable (string targetDirectory, string code = null, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp", string extraCode = null, string usings = null, bool use_csc = true)
+		public static string CompileTestAppExecutable (string targetDirectory, string code = null, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp", string extraCode = null, string usings = null, bool use_csc = true)
 		{
-			return BundlerTool.CompileTestAppExecutable (targetDirectory, code, extraArg, profile, appName, extraCode, usings, use_csc);
+			return BundlerTool.CompileTestAppExecutable (targetDirectory, code, extraArgs, profile, appName, extraCode, usings, use_csc);
 		}
 
-		public static string CompileTestAppLibrary (string targetDirectory, string code, string extraArg = null, Profile profile = Profile.iOS, string appName = "testApp")
+		public static string CompileTestAppLibrary (string targetDirectory, string code, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp")
 		{
-			return BundlerTool.CompileTestAppLibrary (targetDirectory, code, extraArg, profile, appName);
+			return BundlerTool.CompileTestAppLibrary (targetDirectory, code, extraArgs, profile, appName);
 		}
 
 		public static string CompileTestAppCode (string target, string targetDirectory, string code, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp", bool use_csc = true)
 		{
-			return BundlerTool.CompileTestAppCode (target, targetDirectory, code, extraArg, profile, appName, use_csc);
+			return BundlerTool.CompileTestAppCode (target, targetDirectory, code, new string [] { extraArg }, profile, appName, use_csc);
 		}
 
 		static string CreateBindingLibrary (string targetDirectory, string nativeCode, string bindingCode, string linkWith = null, string extraCode = "", string name = "binding", string[] references = null, string arch = "armv7")
@@ -4340,8 +4373,14 @@ using ObjCRuntime;
 			var x = Path.Combine (targetDirectory, $"extra{name}Code.cs");
 			File.WriteAllText (x, extraCode);
 
-			ExecutionHelper.Execute (Configuration.BtouchPath,
-			                         string.Format ("{0} --out:{1} --link-with={2},{3} -x:{4} {5}", cs, dll, o, Path.GetFileName (o), x, references == null ? string.Empty : string.Join (", ", references.Select ((v) => "-r:" + v))));
+			var args = new List<string> ();
+			args.Add (cs);
+			args.Add ("--out:" + dll);
+			args.Add ("--link-with=" + o + "," + Path.GetFileName (o));
+			args.Add ("-x" + x);
+			if (references != null)
+				args.AddRange (references.Select ((v) => "-r:" + v));
+			ExecutionHelper.Execute (Configuration.BtouchPath, args);
 
 			return dll;
 		}
@@ -4373,9 +4412,22 @@ using ObjCRuntime;
 				throw new NotImplementedException ();
 			}
 
-			string args = $"-gdwarf-2 -arch {arch} -std=c99 -isysroot {Configuration.xcode_root}/Platforms/{sdk}.platform/Developer/SDKs/{sdk}{Configuration.sdk_version}.sdk -m{min_os_version} -c -DDEBUG  -o {o} -x objective-c {m}";
+			var args = new List<string> ();
+			args.Add ("-gdwarf-2");
+			args.Add ("-arch");
+			args.Add (arch);
+			args.Add ("-std=c99");
+			args.Add ("-isysroot");
+			args.Add ($"{Configuration.xcode_root}/Platforms/{sdk}.platform/Developer/SDKs/{sdk}{Configuration.sdk_version}.sdk");
+			args.Add ($"-m{min_os_version}");
+			args.Add ("-c");
+			args.Add ("-DDEBUG");
+			args.Add ("-o");
+			args.Add (o);
+			args.Add ("-x");
+			args.Add ("objective-c");
+			args.Add (m);
 
-			Console.WriteLine ("{0} {1}", fileName, args);
 			if (ExecutionHelper.Execute (fileName, args, out output) != 0) {
 				Console.WriteLine (output);
 				throw new Exception (output);
@@ -4391,17 +4443,16 @@ using ObjCRuntime;
 				File.WriteAllText (tmpFile, code);
 
 				string output;
-				var args = new StringBuilder ();
+				var args = new List<string> ();
 				var compiler = GetCompiler (profile, args);
 
-				args.Append (" -target:").Append (outputPath.EndsWith (".dll", StringComparison.Ordinal) ? "library" : "exe");
-				args.Append (" -r:").Append (StringUtils.Quote (GetBaseLibrary (profile)));
-				args.Append (" -out:").Append (StringUtils.Quote (outputPath));
-				args.Append (" ").Append (StringUtils.Quote (tmpFile));
-				foreach (var aa in additional_arguments)
-					args.Append (" ").Append (aa);
+				args.Add ($"-target:{(outputPath.EndsWith (".dll", StringComparison.Ordinal) ? "library" : "exe")}");
+				args.Add ($"-r:{GetBaseLibrary (profile)}");
+				args.Add ($"-out:{outputPath}");
+				args.Add (tmpFile);
+				args.AddRange (additional_arguments);
 
-				if (ExecutionHelper.Execute (compiler, args.ToString (), out output) != 0)
+				if (ExecutionHelper.Execute (compiler, args, out output) != 0)
 					throw new Exception (output);
 			} finally {
 				File.Delete (tmpFile);
@@ -4429,10 +4480,16 @@ public class TestApp {
  }");
 
 			string output;
-			var args = new StringBuilder ();
-			args.AppendFormat ("\"{0}\" /noconfig /t:exe /nologo /out:\"{1}\" \"/r:{2}\" /r:\"{3}\"", cs, exe, GetBaseLibrary (profile), GetBindingsLibrary (profile));
+			var args = new List<string> ();
+			args.Add (cs);
+			args.Add ("/noconfig");
+			args.Add ("/t:exe");
+			args.Add ("/nologo");
+			args.Add ($"/out:{exe}");
+			args.Add ($"/r:{GetBaseLibrary (profile)}");
+			args.Add ($"/r:{GetBindingsLibrary (profile)}");
 			var compiler = GetCompiler (profile, args);
-			if (ExecutionHelper.Execute (compiler, args.ToString (), out output) != 0)
+			if (ExecutionHelper.Execute (compiler, args, out output) != 0)
 				throw new Exception (output);
 
 			compiled_linkwith_apps [profile] = exe;
@@ -4468,9 +4525,11 @@ public class TestApp {
 
 		public static IEnumerable<string> GetNativeSymbols (string file, string arch = null)
 		{
-			var arguments = $"-gUjA {StringUtils.Quote (file)}";
-			if (!string.IsNullOrEmpty (arch))
-				arguments += " -arch " + arch;
+			var arguments = new List<string> (new string [] { "-gUjA", file });
+			if (!string.IsNullOrEmpty (arch)) {
+				arguments.Add ("-arch");
+				arguments.Add (arch);
+			}
 			var symbols = ExecutionHelper.Execute ("nm", arguments, hide_output: true).Split ('\n');
 			return symbols.Where ((v) => {
 				return !v.EndsWith (": no symbols", StringComparison.Ordinal);
@@ -4486,7 +4545,7 @@ public class TestApp {
 		public static bool IsAPFS {
 			get {
 				if (!is_apfs.HasValue) {
-					var exit_code = ExecutionHelper.Execute ("/bin/df", "-t apfs /", out var output, TimeSpan.FromSeconds (10));
+					var exit_code = ExecutionHelper.Execute ("/bin/df", new string [] { "-t", "apfs", "/" }, out var output, TimeSpan.FromSeconds (10));
 					is_apfs = exit_code == 0 && output.Trim ().Split ('\n').Length >= 2;
 				}
 				return is_apfs.Value;

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -87,12 +87,35 @@ namespace Xamarin
 
 		public int LaunchOnDevice (DeviceInfo device, string appPath, bool waitForUnlock, bool waitForExit)
 		{
-			return Execute ("--devname \"{0}\" --launchdev \"{1}\" --sdkroot \"{2}\" --wait-for-unlock:{3} --wait-for-exit:{4} {5}", device.Name, appPath, Configuration.xcode_root, waitForUnlock ? "yes" : "no", waitForExit ? "yes" : "no", GetVerbosity ());
+			var args = new List<string> ();
+			args.AddRange (
+				new string [] {
+					"--devname", device.Name,
+					"--launchdev", AppPath,
+					"--sdkroot", Configuration.xcode_root,
+					$"--wait-for-unlock:{(waitForUnlock ? "yes" : "no")}",
+					$"--wait-for-exit:{(waitForExit ? "yes" : "no")}",
+				}
+			);
+			GetVerbosity (args);
+			return Execute (args);
 		}
 
 		public int InstallOnDevice (DeviceInfo device, string appPath, string devicetype = null)
 		{
-			return Execute ("--devname \"{0}\" --installdev \"{1}\" --sdkroot \"{2}\" {3} {4}", device.Name, appPath, Configuration.xcode_root, GetVerbosity (), devicetype == null ? string.Empty : "--device " + devicetype);
+			var args = new List<string> ();
+			args.AddRange (
+				new string [] {
+					"--devname", device.Name,
+					"--installdev", AppPath,
+					"--sdkroot", Configuration.xcode_root,
+			});
+			GetVerbosity (args);
+			if (devicetype != null) {
+				args.Add ("--device");
+				args.Add (devicetype);
+			}
+			return Execute (args);
 		}
 
 		// The default is to build for the simulator
@@ -224,7 +247,7 @@ namespace Xamarin
 			}
 		}
 
-		protected override void BuildArguments (StringBuilder sb)
+		protected override void BuildArguments (IList<string> sb)
 		{
 			base.BuildArguments (sb);
 
@@ -235,75 +258,84 @@ namespace Xamarin
 				MTouch.AssertDeviceAvailable ();
 				if (AppPath == null)
 					throw new Exception ("No AppPath specified.");
-				sb.Append (" --dev ").Append (StringUtils.Quote (AppPath));
+				sb.Add ("--dev");
+				sb.Add (AppPath);
 				break;
 			case MTouchAction.BuildSim:
 				if (AppPath == null)
 					throw new Exception ("No AppPath specified.");
-				sb.Append (" --sim ").Append (StringUtils.Quote (AppPath));
+				sb.Add ("--sim");
+				sb.Add (AppPath);
 				break;
 			case MTouchAction.LaunchSim:
 				if (AppPath == null)
 					throw new Exception ("No AppPath specified.");
-				sb.Append (" --launchsim ").Append (StringUtils.Quote (AppPath));
+				sb.Add ("--launchsim");
+				sb.Add (AppPath);
 				break;
 			default:
 				throw new NotImplementedException ();
 			}
 
 			if (FastDev.HasValue && FastDev.Value)
-				sb.Append (" --fastdev");
+				sb.Add ("--fastdev");
 
 			if (PackageMdb.HasValue)
-				sb.Append (" --package-mdb:").Append (PackageMdb.Value ? "true" : "false");
+				sb.Add ($"--package-mdb:{(PackageMdb.Value ? "true" : "false")}");
 
 			if (NoStrip.HasValue && NoStrip.Value)
-				sb.Append (" --nostrip");
+				sb.Add ("--nostrip");
 
 			if (NoSymbolStrip != null) {
 				if (NoSymbolStrip.Length == 0) {
-					sb.Append (" --nosymbolstrip");
+					sb.Add ("--nosymbolstrip");
 				} else {
-					sb.Append (" --nosymbolstrip:").Append (NoSymbolStrip);
+					sb.Add ($"--nosymbolstrip:{NoSymbolStrip}");
 				}
 			}
 
 			if (!string.IsNullOrEmpty (SymbolList))
-				sb.Append (" --symbollist=").Append (StringUtils.Quote (SymbolList));
+				sb.Add ($"--symbollist={SymbolList}");
 
 			if (MSym.HasValue)
-				sb.Append (" --msym:").Append (MSym.Value ? "true" : "false");
+				sb.Add ($"--msym:{(MSym.Value ? "true" : "false")}");
 
 			if (DSym.HasValue)
-				sb.Append (" --dsym:").Append (DSym.Value ? "true" : "false");
+				sb.Add ($"--dsym:{(DSym.Value ? "true" : "false")}");
 
-			foreach (var appext in AppExtensions)
-				sb.Append (" --app-extension ").Append (StringUtils.Quote (appext.AppPath));
+			foreach (var appext in AppExtensions) {
+				sb.Add ($"--app-extension");
+				sb.Add (appext.AppPath);
+			}
 
-			foreach (var framework in Frameworks)
-				sb.Append (" --framework ").Append (StringUtils.Quote (framework));
+			foreach (var framework in Frameworks) {
+				sb.Add ($"--framework");
+				sb.Add (framework);
+			}
 
 			if (!string.IsNullOrEmpty (Mono))
-				sb.Append (" --mono:").Append (StringUtils.Quote (Mono));
+				sb.Add ($"--mono:{Mono}");
 			
 			if (Dlsym.HasValue)
-				sb.Append (" --dlsym:").Append (Dlsym.Value ? "true" : "false");
-			
-			if (!string.IsNullOrEmpty (Executable))
-				sb.Append (" --executable ").Append (StringUtils.Quote (Executable));
+				sb.Add ($"--dlsym:{(Dlsym.Value ? "true" : "false")}");
+
+			if (!string.IsNullOrEmpty (Executable)) {
+				sb.Add ("--executable");
+				sb.Add (Executable);
+			}
 
 			switch (SymbolMode) {
 			case MTouchSymbolMode.Ignore:
-				sb.Append (" --dynamic-symbol-mode=ignore");
+				sb.Add ("--dynamic-symbol-mode=ignore");
 				break;
 			case MTouchSymbolMode.Code:
-				sb.Append (" --dynamic-symbol-mode=code");
+				sb.Add ("--dynamic-symbol-mode=code");
 				break;
 			case MTouchSymbolMode.Default:
-				sb.Append (" --dynamic-symbol-mode=default");
+				sb.Add ("--dynamic-symbol-mode=default");
 				break;
 			case MTouchSymbolMode.Linker:
-				sb.Append (" --dynamic-symbol-mode=linker");
+				sb.Add ("--dynamic-symbol-mode=linker");
 				break;
 			case MTouchSymbolMode.Unspecified:
 				break;
@@ -312,25 +344,25 @@ namespace Xamarin
 			}
 
 			if (NoFastSim.HasValue && NoFastSim.Value)
-				sb.Append (" --nofastsim");
+				sb.Add ("--nofastsim");
 
 			if (!string.IsNullOrEmpty (Device))
-				sb.Append (" --device:").Append (StringUtils.Quote (Device));
+				sb.Add ($"--device:{Device}");
 
 			if (!string.IsNullOrEmpty (LLVMOptimizations))
-				sb.Append (" --llvm-opt=").Append (StringUtils.Quote (LLVMOptimizations));
+				sb.Add ($"--llvm-opt={LLVMOptimizations}");
 			
 			if (Bitcode != MTouchBitcode.Unspecified)
-				sb.Append (" --bitcode:").Append (Bitcode.ToString ().ToLower ());
+				sb.Add ($"--bitcode:{Bitcode.ToString ().ToLower ()}");
 
 			foreach (var abt in AssemblyBuildTargets)
-				sb.Append (" --assembly-build-target=").Append (StringUtils.Quote (abt));
+				sb.Add ($"--assembly-build-target={abt}");
 
 			if (!string.IsNullOrEmpty (AotArguments))
-				sb.Append (" --aot:").Append (StringUtils.Quote (AotArguments));
+				sb.Add ($"--aot:{AotArguments}");
 
 			if (!string.IsNullOrEmpty (AotOtherArguments))
-				sb.Append (" --aot-options:").Append (StringUtils.Quote (AotOtherArguments));
+				sb.Add ($"--aot-options:{AotOtherArguments}");
 		}
 
 		XmlDocument FetchDeviceList (bool allowCache = true)
@@ -338,7 +370,7 @@ namespace Xamarin
 			if (device_list_cache == null || !allowCache) {
 				var output_file = Path.GetTempFileName ();
 				try {
-					if (Execute ("--listdev:{1} --sdkroot {0} --output-format xml", Configuration.xcode_root, output_file) != 0)
+					if (Execute (new string [] { "--listdev", output_file, "--sdkroot", Configuration.xcode_root }) != 0)
 						throw new Exception ("Failed to list devices.");
 					device_list_cache = new XmlDocument ();
 					device_list_cache.Load (output_file);
@@ -455,13 +487,18 @@ namespace Xamarin
 			return MTouch.CompileTestAppLibrary (asm_dir, "class X {}", appName: Path.GetFileNameWithoutExtension (asm_name));
 		}
 
-		public override void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, string extraArg = "", string extraCode = null, string usings = null, bool use_csc = true)
+		public override void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, IList<string> extraArgs = null, string extraCode = null, string usings = null, bool use_csc = true)
 		{
 			Profile = profile;
-			CreateTemporaryApp (appName: appName, code: code, extraArg: extraArg, extraCode: extraCode, usings: usings, use_csc: use_csc);
+			CreateTemporaryApp (appName: appName, code: code, extraArgs: extraArgs, extraCode: extraCode, usings: usings, use_csc: use_csc);
 		}
 
-		public void CreateTemporaryApp (bool hasPlist = false, string appName = "testApp", string code = null, string extraArg = "", string extraCode = null, string usings = null, bool use_csc = true)
+		public void CreateTemporaryApp ()
+		{
+			CreateTemporaryApp (false, "testApp", null, (IList<string>) null);
+		}
+
+		public void CreateTemporaryApp (bool hasPlist = false, string appName = "testApp", string code = null, IList<string> extraArgs = null, string extraCode = null, string usings = null, bool use_csc = true)
 		{
 			string testDir;
 			if (RootAssembly == null) {
@@ -473,13 +510,13 @@ namespace Xamarin
 			var app = AppPath ?? Path.Combine (testDir, appName + ".app");
 			Directory.CreateDirectory (app);
 			AppPath = app;
-			RootAssembly = CompileTestAppExecutable (testDir, code, extraArg, Profile, appName, extraCode, usings, use_csc);
+			RootAssembly = CompileTestAppExecutable (testDir, code, extraArgs, Profile, appName, extraCode, usings, use_csc);
 
 			if (hasPlist)
 				File.WriteAllText (Path.Combine (app, "Info.plist"), CreatePlist (Profile, appName));
 		}
 
-		public void CreateTemporaryServiceExtension (string code = null, string extraCode = null, string extraArg = null, string appName = "testServiceExtension")
+		public void CreateTemporaryServiceExtension (string code = null, string extraCode = null, IList<string> extraArgs = null, string appName = "testServiceExtension")
 		{
 			string testDir;
 			if (RootAssembly == null) {
@@ -504,7 +541,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 
 			AppPath = app;
 			Extension = true;
-			RootAssembly = MTouch.CompileTestAppLibrary (testDir, code: code, profile: Profile, extraArg: extraArg, appName: appName);
+			RootAssembly = MTouch.CompileTestAppLibrary (testDir, code: code, profile: Profile, extraArgs: extraArgs, appName: appName);
 
 			var info_plist = 
 @"<?xml version=""1.0"" encoding=""UTF-8""?>
@@ -544,7 +581,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 				File.WriteAllText (plist_path, info_plist);
 		}
 
-		public void CreateTemporaryTodayExtension (string code = null, string extraCode = null, string extraArg = null, string appName = "testTodayExtension")
+		public void CreateTemporaryTodayExtension (string code = null, string extraCode = null, IList<string> extraArgs = null, string appName = "testTodayExtension")
 		{
 			string testDir;
 			if (RootAssembly == null) {
@@ -581,7 +618,7 @@ public partial class TodayViewController : UIViewController, INCWidgetProviding
 
 			AppPath = app;
 			Extension = true;
-			RootAssembly = MTouch.CompileTestAppLibrary (testDir, code: code, profile: Profile, extraArg: extraArg, appName: appName);
+			RootAssembly = MTouch.CompileTestAppLibrary (testDir, code: code, profile: Profile, extraArgs: extraArgs, appName: appName);
 
 			var info_plist = // FIXME: this includes a NSExtensionMainStoryboard key which points to a non-existent storyboard. This won't matter as long as we're only building, and not running the extension.
 @"<?xml version=""1.0"" encoding=""UTF-8""?>
@@ -621,7 +658,7 @@ public partial class TodayViewController : UIViewController, INCWidgetProviding
 				File.WriteAllText (plist_path, info_plist);
 		}
 
-		public void CreateTemporaryWatchKitExtension (string code = null, string extraCode = null, string extraArg = "")
+		public void CreateTemporaryWatchKitExtension (string code = null, string extraCode = null, IList<string> extraArgs = null)
 		{
 			string testDir;
 			if (RootAssembly == null) {
@@ -646,7 +683,7 @@ public partial class NotificationController : WKUserNotificationInterfaceControl
 
 			AppPath = app;
 			Extension = true;
-			RootAssembly = MTouch.CompileTestAppLibrary (testDir, code: code, extraArg: extraArg, profile: Profile);
+			RootAssembly = MTouch.CompileTestAppLibrary (testDir, code: code, extraArgs: extraArgs, profile: Profile);
 
 			File.WriteAllText (Path.Combine (app, "Info.plist"), @"<?xml version=""1.0"" encoding=""UTF-8""?>
 <!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
@@ -805,7 +842,14 @@ public class IntentHandler : INExtension, IINRidesharingDomainHandling {
 
 		public static IEnumerable<string> GetNativeSymbolsInExecutable (string executable, string arch = null)
 		{
-			IEnumerable<string> rv = ExecutionHelper.Execute ("nm", $"{(arch == null ? string.Empty : $"-arch {arch} ")}-gUj {StringUtils.Quote (executable)}", hide_output: true).Split ('\n');
+			var args = new List<string> ();
+			if (arch != null) {
+				args.Add ("-arch");
+				args.Add (arch);
+			}
+			args.Add ("-gUj");
+			args.Add (executable);
+			IEnumerable<string> rv = ExecutionHelper.Execute ("nm", args, hide_output: true).Split ('\n');
 			
 			rv = rv.Where ((v) => {
 				if (string.IsNullOrEmpty (v))

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -89,7 +89,7 @@ namespace Xamarin
 		{
 			var args = new List<string> ();
 			args.AddRange (
-				new string [] {
+				new [] {
 					"--devname", device.Name,
 					"--launchdev", AppPath,
 					"--sdkroot", Configuration.xcode_root,
@@ -105,7 +105,7 @@ namespace Xamarin
 		{
 			var args = new List<string> ();
 			args.AddRange (
-				new string [] {
+				new [] {
 					"--devname", device.Name,
 					"--installdev", AppPath,
 					"--sdkroot", Configuration.xcode_root,
@@ -370,7 +370,7 @@ namespace Xamarin
 			if (device_list_cache == null || !allowCache) {
 				var output_file = Path.GetTempFileName ();
 				try {
-					if (Execute (new string [] { "--listdev", output_file, "--sdkroot", Configuration.xcode_root }) != 0)
+					if (Execute (new [] { "--listdev", output_file, "--sdkroot", Configuration.xcode_root }) != 0)
 						throw new Exception ("Failed to list devices.");
 					device_list_cache = new XmlDocument ();
 					device_list_cache.Load (output_file);

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -97,7 +97,7 @@ namespace Xamarin
 					$"--wait-for-exit:{(waitForExit ? "yes" : "no")}",
 				}
 			);
-			GetVerbosity (args);
+			AddVerbosity (args);
 			return Execute (args);
 		}
 
@@ -110,7 +110,7 @@ namespace Xamarin
 					"--installdev", AppPath,
 					"--sdkroot", Configuration.xcode_root,
 			});
-			GetVerbosity (args);
+			AddVerbosity (args);
 			if (devicetype != null) {
 				args.Add ("--device");
 				args.Add (devicetype);

--- a/tests/mtouch/MonoNativeTests.cs
+++ b/tests/mtouch/MonoNativeTests.cs
@@ -140,7 +140,7 @@ namespace Xamarin
 				var mono_native_path = Path.Combine (mtouch.AppPath, mono_native_dylib);
 
 				var symbols = MTouch.GetNativeSymbols (mono_native_path);
-				var otool_dylib = ExecutionHelper.Execute ("otool", new string [] { "-L", mono_native_path }, hide_output: true);
+				var otool_dylib = ExecutionHelper.Execute ("otool", new [] { "-L", mono_native_path }, hide_output: true);
 
 				Assert.That (symbols, Does.Contain ("_mono_native_initialize"));
 				Assert.That (otool_dylib, Does.Contain ($"@rpath/{mono_native_dylib}"));
@@ -154,7 +154,7 @@ namespace Xamarin
 					Assert.That (otool_dylib, Does.Not.Contain ("/System/Library/Frameworks/GSS.framework/GSS"));
 				}
 
-				var otool_exe = ExecutionHelper.Execute ("otool", new string [] { "-L", mtouch.NativeExecutablePath }, hide_output: true);
+				var otool_exe = ExecutionHelper.Execute ("otool", new [] { "-L", mtouch.NativeExecutablePath }, hide_output: true);
 				Assert.That (otool_exe, Does.Not.Contain ("GSS"));
 				Assert.That (otool_exe, Does.Contain ($"@rpath/{mono_native_dylib}"));
 			}
@@ -189,7 +189,7 @@ namespace Xamarin
 				Assert.That (symbols, Does.Contain ("_mono_native_initialize"));
 				Assert.That (symbols, Does.Contain ("_NetSecurityNative_ImportUserName"));
 
-				var otool_exe = ExecutionHelper.Execute ("otool", new string [] { "-L", mtouch.NativeExecutablePath }, hide_output: true);
+				var otool_exe = ExecutionHelper.Execute ("otool", new [] { "-L", mtouch.NativeExecutablePath }, hide_output: true);
 				Assert.That (otool_exe, Does.Contain ("/System/Library/Frameworks/GSS.framework/GSS"));
 			}
 		}

--- a/tests/mtouch/MonoNativeTests.cs
+++ b/tests/mtouch/MonoNativeTests.cs
@@ -140,7 +140,7 @@ namespace Xamarin
 				var mono_native_path = Path.Combine (mtouch.AppPath, mono_native_dylib);
 
 				var symbols = MTouch.GetNativeSymbols (mono_native_path);
-				var otool_dylib = ExecutionHelper.Execute ("otool", $"-L {StringUtils.Quote (mono_native_path)}", hide_output: true);
+				var otool_dylib = ExecutionHelper.Execute ("otool", new string [] { "-L", mono_native_path }, hide_output: true);
 
 				Assert.That (symbols, Does.Contain ("_mono_native_initialize"));
 				Assert.That (otool_dylib, Does.Contain ($"@rpath/{mono_native_dylib}"));
@@ -154,7 +154,7 @@ namespace Xamarin
 					Assert.That (otool_dylib, Does.Not.Contain ("/System/Library/Frameworks/GSS.framework/GSS"));
 				}
 
-				var otool_exe = ExecutionHelper.Execute ("otool", $"-L {StringUtils.Quote (mtouch.NativeExecutablePath)}", hide_output: true);
+				var otool_exe = ExecutionHelper.Execute ("otool", new string [] { "-L", mtouch.NativeExecutablePath }, hide_output: true);
 				Assert.That (otool_exe, Does.Not.Contain ("GSS"));
 				Assert.That (otool_exe, Does.Contain ($"@rpath/{mono_native_dylib}"));
 			}
@@ -189,7 +189,7 @@ namespace Xamarin
 				Assert.That (symbols, Does.Contain ("_mono_native_initialize"));
 				Assert.That (symbols, Does.Contain ("_NetSecurityNative_ImportUserName"));
 
-				var otool_exe = ExecutionHelper.Execute ("otool", $"-L {StringUtils.Quote (mtouch.NativeExecutablePath)}", hide_output: true);
+				var otool_exe = ExecutionHelper.Execute ("otool", new string [] { "-L", mtouch.NativeExecutablePath }, hide_output: true);
 				Assert.That (otool_exe, Does.Contain ("/System/Library/Frameworks/GSS.framework/GSS"));
 			}
 		}

--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -93,7 +93,7 @@ class C { static void Main () {} }
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.Linker = MTouchLinker.DontLink; // faster
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (code: code, extraArgs: new string [] { "-debug" });
+				mtouch.CreateTemporaryApp (code: code, extraArgs: new [] { "-debug" });
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
 				mtouch.AssertError (4138, "The registrar cannot marshal the property type 'System.Object' of the property 'Foo.Bar10'.", "testApp.cs", 54);
 				mtouch.AssertError (4136, "The registrar cannot marshal the parameter type 'System.Object[]' of the parameter 'arg' in the method 'Foo.Bar1(System.Object[])'", "testApp.cs", 7);
@@ -132,7 +132,7 @@ class DateMembers : NSObject {
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -169,7 +169,7 @@ class DateMembers : NSObject {
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -202,7 +202,7 @@ class ArgCount : NSObject {
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -232,7 +232,7 @@ class ArgCount : NSObject {
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -272,7 +272,7 @@ class MyObjectErr : NSObject, IFoo1, IFoo2
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: str1, usings: "using Foundation; using System;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: str1, usings: "using Foundation; using System;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -314,7 +314,7 @@ class MyObjectErr : NSObject, IFoo1, IFoo2
 					sb.AppendLine ($"System.Console.WriteLine (typeof ({t.Namespace}.{t.Name}));");
 				sb.AppendLine ("}}");
 
-				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), usings: "using System; using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), usings: "using System; using Foundation; using ObjCRuntime;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.LinkSdk;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure (MTouchAction.BuildDev);
@@ -358,7 +358,7 @@ class C : NSObject {
 }";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -380,7 +380,7 @@ class C : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -404,7 +404,7 @@ class C : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -432,7 +432,7 @@ class C : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -458,7 +458,7 @@ class C : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -478,7 +478,7 @@ class C : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecute ();
@@ -498,7 +498,7 @@ class C : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -522,7 +522,7 @@ interface IProtocol2 {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -546,7 +546,7 @@ public static class Category
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -567,7 +567,7 @@ public static class Category
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -588,7 +588,7 @@ public static class Category
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -614,7 +614,7 @@ public class Category2 : INativeObject
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System; using ObjCRuntime;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -636,7 +636,7 @@ public class Category<T>
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -659,7 +659,7 @@ public class Category
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -686,7 +686,7 @@ public class Category2
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -712,7 +712,7 @@ public class Category
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -735,7 +735,7 @@ public class Category
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -768,7 +768,7 @@ public class Category
 					sb.AppendLine ($"\tpublic void X{i} () {{}}");
 				}
 				sb.AppendLine ("}");
-				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArgs: new string [] { "-debug" });
+				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArgs: new [] { "-debug" });
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
@@ -812,7 +812,7 @@ public struct FooF { public NSObject Obj; }
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -887,7 +887,7 @@ public struct FooF { public NSObject Obj; }
 				mtouch.Profile = profile;
 				mtouch.Linker = linker;
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new string [] { "-debug" }, usings: "using System;\nusing Foundation;\nusing ObjCRuntime;\n");
+				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new [] { "-debug" }, usings: "using System;\nusing Foundation;\nusing ObjCRuntime;\n");
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
 				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a base type of CurrentType) is not available in {name} .* (it was introduced in {name} 99.0.0): 'use Z instead'. Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", custom_pattern_syntax: true);
 				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a base type of CurrentType) is not available in {name} .* (it was introduced in {name} 89.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", custom_pattern_syntax: true);
@@ -931,7 +931,7 @@ public struct FooF { public NSObject Obj; }
 				sb.AppendLine ("}");
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArgs: new string [] { "-debug" });
+				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArgs: new [] { "-debug" });
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
 				foreach (var kw in objective_c_keywords)
 					mtouch.AssertError (4164, $"Cannot export the property 'X{kw}' because its selector '{kw}' is an Objective-C keyword. Please use a different name.", "testApp.cs");
@@ -952,7 +952,7 @@ class X : ReplayKit.RPBroadcastControllerDelegate
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using System; using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using System; using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecute ();
@@ -994,7 +994,7 @@ class X : ReplayKit.RPBroadcastControllerDelegate
 				mtouch.CustomArguments = new string [] { "--marshal-objectivec-exceptions=throwmanaged" };
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArgs: new string [] { "-debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArgs: new [] { "-debug:full" });
 				mtouch.AssertExecuteFailure (MTouchAction.BuildDev, "build");
 				mtouch.AssertError (4169, $"Failed to generate a P/Invoke wrapper for objc_msgSend(System.Object): The registrar cannot get the ObjectiveC type for managed type `System.Object`.");
 			}
@@ -1020,7 +1020,7 @@ class X : ReplayKit.RPBroadcastControllerDelegate
 				}";
 				mtouch.Linker = MTouchLinker.DontLink; // faster
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new string [] { "-debug" });
+				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new [] { "-debug" });
 				mtouch.CreateTemporaryCacheDirectory ();
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
 				mtouch.AssertError (4170, "The registrar can't convert from 'System.DateTime' to 'Foundation.NSNumber' for the return value in the method NS.X.A.", "testApp.cs", 9);
@@ -1064,7 +1064,7 @@ class X : ReplayKit.RPBroadcastControllerDelegate
 				}";
 				mtouch.Linker = MTouchLinker.DontLink; // faster
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new string [] { "-debug" });
+				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new [] { "-debug" });
 				mtouch.CreateTemporaryCacheDirectory ();
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
 				mtouch.AssertError (4138, "The registrar cannot marshal the property type 'System.ConsoleColor' of the property 'NS.X.E'.", "testApp.cs", 23);
@@ -1114,7 +1114,7 @@ class X : ReplayKit.RPBroadcastControllerDelegate
 				}";
 				mtouch.Linker = MTouchLinker.DontLink; // faster
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new string [] { "-debug" });
+				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new [] { "-debug" });
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
 				mtouch.AssertError (4172, "The registrar can't convert from 'System.DateTime' to 'Foundation.NSNumber' for the parameter 'value' in the method NS.X.A.", "testApp.cs", 8);
 				mtouch.AssertError (4172, "The registrar can't convert from 'System.Nullable`1<System.DateTime>' to 'Foundation.NSNumber' for the parameter 'value' in the method NS.X.B.", "testApp.cs", 10);
@@ -1218,7 +1218,7 @@ namespace NS {
 ";
 				mtouch.Linker = MTouchLinker.DontLink; // faster
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new string [] { "-debug" });
+				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new [] { "-debug" });
 				mtouch.WarnAsError = new int [] { 4174 };
 				mtouch.AssertExecuteFailure ("build");
 				mtouch.AssertError (4174, "Unable to locate the block to delegate conversion method for the method NS.Consumer.ResolveRecipients's parameter #2.", "testApp.cs", 11);
@@ -1256,7 +1256,7 @@ namespace NS {
 ";
 				mtouch.Linker = MTouchLinker.DontLink; // faster
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new string [] { "-debug" });
+				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new [] { "-debug" });
 				mtouch.WarnAsError = new int [] { 4176 };
 				mtouch.AssertExecuteFailure ("build");
 				mtouch.AssertError (4176, "Unable to locate the delegate to block conversion type for the return value of the method NS.Consumer.GetFunction.", "testApp.cs", 11);
@@ -1334,7 +1334,7 @@ class H : G {
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecute ();
@@ -1355,7 +1355,7 @@ class Generic3<T> : NSObject where T: System.IConvertible {}
 			// and the lack of warnings/errors in the new static registrar.
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using UIKit;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using UIKit;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecute ();
@@ -1380,7 +1380,7 @@ class Generic3<T> : NSObject where T: System.IConvertible {}
 		}";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -1411,7 +1411,7 @@ class Open<U> : NSObject
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -1438,7 +1438,7 @@ class Open<U> : NSObject
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -1467,7 +1467,7 @@ class Open<U> : NSObject
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using UIKit;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using UIKit;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -1493,7 +1493,7 @@ class Open<U> : NSObject
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (code: code, extraArgs: new string [] { "-debug:full" });
+				mtouch.CreateTemporaryApp (code: code, extraArgs: new [] { "-debug:full" });
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.Linker = MTouchLinker.DontLink; // faster test
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
@@ -1545,7 +1545,7 @@ class Open<U> : NSObject
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System; using System.Collections.Generic; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System; using System.Collections.Generic; using ObjCRuntime;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -1581,7 +1581,7 @@ class Open<U> : NSObject
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full", "/unsafe" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new [] { "/debug:full", "/unsafe" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -1607,7 +1607,7 @@ class GenericMethodClass : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: str1, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: str1, usings: "using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -1629,7 +1629,7 @@ class GenericMethodClass : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecute ();
@@ -1686,7 +1686,7 @@ class C { static void Main () {} }
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (code: str1, extraArgs: new string [] { "-debug:full" });
+				mtouch.CreateTemporaryApp (code: str1, extraArgs: new [] { "-debug:full" });
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.Linker = MTouchLinker.DontLink; // faster test
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
@@ -1720,7 +1720,7 @@ class G : NSObject {
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "-debug:full" });
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new [] { "-debug:full" });
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.Linker = MTouchLinker.DontLink; // faster test
 				mtouch.AssertExecuteFailure ();
@@ -1781,7 +1781,7 @@ class CTP4 : CTP3 {
 					sb.AppendLine ("}");
 				}
 
-				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArgs: new string [] { "-debug" });
+				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArgs: new [] { "-debug" });
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
@@ -1832,7 +1832,7 @@ class C : NSObject {
 }
 ";
 
-				mtouch.CreateTemporaryApp (code: code, extraArgs: new string [] { "-debug" });
+				mtouch.CreateTemporaryApp (code: code, extraArgs: new [] { "-debug" });
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build");

--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -93,7 +93,7 @@ class C { static void Main () {} }
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.Linker = MTouchLinker.DontLink; // faster
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (code: code, extraArg: "-debug");
+				mtouch.CreateTemporaryApp (code: code, extraArgs: new string [] { "-debug" });
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
 				mtouch.AssertError (4138, "The registrar cannot marshal the property type 'System.Object' of the property 'Foo.Bar10'.", "testApp.cs", 54);
 				mtouch.AssertError (4136, "The registrar cannot marshal the parameter type 'System.Object[]' of the parameter 'arg' in the method 'Foo.Bar1(System.Object[])'", "testApp.cs", 7);
@@ -132,7 +132,7 @@ class DateMembers : NSObject {
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -169,7 +169,7 @@ class DateMembers : NSObject {
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -202,7 +202,7 @@ class ArgCount : NSObject {
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -232,7 +232,7 @@ class ArgCount : NSObject {
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -272,7 +272,7 @@ class MyObjectErr : NSObject, IFoo1, IFoo2
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: str1, usings: "using Foundation; using System;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: str1, usings: "using Foundation; using System;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -314,7 +314,7 @@ class MyObjectErr : NSObject, IFoo1, IFoo2
 					sb.AppendLine ($"System.Console.WriteLine (typeof ({t.Namespace}.{t.Name}));");
 				sb.AppendLine ("}}");
 
-				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), usings: "using System; using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), usings: "using System; using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.LinkSdk;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure (MTouchAction.BuildDev);
@@ -358,7 +358,7 @@ class C : NSObject {
 }";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -380,7 +380,7 @@ class C : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -404,7 +404,7 @@ class C : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -432,7 +432,7 @@ class C : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -458,7 +458,7 @@ class C : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -478,7 +478,7 @@ class C : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecute ();
@@ -498,7 +498,7 @@ class C : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -522,7 +522,7 @@ interface IProtocol2 {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -546,7 +546,7 @@ public static class Category
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -567,7 +567,7 @@ public static class Category
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -588,7 +588,7 @@ public static class Category
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -614,7 +614,7 @@ public class Category2 : INativeObject
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -636,7 +636,7 @@ public class Category<T>
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -659,7 +659,7 @@ public class Category
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -686,7 +686,7 @@ public class Category2
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -712,7 +712,7 @@ public class Category
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -735,7 +735,7 @@ public class Category
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -768,7 +768,7 @@ public class Category
 					sb.AppendLine ($"\tpublic void X{i} () {{}}");
 				}
 				sb.AppendLine ("}");
-				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArg: "-debug");
+				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArgs: new string [] { "-debug" });
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
@@ -812,7 +812,7 @@ public struct FooF { public NSObject Obj; }
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -887,7 +887,7 @@ public struct FooF { public NSObject Obj; }
 				mtouch.Profile = profile;
 				mtouch.Linker = linker;
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (extraCode: code, extraArg: "-debug", usings: "using System;\nusing Foundation;\nusing ObjCRuntime;\n");
+				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new string [] { "-debug" }, usings: "using System;\nusing Foundation;\nusing ObjCRuntime;\n");
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
 				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a base type of CurrentType) is not available in {name} .* (it was introduced in {name} 99.0.0): 'use Z instead'. Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", custom_pattern_syntax: true);
 				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a base type of CurrentType) is not available in {name} .* (it was introduced in {name} 89.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", custom_pattern_syntax: true);
@@ -931,7 +931,7 @@ public struct FooF { public NSObject Obj; }
 				sb.AppendLine ("}");
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArg: "-debug");
+				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArgs: new string [] { "-debug" });
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
 				foreach (var kw in objective_c_keywords)
 					mtouch.AssertError (4164, $"Cannot export the property 'X{kw}' because its selector '{kw}' is an Objective-C keyword. Please use a different name.", "testApp.cs");
@@ -952,7 +952,7 @@ class X : ReplayKit.RPBroadcastControllerDelegate
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using System; using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using System; using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecute ();
@@ -994,7 +994,7 @@ class X : ReplayKit.RPBroadcastControllerDelegate
 				mtouch.CustomArguments = new string [] { "--marshal-objectivec-exceptions=throwmanaged" };
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArg: "-debug:full");
+				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArgs: new string [] { "-debug:full" });
 				mtouch.AssertExecuteFailure (MTouchAction.BuildDev, "build");
 				mtouch.AssertError (4169, $"Failed to generate a P/Invoke wrapper for objc_msgSend(System.Object): The registrar cannot get the ObjectiveC type for managed type `System.Object`.");
 			}
@@ -1020,7 +1020,7 @@ class X : ReplayKit.RPBroadcastControllerDelegate
 				}";
 				mtouch.Linker = MTouchLinker.DontLink; // faster
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (extraCode: code, extraArg: "-debug");
+				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new string [] { "-debug" });
 				mtouch.CreateTemporaryCacheDirectory ();
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
 				mtouch.AssertError (4170, "The registrar can't convert from 'System.DateTime' to 'Foundation.NSNumber' for the return value in the method NS.X.A.", "testApp.cs", 9);
@@ -1064,7 +1064,7 @@ class X : ReplayKit.RPBroadcastControllerDelegate
 				}";
 				mtouch.Linker = MTouchLinker.DontLink; // faster
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (extraCode: code, extraArg: "-debug");
+				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new string [] { "-debug" });
 				mtouch.CreateTemporaryCacheDirectory ();
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
 				mtouch.AssertError (4138, "The registrar cannot marshal the property type 'System.ConsoleColor' of the property 'NS.X.E'.", "testApp.cs", 23);
@@ -1114,7 +1114,7 @@ class X : ReplayKit.RPBroadcastControllerDelegate
 				}";
 				mtouch.Linker = MTouchLinker.DontLink; // faster
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (extraCode: code, extraArg: "-debug");
+				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new string [] { "-debug" });
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
 				mtouch.AssertError (4172, "The registrar can't convert from 'System.DateTime' to 'Foundation.NSNumber' for the parameter 'value' in the method NS.X.A.", "testApp.cs", 8);
 				mtouch.AssertError (4172, "The registrar can't convert from 'System.Nullable`1<System.DateTime>' to 'Foundation.NSNumber' for the parameter 'value' in the method NS.X.B.", "testApp.cs", 10);
@@ -1218,7 +1218,7 @@ namespace NS {
 ";
 				mtouch.Linker = MTouchLinker.DontLink; // faster
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (extraCode: code, extraArg: "-debug");
+				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new string [] { "-debug" });
 				mtouch.WarnAsError = new int [] { 4174 };
 				mtouch.AssertExecuteFailure ("build");
 				mtouch.AssertError (4174, "Unable to locate the block to delegate conversion method for the method NS.Consumer.ResolveRecipients's parameter #2.", "testApp.cs", 11);
@@ -1256,7 +1256,7 @@ namespace NS {
 ";
 				mtouch.Linker = MTouchLinker.DontLink; // faster
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.CreateTemporaryApp (extraCode: code, extraArg: "-debug");
+				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new string [] { "-debug" });
 				mtouch.WarnAsError = new int [] { 4176 };
 				mtouch.AssertExecuteFailure ("build");
 				mtouch.AssertError (4176, "Unable to locate the delegate to block conversion type for the return value of the method NS.Consumer.GetFunction.", "testApp.cs", 11);
@@ -1334,7 +1334,7 @@ class H : G {
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecute ();
@@ -1355,7 +1355,7 @@ class Generic3<T> : NSObject where T: System.IConvertible {}
 			// and the lack of warnings/errors in the new static registrar.
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using UIKit;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using UIKit;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecute ();
@@ -1380,7 +1380,7 @@ class Generic3<T> : NSObject where T: System.IConvertible {}
 		}";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -1411,7 +1411,7 @@ class Open<U> : NSObject
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -1438,7 +1438,7 @@ class Open<U> : NSObject
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -1467,7 +1467,7 @@ class Open<U> : NSObject
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using UIKit;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using UIKit;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -1493,7 +1493,7 @@ class Open<U> : NSObject
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (code: code, extraArg: "-debug:full");
+				mtouch.CreateTemporaryApp (code: code, extraArgs: new string [] { "-debug:full" });
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.Linker = MTouchLinker.DontLink; // faster test
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
@@ -1545,7 +1545,7 @@ class Open<U> : NSObject
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System; using System.Collections.Generic; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System; using System.Collections.Generic; using ObjCRuntime;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -1581,7 +1581,7 @@ class Open<U> : NSObject
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full /unsafe");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArgs: new string [] { "/debug:full", "/unsafe" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -1607,7 +1607,7 @@ class GenericMethodClass : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: str1, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: str1, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecuteFailure ();
@@ -1629,7 +1629,7 @@ class GenericMethodClass : NSObject {
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "/debug:full" });
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.AssertExecute ();
@@ -1686,7 +1686,7 @@ class C { static void Main () {} }
 ";
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (code: str1, extraArg: "-debug:full");
+				mtouch.CreateTemporaryApp (code: str1, extraArgs: new string [] { "-debug:full" });
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.Linker = MTouchLinker.DontLink; // faster test
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
@@ -1720,7 +1720,7 @@ class G : NSObject {
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "-debug:full");
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArgs: new string [] { "-debug:full" });
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.Linker = MTouchLinker.DontLink; // faster test
 				mtouch.AssertExecuteFailure ();
@@ -1781,7 +1781,7 @@ class CTP4 : CTP3 {
 					sb.AppendLine ("}");
 				}
 
-				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArg: "-debug");
+				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), extraArgs: new string [] { "-debug" });
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
@@ -1832,7 +1832,7 @@ class C : NSObject {
 }
 ";
 
-				mtouch.CreateTemporaryApp (code: code, extraArg: "-debug");
+				mtouch.CreateTemporaryApp (code: code, extraArgs: new string [] { "-debug" });
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build");

--- a/tests/mtouch/SdkTest.cs
+++ b/tests/mtouch/SdkTest.cs
@@ -328,20 +328,20 @@ namespace Xamarin.Linker {
 			var arch = "armv7k";
 			var arch_dir = Path.Combine (tmpdir, arch);
 			Directory.CreateDirectory (arch_dir);
-			var args = new StringBuilder ();
-			args.Append ("--debug ");
-			args.Append ("--llvm ");
-			args.Append ("-O=float32 ");
-			args.Append ($"--aot=mtriple={arch}-ios");
-			args.Append ($",data-outfile={Path.Combine (arch_dir, Path.GetFileNameWithoutExtension (asm) + ".aotdata." + arch)}");
-			args.Append ($",static,asmonly,direct-icalls,llvmonly,nodebug,dwarfdebug,direct-pinvoke");
-			args.Append ($",msym-dir={Path.Combine (arch_dir, Path.GetFileNameWithoutExtension (asm) + ".mSYM")}");
-			args.Append ($",llvm-path={llvm_path}");
-			args.Append ($",llvm-outfile={Path.Combine (arch_dir, Path.GetFileName (asm) + ".bc")} ");
-			args.Append (Path.Combine (watchOSPath, asm));
+			var args = new List<string> ();
+			args.Add ("--debug");
+			args.Add ("--llvm");
+			args.Add ("-O=float32");
+			args.Add ($"--aot=mtriple={arch}-ios" +
+				$",data-outfile={Path.Combine (arch_dir, Path.GetFileNameWithoutExtension (asm) + ".aotdata." + arch)}" +
+				$",static,asmonly,direct-icalls,llvmonly,nodebug,dwarfdebug,direct-pinvoke" +
+				$",msym-dir={Path.Combine (arch_dir, Path.GetFileNameWithoutExtension (asm) + ".mSYM")}" +
+				$",llvm-path={llvm_path}" +
+				$",llvm-outfile={Path.Combine (arch_dir, Path.GetFileName (asm) + ".bc")}");
+			args.Add (Path.Combine (watchOSPath, asm));
 
 			StringBuilder output = new StringBuilder ();
-			var rv = ExecutionHelper.Execute (aot_compiler, args.ToString (), stdout: output, stderr: output, environmentVariables: env, timeout: TimeSpan.FromMinutes (5));
+			var rv = ExecutionHelper.Execute (aot_compiler, args, stdout: output, stderr: output, environmentVariables: env, timeout: TimeSpan.FromMinutes (5));
 			var llvm_failed = output.ToString ().Split ('\n').Where ((v) => v.Contains ("LLVM failed"));
 			Console.WriteLine (output);
 

--- a/tests/mtouch/mtouch.csproj
+++ b/tests/mtouch/mtouch.csproj
@@ -10,6 +10,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>MTouchTests</RootNamespace>
     <AssemblyName>mtouch</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/tests/mtouch/packages.config
+++ b/tests/mtouch/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.11.0" targetFramework="net40" />
+  <package id="NUnit" version="3.11.0" targetFramework="net40" requireReinstallation="true" />
   <package id="NUnit.ConsoleRunner" version="3.9.0" targetFramework="net40" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net40" />
   <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net40" />

--- a/tests/sampletester/sampletester.csproj
+++ b/tests/sampletester/sampletester.csproj
@@ -10,7 +10,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>sampletester</RootNamespace>
     <AssemblyName>sampletester</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -987,7 +987,7 @@ namespace xharness
 		{
 			if (!string.IsNullOrEmpty (device_name)) {
 				args.Append (" --devname ");
-				args.Append (StringUtils.Quote (device_name));
+				args.Append (StringUtils.QuoteForProcess (device_name));
 			}
 		}
 	}

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -277,23 +277,27 @@ namespace xharness
 
 			FindDevice ();
 
-			var args = new StringBuilder ();
-			if (!string.IsNullOrEmpty (Harness.XcodeRoot))
-				args.Append (" --sdkroot ").Append (Harness.XcodeRoot);
+			var args = new List<string> ();
+			if (!string.IsNullOrEmpty (Harness.XcodeRoot)) {
+				args.Add ("--sdkroot");
+				args.Add (Harness.XcodeRoot);
+			}
 			for (int i = -1; i < Harness.Verbosity; i++)
-				args.Append (" -v ");
+				args.Add ("-v");
 			
-			args.Append (" --installdev");
-			args.AppendFormat (" \"{0}\" ", appPath);
+			args.Add ("--installdev");
+			args.Add (appPath);
 			AddDeviceName (args, companion_device_name ?? device_name);
 
-			if (mode == "watchos")
-				args.Append (" --device ios,watchos");
+			if (mode == "watchos") {
+				args.Add ("--device");
+				args.Add ("ios,watchos");
+			}
 
 			var totalSize = Directory.GetFiles (appPath, "*", SearchOption.AllDirectories).Select ((v) => new FileInfo (v).Length).Sum ();
 			main_log.WriteLine ($"Installing '{appPath}' to '{companion_device_name ?? device_name}'. Size: {totalSize} bytes = {totalSize / 1024.0 / 1024.0:N2} MB");
 
-			return await ProcessHelper.ExecuteCommandAsync (Harness.MlaunchPath, args.ToString (), main_log, TimeSpan.FromHours (1), cancellation_token: cancellation_token);
+			return await ProcessHelper.ExecuteCommandAsync (Harness.MlaunchPath, args, main_log, TimeSpan.FromHours (1), cancellation_token: cancellation_token);
 		}
 
 		public async Task<ProcessExecutionResult> UninstallAsync ()
@@ -305,17 +309,19 @@ namespace xharness
 
 			FindDevice ();
 
-			var args = new StringBuilder ();
-			if (!string.IsNullOrEmpty (Harness.XcodeRoot))
-				args.Append (" --sdkroot ").Append (Harness.XcodeRoot);
+			var args = new List<string> ();
+			if (!string.IsNullOrEmpty (Harness.XcodeRoot)) {
+				args.Add ("--sdkroot");
+				args.Add (Harness.XcodeRoot);
+			}
 			for (int i = -1; i < Harness.Verbosity; i++)
-				args.Append (" -v ");
+				args.Add ("-v");
 
-			args.Append (" --uninstalldevbundleid");
-			args.AppendFormat (" \"{0}\" ", bundle_identifier);
+			args.Add ("--uninstalldevbundleid");
+			args.Add (bundle_identifier);
 			AddDeviceName (args, companion_device_name ?? device_name);
 
-			return await ProcessHelper.ExecuteCommandAsync (Harness.MlaunchPath, args.ToString (), main_log, TimeSpan.FromMinutes (1));
+			return await ProcessHelper.ExecuteCommandAsync (Harness.MlaunchPath, args, main_log, TimeSpan.FromMinutes (1));
 		}
 
 		bool ensure_clean_simulator_state = true;
@@ -583,8 +589,7 @@ namespace xharness
 			if (!isSimulator)
 				FindDevice ();
 
-			crash_reports = new CrashReportSnapshot ()
-			{
+			crash_reports = new CrashReportSnapshot () {
 				Device = !isSimulator,
 				DeviceName = device_name,
 				Harness = Harness,
@@ -593,36 +598,39 @@ namespace xharness
 				LogDirectory = LogDirectory,
 			};
 
-			var args = new StringBuilder ();
-			if (!string.IsNullOrEmpty (Harness.XcodeRoot))
-				args.Append (" --sdkroot ").Append (Harness.XcodeRoot);
+			var args = new List<string> ();
+			if (!string.IsNullOrEmpty (Harness.XcodeRoot)) {
+				args.Add ("--sdkroot");
+				args.Add (Harness.XcodeRoot);
+			}
 			for (int i = -1; i < Harness.Verbosity; i++)
-				args.Append (" -v ");
-			args.Append (" -argument=-connection-mode -argument=none"); // This will prevent the app from trying to connect to any IDEs
-			args.Append (" -argument=-app-arg:-autostart");
-			args.Append (" -setenv=NUNIT_AUTOSTART=true");
-			args.Append (" -argument=-app-arg:-autoexit");
-			args.Append (" -setenv=NUNIT_AUTOEXIT=true");
-			args.Append (" -argument=-app-arg:-enablenetwork");
-			args.Append (" -setenv=NUNIT_ENABLE_NETWORK=true");
+				args.Add ("-v");
+			args.Add ("-argument=-connection-mode");
+			args.Add ("-argument=none"); // This will prevent the app from trying to connect to any IDEs
+			args.Add ("-argument=-app-arg:-autostart");
+			args.Add ("-setenv=NUNIT_AUTOSTART=true");
+			args.Add ("-argument=-app-arg:-autoexit");
+			args.Add ("-setenv=NUNIT_AUTOEXIT=true");
+			args.Add ("-argument=-app-arg:-enablenetwork");
+			args.Add ("-setenv=NUNIT_ENABLE_NETWORK=true");
 			// detect if we are using a jenkins bot.
 			var useXmlOutput = Harness.InJenkins;
 			if (useXmlOutput) {
-				args.Append (" -setenv=NUNIT_ENABLE_XML_OUTPUT=true");
-				args.Append (" -setenv=NUNIT_ENABLE_XML_MODE=wrapped");
+				args.Add ("-setenv=NUNIT_ENABLE_XML_OUTPUT=true");
+				args.Add ("-setenv=NUNIT_ENABLE_XML_MODE=wrapped");
 			}
 
 			if (Harness.InCI) {
 				// We use the 'BUILD_REVISION' variable to detect whether we're running CI or not.
-				args.Append ($" -setenv=BUILD_REVISION=${Environment.GetEnvironmentVariable ("BUILD_REVISION")}");
+				args.Add ($"-setenv=BUILD_REVISION=${Environment.GetEnvironmentVariable ("BUILD_REVISION")}");
 			}
 
 			if (!Harness.GetIncludeSystemPermissionTests (TestPlatform.iOS, !isSimulator))
-				args.Append (" -setenv=DISABLE_SYSTEM_PERMISSION_TESTS=1");
+				args.Add ("-setenv=DISABLE_SYSTEM_PERMISSION_TESTS=1");
 
 			if (isSimulator) {
-				args.Append (" -argument=-app-arg:-hostname:127.0.0.1");
-				args.Append (" -setenv=NUNIT_HOSTNAME=127.0.0.1");
+				args.Add ("-argument=-app-arg:-hostname:127.0.0.1");
+				args.Add ("-setenv=NUNIT_HOSTNAME=127.0.0.1");
 			} else {
 				var ips = new StringBuilder ();
 				var ipAddresses = System.Net.Dns.GetHostEntry (System.Net.Dns.GetHostName ()).AddressList;
@@ -632,8 +640,8 @@ namespace xharness
 					ips.Append (ipAddresses [i].ToString ());
 				}
 
-				args.AppendFormat (" -argument=-app-arg:-hostname:{0}", ips.ToString ());
-				args.AppendFormat (" -setenv=NUNIT_HOSTNAME={0}", ips.ToString ());
+				args.Add ($"-argument=-app-arg:-hostname:{ips.ToString ()}");
+				args.Add ($"-setenv=NUNIT_HOSTNAME={ips.ToString ()}");
 			}
 			string transport;
 			if (mode == "watchos") {
@@ -641,8 +649,8 @@ namespace xharness
 			} else {
 				transport = "TCP";
 			}
-			args.AppendFormat (" -argument=-app-arg:-transport:{0}", transport);
-			args.AppendFormat (" -setenv=NUNIT_TRANSPORT={0}", transport);
+			args.Add ($"-argument=-app-arg:-transport:{transport}");
+			args.Add ($"-setenv=NUNIT_TRANSPORT={transport}");
 
 			listener_log = Logs.Create ($"test-{mode}-{Harness.Timestamp}.log", "Test log", timestamp: !useXmlOutput);
 
@@ -651,7 +659,7 @@ namespace xharness
 			case "FILE":
 				var fn = listener_log.FullPath + ".tmp";
 				listener = new SimpleFileListener (fn);
-				args.Append (" -setenv=NUNIT_LOG_FILE=").Append (StringUtils.Quote (fn));
+				args.Add ($"-setenv=NUNIT_LOG_FILE={fn}");
 				break;
 			case "HTTP":
 				listener = new SimpleHttpListener ();
@@ -669,8 +677,8 @@ namespace xharness
 			listener.XmlOutput = useXmlOutput;
 			listener.Initialize ();
 
-			args.AppendFormat (" -argument=-app-arg:-hostport:{0}", listener.Port);
-			args.AppendFormat (" -setenv=NUNIT_HOSTPORT={0}", listener.Port);
+			args.Add ($"-argument=-app-arg:-hostport:{listener.Port}");
+			args.Add ($"-setenv=NUNIT_HOSTPORT={listener.Port}");
 
 			listener.StartAsync ();
 
@@ -694,7 +702,7 @@ namespace xharness
 				}).DoNotAwait ();
 
 			foreach (var kvp in Harness.EnvironmentVariables)
-				args.AppendFormat (" -setenv={0}={1}", kvp.Key, kvp.Value);
+				args.Add ($"-setenv={kvp.Key}={kvp.Value}");
 
 			bool? success = null;
 			bool launch_failure = false;
@@ -702,22 +710,21 @@ namespace xharness
 			if (isExtension) {
 				switch (extension) {
 				case Extension.TodayExtension:
-					args.Append (isSimulator ? " --launchsimbundleid" : " --launchdevbundleid");
-					args.Append (" todayviewforextensions:");
-					args.Append (BundleIdentifier);
-					args.Append (" --observe-extension ");
-					args.Append (StringUtils.Quote (launchAppPath));
+					args.Add (isSimulator ? "--launchsimbundleid" : "--launchdevbundleid");
+					args.Add ("todayviewforextensions:" + BundleIdentifier);
+					args.Add ("--observe-extension");
+					args.Add (launchAppPath);
 					break;
 				case Extension.WatchKit2:
 				default:
 					throw new NotImplementedException ();
 				}
 			} else {
-				args.Append (isSimulator ? " --launchsim " : " --launchdev ");
-				args.Append (StringUtils.Quote (launchAppPath));
+				args.Add (isSimulator ? "--launchsim" : "--launchdev");
+				args.Add (launchAppPath);
 			}
 			if (!isSimulator)
-				args.Append (" --disable-memory-limits");
+				args.Add ("--disable-memory-limits");
 
 			var timeout = TimeSpan.FromMinutes (Harness.Timeout * TimeoutMultiplier);
 			if (isSimulator) {
@@ -727,13 +734,13 @@ namespace xharness
 				if (mode != "watchos") {
 					var stderr_tty = Marshal.PtrToStringAuto (ttyname (2));
 					if (!string.IsNullOrEmpty (stderr_tty)) {
-						args.Append (" --stdout=").Append (StringUtils.Quote (stderr_tty));
-						args.Append (" --stderr=").Append (StringUtils.Quote (stderr_tty));
+						args.Add ($"--stdout={stderr_tty}");
+						args.Add ($"--stderr={stderr_tty}");
 					} else {
 						var stdout_log = Logs.CreateFile ($"stdout-{Harness.Timestamp}.log", "Standard output");
 						var stderr_log = Logs.CreateFile ($"stderr-{Harness.Timestamp}.log", "Standard error");
-						args.Append (" --stdout=").Append (StringUtils.Quote (stdout_log));
-						args.Append (" --stderr=").Append (StringUtils.Quote (stderr_log));
+						args.Add ($"--stdout={stdout_log}");
+						args.Add ($"--stderr={stderr_log}");
 					}
 				}
 
@@ -761,13 +768,13 @@ namespace xharness
 						await sim.PrepareSimulatorAsync (main_log, bundle_identifier);
 				}
 
-				args.Append (" --device=:v2:udid=").Append (simulator.UDID).Append (" ");
+				args.Add ($"--device=:v2:udid={simulator.UDID}");
 
 				await crash_reports.StartCaptureAsync ();
 
 				main_log.WriteLine ("Starting test run");
 
-				var result = await ProcessHelper.ExecuteCommandAsync (Harness.MlaunchPath, args.ToString (), run_log, timeout, cancellation_token: cancellation_source.Token);
+				var result = await ProcessHelper.ExecuteCommandAsync (Harness.MlaunchPath, args, run_log, timeout, cancellation_token: cancellation_source.Token);
 				if (result.TimedOut) {
 					timed_out = true;
 					success = false;
@@ -822,9 +829,9 @@ namespace xharness
 				main_log.WriteLine ("*** Executing {0}/{1} on device '{2}' ***", appName, mode, device_name);
 
 				if (mode == "watchos") {
-					args.Append (" --attach-native-debugger"); // this prevents the watch from backgrounding the app.
+					args.Add ("--attach-native-debugger"); // this prevents the watch from backgrounding the app.
 				} else {
-					args.Append (" --wait-for-exit");
+					args.Add ("--wait-for-exit");
 				}
 				
 				AddDeviceName (args);
@@ -851,7 +858,7 @@ namespace xharness
 				});
 				var runLog = Log.CreateAggregatedLog (callbackLog, main_log);
 				var timeoutWatch = Stopwatch.StartNew ();
-				var result = await ProcessHelper.ExecuteCommandAsync (Harness.MlaunchPath, args.ToString (), runLog, timeout, cancellation_token: cancellation_source.Token);
+				var result = await ProcessHelper.ExecuteCommandAsync (Harness.MlaunchPath, args, runLog, timeout, cancellation_token: cancellation_source.Token);
 
 				if (!waitedForExit && !result.TimedOut) {
 					// mlaunch couldn't wait for exit for some reason. Let's assume the app exits when the test listener completes.
@@ -978,16 +985,16 @@ namespace xharness
 			return success.Value ? 0 : 1;
 		}
 
-		public void AddDeviceName (StringBuilder args)
+		public void AddDeviceName (IList<string> args)
 		{
 			AddDeviceName (args, device_name);
 		}
 
-		public static void AddDeviceName (StringBuilder args, string device_name)
+		public static void AddDeviceName (IList<string> args, string device_name)
 		{
 			if (!string.IsNullOrEmpty (device_name)) {
-				args.Append (" --devname ");
-				args.Append (StringUtils.QuoteForProcess (device_name));
+				args.Add ("--devname");
+				args.Add (device_name);
 			}
 		}
 	}

--- a/tests/xharness/DeviceLogCapturer.cs
+++ b/tests/xharness/DeviceLogCapturer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
@@ -22,11 +23,12 @@ namespace xharness
 
 			process = new Process ();
 			process.StartInfo.FileName = Harness.MlaunchPath;
-			var sb = new StringBuilder ();
-			sb.Append ("--logdev ");
-			sb.Append ("--sdkroot ").Append (StringUtils.Quote (Harness.XcodeRoot)).Append (' ');
+			var sb = new List<string> ();
+			sb.Add ("--logdev");
+			sb.Add ("--sdkroot");
+			sb.Add (Harness.XcodeRoot);
 			AppRunner.AddDeviceName (sb, DeviceName);
-			process.StartInfo.Arguments = sb.ToString ();
+			process.StartInfo.Arguments = StringUtils.FormatArguments (sb);
 			process.StartInfo.UseShellExecute = false;
 			process.StartInfo.RedirectStandardOutput = true;
 			process.StartInfo.RedirectStandardError = true;

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -210,7 +210,7 @@ namespace xharness
 					Log ("Extracting mlaunch...");
 					using (var p = new Process ()) {
 						p.StartInfo.FileName = "unzip";
-						p.StartInfo.Arguments = $"-d {StringUtils.Quote (tmp_extraction_dir)} {StringUtils.Quote (local_zip)}";
+						p.StartInfo.Arguments = StringUtils.FormatArguments ("-d", tmp_extraction_dir, local_zip);
 						Log ("{0} {1}", p.StartInfo.FileName, p.StartInfo.Arguments);
 						p.Start ();
 						p.WaitForExit ();
@@ -819,14 +819,14 @@ namespace xharness
 			}
 		}
 
-		public Task<ProcessExecutionResult> ExecuteXcodeCommandAsync (string executable, string args, Log log, TimeSpan timeout)
+		public Task<ProcessExecutionResult> ExecuteXcodeCommandAsync (string executable, IList<string> args, Log log, TimeSpan timeout)
 		{
 			return ProcessHelper.ExecuteCommandAsync (Path.Combine (XcodeRoot, "Contents", "Developer", "usr", "bin", executable), args, log, timeout: timeout);
 		}
 
 		public async Task ShowSimulatorList (Log log)
 		{
-			await ExecuteXcodeCommandAsync ("simctl", "list", log, TimeSpan.FromSeconds (10));
+			await ExecuteXcodeCommandAsync ("simctl", new string [] { "list" }, log, TimeSpan.FromSeconds (10));
 		}
 
 		public async Task<LogFile> SymbolicateCrashReportAsync (Logs logs, Log log, LogFile report)
@@ -843,7 +843,7 @@ namespace xharness
 			var name = Path.GetFileName (report.Path);
 			var symbolicated = logs.Create (Path.ChangeExtension (name, ".symbolicated.log"), $"Symbolicated crash report: {name}", timestamp: false);
 			var environment = new Dictionary<string, string> { { "DEVELOPER_DIR", Path.Combine (XcodeRoot, "Contents", "Developer") } };
-			var rv = await ProcessHelper.ExecuteCommandAsync (symbolicatecrash, StringUtils.Quote (report.Path), symbolicated, TimeSpan.FromMinutes (1), environment);
+			var rv = await ProcessHelper.ExecuteCommandAsync (symbolicatecrash, new string [] { report.Path }, symbolicated, TimeSpan.FromMinutes (1), environment);
 			if (rv.Succeeded) {;
 				log.WriteLine ("Symbolicated {0} successfully.", report.Path);
 				return symbolicated;
@@ -864,12 +864,15 @@ namespace xharness
 			} else {
 				var tmp = Path.GetTempFileName ();
 				try {
-					var sb = new StringBuilder ();
-					sb.Append (" --list-crash-reports=").Append (StringUtils.Quote (tmp));
-					sb.Append (" --sdkroot ").Append (StringUtils.Quote (XcodeRoot));
-					if (!string.IsNullOrEmpty (device))
-						sb.Append (" --devname ").Append (StringUtils.Quote (device));
-					var result = await ProcessHelper.ExecuteCommandAsync (MlaunchPath, sb.ToString (), log, TimeSpan.FromMinutes (1));
+					var sb = new List<string> ();
+					sb.Add ($"--list-crash-reports={tmp}");
+					sb.Add ("--sdkroot");
+					sb.Add (XcodeRoot);
+					if (!string.IsNullOrEmpty (device)) {
+						sb.Add ("--devname");
+						sb.Add (device);
+					}
+					var result = await ProcessHelper.ExecuteCommandAsync (MlaunchPath, sb, log, TimeSpan.FromMinutes (1));
 					if (result.Succeeded)
 						rv.UnionWith (File.ReadAllLines (tmp));
 				} finally {
@@ -925,13 +928,16 @@ namespace xharness
 						foreach (var file in end_crashes) {
 							var name = Path.GetFileName (file);
 							var crash_report_target = Logs.Create (name, $"Crash report: {name}", timestamp: false);
-							var sb = new StringBuilder ();
-							sb.Append (" --download-crash-report=").Append (StringUtils.Quote (file));
-							sb.Append (" --download-crash-report-to=").Append (StringUtils.Quote (crash_report_target.Path));
-							sb.Append (" --sdkroot ").Append (StringUtils.Quote (Harness.XcodeRoot));
-							if (!string.IsNullOrEmpty (DeviceName))
-								sb.Append (" --devname ").Append (StringUtils.Quote (DeviceName));
-							var result = await ProcessHelper.ExecuteCommandAsync (Harness.MlaunchPath, sb.ToString (), Log, TimeSpan.FromMinutes (1));
+							var sb = new List<string> ();
+							sb.Add ($"--download-crash-report={file}");
+							sb.Add ($" --download-crash-report-to={crash_report_target.Path}");
+							sb.Add ("--sdkroot");
+							sb.Add (Harness.XcodeRoot);
+							if (!string.IsNullOrEmpty (DeviceName)) {
+								sb.Add ("--devname");
+								sb.Add (DeviceName);
+							}
+							var result = await ProcessHelper.ExecuteCommandAsync (Harness.MlaunchPath, sb, Log, TimeSpan.FromMinutes (1));
 							if (result.Succeeded) {
 								Log.WriteLine ("Downloaded crash report {0} to {1}", file, crash_report_target.Path);
 								crash_report_target = await Harness.SymbolicateCrashReportAsync (Logs, Log, crash_report_target);

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -826,7 +826,7 @@ namespace xharness
 
 		public async Task ShowSimulatorList (Log log)
 		{
-			await ExecuteXcodeCommandAsync ("simctl", new string [] { "list" }, log, TimeSpan.FromSeconds (10));
+			await ExecuteXcodeCommandAsync ("simctl", new [] { "list" }, log, TimeSpan.FromSeconds (10));
 		}
 
 		public async Task<LogFile> SymbolicateCrashReportAsync (Logs logs, Log log, LogFile report)
@@ -843,7 +843,7 @@ namespace xharness
 			var name = Path.GetFileName (report.Path);
 			var symbolicated = logs.Create (Path.ChangeExtension (name, ".symbolicated.log"), $"Symbolicated crash report: {name}", timestamp: false);
 			var environment = new Dictionary<string, string> { { "DEVELOPER_DIR", Path.Combine (XcodeRoot, "Contents", "Developer") } };
-			var rv = await ProcessHelper.ExecuteCommandAsync (symbolicatecrash, new string [] { report.Path }, symbolicated, TimeSpan.FromMinutes (1), environment);
+			var rv = await ProcessHelper.ExecuteCommandAsync (symbolicatecrash, new [] { report.Path }, symbolicated, TimeSpan.FromMinutes (1), environment);
 			if (rv.Succeeded) {;
 				log.WriteLine ("Symbolicated {0} successfully.", report.Path);
 				return symbolicated;

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2830,7 +2830,7 @@ namespace xharness
 					args.Add ((useXIBuild && !isSolution ? "/" : "") + "restore"); // diff param depending on the tool
 					args.Add (projectPath);
 					if (useXIBuild && !isSolution)
-						args.Add ("/verbosity:detailed ");
+						args.Add ("/verbosity:detailed");
 					else {
 						args.Add ("-verbosity");
 						args.Add ("detailed");

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1193,7 +1193,7 @@ namespace xharness
 
 		void BuildTestLibraries ()
 		{
-			ProcessHelper.ExecuteCommandAsync ("make", new string [] { "all", $"-j{Environment.ProcessorCount}", "-C", Path.Combine (Harness.RootDirectory, "test-libraries") }, MainLog, TimeSpan.FromMinutes (10)).Wait ();
+			ProcessHelper.ExecuteCommandAsync ("make", new [] { "all", $"-j{Environment.ProcessorCount}", "-C", Path.Combine (Harness.RootDirectory, "test-libraries") }, MainLog, TimeSpan.FromMinutes (10)).Wait ();
 		}
 
 		Task RunTestServer ()

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1193,7 +1193,7 @@ namespace xharness
 
 		void BuildTestLibraries ()
 		{
-			ProcessHelper.ExecuteCommandAsync ("make", $"all -j{Environment.ProcessorCount} -C {StringUtils.Quote (Path.Combine (Harness.RootDirectory, "test-libraries"))}", MainLog, TimeSpan.FromMinutes (10)).Wait ();
+			ProcessHelper.ExecuteCommandAsync ("make", new string [] { "all", $"-j{Environment.ProcessorCount}", "-C", Path.Combine (Harness.RootDirectory, "test-libraries") }, MainLog, TimeSpan.FromMinutes (10)).Wait ();
 		}
 
 		Task RunTestServer ()
@@ -2826,14 +2826,16 @@ namespace xharness
 				using (var nuget = new Process ()) {
 					nuget.StartInfo.FileName = useXIBuild && !isSolution ? Harness.XIBuildPath :
 						"/Library/Frameworks/Mono.framework/Versions/Current/Commands/nuget";
-					var args = new StringBuilder ();
-					args.Append ((useXIBuild && !isSolution ? "/" : "") + "restore "); // diff param depending on the tool
-					args.Append (StringUtils.Quote (projectPath));
+					var args = new List<string> ();
+					args.Add ((useXIBuild && !isSolution ? "/" : "") + "restore"); // diff param depending on the tool
+					args.Add (projectPath);
 					if (useXIBuild && !isSolution)
-						args.Append (" /verbosity:detailed ");
-					else
-						args.Append (" -verbosity detailed ");
-					nuget.StartInfo.Arguments = args.ToString ();
+						args.Add ("/verbosity:detailed ");
+					else {
+						args.Add ("-verbosity");
+						args.Add ("detailed");
+					}
+					nuget.StartInfo.Arguments = StringUtils.FormatArguments (args);
 					SetEnvironmentVariables (nuget);
 					LogEvent (log, "Restoring nugets for {0} ({1}) on path {2}", TestName, Mode, projectPath);
 
@@ -2946,16 +2948,16 @@ namespace xharness
 
 				using (var xbuild = new Process ()) {
 					xbuild.StartInfo.FileName = Harness.XIBuildPath;
-					var args = new StringBuilder ();
-					args.Append ("-- ");
-					args.Append ("/verbosity:diagnostic ");
-					args.Append ($"/bl:\"{binlogPath}\" ");
+					var args = new List<string> ();
+					args.Add ("--");
+					args.Add ("/verbosity:diagnostic");
+					args.Add ($"/bl:{binlogPath}");
 					if (SpecifyPlatform)
-						args.Append ($"/p:Platform={ProjectPlatform} ");
+						args.Add ($"/p:Platform={ProjectPlatform}");
 					if (SpecifyConfiguration)
-						args.Append ($"/p:Configuration={ProjectConfiguration} ");
-					args.Append (StringUtils.Quote (ProjectFile));
-					xbuild.StartInfo.Arguments = args.ToString ();
+						args.Add ($"/p:Configuration={ProjectConfiguration}");
+					args.Add (ProjectFile);
+					xbuild.StartInfo.Arguments = StringUtils.FormatArguments (args);
 					SetEnvironmentVariables (xbuild);
 					if (UseMSBuild)
 						xbuild.StartInfo.EnvironmentVariables ["MSBuildExtensionsPath"] = null;
@@ -2984,16 +2986,16 @@ namespace xharness
 			// Don't require the desktop resource here, this shouldn't be that resource sensitive
 			using (var xbuild = new Process ()) {
 				xbuild.StartInfo.FileName = Harness.XIBuildPath;
-				var args = new StringBuilder ();
-				args.Append ("-- ");
-				args.Append ("/verbosity:diagnostic ");
+				var args = new List<string> ();
+				args.Add ("--");
+				args.Add ("/verbosity:diagnostic");
 				if (project_platform != null)
-					args.Append ($"/p:Platform={project_platform} ");
+					args.Add ($"/p:Platform={project_platform}");
 				if (project_configuration != null)
-					args.Append ($"/p:Configuration={project_configuration} ");
-				args.Append (StringUtils.Quote (project_file)).Append (" ");
-				args.Append ("/t:Clean ");
-				xbuild.StartInfo.Arguments = args.ToString ();
+					args.Add ($"/p:Configuration={project_configuration}");
+				args.Add (project_file);
+				args.Add ("/t:Clean");
+				xbuild.StartInfo.Arguments = StringUtils.FormatArguments (args);
 				SetEnvironmentVariables (xbuild);
 				LogEvent (log, "Cleaning {0} ({1}) - {2}", TestName, Mode, project_file);
 				var timeout = TimeSpan.FromMinutes (1);
@@ -3113,20 +3115,21 @@ namespace xharness
 
 					proc.StartInfo.WorkingDirectory = WorkingDirectory;
 					proc.StartInfo.FileName = Harness.XIBuildPath;
-					var args = new StringBuilder ();
-					args.Append ("-t -- ");
-					args.Append (StringUtils.Quote (Path.GetFullPath (TestExecutable))).Append (' ');
-					args.Append (StringUtils.Quote (Path.GetFullPath (TestLibrary))).Append (' ');
+					var args = new List<string> ();
+					args.Add ("-t");
+					args.Add ("--");
+					args.Add (Path.GetFullPath (TestExecutable));
+					args.Add (Path.GetFullPath (TestLibrary));
 					if (IsNUnit3) {
-						args.Append ("-result=").Append (StringUtils.Quote (xmlLog)).Append (";format=nunit2 ");
-						args.Append ("--labels=All ");
+						args.Add ("-result=" + xmlLog + ";format=nunit2");
+						args.Add ("--labels=All");
 						if (InProcess)
-							args.Append ("--inprocess ");
+							args.Add ("--inprocess");
 					} else {
-						args.Append ("-xml=" + StringUtils.Quote (xmlLog)).Append (' ');
-						args.Append ("-labels ");
+						args.Add ("-xml=" + xmlLog);
+						args.Add ("-labels");
 					}
-					proc.StartInfo.Arguments = args.ToString ();
+					proc.StartInfo.Arguments = StringUtils.FormatArguments (args);
 					SetEnvironmentVariables (proc);
 					foreach (DictionaryEntry de in proc.StartInfo.EnvironmentVariables)
 						log.WriteLine ($"export {de.Key}={de.Value}");
@@ -3277,7 +3280,7 @@ namespace xharness
 					proc.StartInfo.FileName = Path;
 					if (IsUnitTest) {
 						var xml = Logs.CreateFile ($"test-{Platform}-{Timestamp}.xml", "NUnit results");
-						proc.StartInfo.Arguments = $"-result={StringUtils.Quote (xml)}";
+						proc.StartInfo.Arguments = StringUtils.FormatArguments ($"-result=" + xml);
 					}
 					if (!Harness.GetIncludeSystemPermissionTests (Platform, false))
 						proc.StartInfo.EnvironmentVariables ["DISABLE_SYSTEM_PERMISSION_TESTS"] = "1";

--- a/tests/xharness/Process_Extensions.cs
+++ b/tests/xharness/Process_Extensions.cs
@@ -21,11 +21,11 @@ namespace xharness
 
 	public static class ProcessHelper
 	{
-		public static async Task<ProcessExecutionResult> ExecuteCommandAsync (string filename, string args, Log log, TimeSpan timeout, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null)
+		public static async Task<ProcessExecutionResult> ExecuteCommandAsync (string filename, IList<string> args, Log log, TimeSpan timeout, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null)
 		{
 			using (var p = new Process ()) {
 				p.StartInfo.FileName = filename;
-				p.StartInfo.Arguments = args;
+				p.StartInfo.Arguments = StringUtils.FormatArguments (args);
 				return await p.RunAsync (log, true, timeout, environment_variables, cancellation_token);
 			}
 		}
@@ -224,7 +224,7 @@ namespace xharness
 							commands.AppendLine ("detach");
 							commands.AppendLine ("quit");
 							dbg.StartInfo.FileName = "/usr/bin/lldb";
-							dbg.StartInfo.Arguments = $"--source {StringUtils.Quote (template)}";
+							dbg.StartInfo.Arguments = StringUtils.FormatArguments ("--source", template);
 							File.WriteAllText (template, commands.ToString ());
 
 							log.WriteLine ($"Printing backtrace for pid={pid}");

--- a/tests/xharness/Simulators.cs
+++ b/tests/xharness/Simulators.cs
@@ -146,7 +146,7 @@ namespace xharness
 					return devices;
 			}
 			
-			var rv = await Harness.ExecuteXcodeCommandAsync ("simctl", new string [] { "create", CreateName (devicetype, runtime), devicetype, runtime }, log, TimeSpan.FromMinutes (1));
+			var rv = await Harness.ExecuteXcodeCommandAsync ("simctl", new [] { "create", CreateName (devicetype, runtime), devicetype, runtime }, log, TimeSpan.FromMinutes (1));
 			if (!rv.Succeeded) {
 				log.WriteLine ($"Could not create device for runtime={runtime} and device type={devicetype}.");
 				return null;
@@ -183,7 +183,7 @@ namespace xharness
 				log.WriteImpl (value);
 				capturedLog.Append (value);
 			});
-			var rv = await Harness.ExecuteXcodeCommandAsync ("simctl", new string [] { "pair", device.UDID, companion_device.UDID }, pairLog, TimeSpan.FromMinutes (1));
+			var rv = await Harness.ExecuteXcodeCommandAsync ("simctl", new [] { "pair", device.UDID, companion_device.UDID }, pairLog, TimeSpan.FromMinutes (1));
 			if (!rv.Succeeded) {
 				if (!create_device) {
 					var try_creating_device = false;
@@ -472,22 +472,22 @@ namespace xharness
 		{
 			// here we don't care if execution fails.
 			// erase the simulator (make sure the device isn't running first)
-			await Harness.ExecuteXcodeCommandAsync ("simctl", new string [] { "shutdown " + UDID }, log, TimeSpan.FromMinutes (1));
-			await Harness.ExecuteXcodeCommandAsync ("simctl", new string [] { "erase " + UDID }, log, TimeSpan.FromMinutes (1));
+			await Harness.ExecuteXcodeCommandAsync ("simctl", new [] { "shutdown " + UDID }, log, TimeSpan.FromMinutes (1));
+			await Harness.ExecuteXcodeCommandAsync ("simctl", new [] { "erase " + UDID }, log, TimeSpan.FromMinutes (1));
 
 			// boot & shutdown to make sure it actually works
-			await Harness.ExecuteXcodeCommandAsync ("simctl", new string [] { "boot " + UDID }, log, TimeSpan.FromMinutes (1));
-			await Harness.ExecuteXcodeCommandAsync ("simctl", new string [] { "shutdown " + UDID }, log, TimeSpan.FromMinutes (1));
+			await Harness.ExecuteXcodeCommandAsync ("simctl", new [] { "boot " + UDID }, log, TimeSpan.FromMinutes (1));
+			await Harness.ExecuteXcodeCommandAsync ("simctl", new [] { "shutdown " + UDID }, log, TimeSpan.FromMinutes (1));
 		}
 
 		public async Task ShutdownAsync (Log log)
 		{
-			await Harness.ExecuteXcodeCommandAsync ("simctl", new string [] { "shutdown " + UDID }, log, TimeSpan.FromMinutes (1));
+			await Harness.ExecuteXcodeCommandAsync ("simctl", new [] { "shutdown " + UDID }, log, TimeSpan.FromMinutes (1));
 		}
 
 		public static async Task KillEverythingAsync (Log log)
 		{
-			await ProcessHelper.ExecuteCommandAsync ("launchctl", new string [] { "remove com.apple.CoreSimulator.CoreSimulatorService" }, log, TimeSpan.FromSeconds (10));
+			await ProcessHelper.ExecuteCommandAsync ("launchctl", new [] { "remove com.apple.CoreSimulator.CoreSimulatorService" }, log, TimeSpan.FromSeconds (10));
 
 			var to_kill = new string [] { "iPhone Simulator", "iOS Simulator", "Simulator", "Simulator (Watch)", "com.apple.CoreSimulator.CoreSimulatorService", "ibtoold" };
 
@@ -612,7 +612,7 @@ namespace xharness
 			}
 
 			log.WriteLine ("Current TCC database contents:");
-			await ProcessHelper.ExecuteCommandAsync ("sqlite3", new string [] { TCC_db, ".dump" }, log, TimeSpan.FromSeconds (5));
+			await ProcessHelper.ExecuteCommandAsync ("sqlite3", new [] { TCC_db, ".dump" }, log, TimeSpan.FromSeconds (5));
 		}
 
 		async Task OpenSimulator (Log log)
@@ -627,7 +627,7 @@ namespace xharness
 					simulator_app = Path.Combine (Harness.XcodeRoot, "Contents", "Developer", "Applications", "iOS Simulator.app");
 			}
 
-			await ProcessHelper.ExecuteCommandAsync ("open", new string [] { "-a ", simulator_app, "--args", "-CurrentDeviceUDID", UDID }, log, TimeSpan.FromSeconds (15));
+			await ProcessHelper.ExecuteCommandAsync ("open", new [] { "-a ", simulator_app, "--args", "-CurrentDeviceUDID", UDID }, log, TimeSpan.FromSeconds (15));
 		}
 
 		public async Task PrepareSimulatorAsync (Log log, params string[] bundle_identifiers)

--- a/tests/xharness/Simulators.cs
+++ b/tests/xharness/Simulators.cs
@@ -146,7 +146,7 @@ namespace xharness
 					return devices;
 			}
 			
-			var rv = await Harness.ExecuteXcodeCommandAsync ("simctl", $"create {StringUtils.Quote (CreateName (devicetype, runtime))} {devicetype} {runtime}", log, TimeSpan.FromMinutes (1));
+			var rv = await Harness.ExecuteXcodeCommandAsync ("simctl", new string [] { "create", CreateName (devicetype, runtime), devicetype, runtime }, log, TimeSpan.FromMinutes (1));
 			if (!rv.Succeeded) {
 				log.WriteLine ($"Could not create device for runtime={runtime} and device type={devicetype}.");
 				return null;
@@ -183,7 +183,7 @@ namespace xharness
 				log.WriteImpl (value);
 				capturedLog.Append (value);
 			});
-			var rv = await Harness.ExecuteXcodeCommandAsync ("simctl", $"pair {device.UDID} {companion_device.UDID}", pairLog, TimeSpan.FromMinutes (1));
+			var rv = await Harness.ExecuteXcodeCommandAsync ("simctl", new string [] { "pair", device.UDID, companion_device.UDID }, pairLog, TimeSpan.FromMinutes (1));
 			if (!rv.Succeeded) {
 				if (!create_device) {
 					var try_creating_device = false;
@@ -472,26 +472,29 @@ namespace xharness
 		{
 			// here we don't care if execution fails.
 			// erase the simulator (make sure the device isn't running first)
-			await Harness.ExecuteXcodeCommandAsync ("simctl", "shutdown " + UDID, log, TimeSpan.FromMinutes (1));
-			await Harness.ExecuteXcodeCommandAsync ("simctl", "erase " + UDID, log, TimeSpan.FromMinutes (1));
+			await Harness.ExecuteXcodeCommandAsync ("simctl", new string [] { "shutdown " + UDID }, log, TimeSpan.FromMinutes (1));
+			await Harness.ExecuteXcodeCommandAsync ("simctl", new string [] { "erase " + UDID }, log, TimeSpan.FromMinutes (1));
 
 			// boot & shutdown to make sure it actually works
-			await Harness.ExecuteXcodeCommandAsync ("simctl", "boot " + UDID, log, TimeSpan.FromMinutes (1));
-			await Harness.ExecuteXcodeCommandAsync ("simctl", "shutdown " + UDID, log, TimeSpan.FromMinutes (1));
+			await Harness.ExecuteXcodeCommandAsync ("simctl", new string [] { "boot " + UDID }, log, TimeSpan.FromMinutes (1));
+			await Harness.ExecuteXcodeCommandAsync ("simctl", new string [] { "shutdown " + UDID }, log, TimeSpan.FromMinutes (1));
 		}
 
 		public async Task ShutdownAsync (Log log)
 		{
-			await Harness.ExecuteXcodeCommandAsync ("simctl", "shutdown " + UDID, log, TimeSpan.FromMinutes (1));
+			await Harness.ExecuteXcodeCommandAsync ("simctl", new string [] { "shutdown " + UDID }, log, TimeSpan.FromMinutes (1));
 		}
 
 		public static async Task KillEverythingAsync (Log log)
 		{
-			await ProcessHelper.ExecuteCommandAsync ("launchctl", "remove com.apple.CoreSimulator.CoreSimulatorService", log, TimeSpan.FromSeconds (10));
+			await ProcessHelper.ExecuteCommandAsync ("launchctl", new string [] { "remove com.apple.CoreSimulator.CoreSimulatorService" }, log, TimeSpan.FromSeconds (10));
 
 			var to_kill = new string [] { "iPhone Simulator", "iOS Simulator", "Simulator", "Simulator (Watch)", "com.apple.CoreSimulator.CoreSimulatorService", "ibtoold" };
 
-			await ProcessHelper.ExecuteCommandAsync ("killall", "-9 " + string.Join (" ", to_kill.Select ((v) => StringUtils.Quote (v)).ToArray ()), log, TimeSpan.FromSeconds (10));
+			var args = new List<string> ();
+			args.Add ("-9");
+			args.AddRange (to_kill);
+			await ProcessHelper.ExecuteCommandAsync ("killall", args, log, TimeSpan.FromSeconds (10));
 
 			foreach (var dir in new string [] {
 				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), "Library", "Saved Application State", "com.apple.watchsimulator.savedState"),
@@ -569,9 +572,9 @@ namespace xharness
 				}
 				failure = false;
 				foreach (var bundle_identifier in bundle_identifiers) {
+					var args = new List<string> ();
 					var sql = new System.Text.StringBuilder ();
-					sql.Append (StringUtils.Quote (TCC_db));
-					sql.Append (" \"");
+					args.Add (TCC_db);
 					foreach (var service in sim_services) {
 						switch (TCCFormat) {
 						case 1:
@@ -593,8 +596,8 @@ namespace xharness
 							throw new NotImplementedException ();
 						}
 					}
-					sql.Append ("\"");
-					var rv = await ProcessHelper.ExecuteCommandAsync ("sqlite3", sql.ToString (), log, TimeSpan.FromSeconds (5));
+					args.Add (sql.ToString ());
+					var rv = await ProcessHelper.ExecuteCommandAsync ("sqlite3", args, log, TimeSpan.FromSeconds (5));
 					if (!rv.Succeeded) {
 						failure = true;
 						break;
@@ -609,7 +612,7 @@ namespace xharness
 			}
 
 			log.WriteLine ("Current TCC database contents:");
-			await ProcessHelper.ExecuteCommandAsync ("sqlite3", $"{StringUtils.Quote (TCC_db)} .dump", log, TimeSpan.FromSeconds (5));
+			await ProcessHelper.ExecuteCommandAsync ("sqlite3", new string [] { TCC_db, ".dump" }, log, TimeSpan.FromSeconds (5));
 		}
 
 		async Task OpenSimulator (Log log)
@@ -624,7 +627,7 @@ namespace xharness
 					simulator_app = Path.Combine (Harness.XcodeRoot, "Contents", "Developer", "Applications", "iOS Simulator.app");
 			}
 
-			await ProcessHelper.ExecuteCommandAsync ("open", "-a " + StringUtils.Quote (simulator_app) + " --args -CurrentDeviceUDID " + UDID, log, TimeSpan.FromSeconds (15));
+			await ProcessHelper.ExecuteCommandAsync ("open", new string [] { "-a ", simulator_app, "--args", "-CurrentDeviceUDID", UDID }, log, TimeSpan.FromSeconds (15));
 		}
 
 		public async Task PrepareSimulatorAsync (Log log, params string[] bundle_identifiers)

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -366,7 +366,7 @@ namespace Xamarin.Bundler {
 				if (!Directory.Exists (path))
 					Directory.CreateDirectory (path);
 
-				if (Driver.RunCommand ("/usr/bin/unzip", string.Format ("-u -o -d {0} {1}", StringUtils.Quote (path), StringUtils.Quote (zipPath))) != 0)
+				if (Driver.RunCommand ("/usr/bin/unzip", "-u", "-o", "-d", path, zipPath) != 0)
 					throw ErrorHelper.CreateError (1303, "Could not decompress the native framework '{0}' from '{1}'. Please review the build log for more information from the native 'unzip' command.", metadata.LibraryName, zipPath);
 			}
 

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -292,7 +292,9 @@ namespace Xamarin.Bundler {
 			if (!string.IsNullOrEmpty (metadata.LinkerFlags)) {
 				if (LinkerFlags == null)
 					LinkerFlags = new List<string> ();
-				LinkerFlags.Add (metadata.LinkerFlags);
+				if (!StringUtils.TryParseArguments (metadata.LinkerFlags, out string [] args, out var ex))
+					throw ErrorHelper.CreateError (148, ex, "Unable to parse the linker flags '{0}' from the LinkWith attribute for the library '{1}' in {2} : {3}", metadata.LinkerFlags, metadata.LibraryName, FileName, ex.Message);
+				LinkerFlags.AddRange (args);
 			}
 
 			if (!string.IsNullOrEmpty (metadata.Frameworks)) {

--- a/tools/common/CompilerFlags.cs
+++ b/tools/common/CompilerFlags.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 using Xamarin.Bundler;
@@ -16,7 +17,7 @@ namespace Xamarin.Utils
 		public HashSet<string> WeakFrameworks;
 		public HashSet<string> LinkWithLibraries; // X, added to Inputs
 		public HashSet<string> ForceLoadLibraries; // -force_load X, added to Inputs
-		public HashSet<string> OtherFlags; // X
+		public HashSet<string[]> OtherFlags; // X
 		public List<string> InitialOtherFlags; // same as OtherFlags, only that they're the first argument(s) to clang (because order matters!). This is a list to preserve order (fifo).
 		public HashSet<string> Defines; // -DX
 		public HashSet<string> UnresolvedSymbols; // -u X
@@ -106,24 +107,21 @@ namespace Xamarin.Utils
 				InitialOtherFlags = new List<string> ();
 			InitialOtherFlags.Add (flag);
 		}
-
-		public void AddOtherFlag (string flag)
-		{
-			if (string.IsNullOrEmpty (flag))
-				return;
-			if (OtherFlags == null)
-				OtherFlags = new HashSet<string> ();
-			OtherFlags.Add (flag);
-		}
-
-		public void AddOtherFlags (IEnumerable<string> flags)
+		
+		public void AddOtherFlag (IList<string> flags)
 		{
 			if (flags == null)
 				return;
+			AddOtherFlag ((string []) flags.ToArray ());
+		}
 
+		public void AddOtherFlag (params string [] flags)
+		{
+			if (flags == null || flags.Length == 0)
+				return;
 			if (OtherFlags == null)
-				OtherFlags = new HashSet<string> ();
-			OtherFlags.UnionWith (flags);
+				OtherFlags = new HashSet<string[]> ();
+			OtherFlags.Add (flags);
 		}
 
 		public void LinkWithMono ()
@@ -227,7 +225,7 @@ namespace Xamarin.Utils
 			Inputs.Add (file);
 		}
 
-		public void WriteArguments (StringBuilder args)
+		public void WriteArguments (IList<string> args)
 		{
 			Prepare ();
 
@@ -235,8 +233,6 @@ namespace Xamarin.Utils
 				var idx = 0;
 				foreach (var flag in InitialOtherFlags) {
 					args.Insert (idx, flag);
-					idx += flag.Length;
-					args.Insert (idx, " ");
 					idx++;
 				}
 			}
@@ -245,42 +241,49 @@ namespace Xamarin.Utils
 
 			if (LinkWithLibraries != null) {
 				foreach (var lib in LinkWithLibraries) {
-					args.Append (' ').Append (StringUtils.Quote (lib));
+					args.Add (lib);
 					AddInput (lib);
 				}
 			}
 
 			if (ForceLoadLibraries != null) {
 				foreach (var lib in ForceLoadLibraries) {
-					args.Append (" -force_load ").Append (StringUtils.Quote (lib));
+					args.Add ("-force_load");
+					args.Add (lib);
 					AddInput (lib);
 				}
 			}
 
 			if (OtherFlags != null) {
-				foreach (var flag in OtherFlags)
-					args.Append (' ').Append (flag);
+				foreach (var flags in OtherFlags) {
+					foreach (var flag in flags)
+						args.Add (flag);
+				}
 			}
 
 			if (Defines != null) {
-				foreach (var define in Defines)
-					args.Append (" -D").Append (define);
+				foreach (var define in Defines) {
+					args.Add ("-D");
+					args.Add (define);
+				}
 			}
 
 			if (UnresolvedSymbols != null) {
-				foreach (var symbol in UnresolvedSymbols)
-					args.Append (" -u ").Append (StringUtils.Quote (symbol));
+				foreach (var symbol in UnresolvedSymbols) {
+					args.Add ("-u");
+					args.Add (symbol);
+				}
 			}
 
 			if (SourceFiles != null) {
 				foreach (var src in SourceFiles) {
-					args.Append (' ').Append (StringUtils.Quote (src));
+					args.Add (src);
 					AddInput (src);
 				}
 			}
 		}
 
-		void ProcessFrameworksForArguments (StringBuilder args)
+		void ProcessFrameworksForArguments (IList<string> args)
 		{
 			bool any_user_framework = false;
 
@@ -295,40 +298,61 @@ namespace Xamarin.Utils
 			}
 
 			if (any_user_framework) {
-				args.Append (" -Xlinker -rpath -Xlinker @executable_path/Frameworks");
-				if (Application.IsExtension)
-					args.Append (" -Xlinker -rpath -Xlinker @executable_path/../../Frameworks");
+				args.Add ("-Xlinker");
+				args.Add ("-rpath");
+				args.Add ("-Xlinker");
+				args.Add ("@executable_path/Frameworks");
+				if (Application.IsExtension) {
+					args.Add ("-Xlinker");
+					args.Add ("-rpath");
+					args.Add ("-Xlinker");
+					args.Add ("@executable_path/../../Frameworks");
+				}
 			}
 
 			if (Application.HasAnyDynamicLibraries) {
-				args.Append (" -Xlinker -rpath -Xlinker @executable_path/");
-				if (Application.IsExtension)
-					args.Append (" -Xlinker -rpath -Xlinker @executable_path/../..");
+				args.Add ("-Xlinker");
+				args.Add ("-rpath");
+				args.Add ("-Xlinker");
+				args.Add ("@executable_path/");
+				if (Application.IsExtension) {
+					args.Add ("-Xlinker");
+					args.Add ("-rpath");
+					args.Add ("-Xlinker");
+					args.Add ("@executable_path/../..");
+				}
 			}
 		}
 
-		void ProcessFrameworkForArguments (StringBuilder args, string fw, bool is_weak, ref bool any_user_framework)
+		void ProcessFrameworkForArguments (IList<string> args, string fw, bool is_weak, ref bool any_user_framework)
 		{
 			var name = Path.GetFileNameWithoutExtension (fw);
 			if (fw.EndsWith (".framework", StringComparison.Ordinal)) {
 				// user framework, we need to pass -F to the linker so that the linker finds the user framework.
 				any_user_framework = true;
 				AddInput (Path.Combine (fw, name));
-				args.Append (" -F ").Append (StringUtils.Quote (Path.GetDirectoryName (fw)));
+				args.Add ("-F");
+				args.Add (Path.GetDirectoryName (fw));
 			}
-			args.Append (is_weak ? " -weak_framework " : " -framework ").Append (name);
+			args.Add (is_weak ? "-weak_framework" : "-framework");
+			args.Add (name);
+		}
+
+		public string[] ToArray ()
+		{
+			var args = new List<string> ();
+			WriteArguments (args);
+			return args.ToArray ();
 		}
 
 		public override string ToString ()
 		{
-			var args = new StringBuilder ();
-			WriteArguments (args);
-			return args.ToString ();
+			return string.Join (" ", ToArray ());
 		}
 
 		public void PopulateInputs ()
 		{
-			var args = new StringBuilder ();
+			var args = new List<string> ();
 			Inputs = new List<string> ();
 			WriteArguments (args);
 		}

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -557,7 +557,7 @@ namespace Xamarin.Bundler {
 		static string FindSystemXcode ()
 		{
 			var output = new StringBuilder ();
-			if (Driver.RunCommand ("xcode-select", new string [] { "-p" }, output: output) != 0) {
+			if (Driver.RunCommand ("xcode-select", new [] { "-p" }, output: output) != 0) {
 				ErrorHelper.Warning (59, "Could not find the currently selected Xcode on the system: {0}", output.ToString ());
 				return null;
 			}
@@ -655,7 +655,7 @@ namespace Xamarin.Bundler {
 			int ret = RunCommand ("xcrun", args, env, output);
 			if (ret != 0 && verbose > 1) {
 				StringBuilder debug = new StringBuilder ();
-				RunCommand ("xcrun", new string [] { "--find", command }, env, debug);
+				RunCommand ("xcrun", new [] { "--find", command }, env, debug);
 				Console.WriteLine ("failed using `{0}` from: {1}", command, debug);
 			}
 			return ret;

--- a/tools/common/Execution.cs
+++ b/tools/common/Execution.cs
@@ -8,20 +8,28 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Xamarin.Utils;
+
 namespace Xamarin.Bundler {
 	public partial class Driver {
-		public static int RunCommand (string path, string args, string [] env, out StringBuilder output, bool suppressPrintOnErrors, int verbose)
+		public static int RunCommand (string path, IList<string> args, string [] env, out StringBuilder output, bool suppressPrintOnErrors, int verbose)
 		{
 			output = new StringBuilder ();
-			return RunCommand (path, args, env, output, suppressPrintOnErrors, verbose);
+			return RunCommand (path, StringUtils.FormatArguments (args), env, output, suppressPrintOnErrors, verbose);
+		}
+		
+		public static int RunCommand (string path, IList<string> args, string [] env, StringBuilder output, bool suppressPrintOnErrors, int verbose)
+		{
+			return RunCommand (path, StringUtils.FormatArguments (args), env, output, suppressPrintOnErrors, verbose);
 		}
 
-		public static int RunCommand (string path, string args, string[] env, StringBuilder output, bool suppressPrintOnErrors, int verbose)
+		static int RunCommand (string path, string args, string[] env, StringBuilder output, bool suppressPrintOnErrors, int verbose)
 		{
 			var info = new ProcessStartInfo (path, args);
 			info.UseShellExecute = false;

--- a/tools/common/StringUtils.cs
+++ b/tools/common/StringUtils.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Utils {
 
 		static char shellQuoteChar;
 		static char[] mustQuoteCharacters = new char [] { ' ', '\'', ',', '$', '\\' };
+		static char [] mustQuoteCharactersProcess = { ' ', '\\', '"' };
 
 		public static string[] Quote (params string[] array)
 		{
@@ -44,6 +45,40 @@ namespace Xamarin.Utils {
 				s.Append (c);
 			}
 			s.Append (shellQuoteChar);
+
+			return s.ToString ();
+		}
+
+		public static string [] QuoteForProcess (params string [] array)
+		{
+			if (array == null || array.Length == 0)
+				return array;
+
+			var rv = new string [array.Length];
+			for (var i = 0; i < array.Length; i++)
+				rv [i] = QuoteForProcess (array [i]);
+			return rv;
+		}
+
+		// Quote input according to how System.Diagnostics.Process needs it quoted.
+		public static string QuoteForProcess (string f)
+		{
+			if (String.IsNullOrEmpty (f))
+				return f ?? String.Empty;
+
+			if (f.IndexOfAny (mustQuoteCharactersProcess) == -1)
+				return f;
+
+			var s = new StringBuilder ();
+
+			s.Append ('"');
+			foreach (var c in f) {
+				if (c == '"' || c == '\\')
+					s.Append ('\\');
+
+				s.Append (c);
+			}
+			s.Append ('"');
 
 			return s.ToString ();
 		}

--- a/tools/common/cache.cs
+++ b/tools/common/cache.cs
@@ -78,7 +78,7 @@ public class Cache {
 		}
 
 		var diff = new StringBuilder ();
-		if (Driver.RunCommand ("diff", $"-ur {StringUtils.Quote (a)} {StringUtils.Quote (b)}", output: diff, suppressPrintOnErrors: true) != 0) {
+		if (Driver.RunCommand ("diff", new string [] { "-ur", a, b, }, output: diff, suppressPrintOnErrors: true) != 0) {
 			Driver.Log (1, "Directories {0} and {1} are considered different because diff said so:\n{2}", a, b, diff);
 			return false;
 		}

--- a/tools/common/cache.cs
+++ b/tools/common/cache.cs
@@ -78,7 +78,7 @@ public class Cache {
 		}
 
 		var diff = new StringBuilder ();
-		if (Driver.RunCommand ("diff", new string [] { "-ur", a, b, }, output: diff, suppressPrintOnErrors: true) != 0) {
+		if (Driver.RunCommand ("diff", new [] { "-ur", a, b, }, output: diff, suppressPrintOnErrors: true) != 0) {
 			Driver.Log (1, "Directories {0} and {1} are considered different because diff said so:\n{2}", a, b, diff);
 			return false;
 		}

--- a/tools/mmp/aot.cs
+++ b/tools/mmp/aot.cs
@@ -217,7 +217,7 @@ namespace Xamarin.Bundler {
 
 			if (IsRelease && options.IsHybridAOT) {
 				Parallel.ForEach (filesToAOT, ParallelOptions, file => {
-					if (RunCommand (StripCommand, new string [] { file }) != 0)
+					if (RunCommand (StripCommand, new [] { file }) != 0)
 						throw ErrorHelper.CreateError (3001, "Could not strip the assembly '{0}'", file);
 				});
 			}
@@ -226,7 +226,7 @@ namespace Xamarin.Bundler {
 				// mono --aot creates .dll.dylib.dSYM directories for each assembly AOTed
 				// There isn't an easy was to disable this behavior, so clean up under release
 				Parallel.ForEach (filesToAOT, ParallelOptions, file => {
-					if (RunCommand (DeleteDebugSymbolCommand, new string [] { "-r", file + ".dylib.dSYM/" }, monoEnv) != 0)
+					if (RunCommand (DeleteDebugSymbolCommand, new [] { "-r", file + ".dylib.dSYM/" }, monoEnv) != 0)
 						throw ErrorHelper.CreateError (3001, "Could not delete debug info from assembly '{0}'", file);
 				});
 			}

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -87,7 +87,7 @@ namespace Xamarin.Bundler {
 		static bool no_executable;
 		static bool embed_mono = true;
 		static bool? profiling = false;
-		static string link_flags = null;
+		static List<string> link_flags;
 		static LinkerOptions linker_options;
 		static bool? disable_lldb_attach = null;
 		static string machine_config_path = null;
@@ -310,7 +310,13 @@ namespace Xamarin.Bundler {
 					}
 				},
 				{ "link_flags=", "Specifies additional arguments to the native linker.",
-					v => { link_flags = v; }
+					v => {
+						if (!StringUtils.TryParseArguments (v, out var lf, out var ex))
+							throw ErrorHelper.CreateError (26, ex, "Could not parse the command line argument '--link_flags={0}': {1}", v, ex.Message);
+						if (link_flags == null)
+							link_flags = new List<string> ();
+						link_flags.AddRange (lf);
+					}
 				},
 				{ "ignore-native-library=", "Add a native library to be ignored during assembly scanning and packaging",
 					v => ignored_assemblies.Add (v)
@@ -897,7 +903,7 @@ namespace Xamarin.Bundler {
 						mono_dir = GetXamMacPrefix ();
 					} else {
 						var dir = new StringBuilder ();
-						RunCommand (pkg_config, "--variable=prefix mono-2", null, dir);
+						RunCommand (pkg_config, new string [] { "--variable=prefix", "mono-2" }, null, dir);
 						mono_dir = Path.GetFullPath (dir.ToString ().Replace (Environment.NewLine, String.Empty));
 					}
 				}
@@ -1088,14 +1094,16 @@ namespace Xamarin.Bundler {
 			return sb.ToString ();
 		}
 
-		static void HandleFramework (StringBuilder args, string framework, bool weak)
+		static void HandleFramework (IList<string> args, string framework, bool weak)
 		{
 			string name = Path.GetFileName (framework);
 			if (name.Contains ('.'))
-				name = name.Remove (name.IndexOf("."));
+				name = name.Remove (name.IndexOf (".", StringComparison.Ordinal));
 			string path = Path.GetDirectoryName (framework);
-			if (!string.IsNullOrEmpty (path))
-				args.Append ("-F ").Append (StringUtils.Quote (path)).Append (' ');
+			if (!string.IsNullOrEmpty (path)) {
+				args.Add ("-F");
+				args.Add (path);
+			}
 		
 			if (weak)
 				BuildTarget.WeakFrameworks.Add (name);
@@ -1120,7 +1128,7 @@ namespace Xamarin.Bundler {
 		{
 			int ret = 1;
 
-			string cflags;
+			string [] cflags = Array.Empty<string> ();
 			string libdir;
 			StringBuilder cflagsb = new StringBuilder ();
 			StringBuilder libdirb = new StringBuilder ();
@@ -1143,13 +1151,13 @@ namespace Xamarin.Bundler {
 				if (!IsUnifiedFullSystemFramework)
 					env = new [] { "PKG_CONFIG_PATH", Path.Combine (GetXamMacPrefix (), "lib", "pkgconfig") };
 
-				RunCommand (pkg_config, "--cflags mono-2", env, cflagsb);
-				RunCommand (pkg_config, "--variable=libdir mono-2", env, libdirb);
+				RunCommand (pkg_config, new string [] { "--cflags", "mono-2" }, env, cflagsb);
+				RunCommand (pkg_config, new string [] { "--variable=libdir", "mono-2" }, env, libdirb);
 				var versionFile = "/Library/Frameworks/Mono.framework/Versions/Current/VERSION";
 				if (File.Exists (versionFile)) {
 					mono_version.Append (File.ReadAllText (versionFile));
 				} else {
-					RunCommand (pkg_config, "--modversion mono-2", env, mono_version);
+					RunCommand (pkg_config, new string [] { "--modversion", "mono-2" }, env, mono_version);
 				}
 			} catch (Win32Exception e) {
 				throw new MonoMacException (5301, true, e, "pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads");
@@ -1159,8 +1167,10 @@ namespace Xamarin.Bundler {
 			if (Version.TryParse (mono_version.ToString ().TrimEnd (), out mono_ver) && mono_ver < MonoVersions.MinimumMonoVersion)
 				throw new MonoMacException (1, true, "This version of Xamarin.Mac requires Mono {0} (the current Mono version is {1}). Please update the Mono.framework from http://mono-project.com/Downloads", 
 					MonoVersions.MinimumMonoVersion, mono_version.ToString ().TrimEnd ());
-			
-			cflags = cflagsb.ToString ().Replace (Environment.NewLine, String.Empty);
+
+			var str_cflags = cflagsb.ToString ().Replace (Environment.NewLine, String.Empty);
+			if (!StringUtils.TryParseArguments (str_cflags, out cflags, out var ex))
+				throw ErrorHelper.CreateError (147, ex, "Unable to parse the cflags '{0} from pkg-config: {1}", str_cflags, ex.Message);
 			libdir = libdirb.ToString ().Replace (Environment.NewLine, String.Empty);
 
 			var libmain = embed_mono ? "libxammac" : "libxammac-system";
@@ -1170,23 +1180,27 @@ namespace Xamarin.Bundler {
 				throw new MonoMacException (5203, true, "Can't find {0}, likely because of a corrupted Xamarin.Mac installation. Please reinstall Xamarin.Mac.", libxammac);
 
 			try {
-				var args = new StringBuilder ();
+				var args = new List<string> ();
 				if (App.EnableDebug)
-					args.Append ("-g ");
-				if (App.Embeddinator)
-					args.Append ($"-shared -install_name \"@loader_path/../Frameworks/{App.Name}.framework/{App.Name}\" ");
-				args.Append ("-mmacosx-version-min=").Append (App.DeploymentTarget.ToString ()).Append (' ');
-				args.Append ("-arch ").Append (arch).Append (' ');
+					args.Add ("-g");
+				if (App.Embeddinator) {
+					args.Add ("-shared");
+					args.Add ("-install_name");
+					args.Add ($"@loader_path/../Frameworks/{App.Name}.framework/{App.Name}");
+				}
+				args.Add ($"-mmacosx-version-min={App.DeploymentTarget.ToString ()}");
+				args.Add ("-arch");
+				args.Add (arch);
 				if (arch == "x86_64")
-					args.Append ("-fobjc-runtime=macosx ");
+					args.Add ("-fobjc-runtime=macosx");
 				if (!embed_mono)
-					args.Append ("-DDYNAMIC_MONO_RUNTIME ");
+					args.Add ("-DDYNAMIC_MONO_RUNTIME");
 
 				if (XcodeVersion >= new Version (9, 0))
-					args.Append ("-Wno-unguarded-availability-new ");
+					args.Add ("-Wno-unguarded-availability-new");
 
 				if (XcodeVersion.Major >= 11)
-					args.Append ("-std=c++14 ");
+					args.Add ("-std=c++14");
 
 				bool appendedObjc = false;
 				var sourceFiles = new List<string> ();
@@ -1199,20 +1213,20 @@ namespace Xamarin.Bundler {
 								// Link against the version copied into MonoBudle, since we install_name_tool'd it already
 								string libName = Path.GetFileName (linkWith);
 								string finalLibPath = Path.Combine (mmp_dir, libName);
-								args.Append (StringUtils.Quote (finalLibPath)).Append (' ');
+								args.Add (finalLibPath);
 							}
 							else {
-								args.Append (StringUtils.Quote (linkWith)).Append (' ');
+								args.Add (linkWith);
 							}
 						}
 						if (!appendedObjc) {
 							appendedObjc = true;
-							args.Append ("-ObjC").Append (' ');
+							args.Add ("-ObjC");
 						}
 					}
 					if (assembly.LinkerFlags != null)
 						foreach (var linkFlag in assembly.LinkerFlags)
-							args.Append (linkFlag).Append (' ');
+							args.Add (linkFlag);
 					if (assembly.Frameworks != null) {
 						foreach (var f in assembly.Frameworks) {
 							if (verbose > 1)
@@ -1237,21 +1251,33 @@ namespace Xamarin.Bundler {
 					// Link against the version copied into MonoBudle, since we install_name_tool'd it already
 					string libName = Path.GetFileName (lib);
 					string finalLibPath = Path.Combine (mmp_dir, libName);
-					args.Append (StringUtils.Quote (finalLibPath)).Append (' ');
+					args.Add (finalLibPath);
 				}
 
-				if (frameworks_copied_to_bundle_dir)
-					args.Append ("-rpath @loader_path/../Frameworks ");
-				if (dylibs_copied_to_bundle_dir)
-					args.Append ($"-rpath @loader_path/../{BundleName} ");
+				if (frameworks_copied_to_bundle_dir) {
+					args.Add ("-rpath");
+					args.Add ("@loader_path/../Frameworks");
+				}
+				if (dylibs_copied_to_bundle_dir) {
+					args.Add ("-rpath");
+					args.Add ($"@loader_path/../{BundleName}");
+				}
 
-				if (is_extension)
-					args.Append ("-e _xamarin_mac_extension_main -framework NotificationCenter").Append(' ');
+				if (is_extension) {
+					args.Add ("-e");
+					args.Add ("_xamarin_mac_extension_main");
+					args.Add ("-framework");
+					args.Add ("NotificationCenter");
+				}
 
-				foreach (var f in BuildTarget.Frameworks)
-					args.Append ("-framework ").Append (f).Append (' ');
-				foreach (var f in BuildTarget.WeakFrameworks)
-					args.Append ("-weak_framework ").Append (f).Append (' ');
+				foreach (var f in BuildTarget.Frameworks) {
+					args.Add ("-framework");
+					args.Add (f);
+				}
+				foreach (var f in BuildTarget.WeakFrameworks) {
+					args.Add ("-weak_framework");
+					args.Add (f);
+				}
 
 				var requiredSymbols = BuildTarget.GetRequiredSymbols ();
 				Driver.WriteIfDifferent (Path.Combine (App.Cache.Location, "exported-symbols-list"), string.Join ("\n", requiredSymbols.Select ((symbol) => symbol.Prefix + symbol.Name).ToArray ()));
@@ -1266,8 +1292,10 @@ namespace Xamarin.Bundler {
 					break;
 				case SymbolMode.Linker:
 				case SymbolMode.Default:
-					foreach (var symbol in requiredSymbols)
-						args.Append ("-u ").Append (StringUtils.Quote (symbol.Prefix + symbol.Name)).Append (' ');
+					foreach (var symbol in requiredSymbols) {
+						args.Add ("-u");
+						args.Add (symbol.Prefix + symbol.Name);
+					}
 					break;
 				default:
 					throw ErrorHelper.CreateError (99, $"Internal error: invalid symbol mode: {App.SymbolMode}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).");
@@ -1275,23 +1303,25 @@ namespace Xamarin.Bundler {
 
 				bool linkWithRequiresForceLoad = BuildTarget.Assemblies.Any (x => x.ForceLoad);
 				if (no_executable || linkWithRequiresForceLoad)
-					args.Append ("-force_load "); // make sure nothing is stripped away if we don't have a root assembly, since anything can end up being used.
-				args.Append (StringUtils.Quote (libxammac)).Append (' ');
-				args.Append ("-o ").Append (StringUtils.Quote (AppPath)).Append (' ');
-				args.Append (cflags).Append (' ');
+					args.Add ("-force_load"); // make sure nothing is stripped away if we don't have a root assembly, since anything can end up being used.
+				args.Add (libxammac);
+				args.Add ("-o");
+				args.Add (AppPath);
+				args.AddRange (cflags);
 				if (embed_mono) {
 					string libmono = Path.Combine (libdir, "libmonosgen-2.0.a");
 
 					if (!File.Exists (libmono))
 						throw new MonoMacException (5202, true, "Mono.framework MDK is missing. Please install the MDK for your Mono.framework version from https://www.mono-project.com/download/");
 
-					args.Append (StringUtils.Quote (libmono)).Append (' ');
+					args.Add (libmono);
 
 					string libmonoSystemNative = Path.Combine (libdir, "libmono-system-native.a");
 					if (File.Exists (libmonoSystemNative)) {
 						// legacy libmono-system-native.a needs to be included if it exists in the mono in question
-						args.Append (StringUtils.Quote (libmonoSystemNative)).Append (' ');
-						args.Append ("-u ").Append ("_SystemNative_RealPath").Append (' '); // This keeps libmono_system_native_la-pal_io.o symbols
+						args.Add (libmonoSystemNative);
+						args.Add ("-u");
+						args.Add ("_SystemNative_RealPath"); // This keeps libmono_system_native_la-pal_io.o symbols
 					} else {
 						// add modern libmono-native
 						string libmono_native_name;
@@ -1306,69 +1336,64 @@ namespace Xamarin.Bundler {
 							throw ErrorHelper.CreateError (99, $"Invalid error: Invalid mono native type: '{BuildTarget.MonoNativeMode}'. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).");
 						}
 
-						args.Append (StringUtils.Quote (Path.Combine (libdir, libmono_native_name + ".a"))).Append (' ');
-						args.Append ("-framework GSS ");
+						args.Add (Path.Combine (libdir, libmono_native_name + ".a"));
+						args.Add ("-framework");
+						args.Add ("GSS");
 					}
 
 					if (profiling.HasValue && profiling.Value) {
-						args.Append (StringUtils.Quote (Path.Combine (libdir, "libmono-profiler-log.a"))).Append (' ');
-						args.Append ("-u _mono_profiler_init_log ");
+						args.Add (Path.Combine (libdir, "libmono-profiler-log.a"));
+						args.Add ("-u");
+						args.Add ("_mono_profiler_init_log");
 					}
-					args.Append ("-lz ");
+					args.Add ("-lz");
 				}
 
 				if (Registrar == RegistrarMode.PartialStatic) {
-					args.Append (PartialStaticLibrary);
-					args.Append (" -framework Quartz ");
+					args.Add (PartialStaticLibrary);
+					args.Add ("-framework");
+					args.Add ("Quartz");
 				}
 
-				args.Append ("-liconv -lc++ -x objective-c++ ");
+				args.Add ("-liconv");
+				args.Add ("-lc++");
+				args.Add ("-x");
+				args.Add ("objective-c++");
 				if (XcodeVersion.Major >= 10) {
 					// Xcode 10 doesn't ship with libstdc++
-					args.Append ("-stdlib=libc++ ");
+					args.Add ("-stdlib=libc++");
 				}
-				args.Append ("-I").Append (StringUtils.Quote (Path.Combine (GetXamMacPrefix (), "include"))).Append (' ');
+				args.Add ($"-I{Path.Combine (GetXamMacPrefix (), "include")}");
 				if (registrarPath != null)
-					args.Append (StringUtils.Quote (registrarPath)).Append (' ');
-				args.Append ("-fno-caret-diagnostics -fno-diagnostics-fixit-info ");
+					args.Add (registrarPath);
+				args.Add ("-fno-caret-diagnostics");
+				args.Add ("-fno-diagnostics-fixit-info");
 				if (link_flags != null)
-					args.Append (link_flags + " ");
+					args.AddRange (link_flags);
 				if (!string.IsNullOrEmpty (DeveloperDirectory))
 				{
 					var sysRootSDKVersion = new Version (App.SdkVersion.Major, App.SdkVersion.Minor); // Sys Root SDKs do not have X.Y.Z, just X.Y 
-					args.Append ("-isysroot ").Append (StringUtils.Quote (Path.Combine (DeveloperDirectory, "Platforms", "MacOSX.platform", "Developer", "SDKs", "MacOSX" + sysRootSDKVersion + ".sdk"))).Append (' ');
+					args.Add ("-isysroot");
+					args.Add (Path.Combine (DeveloperDirectory, "Platforms", "MacOSX.platform", "Developer", "SDKs", "MacOSX" + sysRootSDKVersion + ".sdk"));
 				}
 
 				if (App.RequiresPInvokeWrappers) {
 					var state = linker_options.MarshalNativeExceptionsState;
 					state.End ();
-					args.Append (StringUtils.Quote (state.SourcePath)).Append (' ');
+					args.Add (state.SourcePath);
 				}
 
 				var main = Path.Combine (App.Cache.Location, "main.m");
 				File.WriteAllText (main, mainSource);
 				sourceFiles.Add (main);
+				args.AddRange (sourceFiles);
 
-				foreach (var src in sourceFiles)
-					args.Append (StringUtils.Quote (src)).Append (' ');;
 
-				ret = XcodeRun ("clang", args.ToString (), null);
+				ret = XcodeRun ("clang", args, null);
 			} catch (Win32Exception e) {
 				throw new MonoMacException (5103, true, e, "Failed to compile the file '{0}'. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new", "driver");
 			}
 			
-			return ret;
-		}
-
-		static int XcodeRun (string command, string args, StringBuilder output = null)
-		{
-			string [] env = DeveloperDirectory != string.Empty ? new string [] { "DEVELOPER_DIR", DeveloperDirectory } : null;
-			int ret = RunCommand ("xcrun", String.Concat ("-sdk macosx ", command, " ", args), env, output);
-			if (ret != 0 && verbose > 1) {
-				StringBuilder debug = new StringBuilder ();
-				RunCommand ("xcrun", String.Concat ("--find ", command), env, debug);
-				Console.WriteLine ("failed using `{0}` from: {1}", command, debug);
-			}
 			return ret;
 		}
 
@@ -1497,7 +1522,7 @@ namespace Xamarin.Bundler {
 					string libName = Path.GetFileName (linkWith);
 					string finalLibPath = Path.Combine (mmp_dir, libName);
 					Application.UpdateFile (linkWith, finalLibPath);
-					int ret = XcodeRun ("install_name_tool -id", string.Format ("{0} {1}", StringUtils.Quote("@executable_path/../" + BundleName + "/" + libName), StringUtils.Quote (finalLibPath)));
+					int ret = XcodeRun ("install_name_tool", new string [] { "-id", "@executable_path/../" + BundleName + "/" + libName, finalLibPath });
 					if (ret != 0)
 						throw new MonoMacException (5310, true, "install_name_tool failed with an error code '{0}'. Check build log for details.", ret);
 					native_libraries_copied_in.Add (libName);
@@ -1510,7 +1535,7 @@ namespace Xamarin.Bundler {
 
 			// .dylibs might refers to specific paths (e.g. inside Mono framework directory) and/or
 			// refer to a symlink (pointing to a more specific version of the library)
-			StringBuilder sb = new StringBuilder ();
+			var sb = new List<string> ();
 			foreach (string library in Directory.GetFiles (mmp_dir, "*.dylib")) {
 				foreach (string lib in Xamarin.MachO.GetNativeDependencies (library)) {
 					if (lib.StartsWith ("/Library/Frameworks/Mono.framework/Versions/", StringComparison.Ordinal)) {
@@ -1520,13 +1545,15 @@ namespace Xamarin.Bundler {
 						// if a symlink was specified then re-create it inside the .app
 						if (libname != real_libname)
 							CreateSymLink (mmp_dir, real_libname, libname);
-						sb.Append (" -change ").Append (lib).Append (" @executable_path/../" + BundleName + "/").Append (libname);
+						sb.Add ("-change");
+						sb.Add (lib);
+						sb.Add ("@executable_path/../" + BundleName + "/" + libname);
 					}
 				}
 				// if required update the paths inside the .dylib that was copied
-				if (sb.Length > 0) {
-					sb.Append (' ').Append (StringUtils.Quote (library));
-					int ret = XcodeRun ("install_name_tool", sb.ToString ());
+				if (sb.Count > 0) {
+					sb.Add (library);
+					int ret = XcodeRun ("install_name_tool", sb);
 					if (ret != 0)
 						throw new MonoMacException (5310, true, "install_name_tool failed with an error code '{0}'. Check build log for details.", ret);
 					sb.Clear ();
@@ -1667,7 +1694,7 @@ namespace Xamarin.Bundler {
 
 			if (native_references.Contains (real_src)) {
 				if (!isStaticLib) {
-					int ret = XcodeRun ("install_name_tool -id", string.Format ("{0} {1}", StringUtils.Quote("@executable_path/../" + BundleName + "/" + name), StringUtils.Quote(dest)));
+					int ret = XcodeRun ("install_name_tool", new string [] { "-id", "@executable_path/../" + BundleName + "/" + name, dest });
 					if (ret != 0)
 						throw new MonoMacException (5310, true, "install_name_tool failed with an error code '{0}'. Check build log for details.", ret);
 				}
@@ -1702,7 +1729,7 @@ namespace Xamarin.Bundler {
 			if (existingArchs.Count () < 2)
 				return;
 
-			int ret = XcodeRun ("lipo", $"{StringUtils.Quote (dest)} -thin {arch} -output {StringUtils.Quote (dest)}");
+			int ret = XcodeRun ("lipo", new string [] { dest, "-thin", arch, "-output", dest });
 			if (ret != 0)
 				throw new MonoMacException (5311, true, "lipo failed with an error code '{0}'. Check build log for details.", ret);
 			if (name != "MonoPosixHelper" && name != "libmono-native-unified" && name != "libmono-native-compat")

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -903,7 +903,7 @@ namespace Xamarin.Bundler {
 						mono_dir = GetXamMacPrefix ();
 					} else {
 						var dir = new StringBuilder ();
-						RunCommand (pkg_config, new string [] { "--variable=prefix", "mono-2" }, null, dir);
+						RunCommand (pkg_config, new [] { "--variable=prefix", "mono-2" }, null, dir);
 						mono_dir = Path.GetFullPath (dir.ToString ().Replace (Environment.NewLine, String.Empty));
 					}
 				}
@@ -1151,13 +1151,13 @@ namespace Xamarin.Bundler {
 				if (!IsUnifiedFullSystemFramework)
 					env = new [] { "PKG_CONFIG_PATH", Path.Combine (GetXamMacPrefix (), "lib", "pkgconfig") };
 
-				RunCommand (pkg_config, new string [] { "--cflags", "mono-2" }, env, cflagsb);
-				RunCommand (pkg_config, new string [] { "--variable=libdir", "mono-2" }, env, libdirb);
+				RunCommand (pkg_config, new [] { "--cflags", "mono-2" }, env, cflagsb);
+				RunCommand (pkg_config, new [] { "--variable=libdir", "mono-2" }, env, libdirb);
 				var versionFile = "/Library/Frameworks/Mono.framework/Versions/Current/VERSION";
 				if (File.Exists (versionFile)) {
 					mono_version.Append (File.ReadAllText (versionFile));
 				} else {
-					RunCommand (pkg_config, new string [] { "--modversion", "mono-2" }, env, mono_version);
+					RunCommand (pkg_config, new [] { "--modversion", "mono-2" }, env, mono_version);
 				}
 			} catch (Win32Exception e) {
 				throw new MonoMacException (5301, true, e, "pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads");
@@ -1522,7 +1522,7 @@ namespace Xamarin.Bundler {
 					string libName = Path.GetFileName (linkWith);
 					string finalLibPath = Path.Combine (mmp_dir, libName);
 					Application.UpdateFile (linkWith, finalLibPath);
-					int ret = XcodeRun ("install_name_tool", new string [] { "-id", "@executable_path/../" + BundleName + "/" + libName, finalLibPath });
+					int ret = XcodeRun ("install_name_tool", new [] { "-id", "@executable_path/../" + BundleName + "/" + libName, finalLibPath });
 					if (ret != 0)
 						throw new MonoMacException (5310, true, "install_name_tool failed with an error code '{0}'. Check build log for details.", ret);
 					native_libraries_copied_in.Add (libName);
@@ -1694,7 +1694,7 @@ namespace Xamarin.Bundler {
 
 			if (native_references.Contains (real_src)) {
 				if (!isStaticLib) {
-					int ret = XcodeRun ("install_name_tool", new string [] { "-id", "@executable_path/../" + BundleName + "/" + name, dest });
+					int ret = XcodeRun ("install_name_tool", new [] { "-id", "@executable_path/../" + BundleName + "/" + name, dest });
 					if (ret != 0)
 						throw new MonoMacException (5310, true, "install_name_tool failed with an error code '{0}'. Check build log for details.", ret);
 				}
@@ -1729,7 +1729,7 @@ namespace Xamarin.Bundler {
 			if (existingArchs.Count () < 2)
 				return;
 
-			int ret = XcodeRun ("lipo", new string [] { dest, "-thin", arch, "-output", dest });
+			int ret = XcodeRun ("lipo", new [] { dest, "-thin", arch, "-output", dest });
 			if (ret != 0)
 				throw new MonoMacException (5311, true, "lipo failed with an error code '{0}'. Check build log for details.", ret);
 			if (name != "MonoPosixHelper" && name != "libmono-native-unified" && name != "libmono-native-compat")

--- a/tools/mmp/tests/aot.cs
+++ b/tools/mmp/tests/aot.cs
@@ -29,13 +29,13 @@ namespace Xamarin.MMP.Tests.Unit
 			}
 		}
 
-		List<Tuple<string, string>> commandsRun;
+		List<Tuple<string, IList<string>>> commandsRun;
 
 		[SetUp]
 		public void Init ()
 		{
 			// Make sure this is cleared between every test
-			commandsRun = new List<Tuple<string, string>> ();
+			commandsRun = new List<Tuple<string, IList<string>>> ();
 		}
 
 		void Compile (AOTOptions options, TestFileEnumerator files, AOTCompilerType compilerType = AOTCompilerType.Bundled64, RunCommandDelegate onRunDelegate = null, bool isRelease = false, bool isModern = false)
@@ -59,9 +59,9 @@ namespace Xamarin.MMP.Tests.Unit
 			commandsRun.Clear ();
 		}
 
-		int OnRunCommand (string path, string args, string [] env, StringBuilder output, bool suppressPrintOnErrors)
+		int OnRunCommand (string path, IList<string> args, string [] env, StringBuilder output, bool suppressPrintOnErrors)
 		{
-			commandsRun.Add (Tuple.Create <string, string>(path, args));
+			commandsRun.Add (Tuple.Create <string, IList<string>>(path, args));
 			if (path != AOTCompiler.StripCommand && path != AOTCompiler.DeleteDebugSymbolCommand) {
 				Assert.IsTrue (env[0] == "MONO_PATH", "MONO_PATH should be first env set");
 				Assert.IsTrue (env[1] == TestRootDir, "MONO_PATH should be set to our expected value");
@@ -92,7 +92,7 @@ namespace Xamarin.MMP.Tests.Unit
 				if (expectSymbolDeletion && command.Item1 == AOTCompiler.DeleteDebugSymbolCommand)
 					continue;
 				Assert.IsTrue (command.Item1.EndsWith (GetExpectedMonoCommand (compilerType)), "Unexpected command: " + command.Item1);
-				string [] argParts = command.Item2.Split (' ');
+				var argParts = command.Item2;
 
 				if (kind == AOTKind.Hybrid)
 					Assert.AreEqual (argParts[0], "--aot=hybrid", "First arg should be --aot=hybrid");
@@ -105,35 +105,34 @@ namespace Xamarin.MMP.Tests.Unit
 					Assert.AreNotEqual (argParts[1], "--runtime=mobile", "Second arg should not be --runtime=mobile");
 
 
-				int fileNameBeginningIndex = command.Item2.IndexOf(' ') + 1;
+				var fileName = command.Item2 [1];
 				if (isModern)
-					fileNameBeginningIndex = command.Item2.IndexOf(' ', fileNameBeginningIndex) + 1;
+					fileName = command.Item2 [2];
 
-				string fileName = command.Item2.Substring (fileNameBeginningIndex).Replace ("\'", "");
 				filesAOTed.Add (fileName);
 			}
 			return filesAOTed;
 		}
 
-		List<string> GetFilesStripped ()
+		IEnumerable<string> GetFilesStripped ()
 		{
-			return commandsRun.Where (x => x.Item1 == AOTCompiler.StripCommand).Select (x => x.Item2.Replace ("\'", "")).ToList ();
+			return commandsRun.Where (x => x.Item1 == AOTCompiler.StripCommand).SelectMany (x => x.Item2);
 		}
 		
 		void AssertFilesStripped (IEnumerable <string> expectedFiles)
 		{
-			List<string> filesStripped = GetFilesStripped ();
+			var filesStripped = GetFilesStripped ();
 
 			Func<string> getErrorDetails = () => $"\n {FormatDebugList (filesStripped)} \nvs\n {FormatDebugList (expectedFiles)}\n{AllCommandsRun}";
 
-			Assert.AreEqual (filesStripped.Count, expectedFiles.Count (), "Different number of files stripped than expected: " + getErrorDetails ());
+			Assert.AreEqual (filesStripped.Count (), expectedFiles.Count (), "Different number of files stripped than expected: " + getErrorDetails ());
 			Assert.IsTrue (filesStripped.All (x => expectedFiles.Contains (x)), "Different files stripped than expected: "  + getErrorDetails ());
 		}
 		
 		List<string> GetDeletedSymbols ()
 		{
 			// Chop off -r prefix and quotes around filename
-			return commandsRun.Where (x => x.Item1 == AOTCompiler.DeleteDebugSymbolCommand).Select (x => x.Item2.Substring(3).Replace ("\'", "")).ToList ();
+			return commandsRun.Where (x => x.Item1 == AOTCompiler.DeleteDebugSymbolCommand).Select (x => x.Item2 [1]).ToList ();
 		}
 
 		string AllCommandsRun => "\nCommands Run:\n\t" + String.Join ("\n\t", commandsRun.Select (x => $"{x.Item1} {x.Item2}"));
@@ -299,17 +298,6 @@ namespace Xamarin.MMP.Tests.Unit
 		}
 
 		[Test]
-		public void AssemblyWithSpaces_ShouldAOTWithQuotes ()
-		{
-			var options = new AOTOptions ("+Foo Bar.dll");
-			Assert.IsTrue (options.IsAOT, "Should be IsAOT");
-
-			Compile (options, new TestFileEnumerator (new string [] { "Foo Bar.dll", "Xamarin.Mac.dll" }));
-			AssertFilesAOTed (new string [] {"Foo Bar.dll"});
-			Assert.IsTrue (commandsRun.Where (x => x.Item2.Contains ("Foo Bar.dll")).All (x => x.Item2.EndsWith ("\'Foo Bar.dll\'", StringComparison.InvariantCulture)), "Should end with quoted filename");
-		}
-
-		[Test]
 		public void WhenAOTFails_ShouldReturnError ()
 		{
 			RunCommandDelegate runThatErrors = (path, args, env, output, suppressPrintOnErrors) => 42;
@@ -395,19 +383,6 @@ namespace Xamarin.MMP.Tests.Unit
 			AssertFilesAOTed (expectedFiles, expectStripping : false, expectSymbolDeletion : true);
 			AssertFilesStripped (new string [] {});
 			AssertSymbolsDeleted (expectedFiles);
-		}
-
-		[Test]
-		public void AssemblyWithSpaces_ShouldStripWithQuotes ()
-		{
-			var options = new AOTOptions ("all|hybrid,+Foo Bar.dll");
-
-			var files = new string [] { "Foo Bar.dll", "Xamarin.Mac.dll" };
-			Compile (options, new TestFileEnumerator (files), isRelease : true);
-			AssertFilesStripped (files);
-			AssertSymbolsDeleted (files);
-			// We don't check end quote here, since we might have .dylib.dSYM suffix
-			Assert.IsTrue (commandsRun.Where (x => x.Item2.Contains ("Foo Bar.dll")).All (x => x.Item2.Contains ("\'Foo Bar.dll")), "Should contain quoted filename");
 		}
 
 		[Test]

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1192,12 +1192,7 @@ namespace Xamarin.Bundler {
 				return true;
 			if (a == null ^ b == null)
 				return false;
-			if (a.Count != b.Count)
-				return false;
-			for (var i = 0; i < a.Count; i++)
-				if (a [i] != b [i])
-					return false;
-			return true;
+			return a.SequenceEqual (b);
 		}
 
 		void Initialize ()

--- a/tools/mtouch/BuildTasks.mtouch.cs
+++ b/tools/mtouch/BuildTasks.mtouch.cs
@@ -334,7 +334,7 @@ namespace Xamarin.Bundler
 					// check command length
 					// getconf ARG_MAX
 					StringBuilder getconf_output = new StringBuilder ();
-					if (Driver.RunCommand ("getconf", new string [] { "ARG_MAX" }, output: getconf_output, suppressPrintOnErrors: true) == 0) {
+					if (Driver.RunCommand ("getconf", new [] { "ARG_MAX" }, output: getconf_output, suppressPrintOnErrors: true) == 0) {
 						int arg_max;
 						if (int.TryParse (getconf_output.ToString ().Trim (' ', '\t', '\n', '\r'), out arg_max)) {
 							var cmd_length = Target.App.CompilerPath.Length + 1 + CompilerFlags.ToString ().Length;

--- a/tools/mtouch/Stripper.cs
+++ b/tools/mtouch/Stripper.cs
@@ -24,8 +24,7 @@ namespace MonoTouch.Tuner {
 				Driver.Log (1, "Stripping assembly {0} to {1}", assembly_file, output_file);
 
 				string tool = "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5/mono-cil-strip.exe";
-				string cmd = tool + " " + StringUtils.Quote (assembly_file) + " " + StringUtils.Quote (output_file);
-				if (Driver.RunCommand ("/Library/Frameworks/Mono.framework/Versions/Current/bin/mono", cmd) != 0)
+				if (Driver.RunCommand ("/Library/Frameworks/Mono.framework/Versions/Current/bin/mono", tool, assembly_file, output_file) != 0)
 					throw new MonoTouchException (6002, true, "Could not strip assembly `{0}`.", assembly_file);
 			} catch (NotSupportedException e) {
 				throw new MonoTouchException (6001, true, e.Message);

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -1108,8 +1108,7 @@ namespace Xamarin.Bundler
 								OutputFile = bc + ".o",
 								Abi = abi,
 							};
-							if (!string.IsNullOrEmpty (App.UserGccFlags))
-								compile_task.CompilerFlags.AddOtherFlag (App.UserGccFlags);
+							compile_task.CompilerFlags.AddOtherFlag (App.UserGccFlags);
 							compile_task.AddDependency (info.Task);
 							link_dependencies.Add (compile_task);
 						}
@@ -1149,7 +1148,7 @@ namespace Xamarin.Bundler
 					foreach (var a in assemblies) {
 						compiler_flags.AddFrameworks (a.Frameworks, a.WeakFrameworks);
 						compiler_flags.AddLinkWith (a.LinkWith, a.ForceLoad);
-						compiler_flags.AddOtherFlags (a.LinkerFlags);
+						compiler_flags.AddOtherFlag (a.LinkerFlags.ToArray ());
 						if (a.HasLinkWithAttributes) {
 							var symbols = GetRequiredSymbols (a);
 							switch (App.SymbolMode) {
@@ -1458,7 +1457,7 @@ namespace Xamarin.Bundler
 
 		public NativeLinkTask NativeLink (BuildTasks build_tasks, Abi abi, string output_file)
 		{
-			if (!string.IsNullOrEmpty (App.UserGccFlags))
+			if (App.UserGccFlags?.Count > 0)
 				App.DeadStrip = false;
 			if (App.EnableLLVMOnlyBitCode)
 				App.DeadStrip = false;
@@ -1474,7 +1473,7 @@ namespace Xamarin.Bundler
 				linker_flags.AddFrameworks (a.Frameworks, a.WeakFrameworks);
 				if (a.BuildTarget == AssemblyBuildTarget.StaticObject)
 					linker_flags.AddLinkWith (a.LinkWith, a.ForceLoad);
-				linker_flags.AddOtherFlags (a.LinkerFlags);
+				linker_flags.AddOtherFlag (a.LinkerFlags.ToArray ());
 
 				if (a.BuildTarget == AssemblyBuildTarget.StaticObject) {
 					AotInfo info;
@@ -1502,7 +1501,7 @@ namespace Xamarin.Bundler
 			CompileTask.GetArchFlags (linker_flags, abi);
 			if (App.IsDeviceBuild) {
 				linker_flags.AddOtherFlag ($"-m{Driver.GetTargetMinSdkName (App)}-version-min={App.DeploymentTarget}");
-				linker_flags.AddOtherFlag ($"-isysroot {StringUtils.Quote (Driver.GetFrameworkDirectory (App))}");
+				linker_flags.AddOtherFlag ($"-isysroot", Driver.GetFrameworkDirectory (App));
 			} else {
 				CompileTask.GetSimulatorCompilerFlags (linker_flags, false, App);
 			}
@@ -1513,7 +1512,7 @@ namespace Xamarin.Bundler
 			if (App.LibXamarinLinkMode != AssemblyBuildTarget.StaticObject)
 				AddToBundle (App.GetLibXamarin (App.LibXamarinLinkMode));
 
-			linker_flags.AddOtherFlag ($"-o {StringUtils.Quote (output_file)}");
+			linker_flags.AddOtherFlag ("-o", output_file);
 
 			bool need_libcpp = false;
 			if (App.EnableBitCode)
@@ -1543,12 +1542,12 @@ namespace Xamarin.Bundler
 			var libdir = Path.Combine (Driver.GetProductSdkDirectory (App), "usr", "lib");
 			if (App.Embeddinator) {
 				linker_flags.AddOtherFlag ("-shared");
-				linker_flags.AddOtherFlag ($"-install_name {StringUtils.Quote ($"@rpath/{App.ExecutableName}.framework/{App.ExecutableName}")}");
+				linker_flags.AddOtherFlag ("-install_name", $"@rpath/{App.ExecutableName}.framework/{App.ExecutableName}");
 			} else {
 				string mainlib;
 				if (App.IsWatchExtension) {
 					mainlib = "libwatchextension.a";
-					linker_flags.AddOtherFlag (" -e _xamarin_watchextension_main");
+					linker_flags.AddOtherFlag ("-e", "_xamarin_watchextension_main");
 					if (App.SdkVersion.Major >= 6) {
 						// watchOS 6.0's WatchKit contains a WKExtensionMain function, and that's the entry point for Xcode-compiled watch extensions.
 						// To make watch extensions work on earlier watchOS versions, there's a libWKExtensionMainLegacy.a library with a
@@ -1602,7 +1601,7 @@ namespace Xamarin.Bundler
 			if (App.IsExtension) {
 				if (App.Platform == ApplePlatform.iOS && Driver.XcodeVersion.Major < 7) {
 					linker_flags.AddOtherFlag ("-lpkstart");
-					linker_flags.AddOtherFlag ($"-F {StringUtils.Quote (Path.Combine (Driver.GetFrameworkDirectory (App), "System/Library/PrivateFrameworks"))} -framework PlugInKit");
+					linker_flags.AddOtherFlag ("-F", Path.Combine (Driver.GetFrameworkDirectory (App), "System/Library/PrivateFrameworks"), "-framework", "PlugInKit");
 				}
 				linker_flags.AddOtherFlag ("-fapplication-extension");
 			}
@@ -1707,17 +1706,18 @@ namespace Xamarin.Bundler
 
 		public static void AdjustDylibs (string output)
 		{
-			var sb = new StringBuilder ();
+			var sb = new List<string> ();
 			foreach (var dependency in Xamarin.MachO.GetNativeDependencies (output)) {
 				if (!dependency.StartsWith ("/System/Library/PrivateFrameworks/", StringComparison.Ordinal))
 					continue;
 				var fixed_dep = dependency.Replace ("/PrivateFrameworks/", "/Frameworks/");
-				sb.Append (" -change ").Append (dependency).Append (' ').Append (fixed_dep);
+				sb.Add ("-change");
+				sb.Add (dependency);
+				sb.Add (fixed_dep);
 			}
-			if (sb.Length > 0) {
-				var quoted_name = StringUtils.Quote (output);
-				sb.Append (' ').Append (quoted_name);
-				Driver.XcodeRun ("install_name_tool", sb.ToString ());
+			if (sb.Count > 0) {
+				sb.Add (output);
+				Driver.XcodeRun ("install_name_tool", sb);
 				sb.Clear ();
 			}
 		}

--- a/tools/xibuild/Main.cs
+++ b/tools/xibuild/Main.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using Mono.Options;
+using Xamarin.Utils;
 
 namespace xibuild {
 	class MainClass {
@@ -103,13 +104,11 @@ namespace xibuild {
 				if (no_logo)
 					remaining.Add ("/nologo");
 			}
-
+			var arguments = remaining.Skip (runMSBuild ? 0 : 1).ToArray ();
 			return RunTool (
 					toolPath: runMSBuild ? "msbuild" : remaining [0],
-					combinedArgs: BuildQuotedCommandLine (remaining, runMSBuild ? 0 : 1),
+					combinedArgs: StringUtils.FormatArguments (arguments),
 					baseConfigFile: runMSBuild ? null : baseConfigFile);
-
-			string BuildQuotedCommandLine (List<string> a, int skip) => String.Join (" ", a.Skip (skip).Select (arg => $"\"{arg}\""));
 		}
 
 		static int RunTool (string toolPath, string combinedArgs, string baseConfigFile)

--- a/tools/xibuild/Makefile
+++ b/tools/xibuild/Makefile
@@ -3,7 +3,7 @@ TOP = ../..
 include $(TOP)/Make.config
 
 CONFIGURATION=Debug
-SRC_FILES=Main.cs
+SRC_FILES=Main.cs $(TOP)/tools/common/StringUtils.cs
 
 all: bin/$(CONFIGURATION)/xibuild.exe
 

--- a/tools/xibuild/xibuild.csproj
+++ b/tools/xibuild/xibuild.csproj
@@ -38,6 +38,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />
+    <Compile Include="..\common\StringUtils.cs">
+      <Link>StringUtils.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
mono changed how quotes should be escaped when passed to
System.Diagnostic.Process, so we need to change accordingly.

The main difference is that single quotes don't have to be escaped anymore.

This solves problems like this:

    System.ComponentModel.Win32Exception : ApplicationName='nuget', CommandLine='restore '/Users/vsts/agent/2.158.0/work/1/s/tests/sampletester/bin/Debug/repositories/ios-samples/WorkingWithTables/Part 3 - Customizing a Table\'s appearance/3 - CellCustomTable/CellCustomTable.sln' -Verbosity detailed -SolutionDir '/Users/vsts/agent/2.158.0/work/1/s/tests/sampletester/bin/Debug/repositories/ios-samples/WorkingWithTables/Part 3 - Customizing a Table\'s appearance/3 - CellCustomTable'', CurrentDirectory='/Users/vsts/agent/2.158.0/work/1/s/tests/sampletester/bin/Debug/repositories', Native error= Cannot find the specified file
      at System.Diagnostics.Process.StartWithCreateProcess (System.Diagnostics.ProcessStartInfo startInfo) [0x0029f] in /Users/builder/jenkins/workspace/build-package-osx-mono/2019-08/external/bockbuild/builds/mono-x64/mcs/class/System/System.Diagnostics/Process.cs:778

ref: https://github.com/mono/mono/pull/15047