### PR TITLE
fix: Template typos execution, transition

### DIFF
--- a/msbuild/tests/AppWithExtraArgumentThatOverrides/AppDelegate.cs
+++ b/msbuild/tests/AppWithExtraArgumentThatOverrides/AppDelegate.cs
@@ -35,7 +35,7 @@ namespace AppWithExtraArgumentThatOverrides
 		public override void DidEnterBackground (UIApplication application)
 		{
 			// Use this method to release shared resources, save user data, invalidate timers and store the application state.
-			// If your application supports background exection this method is called instead of WillTerminate when the user quits.
+			// If your application supports background execution this method is called instead of WillTerminate when the user quits.
 		}
 
 		public override void WillEnterForeground (UIApplication application)

--- a/msbuild/tests/AppWithExtraArgumentThatOverrides/AppDelegate.cs
+++ b/msbuild/tests/AppWithExtraArgumentThatOverrides/AppDelegate.cs
@@ -40,7 +40,7 @@ namespace AppWithExtraArgumentThatOverrides
 
 		public override void WillEnterForeground (UIApplication application)
 		{
-			// Called as part of the transiton from background to active state.
+			// Called as part of the transition from background to active state.
 			// Here you can undo many of the changes made on entering the background.
 		}
 

--- a/msbuild/tests/Bug60536/AppDelegate.cs
+++ b/msbuild/tests/Bug60536/AppDelegate.cs
@@ -58,7 +58,7 @@ namespace Bug60536
 		public override void DidEnterBackground (UIApplication application)
 		{
 			// Use this method to release shared resources, save user data, invalidate timers and store the application state.
-			// If your application supports background exection this method is called instead of WillTerminate when the user quits.
+			// If your application supports background execution this method is called instead of WillTerminate when the user quits.
 		}
 
 		public override void WillEnterForeground (UIApplication application)

--- a/msbuild/tests/Bug60536/AppDelegate.cs
+++ b/msbuild/tests/Bug60536/AppDelegate.cs
@@ -63,7 +63,7 @@ namespace Bug60536
 
 		public override void WillEnterForeground (UIApplication application)
 		{
-			// Called as part of the transiton from background to active state.
+			// Called as part of the transition from background to active state.
 			// Here you can undo many of the changes made on entering the background.
 		}
 

--- a/msbuild/tests/My Spaced App/AppDelegate.cs
+++ b/msbuild/tests/My Spaced App/AppDelegate.cs
@@ -23,7 +23,7 @@ namespace MySpacedApp
 		{
 		}
 		// This method should be used to release shared resources and it should store the application state.
-		// If your application supports background exection this method is called instead of WillTerminate
+		// If your application supports background execution this method is called instead of WillTerminate
 		// when the user quits.
 		public override void DidEnterBackground (UIApplication application)
 		{

--- a/msbuild/tests/My Spaced App/AppDelegate.cs
+++ b/msbuild/tests/My Spaced App/AppDelegate.cs
@@ -29,7 +29,7 @@ namespace MySpacedApp
 		{
 		}
 
-		/// This method is called as part of the transiton from background to active state.
+		/// This method is called as part of the transition from background to active state.
 		public override void WillEnterForeground (UIApplication application)
 		{
 		}

--- a/msbuild/tests/MyCoreMLApp/AppDelegate.cs
+++ b/msbuild/tests/MyCoreMLApp/AppDelegate.cs
@@ -58,7 +58,7 @@ namespace MyCoreMLApp
 		public override void DidEnterBackground (UIApplication application)
 		{
 			// Use this method to release shared resources, save user data, invalidate timers and store the application state.
-			// If your application supports background exection this method is called instead of WillTerminate when the user quits.
+			// If your application supports background execution this method is called instead of WillTerminate when the user quits.
 		}
 
 		public override void WillEnterForeground (UIApplication application)

--- a/msbuild/tests/MyCoreMLApp/AppDelegate.cs
+++ b/msbuild/tests/MyCoreMLApp/AppDelegate.cs
@@ -63,7 +63,7 @@ namespace MyCoreMLApp
 
 		public override void WillEnterForeground (UIApplication application)
 		{
-			// Called as part of the transiton from background to active state.
+			// Called as part of the transition from background to active state.
 			// Here you can undo many of the changes made on entering the background.
 		}
 

--- a/msbuild/tests/MyIBToolLinkTest/AppDelegate.cs
+++ b/msbuild/tests/MyIBToolLinkTest/AppDelegate.cs
@@ -34,7 +34,7 @@ namespace MyIBToolLinkTest
         public override void DidEnterBackground (UIApplication application)
         {
             // Use this method to release shared resources, save user data, invalidate timers and store the application state.
-            // If your application supports background exection this method is called instead of WillTerminate when the user quits.
+            // If your application supports background execution this method is called instead of WillTerminate when the user quits.
         }
 
         public override void WillEnterForeground (UIApplication application)

--- a/msbuild/tests/MyIBToolLinkTest/AppDelegate.cs
+++ b/msbuild/tests/MyIBToolLinkTest/AppDelegate.cs
@@ -39,7 +39,7 @@ namespace MyIBToolLinkTest
 
         public override void WillEnterForeground (UIApplication application)
         {
-            // Called as part of the transiton from background to active state.
+            // Called as part of the transition from background to active state.
             // Here you can undo many of the changes made on entering the background.
         }
 

--- a/msbuild/tests/MyLinkedAssets/AppDelegate.cs
+++ b/msbuild/tests/MyLinkedAssets/AppDelegate.cs
@@ -58,7 +58,7 @@ namespace MyLinkedAssets
 		public override void DidEnterBackground (UIApplication application)
 		{
 			// Use this method to release shared resources, save user data, invalidate timers and store the application state.
-			// If your application supports background exection this method is called instead of WillTerminate when the user quits.
+			// If your application supports background execution this method is called instead of WillTerminate when the user quits.
 		}
 
 		public override void WillEnterForeground (UIApplication application)

--- a/msbuild/tests/MyLinkedAssets/AppDelegate.cs
+++ b/msbuild/tests/MyLinkedAssets/AppDelegate.cs
@@ -63,7 +63,7 @@ namespace MyLinkedAssets
 
 		public override void WillEnterForeground (UIApplication application)
 		{
-			// Called as part of the transiton from background to active state.
+			// Called as part of the transition from background to active state.
 			// Here you can undo many of the changes made on entering the background.
 		}
 

--- a/msbuild/tests/MyMasterDetailApp/AppDelegate.cs
+++ b/msbuild/tests/MyMasterDetailApp/AppDelegate.cs
@@ -50,7 +50,7 @@ namespace MyMasterDetailApp
 		}
 
 		// This method should be used to release shared resources and it should store the application state.
-		// If your application supports background exection this method is called instead of WillTerminate
+		// If your application supports background execution this method is called instead of WillTerminate
 		// when the user quits.
 		public override void DidEnterBackground (UIApplication application)
 		{

--- a/msbuild/tests/MyMasterDetailApp/AppDelegate.cs
+++ b/msbuild/tests/MyMasterDetailApp/AppDelegate.cs
@@ -56,7 +56,7 @@ namespace MyMasterDetailApp
 		{
 		}
 
-		// This method is called as part of the transiton from background to active state.
+		// This method is called as part of the transition from background to active state.
 		public override void WillEnterForeground (UIApplication application)
 		{
 		}

--- a/msbuild/tests/MyMetalGame/AppDelegate.cs
+++ b/msbuild/tests/MyMetalGame/AppDelegate.cs
@@ -33,7 +33,7 @@ namespace MyMetalGame
 		{
 		}
 		
-		// This method is called as part of the transiton from background to active state.
+		// This method is called as part of the transition from background to active state.
 		public override void WillEnterForeground (UIApplication application)
 		{
 		}

--- a/msbuild/tests/MyMetalGame/AppDelegate.cs
+++ b/msbuild/tests/MyMetalGame/AppDelegate.cs
@@ -27,7 +27,7 @@ namespace MyMetalGame
 		}
 		
 		// This method should be used to release shared resources and it should store the application state.
-		// If your application supports background exection this method is called instead of WillTerminate
+		// If your application supports background execution this method is called instead of WillTerminate
 		// when the user quits.
 		public override void DidEnterBackground (UIApplication application)
 		{

--- a/msbuild/tests/MyOpenGLApp/AppDelegate.cs
+++ b/msbuild/tests/MyOpenGLApp/AppDelegate.cs
@@ -33,7 +33,7 @@ namespace MyOpenGLApp
 		{
 		}
 		
-		// This method is called as part of the transiton from background to active state.
+		// This method is called as part of the transition from background to active state.
 		public override void WillEnterForeground (UIApplication application)
 		{
 		}

--- a/msbuild/tests/MyOpenGLApp/AppDelegate.cs
+++ b/msbuild/tests/MyOpenGLApp/AppDelegate.cs
@@ -27,7 +27,7 @@ namespace MyOpenGLApp
 		}
 		
 		// This method should be used to release shared resources and it should store the application state.
-		// If your application supports background exection this method is called instead of WillTerminate
+		// If your application supports background execution this method is called instead of WillTerminate
 		// when the user quits.
 		public override void DidEnterBackground (UIApplication application)
 		{

--- a/msbuild/tests/MyReleaseBuild/AppDelegate.cs
+++ b/msbuild/tests/MyReleaseBuild/AppDelegate.cs
@@ -64,7 +64,7 @@ namespace MyReleaseBuild
 
 		public override void WillEnterForeground (UIApplication application)
 		{
-			// Called as part of the transiton from background to active state.
+			// Called as part of the transition from background to active state.
 			// Here you can undo many of the changes made on entering the background.
 		}
 

--- a/msbuild/tests/MyReleaseBuild/AppDelegate.cs
+++ b/msbuild/tests/MyReleaseBuild/AppDelegate.cs
@@ -59,7 +59,7 @@ namespace MyReleaseBuild
 		public override void DidEnterBackground (UIApplication application)
 		{
 			// Use this method to release shared resources, save user data, invalidate timers and store the application state.
-			// If your application supports background exection this method is called instead of WillTerminate when the user quits.
+			// If your application supports background execution this method is called instead of WillTerminate when the user quits.
 		}
 
 		public override void WillEnterForeground (UIApplication application)

--- a/msbuild/tests/MySingleView/AppDelegate.cs
+++ b/msbuild/tests/MySingleView/AppDelegate.cs
@@ -29,7 +29,7 @@ namespace MySingleView
 		{
 		}
 
-		/// This method is called as part of the transiton from background to active state.
+		/// This method is called as part of the transition from background to active state.
 		public override void WillEnterForeground (UIApplication application)
 		{
 		}

--- a/msbuild/tests/MySingleView/AppDelegate.cs
+++ b/msbuild/tests/MySingleView/AppDelegate.cs
@@ -23,7 +23,7 @@ namespace MySingleView
 		{
 		}
 		// This method should be used to release shared resources and it should store the application state.
-		// If your application supports background exection this method is called instead of WillTerminate
+		// If your application supports background execution this method is called instead of WillTerminate
 		// when the user quits.
 		public override void DidEnterBackground (UIApplication application)
 		{

--- a/msbuild/tests/MySpriteKitGame/AppDelegate.cs
+++ b/msbuild/tests/MySpriteKitGame/AppDelegate.cs
@@ -34,7 +34,7 @@ namespace MySpriteKitGame
 		}
 
 		// This method should be used to release shared resources and it should store the application state.
-		// If your application supports background exection this method is called instead of WillTerminate
+		// If your application supports background execution this method is called instead of WillTerminate
 		// when the user quits.
 		public override void DidEnterBackground (UIApplication application)
 		{

--- a/msbuild/tests/MySpriteKitGame/AppDelegate.cs
+++ b/msbuild/tests/MySpriteKitGame/AppDelegate.cs
@@ -40,7 +40,7 @@ namespace MySpriteKitGame
 		{
 		}
 
-		// This method is called as part of the transiton from background to active state.
+		// This method is called as part of the transition from background to active state.
 		public override void WillEnterForeground (UIApplication application)
 		{
 		}

--- a/msbuild/tests/MyTabbedApplication/AppDelegate.cs
+++ b/msbuild/tests/MyTabbedApplication/AppDelegate.cs
@@ -27,7 +27,7 @@ namespace MyTabbedApplication
 		}
 		
 		// This method should be used to release shared resources and it should store the application state.
-		// If your application supports background exection this method is called instead of WillTerminate
+		// If your application supports background execution this method is called instead of WillTerminate
 		// when the user quits.
 		public override void DidEnterBackground (UIApplication application)
 		{

--- a/msbuild/tests/MyTabbedApplication/AppDelegate.cs
+++ b/msbuild/tests/MyTabbedApplication/AppDelegate.cs
@@ -33,7 +33,7 @@ namespace MyTabbedApplication
 		{
 		}
 		
-		// This method is called as part of the transiton from background to active state.
+		// This method is called as part of the transition from background to active state.
 		public override void WillEnterForeground (UIApplication application)
 		{
 		}

--- a/msbuild/tests/MyWatch2Container/AppDelegate.cs
+++ b/msbuild/tests/MyWatch2Container/AppDelegate.cs
@@ -34,7 +34,7 @@ namespace MyWatch2Container
 		public override void DidEnterBackground (UIApplication application)
 		{
 			// Use this method to release shared resources, save user data, invalidate timers and store the application state.
-			// If your application supports background exection this method is called instead of WillTerminate when the user quits.
+			// If your application supports background execution this method is called instead of WillTerminate when the user quits.
 		}
 
 		public override void WillEnterForeground (UIApplication application)

--- a/msbuild/tests/MyWatch2Container/AppDelegate.cs
+++ b/msbuild/tests/MyWatch2Container/AppDelegate.cs
@@ -39,7 +39,7 @@ namespace MyWatch2Container
 
 		public override void WillEnterForeground (UIApplication application)
 		{
-			// Called as part of the transiton from background to active state.
+			// Called as part of the transition from background to active state.
 			// Here you can undo many of the changes made on entering the background.
 		}
 

--- a/msbuild/tests/MyWebViewApp/AppDelegate.cs
+++ b/msbuild/tests/MyWebViewApp/AppDelegate.cs
@@ -29,7 +29,7 @@ namespace MyWebViewApp
 		public override void DidEnterBackground (UIApplication application)
 		{
 		}
-		// This method is called as part of the transiton from background to active state.
+		// This method is called as part of the transition from background to active state.
 		public override void WillEnterForeground (UIApplication application)
 		{
 		}

--- a/msbuild/tests/MyWebViewApp/AppDelegate.cs
+++ b/msbuild/tests/MyWebViewApp/AppDelegate.cs
@@ -24,7 +24,7 @@ namespace MyWebViewApp
 		{
 		}
 		// This method should be used to release shared resources and it should store the application state.
-		// If your application supports background exection this method is called instead of WillTerminate
+		// If your application supports background execution this method is called instead of WillTerminate
 		// when the user quits.
 		public override void DidEnterBackground (UIApplication application)
 		{

--- a/msbuild/tests/MyiOSAppWithBinding/AppDelegate.cs
+++ b/msbuild/tests/MyiOSAppWithBinding/AppDelegate.cs
@@ -40,7 +40,7 @@ namespace MyiOSAppWithBinding
 
 		public override void WillEnterForeground (UIApplication application)
 		{
-			// Called as part of the transiton from background to active state.
+			// Called as part of the transition from background to active state.
 			// Here you can undo many of the changes made on entering the background.
 		}
 

--- a/msbuild/tests/MyiOSAppWithBinding/AppDelegate.cs
+++ b/msbuild/tests/MyiOSAppWithBinding/AppDelegate.cs
@@ -35,7 +35,7 @@ namespace MyiOSAppWithBinding
 		public override void DidEnterBackground (UIApplication application)
 		{
 			// Use this method to release shared resources, save user data, invalidate timers and store the application state.
-			// If your application supports background exection this method is called instead of WillTerminate when the user quits.
+			// If your application supports background execution this method is called instead of WillTerminate when the user quits.
 		}
 
 		public override void WillEnterForeground (UIApplication application)

--- a/tests/bcl-test/templates/watchOS/Container/AppDelegate.cs
+++ b/tests/bcl-test/templates/watchOS/Container/AppDelegate.cs
@@ -34,7 +34,7 @@ namespace Container
 		public override void DidEnterBackground (UIApplication application)
 		{
 			// Use this method to release shared resources, save user data, invalidate timers and store the application state.
-			// If your application supports background exection this method is called instead of WillTerminate when the user quits.
+			// If your application supports background execution this method is called instead of WillTerminate when the user quits.
 		}
 
 		public override void WillEnterForeground (UIApplication application)

--- a/tests/bcl-test/templates/watchOS/Container/AppDelegate.cs
+++ b/tests/bcl-test/templates/watchOS/Container/AppDelegate.cs
@@ -39,7 +39,7 @@ namespace Container
 
 		public override void WillEnterForeground (UIApplication application)
 		{
-			// Called as part of the transiton from background to active state.
+			// Called as part of the transition from background to active state.
 			// Here you can undo many of the changes made on entering the background.
 		}
 

--- a/tests/templates/WatchContainer/AppDelegate.cs
+++ b/tests/templates/WatchContainer/AppDelegate.cs
@@ -34,7 +34,7 @@ namespace Container
 		public override void DidEnterBackground (UIApplication application)
 		{
 			// Use this method to release shared resources, save user data, invalidate timers and store the application state.
-			// If your application supports background exection this method is called instead of WillTerminate when the user quits.
+			// If your application supports background execution this method is called instead of WillTerminate when the user quits.
 		}
 
 		public override void WillEnterForeground (UIApplication application)

--- a/tests/templates/WatchContainer/AppDelegate.cs
+++ b/tests/templates/WatchContainer/AppDelegate.cs
@@ -39,7 +39,7 @@ namespace Container
 
 		public override void WillEnterForeground (UIApplication application)
 		{
-			// Called as part of the transiton from background to active state.
+			// Called as part of the transition from background to active state.
 			// Here you can undo many of the changes made on entering the background.
 		}
 


### PR DESCRIPTION
Spelling checker lights up on File, New Project:

<img width="877" alt="image" src="https://user-images.githubusercontent.com/1633368/72680524-0e36f700-3abb-11ea-9bb9-e2cf1d1d47c2.png">
