### PR TITLE
[Tests] Reuse NetworkResources in the linker tests.

### DIFF
--- a/tests/linker/ios/link all/LinkAllTest.cs
+++ b/tests/linker/ios/link all/LinkAllTest.cs
@@ -36,6 +36,7 @@ using MonoTouch.StoreKit;
 using MonoTouch.UIKit;
 #endif
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
 
 namespace LinkAll {
 	
@@ -206,7 +207,7 @@ namespace LinkAll {
 			try {
 				ServicePointManager.CertificatePolicy = test_policy;
 				WebClient wc = new WebClient ();
-				Assert.IsNotNull (wc.DownloadString ("https://xamarin.com"));
+				Assert.IsNotNull (wc.DownloadString (NetworkResources.XamarinUrl));
 				// caching means it will be called at least for the first run, but it might not
 				// be called again in subsequent requests (unless it expires)
 				Assert.That (test_policy.CheckCount, Is.GreaterThan (0), "policy checked");

--- a/tests/linker/ios/link all/link all.csproj
+++ b/tests/linker/ios/link all/link all.csproj
@@ -201,6 +201,9 @@
     <Compile Include="..\..\CommonLinkAnyTest.cs">
       <Link>CommonLinkAnyTest.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\monotouch-test\System.Net.Http\NetworkResources.cs">
+      <Link>NetworkResources.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="LaunchScreen.storyboard" Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" />

--- a/tests/linker/ios/link sdk/AsyncTest.cs
+++ b/tests/linker/ios/link sdk/AsyncTest.cs
@@ -7,6 +7,7 @@ using Foundation;
 using MonoTouch.Foundation;
 #endif
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
 
 namespace LinkSdk {
 
@@ -16,7 +17,7 @@ namespace LinkSdk {
 
 		public Task<string> LoadCategories ()
 		{
-			return Task.Run (async () => await (new HttpClient ()).GetStringAsync ("https://google.com"));
+			return Task.Run (async () => await (new HttpClient ()).GetStringAsync (NetworkResources.MicrosoftUrl));
 		}
 
 		[Test]

--- a/tests/linker/ios/link sdk/CryptoTest.cs
+++ b/tests/linker/ios/link sdk/CryptoTest.cs
@@ -18,6 +18,7 @@ using Foundation;
 using MonoTouch.Foundation;
 #endif
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
 
 namespace LinkSdk {
 	
@@ -57,7 +58,7 @@ namespace LinkSdk {
 					return true;
 				};
 				WebClient wc = new WebClient ();
-				Assert.IsNotNull (wc.DownloadString ("https://xamarin.com"));
+				Assert.IsNotNull (wc.DownloadString (NetworkResources.XamarinUrl));
 				// caching means it will be called at least for the first run, but it might not
 				// be called again in subsequent requests (unless it expires)
 				Assert.That (trust_validation_callback, Is.GreaterThan (0), "validation done");
@@ -75,7 +76,7 @@ namespace LinkSdk {
 #endif
 			WebClient wc = new WebClient ();
 			// the certificate contains (several rules) the host name
-			Assert.NotNull (wc.DownloadString ("https://www.google.com"));
+			Assert.NotNull (wc.DownloadString (NetworkResources.MicrosoftUrl));
 
 			// IP are (generally) not allowed
 			foreach (var ip in Dns.GetHostAddresses ("www.google.com")) {
@@ -115,7 +116,7 @@ namespace LinkSdk {
 				};
 				ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls;
 				WebClient wc = new WebClient ();
-				Assert.IsNotNull (wc.DownloadString ("https://api.imgur.com/2/stats"));
+				Assert.IsNotNull (wc.DownloadString (NetworkResources.MicrosoftRobotsUrl));
 			}
 			catch (WebException we) {
 				// failing to get data does not mean the SSL/TLS session was not established

--- a/tests/linker/ios/link sdk/CryptoTest.cs
+++ b/tests/linker/ios/link sdk/CryptoTest.cs
@@ -116,7 +116,7 @@ namespace LinkSdk {
 				};
 				ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls;
 				WebClient wc = new WebClient ();
-				Assert.IsNotNull (wc.DownloadString (NetworkResources.MicrosoftRobotsUrl));
+				Assert.IsNotNull (wc.DownloadString (NetworkResources.StatsUrl));
 			}
 			catch (WebException we) {
 				// failing to get data does not mean the SSL/TLS session was not established

--- a/tests/linker/ios/link sdk/HttpClientTest.cs
+++ b/tests/linker/ios/link sdk/HttpClientTest.cs
@@ -7,6 +7,8 @@ using Foundation;
 using MonoTouch.Foundation;
 #endif
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
+
 
 namespace LinkSdk.Net.Http {
 
@@ -16,7 +18,7 @@ namespace LinkSdk.Net.Http {
 
 		async Task<string> Get (HttpClient client)
 		{
-			return await client.GetStringAsync ("http://xamarin.com");
+			return await client.GetStringAsync (NetworkResources.XamarinUrl);
 		}
 
 		string Get (HttpMessageHandler handler)
@@ -38,12 +40,6 @@ namespace LinkSdk.Net.Http {
 		public void NSSimple ()
 		{
 			Assert.NotNull (Get (new NSUrlSessionHandler ()), "NSUrlSessionHandler");
-		}
-
-		//[Test]
-		public void CFSimple ()
-		{
-			Assert.NotNull (Get (new CFNetworkHandler ()), "CFNetworkHandler");
 		}
 
 		// same HttpClient and handler doing two simultaneous calls
@@ -77,7 +73,7 @@ namespace LinkSdk.Net.Http {
 
 		Task<string> Get302 (HttpClient client)
 		{
-			return Task.Run (async () => await client.GetStringAsync ("https://greenbytes.de/tech/tc/httpredirects/t302loc.asis"));
+			return Task.Run (async () => await client.GetStringAsync (NetworkResources.Httpbin.GetRedirectUrl (1)));
 		}
 
 		void Get302 (HttpClient client, bool allowRedirect)
@@ -133,6 +129,13 @@ namespace LinkSdk.Net.Http {
 			Get302 (client, allowRedirect: handler.AllowAutoRedirect);
 		}
 
+#if !__WATCHOS__
+		//[Test]
+		public void CFSimple ()
+		{
+			Assert.NotNull (Get (new CFNetworkHandler ()), "CFNetworkHandler");
+		}
+
 		[Test]
 		public void CF302_Allowed ()
 		{
@@ -150,5 +153,6 @@ namespace LinkSdk.Net.Http {
 			var client = new HttpClient (handler);
 			Get302 (client, allowRedirect: handler.AllowAutoRedirect);
 		}
+#endif
 	}
 }

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -54,6 +54,8 @@ using MonoTouch.OpenGLES;
 using MonoTouch.WebKit;
 #endif
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
+
 
 namespace LinkSdk {
 
@@ -651,7 +653,7 @@ namespace LinkSdk {
 #endif
 			WebClient wc = new WebClient ();
 			// note: needs to be executed under Instrument to verify it does not leak
-			string s = wc.DownloadString ("https://developers.google.com");
+			string s = wc.DownloadString (NetworkResources.MicrosoftUrl);
 			Assert.NotNull (s);
 		}
 

--- a/tests/linker/ios/link sdk/PclTest.cs
+++ b/tests/linker/ios/link sdk/PclTest.cs
@@ -13,6 +13,7 @@ using MonoTouch.Foundation;
 #endif
 using NUnit.Framework;
 
+
 namespace LinkSdk {
 
 	[TestFixture]

--- a/tests/linker/ios/link sdk/PclTest.cs
+++ b/tests/linker/ios/link sdk/PclTest.cs
@@ -13,7 +13,6 @@ using MonoTouch.Foundation;
 #endif
 using NUnit.Framework;
 
-
 namespace LinkSdk {
 
 	[TestFixture]

--- a/tests/linker/ios/link sdk/link sdk.csproj
+++ b/tests/linker/ios/link sdk/link sdk.csproj
@@ -199,7 +199,6 @@
     <Compile Include="..\..\..\monotouch-test\System.Net.Http\NetworkResources.cs">
       <Link>NetworkResources.cs</Link>
     </Compile>
-    <Compile Include="HttpClientTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="LaunchScreen.storyboard" Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" />

--- a/tests/linker/ios/link sdk/link sdk.csproj
+++ b/tests/linker/ios/link sdk/link sdk.csproj
@@ -196,6 +196,10 @@
       <Link>CommonLinkAnyTest.cs</Link>
     </Compile>
     <Compile Include="BitcodeTest.cs" />
+    <Compile Include="..\..\..\monotouch-test\System.Net.Http\NetworkResources.cs">
+      <Link>NetworkResources.cs</Link>
+    </Compile>
+    <Compile Include="HttpClientTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="LaunchScreen.storyboard" Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" />

--- a/tests/linker/mac/LinkAnyTest.cs
+++ b/tests/linker/mac/LinkAnyTest.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Foundation;
 
 using NUnit.Framework;
+using MonoTests.System.Net.Http;
 
 namespace LinkAnyTest {
 	// This test is included in both the LinkAll and LinkSdk projects.
@@ -64,10 +65,9 @@ namespace LinkAnyTest {
 
 		[Test]
 		public void WebClientTest ()
-		{
-			var url = "http://www.microsoft.com";
+		{;
 			var wc = new WebClient ();
-			var data = wc.DownloadString (url);
+			var data = wc.DownloadString (NetworkResources.MicrosoftUrl);
 
 			Assert.That (data, Is.Not.Empty, "Downloaded content");
 		}
@@ -75,9 +75,8 @@ namespace LinkAnyTest {
 		[Test]
 		public void WebClientTest_Https ()
 		{
-			var url = "https://www.microsoft.com";
 			var wc = new WebClient ();
-			var data = wc.DownloadString (url);
+			var data = wc.DownloadString (NetworkResources.MicrosoftUrl);
 
 			Assert.That (data, Is.Not.Empty, "Downloaded content");
 		}
@@ -99,7 +98,7 @@ namespace LinkAnyTest {
 					data = await task;
 				}
 
-				GetWebPage ("http://www.microsoft.com").Wait ();
+				GetWebPage (NetworkResources.MicrosoftUrl).Wait ();
 				Assert.That (data, Is.Not.Empty, "Downloaded content");
 			} finally {
 				SynchronizationContext.SetSynchronizationContext (current_sc);

--- a/tests/linker/mac/LinkAnyTest.cs
+++ b/tests/linker/mac/LinkAnyTest.cs
@@ -65,7 +65,7 @@ namespace LinkAnyTest {
 
 		[Test]
 		public void WebClientTest ()
-		{;
+		{
 			var wc = new WebClient ();
 			var data = wc.DownloadString (NetworkResources.MicrosoftUrl);
 

--- a/tests/linker/mac/link all/link all-mac.csproj
+++ b/tests/linker/mac/link all/link all-mac.csproj
@@ -96,6 +96,9 @@
     <Compile Include="..\..\CommonLinkAnyTest.cs">
       <Link>CommonLinkAnyTest.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\monotouch-test\System.Net.Http\NetworkResources.cs">
+      <Link>NetworkResources.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\external\guiunit\src\framework\GuiUnit_xammac_mobile.csproj">

--- a/tests/linker/mac/link sdk/link sdk-mac.csproj
+++ b/tests/linker/mac/link sdk/link sdk-mac.csproj
@@ -86,6 +86,9 @@
     <Compile Include="..\..\CommonLinkAnyTest.cs">
       <Link>CommonLinkAnyTest.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\monotouch-test\System.Net.Http\NetworkResources.cs">
+      <Link>NetworkResources.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\external\guiunit\src\framework\GuiUnit_xammac_mobile.csproj">

--- a/tests/monotouch-test/System.Net.Http/NetworkResources.cs
+++ b/tests/monotouch-test/System.Net.Http/NetworkResources.cs
@@ -10,6 +10,7 @@ namespace MonoTests.System.Net.Http
 		public static readonly Uri MicrosoftUri = new Uri (MicrosoftUrl);
 		public static readonly string XamarinUrl = "https://xamarin.com";
 		public static readonly Uri XamarinUri = new Uri (XamarinUrl);
+		public static readonly string StatsUrl = "https://api.imgur.com/2/stats";
 
 		public static readonly string [] Urls = {
 			MicrosoftUrl,


### PR DESCRIPTION
The linking tests do use a number of endpoints.
As with PR https://github.com/xamarin/xamarin-macios/pull/7418 we want
to have all the endpoints in a single place to update them if the server
side does give us problems.