### PR TITLE
[msbuild] Provide the correct value for the operating system for tvOS and watchOS to a few tasks. Fixes #6200.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Tasks/CompileSceneKitAssets.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/CompileSceneKitAssets.cs
@@ -4,8 +4,5 @@ namespace Xamarin.Mac.Tasks
 {
 	public class CompileSceneKitAssets : CompileSceneKitAssetsTaskBase
 	{
-		protected override string OperatingSystem {
-			get { return "osx"; }
-		}
 	}
 }

--- a/msbuild/Xamarin.Mac.Tasks/Tasks/Metal.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/Metal.cs
@@ -6,10 +6,6 @@ namespace Xamarin.Mac.Tasks
 {
 	public class Metal : MetalTaskBase
 	{
-		protected override string OperatingSystem {
-			get { return "macosx"; }
-		}
-
 #if !MTOUCH_TESTS
 		protected override string MinimumDeploymentTargetKey {
 			get { return ManifestKeys.LSMinimumSystemVersion; }

--- a/msbuild/Xamarin.Mac.Tasks/Tasks/ScnTool.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/ScnTool.cs
@@ -4,8 +4,5 @@ namespace Xamarin.Mac.Tasks
 {
 	public class ScnTool : ScnToolTaskBase
 	{
-		protected override string OperatingSystem {
-			get { return "osx"; }
-		}
 	}
 }

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -340,6 +340,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			AppManifest="$(_AppManifest)"
 			ProjectDir="$(MSBuildProjectDirectory)"
+			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			ResourcePrefix="$(XamMacResourcePrefix)"
 			SdkDevPath="$(_SdkDevPath)"
 			SdkRoot="$(_SdkRoot)"
@@ -588,6 +589,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			SdkRoot="$(_SdkRoot)"
 			SdkDevPath="$(_SdkDevPath)"
 			SdkVersion="$(MacOSXSdkVersion)"
+			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			InputScene="%(_ColladaAssetWithLogicalName.Identity)"
 			OutputScene="$(IntermediateOutputPath)%(_ColladaAssetWithLogicalName.LogicalName)">
@@ -675,6 +677,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			ToolPath="$(CopySceneKitAssetsPath)"
 			SceneKitAssets="@(SceneKitAsset)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
+			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(XamMacResourcePrefix)"
 			SdkPlatform="MacOSX"

--- a/msbuild/Xamarin.MacDev.Tasks.Core/PlatformFramework.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/PlatformFramework.cs
@@ -57,7 +57,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public static string GetOperatingSystem (string targetFrameworkIdentifier)
 		{
-			var framework = PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier);
+			var framework = PlatformFrameworkHelper.GetFramework (targetFrameworkIdentifier);
 			switch (framework) {
 			case PlatformFramework.WatchOS:
 				return "watchos";

--- a/msbuild/Xamarin.MacDev.Tasks.Core/PlatformFramework.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/PlatformFramework.cs
@@ -54,5 +54,22 @@ namespace Xamarin.MacDev.Tasks
 				throw new InvalidOperationException ("Unknown TargetFrameworkIdentifier: " + targetFrameworkIdentifier);
 			}
 		}
+
+		public static string GetOperatingSystem (string targetFrameworkIdentifier)
+		{
+			var framework = PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier);
+			switch (framework) {
+			case PlatformFramework.WatchOS:
+				return "watchos";
+			case PlatformFramework.TVOS:
+				return "tvos";
+			case PlatformFramework.MacOS:
+				return "osx";
+			case PlatformFramework.iOS:
+				return "ios";
+			default:
+				throw new InvalidOperationException (string.Format ("Unknown target framework {0} for target framework identifier {2}.", framework, targetFrameworkIdentifier));
+			}
+		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
@@ -47,6 +47,9 @@ namespace Xamarin.MacDev.Tasks
 		[Required]
 		public string SdkVersion { get; set; }
 
+		[Required]
+		public string TargetFrameworkIdentifier { get; set; }
+
 		public string ToolExe {
 			get { return toolExe ?? ToolName; }
 			set { toolExe = value; }
@@ -67,8 +70,22 @@ namespace Xamarin.MacDev.Tasks
 			get { return "copySceneKitAssets"; }
 		}
 
-		protected abstract string OperatingSystem {
-			get;
+		protected virtual string OperatingSystem {
+			get {
+				switch (PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier)) {
+				case PlatformFramework.WatchOS:
+					return "watchos";
+				case PlatformFramework.TVOS:
+					return "tvos";
+				case PlatformFramework.MacOS:
+					return "osx";
+				case PlatformFramework.iOS:
+					return "ios";
+				default:
+					Log.LogError ($"Unknown target framework identifier: {TargetFrameworkIdentifier}.");
+					return string.Empty;
+				}
+			}
 		}
 
 		string DeveloperRootBinDir {

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
@@ -72,19 +72,7 @@ namespace Xamarin.MacDev.Tasks
 
 		protected virtual string OperatingSystem {
 			get {
-				switch (PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier)) {
-				case PlatformFramework.WatchOS:
-					return "watchos";
-				case PlatformFramework.TVOS:
-					return "tvos";
-				case PlatformFramework.MacOS:
-					return "osx";
-				case PlatformFramework.iOS:
-					return "ios";
-				default:
-					Log.LogError ($"Unknown target framework identifier: {TargetFrameworkIdentifier}.");
-					return string.Empty;
-				}
+				return PlatformFrameworkHelper.GetOperatingSystem (TargetFrameworkIdentifier);
 			}
 		}
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
@@ -39,6 +39,9 @@ namespace Xamarin.MacDev.Tasks
 		[Required]
 		public ITaskItem SourceFile { get; set; }
 
+		[Required]
+		public string TargetFrameworkIdentifier { get; set; }
+
 		#endregion
 
 		[Output]
@@ -48,8 +51,22 @@ namespace Xamarin.MacDev.Tasks
 			get;
 		}
 
-		protected abstract string OperatingSystem {
-			get;
+		protected virtual string OperatingSystem {
+			get {
+				switch (PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier)) {
+				case PlatformFramework.WatchOS:
+					return "watchos";
+				case PlatformFramework.TVOS:
+					return "tvos";
+				case PlatformFramework.MacOS:
+					return "macosx";
+				case PlatformFramework.iOS:
+					return "ios";
+				default:
+					Log.LogError ($"Unknown target framework identifier: {TargetFrameworkIdentifier}.");
+					return string.Empty;
+				}
+			}
 		}
 
 		protected abstract string DevicePlatformBinDir {
@@ -118,6 +135,8 @@ namespace Xamarin.MacDev.Tasks
 			args.AddQuoted (Path.ChangeExtension (path, ".air"));
 
 			args.Add (string.Format ("-m{0}-version-min={1}", OperatingSystem, minimumDeploymentTarget));
+
+			Console.WriteLine ("OPERATING SYSTEM: {0} in {1}", OperatingSystem, GetType ());
 
 			args.AddQuoted (SourceFile.ItemSpec);
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
@@ -136,8 +136,6 @@ namespace Xamarin.MacDev.Tasks
 
 			args.Add (string.Format ("-m{0}-version-min={1}", OperatingSystem, minimumDeploymentTarget));
 
-			Console.WriteLine ("OPERATING SYSTEM: {0} in {1}", OperatingSystem, GetType ());
-
 			args.AddQuoted (SourceFile.ItemSpec);
 
 			return args.ToString ();

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ScnToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ScnToolTaskBase.cs
@@ -50,19 +50,7 @@ namespace Xamarin.MacDev.Tasks
 
 		protected virtual string OperatingSystem {
 			get {
-				switch (PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier)) {
-				case PlatformFramework.WatchOS:
-					return "watchos";
-				case PlatformFramework.TVOS:
-					return "tvos";
-				case PlatformFramework.MacOS:
-					return "osx";
-				case PlatformFramework.iOS:
-					return "ios";
-				default:
-					Log.LogError ($"Unknown target framework identifier: {TargetFrameworkIdentifier}.");
-					return string.Empty;
-				}
+				return PlatformFrameworkHelper.GetOperatingSystem (TargetFrameworkIdentifier);
 			}
 		}
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ScnToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ScnToolTaskBase.cs
@@ -39,14 +39,31 @@ namespace Xamarin.MacDev.Tasks
 			}
 		}
 
+		[Required]
+		public string TargetFrameworkIdentifier { get; set; }
+
 		#endregion
 
 		string DevicePlatformBinDir {
 			get { return Path.Combine (SdkDevPath, "usr", "bin"); }
 		}
 
-		protected abstract string OperatingSystem {
-			get;
+		protected virtual string OperatingSystem {
+			get {
+				switch (PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier)) {
+				case PlatformFramework.WatchOS:
+					return "watchos";
+				case PlatformFramework.TVOS:
+					return "tvos";
+				case PlatformFramework.MacOS:
+					return "osx";
+				case PlatformFramework.iOS:
+					return "ios";
+				default:
+					Log.LogError ($"Unknown target framework identifier: {TargetFrameworkIdentifier}.");
+					return string.Empty;
+				}
+			}
 		}
 
 		protected override string ToolName {

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
@@ -2,8 +2,5 @@
 {
 	public abstract class CompileSceneKitAssetsTaskBase : Xamarin.MacDev.Tasks.CompileSceneKitAssetsTaskBase
 	{
-		protected override string OperatingSystem {
-			get { return "ios"; }
-		}
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MetalTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MetalTaskBase.cs
@@ -6,10 +6,6 @@ namespace Xamarin.iOS.Tasks
 {
 	public abstract class MetalTaskBase : Xamarin.MacDev.Tasks.MetalTaskBase
 	{
-		protected override string OperatingSystem {
-			get { return "ios"; }
-		}
-
 		protected override string MinimumDeploymentTargetKey {
 			get { return ManifestKeys.MinimumOSVersion; }
 		}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ScnToolTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ScnToolTaskBase.cs
@@ -2,8 +2,5 @@
 {
 	public abstract class ScnToolTaskBase : Xamarin.MacDev.Tasks.ScnToolTaskBase
 	{
-		protected override string OperatingSystem {
-			get { return "ios"; }
-		}
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -603,6 +603,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
 			AppManifest="$(_AppManifest)"
 			ProjectDir="$(MSBuildProjectDirectory)"
+			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			ResourcePrefix="$(IPhoneResourcePrefix)"
 			SdkDevPath="$(_SdkDevPath)"
 			SdkRoot="$(_SdkRoot)"
@@ -1220,6 +1221,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			SdkRoot="$(_SdkRoot)"
 			SdkDevPath="$(_SdkDevPath)"
 			SdkVersion="$(MtouchSdkVersion)"
+			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
 			InputScene="%(_ColladaAssetWithLogicalName.Identity)"
 			OutputScene="$(DeviceSpecificIntermediateOutputPath)%(_ColladaAssetWithLogicalName.LogicalName)">
@@ -1333,6 +1335,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			ToolPath="$(CopySceneKitAssetsPath)"
 			SceneKitAssets="@(SceneKitAsset)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
+			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(IPhoneResourcePrefix)"
 			IsWatchApp="$(IsWatchApp)"

--- a/tests/mtouch/ToolTasksBinPathTest.cs
+++ b/tests/mtouch/ToolTasksBinPathTest.cs
@@ -14,8 +14,10 @@ namespace Xamarin.MacDev.Tasks {
 
 	public abstract class MetalTaskBase {
 
-		protected abstract string OperatingSystem {
-			get;
+		protected virtual string OperatingSystem {
+			get {
+				throw new NotImplementedException ();
+			}
 		}
 
 		protected abstract string DevicePlatformBinDir {
@@ -82,6 +84,7 @@ namespace Xamarin.Mac.Tasks {
 				RedirectStandardError = true,
 			};
 			psi.EnvironmentVariables.Add ("DEVELOPER_DIR", Configuration.xcode_root);
+			psi.EnvironmentVariables.Remove ("XCODE_DEVELOPER_DIR_PATH"); // VSfM sets XCODE_DEVELOPER_DIR_PATH, which confuses the command-line tools if it doesn't match xcode-select, so just unset it.
 			var proc = Process.Start (psi);
 
 			string output = proc.StandardOutput.ReadToEnd ();


### PR DESCRIPTION
The problem with #6200 was that we'd pass -mios-version-min=x.y to the metal
tool even for tvOS apps. This fixes it so that now pass -mtvos-version-min.

Also a minor improvement to some related tests so that their execution is not affected by VSfM's environment.

Fixes https://github.com/xamarin/xamarin-macios/issues/6200.