### PR TITLE
[msbuild] Don't use events and methods that are obsolete and do nothing.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/MacOSXSdks.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/MacOSXSdks.cs
@@ -14,15 +14,10 @@ namespace Xamarin.Mac.Tasks
 		{
 			Native = new MacOSXSdk (AppleSdkSettings.DeveloperRoot, AppleSdkSettings.DeveloperRootVersionPlist);
 			XamMac = new XamMacSdk (null);
-
-			AppleSdkSettings.Changed += delegate {
-				Native = new MacOSXSdk (AppleSdkSettings.DeveloperRoot, AppleSdkSettings.DeveloperRootVersionPlist);
-			};
 		}
 
 		public static void CheckInfoCaches ()
 		{
-			AppleSdkSettings.CheckChanged ();
 			XamMac.CheckCaches ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks.Core/IPhoneSdks.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/IPhoneSdks.cs
@@ -18,17 +18,10 @@ namespace Xamarin.iOS.Tasks
 		static IPhoneSdks ()
 		{
 			Reload ();
-
-			AppleSdkSettings.Changed += delegate {
-				Native = new AppleIPhoneSdk (AppleSdkSettings.DeveloperRoot, AppleSdkSettings.DeveloperRootVersionPlist);
-				Watch = new AppleWatchSdk (AppleSdkSettings.DeveloperRoot, AppleSdkSettings.DeveloperRootVersionPlist);
-				TVOS = new AppleTVOSSdk (AppleSdkSettings.DeveloperRoot, AppleSdkSettings.DeveloperRootVersionPlist);
-			};
 		}
 
 		public static void CheckInfoCaches ()
 		{
-			AppleSdkSettings.CheckChanged ();
 			MonoTouch.CheckCaches ();
 		}
 


### PR DESCRIPTION
Fixes these warnings:

    IPhoneSdks.cs(22,4): warning CS0618: 'AppleSdkSettings.Changed' is obsolete: 'This event is never raised' [/work/maccore/onedotnet/xamarin-macios/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj]
    IPhoneSdks.cs(31,4): warning CS0618: 'AppleSdkSettings.CheckChanged()' is obsolete: 'This method does nothing' [/work/maccore/onedotnet/xamarin-macios/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj]
    MacOSXSdks.cs(18,4): warning CS0618: 'AppleSdkSettings.Changed' is obsolete: 'This event is never raised' [/work/maccore/onedotnet/xamarin-macios/msbuild/Xamarin.Mac.Tasks.Core/Xamarin.Mac.Tasks.Core.csproj]
    MacOSXSdks.cs(25,4): warning CS0618: 'AppleSdkSettings.CheckChanged()' is obsolete: 'This method does nothing' [/work/maccore/onedotnet/xamarin-macios/msbuild/Xamarin.Mac.Tasks.Core/Xamarin.Mac.Tasks.Core.csproj]

Also bump Xamarin.MacDev to pick up updated Xamarin.MacDev:

* xamarin/Xamarin.MacDev@0f578f5 [tests] Upgrade to NUnit 3.12 and use package references. (#65)
* xamarin/Xamarin.MacDev@55a30e2 [tests] Adjust tests to not expect the provisioning profiles in the index in any particular order. (#63)
* xamarin/Xamarin.MacDev@dc270f6 Make methods that do nothing obsolete and fix a compiler warning. (#67)
* xamarin/Xamarin.MacDev@681aef6 Remove unused csproj. (#66)
* xamarin/Xamarin.MacDev@d78a92f Update gitignore (#55)

Diff: https://github.com/xamarin/Xamarin.MacDev/compare/ca221c8fd65a6f1d6e85d77018d4a7619a2c120d..0f578f51e63b6ff93014782dbc9378e6b6bc6d75