### PR TITLE
[registrar] Fixes NSString trampoline code generation in static registrar

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -5466,6 +5466,18 @@ namespace MonoTouchFixtures.ObjCRuntime {
 	{
 	}
 
+	public delegate void ACompletionHandler (string strArg, NSError error);
+
+	// https://github.com/xamarin/xamarin-macios/issues/7733
+	[Preserve]
+	public class GHIssue7733 : NSObject {
+		[Export ("doSomeWork:completion:")]
+		public virtual void DoWork (string who, ACompletionHandler completion)
+		{
+
+		}
+	}
+
 #if !__WATCHOS__ && !__TVOS__ // No WebKit on watchOS/tvOS
 	[Preserve]
 	public class GenericWebNavigationThingie<WebViewModel> : NSObject, IWKNavigationDelegate {

--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -1843,6 +1843,32 @@ class C : NSObject {
 				mtouch.AssertWarning (4179, $"The registrar found the abstract type 'SomeNativeObject' in the signature for 'C.M2'. Abstract types should not be used in the signature for a member exported to Objective-C.", "testApp.cs", 21);
 			}
 		}
+
+		// https://github.com/xamarin/xamarin-macios/issues/7733
+		[Test]
+		public void GHIssue7733 ()
+		{
+			var str1 = @"
+public delegate void ACompletionHandler (string strArg, NSError error);
+
+[Preserve]
+public class WidgetObject : NSObject {
+	[Export (""doSomeWork:completion:"")]
+	public virtual void DoWork (string who, ACompletionHandler completion)
+	{
+
+	}
+}
+";
+
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: str1, usings: "using Foundation; using System;", extraArgs: new [] { "/debug:full" });
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecute ();
+			}
+		}
 	}
 }
 

--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -1843,32 +1843,6 @@ class C : NSObject {
 				mtouch.AssertWarning (4179, $"The registrar found the abstract type 'SomeNativeObject' in the signature for 'C.M2'. Abstract types should not be used in the signature for a member exported to Objective-C.", "testApp.cs", 21);
 			}
 		}
-
-		// https://github.com/xamarin/xamarin-macios/issues/7733
-		[Test]
-		public void GHIssue7733 ()
-		{
-			var str1 = @"
-public delegate void ACompletionHandler (string strArg, NSError error);
-
-[Preserve]
-public class WidgetObject : NSObject {
-	[Export (""doSomeWork:completion:"")]
-	public virtual void DoWork (string who, ACompletionHandler completion)
-	{
-
-	}
-}
-";
-
-			using (var mtouch = new MTouchTool ()) {
-				mtouch.CreateTemporaryCacheDirectory ();
-				mtouch.CreateTemporaryApp (extraCode: str1, usings: "using Foundation; using System;", extraArgs: new [] { "/debug:full" });
-				mtouch.Linker = MTouchLinker.DontLink;
-				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.AssertExecute ();
-			}
-		}
 	}
 }
 

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -488,7 +488,7 @@ namespace Registrar {
 			case "System.Double": return "double";
 			case "System.Boolean": return "BOOL";
 			case "System.Void": return "void";
-			case "System.String": return "NSString";
+			case "System.String": return "NSString *";
 			case "ObjCRuntime.Selector": return "SEL";
 			case "ObjCRuntime.Class": return "Class";
 			}


### PR DESCRIPTION
Fixes xamarin/xamarin-macios#7733

This was introduced as a side effect of commit 8425129, we
used to generate `id foo` instead of the full block signature
in the trampoline code used by the static registrar, this is
the reason we never caught this condition before.

Added registrar test.