### PR TITLE
[xcode11.1] [Foundation] Remove a possible race condition when interacting with the notification centre.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -190,12 +190,13 @@ namespace Foundation {
 
 		void RemoveNotification ()
 		{
+			NSObject localNotificationToken;
 			lock (notificationTokenLock) {
-				if (notificationToken != null) {
-					NSNotificationCenter.DefaultCenter.RemoveObserver (notificationToken);
-					notificationToken = null;
-				}
-			} // lock
+				localNotificationToken = notificationToken;
+				notificationToken = null;
+			}
+			if (localNotificationToken != null)
+				NSNotificationCenter.DefaultCenter.RemoveObserver (localNotificationToken);
 		}
 
 		void BackgroundNotificationCb (NSNotification obj)

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -239,11 +239,11 @@ namespace Foundation {
 
 		protected override void Dispose (bool disposing)
 		{
+			lock (inflightRequestsLock) {
 #if !MONOMAC  && !__WATCHOS__
 			// remove the notification if present, method checks against null
 			RemoveNotification ();
 #endif
-			lock (inflightRequestsLock) {
 				foreach (var pair in inflightRequests) {
 					pair.Key?.Cancel ();
 					pair.Key?.Dispose ();


### PR DESCRIPTION
Although it looked that it was not possible, due to the fact that the
RemoveObserversFromList does lock on the list of observers, we have
threads that are stepping on each other when the list is cleaned up.
Adding a lock around the AddObserver and RemoveObserver will ensure that
the handler does not call the removal more than once with an object that
was already removed.

Fixes https://github.com/xamarin/xamarin-macios/issues/6387

Backport of #6537.

/cc @mandel-macaque 