### PR TITLE
[runtime] Catch and log exceptions in ObjC++ destructor

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2771,7 +2771,11 @@ xamarin_get_managed_method_for_token (guint32 token_ref, guint32 *exception_gcha
 XamarinObject::~XamarinObject ()
 {
 	// COOP: no managed memory access: any mode.
-	xamarin_notify_dealloc (native_object, gc_handle & ~GCHANDLE_MASK);
+	@try {
+		xamarin_notify_dealloc (native_object, gc_handle & ~GCHANDLE_MASK);
+	} @catch (NSException *ex) {
+		NSLog (@"%@", ex);
+	}
 	native_object = NULL;
 	gc_handle = 0;
 }


### PR DESCRIPTION
`xamarin_notify_dealloc` can throw an exception (depending on the mode
used).

Throwing exception in a destructor is problematic in [Obj]C++ and can
abort the application. That might be fine in some cases but there's
not much point in doing so when we're about to forget everything about
that specific object.