### PR TITLE
[introspection] UIMenuController's default ctor stopped working in iOS 13.3. Fixes xamarin/maccore#2067.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1595,8 +1595,14 @@ namespace ObjCRuntime {
 
 		static int MajorVersion = -1;
 		static int MinorVersion = -1;
+		static int BuildVersion = -1;
 
 		internal static bool CheckSystemVersion (int major, int minor, string systemVersion)
+		{
+			return CheckSystemVersion (major, minor, 0, systemVersion);
+		}
+
+		internal static bool CheckSystemVersion (int major, int minor, int build, string systemVersion)
 		{
 			if (MajorVersion == -1) {
 				string[] version = systemVersion.Split (new char[] { '.' });
@@ -1606,9 +1612,25 @@ namespace ObjCRuntime {
 				
 				if (version.Length < 2 || !int.TryParse (version[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out MinorVersion))
 					MinorVersion = 0;
+
+				if (version.Length < 3 || !int.TryParse (version[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out BuildVersion))
+					BuildVersion = 0;
 			}
 			
-			return MajorVersion > major || (MajorVersion == major && MinorVersion >= minor);
+			if (MajorVersion > major)
+				return true;
+			else if (MajorVersion < major)
+				return false;
+
+			if (MinorVersion > minor)
+				return true;
+			else if (MinorVersion < minor)
+				return false;
+
+			if (BuildVersion < build)
+				return false;
+
+			return true;
 		}
 
 		internal static IntPtr CloneMemory (IntPtr source, nint length)

--- a/src/WatchKit/WKInterfaceDevice.cs
+++ b/src/WatchKit/WKInterfaceDevice.cs
@@ -31,6 +31,11 @@ namespace WatchKit {
 		{
 			return Runtime.CheckSystemVersion (major, minor, SystemVersion);
 		}
+
+		public bool CheckSystemVersion (int major, int minor, int build)
+		{
+			return Runtime.CheckSystemVersion (major, minor, build, SystemVersion);
+		}
 	}
 }
 

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -656,6 +656,22 @@ partial class TestRuntime
 #endif
 	}
 
+	// This method returns true if:
+	// system version >= specified version
+	// AND
+	// sdk version >= specified version
+	static bool CheckWatchOSSystemVersion (int major, int minor, int build, bool throwIfOtherPlatform = true)
+	{
+#if __WATCHOS__
+		return WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (major, minor, build);
+#else
+		if (throwIfOtherPlatform)
+			throw new Exception ("Can't get watchOS System version on iOS/tvOS.");
+		// This is both iOS and tvOS
+		return true;
+#endif
+	}
+
 	static void AssertWatchOSSystemVersion (int major, int minor, bool throwIfOtherPlatform = true)
 	{
 		if (CheckWatchOSSystemVersion (major, minor, throwIfOtherPlatform))

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -260,6 +260,18 @@ partial class TestRuntime
 #else
 				throw new NotImplementedException ();
 #endif
+			case 3:
+#if __WATCHOS__
+				return CheckWatchOSSystemVersion (6, 1, 1);
+#elif __TVOS__
+				return ChecktvOSSystemVersion (13, 3);
+#elif __IOS__
+				return CheckiOSSystemVersion (13, 3);
+#elif MONOMAC
+				return CheckMacSystemVersion (10, 15, 2);
+#else
+				throw new NotImplementedException ();
+#endif
 			default:
 				throw new NotImplementedException ();
 			}

--- a/tests/introspection/iOS/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOS/iOSApiCtorInitTest.cs
@@ -239,6 +239,8 @@ namespace Introspection {
 				return Runtime.Arch == Arch.SIMULATOR;
 			case "AVAudioRecorder": // Stopped working with Xcode 11.2 beta 2
 				return TestRuntime.CheckXcodeVersion (11, 2);
+			case "UIMenuController": // Stopped working with Xcode 11.3 beta 1
+				return TestRuntime.CheckXcodeVersion (11, 3);
 			default:
 				return base.Skip (type);
 			}


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/2067.