### PR TITLE
[CoreMedia] Xcode 11.2 updates

### DIFF
--- a/tests/xtro-sharpie/common-CoreMedia.ignore
+++ b/tests/xtro-sharpie/common-CoreMedia.ignore
@@ -126,6 +126,7 @@
 !missing-field! kCMMetadataIdentifier_QuickTimeMetadataPreferredAffineTransform not bound
 !missing-field! kCMMetadataIdentifier_QuickTimeMetadataVideoOrientation not bound
 !missing-field! kCMMetadataIdentifier_QuickTimeMetadataLivePhotoStillImageTransform not bound
+!missing-field! kCMMetadataIdentifier_QuickTimeMetadataLivePhotoStillImageTransformReferenceDimensions not bound
 !missing-field! kCMMetadataKeySpace_HLSDateRange not bound
 !missing-field! kCMMetadataKeySpace_Icy not bound
 !missing-field! kCMMetadataKeySpace_ID3 not bound

--- a/tests/xtro-sharpie/iOS-CoreMedia.todo
+++ b/tests/xtro-sharpie/iOS-CoreMedia.todo
@@ -1,1 +1,0 @@
-!missing-field! kCMMetadataIdentifier_QuickTimeMetadataLivePhotoStillImageTransformReferenceDimensions not bound

--- a/tests/xtro-sharpie/macOS-CoreMedia.todo
+++ b/tests/xtro-sharpie/macOS-CoreMedia.todo
@@ -1,1 +1,0 @@
-!missing-field! kCMMetadataIdentifier_QuickTimeMetadataLivePhotoStillImageTransformReferenceDimensions not bound

--- a/tests/xtro-sharpie/tvOS-CoreMedia.todo
+++ b/tests/xtro-sharpie/tvOS-CoreMedia.todo
@@ -1,1 +1,0 @@
-!missing-field! kCMMetadataIdentifier_QuickTimeMetadataLivePhotoStillImageTransformReferenceDimensions not bound

--- a/tests/xtro-sharpie/watchOS-CoreMedia.todo
+++ b/tests/xtro-sharpie/watchOS-CoreMedia.todo
@@ -1,1 +1,0 @@
-!missing-field! kCMMetadataIdentifier_QuickTimeMetadataLivePhotoStillImageTransformReferenceDimensions not bound


### PR DESCRIPTION
Marking as `ignore` since we have not added any of the `kCMMetadataIdentifier` constants.