### PR TITLE
Bump maccore to clean status messages.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := f355bddd13013b14396d4febdac8a28a5fea1696
+NEEDED_MACCORE_VERSION := e0fa1322c78289614bcdb2cfdb006fcac3f1b0b2
 NEEDED_MACCORE_BRANCH := master
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
We were reporting ddfun as (iOS DDFun) and (iOS-DDFun). Maccore was updated to use the same context in both. 