### PR TITLE
[msbuild] Use System.Text.Json instead of System.Json, since only the former is available in .netcore.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -139,8 +139,12 @@
     </ItemGroup>
     <PropertyGroup>
       <ILRepackArgs Condition="'$(AssemblyOriginatorKeyFile)' != ''">/keyfile:"$(AssemblyOriginatorKeyFile)"</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) @(LibDir -&gt; '/lib:&quot;%(Identity).&quot;', ' ')</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) /out:&quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot;</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) &quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot;</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) @(MergedAssemblies -&gt; '&quot;%(FullPath)&quot;', ' ')</ILRepackArgs>
     </PropertyGroup>
-    <Exec Command="&quot;$(ILRepack)&quot; @(LibDir -&gt; '/lib:&quot;%(Identity).&quot;', ' ') $(ILRepackArgs) /out:&quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot; &quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot; @(MergedAssemblies -&gt; '&quot;%(FullPath)&quot;', ' ')" WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
+    <Exec Command="&quot;$(ILRepack)&quot; $(ILRepackArgs)" WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput" />
       <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
     </Exec>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -131,8 +131,7 @@
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FullFrameworkReferenceAssemblyPaths" />
     </GetReferenceAssemblyPaths>
     <ItemGroup>
-      <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('Xamarin')) And '%(Extension)' == '.dll'" />
-      <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('Mono')) And '%(Extension)' == '.dll'" />
+      <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll' And !$([System.String]::new('%(FileName)').EndsWith('.resources')) And !$([System.String]::new('%(FileName)').StartsWith('Microsoft.Build.')) And !$([System.String]::new('%(FullPath)').StartsWith('/Library/Frameworks/Mono.framework'))" />
       <ReferenceCopyLocalDirs Include="@(ReferenceCopyLocalPaths -&gt; '%(RootDir)%(Directory)')" />
       <ReferenceCopyLocalPaths Remove="@(MergedAssemblies)" />
       <LibDir Include="@(ReferenceCopyLocalDirs -&gt; Distinct())" />

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -131,7 +131,12 @@
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FullFrameworkReferenceAssemblyPaths" />
     </GetReferenceAssemblyPaths>
     <ItemGroup>
-      <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll' And !$([System.String]::new('%(FileName)').EndsWith('.resources')) And !$([System.String]::new('%(FileName)').StartsWith('Microsoft.Build.')) And !$([System.String]::new('%(FullPath)').StartsWith('/Library/Frameworks/Mono.framework'))" />
+      <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="
+        '%(Extension)' == '.dll'
+        And !$([System.String]::new('%(FileName)').EndsWith('.resources', StringComparison.OrdinalIgnoreCase))
+        And !$([System.String]::new('%(FileName)').StartsWith('Microsoft.Build.', StringComparison.OrdinalIgnoreCase))
+        And !$([System.String]::new('%(FullPath)').StartsWith('/Library/Frameworks/Mono.framework', StringComparison.OrdinalIgnoreCase))"
+      />
       <ReferenceCopyLocalDirs Include="@(ReferenceCopyLocalPaths -&gt; '%(RootDir)%(Directory)')" />
       <ReferenceCopyLocalPaths Remove="@(MergedAssemblies)" />
       <LibDir Include="@(ReferenceCopyLocalDirs -&gt; Distinct())" />

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -142,6 +142,7 @@
       <ILRepackArgs>$(ILRepackArgs) /out:&quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot;</ILRepackArgs>
       <ILRepackArgs>$(ILRepackArgs) &quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot;</ILRepackArgs>
       <ILRepackArgs>$(ILRepackArgs) @(MergedAssemblies -&gt; '&quot;%(FullPath)&quot;', ' ')</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) &quot;/lib:$(FrameworkPathOverride)/Facades&quot;</ILRepackArgs> <!-- This is needed for ilrepack to find netstandard.dll, which is referenced by the System.Text.Json assembly -->
     </PropertyGroup>
     <Exec Command="&quot;$(ILRepack)&quot; $(ILRepackArgs)" WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput" />

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -40,8 +40,8 @@
     <Reference Include="System.Xml" />
     <Reference Include="Mono.Posix" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Json" />
     <Reference Include="System.Runtime.Serialization" />
+    <PackageReference Include="System.Text.Json" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj">

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -116,7 +116,12 @@
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FullFrameworkReferenceAssemblyPaths" />
     </GetReferenceAssemblyPaths>
     <ItemGroup>
-      <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll' And !$([System.String]::new('%(FileName)').EndsWith('.resources')) And !$([System.String]::new('%(FileName)').StartsWith('Microsoft.Build.')) And !$([System.String]::new('%(FullPath)').StartsWith('/Library/Frameworks/Mono.framework'))" />
+      <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="
+        '%(Extension)' == '.dll'
+        And !$([System.String]::new('%(FileName)').EndsWith('.resources', StringComparison.OrdinalIgnoreCase))
+        And !$([System.String]::new('%(FileName)').StartsWith('Microsoft.Build.', StringComparison.OrdinalIgnoreCase))
+        And !$([System.String]::new('%(FullPath)').StartsWith('/Library/Frameworks/Mono.framework', StringComparison.OrdinalIgnoreCase))"
+      />
       <ReferenceCopyLocalDirs Include="@(ReferenceCopyLocalPaths -&gt; '%(RootDir)%(Directory)')" />
       <ReferenceCopyLocalPaths Remove="@(MergedAssemblies)" />
       <LibDir Include="@(ReferenceCopyLocalDirs -&gt; Distinct())" />

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -116,8 +116,7 @@
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FullFrameworkReferenceAssemblyPaths" />
     </GetReferenceAssemblyPaths>
     <ItemGroup>
-      <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('Xamarin')) And '%(Extension)' == '.dll'" />
-      <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('Mono')) And '%(Extension)' == '.dll'" />
+      <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll' And !$([System.String]::new('%(FileName)').EndsWith('.resources')) And !$([System.String]::new('%(FileName)').StartsWith('Microsoft.Build.')) And !$([System.String]::new('%(FullPath)').StartsWith('/Library/Frameworks/Mono.framework'))" />
       <ReferenceCopyLocalDirs Include="@(ReferenceCopyLocalPaths -&gt; '%(RootDir)%(Directory)')" />
       <ReferenceCopyLocalPaths Remove="@(MergedAssemblies)" />
       <LibDir Include="@(ReferenceCopyLocalDirs -&gt; Distinct())" />

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -124,8 +124,12 @@
     </ItemGroup>
     <PropertyGroup>
       <ILRepackArgs Condition="'$(AssemblyOriginatorKeyFile)' != ''">/keyfile:"$(AssemblyOriginatorKeyFile)"</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) @(LibDir -&gt; '/lib:&quot;%(Identity).&quot;', ' ')</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) /out:&quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot;</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) &quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot;</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) @(MergedAssemblies -&gt; '&quot;%(FullPath)&quot;', ' ')</ILRepackArgs>
     </PropertyGroup>
-    <Exec Command="&quot;$(ILRepack)&quot; @(LibDir -&gt; '/lib:&quot;%(Identity).&quot;', ' ') $(ILRepackArgs) /out:&quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot; &quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot; @(MergedAssemblies -&gt; '&quot;%(FullPath)&quot;', ' ')" WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
+    <Exec Command="&quot;$(ILRepack)&quot; $(ILRepackArgs)" WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput" />
       <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
     </Exec>

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -127,6 +127,7 @@
       <ILRepackArgs>$(ILRepackArgs) /out:&quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot;</ILRepackArgs>
       <ILRepackArgs>$(ILRepackArgs) &quot;@(IntermediateAssembly -&gt; '%(FullPath)')&quot;</ILRepackArgs>
       <ILRepackArgs>$(ILRepackArgs) @(MergedAssemblies -&gt; '&quot;%(FullPath)&quot;', ' ')</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) &quot;/lib:$(FrameworkPathOverride)/Facades&quot;</ILRepackArgs> <!-- This is needed for ilrepack to find netstandard.dll, which is referenced by the System.Text.Json assembly -->
     </PropertyGroup>
     <Exec Command="&quot;$(ILRepack)&quot; $(ILRepackArgs)" WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput" />

--- a/msbuild/tests/Bug60536/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/msbuild/tests/Bug60536/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -194,7 +194,7 @@
       "size" : "512x512",
       "scale" : "2x"
     },
-  ],
+  ]],
   "info" : {
     "version" : 1,
     "author" : "xcode"

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Bug60536.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Bug60536.cs
@@ -49,8 +49,7 @@ namespace Xamarin.iOS.Tasks
 				}
 
 				if (Directory.Exists (binDir)) {
-					// Note: the .dSYM/Contents string match is a work-around for xbuild which is broken (wrongly interprets %(Directory))
-					var path = Directory.EnumerateFiles (binDir, "*.*", SearchOption.AllDirectories).FirstOrDefault (x => x.IndexOf (".dSYM/Contents/", StringComparison.Ordinal) == -1);
+					var path = Directory.EnumerateFiles (binDir, "*.*", SearchOption.AllDirectories).FirstOrDefault ();
 					Assert.IsNull (path, "File not cleaned: {0}", path);
 				}
 			}
@@ -69,10 +68,10 @@ namespace Xamarin.iOS.Tasks
 			var expectedFile = Path.Combine ("obj", platform, config, "actool", "cloned-assets", "Assets.xcassets", "AppIcon.appiconset", "Contents.json");
 			Assert.AreEqual (expectedFile, Engine.Logger.ErrorEvents[0].File, "File");
 			Assert.AreEqual (197, Engine.Logger.ErrorEvents[0].LineNumber, "LineNumber");
-			Assert.AreEqual (2, Engine.Logger.ErrorEvents[0].ColumnNumber, "ColumnNumber");
+			Assert.AreEqual (4, Engine.Logger.ErrorEvents[0].ColumnNumber, "ColumnNumber");
 			Assert.AreEqual (197, Engine.Logger.ErrorEvents[0].EndLineNumber, "EndLineNumber");
-			Assert.AreEqual (2, Engine.Logger.ErrorEvents[0].EndColumnNumber, "EndColumnNumber");
-			Assert.AreEqual ("Unexpected character ']'. At line 197, column 2.", Engine.Logger.ErrorEvents[0].Message, "Message");
+			Assert.AreEqual (4, Engine.Logger.ErrorEvents[0].EndColumnNumber, "EndColumnNumber");
+			Assert.AreEqual ("']' is invalid without a matching open. LineNumber: 196 | BytePositionInLine: 3.", Engine.Logger.ErrorEvents[0].Message, "Message");
 		}
 	}
 }


### PR DESCRIPTION
* [msbuild] Tell ILRepack where netstandard.dll can be found.
* [msbuild] Calculate assemblies to be IL merged differently.
* [msbuild] Adjust the Bug60536 test so that it continues to fail as expected
  after switching json parser.
* [msbuild] Use System.Text.Json instead of System.Json, since only the former
  is available in .netcore.
* [msbuild] Split long exec command over multiple lines.

PR best reviewed commit-by-commit.