### PR TITLE
[d16-4][Metal] Fix a few issues with the latest Metal API additions. Fixes #7116.

### DIFF
--- a/src/Metal/MTLCompat.cs
+++ b/src/Metal/MTLCompat.cs
@@ -1,4 +1,7 @@
+#if !XAMCORE_4_0
 using System;
+
+using Foundation;
 using ObjCRuntime;
 
 namespace Metal {
@@ -9,4 +12,43 @@ namespace Metal {
 		public MTLSharedTextureHandle () {}
 	}
 
+#if MONOMAC
+	public static partial class MTLDevice_Extensions {
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		public static IMTLCounterSet[] GetIMTLCounterSets (this IMTLDevice This)
+		{
+			return NSArray.ArrayFromHandle<IMTLCounterSet>(global::ObjCRuntime.Messaging.IntPtr_objc_msgSend (This.Handle, Selector.GetHandle ("counterSets")));
+		}
+
+		[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
+		[Unavailable (PlatformName.TvOS, PlatformArchitecture.All)]
+		[Introduced (PlatformName.MacOSX, 10,15, PlatformArchitecture.All)]
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		public static IMTLCounterSampleBuffer CreateIMTLCounterSampleBuffer (this IMTLDevice This, MTLCounterSampleBufferDescriptor descriptor, out NSError error)
+		{
+			if (descriptor == null)
+				throw new ArgumentNullException ("descriptor");
+			IntPtr errorValue = IntPtr.Zero;
+
+			var ret = Runtime.GetINativeObject<IMTLCounterSampleBuffer> (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_ref_IntPtr (This.Handle, Selector.GetHandle ("newCounterSampleBufferWithDescriptor:error:"), descriptor.Handle, ref errorValue), owns: false);
+			error = Runtime.GetNSObject<NSError> (errorValue);
+
+			return ret;
+		}
+	}
+
+	public static partial class MTLComputeCommandEncoder_Extensions {
+		[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
+		[Unavailable (PlatformName.TvOS, PlatformArchitecture.All)]
+		[Introduced (PlatformName.MacOSX, 10,15, PlatformArchitecture.All)]
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		public static void SampleCounters (this IMTLComputeCommandEncoder This, IMTLCounterSampleBuffer sampleBuffer, nuint sampleIndex, bool barrier)
+		{
+			if (sampleBuffer == null)
+				throw new ArgumentNullException ("sampleBuffer");
+			global::ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_nuint_bool (This.Handle, Selector.GetHandle ("sampleCountersInBuffer:atSampleIndex:withBarrier:"), sampleBuffer.Handle, sampleIndex, barrier);
+		}
+	}
+#endif // MONOMAC
 }
+#endif // !XAMCORE_4_0

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -597,7 +597,12 @@ namespace Metal {
 #endif
 		[NoiOS, NoTV, Mac (10,15)]
 		[Export ("sampleCountersInBuffer:atSampleIndex:withBarrier:")]
+#if XAMCORE_4_0
+		void SampleCounters (IMTLCounterSampleBuffer sampleBuffer, nuint sampleIndex, bool barrier);
+#else
+		[Obsolete ("Use the overload that takes an IMTLCounterSampleBuffer instead.")]
 		void SampleCounters (MTLCounterSampleBuffer sampleBuffer, nuint sampleIndex, bool barrier);
+#endif
 	}
 
 	[iOS (8,0)][Mac (10,11)]
@@ -1363,7 +1368,12 @@ namespace Metal {
 #endif
 		[NoiOS, NoTV, Mac (10, 15)]
 		[NullAllowed, Export ("counterSets")]
+#if XAMCORE_4_0
+		IMTLCounterSet[] CounterSets { get; }
+#else
+		[Obsolete ("Use 'GetIMTLCounterSets' instead.")]
 		MTLCounterSet[] CounterSets { get; }
+#endif
 
 #if XAMCORE_4_0
 		[Abstract]
@@ -1371,7 +1381,12 @@ namespace Metal {
 		[NoiOS, NoTV, Mac (10,15)]
 		[Export ("newCounterSampleBufferWithDescriptor:error:")]
 		[return: NullAllowed]
+#if XAMCORE_4_0
+		IMTLCounterSampleBuffer CreateCounterSampleBuffer (MTLCounterSampleBufferDescriptor descriptor, [NullAllowed] out NSError error);
+#else
+		[Obsolete ("Use 'CreateIMTLCounterSampleBuffer' instead.")]
 		MTLCounterSampleBuffer CreateCounterSampleBuffer (MTLCounterSampleBufferDescriptor descriptor, [NullAllowed] out NSError error);
+#endif
 
 #if XAMCORE_4_0
 		[Abstract]
@@ -4148,7 +4163,9 @@ namespace Metal {
 
 	[NoiOS, NoTV, Mac (10,15)]
 	[Protocol]
+#if !XAMCORE_4_0
 	[BaseType (typeof(NSObject))]
+#endif
 	interface MTLCounter {
 		[Abstract]
 		[Export ("name")]
@@ -4159,7 +4176,9 @@ namespace Metal {
 
 	[NoiOS, NoTV, Mac (10,15)]
 	[Protocol]
+#if !XAMCORE_4_0
 	[BaseType (typeof(NSObject))]
+#endif
 	interface MTLCounterSet {
 		[Abstract]
 		[Export ("name")]
@@ -4174,7 +4193,9 @@ namespace Metal {
 
 	[NoiOS, NoTV, Mac (10,15)]
 	[Protocol]
+#if !XAMCORE_4_0
 	[BaseType (typeof(NSObject))]
+#endif
 	interface MTLCounterSampleBuffer {
 		[Abstract]
 		[Export ("device")]


### PR DESCRIPTION
We weren't using protocol types when we should, and we were using [BaseType]
when we shouldn't.