### PR TITLE
[CoreFoundation] Add some helper methods to make DispatchData easier to use.

### DIFF
--- a/src/CoreFoundation/DispatchData.cs
+++ b/src/CoreFoundation/DispatchData.cs
@@ -94,7 +94,7 @@ namespace CoreFoundation {
 			unsafe {
 				fixed (byte* ptr = content) {
 					// set the block that will be used to clean the data once we are done with it
-					var dd = dispatch_data_create ((IntPtr)ptr, (nuint) content.Length, IntPtr.Zero, destructor: IntPtr.Zero);
+					var dd = dispatch_data_create ((IntPtr) ptr, (nuint) content.Length, IntPtr.Zero, destructor: IntPtr.Zero);
 					return new DispatchData (dd, owns: true);
 				}
 			}

--- a/src/CoreFoundation/DispatchData.cs
+++ b/src/CoreFoundation/DispatchData.cs
@@ -93,7 +93,9 @@ namespace CoreFoundation {
 		{
 			unsafe {
 				fixed (byte* ptr = content) {
-					// set the block that will be used to clean the data once we are done with it
+					// As per the documentation for dispatch_data_create, seems the data the pointer points to is copied 
+					// internally when specifying DISPATCH_DATA_DESTRUCTOR_DEFAULT as the destructor,
+					// and DISPATCH_DATA_DESTRUCTOR_DEFAULT=NULL, which is what you're passing, which means the code is OK. 
 					var dd = dispatch_data_create ((IntPtr) ptr, (nuint) content.Length, IntPtr.Zero, destructor: IntPtr.Zero);
 					return new DispatchData (dd, owns: true);
 				}

--- a/tests/monotouch-test/CoreFoundation/DispatchDataTest.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchDataTest.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Text;
+using System.Runtime.InteropServices;
+
+#if XAMCORE_2_0
+using Foundation;
+using CoreFoundation;
+using ObjCRuntime;
+#else
+using MonoTouch.CoreFoundation;
+using MonoTouch.Foundation;
+using MonoTouch.ObjCRuntime;
+#endif
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.CoreFoundation {
+	
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class DispatchDataTest
+	{
+		string testString;
+		byte[] testData;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			testString = "String used for testing";
+			testData = Encoding.UTF8.GetBytes (testString);
+		}
+
+		[Test]
+		public void FromByteBufferTest ()
+		{
+			using (var dd = DispatchData.FromByteBuffer (testData)) {
+				var ddString = Encoding.UTF8.GetString (dd.ToArray ());
+				Assert.AreEqual (testString, ddString);
+			}
+		}
+
+		[Test]
+		public void FromReadOnlySpanTest ()
+		{
+			//var readOnlySpan = new ReadOnlyMemory <byte> (testData);
+			var readOnlySpan = new ReadOnlySpan<byte> (testData);
+			using (var dd = DispatchData.FromReadOnlySpan (readOnlySpan)) {
+				var data = dd.ToArray ();
+				var ddString = Encoding.UTF8.GetString (dd.ToArray ());
+				Assert.AreEqual (testString, ddString);
+			}
+		}
+
+	}
+
+}

--- a/tests/monotouch-test/CoreFoundation/DispatchDataTest.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchDataTest.cs
@@ -41,7 +41,6 @@ namespace MonoTouchFixtures.CoreFoundation {
 		[Test]
 		public void FromReadOnlySpanTest ()
 		{
-			//var readOnlySpan = new ReadOnlyMemory <byte> (testData);
 			var readOnlySpan = new ReadOnlySpan<byte> (testData);
 			using (var dd = DispatchData.FromReadOnlySpan (readOnlySpan)) {
 				var data = dd.ToArray ();


### PR DESCRIPTION
Add the following methods:

1. FromReadOnlySpan - Allows to create DispatchData from Spans.
2. ToArray - Return a managed copy of the data.

Fixes: https://github.com/xamarin/xamarin-macios/issues/7446