### PR TITLE
[appkit] Allow NSColorSpace access on non-UI threads

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -4309,6 +4309,7 @@ namespace AppKit {
 		CGSize MinContentSize { get; }
 	}
 
+	[ThreadSafe]
 	[BaseType (typeof (NSObject))]
 	interface NSColorSpace : NSCoding, NSSecureCoding {
 		[Export ("initWithICCProfileData:")]


### PR DESCRIPTION
- https://github.com/xamarin/xamarin-macios/issues/7731
- Tested with Apple Thread checker