### PR TITLE
[DevOps] Fix DDFun pipeline report in GitHub comment

### DIFF
--- a/jenkins/vsts-device-tests-set-status.sh
+++ b/jenkins/vsts-device-tests-set-status.sh
@@ -79,6 +79,7 @@ if test -z "$START"; then
 	trap cleanup ERR
 	trap cleanup EXIT
 
+	HTML_REPORT=""
 	if [ $DEVICE_TYPE == "iOS-DDFun" ]; then
 		printf "### :construction: Experimental DDFun pipeline\\n" > "$MESSAGE_FILE"
 	else

--- a/tools/devops/add-summaries.sh
+++ b/tools/devops/add-summaries.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -ex
+#!/bin/bash -e
+
+set +x
 
 X="#vso"
 

--- a/tools/devops/device-tests.yml
+++ b/tools/devops/device-tests.yml
@@ -12,26 +12,8 @@ resources:
     ref: refs/heads/device-tests-yaml
     endpoint: xamarin
 
-###
-### Tell GitHub we're starting working on this commit
-###
-
 jobs:
-- job: ReportStartToGitHub
-  displayName: Set pending GitHub status
-  pool:
-    name: '$(poolName)'
-  steps:
-  - bash: ./jenkins/vsts-device-tests-set-status.sh --start "--token=$(GitHub.Token)" "--device=iOS-DDFun"
-    displayName: Set pending GitHub status
-    continueOnError: true
-
-###
-### Run the device tests
-###
-
 - job: macOS
-  dependsOn: ReportStartToGitHub
   displayName: Run Device Tests
   timeoutInMinutes: 1000
 
@@ -108,9 +90,31 @@ jobs:
       sudo launchctl stop com.apple.usbmuxd
     displayName: 'Fix device discovery (reset launchctl)'
 
+###
+### Tell GitHub we're starting working on this commit
+###
+
+  - bash: ./xamarin-macios/jenkins/vsts-device-tests-set-status.sh --start "--token=$(GitHub.Token)" "--device=iOS-DDFun"
+    displayName: Set pending GitHub status
+    continueOnError: true
+    condition: succeededOrFailed()
+
+###
+### Run the device tests
+###
+
   - bash: ./xamarin-macios/tools/devops/run-tests.sh
     displayName: 'Run tests'
     timeoutInMinutes: 600
+
+###
+### Report final results to GitHub
+###
+
+  - bash: ./xamarin-macios/jenkins/vsts-device-tests-set-status.sh "--token=$(GitHub.Token)" "--device=iOS-DDFun"
+    displayName: Report results to GitHub as comment / status
+    continueOnError: true
+    condition: succeededOrFailed()
 
   - bash: ./xamarin-macios/tools/devops/add-summaries.sh
     displayName: 'Add summaries'
@@ -137,19 +141,3 @@ jobs:
       artifactName: HtmlReport
     continueOnError: true
     condition: succeededOrFailed()
-
-###
-### Report final results to GitHub
-###
-
-- job: ReportResultsToGitHub
-  displayName: Report status/results to GitHub
-  dependsOn:
-  - macOS
-  condition: always()
-  pool:
-    name: '$(poolName)'
-  steps:
-  - bash: ./jenkins/vsts-device-tests-set-status.sh "--token=$(GitHub.Token)" "--device=iOS-DDFun"
-    displayName: Report results to GitHub as comment / status
-    condition: always()


### PR DESCRIPTION
- The `TestSummary.md` wasn't found because we were using multiple jobs (multiple cloned repos)
- `HTML_REPORT` variable wasn't bound which broke the `vsts-device-tests-set-status.sh` script