### PR TITLE
[InputMethodKit] Add ignored framework.

### DIFF
--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1864,6 +1864,7 @@ MAC_FRAMEWORKS =            \
 	Intents                 \
 	IOSurface 		\
 	iTunesLibrary           \
+	InputMethodKit           \
 	JavaScriptCore          \
 	LinkPresentation        \
 	LocalAuthentication     \

--- a/src/inputmethodkit.cs
+++ b/src/inputmethodkit.cs
@@ -67,7 +67,7 @@ namespace InputMethodKit {
 		bool OnEvent (NSEvent mouseEvent, NSObject sender);
 
 		[Export ("didCommandBySelector:client:")]
-		bool DidCommandBySelector (Selector aSelector, NSObject sender);
+		bool DidCommand (Selector aSelector, NSObject sender);
 
 		[Export ("composedString:")]
 		NSObject GetComposedString (NSObject sender);
@@ -121,11 +121,11 @@ namespace InputMethodKit {
 	{
 		[Abstract]
 		[Export ("mouseDownOnCharacterIndex:coordinate:withModifier:continueTracking:client:")]
-		bool OnMouseDownOn (nuint index, CGPoint point, nuint flags, out bool keepTracking, NSObject sender);
+		bool OnMouseDown (nuint index, CGPoint point, nuint flags, out bool keepTracking, NSObject sender);
 
 		[Abstract]
 		[Export ("mouseUpOnCharacterIndex:coordinate:withModifier:client:")]
-		bool OnMouseUpOn (nuint index, CGPoint point, nuint flags, NSObject sender);
+		bool OnMouseUp (nuint index, CGPoint point, nuint flags, NSObject sender);
 
 		[Abstract]
 		[Export ("mouseMovedOnCharacterIndex:coordinate:withModifier:client:")]

--- a/tests/xtro-sharpie/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/macOS-AppKit.ignore
@@ -216,7 +216,6 @@
 !missing-field! NSArgumentBinding not bound
 !missing-field! NSAttributedStringBinding not bound
 !missing-field! NSAuthorDocumentAttribute not bound
-!missing-field! NSBackgroundColorDocumentAttribute not bound
 !missing-field! NSBadBitmapParametersException not bound
 !missing-field! NSBadComparisonException not bound
 !missing-field! NSBadRTFColorTableException not bound

--- a/tests/xtro-sharpie/macOS-InputMethodKit.ignore
+++ b/tests/xtro-sharpie/macOS-InputMethodKit.ignore
@@ -1,44 +1,9 @@
-## wip https://github.com/xamarin/xamarin-macios/pull/1930
-## blocked by lack of sample for validation
-
-!missing-field! IMKCandidatesOpacityAttributeName not bound
-!missing-field! IMKCandidatesSendServerKeyEventFirst not bound
+# introspections says that they return null strings.
 !missing-field! IMKControllerClass not bound
 !missing-field! IMKDelegateClass not bound
 !missing-field! IMKModeDictionary not bound
-!missing-field! kIMKCommandClientName not bound
-!missing-field! kIMKCommandMenuItemName not bound
-!missing-protocol! IMKMouseHandling not bound
-!missing-protocol! IMKStateSetting not bound
-!missing-selector! IMKCandidates::attachChild:toCandidate:type: not bound
-!missing-selector! IMKCandidates::candidateIdentifierAtLineNumber: not bound
-!missing-selector! IMKCandidates::candidateStringIdentifier: not bound
-!missing-selector! IMKCandidates::detachChild: not bound
-!missing-selector! IMKCandidates::initWithServer:panelType: not bound
-!missing-selector! IMKCandidates::initWithServer:panelType:styleType: not bound
-!missing-selector! IMKCandidates::lineNumberForCandidateWithIdentifier: not bound
-!missing-selector! IMKCandidates::selectCandidate: not bound
-!missing-selector! IMKCandidates::selectCandidateWithIdentifier: not bound
-!missing-selector! IMKCandidates::setAttributes: not bound
-!missing-selector! IMKCandidates::setCandidateData: not bound
-!missing-selector! IMKCandidates::setCandidateFrameTopLeft: not bound
-!missing-selector! IMKCandidates::setDismissesAutomatically: not bound
-!missing-selector! IMKCandidates::setPanelType: not bound
-!missing-selector! IMKCandidates::setSelectionKeys: not bound
-!missing-selector! IMKCandidates::setSelectionKeysKeylayout: not bound
-!missing-selector! IMKCandidates::show: not bound
-!missing-selector! IMKCandidates::showAnnotation: not bound
-!missing-selector! IMKCandidates::showSublist:subListDelegate: not bound
-!missing-selector! IMKInputController::annotationSelected:forCandidate: not bound
-!missing-selector! IMKInputController::candidateSelected: not bound
-!missing-selector! IMKInputController::candidateSelectionChanged: not bound
-!missing-selector! IMKInputController::compositionAttributesAtRange: not bound
-!missing-selector! IMKInputController::doCommandBySelector:commandDictionary: not bound
-!missing-selector! IMKInputController::initWithServer:delegate:client: not bound
-!missing-selector! IMKInputController::markForStyle:atRange: not bound
-!missing-selector! IMKInputController::setDelegate: not bound
-!missing-selector! IMKServer::initWithName:bundleIdentifier: not bound
-!missing-selector! IMKServer::initWithName:controllerClass:delegateClass: not bound
+
+# this are bound as IMKServerInput informal protocol
 !missing-selector! NSObject::candidates: not bound
 !missing-selector! NSObject::commitComposition: not bound
 !missing-selector! NSObject::composedString: not bound
@@ -47,37 +12,3 @@
 !missing-selector! NSObject::inputText:client: not bound
 !missing-selector! NSObject::inputText:key:modifiers:client: not bound
 !missing-selector! NSObject::originalString: not bound
-!missing-type! IMKCandidates not bound
-!missing-type! IMKInputController not bound
-!missing-type! IMKServer not bound
-
-# Added in Xcode 11 Beta 5
-!missing-selector! IMKCandidates::attributes not bound
-!missing-selector! IMKCandidates::candidateFrame not bound
-!missing-selector! IMKCandidates::clearSelection not bound
-!missing-selector! IMKCandidates::dismissesAutomatically not bound
-!missing-selector! IMKCandidates::hide not bound
-!missing-selector! IMKCandidates::hideChild not bound
-!missing-selector! IMKCandidates::isVisible not bound
-!missing-selector! IMKCandidates::panelType not bound
-!missing-selector! IMKCandidates::selectedCandidate not bound
-!missing-selector! IMKCandidates::selectedCandidateString not bound
-!missing-selector! IMKCandidates::selectionKeys not bound
-!missing-selector! IMKCandidates::selectionKeysKeylayout not bound
-!missing-selector! IMKCandidates::showCandidates not bound
-!missing-selector! IMKCandidates::showChild not bound
-!missing-selector! IMKCandidates::updateCandidates not bound
-!missing-selector! IMKInputController::cancelComposition not bound
-!missing-selector! IMKInputController::client not bound
-!missing-selector! IMKInputController::delegate not bound
-!missing-selector! IMKInputController::hidePalettes not bound
-!missing-selector! IMKInputController::inputControllerWillClose not bound
-!missing-selector! IMKInputController::menu not bound
-!missing-selector! IMKInputController::replacementRange not bound
-!missing-selector! IMKInputController::selectionRange not bound
-!missing-selector! IMKInputController::server not bound
-!missing-selector! IMKInputController::updateComposition not bound
-!missing-selector! IMKServer::bundle not bound
-!missing-selector! IMKServer::lastKeyEventWasDeadKey not bound
-!missing-selector! IMKServer::paletteWillTerminate not bound
-

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -108,6 +108,7 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "QuickLook", 10, 5 },
 					{ "QuartzComposer", "Quartz", 10, 5 },
 					{ "ImageCaptureCore", "ImageCaptureCore", 10,5 },
+					{ "InputMethodKit", 10,5},
 
 					{ "QTKit", 10, 6 },
 					{ "QuickLookUI", "Quartz", 10, 6 },


### PR DESCRIPTION
The InputMethodKit framework was ignored because we did not have a
sample, but that is not longer the case. An apple sample can be found
here: https://developer.apple.com/library/archive/samplecode/NumberInput_IMKit_Sample/Introduction/Intro.html

Once the bindings are landed we can work in the sample.

The framework was never added therefore we are not changing any API from
the old code since it was never released.

Fixes: https://github.com/xamarin/xamarin-macios/issues/7487