### PR TITLE
[Tests] Reenable ignored test after they pass on device.

### DIFF
--- a/tests/bcl-test/common-monotouch_corlib_xunit-test.dll.ignore
+++ b/tests/bcl-test/common-monotouch_corlib_xunit-test.dll.ignore
@@ -410,11 +410,6 @@ System.Collections.Concurrent.Tests.ConcurrentDictionaryTests.TestDebuggerAttrib
 System.SpanTests.ReadOnlySpanTests.BinarySearch_UInt
 System.SpanTests.ReadOnlySpanTests.BinarySearch_Double
 
-# device failures, reported at: https://github.com/mono/mono/issues/15983
-System.Reflection.Tests.MethodBaseTests.Test_GetCurrentMethod_Inlineable
-
-# device issues, it was reported here: https://github.com/mono/mono/issues/14761
-System.Text.Tests.StringBuilderTests.Append_CharPointer_Null_ThrowsNullReferenceException
 
 # mono issue: https://github.com/mono/mono/issues/17752
 # Exception messages: System.OutOfMemoryException : Insufficient memory to continue the execution of the program.


### PR DESCRIPTION
Ran the tests on a iOS 64b device and passed. Looks like test were
fixed, probably by an update in netcore but mono did not close the
issue.

Fixes: https://github.com/xamarin/xamarin-macios/issues/6328