### PR TITLE
[eventkitui] Remove caching in `EKUIBundle.UIBundle`

### DIFF
--- a/src/EventKitUI/EKUIBundle.cs
+++ b/src/EventKitUI/EKUIBundle.cs
@@ -14,14 +14,17 @@ using Foundation;
 using ObjCRuntime;
 
 namespace EventKitUI {
+	[iOS (11,0)]
 	public static class EKUIBundle {
 
-		[iOS (11,0)]
 		[DllImport (Constants.EventKitUILibrary)]
 		static extern IntPtr EventKitUIBundle ();
 
-		[iOS (11,0)]
-		public static NSBundle UIBundle { get; } = Runtime.GetNSObject<NSBundle> (EventKitUIBundle ());
+		public static NSBundle UIBundle {
+			get {
+				return Runtime.GetNSObject<NSBundle> (EventKitUIBundle ());
+			}
+		}
 	}
 }
 #endif


### PR DESCRIPTION
The existing property implementation use `=` (not `=>`) which means that
the call is executed only once (in the `.cctor`).

```csharp
public static NSBundle UIBundle { get; } = Runtime.GetNSObject<NSBundle> (EventKitUIBundle ());
```

While a shorter syntax (good) it becomes easy to miss the difference
while reviewing pull requests (bad) or later when reading the code.

Also the documentation on `EventKitUIBundle` [1] is unclear. It mention
it's based on _user preferences_ which can be interpreted as something
that change at runtime. This would mean the returned pointer can be
different between calls and that we can't cache it from the static
constructor (since we would only return the original one).

So the correct (safe) code would be:

```csharp
public static NSBundle UIBundle { get; } => Runtime.GetNSObject<NSBundle> (EventKitUIBundle ());
```

but that's still hard to review so the older, self explanatory, syntax is
used.

[1] https://developer.apple.com/documentation/eventkitui/2866511-eventkituibundle?language=objc