### PR TITLE
[avfoundation] Use a smart enum for AVMetadataObjectType

### DIFF
--- a/src/AVFoundation/AVMetadataObject.cs
+++ b/src/AVFoundation/AVMetadataObject.cs
@@ -36,7 +36,7 @@ namespace AVFoundation {
 	public partial class AVMetadataObject {
 		public AVMetadataObjectType Type {
 			get {
-				return ObjectToEnum (WeakType);
+				return AVMetadataObjectTypeExtensions.GetValue (WeakType);
 			}
 		}
 
@@ -48,7 +48,7 @@ namespace AVFoundation {
 				return rv;
 
 			foreach (var str in arr) {
-				rv |= ObjectToEnum (str);
+				rv |= AVMetadataObjectTypeExtensions.GetValue (str);
 			}
 
 			return rv;
@@ -65,102 +65,12 @@ namespace AVFoundation {
 
 			while (val != 0) {
 				if ((val & 0x1) == 0x1)
-					rv.Add (EnumToObject ((AVMetadataObjectType) (0x1UL << shifts)));
+					rv.Add (((AVMetadataObjectType) (0x1UL << shifts)).GetConstant ());
 				val >>= 1;
 				shifts++;
 			}
 
 			return rv.ToArray ();
-		}
-
-		internal static AVMetadataObjectType ObjectToEnum (NSString obj)
-		{
-			if (obj == null)
-				return AVMetadataObjectType.None;
-			else if (obj == AVMetadataObject.TypeFace)
-				return AVMetadataObjectType.Face;
-			else if (obj == AVMetadataObject.TypeAztecCode)
-				return AVMetadataObjectType.AztecCode;
-			else if (obj == AVMetadataObject.TypeCode128Code)
-				return AVMetadataObjectType.Code128Code;
-			else if (obj == AVMetadataObject.TypeCode39Code)
-				return AVMetadataObjectType.Code39Code;
-			else if (obj == AVMetadataObject.TypeCode39Mod43Code)
-				return AVMetadataObjectType.Code39Mod43Code;
-			else if (obj == AVMetadataObject.TypeCode93Code)
-				return AVMetadataObjectType.Code93Code;
-			else if (obj == AVMetadataObject.TypeEAN13Code)
-				return AVMetadataObjectType.EAN13Code;
-			else if (obj == AVMetadataObject.TypeEAN8Code)
-				return AVMetadataObjectType.EAN8Code;
-			else if (obj == AVMetadataObject.TypePDF417Code)
-				return AVMetadataObjectType.PDF417Code;
-			else if (obj == AVMetadataObject.TypeQRCode)
-				return AVMetadataObjectType.QRCode;
-			else if (obj == AVMetadataObject.TypeUPCECode)
-				return AVMetadataObjectType.UPCECode;
-			else if (obj == AVMetadataObject.TypeInterleaved2of5Code)
-				return AVMetadataObjectType.Interleaved2of5Code;
-			else if (obj == AVMetadataObject.TypeITF14Code)
-				return AVMetadataObjectType.ITF14Code;
-			else if (obj == AVMetadataObject.TypeDataMatrixCode)
-				return AVMetadataObjectType.DataMatrixCode;
-			else if (obj == AVMetadataObject.TypeCatBody)
-				return AVMetadataObjectType.CatBody;
-			else if (obj == AVMetadataObject.TypeDogBody)
-				return AVMetadataObjectType.DogBody;
-			else if (obj == AVMetadataObject.TypeHumanBody)
-				return AVMetadataObjectType.HumanBody;
-			else if (obj == AVMetadataObject.TypeSalientObject)
-				return AVMetadataObjectType.SalientObject;
-			else
-				throw new ArgumentOutOfRangeException (string.Format ("Unexpected AVMetadataObjectType: {0}", obj));
-		}
-
-		internal static NSString EnumToObject (AVMetadataObjectType val)
-		{
-			switch (val) {
-			case AVMetadataObjectType.None:
-				return null;
-			case AVMetadataObjectType.Face:
-				return AVMetadataObject.TypeFace;
-			case AVMetadataObjectType.AztecCode:
-				return AVMetadataObject.TypeAztecCode;
-			case AVMetadataObjectType.Code128Code:
-				return AVMetadataObject.TypeCode128Code;
-			case AVMetadataObjectType.Code39Code:
-				return AVMetadataObject.TypeCode39Code;
-			case AVMetadataObjectType.Code39Mod43Code:
-				return AVMetadataObject.TypeCode39Mod43Code;
-			case AVMetadataObjectType.Code93Code:
-				return AVMetadataObject.TypeCode93Code;
-			case AVMetadataObjectType.EAN13Code:
-				return AVMetadataObject.TypeEAN13Code;
-			case AVMetadataObjectType.EAN8Code:
-				return AVMetadataObject.TypeEAN8Code;
-			case AVMetadataObjectType.PDF417Code:
-				return AVMetadataObject.TypePDF417Code;
-			case AVMetadataObjectType.QRCode:
-				return AVMetadataObject.TypeQRCode;
-			case AVMetadataObjectType.UPCECode:
-				return AVMetadataObject.TypeUPCECode;
-			case AVMetadataObjectType.Interleaved2of5Code:
-				return AVMetadataObject.TypeInterleaved2of5Code;
-			case AVMetadataObjectType.ITF14Code:
-				return AVMetadataObject.TypeITF14Code;
-			case AVMetadataObjectType.DataMatrixCode:
-				return AVMetadataObject.TypeDataMatrixCode;
-			case AVMetadataObjectType.CatBody:
-				return AVMetadataObject.TypeCatBody;
-			case AVMetadataObjectType.DogBody:
-				return AVMetadataObject.TypeDogBody;
-			case AVMetadataObjectType.HumanBody:
-				return AVMetadataObject.TypeHumanBody;
-			case AVMetadataObjectType.SalientObject:
-				return AVMetadataObject.TypeSalientObject;
-			default:
-				throw new ArgumentOutOfRangeException (string.Format ("Unexpected AVMetadataObjectType: {0}", val));
-			}
 		}
 	}
 }

--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -585,65 +585,6 @@ namespace AVFoundation {
 		PhaseDetection
 	}
 
-	// Convience enum
-	[Flags]
-	public enum AVMetadataObjectType : ulong {
-		None = 0,
-
-		Face = 1 << 0,
-
-		[iOS(7,0)]
-		AztecCode = 1 << 1,
-
-		[iOS(7,0)]
-		Code128Code = 1 << 2,
-
-		[iOS(7,0)]
-		Code39Code = 1 << 3,
-
-		[iOS(7,0)]
-		Code39Mod43Code = 1 << 4,
-
-		[iOS(7,0)]
-		Code93Code = 1 << 5,
-
-		[iOS(7,0)]
-		EAN13Code = 1 << 6,
-
-		[iOS(7,0)]
-		EAN8Code = 1 << 7,
-
-		[iOS(7,0)]
-		PDF417Code = 1 << 8,
-
-		[iOS(7,0)]
-		QRCode = 1 << 9,
-
-		[iOS(7,0)]
-		UPCECode = 1 << 10,
-
-		[iOS (8,0)]
-		Interleaved2of5Code = 1 << 11,
-
-		[iOS (8,0)]
-		ITF14Code = 1 << 12,
-
-		[iOS (8,0)]
-		DataMatrixCode = 1 << 13,
-
-		[iOS (13,0)]
-		CatBody = 1 << 14,
-
-		[iOS (13,0)]
-		DogBody = 1 << 15,
-
-		[iOS (13,0)]
-		HumanBody = 1 << 16,
-
-		[iOS (13,0)]
-		SalientObject = 1 << 17,
-	}
-
 #if !MONOMAC
 	[NoTV, NoWatch]
 	[iOS (9,0)]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -6617,6 +6617,7 @@ namespace AVFoundation {
 		[Export ("time")]
 		CMTime Time{ get;}
 
+#if !XAMCORE_4_0
 		[Field ("AVMetadataObjectTypeFace"), Mac (10,10)]
 		NSString TypeFace { get; }
 
@@ -6687,6 +6688,87 @@ namespace AVFoundation {
 		[NoWatch, NoTV, iOS (13, 0), Mac (10, 15)]
 		[Field ("AVMetadataObjectTypeSalientObject")]
 		NSString TypeSalientObject { get; }
+#endif
+	}
+
+	[NoWatch]
+	[NoTV]
+	[Mac (10,10)]
+	[Flags]
+	enum AVMetadataObjectType : ulong {
+		[Field (null)]
+		None = 0,
+
+		[Field ("AVMetadataObjectTypeFace")]
+		Face = 1 << 0,
+
+		[iOS (7,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeAztecCode")]
+		AztecCode = 1 << 1,
+
+		[iOS (7,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeCode128Code")]
+		Code128Code = 1 << 2,
+
+		[iOS (7,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeCode39Code")]
+		Code39Code = 1 << 3,
+
+		[iOS (7,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeCode39Mod43Code")]
+		Code39Mod43Code = 1 << 4,
+
+		[iOS (7,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeCode93Code")]
+		Code93Code = 1 << 5,
+
+		[NoTV, iOS (7,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeEAN13Code")]
+		EAN13Code = 1 << 6,
+
+		[NoTV, iOS (7,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeEAN8Code")]
+		EAN8Code = 1 << 7,
+
+		[Field ("AVMetadataObjectTypePDF417Code")]
+		[NoTV, iOS (7,0), Mac (10,15)]
+		PDF417Code = 1 << 8,
+
+		[NoTV, iOS (7,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeQRCode")]
+		QRCode = 1 << 9,
+
+		[NoTV, iOS (7,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeUPCECode")]
+		UPCECode = 1 << 10,
+
+		[NoTV, iOS (8,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeInterleaved2of5Code")]
+		Interleaved2of5Code = 1 << 11,
+
+		[iOS (8,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeITF14Code")]
+		ITF14Code = 1 << 12,
+
+		[iOS (8,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeDataMatrixCode")]
+		DataMatrixCode = 1 << 13,
+
+		[iOS (13,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeCatBody")]
+		CatBody = 1 << 14,
+
+		[iOS (13,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeDogBody")]
+		DogBody = 1 << 15,
+
+		[iOS (13,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeHumanBody")]
+		HumanBody = 1 << 16,
+
+		[iOS (13,0), Mac (10,15)]
+		[Field ("AVMetadataObjectTypeSalientObject")]
+		SalientObject = 1 << 17,
 	}
 
 	[NoWatch]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -6691,8 +6691,10 @@ namespace AVFoundation {
 #endif
 	}
 
+#if XAMCORE_4_0
 	[NoWatch]
 	[NoTV]
+#endif
 	[Mac (10,10)]
 	[Flags]
 	enum AVMetadataObjectType : ulong {

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -6701,74 +6701,92 @@ namespace AVFoundation {
 		[Field (null)]
 		None = 0,
 
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeFace")]
 		Face = 1 << 0,
 
 		[iOS (7,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeAztecCode")]
 		AztecCode = 1 << 1,
 
 		[iOS (7,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeCode128Code")]
 		Code128Code = 1 << 2,
 
 		[iOS (7,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeCode39Code")]
 		Code39Code = 1 << 3,
 
 		[iOS (7,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeCode39Mod43Code")]
 		Code39Mod43Code = 1 << 4,
 
 		[iOS (7,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeCode93Code")]
 		Code93Code = 1 << 5,
 
-		[NoTV, iOS (7,0), Mac (10,15)]
+		[iOS (7,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeEAN13Code")]
 		EAN13Code = 1 << 6,
 
-		[NoTV, iOS (7,0), Mac (10,15)]
+		[iOS (7,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeEAN8Code")]
 		EAN8Code = 1 << 7,
 
+		[iOS (7,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypePDF417Code")]
-		[NoTV, iOS (7,0), Mac (10,15)]
 		PDF417Code = 1 << 8,
 
-		[NoTV, iOS (7,0), Mac (10,15)]
+		[iOS (7,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeQRCode")]
 		QRCode = 1 << 9,
 
-		[NoTV, iOS (7,0), Mac (10,15)]
+		[iOS (7,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeUPCECode")]
 		UPCECode = 1 << 10,
 
-		[NoTV, iOS (8,0), Mac (10,15)]
+		[iOS (8,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeInterleaved2of5Code")]
 		Interleaved2of5Code = 1 << 11,
 
 		[iOS (8,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeITF14Code")]
 		ITF14Code = 1 << 12,
 
 		[iOS (8,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeDataMatrixCode")]
 		DataMatrixCode = 1 << 13,
 
 		[iOS (13,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeCatBody")]
 		CatBody = 1 << 14,
 
 		[iOS (13,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeDogBody")]
 		DogBody = 1 << 15,
 
 		[iOS (13,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeHumanBody")]
 		HumanBody = 1 << 16,
 
 		[iOS (13,0), Mac (10,15)]
+		[NoTV][NoWatch]
 		[Field ("AVMetadataObjectTypeSalientObject")]
 		SalientObject = 1 << 17,
 	}

--- a/tests/monotouch-test/AVFoundation/CaptureMetadataOutputTest.cs
+++ b/tests/monotouch-test/AVFoundation/CaptureMetadataOutputTest.cs
@@ -99,20 +99,23 @@ namespace MonoTouchFixtures.AVFoundation {
 			Assert.That (back.Length, Is.EqualTo (1), "l 1");
 			Assert.That (back [0], Is.EqualTo (flags.GetConstant ()), "e2a 1");
 
-			// multiple (flags)
-			flags = AVMetadataObjectType.CatBody | AVMetadataObjectType.DogBody | AVMetadataObjectType.HumanBody;
-			var array = new NSString [] {
-				AVMetadataObjectType.CatBody.GetConstant (),
-				AVMetadataObjectType.DogBody.GetConstant (),
-				AVMetadataObjectType.HumanBody.GetConstant ()
-			};
-			result = (AVMetadataObjectType)array_to_enum.Invoke (null, new [] { array });
-			Assert.AreEqual (flags, result, "a2e 3");
-			back = (NSString [])enum_to_array.Invoke (null, new object [] { result });
-			Assert.That (back.Length, Is.EqualTo (3), "l 3");
-			Assert.That (back [0], Is.EqualTo (array [0]), "e2a 3a");
-			Assert.That (back [1], Is.EqualTo (array [1]), "e2a 3b");
-			Assert.That (back [2], Is.EqualTo (array [2]), "e2a 3c");
+			// constants are only available in recent xcode (and not on any 32bits OS)
+			if (TestRuntime.CheckXcodeVersion (11,0)) {
+				// multiple (flags)
+				flags = AVMetadataObjectType.CatBody | AVMetadataObjectType.DogBody | AVMetadataObjectType.HumanBody;
+				var array = new NSString [] {
+					AVMetadataObjectType.CatBody.GetConstant (),
+					AVMetadataObjectType.DogBody.GetConstant (),
+					AVMetadataObjectType.HumanBody.GetConstant ()
+				};
+				result = (AVMetadataObjectType)array_to_enum.Invoke (null, new [] { array });
+				Assert.AreEqual (flags, result, "a2e 3");
+				back = (NSString [])enum_to_array.Invoke (null, new object [] { result });
+				Assert.That (back.Length, Is.EqualTo (3), "l 3");
+				Assert.That (back [0], Is.EqualTo (array [0]), "e2a 3a");
+				Assert.That (back [1], Is.EqualTo (array [1]), "e2a 3b");
+				Assert.That (back [2], Is.EqualTo (array [2]), "e2a 3c");
+			}
 		}
 
 #if XAMCORE_2_0

--- a/tests/monotouch-test/AVFoundation/CaptureMetadataOutputTest.cs
+++ b/tests/monotouch-test/AVFoundation/CaptureMetadataOutputTest.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Drawing;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 #if XAMCORE_2_0
 using Foundation;
@@ -75,6 +76,43 @@ namespace MonoTouchFixtures.AVFoundation {
 #endif
 				obj.SetDelegate (null, null);
 			}
+		}
+
+		[Test]
+		public void Flags ()
+		{
+			// we can only only work with [Weak]AvailableMetadataObjectTypes on an instance of AVCaptureMetadataOutput
+			// so we use reflection to test the internal of the flags/enum/constants conversions
+			// the previous tests ensure what we need is not removed by the linker
+			var t = typeof (AVMetadataObject);
+			var array_to_enum = t.GetMethod ("ArrayToEnum", BindingFlags.Static | BindingFlags.NonPublic);
+			Assert.NotNull (array_to_enum, "ArrayToEnum");
+
+			var enum_to_array = t.GetMethod ("EnumToArray", BindingFlags.Static | BindingFlags.NonPublic);
+			Assert.NotNull (enum_to_array, "EnumToArray");
+
+			// single
+			var flags = AVMetadataObjectType.Face;
+			var result = (AVMetadataObjectType) array_to_enum.Invoke (null, new [] { new NSString [] { flags.GetConstant () } });
+			Assert.AreEqual (flags, result, "a2e 1");
+			var back = (NSString[]) enum_to_array.Invoke (null, new object [] { result });
+			Assert.That (back.Length, Is.EqualTo (1), "l 1");
+			Assert.That (back [0], Is.EqualTo (flags.GetConstant ()), "e2a 1");
+
+			// multiple (flags)
+			flags = AVMetadataObjectType.CatBody | AVMetadataObjectType.DogBody | AVMetadataObjectType.HumanBody;
+			var array = new NSString [] {
+				AVMetadataObjectType.CatBody.GetConstant (),
+				AVMetadataObjectType.DogBody.GetConstant (),
+				AVMetadataObjectType.HumanBody.GetConstant ()
+			};
+			result = (AVMetadataObjectType)array_to_enum.Invoke (null, new [] { array });
+			Assert.AreEqual (flags, result, "a2e 3");
+			back = (NSString [])enum_to_array.Invoke (null, new object [] { result });
+			Assert.That (back.Length, Is.EqualTo (3), "l 3");
+			Assert.That (back [0], Is.EqualTo (array [0]), "e2a 3a");
+			Assert.That (back [1], Is.EqualTo (array [1]), "e2a 3b");
+			Assert.That (back [2], Is.EqualTo (array [2]), "e2a 3c");
 		}
 
 #if XAMCORE_2_0


### PR DESCRIPTION
and drop the manual, error prone, conversion code.

The fact that this is also used as a `[Flag]` enum does not mean smart
enum could not be used [1]. The flag code only needed to be updated to
use the smart enum generated code.

[1] https://github.com/xamarin/xamarin-macios/issues/7317

Added unit tests.