### PR TITLE
[CoreFoundation] Add Clone method for CFArray.

### DIFF
--- a/src/CoreFoundation/CFArray.cs
+++ b/src/CoreFoundation/CFArray.cs
@@ -35,6 +35,8 @@ using Foundation;
 using ObjCRuntime;
 
 using CFIndex = System.nint;
+using CFArrayRef = System.IntPtr;
+using CFAllocatorRef = System.IntPtr;
 
 namespace CoreFoundation {
 	
@@ -149,6 +151,11 @@ namespace CoreFoundation {
 		{
 			return CFArrayGetCount (array);
 		}
+
+		[DllImport (Constants.CoreFoundationLibrary)]
+		extern static CFArrayRef CFArrayCreateCopy (CFAllocatorRef allocator, CFArrayRef theArray);
+
+		public CFArray Clone () => new CFArray (CFArrayCreateCopy (IntPtr.Zero, this.Handle), true);
 	}
 }
 

--- a/tests/xtro-sharpie/common-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/common-CoreFoundation.ignore
@@ -334,7 +334,6 @@
 !missing-pinvoke! CFArrayApplyFunction is not bound
 !missing-pinvoke! CFArrayBSearchValues is not bound
 !missing-pinvoke! CFArrayContainsValue is not bound
-!missing-pinvoke! CFArrayCreateCopy is not bound
 !missing-pinvoke! CFArrayCreateMutable is not bound
 !missing-pinvoke! CFArrayCreateMutableCopy is not bound
 !missing-pinvoke! CFArrayExchangeValuesAtIndices is not bound


### PR DESCRIPTION
When working on https://github.com/xamarin/maccore/issues/940 we noticed
that clone the array would be a better approach.

The CFArrayCreateCopy add some nice things:

* The pointer values from theArray are copied into the new array.
* The values are also retained by the new array.
* The count of the new array is the same as theArray
* The new array uses the same callbacks as theArray. [IMPORTANT]

With this in, we can have a better fix for https://github.com/xamarin/maccore/issues/940