### PR TITLE
[Tests] Improve error when we have network issues in ImageCaptioningTest.GetCaption

### DIFF
--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -32,7 +32,12 @@ namespace MonoTouchFixtures.MediaAccessibility {
 			using (NSUrl url = new NSUrl (NetworkResources.MicrosoftUrl)) {
 				var s = MAImageCaptioning.GetCaption (url, out var e);
 				Assert.Null (s, "remote / return value");
-				Assert.Null (e, "remote / no error"); // weird should be an "image on disk"
+				if (e != null && e.Description.Contains ("Invalid url:")) {
+					Assert.Null (e, "remote / no internet connection"); // could not connect to the network, fail and add a nice reason
+				} else {
+					Assert.Null (e, "remote / no error"); // weird should be an "image on disk"
+
+				}
 			}
 			string file = Path.Combine (NSBundle.MainBundle.ResourcePath, "basn3p08.png");
 			file = file.Replace (" ", "%20");

--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -33,7 +33,7 @@ namespace MonoTouchFixtures.MediaAccessibility {
 				var s = MAImageCaptioning.GetCaption (url, out var e);
 				Assert.Null (s, "remote / return value");
 				if (e != null && e.Description.Contains ("Invalid url:")) {
-					Assert.Null (e, "remote / no internet connection"); // could not connect to the network, fail and add a nice reason
+					Assert.Fail (e, "Ignore this failure when network is down"); // could not connect to the network, fail and add a nice reason
 				} else {
 					Assert.Null (e, "remote / no error"); // weird should be an "image on disk"
 

--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -33,7 +33,7 @@ namespace MonoTouchFixtures.MediaAccessibility {
 				var s = MAImageCaptioning.GetCaption (url, out var e);
 				Assert.Null (s, "remote / return value");
 				if (e != null && e.Description.Contains ("Invalid url:")) {
-					Assert.Fail (e, "Ignore this failure when network is down"); // could not connect to the network, fail and add a nice reason
+					Assert.Fail ("Ignore this failure when network is down"); // could not connect to the network, fail and add a nice reason
 				} else {
 					Assert.Null (e, "remote / no error"); // weird should be an "image on disk"
 


### PR DESCRIPTION
The error does give a description letting us know that the url was
invalid, that is, we could not reach it.

Fixes: https://github.com/xamarin/maccore/issues/2088