### PR TITLE
[xcode11.1] [Networking] Improve the NWBrowser API.

### DIFF
--- a/src/Network/NWBrowser.cs
+++ b/src/Network/NWBrowser.cs
@@ -29,6 +29,10 @@ namespace Network {
 		Cancelled = 3,
 	}
 
+	public delegate void NWBrowserChangesDelegate (NWBrowseResult oldResult, NWBrowseResult newResult, bool completed);
+
+	public delegate void NWBrowserCompleteChangesDelegate (List<(NWBrowseResult result, NWBrowseResultChange change)> changes);
+
 	[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
 	public class NWBrowser : NativeObject {
 
@@ -126,17 +130,15 @@ namespace Network {
 			var del = BlockLiteral.GetTarget<NWBrowserChangesDelegate> (block);
 			if (del != null) {
 				// we do the cleanup of the objs in the internal handlers
-				var nwOldResult = new NWBrowseResult (oldResult, owns: false);
-				var nwNewResult = new NWBrowseResult (newResult, owns: false);
+				NWBrowseResult nwOldResult = (oldResult == IntPtr.Zero)? null : new NWBrowseResult (oldResult, owns: false);
+				NWBrowseResult nwNewResult = (newResult == IntPtr.Zero)? null : new NWBrowseResult (newResult, owns: false);
 				del (nwOldResult, nwNewResult, completed);
 			}
 		}
 
-		public delegate void NWBrowserChangesDelegate (NWBrowseResult oldResult, NWBrowseResult newResult, bool completed);
 		public Action<NWBrowseResult, NWBrowseResult> IndividualChangesDelegate { get; set; }
 
 		// syntactic sugar for the user, nicer to get all the changes at once
-		public delegate void NWBrowserCompleteChangesDelegate (List<(NWBrowseResult result, NWBrowseResultChange change)> changes);
 		public NWBrowserCompleteChangesDelegate CompleteChangesDelegate { get; set; }
 		object changesLock = new object ();
 		List<(NWBrowseResult result, NWBrowseResultChange change)> changes = new List<(NWBrowseResult result, NWBrowseResultChange change)> ();
@@ -151,22 +153,24 @@ namespace Network {
 				var completeCb = CompleteChangesDelegate;
 				if (completeCb == null) {
 					// we do not want to keep a list of the new results if the user does not care, dipose and move on
-					oldResult.Dispose ();
-					newResult.Dispose ();
+					// results can be null, since we could have a not old one
+					oldResult?.Dispose ();
+					newResult?.Dispose ();
 					return; 
 				}
 				// get the change, add it to the list
 				var change = NWBrowseResult.GetChanges (oldResult, newResult);
 				var result = (result: newResult, change: change);
 				// at this point, we do not longer need the old result
-				oldResult.Dispose ();
+				// results can be null
+				oldResult?.Dispose ();
 				changes.Add (result);
 				// only call when we know we are done
 				if (completed)  {
 					completeCb.Invoke (changes);
 					// clean resources, we never cleaned the new results, therefore we need to dispose them at this stage
 					foreach (var c in changes) {
-						c.result.Dispose ();
+						c.result?.Dispose ();
 					}
 					// be ready for the next collection
 					changes.Clear ();
@@ -194,7 +198,9 @@ namespace Network {
 		}	
 
 		// let to not change the API, but would be nice to remove it in the following releases.
+#if !XAMCORE_4_0
 		public void SetChangesHandler (Action<NWBrowseResult, NWBrowseResult> handler) => IndividualChangesDelegate = handler;
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_browser_set_state_changed_handler (OS_nw_browser browser, void *state_changed_handler);

--- a/src/Network/NWListener.cs
+++ b/src/Network/NWListener.cs
@@ -174,7 +174,7 @@ namespace Network {
 		{
 			lock (connectionHandlerLock) {
 				unsafe {
-					if (callback == null){
+					if (callback == null) {
 						nw_listener_set_new_connection_handler (GetCheckedHandle (), null);
 						return;
 					}

--- a/tests/monotouch-test/Entitlements.plist
+++ b/tests/monotouch-test/Entitlements.plist
@@ -12,5 +12,9 @@
 	<array>
 		<string> A93A5CM278.tests/monotouch-test/Entitlements.plist</string>
 	</array>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 </dict>
 </plist>

--- a/tests/monotouch-test/Network/NWBrowserTest.cs
+++ b/tests/monotouch-test/Network/NWBrowserTest.cs
@@ -80,6 +80,17 @@ namespace MonoTouchFixtures.Network {
 		[Test]
 		public void TestStateChangesHandler ()
 		{
+			// In the test we are doing the following:
+			//
+			// 1. Start a browser. At this point, we have no listeners (unless someone is exposing it in the lab)
+			// and therefore the browser cannot find any services/listeners.
+			// 2. Start a listener that is using the same type/domain pair that the browser expects.
+			// 3. Browser picks up the new listener, and sends an event (service found).
+			// 4. Listener stops, and the service disappears.
+			// 5. The browser is not yet canceled, so it picks up that the service/listener is not longer then and returns it.
+			// 
+			// The test will block until the different events are set by the callbacks that are executed in a diff thread.
+
 			bool firstRun = true;
 			bool eventsDone = false;
 			bool listeningDone = false;
@@ -111,9 +122,6 @@ namespace MonoTouchFixtures.Network {
 				});
 				browser.Start ();
 				browserReady.WaitOne (30000);
-				// we are going to start a browser, which will not pick any results, because
-				// we have not listeners, in another thread, the listener will be started and
-				// changes will get the changes for a new service
 				using (var advertiser = NWAdvertiseDescriptor.CreateBonjourService ("MonoTouchFixtures.Network", type))
 				using (var tcpOptions = NWProtocolOptions.CreateTcp ())
 				using (var tlsOptions = NWProtocolOptions.CreateTls ())

--- a/tests/monotouch-test/Network/NWBrowserTest.cs
+++ b/tests/monotouch-test/Network/NWBrowserTest.cs
@@ -25,7 +25,8 @@ namespace MonoTouchFixtures.Network {
 
 		NWBrowserDescriptor descriptor;
 		NWBrowser browser;
-		string type = "_ssh._tcp.";
+
+		string type = "_tictactoe._tcp";
 		string domain = "local.";
 
 		[TestFixtureSetUp]
@@ -35,7 +36,8 @@ namespace MonoTouchFixtures.Network {
 		public void SetUp ()
 		{
 			descriptor = NWBrowserDescriptor.CreateBonjourService (type, domain);
-			browser = new NWBrowser (descriptor);
+			using (var parameters = new NWParameters { IncludePeerToPeer = true})
+				browser = new NWBrowser (descriptor);
 			browser.SetDispatchQueue (DispatchQueue.DefaultGlobalQueue);
 		}
 
@@ -78,14 +80,70 @@ namespace MonoTouchFixtures.Network {
 		[Test]
 		public void TestStateChangesHandler ()
 		{
-			var e = new AutoResetEvent (false);
-			browser.SetStateChangesHandler ((st, er) => {
-				Assert.IsNotNull (st, "State");
-				Assert.IsNull (er, "Error");
-				e.Set ();
-			});
-			browser.Start ();
-			e.WaitOne ();
+			bool firstRun = true;
+			bool eventsDone = false;
+			bool listeningDone = false;
+			var changesEvent = new AutoResetEvent (false);
+			var browserReady = new AutoResetEvent (false);
+			var finalEvent = new AutoResetEvent (false);
+			TestRuntime.RunAsync (DateTime.Now.AddSeconds (30), async () => {
+				// start the browser, before the listener
+				browser.SetStateChangesHandler ((st, er) => {
+					Assert.IsNotNull (st, "State");
+					Assert.IsNull (er, "Error");
+					if (st == NWBrowserState.Ready)
+						browserReady.Set ();
+				});
+				browser.SetChangesHandler ((oldResult, newResult) => {
+					// first time, listener appears, so we do not have an old result, second time
+					// listener goes, so we do not have a new result
+					if (firstRun) {
+						Assert.IsNull (oldResult, "oldResult first run.");
+						Assert.IsNotNull (newResult, "newResult first run");
+						firstRun = false;
+					} else {
+						Assert.IsNotNull (oldResult, "oldResult first run.");
+						Assert.IsNull (newResult, "newResult first run");
+					}
+					changesEvent.Set ();
+					eventsDone = true;
+
+				});
+				browser.Start ();
+				browserReady.WaitOne (30000);
+				// we are going to start a browser, which will not pick any results, because
+				// we have not listeners, in another thread, the listener will be started and
+				// changes will get the changes for a new service
+				using (var advertiser = NWAdvertiseDescriptor.CreateBonjourService ("MonoTouchFixtures.Network", type))
+				using (var tcpOptions = NWProtocolOptions.CreateTcp ())
+				using (var tlsOptions = NWProtocolOptions.CreateTls ())
+				using (var paramenters = NWParameters.CreateTcp ()) {
+					paramenters.ProtocolStack.PrependApplicationProtocol (tlsOptions);
+					paramenters.ProtocolStack.PrependApplicationProtocol (tcpOptions);
+					paramenters.IncludePeerToPeer = true;
+					using (var listener = NWListener.Create ("1234", paramenters)) {
+						listener.SetQueue (DispatchQueue.CurrentQueue);
+						listener.SetAdvertiseDescriptor (advertiser);
+						// we need the connection handler, else we will get an exception
+						listener.SetNewConnectionHandler ((c) => { });
+						listener.SetStateChangedHandler ((s, e) => {
+							if (e != null) {
+								Console.WriteLine ($"Got error {e.ErrorCode} {e.ErrorDomain} '{e.CFError.FailureReason}' {e.ToString ()}");
+							}
+						});
+						listener.Start ();
+						changesEvent.WaitOne (30000);
+						listener.Cancel ();
+						listeningDone = true;
+						finalEvent.Set ();
+					}
+				}
+
+			}, () => eventsDone);
+
+			finalEvent.WaitOne (30000);
+			Assert.IsTrue (eventsDone);
+			Assert.IsTrue (listeningDone);
 			browser.Cancel ();
 		}
 	}


### PR DESCRIPTION
Kept the API as it was but added a new handler that will be called when
all the changes from the browser have been done. The old Set* method
could be deleted in a future release and just expose the property.

Backport of #7214.

/cc @mandel-macaque 