### PR TITLE
[mtouch] Fix cache.cs wrt response files. Fix #7514

### DIFF
--- a/tools/common/cache.cs
+++ b/tools/common/cache.cs
@@ -190,10 +190,8 @@ public class Cache {
 		var args = new List<string> (arguments);
 
 		sb.Append ("# Version: ").Append (Constants.Version).Append ('.').Append (Constants.Revision).AppendLine ();
-		if (args.Count > 0)
-			sb.Append ("# [first argument, ignore] # ").AppendLine (args [0]);
 		sb.Append (Driver.GetFullPath ()).AppendLine (" \\");
-		CollectArgumentsForCache (args, 1, sb);
+		CollectArgumentsForCache (args, 0, sb);
 		return sb.ToString ();
 	}
 


### PR DESCRIPTION
TL&DR
* re-apply the fix to cache.cs from https://github.com/xamarin/xamarin-macios/pull/7544
* which was reverted in https://github.com/xamarin/xamarin-macios/pull/7589
* since it regressed mscorlib/sim testing in xharness (for other reasons)
* Final part to fix https://github.com/xamarin/xamarin-macios/issues/7514

# Long Story

This was the ~night~ day before christmas... and a tough nut to crack!

Thanksfully we had a good test case (inside #7514) and then xharness
regressed one test in consistent, reproducible manner.

xharness builds mscorlib tests twice (32 and 64 bits) even if it's a
fat application (could be reused). That should not be a huge problem
since the 2nd build should be identical and the cache should be (re)used.

An earlier attempt fixed this (comparison was true for the wrong
reasons [1]) but the fix did not end up with the same arguments !?! and
was reverted.

This is the diff between the first and second builds:

```diff
--- /Users/poupou/a.txt	2019-12-23 09:55:01.000000000 -0500
+++ /Users/poupou/b.txt	2019-12-23 09:55:01.000000000 -0500
@@ -182,5 +182,5 @@
 	-r=/Users/poupou/git/xamarin/xamarin-macios/builds/downloads/ios-release-Darwin-8f396bbb408b5758fccb8602030b9fa5293ce718/ios-bcl/monotouch/tests/Xunit.NetCore.Extensions.dll \
 	' --target-framework=Xamarin.iOS,v1.0' \
 	--root-assembly=/Users/poupou/git/xamarin/xamarin-macios/tests/xharness/tmp-test-dir/mscorlib/bin/mscorlib/iPhoneSimulator/Debug-unified/com.xamarin.bcltests.mscorlib.exe \
-	' -v -v -v -v' \
+	' -v -v' \
 	@/Users/poupou/git/xamarin/xamarin-macios/tests/xharness/tmp-test-dir/mscorlib/obj/iPhoneSimulator/Debug/response-file.rsp \
```

Since they are not identical the cache is invalidated (which is normal,
cache-wise) and produce an output app that is incorrect (and crash
32bits).

Now there is code to ignore verbosity options (both `-v` and -q`) since
they will not affect what `mtouch` generates. However this was broken
because mtouch's response-file parser is quite basic and stricter the the
specification

spec: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/response-file-compiler-option
issue: https://github.com/xamarin/xamarin-macios/issues/7644

That failed in two different ways

1. note the extra space before the first `-v` in the diff (before the `'`
quote). That skipped the line.

2. there are multiple `-v` in the same line, again that make the
filtering skip the line.

*Unknowns*

It's too close to xmas/vacation so I might not find the reasons/issues
for the following, unanswered questions...

1. Why is the re-build app bundle failing at runtime when p/invoking ?
Something is not regenerated (symbol maps?) ?

2. Why xharness 2nd build has more verbosity than the first one (likely
harmless) ?

[1] the original cache.cs issue (prequel)

issue w/test case: https://github.com/xamarin/xamarin-macios/issues/7514
first attempt: https://github.com/xamarin/xamarin-macios/pull/7544

While incorrect the first attempt to fix `cache.cs` was a logical, if
not entirely complete, fix. Without it this is what we _currently_ cache:

```
/Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mtouch/mtouch.exe \
```

and that does not include any of mtouch's arguments, that can change
between executions and (should) invalidate the cache.

In this case it means the cache is used (no difference) but this does
**not** parse the content of the **response file** which is obviously
wrong (and we do have code to process it).

On the original issue's test case this is what makes the difference
between using the same *old* nuget assembly after an update (and fail)
by itself and also because the updated framework was not copied (due
to the 2nd part of the bug report wrt `copyfile`).

OTOH re-using (incorrectly) the cache is what makes xharness's mscorlib
unit tests works right now :(