### PR TITLE
[d16-5] [xharness] Support the split of test assemblies from the BCL.

### DIFF
--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -15,7 +15,7 @@ namespace BCLTestImporter {
 
 		static string NUnitPattern = "monotouch_*_test.dll"; 
 		static string xUnitPattern = "monotouch_*_xunit-test.dll";
-		internal static string splitPattern = ".part";
+		internal static readonly string splitPattern = ".part";
 		internal static readonly string ProjectGuidKey = "%PROJECT GUID%";
 		internal static readonly string NameKey = "%NAME%";
 		internal static readonly string ReferencesKey = "%REFERENCES%";
@@ -441,8 +441,9 @@ namespace BCLTestImporter {
 				// we could be looking at a splitted assembly, if that is the case, lets pass the name of the dll without the 'part{number}.dll
 				// so that we have all the ignores in a single file
 				var assemblyName = assembly;
-				if (assembly.Contains (splitPattern)) {
-					var index = assembly.IndexOf (splitPattern, StringComparison.Ordinal);
+				var index = assembly.IndexOf (splitPattern, StringComparison.Ordinal);
+
+				if (index != -1) {
 					assemblyName = assembly.Substring (0, index) + ".dll";
 				}
 				foreach (var platformFile in GetIgnoreFileNames (assemblyName, platform)) {

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -442,7 +442,7 @@ namespace BCLTestImporter {
 				// so that we have all the ignores in a single file
 				var assemblyName = assembly;
 				if (assembly.Contains (splitPattern)) {
-					var index = assembly.IndexOf(splitPattern, StringComparison.Ordinal);
+					var index = assembly.IndexOf (splitPattern, StringComparison.Ordinal);
 					assemblyName = assembly.Substring (0, index) + ".dll";
 				}
 				foreach (var platformFile in GetIgnoreFileNames (assemblyName, platform)) {

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -15,7 +15,7 @@ namespace BCLTestImporter {
 
 		static string NUnitPattern = "monotouch_*_test.dll"; 
 		static string xUnitPattern = "monotouch_*_xunit-test.dll";
-		internal static readonly string splitPattern = ".part";
+		static readonly string splitPattern = ".part";
 		internal static readonly string ProjectGuidKey = "%PROJECT GUID%";
 		internal static readonly string NameKey = "%NAME%";
 		internal static readonly string ReferencesKey = "%REFERENCES%";
@@ -443,9 +443,8 @@ namespace BCLTestImporter {
 				var assemblyName = assembly;
 				var index = assembly.IndexOf (splitPattern, StringComparison.Ordinal);
 
-				if (index != -1) {
+				if (index != -1)
 					assemblyName = assembly.Substring (0, index) + ".dll";
-				}
 				foreach (var platformFile in GetIgnoreFileNames (assemblyName, platform)) {
 					var commonAssemblyIgnore = Path.Combine (templateDir, GetCommonIgnoreFileName (assemblyName, platform));
 					if (File.Exists (commonAssemblyIgnore))

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -438,7 +438,7 @@ namespace BCLTestImporter {
 			}
 			// do we have ignores per files and not the project name? Add them
 			foreach (var (assembly, hintPath) in assemblies) {
-				// we could be looking at a splitted assembly, if that is the case, less pass the name of the dll without the 'part{number}.dll
+				// we could be looking at a splitted assembly, if that is the case, lets pass the name of the dll without the 'part{number}.dll
 				// so that we have all the ignores in a single file
 				var assemblyName = assembly;
 				if (assembly.Contains (splitPattern)) {

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -15,6 +15,7 @@ namespace BCLTestImporter {
 
 		static string NUnitPattern = "monotouch_*_test.dll"; 
 		static string xUnitPattern = "monotouch_*_xunit-test.dll";
+		internal static string splitPattern = ".part";
 		internal static readonly string ProjectGuidKey = "%PROJECT GUID%";
 		internal static readonly string NameKey = "%NAME%";
 		internal static readonly string ReferencesKey = "%REFERENCES%";
@@ -437,8 +438,15 @@ namespace BCLTestImporter {
 			}
 			// do we have ignores per files and not the project name? Add them
 			foreach (var (assembly, hintPath) in assemblies) {
-				foreach (var platformFile in GetIgnoreFileNames (assembly, platform)) {
-					var commonAssemblyIgnore = Path.Combine (templateDir, GetCommonIgnoreFileName (assembly, platform));
+				// we could be looking at a splitted assembly, if that is the case, less pass the name of the dll without the 'part{number}.dll
+				// so that we have all the ignores in a single file
+				var assemblyName = assembly;
+				if (assembly.Contains (splitPattern)) {
+					var index = assembly.IndexOf(splitPattern, StringComparison.Ordinal);
+					assemblyName = assembly.Substring (0, index) + ".dll";
+				}
+				foreach (var platformFile in GetIgnoreFileNames (assemblyName, platform)) {
+					var commonAssemblyIgnore = Path.Combine (templateDir, GetCommonIgnoreFileName (assemblyName, platform));
 					if (File.Exists (commonAssemblyIgnore))
 						yield return commonAssemblyIgnore;
 					var platformAssemblyIgnore = Path.Combine (templateDir, platformFile);


### PR DESCRIPTION
Some of the test assemblies are too large and will be splitted by mono so
that they can be compiled for iOS 32b. In that case, we are using the
following pattern

`
test_assembly_name.dll
`

becomes

`
test_assembly_name.part1.dll
test_assembly_name.part2.dll
`

Perse the only change we need to add to make our life easier is to be
able to mantain a single .ignore file since mantaining more .ignore
files is hard and more error prone. This change simply checks if we are
working with a splitted dll and ensures that the correct .ignore files
are added to the BCL test application.

Backport of #7625.

/cc @mandel-macaque 