### PR TITLE
[Introspection] Allow introspection to test CAMetalLayer when xcode 11 and simulator.

### DIFF
--- a/tests/introspection/iOS/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOS/iOSApiCtorInitTest.cs
@@ -157,7 +157,7 @@ namespace Introspection {
 
 			// Metal is not available on the (iOS8) simulator
 			case "CAMetalLayer":
-				return  (Runtime.Arch == Arch.SIMULATOR) && !TestRuntime.CheckXcodeVersion (11, 0);
+				return (Runtime.Arch == Arch.SIMULATOR) && !TestRuntime.CheckXcodeVersion (11, 0);
 
 #if !XAMCORE_2_0
 			// from iOS8 (beta4) they do not return a valid handle

--- a/tests/introspection/iOS/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOS/iOSApiCtorInitTest.cs
@@ -157,7 +157,7 @@ namespace Introspection {
 
 			// Metal is not available on the (iOS8) simulator
 			case "CAMetalLayer":
-				return (Runtime.Arch == Arch.SIMULATOR);
+				return  (Runtime.Arch == Arch.SIMULATOR) && !TestRuntime.CheckXcodeVersion (11, 0);
 
 #if !XAMCORE_2_0
 			// from iOS8 (beta4) they do not return a valid handle

--- a/tests/introspection/iOS/iOSApiProtocolTest.cs
+++ b/tests/introspection/iOS/iOSApiProtocolTest.cs
@@ -139,10 +139,7 @@ namespace Introspection {
 
 			switch (type.Name) {
 			case "CAMetalLayer":
-				// that one still does not work with iOS9 beta 4
-				if (Runtime.Arch == Arch.SIMULATOR)
-					return true;
-				break;
+				return (Runtime.Arch == Arch.SIMULATOR) && !TestRuntime.CheckXcodeVersion (11, 0);
 #if !XAMCORE_3_0
 				// mistake (base type) fixed by a breaking change
 			case "MFMailComposeViewControllerDelegate":

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -97,6 +97,7 @@ namespace Introspection {
 
 			// Metal is not available on the simulator
 			case "CAMetalLayer":
+				return (Runtime.Arch == Arch.SIMULATOR) && !TestRuntime.CheckXcodeVersion (11, 0);
 			case "SKRenderer":
 				return (Runtime.Arch == Arch.SIMULATOR);
 


### PR DESCRIPTION
The order of the check matters, we only skip with a sim && not on
xcode11.

The other whay around will do the wrong short circuit. Since if we are
not on Xcode11 we will always skip, including device, which is not
correct.

Fixes: https://github.com/xamarin/xamarin-macios/issues/6243.