### PR TITLE
[d16-5] [Tests] Ensure that if the TCP connection cannot be done, test are run.

### DIFF
--- a/tests/bcl-test/templates/iOSApp/ViewController.cs
+++ b/tests/bcl-test/templates/iOSApp/ViewController.cs
@@ -17,6 +17,7 @@ using NUnit.Framework.Internal.Filters;
 
 namespace BCLTests {
 	public partial class ViewController : UIViewController {
+
 		internal static IEnumerable<TestAssemblyInfo> GetTestAssemblies ()
  		{
 			// var t = Path.GetFileName (typeof (ActivatorCas).Assembly.Location);

--- a/tests/bcl-test/templates/iOSApp/ViewController.cs
+++ b/tests/bcl-test/templates/iOSApp/ViewController.cs
@@ -17,7 +17,6 @@ using NUnit.Framework.Internal.Filters;
 
 namespace BCLTests {
 	public partial class ViewController : UIViewController {
-
 		internal static IEnumerable<TestAssemblyInfo> GetTestAssemblies ()
  		{
 			// var t = Path.GetFileName (typeof (ActivatorCas).Assembly.Location);
@@ -66,8 +65,14 @@ namespace BCLTests {
 			base.ViewDidLoad ();
 			var options = ApplicationOptions.Current;
 			TcpTextWriter writer = null;
-			if (!string.IsNullOrEmpty (options.HostName))
-				writer = new TcpTextWriter (options.HostName, options.HostPort);
+			if (!string.IsNullOrEmpty (options.HostName)) {
+				try {
+					writer = new TcpTextWriter (options.HostName, options.HostPort);
+				} catch (Exception ex) {
+					Console.WriteLine ("Network error: Cannot connect to {0}:{1}: {2}. Continuing on console.", options.HostName, options.HostPort, ex);
+					writer = null; // will default to the console
+				}
+			}
 
 			// we generate the logs in two different ways depending if the generate xml flag was
 			// provided. If it was, we will write the xml file to the tcp writer if present, else


### PR DESCRIPTION
TouchUnit uses Console.Out as the writer when the TCP connection cannot
be performed. The BCL tests were not doing so and were crashing.

With this change, when ran locally, if the TCP connection is not done,
we will use Console.Out as TouchUnit and the file will be parsed by
xharness correctly.

Backport of #7605.

/cc @mandel-macaque 