### PR TITLE
[d16-5] [msbuild] Add verbosity options on separate lines for mtouch parsing

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -246,8 +246,14 @@ namespace Xamarin.Mac.Tasks
 				actualArgs.Add (ExtraArguments);
 
 			var verbosity = VerbosityUtils.Merge (ExtraArguments, (LoggerVerbosity) Verbosity);
-			// for compatibility with earlier versions nothing means one /v
-			actualArgs.AddLine (verbosity.Length > 0 ? verbosity : "/verbose");
+			if (verbosity.Length > 0) {
+				foreach (var arg in verbosity) {
+					actualArgs.AddLine (arg);
+				}
+			} else {
+				// for compatibility with earlier versions nothing means one /v
+				actualArgs.AddLine ("/verbose");
+			}
 
 			return actualArgs.ToString ();
 		}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
@@ -224,8 +224,10 @@ namespace Xamarin.MacDev.Tasks {
 
 			var v = VerbosityUtils.Merge (ExtraArgs, (LoggerVerbosity) Verbosity);
 			if (v.Length > 0) {
-				cmd.AppendTextUnquoted (" ");
-				cmd.AppendTextUnquoted (v);
+				foreach (var arg in v) {
+					cmd.AppendTextUnquoted (" ");
+					cmd.AppendTextUnquoted (arg);
+				}
 			}
 
 			return cmd.ToString ();

--- a/msbuild/Xamarin.MacDev.Tasks.Core/VerbosityUtils.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/VerbosityUtils.cs
@@ -12,9 +12,9 @@ namespace Xamarin.MacDev.Tasks {
 
 		// verbosity can be set in multiple ways
 		// this makes it a consistent interpretation of them
-		static public string Merge (string extraArguments, LoggerVerbosity taskVerbosity)
+		static public string[] Merge (string extraArguments, LoggerVerbosity taskVerbosity)
 		{
-			string result = String.Empty;
+			string[] result = Array.Empty<string> ();
 			var empty_extra = String.IsNullOrEmpty (extraArguments);
 			// We give the priority to the extra arguments given to the tools
   			if (empty_extra || (!empty_extra && !extraArguments.Contains ("-q") && !extraArguments.Contains ("-v"))) {
@@ -39,7 +39,7 @@ namespace Xamarin.MacDev.Tasks {
 		//		The available verbosity levels are: q[uiet], m[inimal],
 		//		n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
 		//
-		static public string GetVerbosityLevel (string commandLine)
+		static public string[] GetVerbosityLevel (string commandLine)
 		{
 			const string shortForm = "v:";
 			const string longForm = "verbosity:";
@@ -91,20 +91,20 @@ namespace Xamarin.MacDev.Tasks {
 
 		// The values here come from: https://github.com/mono/monodevelop/blob/143f9b6617123a0841a5cc5a2a4e13b309535792/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild.Shared/RemoteBuildEngineMessages.cs#L186
 		// Assume 'Normal (2)' is the default verbosity (no change), and the other values follow from there.
-		static public string GetVerbosityLevel (LoggerVerbosity v)
+		static public string[] GetVerbosityLevel (LoggerVerbosity v)
 		{
 			switch ((LoggerVerbosity) v) {
 			case LoggerVerbosity.Quiet:
-				return "-q -q -q -q";
+				return new [] { "-q", "-q", "-q", "-q" };
 			case LoggerVerbosity.Minimal:
-				return "-q -q";
+				return new [] { "-q", "-q" };
 			case LoggerVerbosity.Normal:
 			default:
-				return String.Empty;
+				return Array.Empty<string> ();
 			case LoggerVerbosity.Detailed:
-				return "-v -v";
+				return new [] { "-v", "-v" };
 			case LoggerVerbosity.Diagnostic:
-				return "-v -v -v -v";
+				return new [] { "-v", "-v", "-v", "-v" };
 			}
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -592,8 +592,10 @@ namespace Xamarin.iOS.Tasks
 			args.AddQuotedLine ($"--root-assembly={Path.GetFullPath (MainAssembly.ItemSpec)}");
 
 			var v = VerbosityUtils.Merge (ExtraArgs, (LoggerVerbosity) Verbosity);
-			if (v.Length > 0)
-				args.AddLine (v);
+			if (v.Length > 0) {
+				foreach (var arg in v)
+					args.AddLine (arg);
+			}
 
 			if (!string.IsNullOrWhiteSpace (License))
 				args.AddLine ($"--license={License}");

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/VerbosityTest.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/VerbosityTest.cs
@@ -51,7 +51,8 @@ namespace Xamarin.MacDev.Tasks {
 		[TestCase ((LoggerVerbosity) (-1), "")]
 		public void FromLoggerVerbosity (LoggerVerbosity v, string expectedResult)
 		{
-			Assert.That (VerbosityUtils.GetVerbosityLevel (v), Is.EqualTo (expectedResult), v.ToString ());
+			var s = String.Join (" ", VerbosityUtils.GetVerbosityLevel (v));
+			Assert.That (s, Is.EqualTo (expectedResult), v.ToString ());
 		}
 	}
 }


### PR DESCRIPTION
This is more strict than the response-file spec [0] (and filed as a
separate issue [1]) but `mtouch` currently requires one option-per-line
(for filtering some options) for the cache to work properly (i.e. so it
can ignore the `-v` and the `-q` and re-use the existing, cached,
binaries). E.g. from:

```
...
-v -v -v -v
```

to

```
...
-v
-v
-v
-v
```

This is an optimization fix (since cached output helps build times) and
it's also part of a bug fix [2] (part of another commit [3], that was
reverted [4] due to other issues, like this one).

This needs another fix [5] to work properly (like `mtouch` requires)
but both can be applied separately (so different PR for different
changes).

[0] https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/response-file-compiler-option
[1] https://github.com/xamarin/xamarin-macios/issues/7644
[2] https://github.com/xamarin/xamarin-macios/issues/7514
[3] https://github.com/xamarin/xamarin-macios/pull/7544
[4] https://github.com/xamarin/xamarin-macios/pull/7589
[5] https://github.com/xamarin/xamarin-macios/pull/7647

Backport of #7649.

/cc @mandel-macaque @spouliot