### PR TITLE
[mtouch][mmp] Include satellite assemblies from nuget dependencies. Fix #7113

### DIFF
--- a/tests/mmptest/src/PackageReferenceTests.cs
+++ b/tests/mmptest/src/PackageReferenceTests.cs
@@ -31,6 +31,28 @@ namespace Xamarin.MMP.Tests
 			});
 		}
 
+		[TestCase (true)]
+		[TestCase (false)]
+		// context https://github.com/xamarin/xamarin-macios/issues/7113
+		public void SatellitesFromNuget (bool full)
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				var config = new TI.UnifiedTestConfig (tmpDir) {
+					ItemGroup = @"<ItemGroup><PackageReference Include = ""Humanizer"" Version = ""2.7.2"" /></ItemGroup>",
+					TestCode = "Humanizer.DateHumanizeExtensions.Humanize (System.DateTime.UtcNow.AddHours (-30));\n",
+					XM45 = full
+				};
+				TI.AddGUIDTestCode (config);
+
+				string project = TI.GenerateUnifiedExecutableProject (config);
+				TI.NugetRestore (project);
+				TI.BuildProject (project);
+
+				var appDir = Path.Combine (tmpDir, "bin", "Debug", full ? "XM45Example.app" : "UnifiedExample.app");
+				Assert.True (File.Exists (Path.Combine (appDir, "Contents", "MonoBundle", "fr", "Humanizer.resources.dll")), "fr");
+			});
+		}
+
 		[Test]
 		public void ExtensionProjectPackageReferencs_Build ()
 		{


### PR DESCRIPTION
It's possible for a nuget to have dependencies that will bring satellite
assemblies into a project.

When doing so the satellite assemblies are copied to the right output
(e.g. `Debug`) directory, so they work fine at runtime. However it's
not 100% fine at build time, e.g. msbuild won't detected them as
satellite assemblies.

Something similar happens with `mtouch` (and `mmp`) since the satellite
assemblies won't be found inside a (culture-named) subdirectory from the
original assembly location. In our case this means the assemblies won't
be copied into the .app bundle (since we don't run from `Debug`) and
localization won't work properly.

The solution is to check for both the (culture-named) subdirectories
from the assembly location (like before) and, if nothing is found, also
try to locate them in the _build_ (like `Debug`) directory - so if
something else (nuget or custom build scripts) tried to outsmart the
build logic then we'll still bring those satellite assemblies in the
app bundle we produce.

https://github.com/xamarin/xamarin-macios/issues/7113