### PR TITLE
[src] Add missing availability attributes

### DIFF
--- a/src/CoreGraphics/CGImage.cs
+++ b/src/CoreGraphics/CGImage.cs
@@ -476,6 +476,8 @@ namespace CoreGraphics {
 		[iOS (12,0), Mac(10,14)][TV(12,0)][Watch(5,0)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		static extern CGImageByteOrderInfo CGImageGetByteOrderInfo (/* __nullable CGImageRef */ IntPtr handle);
+
+		[iOS (12,0), Mac(10,14)][TV(12,0)][Watch(5,0)]
 		public CGImageByteOrderInfo ByteOrderInfo => CGImageGetByteOrderInfo (handle);
 		
 #endif // !COREBUILD

--- a/src/MetalPerformanceShaders/MPSCnnConvolutionDescriptor.cs
+++ b/src/MetalPerformanceShaders/MPSCnnConvolutionDescriptor.cs
@@ -1,7 +1,12 @@
 ﻿#if XAMCORE_2_0 || !MONOMAC
 using System;
+using ObjCRuntime;
+
 namespace MetalPerformanceShaders {
 	public partial class MPSCnnConvolutionDescriptor {
+
+		[Introduced (PlatformName.TvOS, 11, 0, PlatformArchitecture.All, null)]
+		[Introduced (PlatformName.iOS, 11, 0, PlatformArchitecture.All, null)]
 		public unsafe void SetBatchNormalizationParameters (float [] mean, float [] variance, float [] gamma, float [] beta, float epsilon)
 		{
 			fixed (void* meanHandle = mean)

--- a/src/VideoToolbox/VTVideoEncoder.cs
+++ b/src/VideoToolbox/VTVideoEncoder.cs
@@ -69,6 +69,7 @@ namespace VideoToolbox {
 			/* CFDictionaryRef */ out IntPtr outSupportedProperties
 		);
 
+		[Mac (10,13), iOS (11,0), TV (11,0)]
 		public static VTSupportedEncoderProperties GetSupportedEncoderProperties (int width, int height, CMVideoCodecType codecType, NSDictionary encoderSpecification = null)
 		{
 			IntPtr encoderIdPtr = IntPtr.Zero;

--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -1829,6 +1829,7 @@ namespace ARKit {
 
 	interface IARSessionProviding {}
 
+	[iOS (13,0)]
 	[Protocol]
 	interface ARSessionProviding {
 


### PR DESCRIPTION
Minor, it's less helpful (inside the IDE) and it also mean generating
code for 32bits that can't be executed successfully at runtime.