### PR TITLE
[mmp] Set ThrowManagedException in debug apps if unset

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
@@ -36,7 +36,11 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		MarshalObjectiveCExceptionMode defaultObjectiveCExceptionMode = MarshalObjectiveCExceptionMode.ThrowManagedException;
 		MarshalManagedExceptionMode defaultManagedExceptionMode = MarshalManagedExceptionMode.Default;
 #else
+#if __MACOS__ && DEBUG
+		MarshalObjectiveCExceptionMode defaultObjectiveCExceptionMode = MarshalObjectiveCExceptionMode.ThrowManagedException;
+#else
 		MarshalObjectiveCExceptionMode defaultObjectiveCExceptionMode = MarshalObjectiveCExceptionMode.UnwindManagedCode;
+#endif
 		MarshalManagedExceptionMode defaultManagedExceptionMode = MarshalManagedExceptionMode.Default;
 #endif
 

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -360,7 +360,7 @@ namespace Xamarin.Bundler {
 #endif
 
 			if (MarshalObjectiveCExceptions == MarshalObjectiveCExceptionMode.Default) {
-				if (EnableCoopGC.Value) {
+				if (EnableCoopGC.Value || (Platform == ApplePlatform.MacOSX && EnableDebug)) {
 					MarshalObjectiveCExceptions = MarshalObjectiveCExceptionMode.ThrowManagedException;
 				} else {
 					MarshalObjectiveCExceptions = isSimulatorOrDesktopDebug ? MarshalObjectiveCExceptionMode.UnwindManagedCode : MarshalObjectiveCExceptionMode.Disable;

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -379,6 +379,11 @@ namespace Xamarin.Bundler {
 			if (!targetFramework.HasValue)
 				targetFramework = TargetFramework.Default;
 
+			if (App.EnableDebug && App.MarshalObjectiveCExceptions == MarshalObjectiveCExceptionMode.Default) {
+				Log (1, $"Selecting ThrowManagedException for marshal-objectivec-exceptions as Application is in debug");
+				App.MarshalObjectiveCExceptions = MarshalObjectiveCExceptionMode.ThrowManagedException;
+			}
+
 			App.RuntimeOptions = RuntimeOptions.Create (App, http_message_provider, tls_provider);
 
 			ErrorHelper.Verbosity = verbose;

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -380,7 +380,7 @@ namespace Xamarin.Bundler {
 				targetFramework = TargetFramework.Default;
 
 			if (App.EnableDebug && App.MarshalObjectiveCExceptions == MarshalObjectiveCExceptionMode.Default) {
-				Log (1, $"Selecting ThrowManagedException for marshal-objectivec-exceptions as Application is in debug");
+				Log (1, "Selecting ThrowManagedException for marshal-objectivec-exceptions as Application is in debug");
 				App.MarshalObjectiveCExceptions = MarshalObjectiveCExceptionMode.ThrowManagedException;
 			}
 

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -379,11 +379,6 @@ namespace Xamarin.Bundler {
 			if (!targetFramework.HasValue)
 				targetFramework = TargetFramework.Default;
 
-			if (App.EnableDebug && App.MarshalObjectiveCExceptions == MarshalObjectiveCExceptionMode.Default) {
-				Log (1, "Selecting ThrowManagedException for marshal-objectivec-exceptions as Application is in debug");
-				App.MarshalObjectiveCExceptions = MarshalObjectiveCExceptionMode.ThrowManagedException;
-			}
-
 			App.RuntimeOptions = RuntimeOptions.Create (App, http_message_provider, tls_provider);
 
 			ErrorHelper.Verbosity = verbose;


### PR DESCRIPTION
- https://github.com/xamarin/xamarin-macios/issues/5738
- There are a number of managed exceptions Apple can throw at you during
debugging, such as expanding a NSColor in the wrong colorspace
- Throwing a managed exception is a nicer debugging experience, and
during debug we don't care about any performance penality.