### PR TITLE
Bumping mono might require re-creating Make.config.inc.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -3,7 +3,7 @@ include $(TOP)/mk/subdirs.mk
 # calculate commit distance and store it in a file so that we don't have to re-calculate it every time make is executed.
 
 -include $(TOP)/Make.config.inc
-$(TOP)/Make.config.inc: $(TOP)/Make.config
+$(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 	@rm -f $@
 	@printf "IOS_COMMIT_DISTANCE:=$(shell LANG=C; export LANG && git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep IOS_PACKAGE_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
 	@printf "MAC_COMMIT_DISTANCE:=$(shell LANG=C; export LANG && git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep MAC_PACKAGE_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@


### PR DESCRIPTION
If the new mono commit has (or doesn't have) mono archives.