### PR TITLE
[runtime] Filter isblank input to 8 bits values

### DIFF
--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -153,7 +153,7 @@ get_mono_env_options (int *count)
 	inptr = (unsigned char *) env;
 
 	while (*inptr) {
-		while (isblank ((int) *inptr))
+		while (isblank ((int) *inptr & 0xff))
 			inptr++;
 
 		if (*inptr == '\0')
@@ -166,7 +166,7 @@ get_mono_env_options (int *count)
 			value = decode_qstring (&inptr, *start);
 			break;
 		default:
-			while (*inptr && !isblank ((int) *inptr))
+			while (*inptr && !isblank ((int) *inptr & 0xff))
 				inptr++;
 
 			// Note: Mac OS X <= 10.6.8 do not have strndup()


### PR DESCRIPTION
Help static analyzer by clarifying that only `char` will be given to
`isblank` so it does not look like it could be used to index an array
and gets out of bounds (important since this is user supplied values).

Digging down into `isblank` will get you to
> Using tainted variable _c as an index to array _DefaultRuneLocale.__runetype.