### PR TITLE
[d16-5] [BCL Tests] Make sure that the xUnit runner is not too greedy.

### DIFF
--- a/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
@@ -934,6 +934,7 @@ namespace Xamarin.iOS.UnitTests.XUnit
 					ITestFrameworkExecutionOptions executionOptions = GetFrameworkOptionsForExecution (configuration);
 					executionOptions.SetDisableParallelization (!RunInParallel);
 					executionOptions.SetSynchronousMessageReporting (true);
+					executionOptions.SetMaxParallelThreads (Environment.ProcessorCount / 2); // lets not be greedy and let the UI breath.
 
 					// set the wait for event cb first, then execute the tests
 					var resultTask = WaitForEvent (resultsSink.Finished, TimeSpan.FromDays (10)).ConfigureAwait (false);


### PR DESCRIPTION
The tests in xunit are ran in parallel, the default number of threads is
to large which is making the iOS watchdog kill the process before we are
done with the tests.

The default value is either 0 (use as many as possible) of the
Enviroment.ProcessorsCount value, in our case we divide that by two to
make sure we do not use too much CPU.

Fixes: https://github.com/xamarin/maccore/issues/2083

Backport of #7653.

/cc @mandel-macaque 