### PR TITLE
[tests] Fix Xamarin.Tests.Misc.PublicSymbols after recent changes in our native code.

### DIFF
--- a/tests/mtouch/MiscTests.cs
+++ b/tests/mtouch/MiscTests.cs
@@ -134,6 +134,8 @@ namespace Xamarin.Tests
 				"___block_descriptor_",
 				"___copy_helper_block_",
 				"___destroy_helper_block_",
+				// compiler-generated helper methods
+				"___os_log_helper_",
 			};
 
 			paths.RemoveWhere ((v) => {


### PR DESCRIPTION
Fixes this test:

     1) Failed : Xamarin.Tests.Misc.PublicSymbols(watchOS)
       Failed libraries
       Expected: <empty>
       But was:  "/Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/Xamarin.WatchOS.sdk/usr/lib/libxamarin-debug.a:
     	___os_log_helper_16_2_1_4_34
     "
       at Xamarin.Tests.Misc.PublicSymbols (Xamarin.Tests.Profile profile) [0x00000] in <1fca7937273a476381dfa5d9399511ee>:0