### PR TITLE
[Networking] Add a generic method to get the metadata from the context.

### DIFF
--- a/src/Network/NWContentContext.cs
+++ b/src/Network/NWContentContext.cs
@@ -131,8 +131,6 @@ namespace Network {
 			if (protocolDefinition == null)
 				throw new ArgumentNullException (nameof (protocolDefinition));
 			var x = nw_content_context_copy_protocol_metadata (GetCheckedHandle (), protocolDefinition.Handle);
-			if (x == IntPtr.Zero)
-				return null;
 			return Runtime.GetINativeObject<T> (x, owns: true);
 		}
 

--- a/src/Network/NWContentContext.cs
+++ b/src/Network/NWContentContext.cs
@@ -126,6 +126,16 @@ namespace Network {
 			return new NWProtocolMetadata (x, owns: true);
 		}
 
+		public T GetProtocolMetadata<T> (NWProtocolDefinition protocolDefinition) where T : NWProtocolMetadata
+		{
+			if (protocolDefinition == null)
+				throw new ArgumentNullException (nameof (protocolDefinition));
+			var x = nw_content_context_copy_protocol_metadata (GetCheckedHandle (), protocolDefinition.Handle);
+			if (x == IntPtr.Zero)
+				return null;
+			return Runtime.GetINativeObject<T> (x, owns: true);
+		}
+
 		[DllImport (Constants.NetworkLibrary)]
 		extern static void nw_content_context_set_metadata_for_protocol (IntPtr handle, IntPtr protocolMetadata);
 


### PR DESCRIPTION
There are different types of NWProtocolMetadata, being one of them (to be
added later) the NWFramerMessage that exposes extra methods.

With the current API we can only do:

```
var metadata = context.GetProtocolMetadata (protocol.ProtocolDefinition);
```

Which just returns the generic object, and if the protocol definition is
from a NWFramer, we want to be able to get the correct metadata object.

With the provided method you can do:

```
var metadata = context.GetProtocolMetadata<NWFramerMessage> (protocol.ProtocolDefinition);
```

Which allows the user to specify the expected metadata type from a given
protocol definition.