### PR TITLE
[Runtime] Enable the -Wsign-conversion on trampolines.m files.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1840,7 +1840,7 @@ xamarin_switch_gchandle (id self, bool to_weak)
 }
 
 void
-xamarin_free_gchandle (id self, int gchandle)
+xamarin_free_gchandle (id self, uint32_t gchandle)
 {
 	// COOP: no managed memory access, but calls mono function mono_gc_handle_free. Assuming that function can be called with any mode: this function can be called with any mode as well
 	if (gchandle) {

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -212,14 +212,14 @@ bool			xamarin_has_managed_ref (id self);
 bool			xamarin_has_managed_ref_safe (id self);
 void			xamarin_switch_gchandle (id self, bool to_weak);
 int				xamarin_get_gchandle (id self);
-void			xamarin_free_gchandle (id self, int gchandle);
+void			xamarin_free_gchandle (id self, uint32_t gchandle);
 void			xamarin_clear_gchandle (id self);
 int				xamarin_get_gchandle_with_flags (id self);
 void			xamarin_set_gchandle (id self, int gchandle);
 void			xamarin_create_gchandle (id self, void *managed_object, int flags, bool force_weak);
 void			xamarin_create_managed_ref (id self, void * managed_object, bool retain);
 void            xamarin_release_managed_ref (id self, MonoObject *managed_obj);
-void			xamarin_notify_dealloc (id self, int gchandle);
+void			xamarin_notify_dealloc (id self, uint32_t gchandle);
 
 int				xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode);
 

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -32,7 +32,7 @@ long long	xamarin_longret_trampoline (id self, SEL sel, ...);
 long long	xamarin_static_longret_trampoline (id self, SEL sel, ...);
 id			xamarin_copyWithZone_trampoline1 (id self, SEL sel, NSZone *zone);
 id			xamarin_copyWithZone_trampoline2 (id self, SEL sel, NSZone *zone);
-int			xamarin_get_gchandle_trampoline (id self, SEL sel);
+uint32_t	xamarin_get_gchandle_trampoline (id self, SEL sel);
 void		xamarin_set_gchandle_trampoline (id self, SEL sel, int gc_handle);
 
 unsigned long	xamarin_get_frame_length (id self, SEL sel);


### PR DESCRIPTION
Enable the flag that was disabled via pragmas and fix warnings.

Continuation of PR: https://github.com/xamarin/xamarin-macios/pull/7405