### PR TITLE
[msbuild] Don't manually quote, instead rely on CommandLineArgumentBuilder's logic.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CodesignVerifyTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CodesignVerifyTaskBase.cs
@@ -10,7 +10,7 @@ namespace Xamarin.iOS.Tasks
 
 			args.Add ("--verify");
 			args.Add ("-vvvv");
-			args.Add ("-R='anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.1] exists and (certificate leaf[field.1.2.840.113635.100.6.1.2] exists or certificate leaf[field.1.2.840.113635.100.6.1.4] exists)'");
+			args.AddQuoted ("-R=anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.1] exists and (certificate leaf[field.1.2.840.113635.100.6.1.2] exists or certificate leaf[field.1.2.840.113635.100.6.1.4] exists)");
 
 			args.AddQuoted (Resource);
 


### PR DESCRIPTION
This fixes an issue related to single quotes and that the fact that mono's behavior
regarding quoting them has changed (by not using single quotes).

This becomes an issue when running with dotnet.