### PR TITLE
[d16-4] [Tests] If we have server errors. Mark test as inconclusive.

### DIFF
--- a/tests/linker/mac/LinkAnyTest.cs
+++ b/tests/linker/mac/LinkAnyTest.cs
@@ -31,7 +31,7 @@ namespace LinkAnyTest {
 		{
 			// do not use GetStringAsync, we are going to miss useful data, such as the resul code
 			using (var client = new HttpClient ()) {
-				HttpResponseMessage response = await client.GetAsync ("http://msdn.microsoft.com"); 
+				HttpResponseMessage response = await client.GetAsync ("http://example.com"); 
 				if(!response.IsSuccessStatusCode) {
 					requestError = true;
 					statusCode = response.StatusCode;

--- a/tests/linker/mac/LinkAnyTest.cs
+++ b/tests/linker/mac/LinkAnyTest.cs
@@ -21,15 +21,27 @@ namespace LinkAnyTest {
 		}
 
 		static bool waited;
+		static bool requestError;
+		static HttpStatusCode statusCode;
+
+
 		// http://blogs.msdn.com/b/csharpfaq/archive/2012/06/26/understanding-a-simple-async-program.aspx
 		// ref: https://bugzilla.xamarin.com/show_bug.cgi?id=7114
 		static async Task GetWebPageAsync ()
 		{
-			Task<string> getWebPageTask = new HttpClient ().GetStringAsync ("http://msdn.microsoft.com");
-			string content = await getWebPageTask;
-			waited = true;
-			bool success = !String.IsNullOrEmpty (content);
-			Assert.IsTrue (success, $"received {content.Length} bytes");
+			// do not use GetStringAsync, we are going to miss useful data, such as the resul code
+			using (var client = new HttpClient ()) {
+				HttpResponseMessage response = await client.GetAsync ("http://msdn.microsoft.com"); 
+				if(!response.IsSuccessStatusCode) {
+					requestError = true;
+					statusCode = response.StatusCode;
+				} else {
+					string content = await response.Content.ReadAsStringAsync ();
+					waited = true;
+					bool success = !String.IsNullOrEmpty (content);
+					Assert.IsTrue (success, $"received {content.Length} bytes");
+				}
+			}
 		}
 
 		[Test]
@@ -40,7 +52,11 @@ namespace LinkAnyTest {
 				// we do not want the async code to get back to the AppKit thread, hanging the process
 				SynchronizationContext.SetSynchronizationContext (null);
 				GetWebPageAsync ().Wait ();
-				Assert.IsTrue (waited, "async/await worked");
+				if (requestError) {
+					Assert.Inconclusive ($"Test cannot be trusted. Issues performing the request. Status code '{statusCode}'");
+				} else {
+					Assert.IsTrue (waited, "async/await worked");
+				}
 			} finally {
 				SynchronizationContext.SetSynchronizationContext (current_sc);
 			}


### PR DESCRIPTION
If we are getting errors (500,401..) do not mark a link all test as a
failure, but as inconclusive.

Fixes: https://github.com/xamarin/maccore/issues/2056

Backport of #7401.

/cc @mandel-macaque 