### PR TITLE
[Runtime] Enable the -Wshorten-64-to-32 flag and fix all warnings.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -190,7 +190,7 @@ IOS_CXX=$(XCODE_CXX)
 SIMULATOR_BIN_PATH=$(XCODE_DEVELOPER_ROOT)/Platforms/iPhoneSimulator.platform/Developer/usr/bin
 SIMULATOR_CC=$(IOS_CC)
 
-CFLAGS= -Wall -fms-extensions -Wno-format-security -Wsign-compare
+CFLAGS= -Wall -fms-extensions -Wno-format-security -Wsign-compare -Wshorten-64-to-32
 
 ifdef ENABLE_BITCODE_ON_IOS
 BITCODE_CFLAGS=-fembed-bitcode-marker

--- a/runtime/bindings.m
+++ b/runtime/bindings.m
@@ -96,7 +96,7 @@ void * monotouch_IntPtr_objc_msgSendSuper_IntPtr (struct objc_super *super, SEL 
  * the code can be simplified once we require to remove dlsym or xcode 9 becomes the minimum supported version
  */
 
-typedef CGPoint (*vision_func) (vector_float2 faceLandmarkPoint, CGRect faceBoundingBox, size_t imageWidth, size_t imageHeight);
+typedef CGPoint (*vision_func) (vector_float2 faceLandmarkPoint, CGRect faceBoundingBox, xm_nuint_t imageWidth, xm_nuint_t imageHeight);
 
 static vision_func
 get_vision_func (const char *func_name, const char **error_msg)

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -52,7 +52,7 @@
 
 		new XDelegate ("MonoObject *", "IntPtr", "xamarin_get_block_wrapper_creator",
 			"MonoObject *", "IntPtr", "method",
-			"int", "int", "parameter"
+			"unsigned long", "uint", "parameter"
 		) {
 			WrappedManagedFunction = "GetBlockWrapperCreator",
 			OnlyDynamicUsage = true,
@@ -203,7 +203,7 @@
 
 		new XDelegate ("bool", "bool", "xamarin_is_parameter_out",
 			"MonoReflectionMethod *", "IntPtr", "method",
-			"int", "int", "parameter"
+			"unsigned long", "uint", "parameter"
 		) {
 			WrappedManagedFunction = "IsParameterOut",
 			OnlyDynamicUsage = true,

--- a/runtime/monotouch-debug.h
+++ b/runtime/monotouch-debug.h
@@ -23,7 +23,7 @@ void monotouch_start_debugging ();
 void monotouch_start_profiling ();
 
 void monotouch_set_connection_mode (const char *mode);
-void monotouch_set_monodevelop_port (int port);
+void monotouch_set_monodevelop_port (long port);
 
 
 typedef struct {

--- a/runtime/monotouch-debug.m
+++ b/runtime/monotouch-debug.m
@@ -1544,7 +1544,7 @@ int monotouch_debug_connect (NSMutableArray *ips, int debug_port, int output_por
 		// Connect to the host
 		if ((rv = connect (sockets[i], (struct sockaddr *) sockaddr, len)) == 0) {
 			// connection completed, this is our man.
-			connected = false;
+			connected = true;
 			connection_port = i;
 			break;
 		}

--- a/runtime/monotouch-debug.m
+++ b/runtime/monotouch-debug.m
@@ -43,10 +43,10 @@
 #include "product.h"
 
 // permanent connection variables
-static int monodevelop_port = -1;
+static long monodevelop_port = -1;
 static int sdb_fd = -1;
 static int heapshot_fd = -1; // this is the socket to write 'heapshot' to to requests heapshots from the profiler
-static int heapshot_port = -1;
+static long heapshot_port = -1;
 static char *profiler_description = NULL;
 // old variables
 static char *debug_host = NULL;
@@ -198,8 +198,8 @@ static volatile int http_connect_counter = 0;
 	-(int) localDescriptor;
 	-(void) reportCompletion: (bool) success;
 
-	-(void) connect: (NSString *) ip port: (int) port completionHandler: (void (^)(bool)) completionHandler;
-	-(void) sendData: (void *) buffer length: (int) length;
+	-(void) connect: (NSString *) ip port: (unsigned long) port completionHandler: (void (^)(bool)) completionHandler;
+	-(void) sendData: (void *) buffer length: (long) length;
 
 	/* NSURLSessionDelegate */
 	-(void) URLSession:(NSURLSession *)session didBecomeInvalidWithError:(NSError *)error;
@@ -223,7 +223,7 @@ xamarin_http_send (void *c)
 		do {
 			LOG_HTTP ("%i http send reading to send data to fd=%i", connection.id, fd);
 			errno = 0;
-			int rv = read (fd, buf, 1024);
+			long rv = read (fd, buf, 1024);
 			LOG_HTTP ("%i http send read %i bytes from fd=%i; %i=%s", connection.id, rv, fd, errno, strerror (errno));
 			if (rv > 0) {
 				[connection sendData: buf length: rv];
@@ -267,7 +267,7 @@ xamarin_http_send (void *c)
 	return http_sockets [1];
 }
 
--(void) connect: (NSString *) ip port: (int) port completionHandler: (void (^)(bool)) completionHandler
+-(void) connect: (NSString *) ip port: (unsigned long) port completionHandler: (void (^)(bool)) completionHandler
 {
 	LOG_HTTP ("Connecting to: %@:%i", ip, port);
 
@@ -297,19 +297,19 @@ xamarin_http_send (void *c)
 
 	http_session = [NSURLSession sessionWithConfiguration: http_session_config delegate: self delegateQueue: NULL];
 
-	NSURL *downloadURL = [NSURL URLWithString: [NSString stringWithFormat: @"http://%@:%i/download?pid=%i&id=%i&uniqueRequest=%i", self.ip, monodevelop_port, getpid (), self.id, self.uniqueRequest]];
+	NSURL *downloadURL = [NSURL URLWithString: [NSString stringWithFormat: @"http://%@:%li/download?pid=%i&id=%i&uniqueRequest=%i", self.ip, monodevelop_port, getpid (), self.id, self.uniqueRequest]];
 	NSURLSessionDataTask *downloadTask = [http_session dataTaskWithURL: downloadURL];
 	[downloadTask resume];
 
 	LOG_HTTP ("%i Connecting to: %@:%i downloadTask: %@", self.id, ip, port, [[downloadTask currentRequest] URL]);
 }
 
--(void) sendData: (void *) buffer length: (int) length
+-(void) sendData: (void *) buffer length: (long) length
 {
 	int c = atomic_fetch_add (&http_send_counter, 1);
 
-	NSURL *uploadURL = [NSURL URLWithString: [NSString stringWithFormat: @"http://%@:%i/upload?pid=%i&id=%i&upload-id=%i", self.ip, monodevelop_port, getpid (), self.id, c]];
-	LOG_HTTP ("%i sendData length: %i url: %@", self.id, length, uploadURL);
+	NSURL *uploadURL = [NSURL URLWithString: [NSString stringWithFormat: @"http://%@:%li/upload?pid=%i&id=%i&upload-id=%i", self.ip, monodevelop_port, getpid (), self.id, c]];
+	LOG_HTTP ("%i sendData length: %li url: %@", self.id, length, uploadURL);
 	NSMutableURLRequest *uploadRequest = [[[NSMutableURLRequest alloc] initWithURL: uploadURL] autorelease];
 	uploadRequest.HTTPMethod = @"POST";
 	NSURLSessionUploadTask *uploadTask = [http_session uploadTaskWithRequest: uploadRequest fromData: [NSData dataWithBytes: buffer length: length]];
@@ -344,7 +344,7 @@ xamarin_http_send (void *c)
 
 	[data enumerateByteRangesUsingBlock: ^(const void *bytes, NSRange byteRange, BOOL *stop) {
 		int fd = self.localDescriptor;
-		int wr;
+		long wr;
 		NSUInteger total = byteRange.length;
 		NSUInteger left = total;
 		while (left > 0) {
@@ -381,7 +381,7 @@ monotouch_set_connection_mode (const char *mode)
 }
 
 void
-monotouch_set_monodevelop_port (int port)
+monotouch_set_monodevelop_port (long port)
 {
 	monodevelop_port = port;
 }
@@ -617,7 +617,7 @@ void monotouch_configure_debugging ()
 					} while (*++nline);
 
 					if (!strncmp (line, "__XAMARIN_DEBUG_PORT__=", 23)) {
-						int shm_monodevelop_port = strtol (line + 23, NULL, 10);
+						long shm_monodevelop_port = strtol (line + 23, NULL, 10);
 						if (monodevelop_port == -1) {
 							monodevelop_port = shm_monodevelop_port;
 							LOG (PRODUCT ": Found port %i in shared memory\n", monodevelop_port);
@@ -736,7 +736,7 @@ static void sdb_close2 (void)
 
 static gboolean send_uninterrupted (int fd, const void *buf, int len)
 {
-	int res;
+	long res;
 
 	do {
 		res = send (fd, buf, len, 0);
@@ -747,7 +747,7 @@ static gboolean send_uninterrupted (int fd, const void *buf, int len)
 
 static int recv_uninterrupted (int fd, void *buf, int len)
 {
-	int res;
+	long res;
 	int total = 0;
 	int flags = 0;
 
@@ -795,7 +795,7 @@ static XamarinHttpConnection *connected_connection = NULL;
 static NSString *connected_ip = NULL;
 static pthread_cond_t connected_event = PTHREAD_COND_INITIALIZER;
 static pthread_mutex_t connected_mutex = PTHREAD_MUTEX_INITIALIZER;
-static int pending_connections = 0;
+static unsigned long pending_connections = 0;
 
 void
 xamarin_connect_http (NSMutableArray *ips)
@@ -803,7 +803,7 @@ xamarin_connect_http (NSMutableArray *ips)
 	// COOP: this is at startup and doesn't access managed memory, so we should be in safe mode here.
 	MONO_ASSERT_GC_STARTING;
 	
-	int ip_count = [ips count];
+	unsigned long ip_count = [ips count];
 	NSMutableArray<XamarinHttpConnection *> *connections = NULL;
 
 	if (ip_count == 0) {
@@ -811,7 +811,7 @@ xamarin_connect_http (NSMutableArray *ips)
 		return;
 	}
 	
-	NSLog (@PRODUCT ": Connecting to %i IPs.", ip_count);
+	NSLog (@PRODUCT ": Connecting to %lu IPs.", ip_count);
 
 	connections = [[[NSMutableArray<XamarinHttpConnection *> alloc] init] autorelease];
 
@@ -875,14 +875,14 @@ monotouch_connect_wifi (NSMutableArray *ips)
 	// COOP: this is at startup and doesn't access managed memory, so we should be in safe mode here.
 	MONO_ASSERT_GC_STARTING;
 	
-	int listen_port = monodevelop_port;
+	long listen_port = monodevelop_port;
 	unsigned char sockaddr[sizeof (struct sockaddr_in6)];
 	struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *) sockaddr;
 	struct sockaddr_in *sin = (struct sockaddr_in *) sockaddr;
-	int family, waiting, len, rv, i;
-	int ip_count = [ips count];
+	int family, waiting, len, rv;
+	unsigned long i, connected;
+	unsigned long ip_count = [ips count];
 	const char *family_str;
-	int connected;
 	const char *ip;
 	int *sockets;
 	long flags;
@@ -953,7 +953,7 @@ monotouch_connect_wifi (NSMutableArray *ips)
 		}
 	
 		// Wait for async socket connections to become available
-		while (connected == -1 && waiting > 0) {
+		while (connected == -1lu && waiting > 0) {
 			socklen_t optlen = sizeof (int);
 			fd_set rset, wset, xset;
 			struct timeval tv;
@@ -1033,7 +1033,7 @@ monotouch_connect_wifi (NSMutableArray *ips)
 			}
 		}
 	
-		if (connected == -1) {
+		if (connected == -1lu) {
 			free (sockets);
 			return;
 		}
@@ -1061,7 +1061,7 @@ monotouch_connect_usb ()
 	// COOP: this is at startup and doesn't access managed memory, so we should be in safe mode here.
 	MONO_ASSERT_GC_STARTING;
 	
-	int listen_port = monodevelop_port;
+	long listen_port = monodevelop_port;
 	struct sockaddr_in listen_addr;
 	int listen_socket = -1;
 	int fd;
@@ -1486,10 +1486,11 @@ int monotouch_debug_connect (NSMutableArray *ips, int debug_port, int output_por
 	unsigned char sockaddr[sizeof (struct sockaddr_in6)];
 	struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *) sockaddr;
 	struct sockaddr_in *sin = (struct sockaddr_in *) sockaddr;
-	int family, waiting, len, rv, i;
-	int ip_count = [ips count];
+	int family, waiting, len, rv;
+	unsigned long i;
+	unsigned long ip_count = [ips count];
 	const char *family_str;
-	int connected = -1;
+	unsigned long connected = -1;
 	const char *ip;
 	int *sockets;
 	long flags;
@@ -1555,7 +1556,7 @@ int monotouch_debug_connect (NSMutableArray *ips, int debug_port, int output_por
 	}
 	
 	// Wait for async socket connections to become available
-	while (connected == -1 && waiting > 0) {
+	while (connected == -1lu && waiting > 0) {
 		socklen_t optlen = sizeof (int);
 		fd_set rset, wset, xset;
 		struct timeval tv;
@@ -1635,7 +1636,7 @@ int monotouch_debug_connect (NSMutableArray *ips, int debug_port, int output_por
 		}
 	}
 	
-	if (connected == -1) {
+	if (connected == -1lu) {
 		free (sockets);
 		return 1;
 	}

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -94,7 +94,7 @@ assembly_preload_hook (MonoAssemblyName *aname, char **assemblies_path, void* us
 
 	// LOG (PRODUCT ": Looking for assembly '%s' (culture: '%s')\n", name, culture);
 
-	int len = strlen (name);
+	size_t len = strlen (name);
 	int has_extension = len > 3 && name [len - 4] == '.' && (!strcmp ("exe", name + (len - 3)) || !strcmp ("dll", name + (len - 3)));
 	bool dual_check = false;
 

--- a/runtime/monotouch-support.h
+++ b/runtime/monotouch-support.h
@@ -9,8 +9,8 @@ extern "C" {
 
 const char *   xamarin_get_locale_country_code ();
 void           xamarin_log (const unsigned short *unicodeMessage);
-void *         xamarin_timezone_get_data (const char *name, int *size);
-char **        xamarin_timezone_get_names (int *count);
+void *         xamarin_timezone_get_data (const char *name, unsigned long *size);
+char **        xamarin_timezone_get_names (unsigned long *count);
 char *         xamarin_timezone_get_local_name ();
 void           xamarin_start_wwan (const char *uri);
 void           xamarin_os_log (os_log_t logger, os_log_type_t type, const char *message);

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -704,7 +704,7 @@ xamarin_check_for_gced_object (MonoObject *obj, SEL sel, id self, MonoMethod *me
 // 
 
 void
-xamarin_verify_parameter (MonoObject *obj, SEL sel, id self, id arg, int index, MonoClass *expected, MonoMethod *method)
+xamarin_verify_parameter (MonoObject *obj, SEL sel, id self, id arg, unsigned long index, MonoClass *expected, MonoMethod *method)
 {
 	// COOP: Reads managed memory, needs to be in UNSAFE mode
 	MONO_ASSERT_GC_UNSAFE;
@@ -2066,7 +2066,7 @@ xamarin_create_managed_ref (id self, gpointer managed_object, bool retain)
 
 typedef struct {
 	MonoMethod *method;
-	int par;
+	unsigned long par;
 } MethodAndPar;
 
 static gboolean
@@ -2094,7 +2094,7 @@ static MonoReferenceQueue *block_wrapper_queue;
  * create the method
  */
 static MonoObject *
-get_method_block_wrapper_creator (MonoMethod *method, int par, guint32 *exception_gchandle)
+get_method_block_wrapper_creator (MonoMethod *method, unsigned long par, guint32 *exception_gchandle)
 {
 	// COOP: accesses managed memory: unsafe mode.
 	MONO_ASSERT_GC_UNSAFE;
@@ -2162,7 +2162,7 @@ xamarin_release_block_on_main_thread (void *obj)
  * Returns: the instantiated delegate.
  */
 int *
-xamarin_get_delegate_for_block_parameter (MonoMethod *method, guint32 token_ref, int par, void *nativeBlock, guint32 *exception_gchandle)
+xamarin_get_delegate_for_block_parameter (MonoMethod *method, guint32 token_ref, unsigned long par, void *nativeBlock, guint32 *exception_gchandle)
 {
 	// COOP: accesses managed memory: unsafe mode.
 	MONO_ASSERT_GC_UNSAFE;
@@ -2511,7 +2511,7 @@ xamarin_vprintf (const char *format, va_list args)
 void
 xamarin_get_assembly_name_without_extension (const char *aname, char *name, int namelen)
 {
-	int len = strlen (aname);
+	size_t len = strlen (aname);
 	strlcpy (name, aname, namelen);
 	if (namelen <= 4 || len <= 4)
 		return;

--- a/runtime/trampolines-arm64.m
+++ b/runtime/trampolines-arm64.m
@@ -40,7 +40,7 @@ dump_state (struct XamarinCallState *state, const char *prefix)
 #define dump_state(...)
 #endif
 
-static int
+static size_t 
 param_read_primitive (struct ParamIterator *it, const char *type_ptr, void *target, size_t total_size, guint32 *exception_gchandle)
 {
 	// COOP: does not access managed memory: any mode.
@@ -182,7 +182,7 @@ param_iter_next (enum IteratorAction action, void *context, const char *type, si
 	const char *t = struct_name;
 	uint8_t *targ = (uint8_t *) target;
 	do {
-		int c = param_read_primitive (it, t, targ, size, exception_gchandle);
+		size_t c = param_read_primitive (it, t, targ, size, exception_gchandle);
 		if (*exception_gchandle != 0)
 			return;
 		if (targ != NULL)

--- a/runtime/trampolines-internal.h
+++ b/runtime/trampolines-internal.h
@@ -48,7 +48,7 @@ typedef void (*marshal_return_value_func) (void *context, const char *type, size
 
 void xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_func iterator, marshal_return_value_func marshal_return_value, void *context);
 
-int xamarin_get_frame_length (id self, SEL sel);
+unsigned long xamarin_get_frame_length (id self, SEL sel);
 const char * xamarin_skip_type_name (const char *ptr);
 
 #ifdef __cplusplus

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -149,7 +149,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 	unsigned long desc_arg_count = num_arg + 2; /* 1 for the return value + 1 if this is a category instance method */
 	size_t desc_size = desc_arg_count * sizeof (BindAsData) + sizeof (MethodDescription);
 	desc = (MethodDescription *) xamarin_calloc (desc_size);
-	desc->bindas_count = desc_arg_count;
+	desc->bindas_count = (int32_t) desc_arg_count;
 	free_list = s_list_prepend (free_list, desc);
 
 	if (is_ctor || is_static) {
@@ -415,7 +415,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 							}
 
 							if (created && obj) {
-								bool is_transient = xamarin_is_parameter_transient (mono_method_get_object (domain, method, NULL), i, &exception_gchandle);
+								bool is_transient = xamarin_is_parameter_transient (mono_method_get_object (domain, method, NULL), (int32_t) i, &exception_gchandle);
 								if (exception_gchandle != 0)
 									goto exception_handling;
 								if (is_transient)

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -26,7 +26,7 @@ xamarin_get_exception_for_method (int code, guint32 inner_exception_gchandle, co
 }
 
 guint32
-xamarin_get_exception_for_parameter (int code, guint32 inner_exception_gchandle, const char *reason, SEL sel, MonoMethod *method, MonoType *p, int i, bool to_managed)
+xamarin_get_exception_for_parameter (int code, guint32 inner_exception_gchandle, const char *reason, SEL sel, MonoMethod *method, MonoType *p, unsigned long i, bool to_managed)
 {
 	guint32 exception_gchandle = 0;
 	char *to_name = xamarin_type_get_full_name (p, &exception_gchandle);
@@ -114,8 +114,8 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 	// pre-prolog
 	SList *dispose_list = NULL;
 	SList *free_list = NULL;
-	int num_arg;
-	int managed_arg_count;
+	unsigned long num_arg;
+	unsigned long managed_arg_count;
 	NSMethodSignature *sig;
 
 	if (is_static) {
@@ -134,7 +134,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 	bool isCategoryInstance;
 
 	// setup callstack
-	int frame_length;
+	unsigned long frame_length;
 	void **arg_frame;
 	void **arg_ptrs;
 	void **arg_copy = NULL; // used to detect if ref/out parameters were changed.
@@ -143,10 +143,10 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 	gboolean needs_writeback = FALSE; // determines if there are any ref/out parameters.
 	MonoType *p;
 	int ofs;
-	int i;
+	unsigned long i;
 	int mofs = 0;
 
-	int desc_arg_count = num_arg + 2; /* 1 for the return value + 1 if this is a category instance method */
+	unsigned long desc_arg_count = num_arg + 2; /* 1 for the return value + 1 if this is a category instance method */
 	size_t desc_size = desc_arg_count * sizeof (BindAsData) + sizeof (MethodDescription);
 	desc = (MethodDescription *) xamarin_calloc (desc_size);
 	desc->bindas_count = desc_arg_count;

--- a/runtime/trampolines-x86_64.m
+++ b/runtime/trampolines-x86_64.m
@@ -48,7 +48,7 @@ dump_state (struct XamarinCallState *state)
 static const char* registers[] =  { "rdi", "rsi", "rdx", "rcx", "r8", "r9", "err"  };
 #endif
 
-static int
+static unsigned long 
 param_read_primitive (struct ParamIterator *it, const char **type_ptr, void *target, size_t total_size, guint32 *exception_gchandle)
 {
 	// COOP: does not access managed memory: any mode.
@@ -227,7 +227,7 @@ param_iter_next (enum IteratorAction action, void *context, const char *type, si
 		if (*t == 0)
 			break;
 
-		int c = param_read_primitive (it, &t, targ, size, exception_gchandle);
+		unsigned long c = param_read_primitive (it, &t, targ, size, exception_gchandle);
 		if (*exception_gchandle != 0)
 			return;
 		if (targ != NULL)
@@ -350,7 +350,7 @@ marshal_return_value (void *context, const char *type, size_t size, void *vvalue
 			}
 			// figure out where to put the values.
 			const char *t = xamarin_skip_type_name (type);
-			int acc = 0;
+			unsigned long acc = 0;
 			int stores = 0;
 
 			while (true) {
@@ -365,7 +365,7 @@ marshal_return_value (void *context, const char *type, size_t size, void *vvalue
 				}
 					
 				bool is_float = *t == _C_FLT || *t == _C_DBL;
-				int s = xamarin_get_primitive_size (*t);
+				unsigned long s = xamarin_get_primitive_size (*t);
 
 				t++;
 

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -134,10 +134,10 @@ xamarin_marshal_return_value_impl (MonoType *mtype, const char *type, MonoObject
 }
 
 static guint32
-xamarin_get_exception_for_element_conversion_failure (guint32 inner_exception_gchandle, int index)
+xamarin_get_exception_for_element_conversion_failure (guint32 inner_exception_gchandle, unsigned long index)
 {
 	guint32 exception_gchandle = 0;
-	char *msg = xamarin_strdup_printf ("Failed to marshal the value at index %i.", index);
+	char *msg = xamarin_strdup_printf ("Failed to marshal the value at index %lu.", index);
 	exception_gchandle = xamarin_create_product_exception_with_inner_exception (8036, inner_exception_gchandle, msg);
 	xamarin_free (msg);
 	return exception_gchandle;
@@ -445,7 +445,7 @@ xamarin_collapse_struct_name (const char *type, char struct_name[], int max_char
 	return true;
 }
 
-int
+unsigned long
 xamarin_get_frame_length (id self, SEL sel)
 {
 	if (self == NULL)
@@ -455,7 +455,7 @@ xamarin_get_frame_length (id self, SEL sel)
 	// which NSMethodSignature chokes on: NSInvalidArgumentException Reason: +[NSMethodSignature signatureWithObjCTypes:]: unsupported type encoding spec '{?}'
 	// So instead parse the description ourselves.
 
-	int length = 0;
+	unsigned long length = 0;
 	[self class]; // There's a bug in the ObjC runtime where we might get an uninitialized Class instance from object_getClass. See #6258. Calling the 'class' selector first makes sure the Class instance is initialized.
 	Class cls = object_getClass (self);
 	const char *method_description = get_method_description (cls, sel);
@@ -467,14 +467,14 @@ xamarin_get_frame_length (id self, SEL sel)
 			length = [sig frameLength];
 		} @catch (NSException *ex) {
 			length = sizeof (void *) * 64; // some high-ish number.
-			fprintf (stderr, PRODUCT ": Failed to calculate the frame size for the method [%s %s] (%s). Using a value of %i instead.\n", class_getName (cls), sel_getName (sel), [[ex description] UTF8String], length);
+			fprintf (stderr, PRODUCT ": Failed to calculate the frame size for the method [%s %s] (%s). Using a value of %lu instead.\n", class_getName (cls), sel_getName (sel), [[ex description] UTF8String], length);
 		}
 	} else {
 		// The format of the method type encoding is described here: http://stackoverflow.com/a/11492151/183422
 		// the return type might have a number after it, which is the size of the argument frame
 		// first get this number (if it's there), and use it as a minimum value for the frame length
 		int rvlength = get_type_description_length (desc);
-		int min_length = 0;
+		unsigned long min_length = 0;
 		if (rvlength > 0) {
 			const char *min_start = desc + rvlength;
 			// the number is at the end of the return type encoding, so find any numbers
@@ -615,7 +615,7 @@ xamarin_release_trampoline (id self, SEL sel)
 	// COOP: does not access managed memory: any mode, but it assumes safe mode upon entry (it takes locks, and doesn't switch to safe mode).
 	MONO_ASSERT_GC_SAFE_OR_DETACHED;
 	
-	int ref_count;
+	unsigned long ref_count;
 	bool detach = false;
 
 	pthread_mutex_lock (&refcount_mutex);
@@ -1496,7 +1496,7 @@ xamarin_convert_managed_to_nsarray_with_func (MonoArray *array, xamarin_managed_
 	if (array == NULL)
 		return NULL;
 
-	int length = mono_array_length (array);
+	unsigned long length = mono_array_length (array);
 	if (length == 0)
 		return [NSArray array];
 
@@ -1507,7 +1507,7 @@ xamarin_convert_managed_to_nsarray_with_func (MonoArray *array, xamarin_managed_
 		element_size = mono_class_value_size (element_class, NULL);
 		ptr = (char *) mono_array_addr_with_size (array, element_size, 0);
 	}
-	for (int i = 0; i < length; i++) {
+	for (unsigned long i = 0; i < length; i++) {
 		MonoObject *value;
 		if (is_value_type) {
 			value = mono_value_box (mono_domain_get (), element_class, ptr + element_size * i);
@@ -1534,7 +1534,7 @@ xamarin_convert_nsarray_to_managed_with_func (NSArray *array, MonoClass *managed
 	if (array == NULL)
 		return NULL;
 
-	int length = [array count];
+	unsigned long length = [array count];
 	MonoArray *rv = mono_array_new (mono_domain_get (), managedElementType, length);
 
 	if (length == 0)
@@ -1550,7 +1550,7 @@ xamarin_convert_nsarray_to_managed_with_func (NSArray *array, MonoClass *managed
 		element_size = mono_class_value_size (managedElementType, NULL);
 		ptr = (char *) mono_array_addr_with_size (rv, element_size, 0);
 	}
-	for (int i = 0; i < length; i++) {
+	for (unsigned long i = 0; i < length; i++) {
 		if (is_value_type) {
 			valueptr = convert ([array objectAtIndex: i], valueptr, managedElementType, context, exception_gchandle);
 			memcpy (ptr, valueptr, element_size);

--- a/runtime/xamarin-support.m
+++ b/runtime/xamarin-support.m
@@ -57,10 +57,10 @@ xamarin_log (const unsigned short *unicodeMessage)
 		// Write in chunks of max 4096 characters; older versions of iOS seems to have a bug where NSLog may hang with long strings (!).
 		// https://github.com/xamarin/maccore/issues/1014
 		const char *utf8 = [msg UTF8String];
-		int len = strlen (utf8);
-		const int max_size = 4096;
+		size_t len = strlen (utf8);
+		const size_t max_size = 4096;
 		while (len > 0) {
-			int chunk_size = len > max_size ? max_size : len;
+			size_t chunk_size = len > max_size ? max_size : len;
 
 			// Try to not break in the middle of a line, by looking backwards for a newline
 			while (chunk_size > 0 && utf8 [chunk_size] != 0 && utf8 [chunk_size] != '\n')
@@ -69,7 +69,7 @@ xamarin_log (const unsigned short *unicodeMessage)
 				// No newline found, break in the middle.
 				chunk_size = len > max_size ? max_size : len;
 			}
-			NSLog (@"%.*s", chunk_size, utf8);
+			NSLog (@"%.*s", (int) chunk_size, utf8);
 
 			len -= chunk_size;
 			utf8 += chunk_size;
@@ -87,7 +87,7 @@ xamarin_log (const unsigned short *unicodeMessage)
 // See in Mono sdks/ios/runtime/runtime.m
 
 void*
-xamarin_timezone_get_data (const char *name, int *size)
+xamarin_timezone_get_data (const char *name, unsigned long *size)
 {
 	// COOP: no managed memory access: any mode.
 	NSTimeZone *tz = nil;
@@ -106,13 +106,13 @@ xamarin_timezone_get_data (const char *name, int *size)
 }
 
 char**
-xamarin_timezone_get_names (int *count)
+xamarin_timezone_get_names (unsigned long *count)
 {
 	// COOP: no managed memory access: any mode.
 	NSArray *array = [NSTimeZone knownTimeZoneNames];
 	*count = array.count;
 	char** result = (char**) malloc (sizeof (char*) * (*count));
-	for (int i = 0; i < *count; i++) {
+	for (unsigned long i = 0; i < *count; i++) {
 		NSString *s = [array objectAtIndex: i];
 		result [i] = strdup (s.UTF8String);
 	}

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -129,7 +129,7 @@ typedef struct {
 typedef struct {
 	MonoReflectionMethod *method;
 	int32_t semantic;
-	unsigned long bindas_count; // The number of elements available in the bindas_types array.
+	int32_t bindas_count; // The number of elements available in the bindas_types array.
 	// An array of BindAs original types. Element 0 is for the return value,
 	// the rest are for parameters (parameters start at 1 even for void methods).
 	// The array must contain space for the return value and all the parameters,

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -129,7 +129,7 @@ typedef struct {
 typedef struct {
 	MonoReflectionMethod *method;
 	int32_t semantic;
-	int32_t bindas_count; // The number of elements available in the bindas_types array.
+	unsigned long bindas_count; // The number of elements available in the bindas_types array.
 	// An array of BindAs original types. Element 0 is for the return value,
 	// the rest are for parameters (parameters start at 1 even for void methods).
 	// The array must contain space for the return value and all the parameters,
@@ -181,7 +181,7 @@ MonoClass *		xamarin_get_nullable_type (MonoClass *cls, guint32 *exception_gchan
 MonoType *		xamarin_get_parameter_type (MonoMethod *managed_method, int index);
 MonoObject *	xamarin_get_nsobject_with_type_for_ptr (id self, bool owns, MonoType* type, guint32 *exception_gchandle);
 MonoObject *	xamarin_get_nsobject_with_type_for_ptr_created (id self, bool owns, MonoType *type, int32_t *created, guint32 *exception_gchandle);
-int *			xamarin_get_delegate_for_block_parameter (MonoMethod *method, guint32 token_ref, int par, void *nativeBlock, guint32 *exception_gchandle);
+int *			xamarin_get_delegate_for_block_parameter (MonoMethod *method, guint32 token_ref, unsigned long par, void *nativeBlock, guint32 *exception_gchandle);
 id              xamarin_get_block_for_delegate (MonoMethod *method, MonoObject *delegate, const char *signature /* NULL allowed, but requires the dynamic registrar at runtime to compute */, guint32 token_ref /* INVALID_TOKEN_REF allowed, but requires the dynamic registrar at runtime */, guint32 *exception_gchandle);
 id				xamarin_get_nsobject_handle (MonoObject *obj);
 void			xamarin_set_nsobject_handle (MonoObject *obj, id handle);
@@ -227,7 +227,7 @@ char *			xamarin_type_get_full_name (MonoType *type, guint32 *exception_gchandle
 char *			xamarin_class_get_full_name (MonoClass *klass, guint32 *exception_gchandle); // return value must be freed with 'mono_free'
 
 #if DEBUG
-void			xamarin_verify_parameter (MonoObject *obj, SEL sel, id self, id arg, int index, MonoClass *expected, MonoMethod *method);
+void			xamarin_verify_parameter (MonoObject *obj, SEL sel, id self, id arg, unsigned long index, MonoClass *expected, MonoMethod *method);
 void			xamarin_check_objc_type (id obj, Class expected_class, SEL sel, id self, int index, MonoMethod *method);
 #endif
 

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -35,7 +35,7 @@ id			xamarin_copyWithZone_trampoline2 (id self, SEL sel, NSZone *zone);
 int			xamarin_get_gchandle_trampoline (id self, SEL sel);
 void		xamarin_set_gchandle_trampoline (id self, SEL sel, int gc_handle);
 
-int			xamarin_get_frame_length (id self, SEL sel);
+unsigned long	xamarin_get_frame_length (id self, SEL sel);
 bool		xamarin_collapse_struct_name (const char *type, char struct_name[], int max_char, guint32 *exception_gchandle);
 guint32		xamarin_create_mt_exception (char *msg);
 size_t		xamarin_get_primitive_size (char type);
@@ -95,7 +95,7 @@ MonoObject *    xamarin_convert_nsnumber_to_managed (NSNumber *value, MonoType *
 MonoObject *    xamarin_convert_nsvalue_to_managed (NSValue *value, MonoType *nativeType, MonoType *managedType, MonoMethod *method, guint32 *exception_gchandle);
 MonoObject *    xamarin_convert_nsstring_to_managed (NSString *value, MonoType *nativeType, MonoType *managedType, MonoMethod *method, guint32 *exception_gchandle);
 guint32         xamarin_create_bindas_exception (MonoType *inputType, MonoType *outputType, MonoMethod *method);
-guint32         xamarin_get_exception_for_parameter (int code, guint32 inner_exception_gchandle, const char *reason, SEL sel, MonoMethod *method, MonoType *p, int i, bool to_managed);
+guint32         xamarin_get_exception_for_parameter (int code, guint32 inner_exception_gchandle, const char *reason, SEL sel, MonoMethod *method, MonoType *p, unsigned long i, bool to_managed);
 
 xamarin_id_to_managed_func xamarin_get_nsnumber_to_managed_func (MonoClass *managedType, MonoMethod *method, guint32 *exception_gchandle);
 xamarin_managed_to_id_func xamarin_get_managed_to_nsnumber_func (MonoClass *managedType, MonoMethod *method, guint32 *exception_gchandle);

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -445,7 +445,7 @@ namespace ObjCRuntime {
 			}
 		}
 
-		static IntPtr GetBlockWrapperCreator (IntPtr method, int parameter)
+		static IntPtr GetBlockWrapperCreator (IntPtr method, uint parameter)
 		{
 			return ObjectWrapper.Convert (GetBlockWrapperCreator ((MethodInfo) ObjectWrapper.Convert (method), parameter));
 		}
@@ -727,7 +727,7 @@ namespace ObjCRuntime {
 			return parameters [parameter].IsDefined (typeof(TransientAttribute), false);
 		}
 
-		static bool IsParameterOut (IntPtr info, int parameter)
+		static bool IsParameterOut (IntPtr info, uint parameter)
 		{
 			var minfo = ObjectWrapper.Convert (info) as MethodInfo;
 			if (minfo == null)
@@ -773,7 +773,7 @@ namespace ObjCRuntime {
 		}
 #endregion
 
-		static MethodInfo GetBlockProxyAttributeMethod (MethodInfo method, int parameter)
+		static MethodInfo GetBlockProxyAttributeMethod (MethodInfo method, uint parameter)
 		{
 			var attrs = method.GetParameters () [parameter].GetCustomAttributes (typeof (BlockProxyAttribute), true);
 			if (attrs.Length == 1) {
@@ -840,7 +840,7 @@ namespace ObjCRuntime {
 #else
 		public 
 #endif
-		static MethodInfo GetBlockWrapperCreator (MethodInfo method, int parameter)
+		static MethodInfo GetBlockWrapperCreator (MethodInfo method, uint parameter)
 		{
 			// A mirror of this method is also implemented in StaticRegistrar:FindBlockProxyCreatorMethod
 			// If this method is changed, that method will probably have to be updated too (tests!!!)


### PR DESCRIPTION
We want to enable the -Wconversion but that will raise too many warning
for a single commit. We are enabiling one by one the flags included in
-Wconversion so that we have smaller diffs.

-Wshorten-64-to-32 adds warnings when there is a implicit conversion that
loses integer precision. We are moving all the 32 to 64 conversions to
use 64. Expecially since most of the code changed is related with sizes,
lengths and params counts that are never going to be negative.