### PR TITLE
[d16-4] [tests] Fix tests on Catalina.

### DIFF
--- a/tests/mac-binding-project/Makefile
+++ b/tests/mac-binding-project/Makefile
@@ -14,17 +14,17 @@ bin:
 	$(Q) mkdir -p bin
 
 bin/SimpleClassDylib.dylib:  bin
-	$(Q) xcrun clang -shared ../common/mac/SimpleClass.m -o bin/SimpleClassDylib.dylib -std=gnu99 -mmacosx-version-min=10.9 -framework Cocoa -lSystem
+	$(Q) xcrun clang -shared ../common/mac/SimpleClass.m -o bin/SimpleClassDylib.dylib -std=gnu99 -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -framework Cocoa -lSystem
 
 bin/SimpleClass\ Dylib.dylib: bin/SimpleClassDylib.dylib
 	$(Q) cp bin/SimpleClassDylib.dylib bin/SimpleClass\ Dylib.dylib
 
 bin/SimpleClass.%.a: ../common/mac/SimpleClass.m bin
-	$(Q) clang -c $< -o bin/SimpleClass.$*.o -std=gnu99 -mmacosx-version-min=10.9 -arch $*
+	$(Q) clang -c $< -o bin/SimpleClass.$*.o -std=gnu99 -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -arch $*
 	$(Q) xcrun ar -rcs $@ bin/SimpleClass.$*.o
 
-bin/SimpleClassStatic.a: bin bin/SimpleClass.i386.a bin/SimpleClass.x86_64.a
-	$(Q) lipo -create bin/SimpleClass.i386.a bin/SimpleClass.x86_64.a -output $@
+bin/SimpleClassStatic.a: bin/SimpleClass.x86_64.a | bin
+	$(Q) $(CP) $< $@
 
 bin/Mobile-dynamic/MobileBinding.dll: bin/SimpleClassDylib.dylib
 	$(Q) $(SYSTEM_XIBUILD) -- $(XBUILD_VERBOSITY) MobileBinding/MobileBinding_dynamic.csproj

--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -34,12 +34,15 @@ namespace MonoTouchFixtures.MediaAccessibility {
 				Assert.Null (e, "remote / no error"); // weird should be an "image on disk"
 			}
 			string file = Path.Combine (NSBundle.MainBundle.ResourcePath, "basn3p08.png");
+			file = file.Replace(" ", "%20");
 			using (NSUrl url = new NSUrl (file)) {
 				var s = MAImageCaptioning.GetCaption (url, out var e);
 				Assert.Null (s, "local / return value");
 				Assert.NotNull (e, "local / error"); // does not like the URL (invalid)
 			}
-			using (NSUrl url = new NSUrl (NSBundle.MainBundle.ResourceUrl.AbsoluteString + "basn3p08.png")) {
+			file = NSBundle.MainBundle.ResourceUrl.AbsoluteString + "basn3p08.png";
+			file = file.Replace(" ", "%20");
+			using (NSUrl url = new NSUrl (file)) {
 				var s = MAImageCaptioning.GetCaption (url, out var e);
 				Assert.Null (s, "local / return value");
 				Assert.Null (e, "local / no error");

--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -34,14 +34,14 @@ namespace MonoTouchFixtures.MediaAccessibility {
 				Assert.Null (e, "remote / no error"); // weird should be an "image on disk"
 			}
 			string file = Path.Combine (NSBundle.MainBundle.ResourcePath, "basn3p08.png");
-			file = file.Replace(" ", "%20");
+			file = file.Replace (" ", "%20");
 			using (NSUrl url = new NSUrl (file)) {
 				var s = MAImageCaptioning.GetCaption (url, out var e);
 				Assert.Null (s, "local / return value");
 				Assert.NotNull (e, "local / error"); // does not like the URL (invalid)
 			}
 			file = NSBundle.MainBundle.ResourceUrl.AbsoluteString + "basn3p08.png";
-			file = file.Replace(" ", "%20");
+			file = file.Replace (" ", "%20");
 			using (NSUrl url = new NSUrl (file)) {
 				var s = MAImageCaptioning.GetCaption (url, out var e);
 				Assert.Null (s, "local / return value");

--- a/tests/monotouch-test/MetalPerformanceShaders/ImageScaleTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/ImageScaleTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 using Foundation;
+using ObjCRuntime;
 
 #if XAMCORE_2_0
 using Metal;
@@ -24,6 +25,11 @@ namespace MonoTouchFixtures.MetalPerformanceShaders {
 		public void Metal ()
 		{
 			TestRuntime.AssertXcodeVersion (9,0);
+
+#if !MONOMAC
+			if (Runtime.Arch == Arch.SIMULATOR && Environment.OSVersion.Version.Major >= 15)
+				Assert.Inconclusive ("Metal is not supported in the simulator on macOS 10.15");
+#endif
 
 			device = MTLDevice.SystemDefault;
 			// some older hardware won't have a default

--- a/tests/monotouch-test/MetalPerformanceShaders/KernelTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/KernelTest.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Foundation;
+using ObjCRuntime;
 
 #if XAMCORE_2_0
 using Metal;
@@ -27,6 +28,9 @@ namespace MonoTouchFixtures.MetalPerformanceShaders {
 		{
 #if !MONOMAC
 			TestRuntime.AssertXcodeVersion (7, 0);
+
+			if (Runtime.Arch == Arch.SIMULATOR && Environment.OSVersion.Version.Major >= 15)
+				Assert.Inconclusive ("Metal is not supported in the simulator on macOS 10.15");
 #else
 			TestRuntime.AssertXcodeVersion (9, 0);
 #endif

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramEqualizationTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramEqualizationTest.cs
@@ -3,6 +3,7 @@
 #if !__WATCHOS__
 
 using System;
+using ObjCRuntime;
 
 #if XAMCORE_2_0
 using Metal;
@@ -27,6 +28,9 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 		{
 #if !MONOMAC
 			TestRuntime.AssertXcodeVersion (7, 0);
+
+			if (Runtime.Arch == Arch.SIMULATOR && Environment.OSVersion.Version.Major >= 15)
+				Assert.Inconclusive ("Metal is not supported in the simulator on macOS 10.15");
 #else
 			TestRuntime.AssertXcodeVersion (9, 0);
 #endif

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramSpecificationTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramSpecificationTest.cs
@@ -3,6 +3,7 @@
 #if !__WATCHOS__
 
 using System;
+using ObjCRuntime;
 
 #if XAMCORE_2_0
 using Metal;
@@ -27,6 +28,9 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 		{
 #if !MONOMAC
 			TestRuntime.AssertXcodeVersion (7, 0);
+
+			if (Runtime.Arch == Arch.SIMULATOR && Environment.OSVersion.Version.Major >= 15)
+				Assert.Inconclusive ("Metal is not supported in the simulator on macOS 10.15");
 #else
 			TestRuntime.AssertXcodeVersion (9, 0);
 #endif

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramTest.cs
@@ -3,6 +3,7 @@
 #if !__WATCHOS__
 
 using System;
+using ObjCRuntime;
 
 #if XAMCORE_2_0
 using Metal;
@@ -27,6 +28,9 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 		{
 #if !MONOMAC
 			TestRuntime.AssertXcodeVersion (7, 0);
+
+			if (Runtime.Arch == Arch.SIMULATOR && Environment.OSVersion.Version.Major >= 15)
+				Assert.Inconclusive ("Metal is not supported in the simulator on macOS 10.15");
 #else
 			TestRuntime.AssertXcodeVersion (9, 0);
 #endif


### PR DESCRIPTION
* [tests] Remove 32-bit slice from macOS test libraries. Fixes xamarin/maccore#2031.
* [tests] Exclude MPS tests in the simulator on macOS 10.15+. Fixes xamarin/maccore#2030.
* [monotouch-test] Percent-escape some local file paths. Fixes xamarin/maccore#2032.

Backport of #7255.

/cc @rolfbjarne 