### PR TITLE
[Runtime] Update cflags and fix warnings accordingly.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -190,7 +190,7 @@ IOS_CXX=$(XCODE_CXX)
 SIMULATOR_BIN_PATH=$(XCODE_DEVELOPER_ROOT)/Platforms/iPhoneSimulator.platform/Developer/usr/bin
 SIMULATOR_CC=$(IOS_CC)
 
-CFLAGS= -Wall -fms-extensions -Wno-format-security -Wsign-compare -Wshorten-64-to-32 -Wsign-conversion -Wdeprecated -Wuninitialized -fstack-protector-strong
+CFLAGS= -Wall -fms-extensions -Werror -Wconversion -Wdeprecated -Wuninitialized -fstack-protector-strong
 
 ifdef ENABLE_BITCODE_ON_IOS
 BITCODE_CFLAGS=-fembed-bitcode-marker

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -495,7 +495,7 @@ xamarin_get_nullable_type (MonoClass *cls, guint32 *exception_gchandle)
 // The XamarinExtendedObject protocol is just to avoid a 
 // compiler warning (no 'xamarinGetGChandle' selector found).
 @protocol XamarinExtendedObject
--(int) xamarinGetGCHandle;
+-(uint32_t) xamarinGetGCHandle;
 -(void) xamarinSetGCHandle: (uint32_t) gc_handle;
 @end
 
@@ -2809,7 +2809,7 @@ XamarinObject::~XamarinObject ()
  */
 
 @implementation NSObject (NonXamarinObject)
--(int) xamarinGetGCHandle
+-(uint32_t) xamarinGetGCHandle
 {
 	// COOP: no managed memory access: any mode.
 	return 0;

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -297,7 +297,7 @@ public:
 @end
 
 @interface NSObject (NonXamarinObject)
--(int) xamarinGetGCHandle;
+-(uint32_t) xamarinGetGCHandle;
 @end
 #endif
 

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -506,7 +506,7 @@ static UltimateMachine *shared;
 
 -(void) completedSetProtocol: (id<ProtocolAssignerProtocol>) value
 {
-	assert (!"THIS FUNCTION SHOULD BE OVERRIDDEN");
+	assert (false); // "THIS FUNCTION SHOULD BE OVERRIDDEN";
 }
 @end
 
@@ -602,7 +602,7 @@ static Class _TestClass = NULL;
 
 -(void) classCallback: (void (^)(int32_t magic_number))completionHandler
 {
-	assert (!"THIS FUNCTION SHOULD BE OVERRIDDEN");
+	assert (false); //!"THIS FUNCTION SHOULD BE OVERRIDDEN"
 }
 
 -(void) callClassCallback
@@ -730,7 +730,7 @@ static Class _TestClass = NULL;
 
 -(void) assertMainThreadBlockReleaseCallback: (innerBlock) completionHandler
 {
-	assert (!"THIS FUNCTION SHOULD BE OVERRIDDEN");
+	assert (false); //!"THIS FUNCTION SHOULD BE OVERRIDDEN");
 }
 
 -(void) testFreedBlocks
@@ -756,7 +756,10 @@ static Class _TestClass = NULL;
 
 static void block_called ()
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 	OSAtomicIncrement32 (&called_blocks);
+#pragma clang diagnostic pop
 }
 
 +(void) callProtocolWithBlockProperties: (id<ProtocolWithBlockProperties>) obj required: (bool) required instance: (bool) instance;
@@ -821,7 +824,10 @@ static void block_called ()
 @implementation FreedNotifier
 -(void) dealloc
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 	OSAtomicIncrement32 (&freed_blocks);
+#pragma clang diagnostic pop
 	[super dealloc];
 }
 @end

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -602,7 +602,7 @@ static Class _TestClass = NULL;
 
 -(void) classCallback: (void (^)(int32_t magic_number))completionHandler
 {
-	assert (false); //!"THIS FUNCTION SHOULD BE OVERRIDDEN"
+	assert (false); // THIS FUNCTION SHOULD BE OVERRIDDEN
 }
 
 -(void) callClassCallback
@@ -730,7 +730,7 @@ static Class _TestClass = NULL;
 
 -(void) assertMainThreadBlockReleaseCallback: (innerBlock) completionHandler
 {
-	assert (false); //!"THIS FUNCTION SHOULD BE OVERRIDDEN");
+	assert (false); // THIS FUNCTION SHOULD BE OVERRIDDEN
 }
 
 -(void) testFreedBlocks

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2523,9 +2523,9 @@ namespace Registrar {
 			else if (method.CurrentTrampoline == Trampoline.Release)
 				return "-(void) release";
 			else if (method.CurrentTrampoline == Trampoline.GetGCHandle)
-				return "-(int) xamarinGetGCHandle";
+				return "-(uint32_t) xamarinGetGCHandle";
 			else if (method.CurrentTrampoline == Trampoline.SetGCHandle)
-				return "-(void) xamarinSetGCHandle: (int) gchandle";
+				return "-(void) xamarinSetGCHandle: (uint32_t) gchandle";
 #if MONOMAC
 			else if (method.CurrentTrampoline == Trampoline.CopyWithZone1 || method.CurrentTrampoline == Trampoline.CopyWithZone2)
 				return "-(id) copyWithZone: (NSZone *)zone";
@@ -3154,14 +3154,14 @@ namespace Registrar {
 				sb.WriteLine ();
 				return;
 			case Trampoline.GetGCHandle:
-				sb.WriteLine ("-(int) xamarinGetGCHandle");
+				sb.WriteLine ("-(uint32_t) xamarinGetGCHandle");
 				sb.WriteLine ("{");
 				sb.WriteLine ("return __monoObjectGCHandle.gc_handle;");
 				sb.WriteLine ("}");
 				sb.WriteLine ();
 				return;
 			case Trampoline.SetGCHandle:
-				sb.WriteLine ("-(void) xamarinSetGCHandle: (int) gc_handle");
+				sb.WriteLine ("-(void) xamarinSetGCHandle: (uint32_t) gc_handle");
 				sb.WriteLine ("{");
 				sb.WriteLine ("__monoObjectGCHandle.gc_handle = gc_handle;");
 				sb.WriteLine ("__monoObjectGCHandle.native_object = self;");


### PR DESCRIPTION
Update flags:

* Add -Werror so that warnings are errors.
* Move to -Wconversion that adds:
  * -Wbitfield-enum-conversion
  * -Wbool-conversion
  * -Wconstant-conversion
  * -Wenum-conversion
  * -Wfloat-conversion
  * -Wimplicit-float-conversion
  * -Wimplicit-int-conversion
  * -Wint-conversion
  * -Wliteral-conversion
  * -Wnon-literal-null-conversion
  * -Wnull-conversion
  * -Wobjc-literal-conversion
  * -Wshorten-64-to-32
  * -Wsign-conversion
  * -Wstring-conversion
Last work related to: https://github.com/xamarin/xamarin-macios/pull/7405