### PR TITLE
[mmp] Add deployment target to the -fobjc-runtime clang argument. Fixes #7204.

### DIFF
--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -736,5 +736,18 @@ namespace Xamarin.MMP.Tests
 
 			// TODO: Add something to validate the archive is loadable by Xcode
 		}
+
+		[Test]
+		public void BuildWithObjcArcFlag ()
+		{
+			RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					CSProjConfig = "<MonoBundlingExtraArgs>-link_flags=-fobjc-arc</MonoBundlingExtraArgs>"
+				};
+				TI.TestUnifiedExecutable (test);
+				var output = TI.BuildProject (Path.Combine (tmpDir, "UnifiedExample.csproj"));
+			});
+
+		}
 	}
 }

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1192,7 +1192,7 @@ namespace Xamarin.Bundler {
 				args.Add ("-arch");
 				args.Add (arch);
 				if (arch == "x86_64")
-					args.Add ("-fobjc-runtime=macosx");
+					args.Add ($"-fobjc-runtime=macosx-{App.DeploymentTarget.ToString ()}");
 				if (!embed_mono)
 					args.Add ("-DDYNAMIC_MONO_RUNTIME");
 


### PR DESCRIPTION
This is required when also passing the -fobjc-arc argument.

Fixes https://github.com/xamarin/xamarin-macios/issues/7204.