### PR TITLE
Fix #7174: ArgumentNullException for NSExpression.FromConstant

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -4197,7 +4197,7 @@ namespace Foundation
 	[DisableDefaultCtor]
 	interface NSExpression : NSSecureCoding, NSCopying {
 		[Static, Export ("expressionForConstantValue:")]
-		NSExpression FromConstant ([NullAllowed]NSObject obj);
+		NSExpression FromConstant ([NullAllowed] NSObject obj);
 
 		[Static, Export ("expressionForEvaluatedObject")]
 		NSExpression ExpressionForEvaluatedObject { get; }

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -4197,7 +4197,7 @@ namespace Foundation
 	[DisableDefaultCtor]
 	interface NSExpression : NSSecureCoding, NSCopying {
 		[Static, Export ("expressionForConstantValue:")]
-		NSExpression FromConstant (NSObject obj);
+		NSExpression FromConstant ([NullAllowed]NSObject obj);
 
 		[Static, Export ("expressionForEvaluatedObject")]
 		NSExpression ExpressionForEvaluatedObject { get; }

--- a/tests/monotouch-test/Foundation/NSExpressionTest.cs
+++ b/tests/monotouch-test/Foundation/NSExpressionTest.cs
@@ -45,22 +45,21 @@ namespace MonoTouchFixtures.Foundation
 			}
 		}
 
-		[TestCase("Foo", Result = "Foo")]
-		[TestCase(null, Result = null)]
+		[TestCase ("Foo", Result = "Foo")]
+		[TestCase (null, Result = null)]
 		public object FromConstant (object input)
 		{
-            NSObject value = null;
+			NSObject value = null;
 
-            switch (input)
-            {
-                case String stringValue:
-                    value = new NSString(stringValue);
-                    break;
-            }
+			switch (input) {
+				case String stringValue:
+					value = new NSString (stringValue);
+					break;
+			}
 
-            using (var expression = NSExpression.FromConstant(value))
-            using (var result = expression.EvaluateWith(null, null) as NSObject)
-                return result?.ToString();
+			using (var expression = NSExpression.FromConstant (value))
+			using (var result = expression.EvaluateWith (null, null) as NSObject)
+				return result?.ToString ();
 		}
 
 		[Test]

--- a/tests/monotouch-test/Foundation/NSExpressionTest.cs
+++ b/tests/monotouch-test/Foundation/NSExpressionTest.cs
@@ -45,13 +45,22 @@ namespace MonoTouchFixtures.Foundation
 			}
 		}
 
-
-		[Test]
-		public void FromConstant ()
+		[TestCase("Foo", Result = "Foo")]
+		[TestCase(null, Result = null)]
+		public object FromConstant (object input)
 		{
-			using (var expression = NSExpression.FromConstant (new NSString ("Foo")))
-			using (var result = expression.EvaluateWith (null, null) as NSString)
-				Assert.AreEqual ("Foo", result.ToString ());
+            NSObject value = null;
+
+            switch (input)
+            {
+                case String stringValue:
+                    value = new NSString(stringValue);
+                    break;
+            }
+
+            using (var expression = NSExpression.FromConstant(value))
+            using (var result = expression.EvaluateWith(null, null) as NSObject)
+                return result?.ToString();
 		}
 
 		[Test]


### PR DESCRIPTION
Fix #7174 
- Add missing NullAllowed attribute
- Add unit test for null value