### PR TITLE
[Network] Fix NWTxtRecord.Apply. Fixes xamarin/maccore#2036.

### DIFF
--- a/tests/monotouch-test/Network/NWTxtRecordTest.cs
+++ b/tests/monotouch-test/Network/NWTxtRecordTest.cs
@@ -131,7 +131,14 @@ namespace MonoTouchFixtures.Network
 				keyCount++;
 				Assert.IsTrue (keys.Contains (k), k);
 			});
+			var keyCount2 = 0;
+			record.Apply ((k, r, v) => {
+				keyCount2++;
+				Assert.IsTrue (keys.Contains (k), k);
+				return true;
+			});
 			Assert.AreEqual (keys.Count, keyCount, "keycount");
+			Assert.AreEqual (keys.Count, keyCount2, "keycount2");
 		}
 
 		[Test]


### PR DESCRIPTION
The block/delegate passed to NWTxtRecord.Apply is supposed to return a bool.
Not returning anything ends up with random behavior, which causes a test
failure on Catalina:

    3) TestApply (MonoTouchFixtures.Network.NWTxtRecordTest.TestApply)
         keycount
      Expected: 4
      But was:  1

        at MonoTouchFixtures.Network.NWTxtRecordTest.TestApply () [0x000a3] in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/monotouch-test/Network/NWTxtRecordTest.cs:134
        at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
        at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/external/mono/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs:395

I've fixed the existing API to return 'true' always in the block callback, to
get consistent behavior, and in addition I've added a new overload that takes
a delegate that returns a bool, which allows the consumer of the API to decide
what to return.

Fixes https://github.com/xamarin/maccore/issues/2036.