### PR TITLE
[runtime] Simplify Vision dlsym'ed functions

### DIFF
--- a/runtime/bindings.m
+++ b/runtime/bindings.m
@@ -103,10 +103,12 @@ static void* vision_handle;
 static vision_func
 get_vision_func (const char *func_name, const char **error_msg)
 {
-	vision_handle = dlopen ("/System/Library/Frameworks/Vision.framework/Vision", RTLD_LAZY);
 	if (vision_handle == NULL) {
-		*error_msg = "Could not open Vision.framework";
-		return NULL;
+		vision_handle = dlopen ("/System/Library/Frameworks/Vision.framework/Vision", RTLD_LAZY);
+		if (vision_handle == NULL) {
+			*error_msg = "Could not open Vision.framework";
+			return NULL;
+		}
 	}
 	return (vision_func) dlsym (vision_handle, func_name);
 }

--- a/runtime/bindings.m
+++ b/runtime/bindings.m
@@ -98,11 +98,10 @@ void * monotouch_IntPtr_objc_msgSendSuper_IntPtr (struct objc_super *super, SEL 
 
 typedef CGPoint (*vision_func) (vector_float2 faceLandmarkPoint, CGRect faceBoundingBox, size_t imageWidth, size_t imageHeight);
 
-static void* vision_handle;
-
 static vision_func
 get_vision_func (const char *func_name, const char **error_msg)
 {
+	static void* vision_handle;
 	if (vision_handle == NULL) {
 		vision_handle = dlopen ("/System/Library/Frameworks/Vision.framework/Vision", RTLD_LAZY);
 		if (vision_handle == NULL) {

--- a/runtime/bindings.m
+++ b/runtime/bindings.m
@@ -98,6 +98,19 @@ void * monotouch_IntPtr_objc_msgSendSuper_IntPtr (struct objc_super *super, SEL 
 
 typedef CGPoint (*vision_func) (vector_float2 faceLandmarkPoint, CGRect faceBoundingBox, size_t imageWidth, size_t imageHeight);
 
+static void* vision_handle;
+
+static vision_func
+get_vision_func (const char *func_name, const char **error_msg)
+{
+	vision_handle = dlopen ("/System/Library/Frameworks/Vision.framework/Vision", RTLD_LAZY);
+	if (vision_handle == NULL) {
+		*error_msg = "Could not open Vision.framework";
+		return NULL;
+	}
+	return (vision_func) dlsym (vision_handle, func_name);
+}
+
 CGPoint
 xamarin_CGPoint__VNNormalizedFaceBoundingBoxPointForLandmarkPoint_Vector2_CGRect_nuint_nuint_string (struct Vector2f faceLandmarkPoint, CGRect faceBoundingBox, xm_nuint_t imageWidth, xm_nuint_t imageHeight, const char **error_msg) {
 
@@ -105,18 +118,11 @@ xamarin_CGPoint__VNNormalizedFaceBoundingBoxPointForLandmarkPoint_Vector2_CGRect
 	*error_msg = NULL;
 
 	if (func == NULL) {
-		void *vision_handle = dlopen ("/System/Library/Frameworks/Vision.framework/Vision", RTLD_LAZY);
-		if (vision_handle == NULL) {
-			*error_msg = "Could not open Vision Framework";
-			return CGPointMake (0, 0);
-		}
-
-		func = (vision_func) dlsym (vision_handle, "VNNormalizedFaceBoundingBoxPointForLandmarkPoint");
-
-		if (func == NULL) {
+		func = get_vision_func ("VNNormalizedFaceBoundingBoxPointForLandmarkPoint", error_msg);
+		if (func == NULL && *error_msg == NULL)
 			*error_msg = "Could not obtain the address for VNNormalizedFaceBoundingBoxPointForLandmarkPoint";
+		if (func == NULL)
 			return CGPointMake (0, 0);
-		}
 	}
 
 	vector_float2 flp;
@@ -133,16 +139,10 @@ xamarin_CGPoint__VNImagePointForFaceLandmarkPoint_Vector2_CGRect_nuint_nuint_str
 	*error_msg = NULL;
 
 	if (func == NULL) {
-		void *vision_handle = dlopen ("/System/Library/Frameworks/Vision.framework/Vision", RTLD_LAZY);
-		if (vision_handle == NULL) {
-			*error_msg = "Could not open Vision Framework";
-			return CGPointMake (0, 0);
-		}
-
-		func = (vision_func) dlsym (vision_handle, "VNImagePointForFaceLandmarkPoint");
-
+		func = get_vision_func ("VNImagePointForFaceLandmarkPoint", error_msg);
 		if (func == NULL) {
-			*error_msg = "Could not obtain the address for VNImagePointForFaceLandmarkPoint";
+			if (*error_msg == NULL)
+				*error_msg = "Could not obtain the address for VNImagePointForFaceLandmarkPoint";
 			return CGPointMake (0, 0);
 		}
 	}


### PR DESCRIPTION
More code sharing - DRYer :)

It also remove complaints (from static analysis tools) that a `dlclose`
should be present. That's not really an issue here since it's reference
counted and won't be unloaded if you use the code (and such a call is
not added in the PR). It silence the warning since it's not a local
variable anymore.