### PR TITLE
[Runtime] Enable the -Wsign-conversion warnings flag and fix some of the warnings.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -190,7 +190,7 @@ IOS_CXX=$(XCODE_CXX)
 SIMULATOR_BIN_PATH=$(XCODE_DEVELOPER_ROOT)/Platforms/iPhoneSimulator.platform/Developer/usr/bin
 SIMULATOR_CC=$(IOS_CC)
 
-CFLAGS= -Wall -fms-extensions -Wno-format-security -Wsign-compare -Wshorten-64-to-32
+CFLAGS= -Wall -fms-extensions -Wno-format-security -Wsign-compare -Wshorten-64-to-32 -Wsign-conversion
 
 ifdef ENABLE_BITCODE_ON_IOS
 BITCODE_CFLAGS=-fembed-bitcode-marker

--- a/runtime/mono-runtime.h.t4
+++ b/runtime/mono-runtime.h.t4
@@ -30,7 +30,7 @@ typedef guint    (*GHashFunc)      (gconstpointer key);
 typedef gboolean (*GEqualFunc)     (gconstpointer a, gconstpointer b);
 
 #ifndef GPOINTER_TO_INT
-#define GPOINTER_TO_INT(p) ((int)  (long) (p))
+#define GPOINTER_TO_INT(p) ((uint32_t)  (long) (p))
 #endif
 
 #ifndef GINT_TO_POINTER

--- a/runtime/mono-runtime.h.t4
+++ b/runtime/mono-runtime.h.t4
@@ -29,8 +29,8 @@ typedef const void *   gconstpointer;
 typedef guint    (*GHashFunc)      (gconstpointer key);
 typedef gboolean (*GEqualFunc)     (gconstpointer a, gconstpointer b);
 
-#ifndef GPOINTER_TO_INT
-#define GPOINTER_TO_INT(p) ((uint32_t)  (long) (p))
+#ifndef GPOINTER_TO_UINT
+#define GPOINTER_TO_UINT(p) ((uint32_t)  (long) (p))
 #endif
 
 #ifndef GINT_TO_POINTER

--- a/runtime/monotouch-debug.m
+++ b/runtime/monotouch-debug.m
@@ -9,6 +9,10 @@
 // Copyright 2011-2013 Xamarin Inc. 
 //
 
+// TODO: temp ignore to minimize diff
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
+
 #ifdef DEBUG
 
 //#define LOG_HTTP(...) do { NSLog (@ __VA_ARGS__); } while (0);
@@ -747,7 +751,7 @@ static gboolean send_uninterrupted (int fd, const void *buf, int len)
 
 static int recv_uninterrupted (int fd, void *buf, int len)
 {
-	long res;
+	ssize_t res;
 	int total = 0;
 	int flags = 0;
 
@@ -1723,3 +1727,5 @@ xamarin_is_native_debugger_attached ()
 int xamarin_fix_ranlib_warning_about_no_symbols_v2;
 #endif /* DEBUG */
 
+
+#pragma clang diagnostic pop

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -28,6 +28,9 @@
 #include "../tools/mtouch/monotouch-fixes.c"
 #endif
 
+// TODO: temp ignore to minimize diff
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
 static unsigned char *
 xamarin_load_aot_data (MonoAssembly *assembly, int size, gpointer user_data, void **out_handle)
 {
@@ -493,3 +496,5 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 	
 	return rv;
 }
+
+#pragma clang diagnostic pop

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -17,6 +17,10 @@
 #include "runtime-internal.h"
 #include "xamarin/xamarin.h"
 
+// TODO: temp ignore to minimize diff
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
+
 #if defined (DEBUG)
 //extern BOOL NSZombieEnabled;
 #endif
@@ -2892,3 +2896,5 @@ xamarin_is_managed_exception_marshaling_disabled ()
 	return handle;
 }
 @end
+
+#pragma clang diagnostic pop

--- a/runtime/shared.m
+++ b/runtime/shared.m
@@ -245,7 +245,7 @@ xamarin_dispose_helper (void *a)
 	// COOP: this method is executed by the ObjC runtime when a block must be freed.
 	// COOP: it does not touch any managed memory (except to free a gchandle), so any mode goes.
 	struct Block_literal *bl = (struct Block_literal *) a;
-	int handle = GPOINTER_TO_INT (bl->global_handle);
+	uint32_t handle = GPOINTER_TO_INT (bl->global_handle);
 	mono_gchandle_free (handle);
 	bl->global_handle = GINT_TO_POINTER (-1);
 	if (atomic_fetch_sub (&bl->descriptor->ref_count, 1) == 0) {

--- a/runtime/shared.m
+++ b/runtime/shared.m
@@ -245,7 +245,7 @@ xamarin_dispose_helper (void *a)
 	// COOP: this method is executed by the ObjC runtime when a block must be freed.
 	// COOP: it does not touch any managed memory (except to free a gchandle), so any mode goes.
 	struct Block_literal *bl = (struct Block_literal *) a;
-	uint32_t handle = GPOINTER_TO_INT (bl->global_handle);
+	uint32_t handle = GPOINTER_TO_UINT (bl->global_handle);
 	mono_gchandle_free (handle);
 	bl->global_handle = GINT_TO_POINTER (-1);
 	if (atomic_fetch_sub (&bl->descriptor->ref_count, 1) == 0) {
@@ -263,7 +263,7 @@ xamarin_copy_helper (void *dst, void *src)
 	struct Block_literal *target = (struct Block_literal *) dst;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wint-to-void-pointer-cast"
-	target->global_handle = GINT_TO_POINTER (mono_gchandle_new (mono_gchandle_get_target (GPOINTER_TO_INT (source->local_handle)), FALSE));
+	target->global_handle = GINT_TO_POINTER (mono_gchandle_new (mono_gchandle_get_target (GPOINTER_TO_UINT (source->local_handle)), FALSE));
 #pragma clang diagnostic pop
 
 	atomic_fetch_add (&source->descriptor->ref_count, 1);

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -12,6 +12,9 @@
 #include "delegates.h"
 #include "product.h"
 
+// TODO: temp ignore to minimize diff
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
 static guint32
 xamarin_get_exception_for_method (int code, guint32 inner_exception_gchandle, const char *reason, SEL sel, id self)
 {
@@ -675,3 +678,5 @@ exception_handling:
 		xamarin_process_managed_exception (exception);
 	}
 }
+
+#pragma clang diagnostic pop

--- a/runtime/trampolines-varargs.m
+++ b/runtime/trampolines-varargs.m
@@ -1,3 +1,7 @@
+// TODO: temp ignore to minimize diff
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
+
 #if !defined (__i386__) && !defined (__x86_64__) && !(defined (__arm64__) && !defined(__ILP32__))
 #define __VARARGS_TRAMPOLINES__ 1
 #endif
@@ -17,6 +21,7 @@
 #include "xamarin/runtime.h"
 #include "runtime-internal.h"
 #include "trampolines-varargs.h"
+
 
 #ifdef TRACE
 static void
@@ -320,3 +325,5 @@ xamarin_static_stret_trampoline (void *buffer, id self, SEL sel, ...)
 }
 
 #endif /* __VARARGS_TRAMPOLINES__ */
+
+#pragma clang diagnostic pop

--- a/runtime/trampolines-x86_64.m
+++ b/runtime/trampolines-x86_64.m
@@ -1,4 +1,8 @@
 
+// TODO: temp ignore to minimize diff
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
+
 #if defined(__x86_64__)
 
 #include <stdint.h>
@@ -494,3 +498,5 @@ xamarin_arch_trampoline (struct XamarinCallState *state)
 }
 
 #endif /* __x86_64__ */
+
+#pragma clang diagnostic pop

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -762,7 +762,7 @@ xamarin_get_gchandle_trampoline (id self, SEL sel)
 	int gc_handle = 0;
 	pthread_mutex_lock (&gchandle_hash_lock);
 	if (gchandle_hash != NULL)
-		gc_handle = GPOINTER_TO_INT (CFDictionaryGetValue (gchandle_hash, self));
+		gc_handle = GPOINTER_TO_UINT (CFDictionaryGetValue (gchandle_hash, self));
 	pthread_mutex_unlock (&gchandle_hash_lock);
 	return gc_handle;
 }
@@ -1395,7 +1395,7 @@ xamarin_get_managed_to_nsvalue_func (MonoClass *managedType, MonoMethod *method,
 void *
 xamarin_smart_enum_to_nsstring (MonoObject *value, void *context /* token ref */, guint32 *exception_gchandle)
 {
-	guint32 context_ref = GPOINTER_TO_INT (context);
+	guint32 context_ref = GPOINTER_TO_UINT (context);
 	if (context_ref == INVALID_TOKEN_REF) {
 		// This requires the dynamic registrar to invoke the correct conversion function
 		int handle = mono_gchandle_new (value, FALSE);
@@ -1432,7 +1432,7 @@ xamarin_smart_enum_to_nsstring (MonoObject *value, void *context /* token ref */
 void *
 xamarin_nsstring_to_smart_enum (id value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle)
 {
-	guint32 context_ref = GPOINTER_TO_INT (context);
+	guint32 context_ref = GPOINTER_TO_UINT (context);
 	int gc_handle = 0;
 	MonoObject *obj;
 
@@ -1441,7 +1441,7 @@ xamarin_nsstring_to_smart_enum (id value, void *ptr, MonoClass *managedType, voi
 		void *rv = xamarin_convert_nsstring_to_smart_enum (value, mono_type_get_object (mono_domain_get (), mono_class_get_type (managedType)), exception_gchandle);
 		if (*exception_gchandle != 0)
 			return ptr;
-		gc_handle = GPOINTER_TO_INT (rv);
+		gc_handle = GPOINTER_TO_UINT (rv);
 		obj = mono_gchandle_get_target (gc_handle);
 	} else {
 		// The static registrar found the correct conversion function, and provided a token ref we can use

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -41,6 +41,9 @@
 #include "runtime-internal.h"
 //#define DEBUG_REF_COUNTING
 
+// TODO: temp ignore to minimize diff
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
 static pthread_mutex_t refcount_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER;
 
 size_t
@@ -1632,3 +1635,5 @@ xamarin_skip_type_name (const char *ptr)
 
 	return ptr;
 }
+
+#pragma clang diagnostic pop

--- a/runtime/xamarin-support.m
+++ b/runtime/xamarin-support.m
@@ -39,7 +39,7 @@ void
 xamarin_log (const unsigned short *unicodeMessage)
 {
 	// COOP: no managed memory access: any mode.
-	int length = 0;
+	unsigned int length = 0;
 	const unsigned short *ptr = unicodeMessage;
 	while (*ptr++)
 		length += sizeof (unsigned short);
@@ -47,7 +47,7 @@ xamarin_log (const unsigned short *unicodeMessage)
 
 #if TARGET_OS_WATCH && defined (__arm__) // maybe make this configurable somehow?
 	const char *utf8 = [msg UTF8String];
-	int len = strlen (utf8);
+	size_t len = strlen (utf8);
 	fwrite (utf8, 1, len, stdout);
 	if (len == 0 || utf8 [len - 1] != '\n')
 		fwrite ("\n", 1, 1, stdout);

--- a/tools/mtouch/monotouch-fixes.c
+++ b/tools/mtouch/monotouch-fixes.c
@@ -80,7 +80,7 @@ patch_sigaction ()
 	}
 
 	// allocate executable memory
-	uint64_t pagesize = getpagesize ();
+	uint64_t pagesize = (uint64_t) getpagesize ();
 	void *exec = mmap (NULL, pagesize, PROT_EXEC | PROT_WRITE | PROT_READ, MAP_ANON | MAP_PRIVATE, -1, 0);
 	if (exec == NULL) {
 		fprintf (stderr, "MonoTouch: Could not allocate memory for sigaction override: %s\n", strerror (errno));


### PR DESCRIPTION
The flag adds a lot (A LOT) of warnings. The diff would be huge and
dangerous to review. We enable the flag and fix file by file.