### PR TITLE
Fix a few introspection issues on Catalina.

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2198,7 +2198,11 @@ namespace AppKit {
 		GenericPreferencesIcon        = 0x70726566,   //'pref'
 		GenericQueryDocumentIcon      = 0x71657279,   //'qery'
 		GenericRamDiskIcon            = 0x72616D64,   //'ramd'
+#if !XAMCORE_4_0
+		[Obsolete ("Use 'GenericSharedLibraryIcon' instead.")]
 		GenericSharedLibaryIcon       = 0x73686C62,   //'shlb'
+#endif
+		GenericSharedLibraryIcon      = 0x73686C62,   //'shlb'
 		GenericStationeryIcon         = 0x73646F63,   //'sdoc'
 		GenericSuitcaseIcon           = 0x73756974,   //'suit'
 		GenericUrlIcon                = 0x6775726C,   //'gurl'

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -1213,7 +1213,7 @@ namespace SceneKit {
 
 #if MONOMAC
 	[iOS (8,0)]
-	[Deprecated (PlatformName.MacOSX, 10, 14, message: "OpenGL API deprecated, please use Metal instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use Metal instead of OpenGL API.")]
 	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
 	[BaseType (typeof (CAOpenGLLayer))]
 	interface SCNLayer : SCNSceneRenderer, SCNTechniqueSupport {
@@ -3507,16 +3507,16 @@ namespace SceneKit {
 		bool AllowsCameraControl { get; set;  }
 
 #if MONOMAC
-		[Deprecated (PlatformName.MacOSX, 10, 14, message: "OpenGL API deprecated, please use Metal instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use Metal instead of OpenGL API.")]
 		[Export ("openGLContext", ArgumentSemantic.Retain)]
 		NSOpenGLContext	OpenGLContext { get; set;  }
 
-		[Deprecated (PlatformName.MacOSX, 10, 14, message: "OpenGL API deprecated, please use Metal instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use Metal instead of OpenGL API.")]
 		[Export ("pixelFormat", ArgumentSemantic.Retain)]
 		NSOpenGLPixelFormat PixelFormat { get; set;  }
 #elif !WATCH
-		[Deprecated (PlatformName.iOS, 12, 0, message: "OpenGL API deprecated, please use Metal instead.")]
-		[Deprecated (PlatformName.TvOS, 12, 0, message: "OpenGL API deprecated, please use Metal instead.")]
+		[Deprecated (PlatformName.iOS, 12, 0, message: "Please use Metal instead of OpenGL API.")]
+		[Deprecated (PlatformName.TvOS, 12, 0, message: "Please use Metal instead of OpenGL API.")]
 		[Export ("eaglContext", ArgumentSemantic.Retain)]
 #if XAMCORE_2_0
 		EAGLContext EAGLContext { get; set; }

--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -299,6 +299,12 @@ namespace Introspection {
 					break;
 				}
 				break;
+#if !XAMCORE_4_0
+			case "MTLCounter":
+			case "MTLCounterSampleBuffer":
+			case "MTLCounterSet":
+				return true; // Incorrectly bound, will be fixed for XAMCORE_4_0.
+#endif
 			}
 			return false;
 		}

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -145,6 +145,7 @@ namespace Introspection
 			"Cartes", // french
 			"Cavlc",
 			"Cda", // acronym: Clinical Document Architecture
+			"Cdrom",
 			"Cfa", // acronym: Color Filter Array
 			"Celp", // MPEG4ObjectID
 			"Characterteristic",
@@ -386,6 +387,7 @@ namespace Introspection
 			"nint",
 			"Nntps",
 			"Ntlm",
+			"Nsl", // InternetLocationNslNeighborhoodIcon
 			"Ntsc",
 			"nuint",
 			"Ndef",
@@ -436,6 +438,7 @@ namespace Introspection
 			"Prerolls",
 			"Preseti",
 			"Prev",
+			"Privs", // SharingPrivsNotApplicableIcon
 			"Propogate",
 			"Psec",
 			"Psm", // Protocol/Service Multiplexer
@@ -864,6 +867,7 @@ namespace Introspection
 			"Attributest",
 			"Failwith",
 			"Imageimage",
+			"Libary",
 			"Musthold",
 			"Olus", // Typo, should be 'Bolus', fixed in 'HKInsulinDeliveryReason'
 			"Ostprandial", // Typo, should be 'Postprandial', fixed in 'HKBloodGlucoseMealTime'

--- a/tests/introspection/Mac/MacApiSelectorTest.cs
+++ b/tests/introspection/Mac/MacApiSelectorTest.cs
@@ -697,7 +697,8 @@ namespace Introspection {
 			case "Metal":
 				switch (type.Name) {
 				case "MTLCounterSampleBufferDescriptor":
-					// This whole type is implemented using a different (internal) type, and it's the internal type who knows how to respond to the selectors.
+					// This whole type is implemented using a different (internal) type,
+					// and it's the internal type who knows how to respond to the selectors.
 					return true;
 				}
 				break;

--- a/tests/introspection/Mac/MacApiSelectorTest.cs
+++ b/tests/introspection/Mac/MacApiSelectorTest.cs
@@ -694,6 +694,13 @@ namespace Introspection {
 				break;
 				}
 				break;
+			case "Metal":
+				switch (type.Name) {
+				case "MTLCounterSampleBufferDescriptor":
+					// This whole type is implemented using a different (internal) type, and it's the internal type who knows how to respond to the selectors.
+					return true;
+				}
+				break;
 			}
 			return base.Skip (type, selectorName);
 		}

--- a/tests/monotouch-test/NaturalLanguage/EmbeddingTest.cs
+++ b/tests/monotouch-test/NaturalLanguage/EmbeddingTest.cs
@@ -22,11 +22,18 @@ namespace MonoTouchFixtures.NaturalLanguage {
 		{
 			TestRuntime.AssertXcodeVersion (11, 0);
 
-			using (var e = NLEmbedding.GetWordEmbedding (NLLanguage.English)) {
-				Assert.NotNull (e, "GetWordEmbedding");
-				Assert.Null (e.GetVector ("Xamarin"), "GetVector");
-				Assert.False (e.TryGetVector ("Xamarin", out var vector), "TryGetVector");
-				Assert.Null (vector, "vector");
+			foreach (NLLanguage v in Enum.GetValues (typeof (NLLanguage))) {
+				if (v == NLLanguage.Unevaluated)
+					continue; // this is not a value provided by Apple.
+
+				NLEmbedding e = null;
+				Assert.DoesNotThrow (() => e = NLEmbedding.GetWordEmbedding (v), $"Throws: {v}");
+				if (e != null) {
+					Assert.NotNull (e, "GetWordEmbedding");
+					Assert.Null (e.GetVector ("Xamarin"), "GetVector");
+					Assert.False (e.TryGetVector ("Xamarin", out var vector), "TryGetVector");
+					Assert.Null (vector, "vector");
+				}
 			}
 		}
 #endif


### PR DESCRIPTION
*  [introspection] Ignore some API we've bound incorrectly. Fixes #7116.

   There are also a few API fixes, those will be submitted in a different PR.

   Fixes https://github.com/xamarin/xamarin-macios/issues/7116.

*  [introspection] Ignore MTLCounterSampleBufferDescriptor's selectors.

   They're implemented using a different/internal type:

       $ nm /System/Library/Frameworks/Metal.framework/Metal | grep MTLCounterSampleBuffer
       00000000000458ab t +[MTLCounterSampleBufferDescriptor allocWithZone:]
       0000000000045897 t +[MTLCounterSampleBufferDescriptor alloc]
       000000000004591e t -[MTLCounterSampleBufferDescriptor copyWithZone:]
       000000000004598e t -[MTLCounterSampleBufferDescriptorInternal copyWithZone:]
       0000000000045c0f t -[MTLCounterSampleBufferDescriptorInternal counterSet]
       0000000000045936 t -[MTLCounterSampleBufferDescriptorInternal dealloc]
       0000000000045b65 t -[MTLCounterSampleBufferDescriptorInternal hash]
       0000000000045a31 t -[MTLCounterSampleBufferDescriptorInternal isEqual:]
       0000000000045c58 t -[MTLCounterSampleBufferDescriptorInternal label]
       0000000000045c7f t -[MTLCounterSampleBufferDescriptorInternal sampleCount]
       0000000000045c25 t -[MTLCounterSampleBufferDescriptorInternal setCounterSet:]
       0000000000045c6e t -[MTLCounterSampleBufferDescriptorInternal setLabel:]
       0000000000045c90 t -[MTLCounterSampleBufferDescriptorInternal setSampleCount:]
       0000000000045c47 t -[MTLCounterSampleBufferDescriptorInternal setStorageMode:]
       0000000000045c36 t -[MTLCounterSampleBufferDescriptorInternal storageMode]
       000000000010b0b8 S _OBJC_CLASS_$_MTLCounterSampleBufferDescriptor
       000000000010b0e0 S _OBJC_CLASS_$_MTLCounterSampleBufferDescriptorInternal
       0000000000107070 S _OBJC_IVAR_$_MTLCounterSampleBufferDescriptorInternal._counterSet
       0000000000107078 S _OBJC_IVAR_$_MTLCounterSampleBufferDescriptorInternal._label
       0000000000107088 S _OBJC_IVAR_$_MTLCounterSampleBufferDescriptorInternal._sampleCount
       0000000000107080 S _OBJC_IVAR_$_MTLCounterSampleBufferDescriptorInternal._storageMode
       000000000010b108 S _OBJC_METACLASS_$_MTLCounterSampleBufferDescriptor
       000000000010b130 S _OBJC_METACLASS_$_MTLCounterSampleBufferDescriptorInternal

   Fixes these test failures:

       1) ApiSelectorTest.InstanceMethods (Introspection.MacApiSelectorTest.ApiSelectorTest.InstanceMethods)
           8 errors found in 26658 instance selector validated:
       Selector not found for Metal.MTLCounterSampleBufferDescriptor : counterSet
       Selector not found for Metal.MTLCounterSampleBufferDescriptor : setCounterSet:
       Selector not found for Metal.MTLCounterSampleBufferDescriptor : label
       Selector not found for Metal.MTLCounterSampleBufferDescriptor : setLabel:
       Selector not found for Metal.MTLCounterSampleBufferDescriptor : sampleCount
       Selector not found for Metal.MTLCounterSampleBufferDescriptor : setSampleCount:
       Selector not found for Metal.MTLCounterSampleBufferDescriptor : storageMode
       Selector not found for Metal.MTLCounterSampleBufferDescriptor : setStorageMode:

*  [tests] Fix introspection and xammac tests on Catalina.

   * [tests] Adjust NaturalLanguage.EmbeddingTest to cope with non-existent embeddings. Fixes xamarin/maccore#2011.
   * [tests] Fix typo test on macOS 10.15. Fixes #7116.

*  [SceneKit] Adjust deprecation message.

   Fixes this introspection failure:

       [FAIL] [Rule 4] Don't use availability keywords in attribute's message: "OpenGL API deprecated, please use Metal instead." - Type: SCNLayer
       [FAIL] [Rule 4] Don't use availability keywords in attribute's message: "OpenGL API deprecated, please use Metal instead." - Member name: get_OpenGLContext, Type: SCNView
       [FAIL] [Rule 4] Don't use availability keywords in attribute's message: "OpenGL API deprecated, please use Metal instead." - Member name: set_OpenGLContext, Type: SCNView
       [FAIL] [Rule 4] Don't use availability keywords in attribute's message: "OpenGL API deprecated, please use Metal instead." - Member name: get_PixelFormat, Type: SCNView
       [FAIL] [Rule 4] Don't use availability keywords in attribute's message: "OpenGL API deprecated, please use Metal instead." - Member name: set_PixelFormat, Type: SCNView