### PR TITLE
[CoreFoundation] [tests] Add new DispatchQueue overloaded method

### DIFF
--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -268,17 +268,17 @@ namespace CoreFoundation {
 
 		public static DispatchQueue GetGlobalQueue (DispatchQueuePriority priority)
 		{
-			return new DispatchQueue (dispatch_get_global_queue ((nint) (int) priority, 0), false);
+			return new DispatchQueue (dispatch_get_global_queue_priority ((nint) (int) priority, 0), false);
 		}
 		
 		public static DispatchQueue GetGlobalQueue (DispatchQualityOfService identifier)
 		{
-			return new DispatchQueue (dispatch_get_global_queue ((nint) (int) identifier, 0), false);
+			return new DispatchQueue (dispatch_get_global_queue_qos ((nint) (int) identifier, 0), false);
 		}
 
 		public static DispatchQueue DefaultGlobalQueue {
 			get {
-				return new DispatchQueue (dispatch_get_global_queue ((nint) (int) DispatchQueuePriority.Default, 0), false);
+				return new DispatchQueue (dispatch_get_global_queue_priority ((nint) (int) DispatchQueuePriority.Default, 0), false);
 			}
 		}
 
@@ -535,11 +535,11 @@ namespace CoreFoundation {
 
 		[DllImport (Constants.libcLibrary)]
 		// dispatch_queue_t dispatch_get_global_queue (long priority, unsigned long flags);
-		extern static IntPtr dispatch_get_global_queue (nint priority, nuint flags);
+		extern static IntPtr dispatch_get_global_queue_priority (nint priority, nuint flags);
 
 		[DllImport (Constants.libcLibrary)]
 		// dispatch_queue_t dispatch_get_global_queue (long identifier, unsigned long flags);
-		extern static IntPtr dispatch_get_global_queue (nint identifier, nuint flags);
+		extern static IntPtr dispatch_get_global_queue_qos (nint identifier, nuint flags);
 
 		[DllImport (Constants.libcLibrary)]
 		// this returns a "const char*" so we cannot make a string out of it since it will be freed (and crash)

--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -270,6 +270,11 @@ namespace CoreFoundation {
 		{
 			return new DispatchQueue (dispatch_get_global_queue ((nint) (int) priority, 0), false);
 		}
+		
+		public static DispatchQueue GetGlobalQueue (DispatchQualityOfService identifier)
+		{
+			return new DispatchQueue (dispatch_get_global_queue ((nint) (int) identifier, 0), false);
+		}
 
 		public static DispatchQueue DefaultGlobalQueue {
 			get {
@@ -531,6 +536,10 @@ namespace CoreFoundation {
 		[DllImport (Constants.libcLibrary)]
 		// dispatch_queue_t dispatch_get_global_queue (long priority, unsigned long flags);
 		extern static IntPtr dispatch_get_global_queue (nint priority, nuint flags);
+
+		[DllImport (Constants.libcLibrary)]
+		// dispatch_queue_t dispatch_get_global_queue (long identifier, unsigned long flags);
+		extern static IntPtr dispatch_get_global_queue (nint identifier, nuint flags);
 
 		[DllImport (Constants.libcLibrary)]
 		// this returns a "const char*" so we cannot make a string out of it since it will be freed (and crash)

--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -268,17 +268,17 @@ namespace CoreFoundation {
 
 		public static DispatchQueue GetGlobalQueue (DispatchQueuePriority priority)
 		{
-			return new DispatchQueue (dispatch_get_global_queue_priority ((nint) (int) priority, 0), false);
+			return new DispatchQueue (dispatch_get_global_queue ((nint) (int) priority, 0), false);
 		}
 		
-		public static DispatchQueue GetGlobalQueue (DispatchQualityOfService identifier)
+		public static DispatchQueue GetGlobalQueue (DispatchQualityOfService service)
 		{
-			return new DispatchQueue (dispatch_get_global_queue_qos ((nint) (int) identifier, 0), false);
+			return new DispatchQueue (dispatch_get_global_queue ((nint) (int) service, 0), false);
 		}
 
 		public static DispatchQueue DefaultGlobalQueue {
 			get {
-				return new DispatchQueue (dispatch_get_global_queue_priority ((nint) (int) DispatchQueuePriority.Default, 0), false);
+				return new DispatchQueue (dispatch_get_global_queue ((nint) (int) DispatchQueuePriority.Default, 0), false);
 			}
 		}
 
@@ -534,12 +534,8 @@ namespace CoreFoundation {
 		extern static IntPtr dispatch_get_current_queue ();
 
 		[DllImport (Constants.libcLibrary)]
-		// dispatch_queue_t dispatch_get_global_queue (long priority, unsigned long flags);
-		extern static IntPtr dispatch_get_global_queue_priority (nint priority, nuint flags);
-
-		[DllImport (Constants.libcLibrary)]
 		// dispatch_queue_t dispatch_get_global_queue (long identifier, unsigned long flags);
-		extern static IntPtr dispatch_get_global_queue_qos (nint identifier, nuint flags);
+		extern static IntPtr dispatch_get_global_queue (nint identifier, nuint flags);
 
 		[DllImport (Constants.libcLibrary)]
 		// this returns a "const char*" so we cannot make a string out of it since it will be freed (and crash)

--- a/tests/bindings-test/ApiDefinition.cs
+++ b/tests/bindings-test/ApiDefinition.cs
@@ -376,8 +376,8 @@ namespace Bindings.Test {
 		void CallOptionalStaticCallback ();
 
 		[Static]
-		[Export ("callAssertMainThreadBlockReleasePriority:")]
-		void CallAssertMainThreadBlockReleasePriority (OuterBlock completionHandler);
+		[Export ("callAssertMainThreadBlockRelease:")]
+		void CallAssertMainThreadBlockRelease (OuterBlock completionHandler);
 
 		[Static]
 		[Export ("callAssertMainThreadBlockReleaseQOS:")]
@@ -386,8 +386,8 @@ namespace Bindings.Test {
 		[Export ("assertMainThreadBlockReleaseCallback:")]
 		void AssertMainThreadBlockReleaseCallback (InnerBlock completionHandler);
 
-		[Export ("callAssertMainThreadBlockReleaseCallbackPriority")]
-		void CallAssertMainThreadBlockReleaseCallbackPriority ();
+		[Export ("callAssertMainThreadBlockReleaseCallback")]
+		void CallAssertMainThreadBlockReleaseCallback ();
 
 		[Export ("callAssertMainThreadBlockReleaseCallbackQOS")]
 		void CallAssertMainThreadBlockReleaseCallbackQOS ();

--- a/tests/bindings-test/ApiDefinition.cs
+++ b/tests/bindings-test/ApiDefinition.cs
@@ -377,7 +377,7 @@ namespace Bindings.Test {
 
 		[Static]
 		[Export ("callAssertMainThreadBlockReleasePriority:")]
-		void callAssertMainThreadBlockReleasePriority (OuterBlock completionHandler);
+		void CallAssertMainThreadBlockReleasePriority (OuterBlock completionHandler);
 
 		[Static]
 		[Export ("callAssertMainThreadBlockReleaseQOS:")]
@@ -387,7 +387,7 @@ namespace Bindings.Test {
 		void AssertMainThreadBlockReleaseCallback (InnerBlock completionHandler);
 
 		[Export ("callAssertMainThreadBlockReleaseCallbackPriority")]
-		void callAssertMainThreadBlockReleaseCallbackPriority ();
+		void CallAssertMainThreadBlockReleaseCallbackPriority ();
 
 		[Export ("callAssertMainThreadBlockReleaseCallbackQOS")]
 		void CallAssertMainThreadBlockReleaseCallbackQOS ();

--- a/tests/bindings-test/ApiDefinition.cs
+++ b/tests/bindings-test/ApiDefinition.cs
@@ -376,14 +376,21 @@ namespace Bindings.Test {
 		void CallOptionalStaticCallback ();
 
 		[Static]
-		[Export ("callAssertMainThreadBlockRelease:")]
-		void CallAssertMainThreadBlockRelease (OuterBlock completionHandler);
+		[Export ("callAssertMainThreadBlockReleasePriority:")]
+		void callAssertMainThreadBlockReleasePriority (OuterBlock completionHandler);
+
+		[Static]
+		[Export ("callAssertMainThreadBlockReleaseQOS:")]
+		void CallAssertMainThreadBlockReleaseQOS (OuterBlock completionHandler);
 
 		[Export ("assertMainThreadBlockReleaseCallback:")]
 		void AssertMainThreadBlockReleaseCallback (InnerBlock completionHandler);
 
-		[Export ("callAssertMainThreadBlockReleaseCallback")]
-		void CallAssertMainThreadBlockReleaseCallback ();
+		[Export ("callAssertMainThreadBlockReleaseCallbackPriority")]
+		void callAssertMainThreadBlockReleaseCallbackPriority ();
+
+		[Export ("callAssertMainThreadBlockReleaseCallbackQOS")]
+		void CallAssertMainThreadBlockReleaseCallbackQOS ();
 
 		[Export ("testFreedBlocks")]
 		void TestFreedBlocks ();

--- a/tests/bindings-test/RuntimeTest.cs
+++ b/tests/bindings-test/RuntimeTest.cs
@@ -57,19 +57,36 @@ namespace Xamarin.Tests
 		}
 
 		[Test]
-		public void MainThreadDeallocationTest ()
+		public void MainThreadDeallocationTestPriority ()
 		{
 #if OPTIMIZEALL
 			if (!TestRuntime.IsLinkAll)
 				Assert.Ignore ("This test must be processed by the linker if all optimizations are turned on.");
 #endif
 
-			ObjCBlockTester.CallAssertMainThreadBlockRelease ((callback) => {
+			ObjCBlockTester.CallAssertMainThreadBlockReleasePriority ((callback) => {
 				callback (42);
 			});
 
 			using (var main_thread_tester = new MainThreadTest ()) {
-				main_thread_tester.CallAssertMainThreadBlockReleaseCallback ();
+				main_thread_tester.CallAssertMainThreadBlockReleaseCallbackPriority ();
+			}
+		}
+
+		[Test]
+		public void MainThreadDeallocationTestQOS ()
+		{
+#if OPTIMIZEALL
+			if (!TestRuntime.IsLinkAll)
+				Assert.Ignore ("This test must be processed by the linker if all optimizations are turned on.");
+#endif
+
+			ObjCBlockTester.CallAssertMainThreadBlockReleaseQOS ((callback) => {
+				callback (42);
+			});
+
+			using (var main_thread_tester = new MainThreadTest ()) {
+				main_thread_tester.CallAssertMainThreadBlockReleaseCallbackQOS ();
 			}
 		}
 

--- a/tests/bindings-test/RuntimeTest.cs
+++ b/tests/bindings-test/RuntimeTest.cs
@@ -57,19 +57,19 @@ namespace Xamarin.Tests
 		}
 
 		[Test]
-		public void MainThreadDeallocationTestPriority ()
+		public void MainThreadDeallocationTest ()
 		{
 #if OPTIMIZEALL
 			if (!TestRuntime.IsLinkAll)
 				Assert.Ignore ("This test must be processed by the linker if all optimizations are turned on.");
 #endif
 
-			ObjCBlockTester.CallAssertMainThreadBlockReleasePriority ((callback) => {
+			ObjCBlockTester.CallAssertMainThreadBlockRelease ((callback) => {
 				callback (42);
 			});
 
 			using (var main_thread_tester = new MainThreadTest ()) {
-				main_thread_tester.CallAssertMainThreadBlockReleaseCallbackPriority ();
+				main_thread_tester.CallAssertMainThreadBlockReleaseCallback ();
 			}
 		}
 

--- a/tests/monotouch-test/CoreFoundation/DispatchTests.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchTests.cs
@@ -56,7 +56,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 
 #if !MONOMAC // UIKitThreadAccessException and NSStringDrawing.WeakDrawString don't exist on mac
 		[Test]
-		public void MainQueueDispatchPriority ()
+		public void MainQueueDispatch ()
 		{
 #if !DEBUG || OPTIMIZEALL
 			Assert.Ignore ("UIKitThreadAccessException is not throw, by default, on release builds (removed by the linker)");
@@ -272,7 +272,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 
 #if !MONOMAC // UIKitThreadAccessException and NSStringDrawing.WeakDrawString don't exist on mac
 		[Test]
-		public void EverAfterPriority ()
+		public void EverAfter ()
 		{
 #if !DEBUG || OPTIMIZEALL
 			Assert.Ignore ("UIKitThreadAccessException is not throw, by default, on release builds (removed by the linker)");

--- a/tests/monotouch-test/CoreFoundation/DispatchTests.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchTests.cs
@@ -56,7 +56,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 
 #if !MONOMAC // UIKitThreadAccessException and NSStringDrawing.WeakDrawString don't exist on mac
 		[Test]
-		public void MainQueueDispatch ()
+		public void MainQueueDispatchPriority ()
 		{
 #if !DEBUG || OPTIMIZEALL
 			Assert.Ignore ("UIKitThreadAccessException is not throw, by default, on release builds (removed by the linker)");
@@ -79,6 +79,64 @@ namespace MonoTouchFixtures.CoreFoundation {
 			Exception queue_ex = null;
 
 			var defaultQ = DispatchQueue.GetGlobalQueue (DispatchQueuePriority.Default);
+			defaultQ.DispatchAsync (delegate {	
+				try {
+					NSStringDrawing.WeakDrawString (null, PointF.Empty, null);
+				} catch (Exception e) {
+					queue_ex = e;
+				}
+
+				queueThread = Thread.CurrentThread;
+				var mainQ = DispatchQueue.MainQueue;
+				mainQ.DispatchAsync (delegate {
+					mainQthread = Thread.CurrentThread;
+					try {
+						NSStringDrawing.WeakDrawString (null, PointF.Empty, null);
+					} catch (Exception e) {
+						ex = e;
+					} finally {
+						hit = true;
+					}
+				} );
+
+			} );
+			
+			// Now wait for the above to actually run
+			while (hit == false){
+		        NSRunLoop.Current.RunUntil (NSDate.FromTimeIntervalSinceNow (0.5));
+		    }
+			Assert.IsNotNull (ex, "main ex");
+			Assert.That (ex.GetType (), Is.SameAs (typeof (ArgumentNullException)), "no thread check hit");
+			Assert.IsNotNull (queue_ex, "queue ex");
+			Assert.That (queue_ex.GetType (), Is.SameAs (typeof (UIKitThreadAccessException)), "thread check hit");
+			Assert.That (uiThread, Is.EqualTo (mainQthread), "mainq thread is equal to uithread");
+			Assert.That (queueThread, Is.Not.EqualTo (mainQthread), "queueThread is not the same as the UI thread");
+		}
+
+		[Test]
+		public void MainQueueDispatchQualityOfService ()
+		{
+#if !DEBUG || OPTIMIZEALL
+			Assert.Ignore ("UIKitThreadAccessException is not throw, by default, on release builds (removed by the linker)");
+#endif
+			if (RunningOnSnowLeopard)
+				Assert.Ignore ("this test crash when executed with the iOS simulator on Snow Leopard");
+
+			bool hit = false;
+			// We need to check the UIKitThreadAccessException, but there are very few API
+			// with that check on WatchOS. NSStringDrawing.WeakDrawString is one example, here we pass
+			// it null for the parameter so that it immediately returns with an ArgumentNullException
+			// instead of trying to load an image (which is not what we're testing). There
+			// is also a test to ensure UIKitThreadAccessException is thrown if not on
+			// the UI thread (so that we'll notice if the UIKitThreadAccessException is ever
+			// removed from NSStringDrawing.WeakDrawString).
+			var uiThread = Thread.CurrentThread;
+			Thread queueThread = null;
+			Thread mainQthread = null;
+			Exception ex = null;
+			Exception queue_ex = null;
+
+			var defaultQ = DispatchQueue.GetGlobalQueue (DispatchQualityOfService.Default);
 			defaultQ.DispatchAsync (delegate {	
 				try {
 					NSStringDrawing.WeakDrawString (null, PointF.Empty, null);
@@ -188,6 +246,15 @@ namespace MonoTouchFixtures.CoreFoundation {
 		}
 
 		[Test]
+		public void GetGlobalQueue_QualityOfService ()
+		{
+			// values changes in OS versions (and even in arch) but we only want to make sure we get a valid string so the prefix is enough
+			Assert.True (DispatchQueue.GetGlobalQueue (DispatchQualityOfService.Default).Label.StartsWith ("com.apple.root."), "Default");
+			Assert.True (DispatchQueue.GetGlobalQueue (DispatchQualityOfService.Utility).Label.StartsWith ("com.apple.root."), "Low");
+			Assert.True (DispatchQueue.GetGlobalQueue (DispatchQualityOfService.UserInitiated).Label.StartsWith ("com.apple.root."), "High");
+		}
+
+		[Test]
 		public void NeverTooLate ()
 		{
 			Assert.That (DispatchTime.Now.Nanoseconds, Is.EqualTo (0), "Now");
@@ -205,7 +272,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 
 #if !MONOMAC // UIKitThreadAccessException and NSStringDrawing.WeakDrawString don't exist on mac
 		[Test]
-		public void EverAfter ()
+		public void EverAfterPriority ()
 		{
 #if !DEBUG || OPTIMIZEALL
 			Assert.Ignore ("UIKitThreadAccessException is not throw, by default, on release builds (removed by the linker)");
@@ -228,6 +295,63 @@ namespace MonoTouchFixtures.CoreFoundation {
 			Exception queue_ex = null;
 
 			var defaultQ = DispatchQueue.GetGlobalQueue (DispatchQueuePriority.Default);
+			defaultQ.DispatchAfter (new DispatchTime (DispatchTime.Now, 1000), delegate {	
+				try {
+					NSStringDrawing.WeakDrawString (null, PointF.Empty, null);
+				} catch (Exception e) {
+					queue_ex = e;
+				}
+
+				queueThread = Thread.CurrentThread;
+				var mainQ = DispatchQueue.MainQueue;
+				mainQ.DispatchAfter (DispatchTime.Now, delegate {
+					mainQthread = Thread.CurrentThread;
+					try {
+						NSStringDrawing.WeakDrawString (null, PointF.Empty, null);
+					} catch (Exception e) {
+						ex = e;
+					} finally {
+						hit = true;
+					}
+				} );
+			} );
+
+			// Now wait for the above to actually run
+			while (hit == false){
+				NSRunLoop.Current.RunUntil (NSDate.FromTimeIntervalSinceNow (0.5));
+			}
+			Assert.IsNotNull (ex, "main ex");
+			Assert.That (ex.GetType (), Is.SameAs (typeof (ArgumentNullException)), "no thread check hit");
+			Assert.IsNotNull (queue_ex, "queue ex");
+			Assert.That (queue_ex.GetType (), Is.SameAs (typeof (UIKitThreadAccessException)), "thread check hit");
+			Assert.That (uiThread, Is.EqualTo (mainQthread), "mainq thread is equal to uithread");
+			Assert.That (queueThread, Is.Not.EqualTo (mainQthread), "queueThread is not the same as the UI thread");
+		}
+
+		[Test]
+		public void EverAfterQualityOfService ()
+		{
+#if !DEBUG || OPTIMIZEALL
+			Assert.Ignore ("UIKitThreadAccessException is not throw, by default, on release builds (removed by the linker)");
+#endif
+			if (RunningOnSnowLeopard)
+				Assert.Ignore ("this test crash when executed with the iOS simulator on Snow Leopard");
+
+			bool hit = false;
+			// We need to check the UIKitThreadAccessException, but there are very few API
+			// with that check on WatchOS. NSStringDrawing.WeakDrawString is one example, here we pass
+			// it null for the parameter so that it immediately returns with an ArgumentNullException
+			// instead of trying to load an image (which is not what we're testing). There
+			// is also a test to ensure UIKitThreadAccessException is thrown if not on
+			// the UI thread (so that we'll notice if the UIKitThreadAccessException is ever
+			// removed from NSStringDrawing.WeakDrawString).
+			var uiThread = Thread.CurrentThread;
+			Thread queueThread = null;
+			Thread mainQthread = null;
+			Exception ex = null;
+			Exception queue_ex = null;
+
+			var defaultQ = DispatchQueue.GetGlobalQueue (DispatchQualityOfService.Default);
 			defaultQ.DispatchAfter (new DispatchTime (DispatchTime.Now, 1000), delegate {	
 				try {
 					NSStringDrawing.WeakDrawString (null, PointF.Empty, null);

--- a/tests/test-libraries/libtest.h
+++ b/tests/test-libraries/libtest.h
@@ -207,8 +207,10 @@ typedef void (^simple_callback)();
 +(void) callOptionalStaticCallback;
 typedef void (^innerBlock) (int magic_number);
 typedef void (^outerBlock) (innerBlock callback);
-+(void) callAssertMainThreadBlockRelease: (outerBlock) completionHandler;
--(void) callAssertMainThreadBlockReleaseCallback;
++(void) callAssertMainThreadBlockReleasePriority: (outerBlock) completionHandler;
++(void) callAssertMainThreadBlockReleaseQOS: (outerBlock) completionHandler;
+-(void) callAssertMainThreadBlockReleaseCallbackPriority;
+-(void) callAssertMainThreadBlockReleaseCallbackQOS;
 -(void) assertMainThreadBlockReleaseCallback: (innerBlock) completionHandler;
 
 -(void) testFreedBlocks;

--- a/tests/test-libraries/libtest.h
+++ b/tests/test-libraries/libtest.h
@@ -207,9 +207,9 @@ typedef void (^simple_callback)();
 +(void) callOptionalStaticCallback;
 typedef void (^innerBlock) (int magic_number);
 typedef void (^outerBlock) (innerBlock callback);
-+(void) callAssertMainThreadBlockReleasePriority: (outerBlock) completionHandler;
++(void) callAssertMainThreadBlockRelease: (outerBlock) completionHandler;
 +(void) callAssertMainThreadBlockReleaseQOS: (outerBlock) completionHandler;
--(void) callAssertMainThreadBlockReleaseCallbackPriority;
+-(void) callAssertMainThreadBlockReleaseCallback;
 -(void) callAssertMainThreadBlockReleaseCallbackQOS;
 -(void) assertMainThreadBlockReleaseCallback: (innerBlock) completionHandler;
 

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -660,7 +660,7 @@ static Class _TestClass = NULL;
 	assert (called);
 }
 
-+(void) callAssertMainThreadBlockReleasePriority: (outerBlock) completionHandler
++(void) callAssertMainThreadBlockRelease: (outerBlock) completionHandler
 {
 	MainThreadDeallocator *obj = [[MainThreadDeallocator alloc] init];
 	__block bool success = false;
@@ -694,7 +694,7 @@ static Class _TestClass = NULL;
     [obj release];
 }
 
--(void) callAssertMainThreadBlockReleaseCallbackPriority
+-(void) callAssertMainThreadBlockReleaseCallback
 {
 	MainThreadDeallocator *obj = [[MainThreadDeallocator alloc] init];
 	__block bool success = false;

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -660,7 +660,7 @@ static Class _TestClass = NULL;
 	assert (called);
 }
 
-+(void) callAssertMainThreadBlockRelease: (outerBlock) completionHandler
++(void) callAssertMainThreadBlockReleasePriority: (outerBlock) completionHandler
 {
 	MainThreadDeallocator *obj = [[MainThreadDeallocator alloc] init];
 	__block bool success = false;
@@ -677,12 +677,46 @@ static Class _TestClass = NULL;
     [obj release];
 }
 
--(void) callAssertMainThreadBlockReleaseCallback
++(void) callAssertMainThreadBlockReleaseQOS: (outerBlock) completionHandler
+{
+	MainThreadDeallocator *obj = [[MainThreadDeallocator alloc] init];
+	__block bool success = false;
+
+	dispatch_sync (dispatch_get_global_queue (QOS_CLASS_DEFAULT, 0ul), ^{
+		completionHandler (^(int magic_number)
+		{
+			assert (magic_number == 42);
+			assert ([NSThread isMainThread]); // This may crash way after the failed test has finished executing.
+			success = obj != NULL; // this captures the 'obj', and it's only freed when the block is freed.
+		});
+    });
+	assert (success);
+    [obj release];
+}
+
+-(void) callAssertMainThreadBlockReleaseCallbackPriority
 {
 	MainThreadDeallocator *obj = [[MainThreadDeallocator alloc] init];
 	__block bool success = false;
 
 	dispatch_sync (dispatch_get_global_queue (DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul), ^{
+		[self assertMainThreadBlockReleaseCallback: ^(int magic_number)
+		{
+			assert (magic_number == 42);
+			assert ([NSThread isMainThread]); // This may crash way after the failed test has finished executing.
+			success = obj != NULL; // this captures the 'obj', and it's only freed when the block is freed.
+		}];
+    });
+	assert (success);
+    [obj release];
+}
+
+-(void) callAssertMainThreadBlockReleaseCallbackQOS
+{
+	MainThreadDeallocator *obj = [[MainThreadDeallocator alloc] init];
+	__block bool success = false;
+
+	dispatch_sync (dispatch_get_global_queue (QOS_CLASS_DEFAULT, 0ul), ^{
 		[self assertMainThreadBlockReleaseCallback: ^(int magic_number)
 		{
 			assert (magic_number == 42);

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -665,7 +665,7 @@ static Class _TestClass = NULL;
 	MainThreadDeallocator *obj = [[MainThreadDeallocator alloc] init];
 	__block bool success = false;
 
-	dispatch_sync (dispatch_get_global_queue_priority (DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul), ^{
+	dispatch_sync (dispatch_get_global_queue (DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul), ^{
 		completionHandler (^(int magic_number)
 		{
 			assert (magic_number == 42);
@@ -682,7 +682,7 @@ static Class _TestClass = NULL;
 	MainThreadDeallocator *obj = [[MainThreadDeallocator alloc] init];
 	__block bool success = false;
 
-	dispatch_sync (dispatch_get_global_queue_qos (QOS_CLASS_DEFAULT, 0ul), ^{
+	dispatch_sync (dispatch_get_global_queue (QOS_CLASS_DEFAULT, 0ul), ^{
 		completionHandler (^(int magic_number)
 		{
 			assert (magic_number == 42);
@@ -699,7 +699,7 @@ static Class _TestClass = NULL;
 	MainThreadDeallocator *obj = [[MainThreadDeallocator alloc] init];
 	__block bool success = false;
 
-	dispatch_sync (dispatch_get_global_queue_priority (DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul), ^{
+	dispatch_sync (dispatch_get_global_queue (DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul), ^{
 		[self assertMainThreadBlockReleaseCallback: ^(int magic_number)
 		{
 			assert (magic_number == 42);
@@ -716,7 +716,7 @@ static Class _TestClass = NULL;
 	MainThreadDeallocator *obj = [[MainThreadDeallocator alloc] init];
 	__block bool success = false;
 
-	dispatch_sync (dispatch_get_global_queue_qos (QOS_CLASS_DEFAULT, 0ul), ^{
+	dispatch_sync (dispatch_get_global_queue (QOS_CLASS_DEFAULT, 0ul), ^{
 		[self assertMainThreadBlockReleaseCallback: ^(int magic_number)
 		{
 			assert (magic_number == 42);

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -665,7 +665,7 @@ static Class _TestClass = NULL;
 	MainThreadDeallocator *obj = [[MainThreadDeallocator alloc] init];
 	__block bool success = false;
 
-	dispatch_sync (dispatch_get_global_queue (DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul), ^{
+	dispatch_sync (dispatch_get_global_queue_priority (DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul), ^{
 		completionHandler (^(int magic_number)
 		{
 			assert (magic_number == 42);
@@ -682,7 +682,7 @@ static Class _TestClass = NULL;
 	MainThreadDeallocator *obj = [[MainThreadDeallocator alloc] init];
 	__block bool success = false;
 
-	dispatch_sync (dispatch_get_global_queue (QOS_CLASS_DEFAULT, 0ul), ^{
+	dispatch_sync (dispatch_get_global_queue_qos (QOS_CLASS_DEFAULT, 0ul), ^{
 		completionHandler (^(int magic_number)
 		{
 			assert (magic_number == 42);
@@ -699,7 +699,7 @@ static Class _TestClass = NULL;
 	MainThreadDeallocator *obj = [[MainThreadDeallocator alloc] init];
 	__block bool success = false;
 
-	dispatch_sync (dispatch_get_global_queue (DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul), ^{
+	dispatch_sync (dispatch_get_global_queue_priority (DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul), ^{
 		[self assertMainThreadBlockReleaseCallback: ^(int magic_number)
 		{
 			assert (magic_number == 42);
@@ -716,7 +716,7 @@ static Class _TestClass = NULL;
 	MainThreadDeallocator *obj = [[MainThreadDeallocator alloc] init];
 	__block bool success = false;
 
-	dispatch_sync (dispatch_get_global_queue (QOS_CLASS_DEFAULT, 0ul), ^{
+	dispatch_sync (dispatch_get_global_queue_qos (QOS_CLASS_DEFAULT, 0ul), ^{
 		[self assertMainThreadBlockReleaseCallback: ^(int magic_number)
 		{
 			assert (magic_number == 42);

--- a/tests/xtro-sharpie/common-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/common-CoreFoundation.ignore
@@ -935,8 +935,7 @@
 !unknown-pinvoke! dispatch_data_get_size bound
 !unknown-pinvoke! dispatch_get_context bound
 !unknown-pinvoke! dispatch_get_current_queue bound
-!unknown-pinvoke! dispatch_get_global_queue_priority bound
-!unknown-pinvoke! dispatch_get_global_queue_qos bound
+!unknown-pinvoke! dispatch_get_global_queue bound
 !unknown-pinvoke! dispatch_group_async_f bound
 !unknown-pinvoke! dispatch_group_create bound
 !unknown-pinvoke! dispatch_group_enter bound

--- a/tests/xtro-sharpie/common-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/common-CoreFoundation.ignore
@@ -935,7 +935,8 @@
 !unknown-pinvoke! dispatch_data_get_size bound
 !unknown-pinvoke! dispatch_get_context bound
 !unknown-pinvoke! dispatch_get_current_queue bound
-!unknown-pinvoke! dispatch_get_global_queue bound
+!unknown-pinvoke! dispatch_get_global_queue_priority bound
+!unknown-pinvoke! dispatch_get_global_queue_qos bound
 !unknown-pinvoke! dispatch_group_async_f bound
 !unknown-pinvoke! dispatch_group_create bound
 !unknown-pinvoke! dispatch_group_enter bound


### PR DESCRIPTION
Add new `DispatchQueue.GetGlobalQueue` overloaded method that is fully capable of supporting `DispatchQualityOfService` enum in `Dispatch.cs`. Also added appropriate unit tests within `DispatchTests.cs` and other associated test scripts that call `DispatchQueue.GetGlobalQueue`.

Fixes #6783