### PR TITLE
add avmetadata enums for macOS 10.15 & update AVMetadataObject.cs

### DIFF
--- a/src/AVFoundation/AVMetadataObject.cs
+++ b/src/AVFoundation/AVMetadataObject.cs
@@ -105,6 +105,14 @@ namespace AVFoundation {
 				return AVMetadataObjectType.ITF14Code;
 			else if (obj == AVMetadataObject.TypeDataMatrixCode)
 				return AVMetadataObjectType.DataMatrixCode;
+			else if (obj == AVMetadataObject.TypeCatBody)
+				return AVMetadataObjectType.CatBody;
+			else if (obj == AVMetadataObject.TypeDogBody)
+				return AVMetadataObjectType.DogBody;
+			else if (obj == AVMetadataObject.TypeHumanBody)
+				return AVMetadataObjectType.HumanBody;
+			else if (obj == AVMetadataObject.TypeSalientObject)
+				return AVMetadataObjectType.SalientObject;
 			else
 				throw new ArgumentOutOfRangeException (string.Format ("Unexpected AVMetadataObjectType: {0}", obj));
 		}

--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -630,6 +630,18 @@ namespace AVFoundation {
 
 		[iOS (8,0)]
 		DataMatrixCode = 1 << 13,
+
+		[iOS (13,0)]
+		CatBody = 1 << 14,
+
+		[iOS (13,0)]
+		DogBody = 1 << 15,
+
+		[iOS (13,0)]
+		HumanBody = 1 << 16,
+
+		[iOS (13,0)]
+		SalientObject = 1 << 17,
 	}
 
 #if !MONOMAC

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -6672,19 +6672,19 @@ namespace AVFoundation {
 		[Field ("AVMetadataObjectTypeDataMatrixCode")]
 		NSString TypeDataMatrixCode { get; }
 
-		[NoWatch, NoTV, NoMac, iOS (13, 0)]
+		[NoWatch, NoTV, iOS (13, 0), Mac (10, 15)]
 		[Field ("AVMetadataObjectTypeCatBody")]
 		NSString TypeCatBody { get; }
 
-		[NoWatch, NoTV, NoMac, iOS (13, 0)]
+		[NoWatch, NoTV, iOS (13, 0), Mac (10, 15)]
 		[Field ("AVMetadataObjectTypeDogBody")]
 		NSString TypeDogBody { get; }
 
-		[NoWatch, NoTV, NoMac, iOS (13, 0)]
+		[NoWatch, NoTV, iOS (13, 0), Mac (10, 15)]
 		[Field ("AVMetadataObjectTypeHumanBody")]
 		NSString TypeHumanBody { get; }
 
-		[NoWatch, NoTV, NoMac, iOS (13, 0)]
+		[NoWatch, NoTV, iOS (13, 0), Mac (10, 15)]
 		[Field ("AVMetadataObjectTypeSalientObject")]
 		NSString TypeSalientObject { get; }
 	}

--- a/tests/xtro-sharpie/macOS-AVFoundation.ignore
+++ b/tests/xtro-sharpie/macOS-AVFoundation.ignore
@@ -39,7 +39,3 @@
 !missing-field! AVMetadataIdentifierQuickTimeMetadataLivePhotoVitalityScoringVersion not bound
 !missing-field! AVMetadataIdentifierQuickTimeMetadataSpatialOverCaptureQualityScore not bound
 !missing-field! AVMetadataIdentifierQuickTimeMetadataSpatialOverCaptureQualityScoringVersion not bound
-!missing-field! AVMetadataObjectTypeCatBody not bound
-!missing-field! AVMetadataObjectTypeDogBody not bound
-!missing-field! AVMetadataObjectTypeHumanBody not bound
-!missing-field! AVMetadataObjectTypeSalientObject not bound


### PR DESCRIPTION
fixes https://github.com/xamarin/xamarin-macios/issues/7291
add new `enum` for `macOS 10.15` - tested that these are available on Catalina machine

Unfortunately we can't use a smart enum because it's used as a flag in `AVMetadataObject.cs`:

```
		internal static AVMetadataObjectType ArrayToEnum (NSString[] arr)
		{
			AVMetadataObjectType rv = AVMetadataObjectType.None;

			if (arr == null || arr.Length == 0)
				return rv;

			foreach (var str in arr) {
				rv |= ObjectToEnum (str);
			}

			return rv;
		}
```