### PR TITLE
[Runtime] Ensure that all comparisons between signed and unsigned values are fixed.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -190,7 +190,7 @@ IOS_CXX=$(XCODE_CXX)
 SIMULATOR_BIN_PATH=$(XCODE_DEVELOPER_ROOT)/Platforms/iPhoneSimulator.platform/Developer/usr/bin
 SIMULATOR_CC=$(IOS_CC)
 
-CFLAGS= -Wall -fms-extensions -Wno-format-security
+CFLAGS= -Wall -fms-extensions -Wno-format-security -Wsign-compare
 
 ifdef ENABLE_BITCODE_ON_IOS
 BITCODE_CFLAGS=-fembed-bitcode-marker

--- a/runtime/monotouch-debug.m
+++ b/runtime/monotouch-debug.m
@@ -572,7 +572,7 @@ void monotouch_configure_debugging ()
 	evar = getenv ("__XAMARIN_DEBUG_HOSTS__");
 	if (evar && *evar) {
 		NSArray *ips = [[NSString stringWithUTF8String:evar] componentsSeparatedByString:@";"];
-		for (int i = 0; i < [ips count]; i++) {
+		for (unsigned int i = 0; i < [ips count]; i++) {
 			NSString *ip = [ips objectAtIndex:i];
 			if (![hosts containsObject:ip]) {
 				[hosts addObject:ip];
@@ -828,7 +828,7 @@ xamarin_connect_http (NSMutableArray *ips)
 		pthread_mutex_unlock (&connected_mutex);
 
 		pending_connections = [ips count];
-		for (int i = 0; i < [ips count]; i++) {
+		for (unsigned int i = 0; i < [ips count]; i++) {
 			XamarinHttpConnection *connection = [[[XamarinHttpConnection alloc] init] autorelease];
 			connection.ip = [ips objectAtIndex: i];
 			connection.uniqueRequest = unique_request;
@@ -1184,19 +1184,19 @@ monotouch_dump_objc_api (Class klass)
 	
 	vars = class_copyIvarList (klass, &c);
 	printf ("\t%i instance variables:\n", c);
-	for (int i = 0; i < c; i++)
+	for (unsigned int i = 0; i < c; i++)
 		printf ("\t\t#%i: %s\n", i + 1, ivar_getName (vars [i]));
 	free (vars);
 	
 	methods = class_copyMethodList (klass, &c);
 	printf ("\t%i instance methods:\n", c);
-	for (int i = 0; i < c; i++)
+	for (unsigned int i = 0; i < c; i++)
 		printf ("\t\t#%i: %s\n", i + 1, sel_getName (method_getName (methods [i])));
 	free (methods);
 	
 	props = class_copyPropertyList (klass, &c);
 	printf ("\t%i instance properties:\n", c);
-	for (int i = 0; i < c; i++)
+	for (unsigned int i = 0; i < c; i++)
 		printf ("\t\t#%i: %s\n", i + 1, property_getName (props [i]));
 	free (props);
 	

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1598,7 +1598,7 @@ objc_skip_type (const char *type)
 	}
 }
 
-int
+unsigned long
 xamarin_objc_type_size (const char *type)
 {
 	const char *original_type = type;
@@ -1642,7 +1642,7 @@ xamarin_objc_type_size (const char *type)
 			xamarin_assertion_message ("Unhandled type encoding: %s", type);
 			break;
 		case _C_ARY_B: {
-			int size = 0;
+			unsigned long size = 0;
 			int len = atoi (type+1);
 			do {
 				type++;
@@ -1655,7 +1655,7 @@ xamarin_objc_type_size (const char *type)
 			return len * size;
 		}
 		case _C_UNION_B: {
-			int size = 0;
+			unsigned long size = 0;
 
 			do {
 				type++;
@@ -1670,7 +1670,7 @@ xamarin_objc_type_size (const char *type)
 				if (*type == 0)
 					xamarin_assertion_message ("Unsupported union type: %s", original_type);
 
-				int tsize = xamarin_objc_type_size (type);
+				unsigned long tsize = xamarin_objc_type_size (type);
 				type = objc_skip_type (type);
 
 				tsize = (tsize + (sizeof (void *) - 1)) & ~((sizeof (void *) - 1));
@@ -1680,7 +1680,7 @@ xamarin_objc_type_size (const char *type)
 			return size;
 		}
 		case _C_STRUCT_B: {
-			int size = 0;
+			unsigned long size = 0;
 
 			do {
 				type++;
@@ -1694,7 +1694,7 @@ xamarin_objc_type_size (const char *type)
 			while (*type != _C_STRUCT_E) {
 				if (*type == 0)
 					xamarin_assertion_message ("Unsupported struct type: %s", original_type);
-				int item_size = xamarin_objc_type_size (type);
+				unsigned long item_size = xamarin_objc_type_size (type);
 				
 				size += (item_size + (sizeof (void *) - 1)) & ~((sizeof (void *) - 1));
 

--- a/runtime/trampolines-arm64.m
+++ b/runtime/trampolines-arm64.m
@@ -230,7 +230,7 @@ marshal_return_value (void *context, const char *type, size_t size, void *vvalue
 			(size == 8 && !strncmp (struct_name, "d", 1))) {
 			LOGZ ("        marshalling as %i doubles (struct name: %s)\n", (int) size / 8, struct_name);
 			double* ptr = (double *) mono_object_unbox (value);
-			for (int i = 0; i < size / 8; i++) {
+			for (unsigned long i = 0; i < size / 8; i++) {
 				LOGZ ("        #%i: %f\n", i, ptr [i]);
 				it->q [i].d = ptr [i];
 			}
@@ -240,7 +240,7 @@ marshal_return_value (void *context, const char *type, size_t size, void *vvalue
 				   (size == 4 && !strncmp (struct_name, "f", 1))) {
 			LOGZ ("        marshalling as %i floats (struct name: %s)\n", (int) size / 4, struct_name);
 			float* ptr = (float *) mono_object_unbox (value);
-			for (int i = 0; i < size / 4; i++) {
+			for (unsigned long i = 0; i < size / 4; i++) {
 				LOGZ ("        #%i: %f\n", i, ptr [i]);
 				it->q [i].f.f1 = ptr [i];
 			}

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -193,7 +193,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 
 	for (i = 0, ofs = 0; i < num_arg; i++) {
 		const char *type = xamarin_skip_encoding_flags ([sig getArgumentTypeAtIndex: (i+2)]);
-		int size = xamarin_objc_type_size (type);
+		unsigned long size = xamarin_objc_type_size (type);
 		int frameofs = ofs;
 		p = mono_signature_get_params (msig, &iter);
 		
@@ -546,7 +546,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 
 			type = xamarin_skip_encoding_flags (type);
 
-			int size = xamarin_objc_type_size (type);
+			unsigned long size = xamarin_objc_type_size (type);
 
 			p = mono_signature_get_params (msig, &iter);
 

--- a/runtime/trampolines-x86_64.m
+++ b/runtime/trampolines-x86_64.m
@@ -119,11 +119,12 @@ param_read_primitive (struct ParamIterator *it, const char **type_ptr, void *tar
 
 		uint8_t *ptr;
 		bool read_register = true;
-		if (it->byte_count >= 48) { // 48 == 6 registers * 8 bytes
+		unsigned long register_size = 48; // 48 == 6 registers * 8 bytes
+		if ((unsigned long)it->byte_count >= register_size) { 
 			read_register = false;
-		} else if (48 - it->byte_count < total_size) {
+		} else if (register_size - it->byte_count < total_size) {
 			read_register = false;
-			LOGZ (" total size (%i) is less that available register size (%i)", (int) total_size, 48 - it->byte_count);
+			LOGZ (" total size (%i) is less that available register size (%i)", (int) total_size, register_size - it->byte_count);
 		}
 
 		if (read_register) {

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -492,7 +492,7 @@ xamarin_get_frame_length (id self, SEL sel)
 		// skip the return value.
 		desc += rvlength;
 		while (*desc) {
-			int tl = xamarin_objc_type_size (desc);
+			unsigned long tl = xamarin_objc_type_size (desc);
 			// round up to pointer size
 			if (tl % sizeof (void *) != 0)
 				tl += sizeof (void *) - (tl % sizeof (void *));

--- a/runtime/xamarin-classic/runtime.h
+++ b/runtime/xamarin-classic/runtime.h
@@ -169,7 +169,7 @@ void			xamarin_set_bundle_path (const char *path); /* Public API */
 MonoObject *	xamarin_get_managed_object_for_ptr (id self, guint32 *exception_gchandle);
 MonoObject *	xamarin_get_managed_object_for_ptr_fast (id self, guint32 *exception_gchandle);
 void			xamarin_check_for_gced_object (MonoObject *obj, SEL sel, id self, MonoMethod *method, guint32 *exception_gchandle);
-int				xamarin_objc_type_size (const char *type);
+unsigned long	xamarin_objc_type_size (const char *type);
 bool			xamarin_is_class_nsobject (MonoClass *cls);
 bool			xamarin_is_class_inativeobject (MonoClass *cls);
 bool			xamarin_is_class_array (MonoClass *cls);

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -169,7 +169,7 @@ void			xamarin_set_bundle_path (const char *path); /* Public API */
 MonoObject *	xamarin_get_managed_object_for_ptr (id self, guint32 *exception_gchandle);
 MonoObject *	xamarin_get_managed_object_for_ptr_fast (id self, guint32 *exception_gchandle);
 void			xamarin_check_for_gced_object (MonoObject *obj, SEL sel, id self, MonoMethod *method, guint32 *exception_gchandle);
-int				xamarin_objc_type_size (const char *type);
+unsigned long 	xamarin_objc_type_size (const char *type);
 bool			xamarin_is_class_nsobject (MonoClass *cls);
 bool			xamarin_is_class_inativeobject (MonoClass *cls);
 bool			xamarin_is_class_array (MonoClass *cls);


### PR DESCRIPTION
Enable the -Wsign-compare which will raise issues when a comparison
between signed and unsigned values could produce an incorrect result
and fix all the raised warnings.