### PR TITLE
[jenkins] Fix a couple of issues.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -156,8 +156,8 @@ def reportFinalStatusToSlack (err, gitHash, currentStage, fileContents)
             authorEmail = env.CHANGE_AUTHOR_EMAIL
             slackMessage = "Pull Request #<${env.CHANGE_URL}|${env.CHANGE_ID}> failed to build."
         } else {
-            authorName = sh (script: "cd ${workspace} && git log -1 --pretty=%an", returnStdout: true).trim ()
-            authorEmail = sh (script: "cd ${workspace} && git log -1 --pretty=%ae", returnStdout: true).trim ()
+            authorName = sh (script: "cd ${workspace}/xamarin-macios && git log -1 --pretty=%an", returnStdout: true).trim ()
+            authorEmail = sh (script: "cd ${workspace}/xamarin-macios && git log -1 --pretty=%ae", returnStdout: true).trim ()
             slackMessage = "Commit <https://github.com/${repository}/commit/${gitHash}|${gitHash}> failed to build."
         }
 
@@ -594,8 +594,15 @@ timestamps {
                         stage ('Generate artifacts.json') {
                             withCredentials ([string (credentialsId: '92cf81e5-6db5-408c-8a0d-192b36200a16', variable: 'GITHUB_AUTH_TOKEN'), usernamePassword (credentialsId: 'd146d4aa-a437-4633-908f-b455876c44d0', passwordVariable: 'STORAGE_PASSWORD', usernameVariable: 'STORAGE_ACCOUNT')]) {
                                 dir ("BuildTasks") {
-                                    sh "mono tools/BuildTasks/build-tasks.exe artifacts -s ${workspace}/xamarin-macios -a ${env.STORAGE_ACCOUNT} -c ${env.STORAGE_PASSWORD} -u wrench/${virtualPath}/package"
-                                    artifactsFilename = "artifacts.json"
+                                    try {
+                                        sh "mono tools/BuildTasks/build-tasks.exe artifacts -s ${workspace}/xamarin-macios -a ${env.STORAGE_ACCOUNT} -c ${env.STORAGE_PASSWORD} -u wrench/${virtualPath}/package"
+                                        artifactsFilename = "artifacts.json"
+                                    } catch {
+                                        def msg = "Failed to generate/upload artifacts.json: " + err.getMessage ();
+                                        echo ("⚠️ ${msg} ⚠️")
+                                        manager.addWarningBadge (msg)
+                                        appendFileComment ("⚠️ [${msg}](${env.RUN_DISPLAY_URL}) 🔥\n")
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
* Fix fetching author's name + email for failure reporting by running git in
  the directory where the repo actually is.
* Don't fail the build if we fail to generate/upload artifacts.json, instead
  show the failure everywhere and continue as if nothing happened. There seems
  to be a random issue with GitHub where a network request fails, and there's
  no need for that to fail the entire build.