### PR TITLE
[d16-4] [xharness] Fix 32 bit device tests selection

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -23,6 +23,7 @@ namespace xharness
 		public bool IncludeBcl;
 		public bool IncludeMac = true;
 		public bool IncludeiOS = true;
+		public bool IncludeiOS64 = true;
 		public bool IncludeiOS32 = true;
 		public bool IncludeiOSExtensions;
 		public bool ForceExtensionBuildOnly;
@@ -481,9 +482,9 @@ namespace xharness
 
 				var ps = new List<Tuple<TestProject, TestPlatform, bool>> ();
 				if (!project.SkipiOSVariation)
-					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project, TestPlatform.iOS_Unified, ignored || !IncludeiOS));
+					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project, TestPlatform.iOS_Unified, ignored || !IncludeiOS64));
 				if (project.MonoNativeInfo != null)
-					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project, TestPlatform.iOS_TodayExtension64, ignored || !IncludeiOS));
+					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project, TestPlatform.iOS_TodayExtension64, ignored || !IncludeiOS64));
 				if (!project.SkiptvOSVariation)
 					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project.AsTvOSProject (), TestPlatform.tvOS, ignored || !IncludetvOS));
 				if (!project.SkipwatchOSVariation)
@@ -555,7 +556,7 @@ namespace xharness
 						TestName = project.Name,
 					};
 					build64.CloneTestProject (project);
-					projectTasks.Add (new RunDeviceTask (build64, Devices.Connected64BitIOS.Where (d => d.IsSupported (project))) { Ignored = !IncludeiOS });
+					projectTasks.Add (new RunDeviceTask (build64, Devices.Connected64BitIOS.Where (d => d.IsSupported (project))) { Ignored = !IncludeiOS64 });
 
 					var build32 = new XBuildTask {
 						Jenkins = this,
@@ -565,7 +566,7 @@ namespace xharness
 						TestName = project.Name,
 					};
 					build32.CloneTestProject (project);
-					projectTasks.Add (new RunDeviceTask (build32, Devices.Connected32BitIOS.Where (d => d.IsSupported (project))) { Ignored = !IncludeiOS || !IncludeiOS32 });
+					projectTasks.Add (new RunDeviceTask (build32, Devices.Connected32BitIOS.Where (d => d.IsSupported (project))) { Ignored = !IncludeiOS32 });
 
 					var todayProject = project.AsTodayExtensionProject ();
 					var buildToday = new XBuildTask {
@@ -653,8 +654,10 @@ namespace xharness
 			DisableKnownFailingDeviceTests ();
 
 			if (!Harness.INCLUDE_IOS) {
-				MainLog.WriteLine ("The iOS build is diabled, so any iOS tests will be disabled as well.");
+				MainLog.WriteLine ("The iOS build is disabled, so any iOS tests will be disabled as well.");
 				IncludeiOS = false;
+				IncludeiOS64 = false;
+				IncludeiOS32 = false;
 			}
 
 			if (!Harness.INCLUDE_WATCH) {
@@ -796,9 +799,10 @@ namespace xharness
 			SetEnabled (labels, "all", ref IncludeAll);
 
 			// enabled by default
-			SetEnabled (labels, "ios", ref IncludeiOS);
-			SetEnabled (labels, "tvos", ref IncludetvOS);
 			SetEnabled (labels, "ios-32", ref IncludeiOS32);
+			SetEnabled (labels, "ios-64", ref IncludeiOS64);
+			SetEnabled (labels, "ios", ref IncludeiOS); // Needs to be set after `ios-32` and `ios-64` (because it can reset them)
+			SetEnabled (labels, "tvos", ref IncludetvOS);
 			SetEnabled (labels, "watchos", ref IncludewatchOS);
 			SetEnabled (labels, "mac", ref IncludeMac);
 			SetEnabled (labels, "ios-msbuild", ref IncludeiOSMSBuild);
@@ -845,10 +849,14 @@ namespace xharness
 		{
 			if (labels.Contains ("skip-" + testname + "-tests")) {
 				MainLog.WriteLine ("Disabled '{0}' tests because the label 'skip-{0}-tests' is set.", testname);
+				if (testname == "ios")
+					IncludeiOS32 = IncludeiOS64 = false;
 				value = false;
 				return true;
 			} else if (labels.Contains ("run-" + testname + "-tests")) {
 				MainLog.WriteLine ("Enabled '{0}' tests because the label 'run-{0}-tests' is set.", testname);
+				if (testname == "ios")
+					IncludeiOS32 = IncludeiOS64 = true;
 				value = true;
 				return true;
 			} else if (labels.Contains ("skip-all-tests")) {


### PR DESCRIPTION
**Problem**

32 bit tests could only be executed with 64 bit tests. E.g: `run-ios-32-tests` didn't work on its own, only `run-ios-tests,run-ios-32-tests` worked

**Solution**

- Change the logic so that 32 bit tests are only looking for `IncludeiOS32` and 64 bit tests only `IncludeiOS64`
- To keep `run-ios-tests` and `skip-ios-tests` working, hack `SetEnabled` so `IncludeiOS` also sets `IncludeiOS32` and `IncludeiOS64`.
  Otherwise the way the code is currently organised we'd have to use `skip-ios-32-tests` and `skip-ios-64-tests`.

Backport of #7540.

/cc @VincentDondain 