### PR TITLE
[d16-5] Update APIDIFF_REFERENCES to current stable

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -31,7 +31,7 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 
 include $(TOP)/Make.versions
 
-APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode11.1/e37549bc9052bff81d5c7da8a3b7992b47a08154/29/package/bundle.zip
+APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode11.2/a82239687c7c498844137779ee529154f260cb6f/48/package/bundle.zip
 
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 


### PR DESCRIPTION


Backport of #7372.

/cc @VincentDondain 