### PR TITLE
[build] lipo x86-64-slice into libs according to their kind

### DIFF
--- a/builds/.gitignore
+++ b/builds/.gitignore
@@ -25,3 +25,4 @@ watchbcl
 mono-ios-sdk-destdir
 *.dylib
 *.o
+x86-64-slice.*

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -54,9 +54,22 @@ downloads/%: downloads/%.7z
 clean-local::
 	$(Q) rm -Rf downloads .stamp-download-mono
 
-X86_64_SLICE=$(abspath $(CURDIR)/x86-64-slice.dylib)
-$(X86_64_SLICE): Makefile
-	echo "void xamarin_x86_64_function_for_notarization_workaround () {}" | $(MAC_CC) -shared -x c -o$@ -
+x86-64-slice.c: Makefile
+	echo "void xamarin_x86_64_function_for_notarization_workaround () {}" > $@
+
+x86-64-slice.o: x86-64-slice.c
+	$(MAC_CC) -c -ggdb3 $< -o $@
+
+X86_64_SLICE_BASE=$(abspath $(CURDIR)/x86-64-slice)
+X86_64_SLICE_DYLIB=$(X86_64_SLICE_BASE).dylib
+X86_64_SLICE_A=$(X86_64_SLICE_BASE).a
+X86_64_SLICE:=$(X86_64_SLICE)$(suffix $@)
+
+$(X86_64_SLICE_DYLIB): x86-64-slice.o
+	$(MAC_CC) -shared -o$@ $<
+
+$(X86_64_SLICE_A): x86-64-slice.o
+	$(AR) -rv $@ $<
 
 ifeq ($(MONO_BUILD_FROM_SOURCE),)
 


### PR DESCRIPTION
The result of `lipo`ing `.a`s and `.dylib`s together is not well defined.
In this specific case, using `lipo` on `libmonosgen-2.0.a` to inject `x86-64-slice.dylib` resulted into `dsymutil` (run by `mtouch` when building the app) not finding the proper debug information anymore.

Also putting the dummy slice into a file and adding `-ggdb3` to avoid those warnings:

```console
$ dsymutil ./_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/MonoTouch.iphoneos.sdk/usr/lib/libmonosgen-2.0.dylib
warning: (x86_64) /var/folders/p3/5279mmgn1p575bz28j0ngfqw0000gn/T/--19c1b5.o unable to open object file: No such file or directory
warning: no debug symbols in executable (-arch x86_64)
```