### PR TITLE
[Foundation] Xcode11.1 GM Binding

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -5473,7 +5473,7 @@ namespace Foundation
 
 		// Inlined from NSUserActivity (UISceneActivationConditions)
 
-		[iOS (13,0), TV (13,0), NoMac, NoWatch]
+		[iOS (13,0), TV (13,0), Mac (10,15), Watch (6,0)]
 		[NullAllowed, Export ("targetContentIdentifier")]
 		string TargetContentIdentifier { get; set; }
 	}

--- a/tests/xtro-sharpie/macOS-Foundation.todo
+++ b/tests/xtro-sharpie/macOS-Foundation.todo
@@ -28,6 +28,3 @@
 !missing-selector! NSOrderedSet::orderedSetByApplyingDifference: not bound
 !missing-type! NSOrderedCollectionChange not bound
 !missing-type! NSOrderedCollectionDifference not bound
-## appended from unclassified file
-!missing-selector! NSUserActivity::setTargetContentIdentifier: not bound
-!missing-selector! NSUserActivity::targetContentIdentifier not bound

--- a/tests/xtro-sharpie/watchOS-Foundation.todo
+++ b/tests/xtro-sharpie/watchOS-Foundation.todo
@@ -28,6 +28,3 @@
 !missing-selector! NSOrderedSet::orderedSetByApplyingDifference: not bound
 !missing-type! NSOrderedCollectionChange not bound
 !missing-type! NSOrderedCollectionDifference not bound
-## appended from unclassified file
-!missing-selector! NSUserActivity::setTargetContentIdentifier: not bound
-!missing-selector! NSUserActivity::targetContentIdentifier not bound


### PR DESCRIPTION
Added missing attributes for MacOS and WatchOS for `targetContentIdentifier` selector