### PR TITLE
[d16-5] [monotouch-test] Simplify NetworkReachabilityTest.CtorIPAddressPair test.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -652,7 +652,7 @@ partial class TestRuntime
 		NUnit.Framework.Assert.Ignore ($"This test requires watchOS {major}.{minor}");
 	}
 
-	static bool CheckMacSystemVersion (int major, int minor, int build = 0, bool throwIfOtherPlatform = true)
+	public static bool CheckMacSystemVersion (int major, int minor, int build = 0, bool throwIfOtherPlatform = true)
 	{
 #if MONOMAC
 		return OSXVersion >= new Version (major, minor, build);

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -652,7 +652,7 @@ partial class TestRuntime
 		NUnit.Framework.Assert.Ignore ($"This test requires watchOS {major}.{minor}");
 	}
 
-	public static bool CheckMacSystemVersion (int major, int minor, int build = 0, bool throwIfOtherPlatform = true)
+	static bool CheckMacSystemVersion (int major, int minor, int build = 0, bool throwIfOtherPlatform = true)
 	{
 #if MONOMAC
 		return OSXVersion >= new Version (major, minor, build);

--- a/tests/monotouch-test/SystemConfiguration/NetworkReachabilityTest.cs
+++ b/tests/monotouch-test/SystemConfiguration/NetworkReachabilityTest.cs
@@ -135,7 +135,7 @@ namespace MonoTouchFixtures.SystemConfiguration {
 			if (has_address) {
 				shouldBeReachable = true;
 			} else {
-				shouldBeReachable = !TestRuntime.CheckMacSystemVersion (10, 12);
+				shouldBeReachable = !TestRuntime.CheckMacSystemVersion (10, 12) || TestRuntime.CheckMacSystemVersion (10, 15, 2);
 			}
 #elif __IOS__
 			if (Runtime.Arch == Arch.DEVICE) {
@@ -154,8 +154,8 @@ namespace MonoTouchFixtures.SystemConfiguration {
 				has_local_address = false;
 				has_isdirect = has_local_address;
 			} else {
-				has_local_address = !TestRuntime.CheckMacSystemVersion (10, 11);
-				has_isdirect = false;
+				has_local_address = !TestRuntime.CheckMacSystemVersion (10, 11) || TestRuntime.CheckMacSystemVersion (10, 15, 2);
+				has_isdirect = TestRuntime.CheckMacSystemVersion (10, 12);
 			}
 #elif __IOS__
 			if (Runtime.Arch == Arch.DEVICE) {

--- a/tests/monotouch-test/SystemConfiguration/NetworkReachabilityTest.cs
+++ b/tests/monotouch-test/SystemConfiguration/NetworkReachabilityTest.cs
@@ -122,66 +122,13 @@ namespace MonoTouchFixtures.SystemConfiguration {
 
 		void CheckLoopbackFlags (NetworkReachabilityFlags flags, string number, bool has_address)
 		{
-			// Varios OS versions do different things.
-			// It seems Apple throws a dice before every OS release to see what they'll do that year...
 			var noFlags = (NetworkReachabilityFlags) 0;
-
-			var isReachable = (flags & NetworkReachabilityFlags.Reachable) == NetworkReachabilityFlags.Reachable;
-			var isLocalAddress = (flags & NetworkReachabilityFlags.IsLocalAddress) == NetworkReachabilityFlags.IsLocalAddress;
-			var isDirect = (flags & NetworkReachabilityFlags.IsDirect) == NetworkReachabilityFlags.IsDirect;
 			var otherFlags = (flags & ~(NetworkReachabilityFlags.Reachable | NetworkReachabilityFlags.IsLocalAddress | NetworkReachabilityFlags.IsDirect));
-			var shouldBeReachable = true;
-#if MONOMAC
-			if (has_address) {
-				shouldBeReachable = true;
-			} else {
-				shouldBeReachable = !TestRuntime.CheckMacSystemVersion (10, 12) || TestRuntime.CheckMacSystemVersion (10, 15, 2);
-			}
-#elif __IOS__
-			if (Runtime.Arch == Arch.DEVICE) {
-				shouldBeReachable = !TestRuntime.CheckXcodeVersion (8, 0) || TestRuntime.CheckXcodeVersion (11, 2);
-			} else {
-				shouldBeReachable = true;
-			}
-#endif
 
-			Assert.AreEqual (shouldBeReachable, isReachable, $"#{number} Reachable: {flags.ToString ()}");
-
-			bool has_local_address;
-			bool has_isdirect;
-#if MONOMAC
-			if (has_address) {
-				has_local_address = false;
-				has_isdirect = has_local_address;
-			} else {
-				has_local_address = !TestRuntime.CheckMacSystemVersion (10, 11) || TestRuntime.CheckMacSystemVersion (10, 15, 2);
-				has_isdirect = TestRuntime.CheckMacSystemVersion (10, 12);
-			}
-#elif __IOS__
-			if (Runtime.Arch == Arch.DEVICE) {
-				if (has_address) {
-					has_local_address = !TestRuntime.CheckXcodeVersion (6, 0) || TestRuntime.CheckXcodeVersion (11, 2);
-					has_isdirect = TestRuntime.CheckXcodeVersion (11, 2);
-				} else {
-					has_local_address = !TestRuntime.CheckXcodeVersion (7, 0) || TestRuntime.CheckXcodeVersion (11, 2);
-					has_isdirect = TestRuntime.CheckXcodeVersion (11, 2);
-				}
-			} else {
-				has_local_address = !TestRuntime.CheckXcodeVersion (7, 0);
-				has_isdirect = false;
-			}
-#else
-			if (Runtime.Arch == Arch.DEVICE) {
-				has_local_address = true;
-				has_isdirect = true;
-			} else {
-				has_local_address = !TestRuntime.CheckXcodeVersion (7, 0);
-				has_isdirect = false;
-			}
-#endif
-
-			Assert.AreEqual (has_local_address, isLocalAddress, $"#{number} IsLocalAddress: {flags.ToString ()}");
-			Assert.AreEqual (has_isdirect, isDirect, $"#{number} IsDirect: {flags.ToString ()}");
+			// Different versions of OSes report different flags. Trying to
+			// figure out which OS versions have which flags set turned out to
+			// be a never-ending game of whack-a-mole, so just don't assert
+			// that any specific flags are set.
 			Assert.AreEqual (noFlags, otherFlags, $"#{number} No other flags: {flags.ToString ()}");
 		}
 

--- a/tests/monotouch-test/SystemConfiguration/NetworkReachabilityTest.cs
+++ b/tests/monotouch-test/SystemConfiguration/NetworkReachabilityTest.cs
@@ -100,14 +100,7 @@ namespace MonoTouchFixtures.SystemConfiguration {
 				NetworkReachabilityFlags flags;
 
 				Assert.IsTrue (nr.TryGetFlags (out flags), "#1");
-				// using Loopback iOS 10 / tvOS 10 returns no flags (0) on devices
-				// but only sometimes... so check for Reachable as well (as a flag).
-#if !MONOMAC
-				if ((Runtime.Arch == Arch.DEVICE) && TestRuntime.CheckXcodeVersion (8, 0))
-					Assert.That ((flags == (NetworkReachabilityFlags) 0) || ((flags & NetworkReachabilityFlags.Reachable) == NetworkReachabilityFlags.Reachable) , $"#1 Reachable: {flags.ToString ()}");
-				else
-#endif
-					Assert.That (flags, Is.EqualTo (NetworkReachabilityFlags.Reachable), "#1 Reachable");
+				CheckLoopbackFlags (flags, "1", true);
 			}
 
 			using (var nr = new NetworkReachability (null, address))
@@ -123,25 +116,73 @@ namespace MonoTouchFixtures.SystemConfiguration {
 				NetworkReachabilityFlags flags;
 
 				Assert.IsTrue (nr.TryGetFlags (out flags), "#3");
-				// using Loopback iOS 10 / tvOS 10 / macOS 10.12 returns no flags (0) on devices
-				var expected = (NetworkReachabilityFlags) 0;
-#if MONOMAC
-				if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 12)) {
-					expected = NetworkReachabilityFlags.Reachable;
-					if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 11))
-						expected |= NetworkReachabilityFlags.IsLocalAddress;
-				}
-#else
-				if ((Runtime.Arch == Arch.DEVICE) && TestRuntime.CheckXcodeVersion (8, 0)) {
-					// 
-				} else {
-					expected = NetworkReachabilityFlags.Reachable;
-					if (!TestRuntime.CheckXcodeVersion (7, 0))
-						expected |= NetworkReachabilityFlags.IsLocalAddress;
-				}
-#endif
-				Assert.That (flags, Is.EqualTo (expected), "#3 Reachable");
+				CheckLoopbackFlags (flags, "3", false);
 			}
+		}
+
+		void CheckLoopbackFlags (NetworkReachabilityFlags flags, string number, bool has_address)
+		{
+			// Varios OS versions do different things.
+			// It seems Apple throws a dice before every OS release to see what they'll do that year...
+			var noFlags = (NetworkReachabilityFlags) 0;
+
+			var isReachable = (flags & NetworkReachabilityFlags.Reachable) == NetworkReachabilityFlags.Reachable;
+			var isLocalAddress = (flags & NetworkReachabilityFlags.IsLocalAddress) == NetworkReachabilityFlags.IsLocalAddress;
+			var isDirect = (flags & NetworkReachabilityFlags.IsDirect) == NetworkReachabilityFlags.IsDirect;
+			var otherFlags = (flags & ~(NetworkReachabilityFlags.Reachable | NetworkReachabilityFlags.IsLocalAddress | NetworkReachabilityFlags.IsDirect));
+			var shouldBeReachable = true;
+#if MONOMAC
+			if (has_address) {
+				shouldBeReachable = true;
+			} else {
+				shouldBeReachable = !TestRuntime.CheckMacSystemVersion (10, 12);
+			}
+#elif __IOS__
+			if (Runtime.Arch == Arch.DEVICE) {
+				shouldBeReachable = !TestRuntime.CheckXcodeVersion (8, 0) || TestRuntime.CheckXcodeVersion (11, 2);
+			} else {
+				shouldBeReachable = true;
+			}
+#endif
+
+			Assert.AreEqual (shouldBeReachable, isReachable, $"#{number} Reachable: {flags.ToString ()}");
+
+			bool has_local_address;
+			bool has_isdirect;
+#if MONOMAC
+			if (has_address) {
+				has_local_address = false;
+				has_isdirect = has_local_address;
+			} else {
+				has_local_address = !TestRuntime.CheckMacSystemVersion (10, 11);
+				has_isdirect = false;
+			}
+#elif __IOS__
+			if (Runtime.Arch == Arch.DEVICE) {
+				if (has_address) {
+					has_local_address = !TestRuntime.CheckXcodeVersion (6, 0) || TestRuntime.CheckXcodeVersion (11, 2);
+					has_isdirect = TestRuntime.CheckXcodeVersion (11, 2);
+				} else {
+					has_local_address = !TestRuntime.CheckXcodeVersion (7, 0) || TestRuntime.CheckXcodeVersion (11, 2);
+					has_isdirect = TestRuntime.CheckXcodeVersion (11, 2);
+				}
+			} else {
+				has_local_address = !TestRuntime.CheckXcodeVersion (7, 0);
+				has_isdirect = false;
+			}
+#else
+			if (Runtime.Arch == Arch.DEVICE) {
+				has_local_address = true;
+				has_isdirect = true;
+			} else {
+				has_local_address = !TestRuntime.CheckXcodeVersion (7, 0);
+				has_isdirect = false;
+			}
+#endif
+
+			Assert.AreEqual (has_local_address, isLocalAddress, $"#{number} IsLocalAddress: {flags.ToString ()}");
+			Assert.AreEqual (has_isdirect, isDirect, $"#{number} IsDirect: {flags.ToString ()}");
+			Assert.AreEqual (noFlags, otherFlags, $"#{number} No other flags: {flags.ToString ()}");
 		}
 
 		[Test]


### PR DESCRIPTION
Don't assert anything about the flags, it's a never ending game to keep up with OS versions.

Fixes https://github.com/xamarin/maccore/issues/2047 for good.

Backport of #7546.

/cc @rolfbjarne 