### PR TITLE
[tests] Fix tests after a modification to our dummy x86-64 slice in our shipping libraries. Fixes xamarin/maccore#2026.

### DIFF
--- a/tests/common/ProductTests.cs
+++ b/tests/common/ProductTests.cs
@@ -72,7 +72,7 @@ namespace Xamarin.Tests
 				foreach (var slice in fatfile) {
 					if (slice.IsDynamicLibrary && slice.Architecture == MachO.Architectures.x86_64 && slice.Parent != null && slice.Parent.size < 10240 /* this is the dummy x86_64 slice to appease Apple's notarization tooling */)
 						continue;
-					else if (!slice.IsDynamicLibrary && slice.Architecture == MachO.Architectures.x86_64 && slice.Filename == "x86-64-slice.o" /* a static versio of the x86_64 dummy slice */)
+					else if (!slice.IsDynamicLibrary && slice.Architecture == MachO.Architectures.x86_64 && slice.Filename == "x86-64-slice.o" /* a static version of the x86_64 dummy slice */)
 						continue;
 					var any_load_command = false;
 					foreach (var lc in slice.load_commands) {

--- a/tests/common/ProductTests.cs
+++ b/tests/common/ProductTests.cs
@@ -72,6 +72,8 @@ namespace Xamarin.Tests
 				foreach (var slice in fatfile) {
 					if (slice.IsDynamicLibrary && slice.Architecture == MachO.Architectures.x86_64 && slice.Parent != null && slice.Parent.size < 10240 /* this is the dummy x86_64 slice to appease Apple's notarization tooling */)
 						continue;
+					else if (!slice.IsDynamicLibrary && slice.Architecture == MachO.Architectures.x86_64 && slice.Filename == "x86-64-slice.o" /* a static versio of the x86_64 dummy slice */)
+						continue;
 					var any_load_command = false;
 					foreach (var lc in slice.load_commands) {
 


### PR DESCRIPTION
Previously we only had a single dynamic library that was used as the dummy
slice, but there may be a static library instead. So teach the tests about
that static library.

Fixes these test failures:

    1) Failed : Xamarin.Tests.ProductTests.MinOSVersion(iOS,MiniPhoneOS,IOS,True)
      Unexpected build version command in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/MonoTouch.iphoneos.sdk/usr/lib/libmono-profiler-log.a (x86-64-slice.o)
      Expected: IOS or 0
      But was:  MacOS
      at Xamarin.Tests.ProductTests.MinOSVersion (Xamarin.Tests.Profile profile, Xamarin.MachO+LoadCommands load_command, Xamarin.MachO+Platform platform, System.Boolean device) [0x00000] in <a0c772db19e5407bb3edc34b20e04476>:0

    2) Failed : Xamarin.Tests.ProductTests.MinOSVersion(watchOS,MinwatchOS,WatchOS,True)
      Unexpected build version command in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/Xamarin.WatchOS.sdk/usr/lib/libmono-profiler-log.a (x86-64-slice.o)
      Expected: WatchOS or 0
      But was:  MacOS
      at Xamarin.Tests.ProductTests.MinOSVersion (Xamarin.Tests.Profile profile, Xamarin.MachO+LoadCommands load_command, Xamarin.MachO+Platform platform, System.Boolean device) [0x00000] in <a0c772db19e5407bb3edc34b20e04476>:0

    3) Failed : Xamarin.Tests.ProductTests.MinOSVersion(tvOS,MintvOS,TvOS,True)
      Unexpected build version command in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/Xamarin.AppleTVOS.sdk/usr/lib/libmono-profiler-log.a (x86-64-slice.o)
      Expected: TvOS or 0
      But was:  MacOS
      at Xamarin.Tests.ProductTests.MinOSVersion (Xamarin.Tests.Profile profile, Xamarin.MachO+LoadCommands load_command, Xamarin.MachO+Platform platform, System.Boolean device) [0x00000] in <a0c772db19e5407bb3edc34b20e04476>:0

Fixes https://github.com/xamarin/maccore/issues/2026.