### PR TITLE
Remove redundant class_ptr initialization

### DIFF
--- a/src/AppKit/NSApplication.cs
+++ b/src/AppKit/NSApplication.cs
@@ -37,10 +37,6 @@ namespace AppKit {
 
 		private static Thread mainThread;
 
-		static NSApplication () {
-			class_ptr = Class.GetHandle ("NSApplication");
-		}
-
 		[DllImport (Constants.AppKitLibrary)]
 		extern static int /* int */ NSApplicationMain (int /* int */ argc, string [] argv);
 


### PR DESCRIPTION
This is already done by the generated code, as seen below.

```csharp
static NSApplication()
{
...
selWindowWithWindowNumber_Handle = Selector.GetHandle ("windowWithWindowNumber:");
selWindowsHandle = Selector.GetHandle ("windows");
selWindowsMenuHandle = Selector.GetHandle ("windowsMenu");
class_ptr = Class.GetHandle ("NSApplication");
class_ptr = Class.GetHandle ("NSApplication");
}
```

With this change, we've also removed the static constructor, therefore all the fields are going to be initialized when they are used, as opposed to being forcefully loaded on the first access. This may improve startup times