### PR TITLE
[Foundation] Fix expressionForConstantValue: NullAllowed param

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -4197,7 +4197,7 @@ namespace Foundation
 	[DisableDefaultCtor]
 	interface NSExpression : NSSecureCoding, NSCopying {
 		[Static, Export ("expressionForConstantValue:")]
-		NSExpression FromConstant (NSObject obj);
+		NSExpression FromConstant ([NullAllowed] NSObject obj);
 
 		[Static, Export ("expressionForEvaluatedObject")]
 		NSExpression ExpressionForEvaluatedObject { get; }


### PR DESCRIPTION
Fixes [issue](https://github.com/xamarin/xamarin-macios/issues/7174) #7174 