### PR TITLE
[linker] Fix "Linked Away" exceptions with Thread.CurrentPrincipal. Fix #7321

### DIFF
--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -15,6 +15,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
+using System.Security.Principal;
 using System.Threading;
 using System.Xml;
 using Mono.Data.Sqlite;
@@ -1114,6 +1115,25 @@ namespace LinkSdk {
 		{
 			var list = new List<string> { "hello hello" };
 			Assert.NotNull (list.AsQueryable ().GroupBy (x => x).FirstOrDefault ()?.FirstOrDefault (), "Enumerable");
+		}
+
+		public class CustomIdentity : IIdentity {
+			public string AuthenticationType => "test";
+			public bool IsAuthenticated => true;
+			public string Name => "abc";
+		}
+
+		public class CustomPrincipal : IPrincipal {
+			public IIdentity Identity => new CustomIdentity ();
+			public bool IsInRole (string role) => true;
+		}
+
+		[Test]
+		// https://github.com/xamarin/xamarin-macios/issues/7321
+		public void Principal ()
+		{
+			Thread.CurrentPrincipal = new CustomPrincipal ();
+			Assert.That (Thread.CurrentPrincipal.Identity.Name, Is.EqualTo ("abc"), "Name");
 		}
 	}
 }

--- a/tools/linker/MonoTouch.Tuner/RemoveCode.cs
+++ b/tools/linker/MonoTouch.Tuner/RemoveCode.cs
@@ -176,8 +176,14 @@ namespace MonoTouch.Tuner {
 			case "System.Runtime.Remoting.Proxies":
 				return true;
 			case "System.Runtime.Remoting.Messaging":
-				return type.Name != "AsyncResult" && type.Name != "LogicalCallContext"
-					&& type.Name != "MonoMethodMessage";
+				switch (type.Name) {
+				case "AsyncResult":
+				case "CallContextSecurityData":
+				case "LogicalCallContext":
+				case "MonoMethodMessage":
+					return false;
+				}
+				return true;
 			case "System.Security.AccessControl":
 			case "System.Security.Permissions":
 			case "System.Security.Policy":


### PR DESCRIPTION
Keep 'CallContextSecurityData' around since it's quite small (and the
normal linker logic will be able to deal with it if unused) and allows
the use of `Thread.CurrentPrincipal`

Also add unit test.

Fix https://github.com/xamarin/xamarin-macios/issues/7321