### PR TITLE
[d16-4] Bump system mono to get fix for mono/mono#17151.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -69,9 +69,9 @@ include $(TOP)/mk/mono.mk
 MONO_HASH := $(NEEDED_MONO_VERSION)
 
 # Minimum Mono version for building XI/XM
-MIN_MONO_VERSION=6.6.0.48
+MIN_MONO_VERSION=6.6.0.117
 MAX_MONO_VERSION=6.6.99
-MIN_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-08/51/23cc371009da14640980f98ad7b8b83818568f73/MonoFramework-MDK-6.6.0.48.macos10.xamarin.universal.pkg
+MIN_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-08/117/617f399efca133f357cb8207bc7f58b1120f12f1/MonoFramework-MDK-6.6.0.117.macos10.xamarin.universal.pkg
 
 # Minimum Mono version for Xamarin.Mac apps using the system mono
 MIN_XM_MONO_VERSION=6.4.0.94


### PR DESCRIPTION
mono/mono#17151 prevents xharness from running tests on Catalina, because
xharness thinks the root drive has no more space.

Backport of #7220.

This becomes important now that we have PR bots running on Catalina.

/cc @rolfbjarne 