### PR TITLE
[MMP] Allow to compile assemblies that do have a comma.

### DIFF
--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -752,16 +752,10 @@ namespace Xamarin.MMP.Tests
 
 		// some users add ',' in their assembly names :( 
 		[Test]
-		public void AssemblyNameWithCommaShouldNotFail ()
-		{
-			RunMMPTest (tmpDir => {
-				Action<string, bool> testCore = (assemblyName, XM45) => {
-					// Build a library with the conflicting name
-					TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { XM45 = XM45, AssemblyName = assemblyName,  ProjectName = assemblyName };
-					TI.TestUnifiedExecutable (test, shouldFail: false);
-				};
-				testCore ("UserLikes,ToEnumerate.Mac", true);
-			});
-		}
+		public void AssemblyNameWithCommaShouldNotFail () => RunMMPTest (tmpDir => {
+			// Build a library with the conflicting name
+			TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { XM45 = true, AssemblyName = "UserLikes,ToEnumerate.Mac",  ProjectName = "UserLikes,ToEnumerate.Mac" };
+			TI.TestUnifiedExecutable (test, shouldFail: false);
+		});
 	}
 }

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -752,7 +752,7 @@ namespace Xamarin.MMP.Tests
 
 		// some users add ',' in their assembly names :( 
 		[Test]
-		public void FunnyAssemblyNameShouldNotFail ()
+		public void AssemblyNameWithCommaShouldNotFail ()
 		{
 			RunMMPTest (tmpDir => {
 				Action<string, bool> testCore = (assemblyName, XM45) => {

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -749,5 +749,19 @@ namespace Xamarin.MMP.Tests
 			});
 
 		}
+
+		// some users add ',' in their assembly names :( 
+		[Test]
+		public void FunnyAssemblyNameShouldNotFail ()
+		{
+			RunMMPTest (tmpDir => {
+				Action<string, bool> testCore = (assemblyName, XM45) => {
+					// Build a library with the conflicting name
+					TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { XM45 = XM45, AssemblyName = assemblyName,  ProjectName = assemblyName };
+					TI.TestUnifiedExecutable (test, shouldFail: false);
+				};
+				testCore ("UserLikes,ToEnumerate.Mac", true);
+			});
+		}
 	}
 }

--- a/tools/mmp/resolver.cs
+++ b/tools/mmp/resolver.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Bundler {
 
 		public AssemblyDefinition GetAssembly (string fileName)
 		{
-			return Resolve (Path.GetFileNameWithoutExtension (fileName));
+			return Resolve (new AssemblyNameReference (Path.GetFileNameWithoutExtension (fileName), null), new ReaderParameters { AssemblyResolver = this });
 		}
 
 		public AssemblyDefinition Resolve (string fullName)


### PR DESCRIPTION
Users sometimes add commas to their assemblies. Make sure we can handle
that case.

Fixes: https://github.com/xamarin/xamarin-macios/issues/6726