### PR TITLE
[xcode11.3] [Install] Ensure that sources from mono are included when building from source.

### DIFF
--- a/tools/install-source/PathManglerFactory.cs
+++ b/tools/install-source/PathManglerFactory.cs
@@ -82,6 +82,10 @@ namespace InstallSources
 					Console.WriteLine($"Mono path is {monoPath}");
 				return File.Exists(monoPath);
 			}
+			// check if the path is the xamarin source path + the mono external submodule
+			var monoSubmodule = Path.Combine (XamarinSourcePath.Replace ("src/", ""), "external", "mono");
+			if (path.StartsWith (monoSubmodule, StringComparison.Ordinal))
+				return true;
 			if (path.StartsWith (XamarinSourcePath, StringComparison.Ordinal))
 				return false;
 			var xamarinRuntimePath = XamarinSourcePath.Replace($"/{srcSubPath}/", $"/{runtimeSubPath}/");


### PR DESCRIPTION
The PathManglerFactory was getting confused when building mono from
source again and since it did not find the sources in the download
directory it considered that the path to modify was part of Xamarin.

Now the factory tests first if we are getting a path from the mono
external submodule, if that is the case we know is a mono path and do
the right thing.

Fixes https://github.com/xamarin/maccore/issues/2053

Backport of #7385.

/cc @mandel-macaque 