### PR TITLE
[CoreImage] Fix a couple of test/availability issues.

### DIFF
--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -4485,6 +4485,7 @@ namespace CoreImage {
 
 	[iOS (9,3)]
 	[TV (9,2)]
+	[Mac (10,10)]
 	[CoreImageFilter]
 	[BaseType (typeof (CIFilter))]
 	interface CIMaskedVariableBlur : CIMaskedVariableBlurProtocol {
@@ -6005,6 +6006,12 @@ namespace CoreImage {
 		[Export ("quietSpace")]
 		float QuietSpace { get; set; }
 
+		// The availability attributes here look redundant because they're already on the type,
+		// but it makes a difference when this member is inlined into another type, in which case
+		// these attributes are copied as well (while the type's attributes aren't).
+		[iOS (13,0)]
+		[TV (13,0)]
+		[Mac (10,15)]
 		[Abstract]
 		[Export ("barcodeHeight")]
 		float BarcodeHeight { get; set; }

--- a/tests/introspection/ApiCoreImageFiltersTest.cs
+++ b/tests/introspection/ApiCoreImageFiltersTest.cs
@@ -509,6 +509,13 @@ namespace Introspection {
 							continue;
 						}
 						break;
+					case "CIGaussianBlur":
+						switch (key) {
+						case "outputImageV1":
+							// existed briefly in macOS 10.11, but neither before nor after.
+							continue;
+						}
+						break;
 					}
 
 					var cap = Char.ToUpperInvariant (key [0]) + key.Substring (1);


### PR DESCRIPTION
Fixes this on macOS 10.9:

    1) ApiCtorInitTest.DefaultCtorAllowed (Introspection.MacApiCtorInitTest.ApiCtorInitTest.DefaultCtorAllowed)
         1 potential errors found in 860 default ctor validated:
    CoreImage.CIMaskedVariableBlur : Handle

      Expected: 0
      But was:  1

      at Introspection.ApiCtorInitTest.DefaultCtorAllowed () [0x0019b] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/introspection/ApiCtorInitTest.cs:295
      at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
      at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/external/mono/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs:395

    2) ApiCoreImageFiltersTest.Keys (Introspection.MacCoreImageFiltersTest.ApiCoreImageFiltersTest.Keys)
       System.ArgumentNullException : Value cannot be null.
    Parameter name: array
      at System.Array.IndexOf[T] (T[] array, T value) [0x0000e] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/external/mono/external/corert/src/System.Private.CoreLib/src/System/Array.cs:666
      at Introspection.ApiCoreImageFiltersTest.Keys () [0x002b7] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/introspection/ApiCoreImageFiltersTest.cs:445
      at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
      at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/external/mono/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs:395

    3) ApiCoreImageFiltersTest.Protocols (Introspection.MacCoreImageFiltersTest.ApiCoreImageFiltersTest.Protocols)
         1 potential errors found:
    Managed CIMaskedVariableBlur was not part of the native filter list

      Expected: 0
      But was:  1

      at Introspection.ApiCoreImageFiltersTest.Protocols () [0x0104e] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/introspection/ApiCoreImageFiltersTest.cs:370
      at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
      at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/external/mono/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs:395

And this on macOS 10.10:

    1) ApiCoreImageFiltersTest.Keys (Introspection.MacCoreImageFiltersTest.ApiCoreImageFiltersTest.Keys)
         1 potential errors found:
    CICode128BarcodeGenerator: Property `BarcodeHeight` mapped to key `inputBarcodeHeight` is not part of `InputKeys`.

      Expected: 0
      But was:  1

      at Introspection.ApiCoreImageFiltersTest.Keys () [0x006b1] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/introspection/ApiCoreImageFiltersTest.cs:524
      at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
      at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/external/mono/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs:395

    2) ApiCoreImageFiltersTest.Protocols (Introspection.MacCoreImageFiltersTest.ApiCoreImageFiltersTest.Protocols)
         1 potential errors found:
    CICode128BarcodeGenerator: Property `BarcodeHeight` mapped to key `inputBarcodeHeight` is not part of `InputKeys`.

      Expected: 0
      But was:  1

      at Introspection.ApiCoreImageFiltersTest.Protocols () [0x0104e] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/introspection/ApiCoreImageFiltersTest.cs:370
      at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
      at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/external/mono/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs:395

And this on macOS 11.11:

    1) ApiCoreImageFiltersTest.Keys (Introspection.MacCoreImageFiltersTest.ApiCoreImageFiltersTest.Keys)
         2 potential errors found:
    CICode128BarcodeGenerator: Property `BarcodeHeight` mapped to key `inputBarcodeHeight` is not part of `InputKeys`.
    CIGaussianBlur: Output Key `outputImageV1` is NOT mapped to a `OutputImageV1` property.

      Expected: 0
      But was:  2

      at Introspection.ApiCoreImageFiltersTest.Keys () [0x006b1] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/introspection/ApiCoreImageFiltersTest.cs:524
      at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
      at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/external/mono/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs:395

    2) ApiCoreImageFiltersTest.Protocols (Introspection.MacCoreImageFiltersTest.ApiCoreImageFiltersTest.Protocols)
         2 potential errors found:
    CICode128BarcodeGenerator: Property `BarcodeHeight` mapped to key `inputBarcodeHeight` is not part of `InputKeys`.
    CIGaussianBlur: Output Key `outputImageV1` is NOT mapped to a `OutputImageV1` property.

      Expected: 0
      But was:  2

      at Introspection.ApiCoreImageFiltersTest.Protocols () [0x0104e] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/introspection/ApiCoreImageFiltersTest.cs:370
      at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
      at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/external/mono/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs:395