### PR TITLE
[NetworkExtension] Bindings xcode11.2 - missing selector

### DIFF
--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -421,6 +421,10 @@ namespace NetworkExtension {
 		[NoiOS]
 		[NullAllowed, Export ("sourceAppAuditToken")]
 		NSData SourceAppAuditToken { get; }
+
+		[Mac (10, 15), iOS (13, 1)]
+		[Export ("identifier")]
+		NSUuid Identifier { get; }
 	}
 
 	// according to Xcode7 SDK this was available (in parts) in iOS8

--- a/tests/xtro-sharpie/iOS-NetworkExtension.todo
+++ b/tests/xtro-sharpie/iOS-NetworkExtension.todo
@@ -1,1 +1,0 @@
-!missing-selector! NEFilterFlow::identifier not bound

--- a/tests/xtro-sharpie/macOS-NetworkExtension.todo
+++ b/tests/xtro-sharpie/macOS-NetworkExtension.todo
@@ -1,1 +1,0 @@
-!missing-selector! NEFilterFlow::identifier not bound


### PR DESCRIPTION
Added missing selector `identifier` for NetworkExtension xcode11.2