### PR TITLE
[msbuild] Update tests to NUnit 3.12.

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CompileSceneKitAssetsTest.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CompileSceneKitAssetsTest.cs
@@ -27,7 +27,7 @@ namespace Xamarin.iOS.Tasks
 			var scenePath = Path.GetFullPath (Path.Combine (appPath, "art.scnassets", "scene.scn"));
 
 			var xml = Configuration.ReadPListAsXml (scenePath);
-			Assert.That (xml, Is.StringContaining ("<string>art.scnassets/texture.png</string>"), "asset with path");
+			Assert.That (xml, Does.Contain ("<string>art.scnassets/texture.png</string>"), "asset with path");
 		}
 
 		[Test]

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ReleaseBuild.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ReleaseBuild.cs
@@ -20,7 +20,7 @@ namespace Xamarin.iOS.Tasks
 			BuildProject ("MyReleaseBuild", Platform, "Release");
 		}
 
-		[Ignore] // requires msbuild instead of xbuild
+		[Ignore ("requires msbuild instead of xbuild")]
 		[Test]
 		public void RebuildTest ()
 		{

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
@@ -575,7 +575,7 @@ namespace Xamarin.iOS.Tasks
 			MonoTouchProjectInstance = MonoTouchProject.CreateProjectInstance ();
 
 			RunTarget_WithErrors (MonoTouchProjectInstance, TargetName.DetectAppManifest);
-			Assert.IsNullOrEmpty (MonoTouchProjectInstance.GetPropertyValue ("_AppManifest"), "#1");
+			Assert.That (MonoTouchProjectInstance.GetPropertyValue ("_AppManifest"), Is.Null.Or.Empty, "#1");
 		}
 
 		[Test]
@@ -625,7 +625,7 @@ namespace Xamarin.iOS.Tasks
 		public void DetectAppManifest_LibraryProject ()
 		{
 			RunTargetOnInstance (LibraryProjectInstance, TargetName.DetectAppManifest);
-			Assert.IsNullOrEmpty (LibraryProjectInstance.GetPropertyValue ("_AppManifest"), "#1");
+			Assert.That (LibraryProjectInstance.GetPropertyValue ("_AppManifest"), Is.Not.Null.Or.Empty, "#1");
 		}
 	}
 }

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
@@ -91,7 +91,7 @@ namespace Xamarin.iOS.Tasks
 		public virtual void XamarinVersion ()
 		{
 			Assert.That (CompiledPlist.ContainsKey ("com.xamarin.ios"), "#1");
-			Assert.IsNotNullOrEmpty (CompiledPlist.Get<PDictionary> ("com.xamarin.ios").GetString ("Version").Value, "#2");
+			Assert.That (CompiledPlist.Get<PDictionary> ("com.xamarin.ios").GetString ("Version").Value, Is.Not.Null.Or.Empty, "#2");
 		}
 		#endregion
 
@@ -100,7 +100,7 @@ namespace Xamarin.iOS.Tasks
 		public void BuildMachineOSBuild ()
 		{
 			Assert.That (CompiledPlist.ContainsKey (ManifestKeys.BuildMachineOSBuild), "#1");
-			Assert.IsNotNullOrEmpty (CompiledPlist.Get<PString> (ManifestKeys.BuildMachineOSBuild).Value, "#2");
+			Assert.That (CompiledPlist.Get<PString> (ManifestKeys.BuildMachineOSBuild).Value, Is.Not.Null.Or.Empty, "#2");
 		}
 
 		[Test]
@@ -134,7 +134,7 @@ namespace Xamarin.iOS.Tasks
 		public virtual void BundleInfoDictionaryVersion ()
 		{
 			Assert.That (CompiledPlist.ContainsKey (ManifestKeys.CFBundleInfoDictionaryVersion), "#1");
-			Assert.IsNotNullOrEmpty (CompiledPlist.Get<PString> (ManifestKeys.CFBundleInfoDictionaryVersion).Value, "#2");
+			Assert.That (CompiledPlist.Get<PString> (ManifestKeys.CFBundleInfoDictionaryVersion).Value, Is.Not.Null.Or.Empty, "#2");
 		}
 
 		[Test]
@@ -162,7 +162,7 @@ namespace Xamarin.iOS.Tasks
 		public virtual void BundleVersion ()
 		{
 			Assert.That (CompiledPlist.ContainsKey (ManifestKeys.CFBundleVersion), "#1");
-			Assert.IsNotNullOrEmpty (CompiledPlist.Get<PString> (ManifestKeys.CFBundleVersion).Value, "#2");
+			Assert.That (CompiledPlist.Get<PString> (ManifestKeys.CFBundleVersion).Value, Is.Not.Null.Or.Empty, "#2");
 		}
 
 		[Test]
@@ -184,14 +184,14 @@ namespace Xamarin.iOS.Tasks
 			Assert.That (CompiledPlist.ContainsKey (dtSDKName), "#5");
 			Assert.That (CompiledPlist.ContainsKey (dtXcode), "#6");
 			Assert.That (CompiledPlist.ContainsKey (dtXcodeBuild), "#7");
-			Assert.IsNotNullOrEmpty (CompiledPlist.Get<PString> (dtCompiler).Value, "#8");
-			Assert.IsNotNullOrEmpty (CompiledPlist.Get<PString> (dtPlatformBuild).Value, "#9");
-			Assert.IsNotNullOrEmpty (CompiledPlist.Get<PString> (dtSDKBuild).Value, "#10");
-			Assert.IsNotNullOrEmpty (CompiledPlist.Get<PString> (dtPlatformName).Value, "#11");
-			Assert.IsNotNullOrEmpty (CompiledPlist.Get<PString> (dtPlatformVersion).Value, "#12");
-			Assert.IsNotNullOrEmpty (CompiledPlist.Get<PString> (dtSDKName).Value, "#13");
-			Assert.IsNotNullOrEmpty (CompiledPlist.Get<PString> (dtXcode).Value, "#14");
-			Assert.IsNotNullOrEmpty (CompiledPlist.Get<PString> (dtXcodeBuild).Value, "#15");
+			Assert.That (CompiledPlist.Get<PString> (dtCompiler).Value, Is.Not.Null.Or.Empty, "#8");
+			Assert.That (CompiledPlist.Get<PString> (dtPlatformBuild).Value, Is.Not.Null.Or.Empty, "#9");
+			Assert.That (CompiledPlist.Get<PString> (dtSDKBuild).Value, Is.Not.Null.Or.Empty, "#10");
+			Assert.That (CompiledPlist.Get<PString> (dtPlatformName).Value, Is.Not.Null.Or.Empty, "#11");
+			Assert.That (CompiledPlist.Get<PString> (dtPlatformVersion).Value, Is.Not.Null.Or.Empty, "#12");
+			Assert.That (CompiledPlist.Get<PString> (dtSDKName).Value, Is.Not.Null.Or.Empty, "#13");
+			Assert.That (CompiledPlist.Get<PString> (dtXcode).Value, Is.Not.Null.Or.Empty, "#14");
+			Assert.That (CompiledPlist.Get<PString> (dtXcodeBuild).Value, Is.Not.Null.Or.Empty, "#15");
 		}
 
 		[Test]
@@ -205,7 +205,7 @@ namespace Xamarin.iOS.Tasks
 		public virtual void MinimumOSVersion ()
 		{
 			Assert.That (CompiledPlist.ContainsKey (ManifestKeys.MinimumOSVersion), "#1");
-			Assert.IsNotNullOrEmpty (CompiledPlist.Get<PString> (ManifestKeys.MinimumOSVersion).Value, "#2");
+			Assert.That (CompiledPlist.Get<PString> (ManifestKeys.MinimumOSVersion).Value, Is.Not.Null.Or.Empty, "#2");
 		}
 		#endregion
 	}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
@@ -74,8 +74,8 @@ namespace Xamarin.iOS.Tasks
 
 				foreach (var bundleResource in ibtool.BundleResources) {
 					Assert.IsTrue (File.Exists (bundleResource.ItemSpec), "File does not exist: {0}", bundleResource.ItemSpec);
-					Assert.IsNotNullOrEmpty (bundleResource.GetMetadata ("LogicalName"), "The 'LogicalName' metadata must be set.");
-					Assert.IsNotNullOrEmpty (bundleResource.GetMetadata ("Optimize"), "The 'Optimize' metadata must be set.");
+					Assert.That (bundleResource.GetMetadata ("LogicalName"), Is.Not.Null.Or.Empty, "The 'LogicalName' metadata must be set.");
+					Assert.That (bundleResource.GetMetadata ("Optimize"), Is.Not.Null.Or.Empty, "The 'Optimize' metadata must be set.");
 
 					bundleResources.Add (bundleResource.GetMetadata ("LogicalName"));
 				}
@@ -141,10 +141,10 @@ namespace Xamarin.iOS.Tasks
 					var tag = bundleResource.GetMetadata ("ResourceTags");
 
 					Assert.IsTrue (File.Exists (bundleResource.ItemSpec), "File does not exist: {0}", bundleResource.ItemSpec);
-					Assert.IsNotNullOrEmpty (bundleResource.GetMetadata ("LogicalName"), "The 'LogicalName' metadata must be set.");
-					Assert.IsNotNullOrEmpty (bundleResource.GetMetadata ("Optimize"), "The 'Optimize' metadata must be set.");
+					Assert.That (bundleResource.GetMetadata ("LogicalName"), Is.Not.Null.Or.Empty, "The 'LogicalName' metadata must be set.");
+					Assert.That (bundleResource.GetMetadata ("Optimize"), Is.Not.Null.Or.Empty, "The 'Optimize' metadata must be set.");
 
-					Assert.IsNotNullOrEmpty (tag, "The 'ResourceTags' metadata should be set.");
+					Assert.That (tag, Is.Not.Null.Or.Empty, "The 'ResourceTags' metadata should be set.");
 					Assert.IsTrue (bundleName.Contains (".lproj/" + tag + ".storyboardc/"), "BundleResource does not have the proper ResourceTags set: {0}", bundleName);
 
 					bundleResources.Add (bundleName);
@@ -233,10 +233,10 @@ namespace Xamarin.iOS.Tasks
 					var tag = bundleResource.GetMetadata ("ResourceTags");
 
 					Assert.IsTrue (File.Exists (bundleResource.ItemSpec), "File does not exist: {0}", bundleResource.ItemSpec);
-					Assert.IsNotNullOrEmpty (bundleResource.GetMetadata ("LogicalName"), "The 'LogicalName' metadata must be set.");
-					Assert.IsNotNullOrEmpty (bundleResource.GetMetadata ("Optimize"), "The 'Optimize' metadata must be set.");
+					Assert.That (bundleResource.GetMetadata ("LogicalName"), Is.Not.Null.Or.Empty, "The 'LogicalName' metadata must be set.");
+					Assert.That (bundleResource.GetMetadata ("Optimize"), Is.Not.Null.Or.Empty, "The 'Optimize' metadata must be set.");
 
-					Assert.IsNotNullOrEmpty (tag, "The 'ResourceTags' metadata should be set.");
+					Assert.That (tag, Is.Not.Null.Or.Empty, "The 'ResourceTags' metadata should be set.");
 					Assert.AreEqual (Path.Combine (tmp, "ibtool", tag + ".nib", Path.GetFileName (bundleName)), bundleResource.ItemSpec, $"BundleResource {bundleName} is not at the expected location.");
 
 					bundleResources.Add (bundleName);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/MTouchTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/MTouchTaskTests.cs
@@ -136,12 +136,12 @@ namespace Xamarin.iOS.Tasks
 		}
 
 		[Test]
-		[ExpectedException (typeof(InvalidOperationException), ExpectedMessage = "Bitcode is currently not supported on iOS.")]
 		public void StandardCommandline_WithBitcodeEnabled_iOS ()
 		{
 			MTouchEnableBitcode("Xamarin.iOS");
 
-			Task.GenerateCommandLineCommands ();
+			var ex = Assert.Throws<InvalidOperationException> (() => Task.GenerateCommandLineCommands (), "Exception");
+			Assert.AreEqual ("Bitcode is currently not supported on iOS.", ex.Message, "Message");
 		}
 
 		[Test]

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -35,9 +35,9 @@
     <Reference Include="Microsoft.Build" HintPath="$(MSBuildBinPath)\Microsoft.Build.dll" />
     <Reference Include="Microsoft.Build.Utilities.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Utilities.Core.dll" />
     <Reference Include="System.Xml" />
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />
+    <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Xamarin.iOS.Tasks\Xamarin.iOS.Tasks.csproj">
@@ -120,7 +120,6 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
     <None Include="Resources\Entitlements.plist">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/packages.config
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="NUnit.Runners" version="2.6.4" />
-</packages>

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -209,7 +209,7 @@ killall:
 NUNIT_MSBUILD_DIR=$(TOP)/packages/NUnit.Runners.2.6.4/tools/lib
 test-ios-tasks:
 	$(SYSTEM_XIBUILD) -- $(TOP)/msbuild/Xamarin.MacDev.Tasks.sln
-	cd $(NUNIT_MSBUILD_DIR) && $(SYSTEM_XIBUILD) -t -- ../nunit-console.exe ../../../../msbuild/tests/bin/Xamarin.iOS.Tasks.Tests.dll -xml=TestResults_Xamarin.iOS.Tasks.Tests.xml -labels $(TEST_FIXTURE) || touch .failed-stamp
+	cd $(TOP)/msbuild/tests/Xamarin.iOS.Tasks.Tests && $(SYSTEM_XIBUILD) -t -- $(abspath $(TOP)/tools/nunit3-console-3.10.0) $(abspath $(TOP)/msbuild/tests/bin/Xamarin.iOS.Tasks.Tests.dll) "--result=$(abspath $(CURDIR)/TestResults_Xamarin.iOS.Tasks.Tests.xml);format=nunit2" -labels=All $(TEST_FIXTURE) || touch .failed-stamp
 	@[[ -z "$$BUILD_REPOSITORY" ]] || ( xsltproc $(TOP)/tests/HtmlTransform.xslt $(NUNIT_MSBUILD_DIR)/TestResults_Xamarin.iOS.Tasks.Tests.xml > $(TOP)/tests/index.html && echo "@MonkeyWrench: AddFile: $$PWD/index.html" )
 	@if test -e $(NUNIT_MSBUILD_DIR)/.failed-stamp; then rm $(NUNIT_MSBUILD_DIR)/.failed-stamp; exit 1; fi
 

--- a/tools/nunit3-console-3.10.0
+++ b/tools/nunit3-console-3.10.0
@@ -1,0 +1,3 @@
+#!/bin/bash -eu
+
+exec mono ~/.nuget/packages/nunit.consolerunner/3.10.0/tools/nunit3-console.exe "$@"


### PR DESCRIPTION
Updating the msbuild tasks to use netstandard2.0 requires us to bump NUnit to 3+.

This requires:

* A few code changes due to breaking API changes in NUnit.
* Changes in xharness and a makefile to cope with the new location for the
  NUnit console runner (I added a helper script to make things slightly
  easier).