### PR TITLE
[registrar] Check parameter pointer before de-referencing it

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3609,7 +3609,8 @@ namespace Registrar {
 							body_setup.AppendLine ("MonoObject *mobj{0} = NULL;", i);
 							if (!isOut) {
 								body_setup.AppendLine ("NSObject *nsobj{0} = NULL;", i);
-								setup_call_stack.AppendLine ("nsobj{0} = *(NSObject **) p{0};", i);
+								setup_call_stack.AppendLine ("if (p{0} != NULL)", i).Indent ();
+								setup_call_stack.AppendLine ("nsobj{0} = *(NSObject **) p{0};", i).Unindent ();
 								setup_call_stack.AppendLine ("if (nsobj{0}) {{", i);
 								body_setup.AppendLine ("MonoType *paramtype{0} = NULL;", i);
 								setup_call_stack.AppendLine ("paramtype{0} = xamarin_get_parameter_type (managed_method, {0});", i);


### PR DESCRIPTION
This case was generated (only) twice

1. https://developer.apple.com/documentation/uikit/uipopoverpresentationcontrollerdelegate/1622326-popoverpresentationcontroller?language=objc
where `inView:(inout UIView * _Nonnull *)view;`

2. https://developer.apple.com/documentation/quicklook/qlpreviewcontrollerdelegate/1617007-previewcontroller?language=objc
where `inSourceView:(UIView * _Nullable *)view;`
and `CGRect FrameForPreviewItem (QLPreviewController controller, [Protocolize] QLPreviewItem item, ref UIView view);`

This is not an issue because it won't be `null` in those case
but making the code safer (against future changes/API) is safer.

The output (copy-back) to the pointer already has a null-check.