### PR TITLE
[d16-5] [xharness] Only run 'dont link' on release configuration

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -267,11 +267,13 @@ namespace xharness
 			// 32-bit interpreter doesn't work yet: https://github.com/mono/mono/issues/9871
 			var supports_interpreter = test.Platform != TestPlatform.iOS_Unified32;
 			var supports_dynamic_registrar_on_device = test.Platform == TestPlatform.iOS_Unified64 || test.Platform == TestPlatform.tvOS;
-			// arm64_32 is only supported for Release builds for now.
-			var supports_debug = test.Platform != TestPlatform.watchOS_64_32;
 
 			switch (test.ProjectPlatform) {
 			case "iPhone":
+				// arm64_32 is only supported for Release builds for now.
+				// arm32 bits too big for debug builds - https://github.com/xamarin/maccore/issues/2080
+				var supports_debug = test.Platform != TestPlatform.watchOS_64_32 && !(test.TestName == "dont link" && test.Platform == TestPlatform.iOS_Unified32);
+
 				/* we don't add --assembly-build-target=@all=staticobject because that's the default in all our test projects */
 				if (supports_debug) {
 					yield return new TestData { Variation = "AssemblyBuildTarget: dylib (debug)", MTouchExtraArgs = $"--assembly-build-target=@all=dynamiclibrary {test.TestProject.MTouchExtraArgs}", Debug = true, Profiling = false, MonoNativeLinkMode = MonoNativeLinkMode.Dynamic, MonoNativeFlavor = flavor };
@@ -560,7 +562,7 @@ namespace xharness
 
 					var build32 = new XBuildTask {
 						Jenkins = this,
-						ProjectConfiguration = "Debug32",
+						ProjectConfiguration = project.Name != "dont link" ? "Debug32" : "Release32",
 						ProjectPlatform = "iPhone",
 						Platform = TestPlatform.iOS_Unified32,
 						TestName = project.Name,

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -169,6 +169,7 @@ namespace xharness
 		public iOSTestProject (string path, bool isExecutableProject = true)
 			: base (path, isExecutableProject)
 		{
+			Name = System.IO.Path.GetFileNameWithoutExtension (path);
 		}
 	}
 


### PR DESCRIPTION
The 32bits **debug** binaries are now too big for Apple's native linker
to process, which gives us (non useful) build errors on the bots.

This will still run the release builds configuration of the tests since
they are smaller and still within the limits of the tooling.

Backport of #7662.

/cc @mandel-macaque @spouliot