### PR TITLE
[runtime] Throw a OutOfMemoryException when processing parameters

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -466,6 +466,8 @@
 			"const char *", "msg"
 		),
 
+		new Export ("MonoException *", "mono_get_exception_out_of_memory"),
+
 		#endregion
 
 		#region metadata/gc-internal.h

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -254,6 +254,10 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 								needs_writeback = TRUE;
 								arg_copy = (void **) calloc (managed_arg_count, sizeof (void *));
 								writeback = (bool *) calloc (managed_arg_count, sizeof (bool));
+								if (!arg_copy || !writeback) {
+									exception = (MonoObject *) mono_get_exception_out_of_memory ();
+									goto exception_handling;
+								}
 							}
 							arg_frame [ofs] = NULL;
 							arg_ptrs [i + mofs] = &arg_frame [frameofs];


### PR DESCRIPTION
`calloc` can return `null` and we're writing to the memory location
which would crash the process.

An `OutOfMemoryException` is the correct way to handle this (even if
will likely crash the process anyway).