### PR TITLE
[Tests] GetGlobalQueue_QualityOfService is only supported on Mac OS X 10.10 and later

### DIFF
--- a/tests/monotouch-test/CoreFoundation/DispatchTests.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchTests.cs
@@ -248,6 +248,8 @@ namespace MonoTouchFixtures.CoreFoundation {
 		[Test]
 		public void GetGlobalQueue_QualityOfService ()
 		{
+			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+
 			// values changes in OS versions (and even in arch) but we only want to make sure we get a valid string so the prefix is enough
 			Assert.True (DispatchQueue.GetGlobalQueue (DispatchQualityOfService.Default).Label.StartsWith ("com.apple.root."), "Default");
 			Assert.True (DispatchQueue.GetGlobalQueue (DispatchQualityOfService.Utility).Label.StartsWith ("com.apple.root."), "Low");


### PR DESCRIPTION
Ensure that the test does not fail in earlier versions of the os.

Fixes: https://github.com/xamarin/maccore/issues/2062