### PR TITLE
[Runtime] Add -fstack-protector-strong to the C flags used.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -190,7 +190,7 @@ IOS_CXX=$(XCODE_CXX)
 SIMULATOR_BIN_PATH=$(XCODE_DEVELOPER_ROOT)/Platforms/iPhoneSimulator.platform/Developer/usr/bin
 SIMULATOR_CC=$(IOS_CC)
 
-CFLAGS= -Wall -fms-extensions -Wno-format-security
+CFLAGS= -Wall -fms-extensions -Wno-format-security -fstack-protector-strong
 
 ifdef ENABLE_BITCODE_ON_IOS
 BITCODE_CFLAGS=-fembed-bitcode-marker


### PR DESCRIPTION
This PR will have some tests failing until https://github.com/xamarin/xamarin-macios/pull/7585 is merged.