### PR TITLE
[mtouch] Fix caching issues. Fix #7514

### DIFF
--- a/tools/common/FileCopier.cs
+++ b/tools/common/FileCopier.cs
@@ -77,8 +77,21 @@ namespace Xamarin.Bundler {
 
 		public static void UpdateDirectory (string source, string target)
 		{
-			if (!Directory.Exists (target))
-				Directory.CreateDirectory (target);
+			// first chance, try to update existing content inside `target`
+			int rv = TryUpdateDirectory (source, target);
+			if (rv == 0)
+				return;
+
+			// 2nd chance, nuke `target` then copy everything
+			Log (1, "Could not update `{0}` content, trying to overwrite everything...", target);
+			Directory.Delete (target, true);
+			if (TryUpdateDirectory (source, target) != 0)
+				throw CreateError (1022, "Could not copy the directory '{0}' to '{1}': {2}", source, target, strerror (Marshal.GetLastWin32Error ()));
+		}
+
+		static int TryUpdateDirectory (string source, string target)
+		{
+			Directory.CreateDirectory (target);
 
 			// Mono's File.Copy can't handle symlinks (the symlinks are followed instead of copied),
 			// so we need to use native functions directly. Luckily OSX provides exactly what we need.
@@ -86,9 +99,7 @@ namespace Xamarin.Bundler {
 			try {
 				CopyFileCallbackDelegate del = CopyFileCallback;
 				copyfile_state_set (state, CopyFileState.StatusCB, Marshal.GetFunctionPointerForDelegate (del));
-				int rv = copyfile (source, target, state, CopyFileFlags.Data | CopyFileFlags.Recursive | CopyFileFlags.Nofollow | CopyFileFlags.Clone);
-				if (rv != 0)
-					throw CreateError (1022, "Could not copy the directory '{0}' to '{1}': {2}", source, target, strerror (Marshal.GetLastWin32Error ()));
+				return copyfile (source, target, state, CopyFileFlags.Data | CopyFileFlags.Recursive | CopyFileFlags.Nofollow | CopyFileFlags.Clone);
 			} finally {
 				copyfile_state_free (state);
 			}
@@ -102,6 +113,12 @@ namespace Xamarin.Bundler {
 				if (!IsUptodate (source, target)) {
 					if (stage == CopyFileStep.Finish)
 						Log (1, "Copied {0} to {1}", source, target);
+					else if (stage == CopyFileStep.Err) {
+						// don't call `strerror` because the most common `260` returns `Unknown error : 260`
+						// which `msbuild` will parse as an error and fail the build :(
+						Log (1, "Could not copy the file '{0}' to '{1}': {2}", source, target, Marshal.GetLastWin32Error ());
+						return CopyFileResult.Quit;
+					}
 					return CopyFileResult.Continue;
 				} else {
 					Log (3, "Target '{0}' is up-to-date", target);
@@ -113,7 +130,8 @@ namespace Xamarin.Bundler {
 			case CopyFileWhat.CopyXattr:
 				return CopyFileResult.Continue;
 			case CopyFileWhat.Error:
-				throw CreateError (1021, "Could not copy the file '{0}' to '{1}': {2}", source, target, strerror (Marshal.GetLastWin32Error ()));
+				Log (1, "Could not copy the file '{0}' to '{1}': {2}", source, target, Marshal.GetLastWin32Error ());
+				return CopyFileResult.Quit;
 			default:
 				return CopyFileResult.Continue;
 			}

--- a/tools/common/cache.cs
+++ b/tools/common/cache.cs
@@ -190,10 +190,8 @@ public class Cache {
 		var args = new List<string> (arguments);
 
 		sb.Append ("# Version: ").Append (Constants.Version).Append ('.').Append (Constants.Revision).AppendLine ();
-		if (args.Count > 0)
-			sb.Append ("# [first argument, ignore] # ").AppendLine (args [0]);
 		sb.Append (Driver.GetFullPath ()).AppendLine (" \\");
-		CollectArgumentsForCache (args, 1, sb);
+		CollectArgumentsForCache (args, 0, sb);
 		return sb.ToString ();
 	}
 


### PR DESCRIPTION
The nice, repeatable test case from #7514 pointed out two issues

1. `cache.cs` ignored some changes

It looks like something changed (at some point) and the first _ignored_
line was the `@x.rsp` our response file - which should not be ignored.

This solved the build issue where updating the nuget should have
triggered a rebuild because
> /Users/poupou/.nuget/packages/skiasharp/1.68.0/lib/Xamarin.iOS/SkiaSharp.dll
and
> /Users/poupou/.nuget/packages/skiasharp/1.68.1/lib/Xamarin.iOS/SkiaSharp.dll
are different assemblies (but the same response file).

2. `copyfile` could fail silently

Copying the framework could fail (error 260) and the failure was never
reported so the build succeeded - but without updating (completely) the
framework.

The exact reason it fails is unknown :( but we can recover from it by
deleting the target and copying (everything) back to the expected
(target) location.

Build logs will now indicate when this fails and will try to recover
before reporting a build error. Best case it works :) worse case we'll
be aware something is wrong (which is better than ignoring)

ref: https://github.com/xamarin/xamarin-macios/issues/7514