### PR TITLE
[mk] Bump maccore to get xcode11.3 script bump

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := b2d37c77cc34558a67fd328cf886ca00ba413db4
+NEEDED_MACCORE_VERSION := f8e800caa5e01678d4f6135f4d4309f6f567f502
 NEEDED_MACCORE_BRANCH := master
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
https://github.com/xamarin/maccore/compare/b2d37c77cc34558a67fd328cf886ca00ba413db4...f8e800caa5e01678d4f6135f4d4309f6f567f502

* [Roslyn Analyzers] Availability attribute analyzer v2 (#2101) - xamarin/maccore@673946d
* clean up PlatformAvailability.cs (#2119) xamarin/maccore@f00816c
* [provisionator] Add Xcode 11.3 and 11.3.1 to the list (#2120) xamarin/maccore@f8e800c