### PR TITLE
[Generator] Allow 1 level nested classes. Fixes: #7304

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3364,12 +3364,18 @@ public partial class Generator : IMemberGatherer {
 
 		var interfaceTag = protocolized == true ? "I" : "";
 		string tname;
+		// we are adding the usage of ReflectedType just for those cases in which we have nested enums/classes, this soluction does not
+		// work with nested/nested/nested classes. But we are not writing a general solution because:
+		// 1. We have only encountered nested classes.
+		// 2. We are not going to complicate the code more than needed if we have never ever faced a situation with a crazy nested hierarchy, 
+		//    so we only solve the problem we have, no more.
+		var parentClass = (type.ReflectedType == null) ? String.Empty : type.ReflectedType.Name + "."; 
 		if (types_that_must_always_be_globally_named.Contains (type.Name))
-			tname = $"global::{type.Namespace}.{interfaceTag}{type.Name}";
+			tname = $"global::{type.Namespace}.{parentClass}{interfaceTag}{type.Name}";
 		else if ((usedInNamespace != null && type.Namespace == usedInNamespace) || ns.StandardNamespaces.Contains (type.Namespace) || string.IsNullOrEmpty (type.FullName))
 			tname = interfaceTag + type.Name;
 		else
-			tname = $"global::{type.Namespace}.{interfaceTag}{type.Name}";
+			tname = $"global::{type.Namespace}.{parentClass}{interfaceTag}{type.Name}";
 		
 		var targs = type.GetGenericArguments ();
 		if (targs.Length > 0) {

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -581,6 +581,9 @@ namespace GeneratorTests
 		public void GHIssue5692 () => BuildFile (Profile.iOS, "ghissue5692.cs");
 
 		[Test]
+		public void GHIssue7304 () => BuildFile (Profile.macOSFull, "ghissue7304.cs");
+
+		[Test]
 		public void RefOutParameters ()
 		{
 			BuildFile (Profile.macOSMobile, true, "tests/ref-out-parameters.cs");

--- a/tests/generator/ghissue7304.cs
+++ b/tests/generator/ghissue7304.cs
@@ -1,0 +1,23 @@
+using Foundation;
+using ObjCRuntime;
+using AppKit;
+using CoreFoundation;
+
+namespace GHIssue7304 {
+	
+	[BaseType (typeof (NSObject))]
+	interface FooClass {
+
+		[Internal]
+		[Export ("architecture")]
+		int _Arch { get; set; }
+
+		CFBundle.Architecture Arch {
+			[Wrap ("(CFBundle.Architecture) _Arch")]
+			get;
+			[Wrap ("_Arch = (int)value")]
+			set;
+		}
+	}
+
+}


### PR DESCRIPTION
We have only encountered a case in which we had to add a nested
class/enum as the return type of a property. This fix ensures that we
can work with 1 level nested classes. A more general situation with
nested/nested/nested/.. classes is not taken into account because:

1. Would complicate too much the code.
2. Is fixing problems we do not have AFAIK.

So I'm keeping the fix simple, as I said, we have never faced anything
deeper than one level.