### PR TITLE
[msbuild] Ensure the output of `mtouch` (and friends) are included in binary logs. Fix #7035

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -242,6 +242,9 @@ namespace Xamarin.Mac.Tasks
 
 			actualArgs.AddQuoted ($"@{responseFile}");
 
+			if (!string.IsNullOrWhiteSpace (ExtraArguments))
+				actualArgs.Add (ExtraArguments);
+
 			var verbosity = VerbosityUtils.Merge (ExtraArguments, (LoggerVerbosity) Verbosity);
 			// for compatibility with earlier versions nothing means one /v
 			args.AddLine (verbosity.Length > 0 ? verbosity : "/verbose");

--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -247,7 +247,7 @@ namespace Xamarin.Mac.Tasks
 
 			var verbosity = VerbosityUtils.Merge (ExtraArguments, (LoggerVerbosity) Verbosity);
 			// for compatibility with earlier versions nothing means one /v
-			args.AddLine (verbosity.Length > 0 ? verbosity : "/verbose");
+			actualArgs.AddLine (verbosity.Length > 0 ? verbosity : "/verbose");
 
 			return actualArgs.ToString ();
 		}

--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -72,6 +72,7 @@ namespace Xamarin.Mac.Tasks
 		public bool Profiling { get; set; }
 		public string I18n { get; set; }
 		public string ExtraArguments { get; set; }
+		public int Verbosity { get; set; }
 
 		public string AotMode { get; set; }
 		public bool HybridAOT { get; set; }
@@ -104,8 +105,6 @@ namespace Xamarin.Mac.Tasks
 		{
 			var args = new CommandLineArgumentBuilder ();
 			bool msym;
-
-			args.AddLine ("/verbose");
 
 			if (Debug)
 				args.AddLine ("/debug");
@@ -243,8 +242,9 @@ namespace Xamarin.Mac.Tasks
 
 			actualArgs.AddQuoted ($"@{responseFile}");
 
-			if (!string.IsNullOrWhiteSpace (ExtraArguments))
-				actualArgs.Add (ExtraArguments);
+			var verbosity = VerbosityUtils.Merge (ExtraArguments, (LoggerVerbosity) Verbosity);
+			// for compatibility with earlier versions nothing means one /v
+			args.AddLine (verbosity.Length > 0 ? verbosity : "/verbose");
 
 			return actualArgs.ToString ();
 		}

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -561,7 +561,9 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			EnableSGenConc="$(EnableSGenConc)"
 			AotMode="$(AOTMode)"
 			HybridAOT="$(HybridAOT)"
-			ExplicitAotAssemblies="$(ExplicitAotAssemblies)">
+			ExplicitAotAssemblies="$(ExplicitAotAssemblies)"
+			StandardOutputImportance="High"
+			>
 			<Output TaskParameter="NativeLibraries" ItemName="_NativeLibrary" />
 		</Mmp>
 	</Target>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -112,7 +112,9 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			FrameworkRoot="$(XamarinMacFrameworkRoot)"
 			BTouchToolPath="$(BTouchToolPath)"
-			BTouchToolExe="$(BTouchToolExe)">
+			BTouchToolExe="$(BTouchToolExe)"
+			StandardOutputImportance="High"
+			>
 		</BTouch>
 	</Target>
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
@@ -40,6 +40,8 @@ namespace Xamarin.MacDev.Tasks {
 
 		public string ExtraArgs { get; set; }
 
+		public int Verbosity { get; set; }
+
 		public string GeneratedSourcesDir { get; set; }
 
 		public string GeneratedSourcesFileList { get; set; }
@@ -219,6 +221,10 @@ namespace Xamarin.MacDev.Tasks {
 					cmd.AppendTextUnquoted (StringParserService.Parse (argument, customTags));
 				}
 			}
+
+			var v = VerbosityUtils.Merge (ExtraArgs, (LoggerVerbosity) Verbosity);
+			if (v.Length > 0)
+				cmd.AppendTextUnquoted (v);
 
 			return cmd.ToString ();
 		}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
@@ -223,8 +223,10 @@ namespace Xamarin.MacDev.Tasks {
 			}
 
 			var v = VerbosityUtils.Merge (ExtraArgs, (LoggerVerbosity) Verbosity);
-			if (v.Length > 0)
+			if (v.Length > 0) {
+				cmd.AppendTextUnquoted (" ");
 				cmd.AppendTextUnquoted (v);
+			}
 
 			return cmd.ToString ();
 		}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/VerbosityUtils.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/VerbosityUtils.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Corp
+
+using System;
+using Microsoft.Build.Framework;
+
+namespace Xamarin.MacDev.Tasks {
+
+	// Helper code for Task delegating work to external tools but that still
+	// needs to be verbosity-aware
+	public static class VerbosityUtils {
+
+		// verbosity can be set in multiple ways
+		// this makes it a consistent interpretation of them
+		static public string Merge (string extraArguments, LoggerVerbosity taskVerbosity)
+		{
+			string result = String.Empty;
+			var empty_extra = String.IsNullOrEmpty (extraArguments);
+			// We give the priority to the extra arguments given to the tools
+  			if (empty_extra || (!empty_extra && !extraArguments.Contains ("-q") && !extraArguments.Contains ("-v"))) {
+				// if nothing is specified fall back to msbuild settings
+				// first check if some were supplied on the command-line
+				result = GetVerbosityLevel (Environment.CommandLine);
+				// if not then use the default from the msbuild config files, which Visual Studio for Mac can override (to match the IDE setting for msbuild)
+				if (result.Length == 0)
+					result = GetVerbosityLevel (taskVerbosity);
+			}
+			return result;
+		}
+
+		//
+		// This is an hack, since there can be multiple loggers.
+		// However it's the most common use case and `mtouch` logs
+		// are often the most important to gather and developers expect
+		// a single change (in verbosity) to do the job and be consistent in CI.
+		//
+		// msbuild argument format
+		//	-verbosity:<level> Display this amount of information in the event log.
+		//		The available verbosity levels are: q[uiet], m[inimal],
+		//		n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
+		//
+		static public string GetVerbosityLevel (string commandLine)
+		{
+			var verbosity = String.Empty;
+			char sep = ' ';
+			// first chance: short form, case sensitive
+			// note: `-v` (without arguments) is not a valid option
+			var p = commandLine.IndexOf ("v:", StringComparison.Ordinal);
+			if (p > 0) {
+				sep = commandLine[p - 1];
+				p += 2; // skip `v:`
+			} else {
+				// second change: long form, case sensitive
+				p = commandLine.IndexOf ("verbosity:", StringComparison.Ordinal);
+				if (p > 0) {
+					sep = commandLine[p - 1];
+					p += 10;
+				}
+			}
+			// check separator, e.g. `-approv:`
+			if ((p > 0) && (sep == '-' || sep == '/')) {
+				// might (or not) be the last argument provided
+				var end = commandLine.IndexOf (' ', p);
+				verbosity = end == -1 ? commandLine.Substring (p) : commandLine.Substring (p, end - p);
+			}
+
+			// case sensitive
+			switch (verbosity) {
+			case "q":
+			case "quiet":
+				return GetVerbosityLevel (LoggerVerbosity.Quiet);
+			case "m":
+			case "minimal":
+				return GetVerbosityLevel (LoggerVerbosity.Minimal);
+			case "n":
+			case "normal":
+			default:
+				return GetVerbosityLevel (LoggerVerbosity.Normal);
+			case "d":
+			case "detailed":
+				return GetVerbosityLevel (LoggerVerbosity.Detailed);
+			case "diag":
+			case "diagnostic":
+				return GetVerbosityLevel (LoggerVerbosity.Diagnostic);
+			}
+		}
+
+		// The values here come from: https://github.com/mono/monodevelop/blob/143f9b6617123a0841a5cc5a2a4e13b309535792/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild.Shared/RemoteBuildEngineMessages.cs#L186
+		// Assume 'Normal (2)' is the default verbosity (no change), and the other values follow from there.
+		static public string GetVerbosityLevel (LoggerVerbosity v)
+		{
+			switch ((LoggerVerbosity) v) {
+			case LoggerVerbosity.Quiet:
+				return "-q -q -q -q";
+			case LoggerVerbosity.Minimal:
+				return "-q -q";
+			case LoggerVerbosity.Normal:
+			default:
+				return String.Empty;
+			case LoggerVerbosity.Detailed:
+				return "-v -v";
+			case LoggerVerbosity.Diagnostic:
+				return "-v -v -v -v";
+			}
+		}
+	}
+}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -57,6 +57,7 @@
     <Compile Include="..\..\tools\common\StringUtils.cs">
       <Link>StringUtils.cs</Link>
     </Compile>
+    <Compile Include="VerbosityUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MsBuildTasks\CopyBase.cs" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -883,6 +883,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			AppExtensionReferences="@(_ResolvedAppExtensionReferences)"
 			ArchiveSymbols="$(MonoSymbolArchive)"
 			Verbosity="$(MtouchVerbosity)"
+			StandardOutputImportance="High"
 			>
 			<Output TaskParameter="CompiledArchitectures" PropertyName="_CompiledArchitectures" />
 		</MTouch>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
@@ -81,7 +81,9 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 			References="@(ReferencePath)"
 			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			BTouchToolPath="$(BTouchToolPath)"
-			BTouchToolExe="$(BTouchToolExe)">
+			BTouchToolExe="$(BTouchToolExe)"
+			StandardOutputImportance="High"
+			>
 		</BTouch>
 	</Target>
 

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/VerbosityTest.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/VerbosityTest.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corp
+
+using System;
+using Microsoft.Build.Framework;
+using NUnit.Framework;
+
+namespace Xamarin.MacDev.Tasks {
+
+	[TestFixture]
+	public class VerbosityTest {
+
+		// when executed from VSfM the command line looks like this:
+		[TestCase ("/Users/poupou/Library/Caches/VisualStudio/8.0/MSBuild/98811_1/MonoDevelop.MSBuildBuilder.exe 64249 False ...", LoggerVerbosity.Normal)]
+		// when executed from the terminal it looks like:
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll /t:rebuild introspection-ios.csproj /v:q", LoggerVerbosity.Quiet)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll /v:quiet /t:build introspection-ios.csproj", LoggerVerbosity.Quiet)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll /t:clean introspection-ios.csproj /v:m", LoggerVerbosity.Minimal)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll /v:minimal introspection-ios.csproj", LoggerVerbosity.Minimal)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll -t:rebuild introspection-ios.csproj -v:n", LoggerVerbosity.Normal)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll -v:normal -t:build introspection-ios.csproj", LoggerVerbosity.Normal)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll -t:clean introspection-ios.csproj -v:d", LoggerVerbosity.Detailed)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll -v:detailed introspection-ios.csproj", LoggerVerbosity.Detailed)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll -t:clean introspection-ios.csproj -v:diag", LoggerVerbosity.Diagnostic)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll -v:diagnostic introspection-ios.csproj", LoggerVerbosity.Diagnostic)]
+
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll /t:rebuild introspection-ios.csproj /verbosity:quiet", LoggerVerbosity.Quiet)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll /verbosity:q /t:build introspection-ios.csproj", LoggerVerbosity.Quiet)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll /t:clean introspection-ios.csproj /verbosity:minimal", LoggerVerbosity.Minimal)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll /verbosity:m introspection-ios.csproj", LoggerVerbosity.Minimal)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll -t:rebuild introspection-ios.csproj -verbosity:normal", LoggerVerbosity.Normal)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll -verbosity:n -t:build introspection-ios.csproj", LoggerVerbosity.Normal)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll -t:clean introspection-ios.csproj -verbosity:detailed", LoggerVerbosity.Detailed)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll -verbosity:d introspection-ios.csproj", LoggerVerbosity.Detailed)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll -t:clean introspection-ios.csproj -verbosity:diagnostic", LoggerVerbosity.Diagnostic)]
+		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll -verbosity:diag introspection-ios.csproj", LoggerVerbosity.Diagnostic)]
+
+		public void FromString (string commandLine, LoggerVerbosity expected)
+		{
+			var result = VerbosityUtils.GetVerbosityLevel (expected);
+			Assert.That (VerbosityUtils.GetVerbosityLevel (commandLine), Is.EqualTo (result), commandLine);
+		}
+
+		[TestCase (LoggerVerbosity.Quiet, "-q -q -q -q")]
+		[TestCase (LoggerVerbosity.Minimal, "-q -q")]
+		[TestCase (LoggerVerbosity.Normal, "")]
+		[TestCase (LoggerVerbosity.Detailed, "-v -v")]
+		[TestCase (LoggerVerbosity.Diagnostic, "-v -v -v -v")]
+		[TestCase ((LoggerVerbosity) (-1), "")]
+		public void FromLoggerVerbosity (LoggerVerbosity v, string expectedResult)
+		{
+			Assert.That (VerbosityUtils.GetVerbosityLevel (v), Is.EqualTo (expectedResult), v.ToString ());
+		}
+	}
+}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/VerbosityTest.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/VerbosityTest.cs
@@ -34,6 +34,9 @@ namespace Xamarin.MacDev.Tasks {
 		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll -t:clean introspection-ios.csproj -verbosity:diagnostic", LoggerVerbosity.Diagnostic)]
 		[TestCase ("/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/15.0/bin/MSBuild.dll -verbosity:diag introspection-ios.csproj", LoggerVerbosity.Diagnostic)]
 
+		[TestCase ("/prev:q", LoggerVerbosity.Normal)]
+		[TestCase ("/evil-command-line-v:diag", LoggerVerbosity.Normal)]
+
 		public void FromString (string commandLine, LoggerVerbosity expected)
 		{
 			var result = VerbosityUtils.GetVerbosityLevel (expected);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="ProjectsTests\CompileSceneKitAssetsTest.cs" />
     <Compile Include="ProjectsTests\NativeReferencesNoEmbedding.cs" />
     <Compile Include="FrameworkListTest.cs" />
+    <Compile Include="VerbosityTest.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -245,6 +245,7 @@ public class BindingTouch {
 			{ "d=", "Defines a symbol", v => defines.Add (v) },
 			{ "api=", "Adds a API definition source file", v => api_sources.Add (v) },
 			{ "s=", "Adds a source file required to build the API", v => core_sources.Add (v) },
+			{ "q", "Quiet", v => verbose = false },
 			{ "v", "Sets verbose mode", v => verbose = true },
 			{ "x=", "Adds the specified file to the build, used after the core files are compiled", v => extra_sources.Add (v) },
 			{ "e", "Generates smaller classes that can not be subclassed (previously called 'external mode')", v => external = true },


### PR DESCRIPTION
and by friends I mean `mmp` and `btouch`

What does this do ?

1. Assume that output of `mtouch` (and other similar tools) is **always** of high importance. Why ?

- If not then it's not saved in the binary log (even if visible on the console/text logs).
- The logging of `mtouch` (and friends) is dynamic, based on a supplied verbosity level.
- If a verbosity level _anywhere_ then it's a clear sign that the developer wants that extra output (and that includes binary logs).

2. Assume the _global_ verbosity of `msbuild` from the console is just as valid/useful than the one from VSfM.

- CI/bots produce logs and they should be useful to diagnose build issues.
- Setting verbosity in several places is error-prone, which delay investigations and results.
- Running the same project, with the same `msbuild` verbosity, should be identical between IDE and console.

What does that mean ?

Using `msbuild /v:diag /bl:out.binlog` you get a small(er) binary log that has everything[1] you need to diagnose a Xamarin.iOS (or Mac) build. It's also identical to the output what VSfM produce (for the same `msbuild` verbosity level).

[1] we might need to review what we log if we're missing interesting stuff

References:
https://github.com/xamarin/xamarin-macios/issues/7035