### PR TITLE
[d16-5] [Makefile] Make csc strict and fix some small errors.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -216,9 +216,9 @@ DEVICE_BIN_PATH=$(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/
 DEVICE_CC=$(IOS_CC)
 DEVICE_CXX=$(IOS_CXX)
 
-IOS_CSC=$(SYSTEM_CSC) -nostdlib -noconfig -r:$(MONOTOUCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_MONO_PATH)/System.Core.dll -r:$(MONOTOUCH_MONO_PATH)/System.Xml.dll -r:$(MONOTOUCH_MONO_PATH)/mscorlib.dll -r:$(MONOTOUCH_MONO_PATH)/System.Net.Http.dll -r:$(MONOTOUCH_MONO_PATH)/Facades/System.Drawing.Common.dll -deterministic
-TV_CSC=$(SYSTEM_CSC) -nostdlib -noconfig -r:$(MONOTOUCH_TV_MONO_PATH)/System.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Core.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Xml.dll -r:$(MONOTOUCH_TV_MONO_PATH)/mscorlib.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Net.Http.dll -r:$(MONOTOUCH_TV_MONO_PATH)/Facades/System.Drawing.Common.dll -deterministic
-WATCH_CSC=$(SYSTEM_CSC) -nostdlib -noconfig -r:$(MONOTOUCH_WATCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/System.Core.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/System.Xml.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/mscorlib.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/System.Net.Http.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/Facades/System.Drawing.Common.dll -deterministic
+IOS_CSC=$(SYSTEM_CSC) -features:strict -nostdlib -noconfig -r:$(MONOTOUCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_MONO_PATH)/System.Core.dll -r:$(MONOTOUCH_MONO_PATH)/System.Xml.dll -r:$(MONOTOUCH_MONO_PATH)/mscorlib.dll -r:$(MONOTOUCH_MONO_PATH)/System.Net.Http.dll -r:$(MONOTOUCH_MONO_PATH)/Facades/System.Drawing.Common.dll -deterministic
+TV_CSC=$(SYSTEM_CSC) -features:strict -nostdlib -noconfig -r:$(MONOTOUCH_TV_MONO_PATH)/System.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Core.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Xml.dll -r:$(MONOTOUCH_TV_MONO_PATH)/mscorlib.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Net.Http.dll -r:$(MONOTOUCH_TV_MONO_PATH)/Facades/System.Drawing.Common.dll -deterministic
+WATCH_CSC=$(SYSTEM_CSC) -features:strict -nostdlib -noconfig -r:$(MONOTOUCH_WATCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/System.Core.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/System.Xml.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/mscorlib.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/System.Net.Http.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/Facades/System.Drawing.Common.dll -deterministic
 
 DEVICE_OBJC_CFLAGS=$(OBJC_CFLAGS) $(BITCODE_CFLAGS)
 
@@ -276,7 +276,7 @@ MACIOS_BINARIES_PATH=$(TOP)/external/macios-binaries
 
 MONO_PREFIX ?= /Library/Frameworks/Mono.framework/Versions/Current
 SYSTEM_MCS=$(MONO_PREFIX)/bin/mcs
-SYSTEM_CSC=$(MONO_PREFIX)/bin/csc /features:strict
+SYSTEM_CSC=$(MONO_PREFIX)/bin/csc
 SYSTEM_SN=$(MONO_PREFIX)/bin/sn
 SYSTEM_MONO=$(MONO_PREFIX)/bin/mono
 SYSTEM_MONO32=$(MONO_PREFIX)/bin/mono32
@@ -313,10 +313,10 @@ MAC_FRAMEWORK_VERSIONED_DIR = $(MAC_FRAMEWORK_DIR)/Versions/$(MAC_PACKAGE_VERSIO
 MAC_FRAMEWORK_CURRENT_DIR = $(MAC_FRAMEWORK_DIR)/Versions/$(MAC_INSTALL_VERSION)
 
 MOBILE_BCL_DIR = $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/Xamarin.Mac
-MAC_mobile_CSC = $(SYSTEM_CSC) -nostdlib -noconfig -r:$(MOBILE_BCL_DIR)/System.dll -r:$(MOBILE_BCL_DIR)/System.Core.dll -r:$(MOBILE_BCL_DIR)/System.Xml.dll -r:$(MOBILE_BCL_DIR)/mscorlib.dll -r:$(MOBILE_BCL_DIR)/System.Net.Http.dll -r:$(MOBILE_BCL_DIR)/Facades/System.Drawing.Common.dll -deterministic
+MAC_mobile_CSC = $(SYSTEM_CSC) -features:strict -nostdlib -noconfig -r:$(MOBILE_BCL_DIR)/System.dll -r:$(MOBILE_BCL_DIR)/System.Core.dll -r:$(MOBILE_BCL_DIR)/System.Xml.dll -r:$(MOBILE_BCL_DIR)/mscorlib.dll -r:$(MOBILE_BCL_DIR)/System.Net.Http.dll -r:$(MOBILE_BCL_DIR)/Facades/System.Drawing.Common.dll -deterministic
 
 FULL_BCL_DIR = $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/4.5
-MAC_full_CSC = $(SYSTEM_CSC) -nostdlib -noconfig -r:$(FULL_BCL_DIR)/System.dll -r:$(FULL_BCL_DIR)/System.Core.dll -r:$(FULL_BCL_DIR)/System.Xml.dll -r:$(FULL_BCL_DIR)/mscorlib.dll -r:$(FULL_BCL_DIR)/System.Net.Http.dll -r:$(FULL_BCL_DIR)/Facades/System.Drawing.Common.dll -deterministic
+MAC_full_CSC = $(SYSTEM_CSC) -features:strict -nostdlib -noconfig -r:$(FULL_BCL_DIR)/System.dll -r:$(FULL_BCL_DIR)/System.Core.dll -r:$(FULL_BCL_DIR)/System.Xml.dll -r:$(FULL_BCL_DIR)/mscorlib.dll -r:$(FULL_BCL_DIR)/System.Net.Http.dll -r:$(FULL_BCL_DIR)/Facades/System.Drawing.Common.dll -deterministic
 
 MAC_PACKAGE_FILENAME=$(MAC_PACKAGE_NAME_LOWER)-$(MAC_PACKAGE_VERSION).pkg
 MAC_PACKAGE_DMG_FILENAME=$(MAC_PACKAGE_NAME_LOWER)-$(MAC_PACKAGE_VERSION).dmg

--- a/Make.config
+++ b/Make.config
@@ -276,12 +276,12 @@ MACIOS_BINARIES_PATH=$(TOP)/external/macios-binaries
 
 MONO_PREFIX ?= /Library/Frameworks/Mono.framework/Versions/Current
 SYSTEM_MCS=$(MONO_PREFIX)/bin/mcs
-SYSTEM_CSC=$(MONO_PREFIX)/bin/csc
+SYSTEM_CSC=$(MONO_PREFIX)/bin/csc /features:strict
 SYSTEM_SN=$(MONO_PREFIX)/bin/sn
 SYSTEM_MONO=$(MONO_PREFIX)/bin/mono
 SYSTEM_MONO32=$(MONO_PREFIX)/bin/mono32
-SYSTEM_XBUILD=$(MONO_PREFIX)/bin/msbuild
-SYSTEM_MSBUILD=unset MSBuildExtensionsPath && $(MONO_PREFIX)/bin/msbuild
+SYSTEM_XBUILD=$(MONO_PREFIX)/bin/msbuild /p:Features=strict
+SYSTEM_MSBUILD=unset MSBuildExtensionsPath && $(MONO_PREFIX)/bin/msbuild /p:Features=strict
 SYSTEM_RESGEN=$(MONO_PREFIX)/bin/resgen
 
 XIBUILD_EXE_PATH=$(abspath $(TOP)/tools/xibuild/bin/Debug/xibuild.exe)

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -50,7 +50,7 @@ Delegates.generated.cs: Delegates.cs.t4 delegates.t4
 	$(Q_GEN) $(TT) $< -o $@
 
 bindings-generator.exe: bindings-generator.cs
-	$(Q) $(SYSTEM_CSC) $< -out:$@ -debug:full
+	$(Q) $(SYSTEM_CSC) $< -out:$@ -debug:full -features:strict 
 
 bindings-generated.m: bindings-generator.exe
 	$(Q_GEN) $(SYSTEM_MONO) --debug $< $@

--- a/src/CFNetwork/CFHTTPMessage.cs
+++ b/src/CFNetwork/CFHTTPMessage.cs
@@ -339,7 +339,7 @@ namespace CoreServices {
 			case AuthenticationScheme.Digest:
 				return _AuthenticationSchemeDigest;
 			case AuthenticationScheme.OAuth1:
-				if (_AuthenticationSchemeOAuth1 == null)
+				if (_AuthenticationSchemeOAuth1 == IntPtr.Zero)
 					throw new NotSupportedException ("Requires iOS 7.0 or macOS 10.9 and lower than iOS 12 or macOS 10.14");
 				return _AuthenticationSchemeOAuth1;
 			default:

--- a/src/CoreFoundation/DispatchData.cs
+++ b/src/CoreFoundation/DispatchData.cs
@@ -82,7 +82,7 @@ namespace CoreFoundation {
 		//
 		public static DispatchData FromBuffer (IntPtr buffer, nuint size)
 		{
-			if (buffer == null)
+			if (buffer == IntPtr.Zero)
 				throw new ArgumentNullException (nameof (buffer));
 			var dd = dispatch_data_create (buffer, (nuint) size, IntPtr.Zero, destructor: IntPtr.Zero);
 			return new DispatchData (dd, owns: true);

--- a/src/Makefile
+++ b/src/Makefile
@@ -622,7 +622,7 @@ $(WATCH_BUILD_DIR)/reference/Xamarin.WatchOS.pdb: $(WATCH_BUILD_DIR)/watch-32/Xa
 
 # MonoTouch.NUnitLite
 $(WATCH_BUILD_DIR)/reference/MonoTouch.NUnitLite%dll $(WATCH_BUILD_DIR)/reference/MonoTouch.NUnitLite%pdb: $(WATCHOS_TOUCHUNIT_SOURCES) $(PRODUCT_KEY_PATH) $(WATCH_BUILD_DIR)/reference/Xamarin.WatchOS.dll
-	$(call Q_PROF_CSC,watch) $(SYSTEM_CSC) -nologo -out:$(basename $@).dll -target:library -debug:portable -optimize -publicsign -noconfig -nostdlib \
+	$(call Q_PROF_CSC,watch) $(SYSTEM_CSC) -features:strict -nologo -out:$(basename $@).dll -target:library -debug:portable -optimize -publicsign -noconfig -nostdlib \
 		-keyfile:$(PRODUCT_KEY_PATH) -r:$(WATCH_BUILD_DIR)/reference/Xamarin.WatchOS.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/mscorlib.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/System.Xml.dll \
 		-nowarn:3006,612,649,414,1635 \
 		-define:NUNITLITE,CLR_4_0,NET_4_5,__MOBILE__ $(WATCH_DEFINES) \
@@ -787,7 +787,7 @@ $(TVOS_BUILD_DIR)/reference/Xamarin.TVOS.pdb: $(TVOS_BUILD_DIR)/tvos-64/Xamarin.
 
 # MonoTouch.NUnitLite
 $(TVOS_BUILD_DIR)/reference/MonoTouch.NUnitLite%dll $(TVOS_BUILD_DIR)/reference/MonoTouch.NUnitLite%pdb: $(TVOS_TOUCHUNIT_SOURCES) $(PRODUCT_KEY_PATH) $(TVOS_BUILD_DIR)/reference/Xamarin.TVOS.dll $(TVOS_BUILD_DIR)/reference/MonoTouch.Dialog-1.dll
-	$(call Q_PROF_CSC,tvos) $(SYSTEM_CSC) -nologo -r:$(MONOTOUCH_TV_MONO_PATH)/mscorlib.dll -out:$(basename $@).dll -target:library -debug:portable -optimize -noconfig -nostdlib -publicsign \
+	$(call Q_PROF_CSC,tvos) $(SYSTEM_CSC) -features:strict -nologo -r:$(MONOTOUCH_TV_MONO_PATH)/mscorlib.dll -out:$(basename $@).dll -target:library -debug:portable -optimize -noconfig -nostdlib -publicsign \
 		-keyfile:$(PRODUCT_KEY_PATH) -r:$(TVOS_BUILD_DIR)/reference/Xamarin.TVOS.dll -r:$(TVOS_BUILD_DIR)/reference/MonoTouch.Dialog-1.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Xml.dll \
 		-nowarn:3006,612,649,414,1635 \
 		-define:NUNITLITE,CLR_4_0,NET_4_5,__MOBILE__ $(TVOS_DEFINES) \

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -58,7 +58,7 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen/bgen.exe: $(BUILD_DIR)/common/bgen.ex
 
 $(IOS_BUILD_DIR)/native/Xamarin.iOS.BindingAttributes.dll: generator-attributes.cs Makefile.generator
 	$(Q) mkdir -p $(dir $@)
-	$(Q_GEN) $(SYSTEM_CSC) -nologo -out:$@ -debug generator-attributes.cs -target:library -deterministic
+	$(Q_GEN) $(SYSTEM_CSC) -features:strict -nologo -out:$@ -debug generator-attributes.cs -target:library -deterministic
 
 #
 # Xamarin.Watch (bwatch)
@@ -83,7 +83,7 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen/%.dll: $(WATCH_BUILD_DIR)/%.dll | $(I
 
 $(WATCH_BUILD_DIR)/Xamarin.WatchOS.BindingAttributes.dll: generator-attributes.cs Makefile.generator
 	$(Q) mkdir -p $(dir $@)
-	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug -out:$@ -debug generator-attributes.cs -target:library -deterministic
+	$(Q_GEN) $(SYSTEM_CSC) -features:strict -nologo -debug -out:$@ -debug generator-attributes.cs -target:library -deterministic
 
 # #
 # # Xamarin.TVOS (btv)
@@ -108,7 +108,7 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen/%.dll: $(TVOS_BUILD_DIR)/%.dll | $(IO
 
 $(TVOS_BUILD_DIR)/Xamarin.TVOS.BindingAttributes.dll: generator-attributes.cs Makefile.generator
 	$(Q) mkdir -p $(dir $@)
-	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug -out:$@ -debug generator-attributes.cs -target:library -deterministic
+	$(Q_GEN) $(SYSTEM_CSC) -features:strict -nologo -debug -out:$@ -debug generator-attributes.cs -target:library -deterministic
 
 #
 # Xamarin.Mac (bmac)
@@ -154,7 +154,7 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/%.exe: $(BUILD_DIR)/common/b
 
 $(MAC_BUILD_DIR)/Xamarin.Mac-%.BindingAttributes.dll: generator-attributes.cs Makefile.generator
 	$(Q) mkdir -p $(dir $@)
-	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug -out:$@ -debug generator-attributes.cs -target:library -deterministic
+	$(Q_GEN) $(SYSTEM_CSC) -features:strict -nologo -debug -out:$@ -debug generator-attributes.cs -target:library -deterministic
 
 bgen:	\
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/bgen                     \

--- a/tests/common.mk
+++ b/tests/common.mk
@@ -25,14 +25,14 @@ clean-local::
 
 build/%/$(TESTDLL): $(MAC_SOURCES) build/GuiUnit.exe Makefile $(BASE_DLLS)
 	@mkdir -p $(dir $@)
-	$(Q_CSC) $(SYSTEM_CSC) -out:$@ -t:library -debug -d:MONOMAC -d:XAMCORE_2_0 \
+	$(Q_CSC) $(SYSTEM_CSC) -out:$@ -t:library -features:strict -debug -d:MONOMAC -d:XAMCORE_2_0 \
 		-r:build/GuiUnit.exe \
 		-r:$(TOP)/src/build/mac/$*/Xamarin.Mac.dll \
 		$(MAC_SOURCES)
 
 build/compat/$(TESTDLL): $(MAC_SOURCES) build/GuiUnit.exe Makefile $(BASE_DLLS)
 	@mkdir -p $(dir $@)
-	$(Q_CSC) $(SYSTEM_CSC) -out:$@ -t:library -debug -d:MONOMAC \
+	$(Q_CSC) $(SYSTEM_CSC) -out:$@ -t:library -features:strict -debug -d:MONOMAC \
 		-r:build/GuiUnit.exe \
 		-r:System.Drawing \
 		-r:$(TOP)/src/build/mac/compat/XamMac.dll \

--- a/tests/common/mac/project_building.mk
+++ b/tests/common/mac/project_building.mk
@@ -32,4 +32,4 @@ run run-test run-tests:: $(TESTDLL) $(EXTRA_DEPS)
 
 $(TESTDLL): $(ALL_SOURCE_FILES) 
 	$(Q) mkdir -p build
-	$(Q) $(SYSTEM_CSC) /debug $(SOURCES) -d:MMP_TEST -d:XAMCORE_2_0 -d:MONOMAC -t:library -r:nunit.framework -out:$(TESTDLL)
+	$(Q) $(SYSTEM_CSC) /debug $(SOURCES) -d:MMP_TEST -d:XAMCORE_2_0 -d:MONOMAC -t:library -r:nunit.framework -features:strict -out:$(TESTDLL)

--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -118,5 +118,5 @@ remove-empty-files:
 	find . -empty -exec git rm -f {} \;
 
 unclassified2todo:
-	$(SYSTEM_CSC) Filter.cs u2todo/u2todo.cs
+	$(SYSTEM_CSC) -features:strict Filter.cs u2todo/u2todo.cs
 	$(MONO) u2todo.exe


### PR DESCRIPTION
Make csc to be more strict when compiling the projects and mix some
small errors we had in the bindings.

Fixes: https://github.com/xamarin/xamarin-macios/issues/5398

Backport of #7665.

/cc @mandel-macaque 