### PR TITLE
[Runtime] Enable the -Wsign-conversion on monotouch-main.m files.

### DIFF
--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -28,9 +28,6 @@
 #include "../tools/mtouch/monotouch-fixes.c"
 #endif
 
-// TODO: temp ignore to minimize diff
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wsign-conversion"
 static unsigned char *
 xamarin_load_aot_data (MonoAssembly *assembly, int size, gpointer user_data, void **out_handle)
 {
@@ -60,7 +57,7 @@ xamarin_load_aot_data (MonoAssembly *assembly, int size, gpointer user_data, voi
 		return NULL;
 	}
 
-	void *ptr = mmap (NULL, size, PROT_READ, MAP_FILE | MAP_PRIVATE, fd, 0);
+	void *ptr = mmap (NULL, (size_t) size, PROT_READ, MAP_FILE | MAP_PRIVATE, fd, 0);
 	if (ptr == MAP_FAILED) {
 		LOG (PRODUCT ": Could not map the aot file for %s: %s\n", aname, strerror (errno));
 		close (fd);
@@ -80,7 +77,7 @@ static void
 xamarin_free_aot_data (MonoAssembly *assembly, int size, gpointer user_data, void *handle)
 {
 	// COOP: This is a callback called by the AOT runtime, I belive we don't have to change the GC mode here.
-	munmap (handle, size);
+	munmap (handle, (size_t) size);
 }
 
 /*
@@ -239,7 +236,7 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 
 	xamarin_launch_mode = launch_mode;
 
-	memset (managed_argv, 0, sizeof (char*) * (argc + 2));
+	memset (managed_argv, 0, sizeof (char*) * (unsigned long) (argc + 2));
 	managed_argv [0] = "monotouch";
 
 	DEBUG_LAUNCH_TIME_PRINT ("Main entered");
@@ -324,7 +321,7 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 			
 			while (*++value) {
 				if (*value == '=' || *value == ':') {
-					name = strndup (arg, value - arg);
+					name = strndup (arg, (size_t) (value - arg));
 					value++;
 					break;
 				}
@@ -496,5 +493,3 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 	
 	return rv;
 }
-
-#pragma clang diagnostic pop


### PR DESCRIPTION
Enable the flag that was disabled via pragmas and fix warnings.

Continuation of PR: https://github.com/xamarin/xamarin-macios/pull/7405