### PR TITLE
[DevOps] Add cleanup step to device-tests.yml

### DIFF
--- a/tools/devops/cleanup.sh
+++ b/tools/devops/cleanup.sh
@@ -1,0 +1,6 @@
+sudo rm -rf /Applications/Visual\ Studio*
+rm -rf ~/Library/Caches/VisualStudio
+rm -rf ~/Library/Logs/VisualStudio
+rm -rf ~/Library/VisualStudio
+rm -rf ~/Library/Preferences/Xamarin/
+rm -rf ~/Library/Caches/com.xamarin.provisionator

--- a/tools/devops/device-tests.yml
+++ b/tools/devops/device-tests.yml
@@ -141,3 +141,12 @@ jobs:
       artifactName: HtmlReport
     continueOnError: true
     condition: succeededOrFailed()
+
+###
+### Cleanup after us, not having that can lead to VSMac install issues
+###
+
+  - bash: ./xamarin-macios/tools/devops/cleanup.sh
+    displayName: 'Cleanup'
+    continueOnError: true
+    condition: succeededOrFailed()


### PR DESCRIPTION
This was recommended by QA / DDFun because they were running into issues re-installing VSMac on the machines we ran the pipeline on.