### PR TITLE
[generator] Remove unrequired `Class.GetHandle` calls on 32bits bindings

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -6371,7 +6371,9 @@ $" using methods with different signatures ('{distinctMethodsBySignature [0].Met
 					if (is32BitNotSupported) {
 						// potentially avoid a .cctor and extra, unusable code
 						print ("#if ARCH_32");
+						print ("#pragma warning disable {0}", is_static_class ? "169" : "649");
 						print ("static readonly IntPtr class_ptr;");
+						print ("#pragma warning restore {0}", is_static_class ? "169" : "649");
 						print ("#else");
 					}
 					print ("static readonly IntPtr class_ptr = Class.GetHandle (\"{0}\");", objc_type_name);

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -6367,7 +6367,17 @@ $" using methods with different signatures ('{distinctMethodsBySignature [0].Met
 				
 				if (!is_model) {
 					print_generated_code ();
-					print ("static readonly IntPtr class_ptr = Class.GetHandle (\"{0}\");\n", objc_type_name);
+					var is32BitNotSupported = Is64BitiOSOnly (type);
+					if (is32BitNotSupported) {
+						// potentially avoid a .cctor and extra, unusable code
+						print ("#if ARCH_32");
+						print ("static readonly IntPtr class_ptr;");
+						print ("#else");
+					}
+					print ("static readonly IntPtr class_ptr = Class.GetHandle (\"{0}\");", objc_type_name);
+					if (is32BitNotSupported)
+						print ("#endif");
+					print ("");
 				}
 			}
 			


### PR DESCRIPTION
Some types are not available in any 32bits iOS versions. We are _mostly_
(but not always) throwing a `PlatformNotSupportedException` when they are
used. However we're missing cases where we can reduce the generated code.
This is one (of a few) occurrences.

New generated code looks like:

```csharp
[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
#if ARCH_32
static readonly IntPtr class_ptr;
#else
static readonly IntPtr class_ptr = Class.GetHandle ("ARFaceGeometry");
#endif
```

Beside the obvious `Class.GetHandle` call removal, this has the nice,
side benefit of removing several `.cctor` from the assembly (that were
only needed to set this field).

This reduce the code size for the 32bits version of Xamarin.iOS.dll [1]

```
Before: 16,338,944
After:  16,255,488
Diff:       83,456
```

[1] While this might not sound very useful, since it's going away, its
becoming a problem (because it's not going away fast enough) since we're
not able to build some (non-linked) test suites anymore due to size
constraints (and Apple's `ld` branching limit).