### PR TITLE
[Foundation] Add CookieContainer support in NSUrlSessionHandler.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -398,7 +398,7 @@ namespace Foundation {
 			var stream = Stream.Null;
 			// set header cookies if needed from the managed cookie container
 			var cookies = cookieContainer?.GetCookieHeader (request.RequestUri); // as per docs: An HTTP cookie header, with strings representing Cookie instances delimited by semicolons.
-			if (! string.IsNullOrEmpty (cookies))
+			if (!string.IsNullOrEmpty (cookies))
 				request.Headers.TryAddWithoutValidation (Cookie, cookies); 
 
 			var headers = request.Headers as IEnumerable<KeyValuePair<string, IEnumerable<string>>>;

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -126,7 +126,7 @@ namespace MonoTests.System.Net.Http
 		public void TestNSUrlSessionHandlerCookieContainer ()
 		{
 			var url = NetworkResources.Httpbin.CookiesUrl;
-			var cookie = new Cookie ("cookie", "chocolte-chip");
+			var cookie = new Cookie ("cookie", "chocolate-chip");
 			var cookieContainer = new CookieContainer ();
 			cookieContainer.Add (new Uri (url), cookie);
 

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -120,6 +120,84 @@ namespace MonoTests.System.Net.Http
 			Assert.That (nativeCookies.First (), Is.StringStarting ("cookie=chocolate-chip;"), $"Native Cookie Value");
 			Assert.That (managedCookies.First (), Is.StringStarting ("cookie=chocolate-chip;"), $"Managed Cookie Value");
 		}
+
+		// ensure that we can use a cookie container to set the cookies for a url
+		[Test]
+		public void TestNSUrlSessionHandlerCookieContainer ()
+		{
+			var url = NetworkResources.Httpbin.CookiesUrl;
+			var cookie = new Cookie ("cookie", "chocolte-chip");
+			var cookieContainer = new CookieContainer ();
+			cookieContainer.Add (new Uri (url), cookie);
+
+			string managedCookieResult = null;
+			string nativeCookieResult = null;
+			Exception ex = null;
+			var completed = false;
+
+			TestRuntime.RunAsync (DateTime.Now.AddSeconds (30), async () => {
+				try {
+					var managedHandler = new HttpClientHandler () {
+						AllowAutoRedirect = false,
+						CookieContainer = cookieContainer,
+					};
+					var managedClient = new HttpClient (managedHandler);
+					var managedResponse = await managedClient.GetAsync (url);
+					managedCookieResult = await managedResponse.Content.ReadAsStringAsync ();
+					
+					var nativeHandler = new NSUrlSessionHandler () {
+						AllowAutoRedirect = true,
+						CookieContainer = cookieContainer,
+					};
+					var nativeClient = new HttpClient (nativeHandler);
+					var nativeResponse = await nativeClient.GetAsync (url);
+					nativeCookieResult = await nativeResponse.Content.ReadAsStringAsync ();
+				} catch (Exception e) {
+					ex = e;
+				} finally {
+					completed = true;
+				}
+			}, () => completed);
+
+			Assert.IsNull (ex, "Exception");
+			Assert.IsNotNull (managedCookieResult, "Managed cookies result");
+			Assert.IsNotNull (nativeCookieResult, "Native cookies result");
+			Assert.AreEqual (managedCookieResult, nativeCookieResult, "Cookies");
+		}
+
+		// ensure that the Set-Cookie headers do update the CookieContainer
+		[Test]
+		public void TestNSurlSessionHandlerCookieContainerSetCookie ()
+		{
+			var url = NetworkResources.Httpbin.GetSetCookieUrl ("cookie", "chocolate-chip");
+			var cookieContainer = new CookieContainer ();
+
+			string nativeCookieResult = null;
+			Exception ex = null;
+			var completed = false;
+
+			TestRuntime.RunAsync (DateTime.Now.AddSeconds (30), async () => {
+				try {
+		
+					var nativeHandler = new NSUrlSessionHandler () {
+						AllowAutoRedirect = true,
+						CookieContainer = cookieContainer,
+					};
+					var nativeClient = new HttpClient (nativeHandler);
+					var nativeResponse = await nativeClient.GetAsync (url);
+					nativeCookieResult = await nativeResponse.Content.ReadAsStringAsync ();
+				} catch (Exception e) {
+					ex = e;
+				} finally {
+					completed = true;
+				}
+			}, () => completed);
+
+			Assert.IsNull (ex, "Exception");
+			Assert.IsNotNull (nativeCookieResult, "Native cookies result");
+			var cookiesFromServer = cookieContainer.GetCookies (new Uri (url));
+			Assert.AreEqual (1, cookiesFromServer.Count, "Cookies received from server.");
+		}
 #endif
 
 		// ensure that if we have a redirect, we do not have the auth headers in the following requests

--- a/tests/monotouch-test/System.Net.Http/NetworkResources.cs
+++ b/tests/monotouch-test/System.Net.Http/NetworkResources.cs
@@ -42,6 +42,8 @@ namespace MonoTests.System.Net.Http
 			public static readonly string PatchUrl = "https://httpbin.org/patch";
 			public static readonly string PostUrl = "https://httpbin.org/post";
 			public static readonly string PutUrl = "https://httpbin.org/put";
+			public static readonly string CookiesUrl = $"https://httpbin.org/cookies";
+
 
 			public static string GetAbsoluteRedirectUrl (int count) => $"https://httpbin.org/absolute-redirect/{count}";
 			public static string GetRedirectUrl (int count) => $"https://httpbin.org/redirect/{count}";


### PR DESCRIPTION
There are two important things to look at this:

1. That we do set the cookies that are present in the CookieContainer in
the request. That is, we need to set Cookie headers for all of them.
2. That if we receive a Set-Cookie from the server, the CookieContainer
gets correctly updated else we will have issues since we do not respect
the data sent from the server side.

Tests show both that we are setting the Cookie header and that we honour
the Set-Cookie header.

Fixes: https://github.com/xamarin/xamarin-macios/issues/5665