### PR TITLE
Fixing failure when compiling linker

### DIFF
--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -166,6 +166,9 @@
     <Compile Include="..\..\builds\mono-ios-sdk-destdir\ios-sources\external\linker\src\linker\Linker\XApiReader.cs">
       <Link>Linker\XApiReader.cs</Link>
     </Compile>
+    <Compile Include="..\..\builds\mono-ios-sdk-destdir\ios-sources\external\linker\src\linker\Linker\OutputException.cs">
+      <Link>Linker\OutputException.cs</Link>
+    </Compile>
     <Compile Include="..\..\builds\mono-ios-sdk-destdir\ios-sources\external\linker\src\linker\Linker.Steps\BaseStep.cs">
       <Link>Linker.Steps\BaseStep.cs</Link>
     </Compile>


### PR DESCRIPTION
/Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/builds/mono-ios-sdk-destdir/ios-sources/external/linker/src/linker/Linker.Steps/OutputStep.cs(110,15): error CS0246: The type or namespace name ‘OutputException’ could not be found (are you missing a using directive or an assembly reference?) [/Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tools/mmp/mmp.csproj]