### PR TITLE
[xcode11.3] [Tests] Fix introspection failing due to a typo.

### DIFF
--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -180,6 +180,7 @@ namespace Introspection
 			"Descendents",
 			"Descrete",
 			"Dhe", // Diffie–Hellman key exchange
+			"Diffable", // that you can diff it.. made up word from apple
 			"Differental",
 			"Diffie",
 			"Directionfor",


### PR DESCRIPTION
Fixes: https://github.com/xamarin/maccore/issues/2052

Backport of #7369.

/cc @mandel-macaque 