### PR TITLE
[xharness] Fix 32 bit device tests selection

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -22,7 +22,7 @@ namespace xharness
 		public bool IncludeAll;
 		public bool IncludeBcl;
 		public bool IncludeMac = true;
-		public bool IncludeiOS = true;
+		public bool IncludeiOS64 = true;
 		public bool IncludeiOS32 = true;
 		public bool IncludeiOSExtensions;
 		public bool ForceExtensionBuildOnly;
@@ -481,9 +481,9 @@ namespace xharness
 
 				var ps = new List<Tuple<TestProject, TestPlatform, bool>> ();
 				if (!project.SkipiOSVariation)
-					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project, TestPlatform.iOS_Unified, ignored || !IncludeiOS));
+					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project, TestPlatform.iOS_Unified, ignored || !IncludeiOS64));
 				if (project.MonoNativeInfo != null)
-					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project, TestPlatform.iOS_TodayExtension64, ignored || !IncludeiOS));
+					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project, TestPlatform.iOS_TodayExtension64, ignored || !IncludeiOS64));
 				if (!project.SkiptvOSVariation)
 					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project.AsTvOSProject (), TestPlatform.tvOS, ignored || !IncludetvOS));
 				if (!project.SkipwatchOSVariation)
@@ -555,7 +555,7 @@ namespace xharness
 						TestName = project.Name,
 					};
 					build64.CloneTestProject (project);
-					projectTasks.Add (new RunDeviceTask (build64, Devices.Connected64BitIOS.Where (d => d.IsSupported (project))) { Ignored = !IncludeiOS });
+					projectTasks.Add (new RunDeviceTask (build64, Devices.Connected64BitIOS.Where (d => d.IsSupported (project))) { Ignored = !IncludeiOS64 });
 
 					var build32 = new XBuildTask {
 						Jenkins = this,
@@ -621,7 +621,7 @@ namespace xharness
 				foreach (var task in projectTasks) {
 					task.TimeoutMultiplier = project.TimeoutMultiplier;
 					task.BuildOnly |= project.BuildOnly;
-					task.Ignored |= ignored;
+					task.Ignored &= ignored;
 				}
 				rv.AddRange (projectTasks);
 			}
@@ -653,8 +653,9 @@ namespace xharness
 			DisableKnownFailingDeviceTests ();
 
 			if (!Harness.INCLUDE_IOS) {
-				MainLog.WriteLine ("The iOS build is diabled, so any iOS tests will be disabled as well.");
-				IncludeiOS = false;
+				MainLog.WriteLine ("The iOS build is disabled, so any iOS tests will be disabled as well.");
+				IncludeiOS64 = false;
+				IncludeiOS32 = false;
 			}
 
 			if (!Harness.INCLUDE_WATCH) {
@@ -796,7 +797,7 @@ namespace xharness
 			SetEnabled (labels, "all", ref IncludeAll);
 
 			// enabled by default
-			SetEnabled (labels, "ios", ref IncludeiOS);
+			SetEnabled (labels, "ios-64", ref IncludeiOS64);
 			SetEnabled (labels, "tvos", ref IncludetvOS);
 			SetEnabled (labels, "ios-32", ref IncludeiOS32);
 			SetEnabled (labels, "watchos", ref IncludewatchOS);

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -565,7 +565,7 @@ namespace xharness
 						TestName = project.Name,
 					};
 					build32.CloneTestProject (project);
-					projectTasks.Add (new RunDeviceTask (build32, Devices.Connected32BitIOS.Where (d => d.IsSupported (project))) { Ignored = !IncludeiOS || !IncludeiOS32 });
+					projectTasks.Add (new RunDeviceTask (build32, Devices.Connected32BitIOS.Where (d => d.IsSupported (project))) { Ignored = !IncludeiOS32 });
 
 					var todayProject = project.AsTodayExtensionProject ();
 					var buildToday = new XBuildTask {


### PR DESCRIPTION
With the `run-ios-32-tests` label, all iOS device tests were ignored.
This is because the ignore condition was incorrect, `IncludeiOS` is not set for 32 bit device tests.
Now we only enable/disable the 32 bit device tests based on `IncludeiOS32` which is set by the `run-ios-32-tests` label.