### PR TITLE
[CoreAudioTypes] Binding - Changed AudioTypes enum

### DIFF
--- a/src/AudioToolbox/AudioType.cs
+++ b/src/AudioToolbox/AudioType.cs
@@ -390,16 +390,13 @@ namespace AudioToolbox {
 		DialogCentricMix      = 43,
 		CenterSurroundDirect  = 44,
 		Haptic                = 45,
-   
-#if false
-		// with xcode11 GM the tvOS and macOS headers drifted from the iOS ones
-		// https://github.com/xamarin/maccore/issues/1960
-		LeftTopFront          = 46,
-		CenterTopFront        = 47,
-		RightTopFront         = 48,
+
+		LeftTopFront          = VerticalHeightLeft,
+		CenterTopFront        = VerticalHeightCenter,
+		RightTopFront         = VerticalHeightRight,
 		LeftTopMiddle         = 49,
-		CenterTopMiddle       = 50,
-#endif
+		CenterTopMiddle       = TopCenterSurround,
+
 		RightTopMiddle        = 51,
 		LeftTopRear           = 52,
 		CenterTopRear         = 53,
@@ -507,15 +504,13 @@ namespace AudioToolbox {
 		TopBackLeft                = 1<<15,
 		TopBackCenter              = 1<<16,
 		TopBackRight               = 1<<17,
-#if false
-		// with xcode11 GM the tvOS and macOS headers drifted from the iOS ones
-		// https://github.com/xamarin/maccore/issues/1960
-		LeftTopFront               = 1<<18,
-		CenterTopFront             = 1<<19,
-		RightTopFront              = 1<<20,
+
+		LeftTopFront               = VerticalHeightLeft,
+		CenterTopFront             = VerticalHeightCenter,
+		RightTopFront              = VerticalHeightRight,
 		LeftTopMiddle              = 1<<21,
-		CenterTopMiddle            = 1<<22,
-#endif
+		CenterTopMiddle            = TopCenterSurround,
+
 		RightTopMiddle             = 1<<23,
 		LeftTopRear                = 1<<24,
 		CenterTopRear              = 1<<25,


### PR DESCRIPTION
Adopted new enums for xcode11.1 (https://github.com/xamarin/xamarin-macios/wiki/CoreAudioTypes-iOS-xcode11.1-GM)
Might be solving issue [#1960](https://github.com/xamarin/maccore/issues/1960)
