### PR TITLE
[monotouch-test] Make NetworkReachabilityTest.CtorIPAddressPair a bit more permissive. Fixes xamarin/maccore#2047.

### DIFF
--- a/tests/monotouch-test/SystemConfiguration/NetworkReachabilityTest.cs
+++ b/tests/monotouch-test/SystemConfiguration/NetworkReachabilityTest.cs
@@ -101,9 +101,10 @@ namespace MonoTouchFixtures.SystemConfiguration {
 
 				Assert.IsTrue (nr.TryGetFlags (out flags), "#1");
 				// using Loopback iOS 10 / tvOS 10 returns no flags (0) on devices
+				// but only sometimes... so check for Reachable as well (as a flag).
 #if !MONOMAC
 				if ((Runtime.Arch == Arch.DEVICE) && TestRuntime.CheckXcodeVersion (8, 0))
-					Assert.That ((int)flags, Is.EqualTo (0), "#1 Reachable");
+					Assert.That ((flags == (NetworkReachabilityFlags) 0) || ((flags & NetworkReachabilityFlags.Reachable) == NetworkReachabilityFlags.Reachable) , $"#1 Reachable: {flags.ToString ()}");
 				else
 #endif
 					Assert.That (flags, Is.EqualTo (NetworkReachabilityFlags.Reachable), "#1 Reachable");


### PR DESCRIPTION
Try to fix https://github.com/xamarin/maccore/issues/2047 by making the test
accept NetworkReachabilityFlags.Reachable for the loopback address on device.

Fixes https://github.com/xamarin/maccore/issues/2047.