### PR TITLE
[xcode11.2] [Packaging] Ensure that when we build from source,  the srcs go to the correct place.

### DIFF
--- a/tools/install-source/InstallSourcesTests/MonoPathManglerTest.cs
+++ b/tools/install-source/InstallSourcesTests/MonoPathManglerTest.cs
@@ -19,10 +19,11 @@ namespace InstallSourcesTests
 			monoPath = "/Users/test/xamarin-macios/external/mono/";
 			installDir = "/Users/test/xamarin-macios/_ios-build//Library/Frameworks/Xamarin.iOS.framework/Versions/git";
 			destinationDir = "/Users/test/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git";
-			mangler = new MonoPathMangler { 
+			mangler = new MonoPathMangler {
 				InstallDir = installDir,
 				MonoSourcePath = monoPath,
 				DestinationDir = destinationDir,
+				XamarinSourcePath = "/Users/test/xamarin-macios/src",
 			};
 		}
 

--- a/tools/install-source/MonoPathMangler.cs
+++ b/tools/install-source/MonoPathMangler.cs
@@ -7,6 +7,9 @@ namespace InstallSources
 	{
 		public static readonly string iOSFramework = "/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/src/Xamarin.iOS/";
 		public static readonly string MacFramework = "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/";
+		string monoSubmodulePath;
+		string xamarinSourcePath;
+
 		/// <summary>
 		/// Gets and sets the location of the mono sources.
 		/// </summary>
@@ -20,10 +23,27 @@ namespace InstallSources
 		public string DestinationDir { get; set; }
 
 		/// <summary>
+		/// Gets and sets the path to the xamarin source.
+		/// </summary>
+		/// <value>The xamarin source path.</value>
+		public string XamarinSourcePath {
+			get {
+				return xamarinSourcePath;
+			}
+			set {
+				xamarinSourcePath = value;
+				monoSubmodulePath = Path.Combine (value.Replace ("src/", ""), "external", "mono") + "/";
+			}
+		}
+
+		/// <summary>
 		/// Gets or sets the install dir.
 		/// </summary>
 		/// <value>The install dir.</value>
 		public string InstallDir { get; set; }
+
+		bool IsCheckout (string path)
+			=> path.StartsWith (monoSubmodulePath, StringComparison.Ordinal);
 
 		public string GetSourcePath (string path)
 		{
@@ -40,7 +60,7 @@ namespace InstallSources
 
 		public string GetTargetPath (string path)
 		{
-			var relativePath = path.Substring (MonoSourcePath.Length);
+			var relativePath = path.Substring (IsCheckout (path) ? monoSubmodulePath.Length : MonoSourcePath.Length);
 			if (relativePath.StartsWith ("/", StringComparison.Ordinal))
 				relativePath = relativePath.Remove (0, 1);
 			var target = Path.Combine (DestinationDir, "src", (InstallDir.Contains("Xamarin.iOS")?"Xamarin.iOS":"Xamarin.Mac"), relativePath);

--- a/tools/install-source/PathManglerFactory.cs
+++ b/tools/install-source/PathManglerFactory.cs
@@ -28,7 +28,8 @@ namespace InstallSources
 					monoMangler = new MonoPathMangler {
 						InstallDir = InstallDir,
 						DestinationDir = DestinationDir,
-						MonoSourcePath = MonoSourcePath
+						MonoSourcePath = MonoSourcePath,
+						XamarinSourcePath = XamarinSourcePath,
 					};
 				return monoMangler;
 			}


### PR DESCRIPTION
When building from source, the install-sources command was not moving
the files correctly. This change makes sure that, if we build from
source, we do add the mono sources in the correct location.

Fixes: https://github.com/xamarin/xamarin-macios/issues/7393

Backport of #7394.

/cc @mandel-macaque 