### PR TITLE
[Tests] Centralized the endpoints for the different network tests.

### DIFF
--- a/tests/monotouch-test/AVFoundation/AVAssetDownloadUrlSessionTests.cs
+++ b/tests/monotouch-test/AVFoundation/AVAssetDownloadUrlSessionTests.cs
@@ -53,33 +53,33 @@ namespace monotouchtest {
 			}
 		}
 
-		// FIXME: Disabling this test from now, will reenable once apple releases docs on what is ecpected to have this entitlement key
-		// Reason: Creating an AVAssetDownloadURLSession requires the com.apple.developer.media-asset-download entitlement
-		//		[Test]
-		//		public void AVAssetDownloadUrlSessionNotSupported ()
-		//		{
-		//			if (!TestRuntime.CheckSystemAndSDKVersion (9, 0))
-		//				Assert.Ignore ("Ignoring AVAssetDownloadUrlSession tests: Requires iOS9+");
-		//
-		//			var session = AVAssetDownloadUrlSession.CreateSession (NSUrlSessionConfiguration.BackgroundSessionConfiguration ("XamFoo"), null, null);
-		//
-		//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrlRequest ()), "CreateDataTask should throw NotSupportedException");
-		//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrl (NetworkResources.MicrosoftUrl)), "CreateDataTask should throw NotSupportedException");
-		//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSUrl (NetworkResources.MicrosoftUrl)), "CreateUploadTask should throw NotSupportedException");
-		//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSData ()), "CreateUploadTask should throw NotSupportedException");
-		//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest ()), "CreateUploadTask should throw NotSupportedException");
-		//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrlRequest ()), "CreateDownloadTask should throw NotSupportedException");
-		//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrl (NetworkResources.MicrosoftUrl)), "CreateDownloadTask should throw NotSupportedException");
-		//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSData ()), "CreateDownloadTask should throw NotSupportedException");
-		//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrlRequest (), (data, response, error) => {}), "CreateDataTask should throw NotSupportedException");
-		//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrl (NetworkResources.MicrosoftUrl), (data, response, error) => {}), "CreateDataTask should throw NotSupportedException");
-		//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSUrl (NetworkResources.MicrosoftUrl), (data, response, error) => {}), "CreateUploadTask should throw NotSupportedException");
-		//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSData (), (data, response, error) => {}), "CreateUploadTask should throw NotSupportedException");
-		//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrlRequest (), (NSUrl location, NSUrlResponse response, NSError error) => {}), "CreateDownloadTask should throw NotSupportedException");
-		//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrl (NetworkResources.MicrosoftUrl), (NSUrl location, NSUrlResponse response, NSError error) => {}), "CreateDownloadTask should throw NotSupportedException");
-		//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTaskFromResumeData (new NSData (), (NSUrl location, NSUrlResponse response, NSError error) => {}), "CreateDownloadTask should throw NotSupportedException");
-		//
-		//		}
+// FIXME: Disabling this test from now, will reenable once apple releases docs on what is ecpected to have this entitlement key
+// Reason: Creating an AVAssetDownloadURLSession requires the com.apple.developer.media-asset-download entitlement
+//		[Test]
+//		public void AVAssetDownloadUrlSessionNotSupported ()
+//		{
+//			if (!TestRuntime.CheckSystemAndSDKVersion (9, 0))
+//				Assert.Ignore ("Ignoring AVAssetDownloadUrlSession tests: Requires iOS9+");
+//
+//			var session = AVAssetDownloadUrlSession.CreateSession (NSUrlSessionConfiguration.BackgroundSessionConfiguration ("XamFoo"), null, null);
+//
+//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrlRequest ()), "CreateDataTask should throw NotSupportedException");
+//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrl (NetworkResources.MicrosoftUrl)), "CreateDataTask should throw NotSupportedException");
+//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSUrl (NetworkResources.MicrosoftUrl)), "CreateUploadTask should throw NotSupportedException");
+//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSData ()), "CreateUploadTask should throw NotSupportedException");
+//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest ()), "CreateUploadTask should throw NotSupportedException");
+//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrlRequest ()), "CreateDownloadTask should throw NotSupportedException");
+//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrl (NetworkResources.MicrosoftUrl)), "CreateDownloadTask should throw NotSupportedException");
+//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSData ()), "CreateDownloadTask should throw NotSupportedException");
+//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrlRequest (), (data, response, error) => {}), "CreateDataTask should throw NotSupportedException");
+//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrl (NetworkResources.MicrosoftUrl), (data, response, error) => {}), "CreateDataTask should throw NotSupportedException");
+//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSUrl (NetworkResources.MicrosoftUrl), (data, response, error) => {}), "CreateUploadTask should throw NotSupportedException");
+//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSData (), (data, response, error) => {}), "CreateUploadTask should throw NotSupportedException");
+//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrlRequest (), (NSUrl location, NSUrlResponse response, NSError error) => {}), "CreateDownloadTask should throw NotSupportedException");
+//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrl (NetworkResources.MicrosoftUrl), (NSUrl location, NSUrlResponse response, NSError error) => {}), "CreateDownloadTask should throw NotSupportedException");
+//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTaskFromResumeData (new NSData (), (NSUrl location, NSUrlResponse response, NSError error) => {}), "CreateDownloadTask should throw NotSupportedException");
+//
+//		}
 	}
 }
 

--- a/tests/monotouch-test/AVFoundation/AVAssetDownloadUrlSessionTests.cs
+++ b/tests/monotouch-test/AVFoundation/AVAssetDownloadUrlSessionTests.cs
@@ -21,6 +21,7 @@ using MonoTouch.Foundation;
 using MonoTouch.AVFoundation;
 #endif
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
 
 namespace monotouchtest {
 	[TestFixture]
@@ -54,31 +55,31 @@ namespace monotouchtest {
 
 		// FIXME: Disabling this test from now, will reenable once apple releases docs on what is ecpected to have this entitlement key
 		// Reason: Creating an AVAssetDownloadURLSession requires the com.apple.developer.media-asset-download entitlement
-//		[Test]
-//		public void AVAssetDownloadUrlSessionNotSupported ()
-//		{
-//			if (!TestRuntime.CheckSystemAndSDKVersion (9, 0))
-//				Assert.Ignore ("Ignoring AVAssetDownloadUrlSession tests: Requires iOS9+");
-//
-//			var session = AVAssetDownloadUrlSession.CreateSession (NSUrlSessionConfiguration.BackgroundSessionConfiguration ("XamFoo"), null, null);
-//
-//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrlRequest ()), "CreateDataTask should throw NotSupportedException");
-//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrl ("http://google.com")), "CreateDataTask should throw NotSupportedException");
-//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSUrl ("http://google.com")), "CreateUploadTask should throw NotSupportedException");
-//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSData ()), "CreateUploadTask should throw NotSupportedException");
-//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest ()), "CreateUploadTask should throw NotSupportedException");
-//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrlRequest ()), "CreateDownloadTask should throw NotSupportedException");
-//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrl ("http://google.com")), "CreateDownloadTask should throw NotSupportedException");
-//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSData ()), "CreateDownloadTask should throw NotSupportedException");
-//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrlRequest (), (data, response, error) => {}), "CreateDataTask should throw NotSupportedException");
-//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrl ("http://google.com"), (data, response, error) => {}), "CreateDataTask should throw NotSupportedException");
-//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSUrl ("http://google.com"), (data, response, error) => {}), "CreateUploadTask should throw NotSupportedException");
-//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSData (), (data, response, error) => {}), "CreateUploadTask should throw NotSupportedException");
-//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrlRequest (), (NSUrl location, NSUrlResponse response, NSError error) => {}), "CreateDownloadTask should throw NotSupportedException");
-//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrl ("http://google.com"), (NSUrl location, NSUrlResponse response, NSError error) => {}), "CreateDownloadTask should throw NotSupportedException");
-//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTaskFromResumeData (new NSData (), (NSUrl location, NSUrlResponse response, NSError error) => {}), "CreateDownloadTask should throw NotSupportedException");
-//
-//		}
+		//		[Test]
+		//		public void AVAssetDownloadUrlSessionNotSupported ()
+		//		{
+		//			if (!TestRuntime.CheckSystemAndSDKVersion (9, 0))
+		//				Assert.Ignore ("Ignoring AVAssetDownloadUrlSession tests: Requires iOS9+");
+		//
+		//			var session = AVAssetDownloadUrlSession.CreateSession (NSUrlSessionConfiguration.BackgroundSessionConfiguration ("XamFoo"), null, null);
+		//
+		//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrlRequest ()), "CreateDataTask should throw NotSupportedException");
+		//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrl (NetworkResources.MicrosoftUrl)), "CreateDataTask should throw NotSupportedException");
+		//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSUrl (NetworkResources.MicrosoftUrl)), "CreateUploadTask should throw NotSupportedException");
+		//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSData ()), "CreateUploadTask should throw NotSupportedException");
+		//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest ()), "CreateUploadTask should throw NotSupportedException");
+		//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrlRequest ()), "CreateDownloadTask should throw NotSupportedException");
+		//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrl (NetworkResources.MicrosoftUrl)), "CreateDownloadTask should throw NotSupportedException");
+		//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSData ()), "CreateDownloadTask should throw NotSupportedException");
+		//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrlRequest (), (data, response, error) => {}), "CreateDataTask should throw NotSupportedException");
+		//			Assert.Throws <NotSupportedException> (() => session.CreateDataTask (new NSUrl (NetworkResources.MicrosoftUrl), (data, response, error) => {}), "CreateDataTask should throw NotSupportedException");
+		//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSUrl (NetworkResources.MicrosoftUrl), (data, response, error) => {}), "CreateUploadTask should throw NotSupportedException");
+		//			Assert.Throws <NotSupportedException> (() => session.CreateUploadTask (new NSUrlRequest (), new NSData (), (data, response, error) => {}), "CreateUploadTask should throw NotSupportedException");
+		//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrlRequest (), (NSUrl location, NSUrlResponse response, NSError error) => {}), "CreateDownloadTask should throw NotSupportedException");
+		//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTask (new NSUrl (NetworkResources.MicrosoftUrl), (NSUrl location, NSUrlResponse response, NSError error) => {}), "CreateDownloadTask should throw NotSupportedException");
+		//			Assert.Throws <NotSupportedException> (() => session.CreateDownloadTaskFromResumeData (new NSData (), (NSUrl location, NSUrlResponse response, NSError error) => {}), "CreateDownloadTask should throw NotSupportedException");
+		//
+		//		}
 	}
 }
 

--- a/tests/monotouch-test/CoreFoundation/NetworkTest.cs
+++ b/tests/monotouch-test/CoreFoundation/NetworkTest.cs
@@ -23,6 +23,8 @@ using NUnit.Framework;
 #if !__WATCHOS__
 using PlatformCFNetwork = CoreFoundation.CFNetwork;
 #endif
+using MonoTests.System.Net.Http;
+
 
 namespace MonoTouchFixtures.CoreFoundation {
 	
@@ -64,7 +66,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		public void Bug_7923 ()
 		{
 			// Bug #7923 - crash when proxy is in effect.
-			var uri = new Uri ("http://www.google.com");
+			var uri = NetworkResources.MicrosoftUri;
 
 			if (PlatformCFNetwork.GetProxiesForUri (uri, settings).Length <= 1)
 				Assert.Ignore ("Only run when proxy is configured.");

--- a/tests/monotouch-test/CoreFoundation/ProxyTest.cs
+++ b/tests/monotouch-test/CoreFoundation/ProxyTest.cs
@@ -23,6 +23,8 @@ using MonoTouch.Foundation;
 using MonoTouch.ObjCRuntime;
 #endif
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
+
 
 namespace MonoTouchFixtures.CoreFoundation {
 	
@@ -123,7 +125,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 			string pacPath = Path.Combine (NSBundle.MainBundle.BundlePath, "example.pac");
 			NSError error = null;
 			var script = File.ReadAllText (pacPath);
-			var targetUri = new Uri ("http://docs.xamarin.com");
+			var targetUri = NetworkResources.XamarinUri;
 			var proxies = CFNetwork.ExecuteProxyAutoConfigurationScript (script, targetUri, out error);
 			Assert.IsNull (error, "Null error");
 			Assert.AreEqual (1, proxies.Length, "Length");
@@ -137,7 +139,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 			string pacPath = Path.Combine (NSBundle.MainBundle.BundlePath, "example.pac");
 			NSError error = null;
 			var script = File.ReadAllText (pacPath);
-			var targetUri = new Uri ("http://google.com");
+			var targetUri = NetworkResources.MicrosoftUri;
 			var proxies = CFNetwork.ExecuteProxyAutoConfigurationScript (script, targetUri, out error);
 			Assert.IsNull (error, "Null error");
 			Assert.IsNotNull (proxies, "Not null proxies");
@@ -150,7 +152,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		{
 			NSError error = null;
 			var script = "Not VALID js";
-			var targetUri = new Uri ("http://google.com");
+			var targetUri = NetworkResources.MicrosoftUri;
 			var proxies = CFNetwork.ExecuteProxyAutoConfigurationScript (script, targetUri, out error);
 			Assert.IsNotNull (error, "Not null error");
 			Assert.IsNull (proxies, "Null proxies");
@@ -166,7 +168,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 			string pacPath = Path.Combine (NSBundle.MainBundle.BundlePath, "example.pac");
 
 			var script = File.ReadAllText (pacPath);
-			var targetUri = new Uri ("http://docs.xamarin.com");
+			var targetUri = NetworkResources.XamarinUri;
 			
 			Exception ex;
 			bool foundProxies;
@@ -204,7 +206,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 			string pacPath = Path.Combine (NSBundle.MainBundle.BundlePath, "example.pac");
 
 			var script = File.ReadAllText (pacPath);
-			var targetUri = new Uri ("http://docs.xamarin.com");
+			var targetUri = NetworkResources.XamarinUri;
 
 			Exception ex;
 			bool foundProxies;
@@ -234,7 +236,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		{
 			NSError error;
 			var pacUri = new Uri ($"http://localhost:{port}/example.pac");
-			var targetUri = new Uri ("http://docs.xamarin.com");
+			var targetUri = NetworkResources.XamarinUri;
 			var proxies = CFNetwork.ExecuteProxyAutoConfigurationUrl (pacUri, targetUri, out error);
 			Assert.IsNull (error, "Null error");
 			Assert.AreEqual (1, proxies.Length, "Length");
@@ -247,7 +249,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		{
 			NSError error;
 			var pacUri = new Uri ($"http://localhost:{port}/example.pac");
-			var targetUri = new Uri ("http://google.com");
+			var targetUri = NetworkResources.MicrosoftUri;
 			var proxies = CFNetwork.ExecuteProxyAutoConfigurationUrl (pacUri, targetUri, out error);
 			Assert.IsNull (error, "Null error");
 			Assert.IsNotNull (proxies, "Not null proxies");
@@ -263,7 +265,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 			NSObject cbClient = null;
 			bool done = false;
 			var pacUri = new Uri ($"http://localhost:{port}/example.pac");
-			var targetUri = new Uri ("http://docs.xamarin.com");
+			var targetUri = NetworkResources.XamarinUri;
 
 			Exception ex;
 			bool foundProxies;
@@ -298,7 +300,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 			NSObject cbClient = null;
 			bool done = false;
 			var pacUri = new Uri ($"http://localhost:{port}/example.pac");
-			var targetUri = new Uri ("http://docs.google.com");
+			var targetUri = NetworkResources.MicrosoftUri;
 
 			Exception ex;
 			bool foundProxies;

--- a/tests/monotouch-test/Foundation/NSDataTest.cs
+++ b/tests/monotouch-test/Foundation/NSDataTest.cs
@@ -34,6 +34,7 @@ using nfloat=global::System.Single;
 using nint=global::System.Int32;
 using nuint=global::System.UInt32;
 #endif
+using MonoTests.System.Net.Http;
 
 namespace MonoTouchFixtures.Foundation {
 	
@@ -156,17 +157,9 @@ namespace MonoTouchFixtures.Foundation {
 			}
 #endif
 			// we have network issues, try several urls, if one works, be happy, else fail
-			var urls = new string [] {
-				"https://www.microsoft.com/robots.txt",
-				"https://www.xamarin.com/robots.txt",
-				"http://www.bing.com/robots.txt",
-				"https://www.xbox.com/robots.txt",
-				"https://www.msn.com/robots.txt",
-				"https://visualstudio.microsoft.com/robots.txt",
-			};
-			for (var i = 0; i < urls.Length; i++) {
+			for (var i = 0; i < NetworkResources.RobotsUrls.Length; i++) {
 				NSError error;
-				using (var nsUrl = new NSUrl (urls [i]))
+				using (var nsUrl = new NSUrl (NetworkResources.RobotsUrls [i]))
 				using (var x = NSData.FromUrl (nsUrl, NSDataReadingOptions.Uncached, out error)) {
 					if (error != null)
 						continue;

--- a/tests/monotouch-test/Foundation/UrlConnectionTest.cs
+++ b/tests/monotouch-test/Foundation/UrlConnectionTest.cs
@@ -22,6 +22,8 @@ using MonoTouch.ObjCRuntime;
 using MonoTouch.UIKit;
 #endif
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
+
 
 namespace MonoTouchFixtures.Foundation {
 
@@ -36,7 +38,7 @@ namespace MonoTouchFixtures.Foundation {
 		[Test]
 		public void StartCancel ()
 		{
-			using (var url = new NSUrl ("http://www.google.com"))
+			using (var url = new NSUrl (NetworkResources.MicrosoftUrl))
 			using (var r = new NSUrlRequest (url))
 			using (var d = new MyDelegate ())
 			using (var c = new NSUrlConnection (r, d)) {

--- a/tests/monotouch-test/Foundation/UrlProtocolTest.cs
+++ b/tests/monotouch-test/Foundation/UrlProtocolTest.cs
@@ -26,6 +26,8 @@ using MonoTouch.ObjCRuntime;
 using MonoTouch.UIKit;
 #endif
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
+
 
 namespace MonoTouchFixtures.Foundation {
 	
@@ -144,7 +146,7 @@ namespace MonoTouchFixtures.Foundation {
 				var config = NSUrlSession.SharedSession.Configuration;
 				var session = NSUrlSession.FromConfiguration (config, this, new NSOperationQueue ());
 
-				var task = session.CreateDataTask (new NSUrlRequest (new NSUrl ("https://example.com")));
+				var task = session.CreateDataTask (new NSUrlRequest (new NSUrl (NetworkResources.MicrosoftRobotsUrl)));
 				task.Resume ();
 			}
 			public bool Called_StartLoading;

--- a/tests/monotouch-test/Foundation/UrlSessionTaskTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTaskTest.cs
@@ -22,6 +22,7 @@ using MonoTouch.ObjCRuntime;
 using MonoTouch.UIKit;
 #endif
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
 
 namespace MonoTouchFixtures.Foundation {
 
@@ -82,14 +83,14 @@ namespace MonoTouchFixtures.Foundation {
 				Assert.IsInstanceOfType (typeof (NSUrlSessionDownloadTask), task, "task should be an instance of NSUrlSessionDownloadTask 2");
 			}
 
-			using (var ur = new NSUrl ("https://www.microsoft.com")) {
+			using (var ur = new NSUrl (NetworkResources.MicrosoftUrl)) {
 				NSUrlSessionDownloadTask task = null;
 				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateDownloadTask (ur), "Should not throw InvalidCastException 3");
 				Assert.IsNotNull (task, "task should not be null 3");
 				Assert.IsInstanceOfType (typeof (NSUrlSessionDownloadTask), task, "task should be an instance of NSUrlSessionDownloadTask 3");
 			}
 
-			using (var ur = new NSUrl ("https://www.microsoft.com")) {
+			using (var ur = new NSUrl (NetworkResources.MicrosoftUrl)) {
 				NSUrlSessionDownloadTask task = null;
 				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateDownloadTask (ur, null), "Should not throw InvalidCastException 4");
 				Assert.IsNotNull (task, "task should not be null 4");
@@ -116,14 +117,14 @@ namespace MonoTouchFixtures.Foundation {
 				Assert.IsInstanceOfType (typeof (NSUrlSessionDataTask), task, "task should be an instance of NSUrlSessionDataTask 2");
 			}
 
-			using (var ur = new NSUrl ("https://www.microsoft.com")) {
+			using (var ur = new NSUrl (NetworkResources.MicrosoftUrl)) {
 				NSUrlSessionDataTask task = null;
 				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateDataTask (ur), "Should not throw InvalidCastException 3");
 				Assert.IsNotNull (task, "task should not be null 3");
 				Assert.IsInstanceOfType (typeof (NSUrlSessionDataTask), task, "task should be an instance of NSUrlSessionDataTask 3");
 			}
 
-			using (var ur = new NSUrl ("https://www.microsoft.com")) {
+			using (var ur = new NSUrl (NetworkResources.MicrosoftUrl)) {
 				NSUrlSessionDataTask task = null;
 				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateDataTask (ur, null), "Should not throw InvalidCastException 4");
 				Assert.IsNotNull (task, "task should not be null 4");
@@ -152,7 +153,7 @@ namespace MonoTouchFixtures.Foundation {
 			}
 
 			using (var ur = new NSUrlRequest ())
-			using (var url = new NSUrl ("https://www.microsoft.com")) {
+			using (var url = new NSUrl (NetworkResources.MicrosoftUrl)) {
 				NSUrlSessionUploadTask task = null;
 				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateUploadTask (ur, url), "Should not throw InvalidCastException 3");
 				Assert.IsNotNull (task, "task should not be null 3");
@@ -160,7 +161,7 @@ namespace MonoTouchFixtures.Foundation {
 			}
 
 			using (var ur = new NSUrlRequest ())
-			using (var url = new NSUrl ("https://www.microsoft.com")) {
+			using (var url = new NSUrl (NetworkResources.MicrosoftUrl)) {
 				NSUrlSessionUploadTask task = null;
 				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateUploadTask (ur, url, (data, response, error) => { }), "Should not throw InvalidCastException 4");
 				Assert.IsNotNull (task, "task should not be null 4");

--- a/tests/monotouch-test/Foundation/UrlSessionTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTest.cs
@@ -24,6 +24,7 @@ using MonoTouch.ObjCRuntime;
 using MonoTouch.UIKit;
 #endif
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
 
 namespace MonoTouchFixtures.Foundation {
 
@@ -122,7 +123,7 @@ namespace MonoTouchFixtures.Foundation {
 						// Use the default configuration so we can make use of the shared cookie storage.
 						var session = NSUrlSession.FromConfiguration (NSUrlSessionConfiguration.DefaultSessionConfiguration);
 
-						var downloadUri = new Uri ("https://google.com");
+						var downloadUri = NetworkResources.MicrosoftUri;
 						var downloadResponse = await session.CreateDownloadTaskAsync (downloadUri);
 
 						var tempLocation = downloadResponse.Location;

--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -15,6 +15,7 @@ using Foundation;
 using MediaAccessibility;
 using ObjCRuntime;
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
 
 namespace MonoTouchFixtures.MediaAccessibility {
 
@@ -28,7 +29,7 @@ namespace MonoTouchFixtures.MediaAccessibility {
 		{
 			TestRuntime.AssertXcodeVersion (11, 0);
 			Assert.Throws<ArgumentNullException> (() => MAImageCaptioning.GetCaption (null, out _));
-			using (NSUrl url = new NSUrl ("https://microsoft.com")) {
+			using (NSUrl url = new NSUrl (NetworkResources.MicrosoftUrl)) {
 				var s = MAImageCaptioning.GetCaption (url, out var e);
 				Assert.Null (s, "remote / return value");
 				Assert.Null (e, "remote / no error"); // weird should be an "image on disk"

--- a/tests/monotouch-test/Network/NWConnectionTest.cs
+++ b/tests/monotouch-test/Network/NWConnectionTest.cs
@@ -16,6 +16,8 @@ using MonoTouch.Security;
 #endif
 
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
+
 
 namespace MonoTouchFixtures.Network {
 
@@ -48,7 +50,7 @@ namespace MonoTouchFixtures.Network {
 		{
 			// connect and once the connection is done, deal with the diff tests
 			connectedEvent = new AutoResetEvent(false);
-			host = "www.google.com";
+			host = NetworkResources.MicrosoftUri.Host;
 			// we create a connection which we are going to use to get the availabe
 			// interfaces, that way we can later test protperties of the NWParameters class.
 			using (var parameters = NWParameters.CreateUdp ())

--- a/tests/monotouch-test/Network/NWEstablishmentReportTest.cs
+++ b/tests/monotouch-test/Network/NWEstablishmentReportTest.cs
@@ -16,6 +16,8 @@ using MonoTouch.Security;
 #endif
 
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
+
 
 namespace MonoTouchFixtures.Network {
 
@@ -49,7 +51,7 @@ namespace MonoTouchFixtures.Network {
 			// connect so that we can later when the report and test with it
 			connectedEvent = new AutoResetEvent(false);
 			reportEvent = new AutoResetEvent (false);
-			host = "www.google.com";
+			host = NetworkResources.MicrosoftUri.Host;
 			// we create a connection which we are going to use to get the availabe
 			// interfaces, that way we can later test protperties of the NWParameters class.
 			using (var parameters = NWParameters.CreateUdp ())

--- a/tests/monotouch-test/Network/NWParametersTest.cs
+++ b/tests/monotouch-test/Network/NWParametersTest.cs
@@ -16,6 +16,7 @@ using MonoTouch.Security;
 #endif
 
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
 
 namespace MonoTouchFixtures.Network {
 
@@ -39,7 +40,7 @@ namespace MonoTouchFixtures.Network {
 			TestRuntime.AssertXcodeVersion (10, 0);
 			// we want to use a single connection, since it is expensive
 			connectedEvent = new AutoResetEvent(false);
-			host = "www.google.com";
+			host = NetworkResources.MicrosoftUri.Host;
 			interfaces = new List<NWInterface> ();
 			using (var parameters = NWParameters.CreateUdp ())
 			using (var endpoint = NWEndpoint.Create (host, "80")) {
@@ -123,7 +124,7 @@ namespace MonoTouchFixtures.Network {
 			var setUpProtocol = CreateConfigureProtocolHandler ();
 
 			using (var parameters = NWParameters.CreateSecureUdp (configureTls: setUpTls, configureUdp: setUpProtocol))
-			using (var endpoint = NWEndpoint.Create ("wwww.google.com", "80")) { 
+			using (var endpoint = NWEndpoint.Create (NetworkResources.MicrosoftUri.Host, "80")) { 
 				secureEvent.WaitOne ();
 				configureEvent.WaitOne ();
 				Assert.True (secureConnectionWasSet, "Configure TLS handler was not called.");
@@ -137,7 +138,7 @@ namespace MonoTouchFixtures.Network {
 			var setUpTls = CreateTlsHandler ();
 
 			using (var parameters = NWParameters.CreateSecureUdp (configureTls: setUpTls))
-			using (var endpoint = NWEndpoint.Create ("wwww.google.com", "80")) { 
+			using (var endpoint = NWEndpoint.Create (NetworkResources.MicrosoftUri.Host, "80")) { 
 				secureEvent.WaitOne ();
 				Assert.True (secureConnectionWasSet, "Configure TLS handler was not called.");
 				Assert.False (protocolConfigured, "Protocol configure handler was called.");
@@ -150,7 +151,7 @@ namespace MonoTouchFixtures.Network {
 			var setUpProtocol = CreateConfigureProtocolHandler ();
 
 			using (var parameters = NWParameters.CreateSecureUdp (configureTls: null, configureUdp: setUpProtocol))
-			using (var endpoint = NWEndpoint.Create ("wwww.google.com", "80")) {
+			using (var endpoint = NWEndpoint.Create (NetworkResources.MicrosoftUri.Host, "80")) {
 				configureEvent.WaitOne ();
 				Assert.False (secureConnectionWasSet, "Configure TLS handler was not called.");
 				Assert.True (protocolConfigured, "Protocol configure handler was not called.");
@@ -164,7 +165,7 @@ namespace MonoTouchFixtures.Network {
 			var setUpProtocol = CreateConfigureProtocolHandler ();
 
 			using (var parameters = NWParameters.CreateSecureTcp (configureTls: setUpTls, configureTcp: setUpProtocol))
-			using (var endpoint = NWEndpoint.Create ("wwww.google.com", "80")) { 
+			using (var endpoint = NWEndpoint.Create (NetworkResources.MicrosoftUri.Host, "80")) { 
 				secureEvent.WaitOne ();
 				configureEvent.WaitOne ();
 				Assert.True (secureConnectionWasSet, "Configure TLS handler was not called.");
@@ -179,7 +180,7 @@ namespace MonoTouchFixtures.Network {
 			var setUpProtocol = CreateConfigureProtocolHandler ();
 
 			using (var parameters = NWParameters.CreateSecureTcp (configureTls: setUpTls))
-			using (var endpoint = NWEndpoint.Create ("wwww.google.com", "80")) { 
+			using (var endpoint = NWEndpoint.Create (NetworkResources.MicrosoftUri.Host, "80")) { 
 				secureEvent.WaitOne ();
 				Assert.True (secureConnectionWasSet, "Configure TLS handler was not called.");
 				Assert.False (protocolConfigured, "Protocol configure handler was called.");
@@ -192,7 +193,7 @@ namespace MonoTouchFixtures.Network {
 			var setUpProtocol = CreateConfigureProtocolHandler ();
 
 			using (var parameters = NWParameters.CreateSecureTcp (configureTls: null, configureTcp: setUpProtocol))
-			using (var endpoint = NWEndpoint.Create ("wwww.google.com", "80")) { 
+			using (var endpoint = NWEndpoint.Create (NetworkResources.MicrosoftUri.Host, "80")) { 
 				configureEvent.WaitOne ();
 				Assert.False (secureConnectionWasSet, "Configure TLS handler was called.");
 				Assert.True (protocolConfigured, "Protocol configure handler was not called.");
@@ -350,7 +351,7 @@ namespace MonoTouchFixtures.Network {
 		{
 			Assert.Ignore ("nw_parameters_copy_local_endpoint always return null. Rdar filled 44095278.");
 			using (var parameters = NWParameters.CreateUdp ())
-			using (var endpoint = NWEndpoint.Create ("wwww.google.com", "80"))
+			using (var endpoint = NWEndpoint.Create (NetworkResources.MicrosoftUri.Host, "80"))
 			{
 				var defaultValue = parameters.LocalEndpoint;
 				Assert.IsNull (defaultValue, "Default value changed.");

--- a/tests/monotouch-test/Network/NWPathTest.cs
+++ b/tests/monotouch-test/Network/NWPathTest.cs
@@ -16,6 +16,8 @@ using MonoTouch.Security;
 #endif
 
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
+
 
 namespace MonoTouchFixtures.Network {
 
@@ -36,7 +38,7 @@ namespace MonoTouchFixtures.Network {
 			// we want to use a single connection, since it is expensive
 			connectedEvent = new AutoResetEvent(false);
 			interfaces = new List<NWInterface> ();
-			host = "www.google.com";
+			host = NetworkResources.MicrosoftUri.Host;
 			// we create a connection which we are going to use to get the availabe
 			// interfaces, that way we can later test protperties of the NWParameters class.
 			using (var parameters = NWParameters.CreateUdp ())

--- a/tests/monotouch-test/Network/NWProtocolIPOptionsTest.cs
+++ b/tests/monotouch-test/Network/NWProtocolIPOptionsTest.cs
@@ -13,6 +13,8 @@ using MonoTouch.CoreFoundation;
 #endif
 
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
+
 
 namespace MonoTouchFixtures.Network {
 
@@ -45,7 +47,7 @@ namespace MonoTouchFixtures.Network {
 			TestRuntime.AssertXcodeVersion (11, 0);
 			// we want to use a single connection, since it is expensive
 			connectedEvent = new AutoResetEvent(false);
-			host = "www.google.com";
+			host = NetworkResources.MicrosoftUri.Host;
 			using (var parameters = NWParameters.CreateTcp ())
 			using (var endpoint = NWEndpoint.Create (host, "80")) {
 				connection = new NWConnection (endpoint, parameters);

--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -33,6 +33,7 @@ using nfloat=global::System.Single;
 using nint=global::System.Int32;
 using nuint=global::System.UInt32;
 #endif
+using MonoTests.System.Net.Http;
 
 namespace MonoTouchFixtures.ObjCRuntime {
 
@@ -144,7 +145,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			NSUrlSession session = NSUrlSession.SharedSession;
-			using (var request = new NSUrlRequest (new NSUrl ("http://www.example.com"))) {
+			using (var request = new NSUrlRequest (new NSUrl (NetworkResources.MicrosoftUrl))) {
 				// In iOS 8 the native CreateDownloadTask function returns an instance of a
 				// __NSCFLocalDownloadTask, which does not derive from 
 				// NSUrlSessionDownloadTask (which is the documented/expected return type from

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -88,10 +88,10 @@ namespace MonoTests.System.Net.Http
 			{
 				try {
 					var managedClient = new HttpClient (new HttpClientHandler ());
-					var managedResponse = await managedClient.GetAsync ("https://google.com");
+					var managedResponse = await managedClient.GetAsync (NetworkResources.MicrosoftUrl);
 					if (managedResponse.Headers.TryGetValues ("Set-Cookie", out var managedCookies)) {
 						var nativeClient = new HttpClient (new NSUrlSessionHandler ());
-						var nativeResponse = await nativeClient.GetAsync ("https://google.com");
+						var nativeResponse = await nativeClient.GetAsync (NetworkResources.MicrosoftUrl);
 						if (managedResponse.Headers.TryGetValues ("Set-Cookie", out var nativeCookies)) {
 							manageCount = managedCookies.Count ();
 							nativeCount = nativeCookies.Count ();
@@ -135,10 +135,10 @@ namespace MonoTests.System.Net.Http
 			{
 				try {
 					HttpClient client = new HttpClient (GetHandler (handlerType));
-					client.BaseAddress = new Uri ("https://httpbin.org");
+					client.BaseAddress = NetworkResources.Httpbin.Uri;
 					var byteArray = new UTF8Encoding ().GetBytes ("username:password");
 					client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue ("Basic", Convert.ToBase64String(byteArray));
-					var result = await client.GetAsync ("https://httpbin.org/redirect/3");
+					var result = await client.GetAsync (NetworkResources.Httpbin.GetRedirectUrl (3));
 					// get the data returned from httpbin which contains the details of the requested performed.
 					json = await result.Content.ReadAsStringAsync ();
 					containsAuthorizarion = json.Contains ("Authorization");
@@ -198,10 +198,10 @@ namespace MonoTests.System.Net.Http
 			{
 				try {
 					HttpClient client = new HttpClient (handler);
-					client.BaseAddress = new Uri ("https://httpbin.org");
+					client.BaseAddress = NetworkResources.Httpbin.Uri;
 					var byteArray = new UTF8Encoding ().GetBytes ("username:password");
 					client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue ("Basic", Convert.ToBase64String(byteArray));
-					result = await client.GetAsync ("https://httpbin.org/redirect/3");
+					result = await client.GetAsync (NetworkResources.Httpbin.GetRedirectUrl (3));
 				} catch (Exception e) {
 					ex = e;
 				} finally {
@@ -251,10 +251,10 @@ namespace MonoTests.System.Net.Http
 			{
 				try {
 					HttpClient client = new HttpClient (handler);
-					client.BaseAddress = new Uri ("https://httpbin.org");
+					client.BaseAddress = NetworkResources.Httpbin.Uri;
 					var byteArray = new UTF8Encoding ().GetBytes ("username:password");
 					client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue ("Basic", Convert.ToBase64String(byteArray));
-					var result = await client.GetAsync ("https://httpbin.org/redirect/3");
+					var result = await client.GetAsync (NetworkResources.Httpbin.GetRedirectUrl (3));
 				} catch (Exception e) {
 					ex = e;
 				} finally {

--- a/tests/monotouch-test/System.Net.Http/NetworkResources.cs
+++ b/tests/monotouch-test/System.Net.Http/NetworkResources.cs
@@ -19,7 +19,7 @@ namespace MonoTests.System.Net.Http
 		public static readonly string MicrosoftRobotsUrl = "https://www.microsoft.com/robots.txt";
 		public static readonly string XamarinRobotsUrl = "https://www.xamarin.com/robots.txt";
 		public static readonly string BingRobotsUrl = "http://www.bing.com/robots.txt";
-		public static readonly string XboxRobtosUrl = "https://www.xbox.com/robots.txt";
+		public static readonly string XboxRobotsUrl = "https://www.xbox.com/robots.txt";
 		public static readonly string MSNRobotsUrl = "https://www.msn.com/robots.txt";
 		public static readonly string VisualStudioRobotsUrl = "https://visualstudio.microsoft.com/robots.txt";
 
@@ -27,7 +27,7 @@ namespace MonoTests.System.Net.Http
 			MicrosoftRobotsUrl,
 			XamarinRobotsUrl,
 			BingRobotsUrl,
-			XboxRobtosUrl,
+			XboxRobotsUrl,
 			MSNRobotsUrl,
 			VisualStudioRobotsUrl,
 		};
@@ -41,7 +41,7 @@ namespace MonoTests.System.Net.Http
 			public static readonly string PostUrl = "https://httpbin.org/post";
 			public static readonly string PutUrl = "https://httpbin.org/put";
 
-			public static string GetAbsolureRedirectUrl (int count) => $"https://httpbin.org/absolute-redirect/{count}";
+			public static string GetAbsoluteRedirectUrl (int count) => $"https://httpbin.org/absolute-redirect/{count}";
 			public static string GetRedirectUrl (int count) => $"https://httpbin.org/redirect/{count}";
 			public static string GetRelativeRedirectUrl (int count) => $"http://httpbin.org/relative-redirect/{count}";
 

--- a/tests/monotouch-test/System.Net.Http/NetworkResources.cs
+++ b/tests/monotouch-test/System.Net.Http/NetworkResources.cs
@@ -1,0 +1,50 @@
+using System;
+using Foundation;
+
+namespace MonoTests.System.Net.Http
+{
+	[Preserve (AllMembers = true)]
+	public static class NetworkResources
+	{
+		public static readonly string MicrosoftUrl = "https://www.microsoft.com";
+		public static readonly Uri MicrosoftUri = new Uri (MicrosoftUrl);
+		public static readonly string XamarinUrl = "https://xamarin.com";
+		public static readonly Uri XamarinUri = new Uri (XamarinUrl);
+
+		public static readonly string [] Urls = {
+			MicrosoftUrl,
+		};
+
+		// Robots urls, useful when we want to get a small file
+		public static readonly string MicrosoftRobotsUrl = "https://www.microsoft.com/robots.txt";
+		public static readonly string XamarinRobotsUrl = "https://www.xamarin.com/robots.txt";
+		public static readonly string BingRobotsUrl = "http://www.bing.com/robots.txt";
+		public static readonly string XboxRobtosUrl = "https://www.xbox.com/robots.txt";
+		public static readonly string MSNRobotsUrl = "https://www.msn.com/robots.txt";
+		public static readonly string VisualStudioRobotsUrl = "https://visualstudio.microsoft.com/robots.txt";
+
+		public static readonly string [] RobotsUrls = {
+			MicrosoftRobotsUrl,
+			XamarinRobotsUrl,
+			BingRobotsUrl,
+			XboxRobtosUrl,
+			MSNRobotsUrl,
+			VisualStudioRobotsUrl,
+		};
+
+		public static class Httpbin {
+			public static readonly string Url = "https://httpbin.org";
+			public static readonly Uri Uri = new Uri ("https://httpbin.org");
+			public static readonly string DeleteUrl = "https://httpbin.org/delete";
+			public static readonly string GetUrl = "https://httpbin.org/get";
+			public static readonly string PatchUrl = "https://httpbin.org/patch";
+			public static readonly string PostUrl = "https://httpbin.org/pos";
+			public static readonly string PutUrl = "https://httpbin.org/put";
+
+			public static string GetAbsolureRedirectUrl (int count) => $"https://httpbin.org/absolute-redirect/{count}";
+			public static string GetRedirectUrl (int count) => $"https://httpbin.org/redirect/{count}";
+			public static string GetRelativeRedirectUrl (int count) => $"http://httpbin.org/relative-redirect/{count}";
+
+		}
+	}
+}

--- a/tests/monotouch-test/System.Net.Http/NetworkResources.cs
+++ b/tests/monotouch-test/System.Net.Http/NetworkResources.cs
@@ -38,7 +38,7 @@ namespace MonoTests.System.Net.Http
 			public static readonly string DeleteUrl = "https://httpbin.org/delete";
 			public static readonly string GetUrl = "https://httpbin.org/get";
 			public static readonly string PatchUrl = "https://httpbin.org/patch";
-			public static readonly string PostUrl = "https://httpbin.org/pos";
+			public static readonly string PostUrl = "https://httpbin.org/post";
 			public static readonly string PutUrl = "https://httpbin.org/put";
 
 			public static string GetAbsolureRedirectUrl (int count) => $"https://httpbin.org/absolute-redirect/{count}";

--- a/tests/monotouch-test/example.pac
+++ b/tests/monotouch-test/example.pac
@@ -1,4 +1,4 @@
-﻿// Exmaple PAC file that returns a proxy for the urls that have the
+﻿// Example PAC file that returns a proxy for the urls that have the
 // xamarin domain name.
 function FindProxyForURL(url, host) {
 	if (dnsDomainIs(host, "xamarin.com"))

--- a/tests/monotouch-test/example.pac
+++ b/tests/monotouch-test/example.pac
@@ -1,9 +1,9 @@
-// Exmaple PAC file that returns a proxy for the urls that have the
+﻿// Exmaple PAC file that returns a proxy for the urls that have the
 // xamarin domain name.
 function FindProxyForURL(url, host) {
 	if (dnsDomainIs(host, "xamarin.com"))
 		return "PROXY example.com:8080";
 	 
-	if (dnsDomainIs(host, "google.com"))
+	if (dnsDomainIs(host, "microsoft.com"))
 		return "DIRECT";
 }	 


### PR DESCRIPTION
Use a single point where the different enpoints can be found so that
if they need to be updated (server issues or other) it is a simple
change that will affect all tests in monotouch-tests