### PR TITLE
[runtime] Free `env-argv` in `xamarin-main`

### DIFF
--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -669,6 +669,7 @@ int xamarin_main (int argc, char **argv, enum XamarinLaunchMode launch_mode)
 		}
 
 		free (new_argv);
+		free (env_argv);
 	}
 
 	return rv;


### PR DESCRIPTION
`get_mono_env_options` allocate memory so it must [1] be freed.

[1] to be polite since it will be freed when the app exit, which
will free everything anyway