### PR TITLE
[msbuild] Copy tests before making changes to them.

### DIFF
--- a/msbuild/tests/Common.props
+++ b/msbuild/tests/Common.props
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<RepositoryPath Condition="Exists ('$(MSBuildThisFileDirectory)/.git')">$(MSBuildThisFileDirectory)</RepositoryPath>
+		<RepositoryPath Condition="Exists ('$(MSBuildThisFileDirectory)/../.git')">$(MSBuildThisFileDirectory)/..</RepositoryPath>
+		<RepositoryPath Condition="Exists ('$(MSBuildThisFileDirectory)/../../.git')">$(MSBuildThisFileDirectory)/../..</RepositoryPath>
+		<RepositoryPath Condition="Exists ('$(MSBuildThisFileDirectory)/../../../.git')">$(MSBuildThisFileDirectory)/../../..</RepositoryPath>
+		<RepositoryPath Condition="Exists ('$(MSBuildThisFileDirectory)/../../../../.git')">$(MSBuildThisFileDirectory)/../../../..</RepositoryPath>
+		<RepositoryPath Condition="Exists ('$(MSBuildThisFileDirectory)/../../../../../.git')">$(MSBuildThisFileDirectory)/../../../..</RepositoryPath>
+		<RepositoryPath Condition="Exists ('$(MSBuildThisFileDirectory)/../../../../../../.git')">$(MSBuildThisFileDirectory)/../../../../../..</RepositoryPath>
+		<RepositoryPath Condition="Exists ('$(MSBuildThisFileDirectory)/../../../../../../../.git')">$(MSBuildThisFileDirectory)/../../../../../../..</RepositoryPath>
+		<RepositoryPath Condition="Exists ('$(MSBuildThisFileDirectory)/../../../../../../../../.git')">$(MSBuildThisFileDirectory)/../../../../../../../..</RepositoryPath>
+		<RepositoryPath>$([MSBuild]::NormalizePath('$(RepositoryPath)'))</RepositoryPath>
+	</PropertyGroup>
+</Project>

--- a/msbuild/tests/My Spaced App/My Spaced App.csproj
+++ b/msbuild/tests/My Spaced App/My Spaced App.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="../Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
@@ -72,7 +73,7 @@
     <Folder Include="en.lproj\" />
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\..\..\tests\test-libraries\.libs\ios-fat\libtest2.a">
+    <NativeReference Include="$(RepositoryPath)\tests\test-libraries\.libs\ios-fat\libtest2.a">
       <Kind>Static</Kind>
       <Link>libtest2.a</Link>
     </NativeReference>

--- a/msbuild/tests/MyiOSFrameworkBinding/MyiOSFrameworkBinding.csproj
+++ b/msbuild/tests/MyiOSFrameworkBinding/MyiOSFrameworkBinding.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="../Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -36,46 +37,46 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\..\..\tests\test-libraries\.libs\ios-fat\XTest.framework">
+    <NativeReference Include="$(RepositoryPath)\tests\test-libraries\.libs\ios-fat\XTest.framework">
       <Kind>Framework</Kind>
       <Link>XTest.framework</Link>
     </NativeReference>
-    <NativeReference Include="..\..\..\tests\test-libraries\.libs\ios-fat\XStaticObjectTest.framework">
+    <NativeReference Include="$(RepositoryPath)\tests\test-libraries\.libs\ios-fat\XStaticObjectTest.framework">
       <Kind>Framework</Kind>
       <Link>XStaticObjectTest.framework</Link>
       <LinkerFlags>-lz</LinkerFlags>
       <Frameworks>CoreLocation Foundation ModelIO</Frameworks>
     </NativeReference>
-    <NativeReference Include="..\..\..\tests\test-libraries\.libs\ios-fat\XStaticArTest.framework">
+    <NativeReference Include="$(RepositoryPath)\tests\test-libraries\.libs\ios-fat\XStaticArTest.framework">
       <Kind>Framework</Kind>
       <Link>XStaticArTest.framework</Link>
       <Frameworks>CoreLocation Foundation ModelIO</Frameworks>
     </NativeReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\..\tests\bindings-framework-test\XTest.framework.linkwith.cs">
+    <Compile Include="$(RepositoryPath)\tests\bindings-framework-test\XTest.framework.linkwith.cs">
       <DependentUpon>XTest.framework</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\..\tests\test-libraries\libframework.m">
+    <None Include="$(RepositoryPath)\tests\test-libraries\libframework.m">
       <Link>libframework.m</Link>
     </None>
-    <None Include="..\..\..\tests\test-libraries\libframework.h">
+    <None Include="$(RepositoryPath)\tests\test-libraries\libframework.h">
       <Link>libframework.h</Link>
     </None>
   </ItemGroup>
-  <Target Name="BeforeBuild" Inputs="..\..\..\tests\test-libraries\libframework.m" Outputs="..\..\..\tests\test-libraries\.libs\ios-fat\XTest.framework ..\..\..\tests\test-libraries\.libs\ios-fat\XSharedObjectTest.framework ..\..\..\tests\test-libraries\.libs\ios-fat\XSharedArTest.framework">
-    <Exec Command="make -j8 -C ..\..\..\tests\test-libraries" />
+  <Target Name="BeforeBuild" Inputs="$(RepositoryPath)\tests\test-libraries\libframework.m" Outputs="$(RepositoryPath)\tests\test-libraries\.libs\ios-fat\XTest.framework;$(RepositoryPath)\tests\test-libraries\.libs\ios-fat\XSharedObjectTest.framework;$(RepositoryPath)\tests\test-libraries\.libs\ios-fat\XSharedArTest.framework">
+    <Exec Command="make -j8 -C $(RepositoryPath)\tests\test-libraries" />
   </Target>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.ObjCBinding.CSharp.targets" />
   <ItemGroup>
-    <ObjcBindingApiDefinition Include="..\..\..\tests\bindings-framework-test\ApiDefinition.cs">
+    <ObjcBindingApiDefinition Include="$(RepositoryPath)\tests\bindings-framework-test\ApiDefinition.cs">
       <Link>ApiDefinition.cs</Link>
     </ObjcBindingApiDefinition>
   </ItemGroup>
   <ItemGroup>
-    <ObjcBindingCoreSource Include="..\..\..\tests\bindings-framework-test\StructsAndEnums.cs">
+    <ObjcBindingCoreSource Include="$(RepositoryPath)\tests\bindings-framework-test\StructsAndEnums.cs">
       <Link>StructsAndEnums.cs</Link>
     </ObjcBindingCoreSource>
   </ItemGroup>

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/BindingProject.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/BindingProject.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using NUnit.Framework;
 using System.IO;
+using Xamarin.Tests;
 
 namespace Xamarin.iOS.Tasks
 {
@@ -17,7 +18,7 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void BuildTest ()
 		{
-			var mtouchPaths = SetupProjectPaths ("bindings-test", "bindings-test", "../../../tests/", false, Platform, "Any CPU/Debug-unified");
+			var mtouchPaths = SetupProjectPaths ("bindings-test", "bindings-test", Path.Combine (Configuration.RootPath, "tests"), false, Platform, "Any CPU/Debug-unified");
 
 			var proj = SetupProject (Engine, mtouchPaths ["project_csprojpath"]);
 
@@ -37,7 +38,7 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void FrameworkTest ()
 		{
-			var mtouchPaths = SetupProjectPaths ("bindings-test", "bindings-test", "../../../tests/", false, Platform, "Any CPU/Debug-unified");
+			var mtouchPaths = SetupProjectPaths ("bindings-test", "bindings-test", Path.Combine (Configuration.RootPath, "tests"), false, Platform, "Any CPU/Debug-unified");
 
 			var proj = SetupProject (Engine, mtouchPaths ["project_csprojpath"]);
 			AppBundlePath = mtouchPaths.AppBundlePath;

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/NativeReferences.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/NativeReferences.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Linq;
 using NUnit.Framework;
 
+using Xamarin.Tests;
+
 namespace Xamarin.iOS.Tasks {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]
@@ -20,7 +22,7 @@ namespace Xamarin.iOS.Tasks {
 			Engine.ProjectCollection.SetGlobalProperty ("Platform", Platform);
 
 			var proj = SetupProject (Engine, mtouchPaths.ProjectCSProjPath);
-			var nr = proj.AddItem ("NativeReference", Path.Combine (".", "..", "..", "..", "tests", "test-libraries", ".libs", "ios-fat", "XTest.framework")).First ();
+			var nr = proj.AddItem ("NativeReference", Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "ios-fat", "XTest.framework")).First ();
 			nr.SetMetadataValue ("IsCxx", "False");
 			nr.SetMetadataValue ("Kind", "Framework");
 

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/NativeReferencesNoEmbedding.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/NativeReferencesNoEmbedding.cs
@@ -102,7 +102,7 @@ namespace Xamarin.iOS.Tasks
 			ClearMessages ();
 
 			// Touching the binding file should
-			Touch (Path.Combine (Path.GetDirectoryName (bindingLib.ProjectCSProjPath), @"../../../tests/bindings-framework-test/ApiDefinition.cs"));
+			Touch (Path.Combine (Configuration.RootPath, "tests", "bindings-framework-test", "ApiDefinition.cs"));
 			BuildProjectNoEmbedding (bindingLib, clean: false);
 			Assert.True (GetMessages ().Contains (CreatePackageString), "Binding file build did not create package?");
 			ClearMessages ();
@@ -113,7 +113,7 @@ namespace Xamarin.iOS.Tasks
 			ClearMessages ();
 
 			// Touching native library should
-			Touch (Path.Combine (Path.GetDirectoryName (bindingLib.ProjectCSProjPath), @"../../../tests/test-libraries/.libs/ios-fat/XTest.framework/XTest"));
+			Touch (Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "ios-fat", "XTest.framework/XTest"));
 			BuildProjectNoEmbedding (bindingLib, clean: false);
 			Assert.True (GetMessages ().Contains (CreatePackageString), "Binding build did not create package?");
 		}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/XamarinForms.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/XamarinForms.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System.IO;
 using NUnit.Framework;
 
 namespace Xamarin.iOS.Tasks
@@ -14,8 +14,9 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void IncrementalBuilds ()
 		{
-			NugetRestore ("../MyXamarinFormsApp/MyXamarinFormsApp.csproj");
-			NugetRestore ("../MyXamarinFormsApp/MyXamarinFormsAppNS/MyXamarinFormsAppNS.csproj");
+			var testdir = GetTestDirectory ();
+			NugetRestore (Path.Combine (testdir, "MyXamarinFormsApp", "MyXamarinFormsApp.csproj"));
+			NugetRestore (Path.Combine (testdir, "MyXamarinFormsApp", "MyXamarinFormsAppNS", "MyXamarinFormsAppNS.csproj"));
 
 			// First build
 			BuildProject ("MyXamarinFormsApp", Platform, "Debug");
@@ -27,7 +28,7 @@ namespace Xamarin.iOS.Tasks
 			Assert.IsTrue (IsTargetSkipped ("_CompileToNative"), "_CompileToNative should be skipped on a build with no changes.");
 
 			// Build with XAML change
-			Touch ("../MyXamarinFormsApp/MyXamarinFormsAppNS/App.xaml");
+			Touch (Path.Combine (testdir, "MyXamarinFormsApp", "MyXamarinFormsAppNS", "App.xaml"));
 			Engine.Logger.Clear ();
 			BuildProject ("MyXamarinFormsApp", Platform, "Debug", clean: false);
 


### PR DESCRIPTION
Copy test projects to a temporary directory before using them for tests. This
makes sure tests don't leave a dirty working tree (because some tests modify
the on-disk test code).

We'll also start running tests using SDK-style project files, and this way
it's much easier to run tests twice, once using the old format and once using
the new format, and then compare the results.

Most of the changes are related to making the test projects and code
relocatable.