### PR TITLE
[Runtime] Enable the -Wsign-conversion on trampolines-invoke.m

### DIFF
--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -12,9 +12,6 @@
 #include "delegates.h"
 #include "product.h"
 
-// TODO: temp ignore to minimize diff
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wsign-conversion"
 static guint32
 xamarin_get_exception_for_method (int code, guint32 inner_exception_gchandle, const char *reason, SEL sel, id self)
 {
@@ -147,7 +144,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 	MonoType *p;
 	int ofs;
 	unsigned long i;
-	int mofs = 0;
+	unsigned long mofs = 0;
 
 	unsigned long desc_arg_count = num_arg + 2; /* 1 for the return value + 1 if this is a category instance method */
 	size_t desc_size = desc_arg_count * sizeof (BindAsData) + sizeof (MethodDescription);
@@ -678,5 +675,3 @@ exception_handling:
 		xamarin_process_managed_exception (exception);
 	}
 }
-
-#pragma clang diagnostic pop


### PR DESCRIPTION
Enable the flag that was disabled via pragmas.

Continuation of PR: https://github.com/xamarin/xamarin-macios/pull/7405