### PR TITLE
[msbuild] Makes DSymUtil task report the Executable as output

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
@@ -21,8 +21,9 @@ namespace Xamarin.MacDev.Tasks
 		[Required]
 		public string DSymDir { get; set; }
 
+		[Output]
 		[Required]
-		public string Executable { get; set; }
+		public ITaskItem Executable { get; set; }
 
 		#endregion
 
@@ -67,7 +68,7 @@ namespace Xamarin.MacDev.Tasks
 			args.AppendSwitch ("-z");
 			args.AppendSwitch ("-o");
 			args.AppendFileNameIfNotNull (DSymDir);
-			args.AppendFileNameIfNotNull (Executable);
+			args.AppendFileNameIfNotNull (Executable.ItemSpec);
 
 			return args.ToString ();
 		}


### PR DESCRIPTION
The DSymUtil tool not only generates the debug symbol files but also modifies the executable file. Marking that property as Output (and changing it to ITaskItem type) makes Visual Studio on Windows aware of that change. Under certain scenarios this was making the build on VS produce an app bundle that was not fully signed on incremental builds. For instance, the DSymUtil task was run for a framework on an incremental build, but as the executable file of that framework was not modified on Windows the inputs/outputs check for CodesignFrameworks did not fail so that target was skipped. This led to a failure on the CodesignVerify target.

Partial fix for https://developercommunity.visualstudio.com/content/problem/729766/codedesign-exited-with-code-1.html