### PR TITLE
[msbuild] Remove dependency on Mono.Posix.

### DIFF
--- a/msbuild/ILMerge.targets
+++ b/msbuild/ILMerge.targets
@@ -32,7 +32,6 @@
       <MergedAssemblies Include="$(OutputPath)/System.Threading.Tasks.Extensions.dll" />
       <MergedAssemblies Include="$(OutputPath)/System.Text.Encodings.Web.dll" />
 
-      <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Mono.Posix.NETStandard'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(Extension)' == '.dll' And $([System.String]::new('%(FileName)').StartsWith('Mono.Cecil', StringComparison.OrdinalIgnoreCase))" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/SmartCopyTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/SmartCopyTaskBase.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-
-using Mono.Unix.Native;
 
 namespace Xamarin.MacDev.Tasks
 {
@@ -67,9 +66,9 @@ namespace Xamarin.MacDev.Tasks
 
 			File.Copy (source, target, true);
 			if (Environment.OSVersion.Platform == PlatformID.Unix) {
-				if (Syscall.stat (target, out var stat) == 0) {
+				if (stat (target, out var stat_rv) == 0) {
 					// ensure it's world read-able or this might trigger an appstore rejection
-					Syscall.chmod (target, stat.st_mode | FilePermissions.S_IROTH);
+					chmod (target, stat_rv.st_mode | FilePermissions.S_IROTH);
 				}
 			}
 
@@ -124,5 +123,66 @@ namespace Xamarin.MacDev.Tasks
 
 			return !Log.HasLoggedErrors;
 		}
+
+		[DllImport ("libc")]
+		static extern int stat (string file_name, out Stat buf);
+
+		[DllImport ("libc")]
+		static extern int chmod (string path, FilePermissions mode);
+
+		struct Stat {
+			public int st_dev;
+			public uint st_ino;
+			public FilePermissions st_mode;
+			public ushort st_nlink;
+			public uint st_uid;
+			public uint st_gid;
+			public int st_rdev;
+			long st_atime;
+			long st_atimensec;
+			long st_mtime;
+			long st_mtimensec;
+			long st_ctime;
+			long st_ctimensec;
+			public long st_size;
+			public long st_blocks;
+			public int st_blksize;
+			public uint st_flags;
+			public uint st_gen;
+			public int st_lspare;
+			public long st_qspare_1;
+			public long st_qspare_2;
+		}
+
+		[Flags]
+		public enum FilePermissions : ushort {
+			ACCESSPERMS = 0x1FF,
+			ALLPERMS = 0xFFF,
+			DEFFILEMODE = 0x1B6,
+			S_IFBLK = 0x6000,
+			S_IFCHR = 0x2000,
+			S_IFDIR = 0x4000,
+			S_IFIFO = 0x1000,
+			S_IFLNK = 0xA000,
+			S_IFMT = 0xF000,
+			S_IFREG = 0x8000,
+			S_IFSOCK = 0xC000,
+			S_IRGRP = 0x20,
+			S_IROTH = 0x4,
+			S_IRUSR = 0x100,
+			S_IRWXG = 0x38,
+			S_IRWXO = 0x7,
+			S_IRWXU = 0x1C0,
+			S_ISGID = 0x400,
+			S_ISUID = 0x800,
+			S_ISVTX = 0x200,
+			S_IWGRP = 0x10,
+			S_IWOTH = 0x2,
+			S_IWUSR = 0x80,
+			S_IXGRP = 0x8,
+			S_IXOTH = 0x1,
+			S_IXUSR = 0x40
+		}
+
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -6,7 +6,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="System.Text.Json" Version="4.7.0" />
     <!-- Compile against Microsoft.Build* NuGet refs, but do not copy to OutputDir. -->
     <PackageReference Include="Microsoft.Build" Version="15.9.20" IncludeAssets="compile" />


### PR DESCRIPTION
Mono.Posix comes with a native library, and that makes IL merging much more
complicated, especially when Mono.Posix comes from a nuget. So remove the
Mono.Posix dependency, and instead write the 2 P/Invokes we need manually.