### PR TITLE
Fix a few introspection issues on Catalina. (#7212)

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -3065,7 +3065,7 @@ namespace AppKit {
 		bool CanDragItems (NSCollectionView collectionView, NSIndexSet indexes, NSEvent evt);
 
 		[Export ("collectionView:writeItemsAtIndexes:toPasteboard:")]
-		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use the 'GetPasteboardWriter' method instead")]
+		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use the 'GetPasteboardWriter' method instead.")]
 		bool WriteItems (NSCollectionView collectionView, NSIndexSet indexes, NSPasteboard toPasteboard);
 
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'NSFilePromiseReceiver' objects instead.")]
@@ -3091,7 +3091,7 @@ namespace AppKit {
 
 		[Mac (10,11)]
 		[Export ("collectionView:writeItemsAtIndexPaths:toPasteboard:")]
-		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use the 'GetPasteboardWriter' method instead")]
+		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use the 'GetPasteboardWriter' method instead.")]
 		bool WriteItems (NSCollectionView collectionView, NSSet indexPaths, NSPasteboard pasteboard);
 
 		[Mac (10,11)]
@@ -17198,7 +17198,7 @@ namespace AppKit {
 		void SortDescriptorsChanged (NSTableView tableView, NSSortDescriptor [] oldDescriptors);
 	
 		[Export ("tableView:writeRowsWithIndexes:toPasteboard:")]
-		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use the 'GetPasteboardWriterForRow' method instead")]
+		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use the 'GetPasteboardWriterForRow' method instead.")]
 		bool WriteRows (NSTableView tableView, NSIndexSet rowIndexes, NSPasteboard pboard );
 	
 		[Export ("tableView:validateDrop:proposedRow:proposedDropOperation:")]

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -1213,7 +1213,7 @@ namespace SceneKit {
 
 #if MONOMAC
 	[iOS (8,0)]
-	[Deprecated (PlatformName.MacOSX, 10, 14, message: "OpenGL API deprecated, please use Metal instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use Metal instead of OpenGL API.")]
 	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
 	[BaseType (typeof (CAOpenGLLayer))]
 	interface SCNLayer : SCNSceneRenderer, SCNTechniqueSupport {
@@ -3507,16 +3507,16 @@ namespace SceneKit {
 		bool AllowsCameraControl { get; set;  }
 
 #if MONOMAC
-		[Deprecated (PlatformName.MacOSX, 10, 14, message: "OpenGL API deprecated, please use Metal instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use Metal instead of OpenGL API.")]
 		[Export ("openGLContext", ArgumentSemantic.Retain)]
 		NSOpenGLContext	OpenGLContext { get; set;  }
 
-		[Deprecated (PlatformName.MacOSX, 10, 14, message: "OpenGL API deprecated, please use Metal instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use Metal instead of OpenGL API.")]
 		[Export ("pixelFormat", ArgumentSemantic.Retain)]
 		NSOpenGLPixelFormat PixelFormat { get; set;  }
 #elif !WATCH
-		[Deprecated (PlatformName.iOS, 12, 0, message: "OpenGL API deprecated, please use Metal instead.")]
-		[Deprecated (PlatformName.TvOS, 12, 0, message: "OpenGL API deprecated, please use Metal instead.")]
+		[Deprecated (PlatformName.iOS, 12, 0, message: "Please use Metal instead of OpenGL API.")]
+		[Deprecated (PlatformName.TvOS, 12, 0, message: "Please use Metal instead of OpenGL API.")]
 		[Export ("eaglContext", ArgumentSemantic.Retain)]
 #if XAMCORE_2_0
 		EAGLContext EAGLContext { get; set; }

--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -299,6 +299,12 @@ namespace Introspection {
 					break;
 				}
 				break;
+#if !XAMCORE_4_0
+			case "MTLCounter":
+			case "MTLCounterSampleBuffer":
+			case "MTLCounterSet":
+				return true; // Incorrectly bound, will be fixed for XAMCORE_4_0.
+#endif
 			}
 			return false;
 		}

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -145,6 +145,7 @@ namespace Introspection
 			"Cartes", // french
 			"Cavlc",
 			"Cda", // acronym: Clinical Document Architecture
+			"Cdrom",
 			"Cfa", // acronym: Color Filter Array
 			"Celp", // MPEG4ObjectID
 			"Characterteristic",
@@ -386,6 +387,7 @@ namespace Introspection
 			"nint",
 			"Nntps",
 			"Ntlm",
+			"Nsl", // InternetLocationNslNeighborhoodIcon
 			"Ntsc",
 			"nuint",
 			"Ndef",
@@ -436,6 +438,7 @@ namespace Introspection
 			"Prerolls",
 			"Preseti",
 			"Prev",
+			"Privs", // SharingPrivsNotApplicableIcon
 			"Propogate",
 			"Psec",
 			"Psm", // Protocol/Service Multiplexer
@@ -865,6 +868,7 @@ namespace Introspection
 			"Attributest",
 			"Failwith",
 			"Imageimage",
+			"Libary",
 			"Musthold",
 			"Olus", // Typo, should be 'Bolus', fixed in 'HKInsulinDeliveryReason'
 			"Ostprandial", // Typo, should be 'Postprandial', fixed in 'HKBloodGlucoseMealTime'

--- a/tests/introspection/Mac/MacApiSelectorTest.cs
+++ b/tests/introspection/Mac/MacApiSelectorTest.cs
@@ -694,6 +694,14 @@ namespace Introspection {
 				break;
 				}
 				break;
+			case "Metal":
+				switch (type.Name) {
+				case "MTLCounterSampleBufferDescriptor":
+					// This whole type is implemented using a different (internal) type,
+					// and it's the internal type who knows how to respond to the selectors.
+					return true;
+				}
+				break;
 			}
 			return base.Skip (type, selectorName);
 		}

--- a/tests/monotouch-test/NaturalLanguage/EmbeddingTest.cs
+++ b/tests/monotouch-test/NaturalLanguage/EmbeddingTest.cs
@@ -22,11 +22,18 @@ namespace MonoTouchFixtures.NaturalLanguage {
 		{
 			TestRuntime.AssertXcodeVersion (11, 0);
 
-			using (var e = NLEmbedding.GetWordEmbedding (NLLanguage.English)) {
-				Assert.NotNull (e, "GetWordEmbedding");
-				Assert.Null (e.GetVector ("Xamarin"), "GetVector");
-				Assert.False (e.TryGetVector ("Xamarin", out var vector), "TryGetVector");
-				Assert.Null (vector, "vector");
+			foreach (NLLanguage v in Enum.GetValues (typeof (NLLanguage))) {
+				if (v == NLLanguage.Unevaluated)
+					continue; // this is not a value provided by Apple.
+
+				NLEmbedding e = null;
+				Assert.DoesNotThrow (() => e = NLEmbedding.GetWordEmbedding (v), $"Throws: {v}");
+				if (e != null) {
+					Assert.NotNull (e, "GetWordEmbedding");
+					Assert.Null (e.GetVector ("Xamarin"), "GetVector");
+					Assert.False (e.TryGetVector ("Xamarin", out var vector), "TryGetVector");
+					Assert.Null (vector, "vector");
+				}
 			}
 		}
 #endif


### PR DESCRIPTION
* [SceneKit] Adjust deprecation message.

Fixes this introspection failure:

    [FAIL] [Rule 4] Don't use availability keywords in attribute's message: "OpenGL API deprecated, please use Metal instead." - Type: SCNLayer
    [FAIL] [Rule 4] Don't use availability keywords in attribute's message: "OpenGL API deprecated, please use Metal instead." - Member name: get_OpenGLContext, Type: SCNView
    [FAIL] [Rule 4] Don't use availability keywords in attribute's message: "OpenGL API deprecated, please use Metal instead." - Member name: set_OpenGLContext, Type: SCNView
    [FAIL] [Rule 4] Don't use availability keywords in attribute's message: "OpenGL API deprecated, please use Metal instead." - Member name: get_PixelFormat, Type: SCNView
    [FAIL] [Rule 4] Don't use availability keywords in attribute's message: "OpenGL API deprecated, please use Metal instead." - Member name: set_PixelFormat, Type: SCNView

* [AppKit] Adjust deprecation messages.

* [tests] Fix introspection and xammac tests on Catalina. (#7200)

* [tests] Adjust NaturalLanguage.EmbeddingTest to cope with non-existent embeddings. Fixes xamarin/maccore#2011.

Fixes https://github.com/xamarin/maccore/issues/2011.

* [tests] Fix typo test on macOS 10.15. Fixes #7116.

Fixes https://github.com/xamarin/xamarin-macios/issues/7116.

* [introspection] Ignore MTLCounterSampleBufferDescriptor's selectors.

They're implemented using a different/internal type:

    $ nm /System/Library/Frameworks/Metal.framework/Metal | grep MTLCounterSampleBuffer
    00000000000458ab t +[MTLCounterSampleBufferDescriptor allocWithZone:]
    0000000000045897 t +[MTLCounterSampleBufferDescriptor alloc]
    000000000004591e t -[MTLCounterSampleBufferDescriptor copyWithZone:]
    000000000004598e t -[MTLCounterSampleBufferDescriptorInternal copyWithZone:]
    0000000000045c0f t -[MTLCounterSampleBufferDescriptorInternal counterSet]
    0000000000045936 t -[MTLCounterSampleBufferDescriptorInternal dealloc]
    0000000000045b65 t -[MTLCounterSampleBufferDescriptorInternal hash]
    0000000000045a31 t -[MTLCounterSampleBufferDescriptorInternal isEqual:]
    0000000000045c58 t -[MTLCounterSampleBufferDescriptorInternal label]
    0000000000045c7f t -[MTLCounterSampleBufferDescriptorInternal sampleCount]
    0000000000045c25 t -[MTLCounterSampleBufferDescriptorInternal setCounterSet:]
    0000000000045c6e t -[MTLCounterSampleBufferDescriptorInternal setLabel:]
    0000000000045c90 t -[MTLCounterSampleBufferDescriptorInternal setSampleCount:]
    0000000000045c47 t -[MTLCounterSampleBufferDescriptorInternal setStorageMode:]
    0000000000045c36 t -[MTLCounterSampleBufferDescriptorInternal storageMode]
    000000000010b0b8 S _OBJC_CLASS_$_MTLCounterSampleBufferDescriptor
    000000000010b0e0 S _OBJC_CLASS_$_MTLCounterSampleBufferDescriptorInternal
    0000000000107070 S _OBJC_IVAR_$_MTLCounterSampleBufferDescriptorInternal._counterSet
    0000000000107078 S _OBJC_IVAR_$_MTLCounterSampleBufferDescriptorInternal._label
    0000000000107088 S _OBJC_IVAR_$_MTLCounterSampleBufferDescriptorInternal._sampleCount
    0000000000107080 S _OBJC_IVAR_$_MTLCounterSampleBufferDescriptorInternal._storageMode
    000000000010b108 S _OBJC_METACLASS_$_MTLCounterSampleBufferDescriptor
    000000000010b130 S _OBJC_METACLASS_$_MTLCounterSampleBufferDescriptorInternal

Fixes these test failures:

    1) ApiSelectorTest.InstanceMethods (Introspection.MacApiSelectorTest.ApiSelectorTest.InstanceMethods)
         8 errors found in 26658 instance selector validated:
    Selector not found for Metal.MTLCounterSampleBufferDescriptor : counterSet
    Selector not found for Metal.MTLCounterSampleBufferDescriptor : setCounterSet:
    Selector not found for Metal.MTLCounterSampleBufferDescriptor : label
    Selector not found for Metal.MTLCounterSampleBufferDescriptor : setLabel:
    Selector not found for Metal.MTLCounterSampleBufferDescriptor : sampleCount
    Selector not found for Metal.MTLCounterSampleBufferDescriptor : setSampleCount:
    Selector not found for Metal.MTLCounterSampleBufferDescriptor : storageMode
    Selector not found for Metal.MTLCounterSampleBufferDescriptor : setStorageMode:

* [introspection] Ignore some API we've bound incorrectly. Fixes #7116.

There are also a few API fixes, those will be submitted in a different PR.

Fixes https://github.com/xamarin/xamarin-macios/issues/7116.