### PR TITLE
[msbuild] Stub out GenerateManifests to prevent Windows ClickOnce target collisions

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -2304,6 +2304,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</Archive>
 	</Target>
 
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.NativeReference.Stubs.targets" />
+
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.NativeReference.Stubs.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.NativeReference.Stubs.targets
@@ -19,18 +19,15 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 	<!-- These "stub" targets are declared to prevent other (Windows specific) external targets from firing.
 	     They are required as we share use of @(NativeReference) with ClickOnce, and if we don't stub then it can do the wrong thing.
 	     Example: https://github.com/xamarin/xamarin-macios/issues/3876
-	     We copy the Condition/DependsOnTargets so our stub don't break on user targets that hook into them for ordering
 	-->
 	<Target Name="GenerateManifests"
 	      Condition="'$(GenerateClickOnceManifests)'=='true' or '@(NativeReference)'!='' or '@(ResolvedIsolatedComModules)'!='' or '$(GenerateAppxManifest)' == 'true'"
-	      DependsOnTargets="$(GenerateManifestsDependsOn)"/>
+	/>
 
 	<Target Name="GenerateApplicationManifest" 
-		DependsOnTargets="_DeploymentComputeNativeManifestInfo;_DeploymentComputeClickOnceManifestInfo;ResolveComReferences;ResolveNativeReferences;_GenerateResolvedDeploymentManifestEntryPoint"
 		Inputs="$(MSBuildAllProjects);@(AppConfigWithTargetPath);$(_DeploymentBaseManifest);@(ResolvedIsolatedComModules);@(_DeploymentManifestDependencies);@(_DeploymentResolvedManifestEntryPoint);@(_DeploymentManifestFiles)"
 		Outputs="@(ApplicationManifest)" />
 
 	<Target Name="ResolveNativeReferences"
-		Condition="'@(NativeReference)'!=''" 
-		DependsOnTargets="ResolveProjectReferences" />
+		Condition="'@(NativeReference)'!=''" />
 </Project>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.NativeReference.Stubs.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.NativeReference.Stubs.targets
@@ -1,0 +1,36 @@
+<!--
+***********************************************************************************************
+Xamarin.iOS.NativeReference.Stubs.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+This file imports the version- and platform-specific targets for the project importing
+this file. This file also defines targets to produce an error if the specified targets
+file does not exist, but the project is built anyway (command-line or IDE build).
+
+Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<!-- These "stub" targets are declared to prevent other (Windows specific) external targets from firing.
+	     They are required as we share use of @(NativeReference) with ClickOnce, and if we don't stub then it can do the wrong thing.
+	     Example: https://github.com/xamarin/xamarin-macios/issues/3876
+	     We copy the Condition/DependsOnTargets so our stub don't break on user targets that hook into them for ordering
+	-->
+	<Target Name="GenerateManifests"
+	      Condition="'$(GenerateClickOnceManifests)'=='true' or '@(NativeReference)'!='' or '@(ResolvedIsolatedComModules)'!='' or '$(GenerateAppxManifest)' == 'true'"
+	      DependsOnTargets="$(GenerateManifestsDependsOn)"/>
+
+	<Target Name="GenerateApplicationManifest" 
+		DependsOnTargets="_DeploymentComputeNativeManifestInfo;_DeploymentComputeClickOnceManifestInfo;ResolveComReferences;ResolveNativeReferences;_GenerateResolvedDeploymentManifestEntryPoint"
+		Inputs="$(MSBuildAllProjects);@(AppConfigWithTargetPath);$(_DeploymentBaseManifest);@(ResolvedIsolatedComModules);@(_DeploymentManifestDependencies);@(_DeploymentResolvedManifestEntryPoint);@(_DeploymentManifestFiles)"
+		Outputs="@(ApplicationManifest)" />
+
+	<Target Name="ResolveNativeReferences"
+		Condition="'@(NativeReference)'!=''" 
+		DependsOnTargets="ResolveProjectReferences" />
+</Project>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.targets
@@ -85,11 +85,7 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 		</CreateEmbeddedResources>
 	</Target>
 
-	<!-- This "stub" target is declared to prevent other Windows specific targets 
-	     from firing, and doing the wrong thing since we overload @(NativeReference)
-		 Example: https://github.com/xamarin/xamarin-macios/issues/3876
-	-->
-	<Target Name="GenerateManifests" />
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.NativeReference.Stubs.targets" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.targets
@@ -85,6 +85,12 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 		</CreateEmbeddedResources>
 	</Target>
 
+	<!-- This "stub" target is declared to prevent other Windows specific targets 
+	     from firing, and doing the wrong thing since we overload @(NativeReference)
+		 Example: https://github.com/xamarin/xamarin-macios/issues/3876
+	-->
+	<Target Name="GenerateManifests" />
+
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
 </Project>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
@@ -127,6 +127,9 @@
     <None Include="Xamarin.iOS.ObjCBinding.Common.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Xamarin.iOS.NativeReference.Stubs.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Xamarin.iOS.ObjCBinding.CSharp.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
- https://devdiv.visualstudio.com/DevDiv/_queries/edit/1041456/
- On Windows the GenerateManifests target will sometimes run and do the wrong thing
as we overload their usages of @(NativeReference). Stub it as a no-op