### PR TITLE
[msbuild] Avoid lines starting with a whitespace inside generated response files. Fix #7645

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -242,9 +242,12 @@ namespace Xamarin.Mac.Tasks
 
 			actualArgs.AddQuoted ($"@{responseFile}");
 
-			if (!string.IsNullOrWhiteSpace (ExtraArguments))
+			if (!string.IsNullOrWhiteSpace (ExtraArguments)) {
+				actualArgs.Add (" ");
 				actualArgs.Add (ExtraArguments);
+			}
 
+			actualArgs.Add (" ");
 			var verbosity = VerbosityUtils.Merge (ExtraArguments, (LoggerVerbosity) Verbosity);
 			// for compatibility with earlier versions nothing means one /v
 			actualArgs.AddLine (verbosity.Length > 0 ? verbosity : "/verbose");

--- a/msbuild/Xamarin.MacDev.Tasks.Core/CommandLineArgumentBuilder.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/CommandLineArgumentBuilder.cs
@@ -38,7 +38,7 @@ namespace Xamarin.MacDev
 		/// </summary>
 		public void Add (string argument, bool appendLine = false)
 		{
-			if (builder.Length > 0)
+			if (builder.Length > 0 && !appendLine)
 				builder.Append (' ');
 
 			builder.Append (argument);


### PR DESCRIPTION
Since the "quote" refactoring there's no real difference between `Add*`
and `Add*Line` methods, everything is now line-oriented.

However `Add` and `AddQuoted` behaved differently, which meant that `Add`
would add a whitespace before a new argument in the `StringBuilder` was
not empty (as a separator needed _when_ different lines were not used).

That resulted in response files that had some lines starting with a white
space. That was not an issue (spec [1] wise) but it broke some (not so
correct) assumptions in `mtouch` and could also break anything that added
comments (which must start with `#`) in the future.

This brings consistency in the output whether quoted/non-quoted arguments
are used.

Reference:
[0] https://github.com/xamarin/xamarin-macios/issues/7645
[1] https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/response-file-compiler-option