### PR TITLE
[xharness] Fix two compiler warnings.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -629,9 +629,7 @@ namespace xharness
 				rv.AddRange (projectTasks);
 			}
 
-			var tcs = new TaskCompletionSource<IEnumerable<TestTask>> ();
-			tcs.SetResult (CreateTestVariations (rv, (buildTask, test, candidates) => new RunDeviceTask (buildTask, candidates?.Cast<Device> () ?? test.Candidates)));
-			return tcs.Task;
+			return Task.FromResult<IEnumerable<TestTask>> (CreateTestVariations (rv, (buildTask, test, candidates) => new RunDeviceTask (buildTask, candidates?.Cast<Device> () ?? test.Candidates)));
 		}
 
 		static string AddSuffixToPath (string path, string suffix)

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -535,7 +535,7 @@ namespace xharness
 			return rv;
 		}
 
-		async Task<IEnumerable<TestTask>> CreateRunDeviceTasksAsync ()
+		Task<IEnumerable<TestTask>> CreateRunDeviceTasksAsync ()
 		{
 			var rv = new List<RunDeviceTask> ();
 			var projectTasks = new List<RunDeviceTask> ();
@@ -629,7 +629,9 @@ namespace xharness
 				rv.AddRange (projectTasks);
 			}
 
-			return CreateTestVariations (rv, (buildTask, test, candidates) => new RunDeviceTask (buildTask, candidates?.Cast<Device> () ?? test.Candidates));
+			var tcs = new TaskCompletionSource<IEnumerable<TestTask>> ();
+			tcs.SetResult (CreateTestVariations (rv, (buildTask, test, candidates) => new RunDeviceTask (buildTask, candidates?.Cast<Device> () ?? test.Candidates)));
+			return tcs.Task;
 		}
 
 		static string AddSuffixToPath (string path, string suffix)
@@ -874,7 +876,7 @@ namespace xharness
 			return false;
 		}
 
-		async Task PopulateTasksAsync ()
+		Task PopulateTasksAsync ()
 		{
 			// Missing:
 			// api-diff
@@ -1125,7 +1127,7 @@ namespace xharness
 				Console.WriteLine ("Got device tasks completed");
 				Tasks.AddRange (v.Result);
 			});
-			Task.WaitAll (loadsim, loaddev);
+			return Task.WhenAll (loadsim, loaddev);
 		}
 
 		async Task ExecutePeriodicCommandAsync (Log periodic_loc)


### PR DESCRIPTION
Fixes these warnings:

    Jenkins.cs(538,37): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
    Jenkins.cs(877,14): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.