### PR TITLE
[xcode11.3] [runtime] Don't zero-terminate after the string buffer. Fixes #7564.

### DIFF
--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -440,6 +440,12 @@ xamarin_collapse_struct_name (const char *type, char struct_name[], int max_char
 		type++;
 	}
 
+	if (c == max_char) {
+		LOGZ ("    xamarin_collapse_struct_name (%s, %i) => failed (too long)!\n", input, max_char);
+		struct_name [0] = 0; // return an empty string
+		return false;
+	}
+
 	struct_name [c] = 0; // Zero-terminate.
 	LOGZ ("    xamarin_collapse_struct_name (%s, %i) => %s (succeeded)\n", input, max_char, struct_name);
 	return true;


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/7564.

Backport of #7571.

/cc @mandel-macaque @rolfbjarne