### PR TITLE
[CoreFoundation] Xcode11 update

### DIFF
--- a/tests/xtro-sharpie/macOS-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/macOS-CoreFoundation.ignore
@@ -74,3 +74,5 @@
 !missing-pinvoke! CFXMLTreeCreateXMLData is not bound
 !missing-pinvoke! CFXMLTreeGetNode is not bound
 !unknown-pinvoke! _NSGetExecutablePath bound
+!missing-field! kCFUserNotificationAlertTopMostKey not bound
+!missing-field! kCFUserNotificationKeyboardTypesKey not bound

--- a/tests/xtro-sharpie/macOS-CoreFoundation.todo
+++ b/tests/xtro-sharpie/macOS-CoreFoundation.todo
@@ -1,2 +1,0 @@
-!missing-field! kCFUserNotificationAlertTopMostKey not bound
-!missing-field! kCFUserNotificationKeyboardTypesKey not bound


### PR DESCRIPTION
Marking as `ignore` since we have not added any of the other `kCFUserNotification` constants.
Should complete - https://github.com/xamarin/xamarin-macios/wiki/CoreFoundation-macOS-xcode11-beta1

Nothing else left in todo