### PR TITLE
Automatically build mono from source if any of the archives aren't available. (#7160)

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -9,12 +9,25 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config
 	@printf "MAC_COMMIT_DISTANCE:=$(shell LANG=C; export LANG && git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep MAC_PACKAGE_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
 	@if which ccache > /dev/null 2>&1; then printf "ENABLE_CCACHE=1\nexport CCACHE_BASEDIR=$(abspath $(TOP)/..)\n" >> $@; echo "Found ccache on the system, enabling it"; fi
 	@if test -d $(TOP)/../maccore; then printf "ENABLE_XAMARIN=1\n" >> $@; echo "Detected the maccore repository, automatically enabled the Xamarin build"; fi
-	@# Build from source for Xcode 11 support until mono has packages
-	@# TODO: to be removed when we can use the mono archive again.
-ifeq ($(XI_PACKAGE),)
-	@# Don't build from source when we're using an XI package in CI (i.e. when the XI_PACKAGE variable is set - typically for device test).
-	@printf "MONO_BUILD_FROM_SOURCE=1\n" >> $@; echo "Disabled the packaged mono build, since it's currently not supported in the xcode11 support branch."
-endif
+	@# Build from source if we're on CI and packages aren't available.
+	@if ! curl -s -f --head "$(MONO_IOS_URL)" &> /dev/null; then \
+		echo "$(COLOR_GRAY)*** The mono archive for iOS ($(MONO_IOS_URL)) can't be downloaded:$(COLOR_CLEAR)"; \
+		echo "$$ curl -s --head '$(MONO_IOS_URL)'" | sed 's/^/    /'; \
+		curl -s --head "$(MONO_IOS_URL)" | sed 's/^/    /'; \
+		MONO_DOWNLOAD_FAIL=1; \
+	fi; \
+	if ! curl -s -f --head "$(MONO_MAC_URL)" &> /dev/null; then \
+		echo "$(COLOR_GRAY)*** The mono archive for macOS ($(MONO_MAC_URL)) can't be downloaded:$(COLOR_CLEAR)"; \
+		echo "$$ curl -s --head '$(MONO_MAC_URL)'" | sed 's/^/    /'; \
+		curl -s --head "$(MONO_MAC_URL)" | sed 's/^/    /'; \
+		MONO_DOWNLOAD_FAIL=1; \
+	fi; \
+	if test -n "$$MONO_DOWNLOAD_FAIL"; then \
+		echo "$(COLOR_GRAY)Building mono from source because one or both of the mono archives aren't downloadable.$(COLOR_CLEAR)"; \
+		printf "MONO_BUILD_FROM_SOURCE=1\n" >> $@; \
+	else \
+		echo "Downloading mono archives"; \
+	fi
 
 include $(TOP)/Make.versions
 

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -128,7 +128,14 @@ echo "Configuring the build with: $CONFIGURE_FLAGS"
 # shellcheck disable=SC2086
 ./configure $CONFIGURE_FLAGS
 
+# If we're building mono from source, we might not have it cloned yet
+make reset
+
 time make -j8
 time make install -j8
 
 printf "✅ [Build succeeded](%s/console)\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
+
+if grep MONO_BUILD_FROM_SOURCE=. configure.inc Make.config.inc >& /dev/null; then
+	printf "    ⚠️ Mono built from source\\n" >> "$WORKSPACE/jenkins/pr-comments.md"
+fi


### PR DESCRIPTION
* Automatically build mono from source if any of the archives aren't available.

* [jenkins] Show in the PR report if mono was built from source.

* [jenkins] Make sure we got everything after running configure.