### PR TITLE
[d16-4] Update APIDIFF_REFERENCES to track current stable (13.4/6.4)

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -31,7 +31,7 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config
 
 include $(TOP)/Make.versions
 
-APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/d532e90de664caf46baea6226d742b9f68b3173a/44/package/bundle.zip
+APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode11.1/e37549bc9052bff81d5c7da8a3b7992b47a08154/29/package/bundle.zip
 
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 


### PR DESCRIPTION


Backport of #7253.

/cc @VincentDondain 