### PR TITLE
[Network] Cleanup the NWProtocolMetadata. 

### DIFF
--- a/src/Network/NWConnection.cs
+++ b/src/Network/NWConnection.cs
@@ -560,6 +560,15 @@ namespace Network {
 			return new NWProtocolMetadata (x, owns: true);
 		}
 
+		public T GetProtocolMetadata<T> (NWProtocolDefinition definition) where T : NWProtocolMetadata
+		{
+			if (definition == null)
+				throw new ArgumentNullException (nameof (definition));
+
+			var x = nw_connection_copy_protocol_metadata (GetCheckedHandle (), definition.Handle);
+			return Runtime.GetINativeObject<T> (x, owns: true);
+		}
+
 		[DllImport (Constants.NetworkLibrary)]
 		extern static /* uint32_t */ uint nw_connection_get_maximum_datagram_size (IntPtr handle);
 

--- a/src/Network/NWIPMetadata.cs
+++ b/src/Network/NWIPMetadata.cs
@@ -30,7 +30,7 @@ namespace Network {
 		public TimeSpan ReceiveTime {
 			get {
 				var time = nw_ip_metadata_get_receive_time (GetCheckedHandle ());
-				return (time == 0) ? TimeSpan.Zero : TimeSpan.FromTicks ((long) time / 100);
+				return TimeSpan.FromTicks ((long) time / 100);
 			}
 		}
 

--- a/src/Network/NWIPMetadata.cs
+++ b/src/Network/NWIPMetadata.cs
@@ -1,0 +1,42 @@
+//
+// NWIPMetadata.cs: Bindings the Netowrk nw_protocol_metadata_t API that is an IP.
+//
+// Authors:
+//   Manuel de la Pena <mandel@microsoft.com>
+//
+// Copyrigh 2019 Microsoft
+//
+using System;
+using ObjCRuntime;
+using Foundation;
+using CoreFoundation;
+
+namespace Network {
+
+	[TV (12,0), Mac (10,14), iOS (12,0), Watch (6,0)]
+	public class NWIPMetadata : NWProtocolMetadata {
+
+		internal NWIPMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
+
+		public NWIPMetadata () : this (nw_ip_create_metadata (), owns: true) {}
+
+		public NWIPEcnFlag EcnFlag {
+			get => nw_ip_metadata_get_ecn_flag (GetCheckedHandle ());
+			set => nw_ip_metadata_set_ecn_flag (GetCheckedHandle (), value);
+		}
+
+		// A single tick represents one hundred nanoseconds, API returns: the time at which a packet was received, in nanoseconds
+		// so we get nanoseconds, divicde by 100 and use from ticks
+		public TimeSpan ReceiveTime {
+			get {
+				var time = nw_ip_metadata_get_receive_time (GetCheckedHandle ());
+				return (time == 0) ? TimeSpan.Zero : TimeSpan.FromTicks ((long) time / 100);
+			}
+		}
+
+		public NWServiceClass ServiceClass {
+			get => nw_ip_metadata_get_service_class (GetCheckedHandle ());
+			set => nw_ip_metadata_set_service_class (GetCheckedHandle (), value);
+		}
+	}
+}

--- a/src/Network/NWProtocolMetadata.cs
+++ b/src/Network/NWProtocolMetadata.cs
@@ -40,53 +40,60 @@ namespace Network {
 	public class NWProtocolMetadata : NativeObject {
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern OS_nw_protocol_metadata nw_ip_create_metadata ();
+		internal static extern OS_nw_protocol_metadata nw_ip_create_metadata ();
 
+#if !XAMCORE_4_0
+		[Obsolete ("Use the 'NWIPMetadata' class and methods instead.")]
 		public static NWProtocolMetadata CreateIPMetadata ()
 		{
 			return new NWProtocolMetadata (nw_ip_create_metadata (), owns: true);
 		}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern OS_nw_protocol_metadata nw_udp_create_metadata ();
+		internal static extern OS_nw_protocol_metadata nw_udp_create_metadata ();
+
+#if !XAMCORE_4_0
+		[Obsolete ("Use the 'NSUdpMetadata' class and methods instead.")]
 		public static NWProtocolMetadata CreateUdpMetadata ()
 		{
 			return new NWProtocolMetadata (nw_udp_create_metadata (), owns: true);
 		}
+#endif
 
 		public NWProtocolMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern OS_nw_protocol_definition nw_protocol_metadata_copy_definition (OS_nw_protocol_metadata metadata);
+		internal static extern OS_nw_protocol_definition nw_protocol_metadata_copy_definition (OS_nw_protocol_metadata metadata);
 
 		public NWProtocolDefinition ProtocolDefinition => new NWProtocolDefinition (nw_protocol_metadata_copy_definition (GetCheckedHandle ()), owns: true);
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern bool nw_protocol_metadata_is_ip (OS_nw_protocol_metadata metadata);
+		internal static extern bool nw_protocol_metadata_is_ip (OS_nw_protocol_metadata metadata);
 
 		public bool IsIP => nw_protocol_metadata_is_ip (GetCheckedHandle ());
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern bool nw_protocol_metadata_is_udp (OS_nw_protocol_metadata metadata);
+		internal static extern bool nw_protocol_metadata_is_udp (OS_nw_protocol_metadata metadata);
 
 		public bool IsUdp => nw_protocol_metadata_is_udp (GetCheckedHandle ());
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern bool nw_protocol_metadata_is_tls (OS_nw_protocol_metadata metadata);
+		internal static extern bool nw_protocol_metadata_is_tls (OS_nw_protocol_metadata metadata);
 
 		public bool IsTls => nw_protocol_metadata_is_tls (GetCheckedHandle ());
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern bool nw_protocol_metadata_is_tcp (OS_nw_protocol_metadata metadata);
+		internal static extern bool nw_protocol_metadata_is_tcp (OS_nw_protocol_metadata metadata);
 
 		public bool IsTcp => nw_protocol_metadata_is_tcp (GetCheckedHandle ());
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern IntPtr nw_tls_copy_sec_protocol_metadata (IntPtr handle);
+		internal static extern IntPtr nw_tls_copy_sec_protocol_metadata (IntPtr handle);
 
 		void CheckIsIP ()
 		{
@@ -107,23 +114,26 @@ namespace Network {
 		}
 
 #if !XAMCORE_4_0
-		[Obsolete ("Use 'TlsSecProtocolMetadata' instead.")]
+		[Obsolete ("Use the 'NWTlsMetadata' class and methods instead.")]
 		public SecProtocolMetadata SecProtocolMetadata => TlsSecProtocolMetadata;
-#endif
 
+		[Obsolete ("Use the 'NWTlsMetadata' class and methods instead.")]
 		public SecProtocolMetadata TlsSecProtocolMetadata {
 			get {
 				CheckIsTls ();
 				return new SecProtocolMetadata (nw_tls_copy_sec_protocol_metadata (GetCheckedHandle ()), owns: true);
 			}
 		}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_ip_metadata_set_ecn_flag (OS_nw_protocol_metadata metadata, NWIPEcnFlag ecn_flag);
+		internal static extern void nw_ip_metadata_set_ecn_flag (OS_nw_protocol_metadata metadata, NWIPEcnFlag ecn_flag);
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern NWIPEcnFlag nw_ip_metadata_get_ecn_flag (OS_nw_protocol_metadata metadata);
+		internal static extern NWIPEcnFlag nw_ip_metadata_get_ecn_flag (OS_nw_protocol_metadata metadata);
 
+#if !XAMCORE_4_0
+		[Obsolete ("Use the 'NWIPMetadata' class and methods instead.")]
 		public NWIPEcnFlag IPMetadataEcnFlag {
 			get {
 				CheckIsIP ();
@@ -134,31 +144,35 @@ namespace Network {
 				nw_ip_metadata_set_ecn_flag (GetCheckedHandle (), value);
 			}
 		}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern /* uint64_t */ ulong nw_ip_metadata_get_receive_time (OS_nw_protocol_metadata metadata);
+		internal static extern /* uint64_t */ ulong nw_ip_metadata_get_receive_time (OS_nw_protocol_metadata metadata);
 
+#if !XAMCORE_4_0
+		[Obsolete ("Use the 'NWIPMetadata' class and methods instead.")]
 		public ulong IPMetadataReceiveTime {
 			get {
 				CheckIsIP ();
 				return nw_ip_metadata_get_receive_time (GetCheckedHandle ());
 			}
 		}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_ip_metadata_set_service_class (OS_nw_protocol_metadata metadata, NWServiceClass service_class);
+		internal static extern void nw_ip_metadata_set_service_class (OS_nw_protocol_metadata metadata, NWServiceClass service_class);
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern NWServiceClass nw_ip_metadata_get_service_class (OS_nw_protocol_metadata metadata);
+		internal static extern NWServiceClass nw_ip_metadata_get_service_class (OS_nw_protocol_metadata metadata);
 
 #if !XAMCORE_4_0
-		[Obsolete ("Use 'IPServiceClass' instead.")]
+		[Obsolete ("Use the 'NWIPMetadata' class and methods instead.")]
 		public NWServiceClass ServiceClass {
 			get => IPServiceClass;
 			set => IPServiceClass = value;
 		}
-#endif
 
+		[Obsolete ("Use the 'NWIPMetadata' class and methods instead.")]
 		public NWServiceClass IPServiceClass {
 			get {
 				CheckIsIP ();
@@ -169,35 +183,42 @@ namespace Network {
 				nw_ip_metadata_set_service_class (GetCheckedHandle (), value);
 			}
 		}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
-		extern static /* uint32_t */ uint nw_tcp_get_available_receive_buffer (IntPtr handle);
+		internal extern static /* uint32_t */ uint nw_tcp_get_available_receive_buffer (IntPtr handle);
 
+#if !XAMCORE_4_0
+		[Obsolete ("Use the 'NWTcpMetadata' class and methods instead.")]
 		public uint TcpGetAvailableReceiveBuffer ()
 		{
 			CheckIsTcp ();
 			return nw_tcp_get_available_receive_buffer (GetCheckedHandle ());
 		}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
-		extern static /* uint32_t */ uint nw_tcp_get_available_send_buffer (IntPtr handle);
+		internal extern static /* uint32_t */ uint nw_tcp_get_available_send_buffer (IntPtr handle);
 
+#if !XAMCORE_4_0
+		[Obsolete ("Use the 'NWTcpMetadata' class and methods instead.")]
 		public uint TcpGetAvailableSendBuffer ()
 		{
 			CheckIsTcp ();
 			return nw_tcp_get_available_send_buffer (GetCheckedHandle ());
 		}
+#endif
 
 		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
 		[DllImport (Constants.NetworkLibrary)]
-		static extern bool nw_protocol_metadata_is_framer_message (OS_nw_protocol_metadata metadata);
+		internal static extern bool nw_protocol_metadata_is_framer_message (OS_nw_protocol_metadata metadata);
 
 		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
 		public bool IsFramerMessage => nw_protocol_metadata_is_framer_message (GetCheckedHandle ());
 
 		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
 		[DllImport (Constants.NetworkLibrary)]
-		static extern bool nw_protocol_metadata_is_ws (OS_nw_protocol_metadata metadata);
+		internal static extern bool nw_protocol_metadata_is_ws (OS_nw_protocol_metadata metadata);
 
 		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
 		public bool IsWebSocket => nw_protocol_metadata_is_ws (GetCheckedHandle ());

--- a/src/Network/NWTcpMetadata.cs
+++ b/src/Network/NWTcpMetadata.cs
@@ -1,0 +1,25 @@
+//
+// NWTcpMetadata.cs: Bindings the Netowrk nw_protocol_metadata_t API that is an Tcp.
+//
+// Authors:
+//   Manuel de la Pena <mandel@microsoft.com>
+//
+// Copyrigh 2019 Microsoft
+//
+using System;
+using ObjCRuntime;
+using Foundation;
+using CoreFoundation;
+
+namespace Network {
+
+	[TV (12,0), Mac (10,14), iOS (12,0), Watch (6,0)]
+	public class NWTcpMetadata : NWProtocolMetadata {
+
+		internal NWTcpMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
+
+		public uint AvailableReceiveBuffer () => nw_tcp_get_available_receive_buffer (GetCheckedHandle ());
+
+		public uint AvailableSendBuffer () => nw_tcp_get_available_send_buffer (GetCheckedHandle ());
+	}
+}

--- a/src/Network/NWTcpMetadata.cs
+++ b/src/Network/NWTcpMetadata.cs
@@ -18,8 +18,8 @@ namespace Network {
 
 		internal NWTcpMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
 
-		public uint AvailableReceiveBuffer () => nw_tcp_get_available_receive_buffer (GetCheckedHandle ());
+		public uint AvailableReceiveBuffer => nw_tcp_get_available_receive_buffer (GetCheckedHandle ());
 
-		public uint AvailableSendBuffer () => nw_tcp_get_available_send_buffer (GetCheckedHandle ());
+		public uint AvailableSendBuffer => nw_tcp_get_available_send_buffer (GetCheckedHandle ());
 	}
 }

--- a/src/Network/NWTlsMetadata.cs
+++ b/src/Network/NWTlsMetadata.cs
@@ -1,0 +1,26 @@
+//
+// NWTlsMetadata.cs: Bindings the Netowrk nw_protocol_metadata_t API that is an Tls.
+//
+// Authors:
+//   Manuel de la Pena <mandel@microsoft.com>
+//
+// Copyrigh 2019 Microsoft
+//
+using System;
+using ObjCRuntime;
+using Foundation;
+using Security;
+using CoreFoundation;
+
+namespace Network {
+
+	[TV (12,0), Mac (10,14), iOS (12,0), Watch (6,0)]
+	public class NWTlsMetadata : NWProtocolMetadata {
+
+		internal NWTlsMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
+
+		public SecProtocolMetadata SecProtocolMetadata
+			=> new SecProtocolMetadata (nw_tls_copy_sec_protocol_metadata (GetCheckedHandle ()), owns: true);
+
+	}
+}

--- a/src/Network/NWUdpMetadata.cs
+++ b/src/Network/NWUdpMetadata.cs
@@ -1,0 +1,25 @@
+//
+// NWUdpMetadata.cs: Bindings the Netowrk nw_protocol_metadata_t API that is an Udp.
+//
+// Authors:
+//   Manuel de la Pena <mandel@microsoft.com>
+//
+// Copyrigh 2019 Microsoft
+//
+using System;
+using ObjCRuntime;
+using Foundation;
+using Security;
+using CoreFoundation;
+
+namespace Network {
+
+	[TV (12,0), Mac (10,14), iOS (12,0), Watch (6,0)]
+	public class NWUdpMetadata : NWProtocolMetadata {
+
+		internal NWUdpMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
+
+		public NWUdpMetadata () : this (nw_udp_create_metadata (), owns: true) {}
+	}
+}
+

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1178,6 +1178,7 @@ NETWORK_SOURCES = \
 	Network/NWError.cs			\
 	Network/NWFramer.cs			\
 	Network/NWInterface.cs			\
+	Network/NWIPMetadata.cs			\
 	Network/NWListener.cs			\
 	Network/NWProtocolIPOptions.cs	\
 	Network/NWParameters.cs			\
@@ -1187,10 +1188,13 @@ NETWORK_SOURCES = \
 	Network/NWProtocolMetadata.cs		\
 	Network/NWProtocolOptions.cs		\
 	Network/NWProtocolStack.cs			\
+	Network/NWTcpMetadata.cs \
+	Network/NWTlsMetadata.cs \
 	Network/NWTxtRecord.cs	\
 	Network/NWProtocolTcpOptions.cs	\
 	Network/NWProtocolTlsOptions.cs	\
 	Network/NWProtocolUdpOptions.cs	\
+	Network/NWUdpMetadata.cs \
 	Network/NWWebSocketMetadata.cs	\
 	Network/NWWebSocketOptions.cs	\
 	Network/NWWebSocketRequest.cs	\

--- a/tests/monotouch-test/Network/NWIPProtocolMetadataTest.cs
+++ b/tests/monotouch-test/Network/NWIPProtocolMetadataTest.cs
@@ -17,7 +17,8 @@ namespace MonoTouchFixtures.Network {
 		public void Init () => TestRuntime.AssertXcodeVersion (10, 0);
 
 		[SetUp]
-		public void SetUp () {
+		public void SetUp () 
+		{
 			metadata = new NWIPMetadata ();
 		}
 

--- a/tests/monotouch-test/Network/NWIPProtocolMetadataTest.cs
+++ b/tests/monotouch-test/Network/NWIPProtocolMetadataTest.cs
@@ -1,0 +1,58 @@
+﻿#if !__WATCHOS__
+using System;
+using Foundation;
+using Network;
+using ObjCRuntime;
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.Network {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class NWIPProtocolMetadataTest {
+		NWIPMetadata metadata;
+
+		[SetUp]
+		public void SetUp () {
+			metadata = new NWIPMetadata ();
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			metadata.Dispose ();
+		}
+
+		[Test]
+		public void TestEcnFlagProperty ()
+		{
+			Assert.That (metadata.EcnFlag, Is.EqualTo (NWIPEcnFlag.NonEct), "default value");
+			metadata.EcnFlag = NWIPEcnFlag.Ect1;
+			Assert.That (metadata.EcnFlag, Is.EqualTo (NWIPEcnFlag.Ect1), "new value");
+		}
+
+		[Test]
+		public void TestServiceClassProperty ()
+		{
+			Assert.That (metadata.ServiceClass, Is.EqualTo (NWServiceClass.BestEffort), "default value");
+			metadata.ServiceClass = NWServiceClass.InteractiveVideo;
+			Assert.That (metadata.ServiceClass, Is.EqualTo (NWServiceClass.InteractiveVideo), "new value");
+		}
+
+		[Test]
+		public void TestReceiveTimeProperty ()
+		{
+			Assert.That (metadata.ReceiveTime, Is.EqualTo (TimeSpan.Zero), "default value");
+		}
+
+		[Test]
+		public void TestMetadataType ()
+		{
+			Assert.True (metadata.IsIP, "IsIP");
+			Assert.False (metadata.IsTcp, "IsTcp");
+			Assert.False (metadata.IsUdp, "IsUdp");
+		}
+	}
+}
+#endif


### PR DESCRIPTION
Add missing types so that users do not mix the diff protocol metadata. Also makes the API cleaner since we will have a WebSocektsMetadata and a NWFramerMessage which are of the metadata type.