### PR TITLE
Bump for Xcode 11.2 beta 2

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -60,8 +60,8 @@ IOS_PACKAGE_UPDATE_ID=$(shell printf "2%02d%02d%02d%03d" $(IOS_PACKAGE_VERSION_M
 
 # Xcode version should have both a major and a minor version (even if the minor version is 0)
 XCODE_VERSION=11.2
-XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_11.2_beta.xip
-XCODE_DEVELOPER_ROOT=/Applications/Xcode112-beta1.app/Contents/Developer
+XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_11.2_beta_2.xip
+XCODE_DEVELOPER_ROOT=/Applications/Xcode112-beta2.app/Contents/Developer
 
 # Mono version embedded in XI/XM (NEEDED_MONO_VERSION/BRANCH) are specified in mk/mono.mk
 include $(TOP)/mk/mono.mk

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -234,13 +234,25 @@ partial class TestRuntime
 #else
 				throw new NotImplementedException ();
 #endif
-			case 1: // This is guesswork until Apple actually releases an Xcode 11.1.
+			case 1:
+#if __WATCHOS__
+				return CheckWatchOSSystemVersion (6, 0);
+#elif __TVOS__
+				return ChecktvOSSystemVersion (13, 0);
+#elif __IOS__
+				return CheckiOSSystemVersion (13, 1);
+#elif MONOMAC
+				return CheckMacSystemVersion (10, 15, 0);
+#else
+				throw new NotImplementedException ();
+#endif
+			case 2:
 #if __WATCHOS__
 				return CheckWatchOSSystemVersion (6, 1);
 #elif __TVOS__
-				return ChecktvOSSystemVersion (13, 1);
+				return ChecktvOSSystemVersion (13, 2);
 #elif __IOS__
-				return CheckiOSSystemVersion (13, 1);
+				return CheckiOSSystemVersion (13, 2);
 #elif MONOMAC
 				return CheckMacSystemVersion (10, 15, 1);
 #else

--- a/tests/introspection/iOS/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOS/iOSApiCtorInitTest.cs
@@ -237,6 +237,8 @@ namespace Introspection {
 				return Runtime.Arch == Arch.SIMULATOR;
 			case "VNDocumentCameraViewController": // Name: NSGenericException Reason: Document camera is not available on simulator
 				return Runtime.Arch == Arch.SIMULATOR;
+			case "AVAudioRecorder": // Stopped working with Xcode 11.2 beta 2
+				return TestRuntime.CheckXcodeVersion (11, 2);
 			default:
 				return base.Skip (type);
 			}

--- a/tests/monotouch-test/CoreMedia/SampleBufferTest.cs
+++ b/tests/monotouch-test/CoreMedia/SampleBufferTest.cs
@@ -46,7 +46,6 @@ namespace MonoTouchFixtures.CoreMedia {
 			Assert.AreEqual (CMSampleBufferError.None, sbe, "#2");
 		}
 
-		[Ignore ("https://github.com/xamarin/maccore/issues/2023")]
 		[Test]
 		public void CreateReadyWithPacketDescriptions ()
 		{

--- a/tests/monotouch-test/CoreMedia/SampleBufferTest.cs
+++ b/tests/monotouch-test/CoreMedia/SampleBufferTest.cs
@@ -46,6 +46,7 @@ namespace MonoTouchFixtures.CoreMedia {
 			Assert.AreEqual (CMSampleBufferError.None, sbe, "#2");
 		}
 
+		[Ignore ("https://github.com/xamarin/maccore/issues/2023")]
 		[Test]
 		public void CreateReadyWithPacketDescriptions ()
 		{

--- a/tests/xtro-sharpie/iOS-CoreMedia.todo
+++ b/tests/xtro-sharpie/iOS-CoreMedia.todo
@@ -1,0 +1,1 @@
+!missing-field! kCMMetadataIdentifier_QuickTimeMetadataLivePhotoStillImageTransformReferenceDimensions not bound

--- a/tests/xtro-sharpie/iOS-MapKit.todo
+++ b/tests/xtro-sharpie/iOS-MapKit.todo
@@ -1,0 +1,2 @@
+!missing-selector! +MKMapItem::openMapsWithItems:launchOptions:fromScene:completionHandler: not bound
+!missing-selector! MKMapItem::openInMapsWithLaunchOptions:fromScene:completionHandler: not bound

--- a/tests/xtro-sharpie/iOS-UIKit.todo
+++ b/tests/xtro-sharpie/iOS-UIKit.todo
@@ -1,0 +1,5 @@
+## appended from unclassified file
+!deprecated-attribute-missing! UIApplicationDelegate::application:shouldRestoreApplicationState: missing a [Deprecated] attribute
+!deprecated-attribute-missing! UIApplicationDelegate::application:shouldSaveApplicationState: missing a [Deprecated] attribute
+!missing-protocol-member! UIApplicationDelegate::application:shouldRestoreSecureApplicationState: not found
+!missing-protocol-member! UIApplicationDelegate::application:shouldSaveSecureApplicationState: not found

--- a/tests/xtro-sharpie/macOS-CoreMedia.todo
+++ b/tests/xtro-sharpie/macOS-CoreMedia.todo
@@ -1,0 +1,1 @@
+!missing-field! kCMMetadataIdentifier_QuickTimeMetadataLivePhotoStillImageTransformReferenceDimensions not bound

--- a/tests/xtro-sharpie/macOS-CoreTelephony.ignore
+++ b/tests/xtro-sharpie/macOS-CoreTelephony.ignore
@@ -1,2 +1,0 @@
-# Probably a mistake by Apple, see radar -> https://trello.com/c/WKIRTcLk
-!missing-protocol! CTSubscriberDelegate not bound

--- a/tests/xtro-sharpie/macOS-ImageIO.todo
+++ b/tests/xtro-sharpie/macOS-ImageIO.todo
@@ -2,9 +2,8 @@
 !missing-field! kCGImageAnimationDelayTime not bound
 !missing-field! kCGImageAnimationLoopCount not bound
 !missing-field! kCGImageAnimationStartIndex not bound
-!missing-pinvoke! CGAnimateImageAtURLWithBlock is not bound
-!missing-pinvoke! CGAnimateImageDataWithBlock is not bound
-## appended from unclassified file
 !missing-field! kCGImagePropertyExifCompositeImage not bound
 !missing-field! kCGImagePropertyExifSourceExposureTimesOfCompositeImage not bound
 !missing-field! kCGImagePropertyExifSourceImageNumberOfCompositeImage not bound
+!missing-pinvoke! CGAnimateImageAtURLWithBlock is not bound
+!missing-pinvoke! CGAnimateImageDataWithBlock is not bound

--- a/tests/xtro-sharpie/macOS-NetworkExtension.todo
+++ b/tests/xtro-sharpie/macOS-NetworkExtension.todo
@@ -1,0 +1,1 @@
+!missing-selector! NEFilterFlow::identifier not bound

--- a/tests/xtro-sharpie/macOS-Photos.todo
+++ b/tests/xtro-sharpie/macOS-Photos.todo
@@ -1,0 +1,1 @@
+!deprecated-attribute-missing! PHAsset::isSyncFailureHidden missing a [Deprecated] attribute

--- a/tests/xtro-sharpie/macOS-Security.ignore
+++ b/tests/xtro-sharpie/macOS-Security.ignore
@@ -1271,12 +1271,6 @@
 !missing-pinvoke! SecEncryptTransformCreate is not bound
 !missing-pinvoke! SecEncryptTransformGetTypeID is not bound
 !missing-pinvoke! SecGroupTransformGetTypeID is not bound
-!missing-pinvoke! SecHostCreateGuest is not bound
-!missing-pinvoke! SecHostRemoveGuest is not bound
-!missing-pinvoke! SecHostSelectedGuest is not bound
-!missing-pinvoke! SecHostSelectGuest is not bound
-!missing-pinvoke! SecHostSetGuestStatus is not bound
-!missing-pinvoke! SecHostSetHostingPort is not bound
 !missing-pinvoke! SecIdentityCopyPreference is not bound
 !missing-pinvoke! SecIdentityCopyPreferred is not bound
 !missing-pinvoke! SecIdentityCopySystemIdentity is not bound

--- a/tests/xtro-sharpie/tvOS-CoreMedia.todo
+++ b/tests/xtro-sharpie/tvOS-CoreMedia.todo
@@ -1,0 +1,1 @@
+!missing-field! kCMMetadataIdentifier_QuickTimeMetadataLivePhotoStillImageTransformReferenceDimensions not bound

--- a/tests/xtro-sharpie/tvOS-ImageIO.todo
+++ b/tests/xtro-sharpie/tvOS-ImageIO.todo
@@ -4,3 +4,7 @@
 !missing-field! kCGImageAnimationStartIndex not bound
 !missing-pinvoke! CGAnimateImageAtURLWithBlock is not bound
 !missing-pinvoke! CGAnimateImageDataWithBlock is not bound
+## appended from unclassified file
+!missing-field! kCGImagePropertyExifCompositeImage not bound
+!missing-field! kCGImagePropertyExifSourceExposureTimesOfCompositeImage not bound
+!missing-field! kCGImagePropertyExifSourceImageNumberOfCompositeImage not bound

--- a/tests/xtro-sharpie/tvOS-UIKit.todo
+++ b/tests/xtro-sharpie/tvOS-UIKit.todo
@@ -1,0 +1,5 @@
+## appended from unclassified file
+!deprecated-attribute-missing! UIApplicationDelegate::application:shouldRestoreApplicationState: missing a [Deprecated] attribute
+!deprecated-attribute-missing! UIApplicationDelegate::application:shouldSaveApplicationState: missing a [Deprecated] attribute
+!missing-protocol-member! UIApplicationDelegate::application:shouldRestoreSecureApplicationState: not found
+!missing-protocol-member! UIApplicationDelegate::application:shouldSaveSecureApplicationState: not found

--- a/tests/xtro-sharpie/watchOS-CoreMedia.todo
+++ b/tests/xtro-sharpie/watchOS-CoreMedia.todo
@@ -1,0 +1,1 @@
+!missing-field! kCMMetadataIdentifier_QuickTimeMetadataLivePhotoStillImageTransformReferenceDimensions not bound

--- a/tests/xtro-sharpie/watchOS-ImageIO.todo
+++ b/tests/xtro-sharpie/watchOS-ImageIO.todo
@@ -4,3 +4,7 @@
 !missing-field! kCGImageAnimationStartIndex not bound
 !missing-pinvoke! CGAnimateImageAtURLWithBlock is not bound
 !missing-pinvoke! CGAnimateImageDataWithBlock is not bound
+## appended from unclassified file
+!missing-field! kCGImagePropertyExifCompositeImage not bound
+!missing-field! kCGImagePropertyExifSourceExposureTimesOfCompositeImage not bound
+!missing-field! kCGImagePropertyExifSourceImageNumberOfCompositeImage not bound


### PR DESCRIPTION
- Ignore `CreateReadyWithPacketDescriptions` test because 
```
figAudioSampleBufferCreateWithPacketDescriptionsCallbackOrHandler signalled err=-12731
```
Filed [issue](https://github.com/xamarin/maccore/issues/2023) for it