### PR TITLE
[msbuild] Convert project files to sdk-style project files.

### DIFF
--- a/msbuild/.gitignore
+++ b/msbuild/.gitignore
@@ -1,3 +1,4 @@
+.failed-stamp
 .build-stamp
 .stamp-test-xml
 

--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -22,6 +22,7 @@ MSBUILD_TASK_ASSEMBLIES      =
 
 ALL_SOURCES:= $(shell git ls-files | sed 's/ /\\ /g') $(wildcard $(XAMARIN_MACDEV_PATH)/Xamarin.MacDev/*.cs) $(wildcard $(XAMARIN_MACDEV_PATH)/Xamarin.MacDev/*.csproj)
 CONFIG      = Debug
+TARGETFRAMEWORK = net461
 
 ##
 ## XI definitions
@@ -306,13 +307,13 @@ all-local:: $(MSBUILD_PRODUCTS) .stamp-test-xml
 	$(Q) touch $@
 
 # make all the target assemblies build when any of the sources have changed
-$(foreach dll,$(MSBUILD_TASK_ASSEMBLIES),$(dll)/bin/$(CONFIG)/$(dll).dll): .build-stamp
+$(foreach dll,$(MSBUILD_TASK_ASSEMBLIES),$(dll)/bin/$(CONFIG)/$(TARGETFRAMEWORK)/$(dll).dll): .build-stamp
 
 # Always remake the symlinks
 .PHONY: $(MSBUILD_SYMLINKS)
 
 define copyToBuild
-build/$(1).dll: $(1)/bin/$(CONFIG)/$(1).dll | build
+build/$(1).dll: $(1)/bin/$(CONFIG)/$(TARGETFRAMEWORK)/$(1).dll | build
 	$$(Q) $(CP) $$< $$@
 endef
 
@@ -331,6 +332,13 @@ install-local:: $(MSBUILD_PRODUCTS)
 	$(Q) xmllint --noout $^
 	@echo Targets files are valid XML
 	@touch $@
+
+test run-test:
+	$(MAKE) -C $(TOP)/tests test-ios-tasks
+
+clean-local::
+	git clean -xfdq
+	cd $(XAMARIN_MACDEV_PATH) && git clean -xfdq
 
 # make will automatically consider files created in chained implicit rules as temporary files, and delete them afterwards
 # marking those files as .SECONDARY will prevent that deletion.

--- a/msbuild/Xamarin.Mac.Tasks.Core/Xamarin.Mac.Tasks.Core.csproj
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Xamarin.Mac.Tasks.Core.csproj
@@ -1,58 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{AF1AC7C3-F6DD-4E46-B897-9DBB90B158EC}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>Xamarin.Mac.Tasks</RootNamespace>
-    <AssemblyName>Xamarin.Mac.Tasks.Core</AssemblyName>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <Prefer32Bit>false</Prefer32Bit>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="Microsoft.Build.Framework" HintPath="$(MSBuildBinPath)\Microsoft.Build.Framework.dll" />
-    <Reference Include="Microsoft.Build" HintPath="$(MSBuildBinPath)\Microsoft.Build.dll" />
-    <Reference Include="Microsoft.Build.Utilities.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Utilities.Core.dll" />
-    <Reference Include="Microsoft.Build.Tasks.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
-    <Compile Include="MacOSXSdks.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Tasks\DetectSdkLocationsTaskBase.cs" />
-    <Compile Include="Tasks\EmbedProvisionProfileTaskBase.cs" />
-    <Compile Include="Tasks\MmpTaskBase.cs" />
-    <Compile Include="Tasks\XamMacArch.cs" />
-    <Compile Include="Tasks\ArchiveTaskBase.cs" />
-    <Compile Include="Tasks\ALToolUploadTaskBase.cs" />
-    <Compile Include="Tasks\ALToolValidateTaskBase.cs" />
+    <!-- Compile against Microsoft.Build* NuGet refs, but do not copy to OutputDir. -->
+    <PackageReference Include="Microsoft.Build" Version="15.9.20" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" IncludeAssets="compile" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj">
-      <Project>{CC3D9353-20C4-467A-8522-A9DED6F0C753}</Project>
-      <Name>Xamarin.MacDev</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Xamarin.MacDev.Tasks\Xamarin.MacDev.Tasks.csproj">
-      <Project>{534D7C5A-0E1C-4C58-9E48-21B1A98919EB}</Project>
-      <Name>Xamarin.MacDev.Tasks</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Xamarin.MacDev.Tasks.Core\Xamarin.MacDev.Tasks.Core.csproj">
-      <Project>{7B095849-6FDB-4BD2-9B59-569D81A1A809}</Project>
-      <Name>Xamarin.MacDev.Tasks.Core</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj" />
+    <ProjectReference Include="..\Xamarin.MacDev.Tasks.Core\Xamarin.MacDev.Tasks.Core.csproj" />
+    <ProjectReference Include="..\Xamarin.MacDev.Tasks\Xamarin.MacDev.Tasks.csproj" />
   </ItemGroup>
 </Project>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -1,135 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{C8D98DC1-5122-4B10-A152-17196C7BD9AC}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>Xamarin.Mac.Tasks</RootNamespace>
-    <AssemblyName>Xamarin.Mac.Tasks</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="Microsoft.Build.Framework" HintPath="$(MSBuildBinPath)\Microsoft.Build.Framework.dll" />
-    <Reference Include="Microsoft.Build" HintPath="$(MSBuildBinPath)\Microsoft.Build.dll" />
-    <Reference Include="Microsoft.Build.Utilities.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Utilities.Core.dll" />
-    <Reference Include="Microsoft.Build.Tasks.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll" />
+    <ProjectReference Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj" />
+    <ProjectReference Include="..\Xamarin.MacDev.Tasks.Core\Xamarin.MacDev.Tasks.Core.csproj" />
+    <ProjectReference Include="..\Xamarin.MacDev.Tasks\Xamarin.MacDev.Tasks.csproj" />
+    <ProjectReference Include="..\Xamarin.Mac.Tasks.Core\Xamarin.Mac.Tasks.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Tasks\ALToolUpload.cs" />
-    <Compile Include="Tasks\ALToolValidate.cs" />
-    <Compile Include="Tasks\ACTool.cs" />
-    <Compile Include="Tasks\BTouch.cs" />
-    <Compile Include="Tasks\CreateBindingResourcePackage.cs" />
-    <Compile Include="Tasks\CodesignVerify.cs" />
-    <Compile Include="Tasks\CompileAppManifest.cs" />
-    <Compile Include="Tasks\CompileEntitlements.cs" />
-    <Compile Include="Tasks\CompileSceneKitAssets.cs" />
-    <Compile Include="Tasks\CreateEmbeddedResources.cs" />
-    <Compile Include="Tasks\DetectSdkLocations.cs" />
-    <Compile Include="Tasks\DetectSigningIdentity.cs" />
-    <Compile Include="Tasks\EmbedProvisionProfile.cs" />
-    <Compile Include="Tasks\IBTool.cs" />
-    <Compile Include="Tasks\Metal.cs" />
-    <Compile Include="Tasks\MetalLib.cs" />
-    <Compile Include="Tasks\Mmp.cs" />
-    <Compile Include="Tasks\ScnTool.cs" />
-    <Compile Include="Tasks\TextureAtlas.cs" />
-    <Compile Include="Tasks\PrepareNativeReferences.cs" />
-    <Compile Include="Tasks\Archive.cs" />
-  </ItemGroup>
-  <ItemGroup />
-  <ItemGroup>
-    <ProjectReference Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj">
-      <Project>{CC3D9353-20C4-467A-8522-A9DED6F0C753}</Project>
-      <Name>Xamarin.MacDev</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Xamarin.Mac.Tasks.Core\Xamarin.Mac.Tasks.Core.csproj">
-      <Project>{af1ac7c3-f6dd-4e46-b897-9dbb90b158ec}</Project>
-      <Name>Xamarin.Mac.Tasks.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Xamarin.MacDev.Tasks\Xamarin.MacDev.Tasks.csproj">
-      <Project>{534D7C5A-0E1C-4C58-9E48-21B1A98919EB}</Project>
-      <Name>Xamarin.MacDev.Tasks</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Xamarin.MacDev.Tasks.Core\Xamarin.MacDev.Tasks.Core.csproj">
-      <Project>{7B095849-6FDB-4BD2-9B59-569D81A1A809}</Project>
-      <Name>Xamarin.MacDev.Tasks.Core</Name>
-    </ProjectReference>
     <PackageReference Include="ILRepack" Version="2.0.18" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Xamarin.Mac.Common.ImplicitFacade.msbuild.targets">
+    <None Include="*.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="Xamarin.Mac.msbuild.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.Mac.TargetFrameworkFix.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.Mac.Common.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.Mac.CSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.Mac.FSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.Mac.Common.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.Mac.ObjCBinding.Common.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.Mac.ObjCBinding.Common.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.Mac.ObjCBinding.CSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.Mac.ObjCBinding.CSharp.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.Mac.AppExtension.Common.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.Mac.AppExtension.CSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.Mac.AppExtension.Common.targets">
+    <None Include="*.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="../Xamarin.Shared/Xamarin.Shared.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
   <Target Name="ILRepack" AfterTargets="CoreCompile" DependsOnTargets="CoreCompile" Inputs="@(IntermediateAssembly -&gt; '%(FullPath)')" Outputs="$(IntermediateOutputPath)ilrepack.txt" Returns="@(MergedAssemblies)" Condition="Exists(@(IntermediateAssembly -&gt; '%(FullPath)')) And '$(ILRepack)' != 'false'">
-    <GetReferenceAssemblyPaths BypassFrameworkInstallChecks="False" TargetFrameworkMoniker="$(TargetFrameworkMoniker)">
-      <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FullFrameworkReferenceAssemblyPaths" />
-    </GetReferenceAssemblyPaths>
     <ItemGroup>
       <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="
         '%(Extension)' == '.dll'

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Properties/AssemblyInfo.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Properties/AssemblyInfo.cs
@@ -42,7 +42,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -1,126 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{7B095849-6FDB-4BD2-9B59-569D81A1A809}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>Xamarin.MacDev.Tasks</RootNamespace>
-    <AssemblyName>Xamarin.MacDev.Tasks.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;MONO_DATACONVERTER_PUBLIC</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>MONO_DATACONVERTER_PUBLIC</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="Microsoft.Build.Framework" HintPath="$(MSBuildBinPath)\Microsoft.Build.Framework.dll" />
-    <Reference Include="Microsoft.Build.Tasks.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll" />
-    <Reference Include="Microsoft.Build.Utilities.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Utilities.Core.dll" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Mono.Posix" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Runtime.Serialization" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="System.Text.Json" Version="4.7.0" />
+    <!-- Compile against Microsoft.Build* NuGet refs, but do not copy to OutputDir. -->
+    <PackageReference Include="Microsoft.Build" Version="15.9.20" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" IncludeAssets="compile" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj">
-      <Project>{CC3D9353-20C4-467A-8522-A9DED6F0C753}</Project>
-      <Name>Xamarin.MacDev</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="PlatformUtils.cs" />
     <Compile Include="..\..\tools\common\StringUtils.cs">
       <Link>StringUtils.cs</Link>
     </Compile>
-    <Compile Include="VerbosityUtils.cs" />
+    <Compile Include="..\..\tools\common\FileCopier.cs">
+        <Link>FileCopier.cs</Link>
+    </Compile>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="MsBuildTasks\CopyBase.cs" />
-    <Compile Include="MsBuildTasks\DeleteBase.cs" />
-    <Compile Include="MsBuildTasks\ExecBase.cs" />
-    <Compile Include="MsBuildTasks\MakeDirBase.cs" />
-    <Compile Include="MsBuildTasks\MoveTaskBase.cs" />
-    <Compile Include="MsBuildTasks\RemoveDirBase.cs" />
-    <Compile Include="MsBuildTasks\TouchBase.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Tasks\ACToolTaskBase.cs" />
-    <Compile Include="Tasks\ALToolTaskBase.cs" />
-    <Compile Include="Tasks\ArchiveTaskBase.cs" />
-    <Compile Include="Tasks\ArToolTaskBase.cs" />
-    <Compile Include="Tasks\BTouchTaskBase.cs" />
-    <Compile Include="Tasks\CreateBindingResourcePackageBase.cs" />
-    <Compile Include="Tasks\CodesignTaskBase.cs" />
-    <Compile Include="Tasks\CodesignVerifyTaskBase.cs" />
-    <Compile Include="Tasks\CollectBundleResourcesTaskBase.cs" />
-    <Compile Include="Tasks\CollectFrameworksBase.cs" />
-    <Compile Include="Tasks\CompileAppManifestTaskBase.cs" />
-    <Compile Include="Tasks\CompileEntitlementsTaskBase.cs" />
-    <Compile Include="Tasks\CompileSceneKitAssetsTaskBase.cs" />
-    <Compile Include="Tasks\ComputeBundleResourceOutputPathsTaskBase.cs" />
-    <Compile Include="Tasks\CoreMLCompilerTaskBase.cs" />
-    <Compile Include="Tasks\CreateAssetPackManifestTaskBase.cs" />
-    <Compile Include="Tasks\CreateEmbeddedResourcesTaskBase.cs" />
-    <Compile Include="Tasks\CreateInstallerPackageTaskBase.cs" />
-    <Compile Include="Tasks\CreatePkgInfoTaskBase.cs" />
-    <Compile Include="Tasks\DetectSigningIdentityTaskBase.cs" />
-    <Compile Include="Tasks\DittoTaskBase.cs" />
-    <Compile Include="Tasks\DSymUtilTaskBase.cs" />
-    <Compile Include="Tasks\FindItemWithLogicalNameTaskBase.cs" />
-    <Compile Include="Tasks\GenerateBundleNameTaskBase.cs" />
-    <Compile Include="Tasks\GetNativeExecutableNameTaskBase.cs" />
-    <Compile Include="Tasks\GetPropertyListValueTaskBase.cs" />
-    <Compile Include="Tasks\IBToolTaskBase.cs" />
-    <Compile Include="Tasks\MetalLibTaskBase.cs" />
-    <Compile Include="Tasks\MetalTaskBase.cs" />
-    <Compile Include="Tasks\OptimizePropertyListTaskBase.cs" />
-    <Compile Include="Tasks\PackLibraryResourcesTaskBase.cs" />
-    <Compile Include="Tasks\PrepareNativeReferencesTaskBase.cs" />
-    <Compile Include="Tasks\PropertyListEditorTaskBase.cs" />
-    <Compile Include="Tasks\ReadItemsFromFileBase.cs" />
-    <Compile Include="Tasks\ScnToolTaskBase.cs" />
-    <Compile Include="Tasks\SmartCopyTaskBase.cs" />
-    <Compile Include="Tasks\SpotlightIndexerTaskBase.cs" />
-    <Compile Include="Tasks\SymbolStripTaskBase.cs" />
-    <Compile Include="Tasks\TextureAtlasTaskBase.cs" />
-    <Compile Include="Tasks\UnpackLibraryResourcesTaskBase.cs" />
-    <Compile Include="Tasks\WriteItemsToFileBase.cs" />
-    <Compile Include="Tasks\XcodeCompilerToolTask.cs" />
-    <Compile Include="Tasks\XcodeToolTaskBase.cs" />
-    <Compile Include="Tasks\ZipTaskBase.cs" />
-    <Compile Include="AssetPackUtils.cs" />
-    <Compile Include="BundleResource.cs" />
-    <Compile Include="CommandLineArgumentBuilder.cs" />
-    <Compile Include="DataConverter.cs" />
-    <Compile Include="LinkTarget.cs" />
-    <Compile Include="LoggingExtensions.cs" />
-    <Compile Include="NativeReferenceKind.cs" />
-    <Compile Include="PathUtils.cs" />
-    <Compile Include="PlatformFramework.cs" />
-    <Compile Include="ProcessUtils.cs" />
-    <Compile Include="StringParserService.cs" />
-    <Compile Include="../../tools/common/FileCopier.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/msbuild/Xamarin.MacDev.Tasks/Properties/AssemblyInfo.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Properties/AssemblyInfo.cs
@@ -42,7 +42,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -1,89 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{534D7C5A-0E1C-4C58-9E48-21B1A98919EB}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>Xamarin.MacDev.Tasks</RootNamespace>
-    <AssemblyName>Xamarin.MacDev.Tasks</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;MONO_DATACONVERTER_PUBLIC</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>MONO_DATACONVERTER_PUBLIC</DefineConstants>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="Microsoft.Build.Framework" HintPath="$(MSBuildBinPath)\Microsoft.Build.Framework.dll" />
-    <Reference Include="Microsoft.Build.Tasks.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll" />
-    <Reference Include="Microsoft.Build.Utilities.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Utilities.Core.dll" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
-    <PackageReference Include="Mono.Cecil" Version="0.9.5.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Mono.Cecil" Version="0.9.5" PrivateAssets="All" />
+    <!-- Compile against Microsoft.Build* NuGet refs, but do not copy to OutputDir. -->
+    <PackageReference Include="Microsoft.Build" Version="15.9.20" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" IncludeAssets="compile" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj">
-      <Project>{CC3D9353-20C4-467A-8522-A9DED6F0C753}</Project>
-      <Name>Xamarin.MacDev</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Xamarin.MacDev.Tasks.Core\Xamarin.MacDev.Tasks.Core.csproj">
-      <Project>{7B095849-6FDB-4BD2-9B59-569D81A1A809}</Project>
-      <Name>Xamarin.MacDev.Tasks.Core</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj" />
+    <ProjectReference Include="..\Xamarin.MacDev.Tasks.Core\Xamarin.MacDev.Tasks.Core.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="MsBuildTasks\Copy.cs" />
-    <Compile Include="MsBuildTasks\Delete.cs" />
-    <Compile Include="MsBuildTasks\Exec.cs" />
-    <Compile Include="MsBuildTasks\MakeDir.cs" />
-    <Compile Include="MsBuildTasks\Move.cs" />
-    <Compile Include="MsBuildTasks\RemoveDir.cs" />
-    <Compile Include="MsBuildTasks\Touch.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Tasks\ArTool.cs" />
-    <Compile Include="Tasks\Codesign.cs" />
-    <Compile Include="Tasks\CollectBundleResources.cs" />
-    <Compile Include="Tasks\ComputeBundleResourceOutputPaths.cs" />
-    <Compile Include="Tasks\CoreMLCompiler.cs" />
-    <Compile Include="Tasks\CreateAssetPackManifest.cs" />
-    <Compile Include="Tasks\CreateInstallerPackage.cs" />
-    <Compile Include="Tasks\CreatePkgInfo.cs" />
-    <Compile Include="Tasks\Ditto.cs" />
-    <Compile Include="Tasks\DSymUtil.cs" />
-    <Compile Include="Tasks\FindItemWithLogicalName.cs" />
-    <Compile Include="Tasks\GenerateBundleName.cs" />
-    <Compile Include="Tasks\GetNativeExecutableName.cs" />
-    <Compile Include="Tasks\GetPropertyListValue.cs" />
-    <Compile Include="Tasks\PackLibraryResources.cs" />
-    <Compile Include="Tasks\PropertyListEditor.cs" />
-    <Compile Include="Tasks\ReadItemsFromFile.cs" />
-    <Compile Include="Tasks\SmartCopy.cs" />
-    <Compile Include="Tasks\SpotlightIndexer.cs" />
-    <Compile Include="Tasks\SymbolStrip.cs" />
-    <Compile Include="Tasks\UnpackLibraryResources.cs" />
-    <Compile Include="Tasks\WriteItemsToFile.cs" />
-    <Compile Include="Tasks\Zip.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
@@ -1,220 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{93E12FA0-089C-4BC8-840F-43CFBC7927C7}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>Xamarin.iOS.Tasks</RootNamespace>
-    <AssemblyName>Xamarin.iOS.Tasks.Core</AssemblyName>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Build" HintPath="$(MSBuildBinPath)\Microsoft.Build.dll" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.Build.Framework" HintPath="$(MSBuildBinPath)\Microsoft.Build.Framework.dll" />
-    <Reference Include="Microsoft.Build.Tasks.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll" />
-    <Reference Include="Microsoft.Build.Utilities.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Utilities.Core.dll" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
+    <!-- Compile against Microsoft.Build* NuGet refs, but do not copy to OutputDir. -->
+    <PackageReference Include="Microsoft.Build" Version="15.9.20" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" IncludeAssets="compile" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj">
-      <Project>{CC3D9353-20C4-467A-8522-A9DED6F0C753}</Project>
-      <Name>Xamarin.MacDev</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Xamarin.MacDev.Tasks.Core\Xamarin.MacDev.Tasks.Core.csproj">
-      <Project>{7B095849-6FDB-4BD2-9B59-569D81A1A809}</Project>
-      <Name>Xamarin.MacDev.Tasks.Core</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj" />
+    <ProjectReference Include="..\Xamarin.MacDev.Tasks.Core\Xamarin.MacDev.Tasks.Core.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Tasks\ACToolTaskBase.cs" />
-    <Compile Include="Tasks\ALToolUploadTaskBase.cs" />
-    <Compile Include="Tasks\ALToolValidateTaskBase.cs" />
-    <Compile Include="Tasks\ArchiveTaskBase.cs" />
-    <Compile Include="Tasks\CodesignVerifyTaskBase.cs" />
-    <Compile Include="Tasks\CollectITunesArtworkTaskBase.cs" />
-    <Compile Include="Tasks\CollectITunesSourceFilesTaskBase.cs" />
-    <Compile Include="Tasks\CompileAppManifestTaskBase.cs" />
-    <Compile Include="Tasks\CompileEntitlementsTaskBase.cs" />
-    <Compile Include="Tasks\CompileITunesMetadataTaskBase.cs" />
-    <Compile Include="Tasks\CompileSceneKitAssetsTaskBase.cs" />
-    <Compile Include="Tasks\CreateDebugConfigurationTaskBase.cs" />
-    <Compile Include="Tasks\CreateDebugSettingsTaskBase.cs" />
-    <Compile Include="Tasks\DetectSdkLocationsTaskBase.cs" />
-    <Compile Include="Tasks\DetectSigningIdentityTaskBase.cs" />
-    <Compile Include="Tasks\EmbedMobileProvisionTaskBase.cs" />
-    <Compile Include="Tasks\FindWatchOS1AppExtensionBundleTaskBase.cs" />
-    <Compile Include="Tasks\GetDirectoriesTaskBase.cs" />
-    <Compile Include="Tasks\GetFilesTaskBase.cs" />
-    <Compile Include="Tasks\GetFullPathTaskBase.cs" />
-    <Compile Include="Tasks\GetPropertyValueTaskBase.cs" />
-    <Compile Include="Tasks\IBToolTaskBase.cs" />
-    <Compile Include="Tasks\MetalLibTaskBase.cs" />
-    <Compile Include="Tasks\MetalTaskBase.cs" />
-    <Compile Include="Tasks\MTouchTaskBase.cs" />
-    <Compile Include="Tasks\OptimizeImageTaskBase.cs" />
-    <Compile Include="Tasks\ParseDeviceSpecificBuildInformationTaskBase.cs" />
-    <Compile Include="Tasks\ParseExtraMtouchArgsTaskBase.cs" />
-    <Compile Include="Tasks\PrepareResourceRulesTaskBase.cs" />
-    <Compile Include="Tasks\ResolveNativeWatchAppTaskBase.cs" />
-    <Compile Include="Tasks\ScnToolTaskBase.cs" />
-    <Compile Include="Tasks\ValidateAppBundleTaskBase.cs" />
-    <Compile Include="IPhoneSdks.cs" />
-    <Compile Include="Tasks\CollectAssetPacksTaskBase.cs" />
-    <Compile Include="Tasks\CreateAssetPackTaskBase.cs" />
-    <Compile Include="Tasks\WriteAssetPackManifestTaskBase.cs" />
-    <Compile Include="Tasks\FindWatchOS2AppBundleTaskBase.cs" />
-    <Compile Include="Tasks\DetectDebugNetworkConfigurationTaskBase.cs" />
-    <Compile Include="Tasks\CodesignNativeLibrariesTaskBase.cs" />
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <None Include="NoCode.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="Xamarin.iOS.Common.props">
+    <None Include="*.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="Xamarin.iOS.Common.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.iOS.CSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.iOS.FSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.iOS.AppExtension.Common.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.iOS.AppExtension.Common.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.iOS.AppExtension.CSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.iOS.AppExtension.FSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.iOS.ObjCBinding.Common.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.iOS.ObjCBinding.Common.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.iOS.NativeReference.Stubs.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.iOS.ObjCBinding.CSharp.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.iOS.ObjCBinding.CSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.iOS.WatchApp.Common.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.iOS.WatchApp.Common.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.iOS.WatchApp.CSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.MonoTouch.CSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.MonoTouch.FSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.TVOS.Common.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.TVOS.Common.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.TVOS.CSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.TVOS.FSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.TVOS.ObjCBinding.CSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.WatchOS.AppExtension.Common.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.WatchOS.AppExtension.Common.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.WatchOS.AppExtension.CSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.WatchOS.AppExtension.FSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.WatchOS.App.Common.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.WatchOS.App.Common.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.WatchOS.App.CSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.WatchOS.App.FSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.WatchOS.Common.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.WatchOS.Common.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.WatchOS.CSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.WatchOS.FSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.TVOS.AppExtension.Common.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.TVOS.AppExtension.Common.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.TVOS.AppExtension.CSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.TVOS.AppExtension.FSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Xamarin.WatchOS.ObjCBinding.CSharp.targets">
+    <None Include="*.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="../Xamarin.Shared/Xamarin.Shared.targets">

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -1,120 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{44605724-8002-48E1-895F-7CB068099B6A}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>Xamarin.iOS.Tasks</RootNamespace>
-    <AssemblyName>Xamarin.iOS.Tasks</AssemblyName>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Tasks\ACTool.cs" />
-    <Compile Include="Tasks\Archive.cs" />
-    <Compile Include="Tasks\BTouch.cs" />
-    <Compile Include="Tasks\CodesignVerify.cs" />
-    <Compile Include="Tasks\CollectFrameworks.cs" />
-    <Compile Include="Tasks\CollectITunesArtwork.cs" />
-    <Compile Include="Tasks\CollectITunesSourceFiles.cs" />
-    <Compile Include="Tasks\CompileAppManifest.cs" />
-    <Compile Include="Tasks\CompileEntitlements.cs" />
-    <Compile Include="Tasks\CompileITunesMetadata.cs" />
-    <Compile Include="Tasks\CompileSceneKitAssets.cs" />
-    <Compile Include="Tasks\CreateDebugConfiguration.cs" />
-    <Compile Include="Tasks\CreateDebugSettings.cs" />
-    <Compile Include="Tasks\CreateEmbeddedResources.cs" />
-    <Compile Include="Tasks\DetectSdkLocations.cs" />
-    <Compile Include="Tasks\DetectSigningIdentity.cs" />
-    <Compile Include="Tasks\EmbedMobileProvision.cs" />
-    <Compile Include="Tasks\FindWatchOS1AppExtensionBundle.cs" />
-    <Compile Include="Tasks\GetDirectories.cs" />
-    <Compile Include="Tasks\GetFiles.cs" />
-    <Compile Include="Tasks\GetFullPath.cs" />
-    <Compile Include="Tasks\GetPropertyValue.cs" />
-    <Compile Include="Tasks\IBTool.cs" />
-    <Compile Include="Tasks\Metal.cs" />
-    <Compile Include="Tasks\MetalLib.cs" />
-    <Compile Include="Tasks\MTouch.cs" />
-    <Compile Include="Tasks\OptimizeImage.cs" />
-    <Compile Include="Tasks\OptimizePropertyList.cs" />
-    <Compile Include="Tasks\ParseDeviceSpecificBuildInformation.cs" />
-    <Compile Include="Tasks\ParseExtraMtouchArgs.cs" />
-    <Compile Include="Tasks\PrepareNativeReferences.cs" />
-    <Compile Include="Tasks\PrepareResourceRules.cs" />
-    <Compile Include="Tasks\ResolveNativeWatchApp.cs" />
-    <Compile Include="Tasks\ScnTool.cs" />
-    <Compile Include="Tasks\TextureAtlas.cs" />
-    <Compile Include="Tasks\ValidateAppBundleTask.cs" />
-    <Compile Include="Tasks\CollectAssetPacks.cs" />
-    <Compile Include="Tasks\CreateAssetPack.cs" />
-    <Compile Include="Tasks\WriteAssetPackManifest.cs" />
-    <Compile Include="Tasks\FindWatchOS2AppBundle.cs" />
-    <Compile Include="Tasks\DetectDebugNetworkConfiguration.cs" />
-    <Compile Include="Tasks\CodesignNativeLibraries.cs" />
-    <Compile Include="Tasks\CreateBindingResourcePackage.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Tasks\ALToolValidate.cs" />
-    <Compile Include="Tasks\ALToolUpload.cs" />
+    <ProjectReference Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj" />
+    <ProjectReference Include="..\Xamarin.MacDev.Tasks.Core\Xamarin.MacDev.Tasks.Core.csproj" />
+    <ProjectReference Include="..\Xamarin.MacDev.Tasks\Xamarin.MacDev.Tasks.csproj" />
+    <ProjectReference Include="..\Xamarin.iOS.Tasks.Core\Xamarin.iOS.Tasks.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Xamarin.iOS.Tasks.Core\Xamarin.iOS.Tasks.Core.csproj">
-      <Project>{93E12FA0-089C-4BC8-840F-43CFBC7927C7}</Project>
-      <Name>Xamarin.iOS.Tasks.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Xamarin.MacDev.Tasks.Core\Xamarin.MacDev.Tasks.Core.csproj">
-      <Project>{7B095849-6FDB-4BD2-9B59-569D81A1A809}</Project>
-      <Name>Xamarin.MacDev.Tasks.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Xamarin.MacDev.Tasks\Xamarin.MacDev.Tasks.csproj">
-      <Project>{534D7C5A-0E1C-4C58-9E48-21B1A98919EB}</Project>
-      <Name>Xamarin.MacDev.Tasks</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj">
-      <Project>{CC3D9353-20C4-467A-8522-A9DED6F0C753}</Project>
-      <Name>Xamarin.MacDev</Name>
-    </ProjectReference>
     <PackageReference Include="ILRepack" Version="2.0.18" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Compile against Microsoft.Build* NuGet refs, but do not copy to OutputDir. -->
+    <Reference Include="Microsoft.Build" HintPath="$(MSBuildBinPath)\Microsoft.Build.dll" />
     <Reference Include="Microsoft.Build.Framework" HintPath="$(MSBuildBinPath)\Microsoft.Build.Framework.dll" />
-    <Reference Include="Microsoft.Build.Utilities.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Utilities.Core.dll" />
     <Reference Include="Microsoft.Build.Tasks.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll" />
+    <Reference Include="Microsoft.Build.Utilities.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Utilities.Core.dll" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
   <Target Name="ILRepack" AfterTargets="CoreCompile" DependsOnTargets="CoreCompile" Inputs="@(IntermediateAssembly -&gt; '%(FullPath)')" Outputs="$(IntermediateOutputPath)ilrepack.txt" Returns="@(MergedAssemblies)" Condition="Exists(@(IntermediateAssembly -&gt; '%(FullPath)')) And '$(ILRepack)' != 'false'">
-    <GetReferenceAssemblyPaths BypassFrameworkInstallChecks="False" TargetFrameworkMoniker="$(TargetFrameworkMoniker)">
-      <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FullFrameworkReferenceAssemblyPaths" />
-    </GetReferenceAssemblyPaths>
     <ItemGroup>
       <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="
         '%(Extension)' == '.dll'

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
@@ -407,7 +407,7 @@ namespace Xamarin.iOS.Tasks
 
 			// Now we should have an AppBundleDir
 			RunTargetOnInstance (MonoTouchProjectInstance, TargetName.GenerateBundleName);
-			Assert.AreEqual (@"bin\iPhoneSimulator\Debug\MySingleView.app", MonoTouchProjectInstance.GetPropertyValue ("AppBundleDir"), "#3");
+			Assert.AreEqual (@"bin/iPhoneSimulator/Debug/MySingleView.app", MonoTouchProjectInstance.GetPropertyValue ("AppBundleDir"), "#3");
 		}
 
 		[Test]

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/CollectITunesArtworkTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/CollectITunesArtworkTaskTests.cs
@@ -58,7 +58,7 @@ namespace Xamarin.iOS.Tasks {
 
 			Assert.IsFalse (task.Execute (), "Execute failure");
 			Assert.AreEqual (1, Engine.Logger.ErrorEvents.Count, "ErrorCount");
-			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Match ($"Multiple iTunesArtwork files with the same dimensions detected [(]{dimension}[)] for '.*/msbuild/tests/bin/Resources/iTunesArtwork{size}.png'."), "ErrorMessage");
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Match ($"Multiple iTunesArtwork files with the same dimensions detected [(]{dimension}[)] for '.*/Resources/iTunesArtwork{size}.png'."), "ErrorMessage");
 		}
 
 		[Test]

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/CollectITunesArtworkTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/CollectITunesArtworkTaskTests.cs
@@ -8,6 +8,8 @@ using NUnit.Framework;
 namespace Xamarin.iOS.Tasks {
 	[TestFixture]
 	public class CollectITunesArtworkTaskTests : TestBase {
+		string AppPath => Path.GetDirectoryName (GetType ().Assembly.Location);
+
 		[Test]
 		public void UnknownImageFormat ()
 		{
@@ -36,7 +38,7 @@ namespace Xamarin.iOS.Tasks {
 		public void InvalidSize (string extension)
 		{
 			var task = CreateTask<CollectITunesArtwork> ();
-			task.ITunesArtwork = new TaskItem [] { new TaskItem (Path.Combine ("..", "bin", "Resources", "iTunesArtwork-invalid-size." + extension)) };
+			task.ITunesArtwork = new TaskItem [] { new TaskItem (Path.Combine (AppPath, "Resources", "iTunesArtwork-invalid-size." + extension)) };
 
 			Assert.IsFalse (task.Execute (), "Execute failure");
 			Assert.AreEqual (1, Engine.Logger.ErrorEvents.Count, "ErrorCount");
@@ -50,8 +52,8 @@ namespace Xamarin.iOS.Tasks {
 		{
 			var task = CreateTask<CollectITunesArtwork> ();
 			task.ITunesArtwork = new TaskItem [] {
-				new TaskItem (Path.Combine ("..", "bin", "Resources", $"iTunesArtwork{size}.jpg")),
-				new TaskItem (Path.Combine ("..", "bin", "Resources", $"iTunesArtwork{size}.png")),
+				new TaskItem (Path.Combine (AppPath, "Resources", $"iTunesArtwork{size}.jpg")),
+				new TaskItem (Path.Combine (AppPath, "Resources", $"iTunesArtwork{size}.png")),
 			};
 
 			Assert.IsFalse (task.Execute (), "Execute failure");
@@ -66,8 +68,8 @@ namespace Xamarin.iOS.Tasks {
 		{
 			var task = CreateTask<CollectITunesArtwork> ();
 			task.ITunesArtwork = new TaskItem [] {
-				new TaskItem (Path.Combine ("..", "bin", "Resources", $"iTunesArtwork.{extension}")),
-				new TaskItem (Path.Combine ("..", "bin", "Resources", $"iTunesArtwork@2x.{extension}")),
+				new TaskItem (Path.Combine (AppPath, "Resources", $"iTunesArtwork.{extension}")),
+				new TaskItem (Path.Combine (AppPath, "Resources", $"iTunesArtwork@2x.{extension}")),
 			};
 
 			Assert.IsTrue (task.Execute (), "Execute");

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
@@ -38,9 +38,9 @@ namespace Xamarin.iOS.Tasks
 			task.AppIdentifier = "32UV7A8CDE.com.xamarin.MySingleView";
 			task.BundleIdentifier = "com.xamarin.MySingleView";
 			task.CompiledEntitlements = new TaskItem (Path.Combine (MonoTouchProjectObjPath, "Entitlements.xcent"));
-			task.Entitlements = Path.Combine ("..", "bin", "Resources", "Entitlements.plist");
+			task.Entitlements = Path.Combine (Path.GetDirectoryName (GetType ().Assembly.Location), "Resources", "Entitlements.plist");
 			task.IsAppExtension = false;
-			task.ProvisioningProfile = Path.Combine ("..", "bin", "Resources", "profile.mobileprovision");
+			task.ProvisioningProfile = Path.Combine (Path.GetDirectoryName (GetType ().Assembly.Location), "Resources", "profile.mobileprovision");
 			task.SdkPlatform = "iPhoneOS";
 			task.SdkVersion = "6.1";
 

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/MTouchTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/MTouchTaskTests.cs
@@ -189,7 +189,7 @@ namespace Xamarin.iOS.Tasks
 				var args = Task.GenerateCommandLineCommands ();
 				Assert.IsFalse (args.Contains ("$"), "#1");
 				Assert.IsTrue (args.Contains ("xyz-path/to-xyz"), "#ProjectDir");
-				Assert.IsTrue (args.Contains ("xxx-../MySingleView/bin/iPhoneSimulator/Debug/MySingleView.app-xxx"), "#AppBundleDir");
+				Assert.That (args, Does.Match ("xxx-.*/MySingleView/bin/iPhoneSimulator/Debug/MySingleView.app-xxx"), "#AppBundleDir");
 				Assert.IsTrue (args.Contains ("yyy-Main.exe-yyy"), "#TargetPath");
 				Assert.IsTrue (args.Contains ("yzy--yzy"), "#TargetDir");
 				Assert.IsTrue (args.Contains ("zzz-Main.exe-zzz"), "#TargetName");
@@ -203,8 +203,8 @@ namespace Xamarin.iOS.Tasks
 		public void BuildEntitlementFlagsTest ()
 		{
 			var args = Task.GenerateCommandLineCommands ();
-			Assert.IsTrue (args.Contains ("\"--gcc_flags=-Xlinker -sectcreate -Xlinker __TEXT -Xlinker __entitlements -Xlinker"), "#1");
-			Assert.IsTrue (args.Contains ("Entitlements.plist"), "#2");
+			Assert.That (args, Does.Contain ("\"--gcc_flags=-Xlinker -sectcreate -Xlinker __TEXT -Xlinker __entitlements -Xlinker"), "#1");
+			Assert.That (args, Does.Contain ("Entitlements.plist"), "#2");
 		}
 
 		[Test]

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/MTouchTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/MTouchTaskTests.cs
@@ -60,7 +60,7 @@ namespace Xamarin.iOS.Tasks
 
 			Task.AppBundleDir = AppBundlePath;
 			Task.AppManifest = new TaskItem (Path.Combine (MonoTouchProjectPath, "Info.plist"));
-			Task.CompiledEntitlements = Path.Combine ("..", "bin", "Resources", "Entitlements.plist");
+			Task.CompiledEntitlements = Path.Combine (Path.GetDirectoryName (GetType ().Assembly.Location), "Resources", "Entitlements.plist");
 			Task.IntermediateOutputPath = Path.Combine ("obj", "mtouch-cache");
 			Task.MainAssembly = new TaskItem ("Main.exe");
 			Task.References = new [] { new TaskItem ("a.dll"), new TaskItem ("b with spaces.dll"), new TaskItem ("c\"quoted\".dll") };

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
@@ -108,7 +108,7 @@ namespace Xamarin.iOS.Tasks
 
 		public ProjectPaths SetupProjectPaths (string projectName, string csprojName, string baseDir = "../", bool includePlatform = true, string platform = "iPhoneSimulator", string config = "Debug")
 		{
-			var projectPath = Path.Combine(baseDir, projectName);
+			var projectPath = Path.Combine (Configuration.RootPath, "msbuild", "tests", "Xamarin.iOS.Tasks.Tests", baseDir, projectName);
 
 			var binPath = includePlatform ? Path.Combine (projectPath, "bin", platform, config) : Path.Combine (projectPath, "bin", config);
 			var objPath = includePlatform ? Path.Combine (projectPath, "obj", platform, config) : Path.Combine (projectPath, "obj", config);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -1,124 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{EDB0E879-5AE6-4E2B-925D-F59023A6AA8D}</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Xamarin.iOS.Tasks</RootNamespace>
     <AssemblyName>Xamarin.iOS.Tasks.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <DisableTransitiveProjectReferences>true</DisableTransitiveProjectReferences>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>..\bin</OutputPath>
-    <DefineConstants>DEBUG;MSBUILD_TESTS</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>..\bin</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata" HintPath="$(MSBuildBinPath)\System.Reflection.Metadata.dll" />
-    <Reference Include="Microsoft.Build.Framework" HintPath="$(MSBuildBinPath)\Microsoft.Build.Framework.dll" />
     <Reference Include="Microsoft.Build" HintPath="$(MSBuildBinPath)\Microsoft.Build.dll" />
+    <Reference Include="Microsoft.Build.Framework" HintPath="$(MSBuildBinPath)\Microsoft.Build.Framework.dll" />
+    <Reference Include="Microsoft.Build.Tasks.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll" />
     <Reference Include="Microsoft.Build.Utilities.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Utilities.Core.dll" />
-    <Reference Include="System.Xml" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />
-    <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.6.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" />
+  </ItemGroup>
+    <ItemGroup>
+      <!-- Copy system Microsoft.Build*.dll and dependencies for tests to run against. We can remove this
+           and rely entirely on NuGet assets when mono/msbuild is merged into microsoft/msbuild. -->
+      <None Include="$(MSBuildToolsPath)\Microsoft.Build*.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Include="$(MSBuildToolsPath)\System.*.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Xamarin.iOS.Tasks\Xamarin.iOS.Tasks.csproj" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Xamarin.iOS.Tasks\Xamarin.iOS.Tasks.csproj">
-      <Project>{44605724-8002-48E1-895F-7CB068099B6A}</Project>
-      <Name>Xamarin.iOS.Tasks</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="TaskTests\EnsureEmptyTasks.cs" />
-    <Compile Include="TaskTests\MTouchTaskTests.cs" />
-    <Compile Include="TaskTests\GetBundleNameTaskTests.cs" />
-    <Compile Include="TargetTests\TargetTests.cs" />
-    <Compile Include="TestHelpers\Logger.cs" />
-    <Compile Include="TestHelpers\TestBase.cs" />
-    <Compile Include="TestHelpers\TestEngine.cs" />
-    <Compile Include="TaskTests\DetectSdkLocationsTaskTests.cs" />
-    <Compile Include="TaskTests\BTouchTaskTest.cs" />
-    <Compile Include="ProjectsTests\Extensions\CustomKeyboard.cs" />
-    <Compile Include="ProjectsTests\Extensions\ExtensionTestBase.cs" />
-    <Compile Include="ProjectsTests\Extensions\Today.cs" />
-    <Compile Include="ProjectsTests\Extensions\Share.cs" />
-    <Compile Include="ProjectsTests\Extensions\PhotoEditing.cs" />
-    <Compile Include="ProjectsTests\Extensions\Action.cs" />
-    <Compile Include="ProjectsTests\Extensions\DocumentPicker.cs" />
-    <Compile Include="ProjectsTests\Extensions\WatchKit.cs" />
-    <Compile Include="ProjectsTests\XIProject.cs" />
-    <Compile Include="ProjectsTests\BindingProject.cs" />
-    <Compile Include="TaskTests\ParseMtouchExtraArgsTests.cs" />
-    <Compile Include="UtilityTests.cs" />
-    <Compile Include="ProjectsTests\ProjectWithFrameworks.cs" />
-    <Compile Include="ProjectsTests\NativeReferences.cs" />
-    <Compile Include="ProjectsTests\ProjectTest.cs" />
-    <Compile Include="ProjectsTests\XamarinForms.cs" />
-    <Compile Include="ProjectsTests\Extensions\WatchKit2.cs" />
     <Compile Include="..\..\..\tests\common\Configuration.cs">
       <Link>Configuration.cs</Link>
     </Compile>
-    <Compile Include="ProjectsTests\TVOS\TVApp.cs" />
-    <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_iOS.cs" />
-    <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_Core.cs" />
-    <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_iOS_AppExtension.cs" />
-    <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_watchOS_WatchKitApp.cs" />
-    <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_tvOS.cs" />
-    <Compile Include="TaskTests\SymbolStripTaskTests.cs" />
-    <Compile Include="TaskTests\ValidateAppBundleTaskTests.cs" />
-    <Compile Include="ProjectsTests\IBToolLinking.cs" />
-    <Compile Include="TaskTests\CompileEntitlementsTaskTests.cs" />
-    <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_iOS_WatchKitExtension.cs" />
-    <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_watchOS_WatchKitExtension.cs" />
-    <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_watchOS.cs" />
-    <Compile Include="ProjectsTests\ReleaseBuild.cs" />
-    <Compile Include="TaskTests\PropertyListEditorTaskTests.cs" />
-    <Compile Include="TaskTests\IBToolTaskTests.cs" />
-    <Compile Include="ProjectsTests\LinkedAssets.cs" />
-    <Compile Include="ProjectsTests\CodesignAppBundle.cs" />
-    <Compile Include="ProjectsTests\BindingReferences.cs" />
-    <Compile Include="ProjectsTests\CoreMLCompiler.cs" />
-    <Compile Include="ProjectsTests\Bug60536.cs" />
     <Compile Include="..\..\..\tests\common\Profile.cs">
       <Link>Profile.cs</Link>
     </Compile>
     <Compile Include="..\..\..\tests\common\ExecutionHelper.cs">
       <Link>ExecutionHelper.cs</Link>
     </Compile>
-    <Compile Include="ProjectsTests\ProjectWithSpaces.cs" />
-    <Compile Include="ProjectsTests\ProjectReference.cs" />
-    <Compile Include="ProjectsTests\ResponseFileArguments.cs" />
-    <Compile Include="ProjectsTests\CompileSceneKitAssetsTest.cs" />
-    <Compile Include="ProjectsTests\NativeReferencesNoEmbedding.cs" />
-    <Compile Include="FrameworkListTest.cs" />
-    <Compile Include="VerbosityTest.cs" />
-    <Compile Include="TaskTests\CollectITunesArtworkTaskTests.cs" />
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
-    <Folder Include="ProjectsTests\" />
-    <Folder Include="ProjectsTests\Extensions\" />
-    <Folder Include="ProjectsTests\TVOS\" />
-    <Folder Include="TaskTests\GeneratePlistTaskTests\" />
-    <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Entitlements.plist">

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461</TargetFrameworks>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TargetFramework>net461</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <RootNamespace>Xamarin.iOS.Tasks</RootNamespace>
-    <AssemblyName>Xamarin.iOS.Tasks.Tests</AssemblyName>
     <DisableTransitiveProjectReferences>true</DisableTransitiveProjectReferences>
   </PropertyGroup>
 

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -17,16 +17,17 @@
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />
   </ItemGroup>
-    <ItemGroup>
-      <!-- Copy system Microsoft.Build*.dll and dependencies for tests to run against. We can remove this
-           and rely entirely on NuGet assets when mono/msbuild is merged into microsoft/msbuild. -->
-      <None Include="$(MSBuildToolsPath)\Microsoft.Build*.dll">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Include="$(MSBuildToolsPath)\System.*.dll">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-   </ItemGroup>
+
+  <ItemGroup>
+    <!-- Copy system Microsoft.Build*.dll and dependencies for tests to run against. We can remove this
+       and rely entirely on NuGet assets when mono/msbuild is merged into microsoft/msbuild. -->
+    <None Include="$(MSBuildToolsPath)\Microsoft.Build*.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="$(MSBuildToolsPath)\System.*.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Xamarin.iOS.Tasks\Xamarin.iOS.Tasks.csproj" PrivateAssets="All" />
   </ItemGroup>

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -15,7 +15,7 @@
     <Reference Include="Microsoft.Build.Tasks.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll" />
     <Reference Include="Microsoft.Build.Utilities.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Utilities.Core.dll" />
     <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />
   </ItemGroup>
     <ItemGroup>
       <!-- Copy system Microsoft.Build*.dll and dependencies for tests to run against. We can remove this

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,6 +1,6 @@
 *index.html
 *.log
-*TestResult.xml
+*TestResult*.xml
 build
 *-tvos.?sproj
 *-tvos.sln

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -209,7 +209,7 @@ killall:
 NUNIT_MSBUILD_DIR=$(TOP)/packages/NUnit.Runners.2.6.4/tools/lib
 test-ios-tasks: verify-system-vsmac-xcode-match
 	$(SYSTEM_XIBUILD) -- $(TOP)/msbuild/Xamarin.MacDev.Tasks.sln
-	cd $(TOP)/msbuild/tests/Xamarin.iOS.Tasks.Tests && $(SYSTEM_XIBUILD) -t -- $(abspath $(TOP)/tools/nunit3-console-3.10.0) $(abspath $(TOP)/msbuild/tests/bin/Xamarin.iOS.Tasks.Tests.dll) "--result=$(abspath $(CURDIR)/TestResults_Xamarin.iOS.Tasks.Tests.xml);format=nunit2" -labels=All $(TEST_FIXTURE) || touch .failed-stamp
+	cd $(TOP)/msbuild/tests/Xamarin.iOS.Tasks.Tests && $(SYSTEM_XIBUILD) -t -- $(abspath $(TOP)/tools/nunit3-console-3.10.0) $(abspath $(TOP)/msbuild/tests/Xamarin.iOS.Tasks.Tests/bin/Debug/net461/Xamarin.iOS.Tasks.Tests.dll) "--result=$(abspath $(CURDIR)/TestResults_Xamarin.iOS.Tasks.Tests.xml);format=nunit2" -labels=All $(TEST_FIXTURE) || touch .failed-stamp
 	@[[ -z "$$BUILD_REPOSITORY" ]] || ( xsltproc $(TOP)/tests/HtmlTransform.xslt $(NUNIT_MSBUILD_DIR)/TestResults_Xamarin.iOS.Tasks.Tests.xml > $(TOP)/tests/index.html && echo "@MonkeyWrench: AddFile: $$PWD/index.html" )
 	@if test -e $(NUNIT_MSBUILD_DIR)/.failed-stamp; then rm $(NUNIT_MSBUILD_DIR)/.failed-stamp; exit 1; fi
 

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -899,7 +899,7 @@ namespace xharness
 			};
 			var nunitExecutioniOSMSBuild = new NUnitExecuteTask (buildiOSMSBuild)
 			{
-				TestLibrary = Path.Combine (Harness.RootDirectory, "..", "msbuild", "tests", "bin", "Xamarin.iOS.Tasks.Tests.dll"),
+				TestLibrary = Path.Combine (Harness.RootDirectory, "..", "msbuild", "tests", "Xamarin.iOS.Tasks.Tests", "bin", "Debug", "net461", "Xamarin.iOS.Tasks.Tests.dll"),
 				TestProject = new TestProject (Path.Combine (Path.GetDirectoryName (buildiOSMSBuild.TestProject.Path), "tests", "Xamarin.iOS.Tasks.Tests", "Xamarin.iOS.Tasks.Tests.csproj")),
 				Platform = TestPlatform.iOS,
 				TestName = "MSBuild tests",


### PR DESCRIPTION
This also requires a few adjustments in other places as well, mostly because msbuild places the build output in a different directory now.