### PR TITLE
[test][monotouch-test] Fix crash on old iOS8 32bits devices

### DIFF
--- a/tests/monotouch-test/AVFoundation/CaptureMetadataOutputTest.cs
+++ b/tests/monotouch-test/AVFoundation/CaptureMetadataOutputTest.cs
@@ -144,6 +144,16 @@ namespace MonoTouchFixtures.AVFoundation {
 
 							AVMetadataObjectType all = AVMetadataObjectType.None;
 							foreach (AVMetadataObjectType val in Enum.GetValues (typeof (AVMetadataObjectType))) {
+								switch (val) {
+								case AVMetadataObjectType.CatBody:
+								case AVMetadataObjectType.DogBody:
+								case AVMetadataObjectType.HumanBody:
+								case AVMetadataObjectType.SalientObject:
+									// fail *and crash* on iOS 8 (at least on 32bits devices)
+									if (!TestRuntime.CheckXcodeVersion (11, 0))
+										continue;
+									break;
+								}
 								metadataOutput.MetadataObjectTypes = val;
 								all |= val;
 								Assert.AreEqual (val, metadataOutput.MetadataObjectTypes, val.ToString ());


### PR DESCRIPTION
```
20:11:28.9562500 2019-12-12 20:11:48.058 monotouchtest[873:239608] Xamarin.iOS: Received unhandled ObjectiveC exception: NSInvalidArgumentException *** -[AVCaptureMetadataOutput setMetadataObjectTypes:] - unsupported type found.  Use -availableMetadataObjectTypes.
20:11:29.0542980 2019-12-12 20:11:48.154 monotouchtest[873:239608]
20:11:29.0543360 Unhandled Exception:
20:11:29.0543440 0   libmonosgen-2.0.dylib               0x04d53c45 setup_stack_trace + 188
20:11:29.0543500 1   libmonosgen-2.0.dylib               0x04d51df9 mono_handle_exception_internal + 2120
20:11:29.0543560 2   libmonosgen-2.0.dylib               0x04d515ad mono_handle_exception + 50
20:11:29.0543620 3   libmonosgen-2.0.dylib               0x04d47de9 mono_arm_throw_exception + 132
20:11:29.0543690 4   libmscorlib.dll.dylib               0x01570648 throw_exception + 72
...
```

Fixes https://github.com/xamarin/maccore/issues/2091