### PR TITLE
Bump maccore to set status of device tests.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := acfea010d8381fd009ce3a1eaa685d5c8286321d
+NEEDED_MACCORE_VERSION := 80ebc03ea89eb4a911bbd73ea45b308b610ab213
 NEEDED_MACCORE_BRANCH := master
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@80ebc03 [VSTS] Add a status to pending after we ping VSTS for device tests. (#2135)

Diff: https://github.com/xamarin/maccore/compare/acfea010d8381fd009ce3a1eaa685d5c8286321d..80ebc03ea89eb4a911bbd73ea45b308b610ab213