### PR TITLE
[d16-5][Runtime] Move some of the changes back to int. (#7529)

### DIFF
--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -52,7 +52,7 @@
 
 		new XDelegate ("MonoObject *", "IntPtr", "xamarin_get_block_wrapper_creator",
 			"MonoObject *", "IntPtr", "method",
-			"unsigned long", "uint", "parameter"
+			"int", "int", "parameter"
 		) {
 			WrappedManagedFunction = "GetBlockWrapperCreator",
 			OnlyDynamicUsage = true,
@@ -203,7 +203,7 @@
 
 		new XDelegate ("bool", "bool", "xamarin_is_parameter_out",
 			"MonoReflectionMethod *", "IntPtr", "method",
-			"unsigned long", "uint", "parameter"
+			"int", "int", "parameter"
 		) {
 			WrappedManagedFunction = "IsParameterOut",
 			OnlyDynamicUsage = true,

--- a/runtime/monotouch-debug.h
+++ b/runtime/monotouch-debug.h
@@ -23,7 +23,7 @@ void monotouch_start_debugging ();
 void monotouch_start_profiling ();
 
 void monotouch_set_connection_mode (const char *mode);
-void monotouch_set_monodevelop_port (long port);
+void monotouch_set_monodevelop_port (int port);
 
 
 typedef struct {

--- a/runtime/monotouch-debug.m
+++ b/runtime/monotouch-debug.m
@@ -381,9 +381,9 @@ monotouch_set_connection_mode (const char *mode)
 }
 
 void
-monotouch_set_monodevelop_port (long port)
+monotouch_set_monodevelop_port (int port)
 {
-	monodevelop_port = port;
+	monodevelop_port = (long) port;
 }
 
 void

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -340,7 +340,7 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 				if (!value && argc > i + 1)
 					value = argv [++i];
 				if (value) {
-					monotouch_set_monodevelop_port (strtol (value, NULL, 10));
+					monotouch_set_monodevelop_port ((int) strtol (value, NULL, 10));
 				} else {
 					PRINT ("MonoTouch: --%s requires an argument.", name);
 				}

--- a/runtime/monotouch-support.h
+++ b/runtime/monotouch-support.h
@@ -9,8 +9,8 @@ extern "C" {
 
 const char *   xamarin_get_locale_country_code ();
 void           xamarin_log (const unsigned short *unicodeMessage);
-void *         xamarin_timezone_get_data (const char *name, unsigned long *size);
-char **        xamarin_timezone_get_names (unsigned long *count);
+void *         xamarin_timezone_get_data (const char *name, uint32_t *size);
+char **        xamarin_timezone_get_names (uint32_t *count);
 char *         xamarin_timezone_get_local_name ();
 void           xamarin_start_wwan (const char *uri);
 void           xamarin_os_log (os_log_t logger, os_log_type_t type, const char *message);

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2066,7 +2066,7 @@ xamarin_create_managed_ref (id self, gpointer managed_object, bool retain)
 
 typedef struct {
 	MonoMethod *method;
-	unsigned long par;
+	int par;
 } MethodAndPar;
 
 static gboolean
@@ -2094,7 +2094,7 @@ static MonoReferenceQueue *block_wrapper_queue;
  * create the method
  */
 static MonoObject *
-get_method_block_wrapper_creator (MonoMethod *method, unsigned long par, guint32 *exception_gchandle)
+get_method_block_wrapper_creator (MonoMethod *method, int par, guint32 *exception_gchandle)
 {
 	// COOP: accesses managed memory: unsafe mode.
 	MONO_ASSERT_GC_UNSAFE;
@@ -2120,7 +2120,7 @@ get_method_block_wrapper_creator (MonoMethod *method, unsigned long par, guint32
 		return res;
 	}
 
-	res = xamarin_get_block_wrapper_creator ((MonoObject *) mono_method_get_object (mono_domain_get (), method, NULL), par, exception_gchandle);
+	res = xamarin_get_block_wrapper_creator ((MonoObject *) mono_method_get_object (mono_domain_get (), method, NULL), (int) par, exception_gchandle);
 	if (*exception_gchandle != 0)
 		return NULL;
 	// PRINT ("New value: %x", (int) res);
@@ -2162,7 +2162,7 @@ xamarin_release_block_on_main_thread (void *obj)
  * Returns: the instantiated delegate.
  */
 int *
-xamarin_get_delegate_for_block_parameter (MonoMethod *method, guint32 token_ref, unsigned long par, void *nativeBlock, guint32 *exception_gchandle)
+xamarin_get_delegate_for_block_parameter (MonoMethod *method, guint32 token_ref, int par, void *nativeBlock, guint32 *exception_gchandle)
 {
 	// COOP: accesses managed memory: unsafe mode.
 	MONO_ASSERT_GC_UNSAFE;

--- a/runtime/trampolines-arm64.m
+++ b/runtime/trampolines-arm64.m
@@ -40,7 +40,7 @@ dump_state (struct XamarinCallState *state, const char *prefix)
 #define dump_state(...)
 #endif
 
-static size_t 
+static int
 param_read_primitive (struct ParamIterator *it, const char *type_ptr, void *target, size_t total_size, guint32 *exception_gchandle)
 {
 	// COOP: does not access managed memory: any mode.
@@ -105,7 +105,7 @@ param_read_primitive (struct ParamIterator *it, const char *type_ptr, void *targ
 
 		if (target == NULL) {
 			LOGZ (" not reading, since target is NULL.\n");
-			return size;
+			return (int) size;
 		}
 
 		switch (size) {
@@ -130,7 +130,7 @@ param_read_primitive (struct ParamIterator *it, const char *type_ptr, void *targ
 			return 0;
 		}
 
-		return size;
+		return (int) size;
 	}
 	}
 }
@@ -182,7 +182,7 @@ param_iter_next (enum IteratorAction action, void *context, const char *type, si
 	const char *t = struct_name;
 	uint8_t *targ = (uint8_t *) target;
 	do {
-		size_t c = param_read_primitive (it, t, targ, size, exception_gchandle);
+		int c = param_read_primitive (it, t, targ, size, exception_gchandle);
 		if (*exception_gchandle != 0)
 			return;
 		if (targ != NULL)
@@ -230,7 +230,7 @@ marshal_return_value (void *context, const char *type, size_t size, void *vvalue
 			(size == 8 && !strncmp (struct_name, "d", 1))) {
 			LOGZ ("        marshalling as %i doubles (struct name: %s)\n", (int) size / 8, struct_name);
 			double* ptr = (double *) mono_object_unbox (value);
-			for (unsigned long i = 0; i < size / 8; i++) {
+			for (int i = 0; i < size / 8; i++) {
 				LOGZ ("        #%i: %f\n", i, ptr [i]);
 				it->q [i].d = ptr [i];
 			}
@@ -240,7 +240,7 @@ marshal_return_value (void *context, const char *type, size_t size, void *vvalue
 				   (size == 4 && !strncmp (struct_name, "f", 1))) {
 			LOGZ ("        marshalling as %i floats (struct name: %s)\n", (int) size / 4, struct_name);
 			float* ptr = (float *) mono_object_unbox (value);
-			for (unsigned long i = 0; i < size / 4; i++) {
+			for (int i = 0; i < size / 4; i++) {
 				LOGZ ("        #%i: %f\n", i, ptr [i]);
 				it->q [i].f.f1 = ptr [i];
 			}

--- a/runtime/trampolines-internal.h
+++ b/runtime/trampolines-internal.h
@@ -48,7 +48,7 @@ typedef void (*marshal_return_value_func) (void *context, const char *type, size
 
 void xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_func iterator, marshal_return_value_func marshal_return_value, void *context);
 
-unsigned long xamarin_get_frame_length (id self, SEL sel);
+int xamarin_get_frame_length (id self, SEL sel);
 const char * xamarin_skip_type_name (const char *ptr);
 
 #ifdef __cplusplus

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -449,7 +449,7 @@ xamarin_collapse_struct_name (const char *type, char struct_name[], int max_char
 	return true;
 }
 
-unsigned long
+int 
 xamarin_get_frame_length (id self, SEL sel)
 {
 	if (self == NULL)
@@ -516,7 +516,7 @@ xamarin_get_frame_length (id self, SEL sel)
 	// we can't detect varargs, so just add 16 more pointer sized arguments to be on the safe-ish side.
 	length += sizeof (void *) * 16;
 
-	return length;
+	return (int) length;
 }
 
 static inline void

--- a/runtime/xamarin-support.m
+++ b/runtime/xamarin-support.m
@@ -87,7 +87,7 @@ xamarin_log (const unsigned short *unicodeMessage)
 // See in Mono sdks/ios/runtime/runtime.m
 
 void*
-xamarin_timezone_get_data (const char *name, unsigned long *size)
+xamarin_timezone_get_data (const char *name, uint32_t *size)
 {
 	// COOP: no managed memory access: any mode.
 	NSTimeZone *tz = nil;
@@ -99,18 +99,18 @@ xamarin_timezone_get_data (const char *name, unsigned long *size)
 		tz = [NSTimeZone localTimeZone];
 	}
 	NSData *data = [tz data];
-	*size = [data length];
+	*size = (uint32_t) [data length];
 	void* result = malloc (*size);
 	memcpy (result, data.bytes, *size);
 	return result;
 }
 
 char**
-xamarin_timezone_get_names (unsigned long *count)
+xamarin_timezone_get_names (uint32_t *count)
 {
 	// COOP: no managed memory access: any mode.
 	NSArray *array = [NSTimeZone knownTimeZoneNames];
-	*count = array.count;
+	*count = (uint32_t) array.count;
 	char** result = (char**) malloc (sizeof (char*) * (*count));
 	for (unsigned long i = 0; i < *count; i++) {
 		NSString *s = [array objectAtIndex: i];

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -181,7 +181,7 @@ MonoClass *		xamarin_get_nullable_type (MonoClass *cls, guint32 *exception_gchan
 MonoType *		xamarin_get_parameter_type (MonoMethod *managed_method, int index);
 MonoObject *	xamarin_get_nsobject_with_type_for_ptr (id self, bool owns, MonoType* type, guint32 *exception_gchandle);
 MonoObject *	xamarin_get_nsobject_with_type_for_ptr_created (id self, bool owns, MonoType *type, int32_t *created, guint32 *exception_gchandle);
-int *			xamarin_get_delegate_for_block_parameter (MonoMethod *method, guint32 token_ref, unsigned long par, void *nativeBlock, guint32 *exception_gchandle);
+int *			xamarin_get_delegate_for_block_parameter (MonoMethod *method, guint32 token_ref, int par, void *nativeBlock, guint32 *exception_gchandle);
 id              xamarin_get_block_for_delegate (MonoMethod *method, MonoObject *delegate, const char *signature /* NULL allowed, but requires the dynamic registrar at runtime to compute */, guint32 token_ref /* INVALID_TOKEN_REF allowed, but requires the dynamic registrar at runtime */, guint32 *exception_gchandle);
 id				xamarin_get_nsobject_handle (MonoObject *obj);
 void			xamarin_set_nsobject_handle (MonoObject *obj, id handle);

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -35,7 +35,7 @@ id			xamarin_copyWithZone_trampoline2 (id self, SEL sel, NSZone *zone);
 int			xamarin_get_gchandle_trampoline (id self, SEL sel);
 void		xamarin_set_gchandle_trampoline (id self, SEL sel, int gc_handle);
 
-unsigned long	xamarin_get_frame_length (id self, SEL sel);
+int 		xamarin_get_frame_length (id self, SEL sel);
 bool		xamarin_collapse_struct_name (const char *type, char struct_name[], int max_char, guint32 *exception_gchandle);
 guint32		xamarin_create_mt_exception (char *msg);
 size_t		xamarin_get_primitive_size (char type);
@@ -95,7 +95,7 @@ MonoObject *    xamarin_convert_nsnumber_to_managed (NSNumber *value, MonoType *
 MonoObject *    xamarin_convert_nsvalue_to_managed (NSValue *value, MonoType *nativeType, MonoType *managedType, MonoMethod *method, guint32 *exception_gchandle);
 MonoObject *    xamarin_convert_nsstring_to_managed (NSString *value, MonoType *nativeType, MonoType *managedType, MonoMethod *method, guint32 *exception_gchandle);
 guint32         xamarin_create_bindas_exception (MonoType *inputType, MonoType *outputType, MonoMethod *method);
-guint32         xamarin_get_exception_for_parameter (int code, guint32 inner_exception_gchandle, const char *reason, SEL sel, MonoMethod *method, MonoType *p, unsigned long i, bool to_managed);
+guint32         xamarin_get_exception_for_parameter (int code, guint32 inner_exception_gchandle, const char *reason, SEL sel, MonoMethod *method, MonoType *p, int i, bool to_managed);
 
 xamarin_id_to_managed_func xamarin_get_nsnumber_to_managed_func (MonoClass *managedType, MonoMethod *method, guint32 *exception_gchandle);
 xamarin_managed_to_id_func xamarin_get_managed_to_nsnumber_func (MonoClass *managedType, MonoMethod *method, guint32 *exception_gchandle);

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -445,7 +445,7 @@ namespace ObjCRuntime {
 			}
 		}
 
-		static IntPtr GetBlockWrapperCreator (IntPtr method, uint parameter)
+		static IntPtr GetBlockWrapperCreator (IntPtr method, int parameter)
 		{
 			return ObjectWrapper.Convert (GetBlockWrapperCreator ((MethodInfo) ObjectWrapper.Convert (method), parameter));
 		}
@@ -727,7 +727,7 @@ namespace ObjCRuntime {
 			return parameters [parameter].IsDefined (typeof(TransientAttribute), false);
 		}
 
-		static bool IsParameterOut (IntPtr info, uint parameter)
+		static bool IsParameterOut (IntPtr info, int parameter)
 		{
 			var minfo = ObjectWrapper.Convert (info) as MethodInfo;
 			if (minfo == null)
@@ -773,7 +773,7 @@ namespace ObjCRuntime {
 		}
 #endregion
 
-		static MethodInfo GetBlockProxyAttributeMethod (MethodInfo method, uint parameter)
+		static MethodInfo GetBlockProxyAttributeMethod (MethodInfo method, int parameter)
 		{
 			var attrs = method.GetParameters () [parameter].GetCustomAttributes (typeof (BlockProxyAttribute), true);
 			if (attrs.Length == 1) {
@@ -840,7 +840,7 @@ namespace ObjCRuntime {
 #else
 		public 
 #endif
-		static MethodInfo GetBlockWrapperCreator (MethodInfo method, uint parameter)
+		static MethodInfo GetBlockWrapperCreator (MethodInfo method, int parameter)
 		{
 			// A mirror of this method is also implemented in StaticRegistrar:FindBlockProxyCreatorMethod
 			// If this method is changed, that method will probably have to be updated too (tests!!!)

--- a/tests/linker/ios/link all/InternalsTest.cs
+++ b/tests/linker/ios/link all/InternalsTest.cs
@@ -73,12 +73,12 @@ namespace LinkAll.InernalCalls {
 		}
 
 		[DllImport ("__Internal")]
-		extern static IntPtr xamarin_timezone_get_data (string name, ref int size);
+		extern static IntPtr xamarin_timezone_get_data (string name, ref uint size);
 
 		[Test]
 		public void TimeZone_Data ()
 		{
-			int size = 0;
+			uint size = 0;
 			IntPtr data = xamarin_timezone_get_data (null, ref size);
 			Assert.That (data, Is.Not.EqualTo (IntPtr.Zero), "default");
 			Assert.That (size, Is.GreaterThan (0), "default size");


### PR DESCRIPTION
Some of the fixes done for the warnings have breaking changes. Move back
to int and ensure that we do not have any compilation errors (we are
using -Werror).

Fixes: https://github.com/xamarin/xamarin-macios/issues/7509