### PR TITLE
[d16-5] [Foundation] Ensure that we do not iterate over a collection accessed by other threads.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -206,11 +206,14 @@ namespace Foundation {
 			// iteration. We split the operation in two, get all the diff cancelation sources, then try to cancel each of them
 			// which will do the correct lock dance. Note that we could be tempted to do a RemoveAll, that will yield the same
 			// runtime issue, this is dull but safe. 
-			var sources = new List <TaskCompletionSource<HttpResponseMessage>> (inflightRequests.Count);
-			foreach (var r in inflightRequests.Values) {
-				sources.Add (r.CompletionSource);
+			List <TaskCompletionSource<HttpResponseMessage>> sources = null; 
+			lock (inflightRequestsLock) { // just lock when we iterate
+				sources = new List <TaskCompletionSource<HttpResponseMessage>> (inflightRequests.Count);
+				foreach (var r in inflightRequests.Values) {
+					sources.Add (r.CompletionSource);
+				}
 			}
-			sources.ForEach (source => { source.TrySetCanceled (); });
+			sources?.ForEach (source => { source.TrySetCanceled (); });
 		}
 #endif
 

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -213,7 +213,7 @@ namespace Foundation {
 					sources.Add (r.CompletionSource);
 				}
 			}
-			sources?.ForEach (source => { source.TrySetCanceled (); });
+			sources.ForEach (source => { source.TrySetCanceled (); });
 		}
 #endif
 


### PR DESCRIPTION
Make sure we do no iterate ove the dictionary while other threads are
accessing it. Lock, get the sources, then cancel.

Fixes: https://github.com/xamarin/xamarin-macios/issues/7386

Backport of #7532.

/cc @mandel-macaque 