### PR TITLE
[Jenkins] Fix the HTML report url.

### DIFF
--- a/jenkins/vsts-device-tests-set-status.sh
+++ b/jenkins/vsts-device-tests-set-status.sh
@@ -44,6 +44,8 @@ if test -z "$DEVICE_TYPE"; then
 	DEVICE_TYPE="iOS/tvOS"
 fi
 
+P=$(cat tmp.p)
+
 VSTS_BUILD_URL="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECT}/_build/index?buildId=${BUILD_BUILDID}"
 
 # Add a GitHub status to the commit we're testing


### PR DESCRIPTION
In commit f1b92747c71224687a190bc088f724d2137b8f4f a line was removed
(https://github.com/xamarin/xamarin-macios/commit/f1b92747c71224687a190bc088f724d2137b8f4f#diff-d3d730446199284b8a960b44a62d4d13L47)
that broke the HTML report url. Re-add the wrongly removed line.

Fixes: https://github.com/xamarin/maccore/issues/2113