### PR TITLE
[d16-5] [CoreFoundation] CFBundle.GetAll better thread safe.

### DIFF
--- a/src/CoreFoundation/CFArray.cs
+++ b/src/CoreFoundation/CFArray.cs
@@ -35,6 +35,8 @@ using Foundation;
 using ObjCRuntime;
 
 using CFIndex = System.nint;
+using CFArrayRef = System.IntPtr;
+using CFAllocatorRef = System.IntPtr;
 
 namespace CoreFoundation {
 	
@@ -149,6 +151,11 @@ namespace CoreFoundation {
 		{
 			return CFArrayGetCount (array);
 		}
+
+		[DllImport (Constants.CoreFoundationLibrary)]
+		extern static CFArrayRef CFArrayCreateCopy (CFAllocatorRef allocator, CFArrayRef theArray);
+
+		public CFArray Clone () => new CFArray (CFArrayCreateCopy (IntPtr.Zero, this.Handle), true);
 	}
 }
 

--- a/tests/xtro-sharpie/common-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/common-CoreFoundation.ignore
@@ -334,7 +334,6 @@
 !missing-pinvoke! CFArrayApplyFunction is not bound
 !missing-pinvoke! CFArrayBSearchValues is not bound
 !missing-pinvoke! CFArrayContainsValue is not bound
-!missing-pinvoke! CFArrayCreateCopy is not bound
 !missing-pinvoke! CFArrayCreateMutable is not bound
 !missing-pinvoke! CFArrayCreateMutableCopy is not bound
 !missing-pinvoke! CFArrayExchangeValuesAtIndices is not bound


### PR DESCRIPTION
The initial solution fixed the rance condition in which the index
changed, but that did not guarantee that we would get the correct
bundles. We now clone the CFArray (which also clones the callbacks set
to the array) and iterate over it to make sure Apple does not do evil
things while we are iteraing.

Better Fixes: https://github.com/xamarin/maccore/issues/940

Backport of #7425.

/cc @mandel-macaque 