### PR TITLE
[xcode11.3] [Install] Do not crash when the directory is not found.

### DIFF
--- a/tools/install-source/Program.cs
+++ b/tools/install-source/Program.cs
@@ -275,12 +275,18 @@ public class ListSourceFiles {
 				}
 				try {
 					File.Copy (fixedSource, target);
-				} catch (FileNotFoundException e) { 
+				} catch (FileNotFoundException e) {
 					Console.WriteLine ("The file {0} could not be copied to {1} because the file does not exists: {2}", fixedSource, target, e);
 					Console.WriteLine ("Debugging info:");
 					Console.WriteLine ("\tSource is {0}", src);
 					Console.WriteLine ("\tFixed source is {0}", fixedSource);
-					Console.WriteLine ("\tPath mangler type is {0}", mangler.GetType().Name);
+					Console.WriteLine ("\tPath mangler type is {0}", mangler.GetType ().Name);
+				} catch (DirectoryNotFoundException e) {
+					Console.WriteLine ("The file {0} could not be copied to {1} because the dir does not exists: {2}", fixedSource, target, e);
+					Console.WriteLine ("Debugging info:");
+					Console.WriteLine ("\tSource is {0}", src);
+					Console.WriteLine ("\tFixed source is {0}", fixedSource);
+					Console.WriteLine ("\tPath mangler type is {0}", mangler.GetType ().Name);
 				} catch (PathTooLongException e) {
 					Console.WriteLine ("The file {0} could not be copied to {1} because the file path is too long: {2}", fixedSource, target, e);
 					return 1;


### PR DESCRIPTION
This is NOT a fix for https://github.com/xamarin/maccore/issues/2053 but
a nice thing to have to make sure that when the file cannot be copied we
have a useful debugging message. Fixing
https://github.com/xamarin/maccore/issues/2053 should be done in the
path mangler that is doing something wrong with the paths.

Backport of #7378.

/cc @mandel-macaque 