### PR TITLE
[Harness] Unify the CI properties.

### DIFF
--- a/tests/xharness/BCLTestImporter/BCLTestImportTargetFactory.cs
+++ b/tests/xharness/BCLTestImporter/BCLTestImportTargetFactory.cs
@@ -26,7 +26,7 @@ namespace xharness.BCLTestImporter {
 				MacMonoSDKPath = Harness.MONO_MAC_SDK_DESTDIR,
 				Override = true,
 				GuidGenerator = Harness.NewStableGuid,
-				GroupTests = Harness.InJenkins || Harness.UseGroupedApps,
+				GroupTests = Harness.InCI || Harness.UseGroupedApps,
 			};
 		}
 		

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -115,7 +115,7 @@ namespace xharness
 
 		public Harness ()
 		{
-			LaunchTimeout = InWrench ? 3 : 120;
+			LaunchTimeout = InCI ? 3 : 120;
 		}
 
 		public bool GetIncludeSystemPermissionTests (TestPlatform platform, bool device)
@@ -667,24 +667,10 @@ namespace xharness
 
 		public void LogWrench (string message)
 		{
-			if (!InWrench)
+			if (!InCI)
 				return;
 
 			Console.WriteLine (message);
-		}
-
-		public bool InWrench {
-			get {
-				var buildRev = Environment.GetEnvironmentVariable ("BUILD_REVISION");
-				return !string.IsNullOrEmpty (buildRev) && buildRev != "jenkins";
-			}
-		}
-		
-		public bool InJenkins {
-			get {
-				var buildRev = Environment.GetEnvironmentVariable ("BUILD_REVISION");
-				return !string.IsNullOrEmpty (buildRev) && buildRev == "jenkins";
-			}
 		}
 		
 		public bool InCI {

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1182,7 +1182,7 @@ namespace xharness
 			try {
 				Directory.CreateDirectory (LogDirectory);
 				Log log = Logs.Create ($"Harness-{Harness.Timestamp}.log", "Harness log");
-				if (Harness.InWrench)
+				if (Harness.InCI)
 					log = Log.CreateAggregatedLog (log, new ConsoleLog ());
 				Harness.HarnessLog = MainLog = log;
 
@@ -1190,7 +1190,7 @@ namespace xharness
 				if (IsServerMode)
 					tasks.Add (RunTestServer ());
 
-				if (Harness.InJenkins) {
+				if (Harness.InCI) {
 					Task.Factory.StartNew (async () => {
 						while (true) {
 							await Task.Delay (TimeSpan.FromMinutes (10));
@@ -3789,7 +3789,7 @@ namespace xharness
 					}
 
 					// Also clean up after us locally.
-					if (Harness.InJenkins || Harness.InWrench || (Jenkins.CleanSuccessfulTestRuns && Succeeded))
+					if (Harness.InCI || (Jenkins.CleanSuccessfulTestRuns && Succeeded))
 						await BuildTask.CleanAsync ();
 				}
 			}

--- a/tests/xharness/MakefileGenerator.cs
+++ b/tests/xharness/MakefileGenerator.cs
@@ -211,7 +211,7 @@ namespace xharness
 
 		public static void CreateMakefile (Harness harness, IEnumerable<UnifiedTarget> unified_targets, IEnumerable<TVOSTarget> tvos_targets, IEnumerable<WatchOSTarget> watchos_targets, IEnumerable<TodayExtensionTarget> today_targets)
 		{
-			var executeSim32 = !harness.InWrench; // Waiting for iOS 10.3 simulator to be installed on wrench
+			var executeSim32 = !harness.InCI; // Waiting for iOS 10.3 simulator to be installed on wrench
 			var makefile = Path.Combine (Harness.RootDirectory, "Makefile.inc");
 			using (var writer = new StreamWriter (makefile, false, new UTF8Encoding (false))) {
 				writer.WriteLine (".stamp-configure-projects: Makefile xharness/xharness.exe");


### PR DESCRIPTION
Unify the harness properties to just look at InCI and remove all the
other ones. There is no real need to have differences between jenkins
and VSTS and Wrench is gone.