### PR TITLE
[tests][sampletester] Allow project(s) removal

### DIFF
--- a/tests/sampletester/Samples.cs
+++ b/tests/sampletester/Samples.cs
@@ -146,6 +146,8 @@ namespace Samples {
 		const string HASH = "d196d3f7ba418d06ef799074eb4f6120e26a9cf4";
 
 		static Dictionary<string, SampleTest> test_data = new Dictionary<string, SampleTest> {
+				// avoid building unneeded projects since they require a lot of nuget packages (and cause a lot of unrelated/network build issues)
+				{ "WebServices/TodoREST/iOS/TodoREST.iOS.csproj", new SampleTest { Solution = "WebServices/TodoREST/TodoREST.sln", RemoveProjects = new [] { "TodoAPI", "TodoREST.Droid" } } },
 				// Build solution instead of csproj.
 				{ "WebServices/TodoWCF/iOS/TodoWCF.iOS.csproj", new SampleTest { BuildSolution = true, Solution = "WebServices/TodoWCF/TodoWCF.sln" } },
 			};
@@ -200,23 +202,22 @@ namespace Samples {
 
 	// TODO: Reenable once we can ignore specific projects
 	// Xappy.UWP.csproj : error MSB4057: The target "_IsProjectRestoreSupported" does not exist in the project.
-	//[Category (CATEGORY)]
-	//public class XappyTester : SampleTester {
-	//	const string ORG = "davidortinau";
-	//	const string REPO = "Xappy";
-	//	const string CATEGORY = "davidortinauxappy"; // categories can't contain dashes
-	//	const string HASH = "46e5897bac974e000fcc7e1d10d01ab8d3072eb2";
+	[Category (CATEGORY)]
+	public class XappyTester : SampleTester {
+		const string ORG = "davidortinau";
+		const string REPO = "Xappy";
+		const string CATEGORY = "davidortinauxappy"; // categories can't contain dashes
+		const string HASH = "46e5897bac974e000fcc7e1d10d01ab8d3072eb2";
 
-	//	static Dictionary<string, SampleTest> test_data = new Dictionary<string, SampleTest> {
-	//		// Known failures
-	//		{ "Xappy/Xappy.UWP/Xappy.UWP.csproj", new SampleTest { BuildSolution = true, Solution = "Xappy.sln", KnownFailure = "The target \"_IsProjectRestoreSupported\" does not exist in the project." } },
-	//	};
+		static Dictionary<string, SampleTest> test_data = new Dictionary<string, SampleTest> {
+			{ "Xappy/Xappy.UWP/Xappy.UWP.csproj", new SampleTest { BuildSolution = true, Solution = "Xappy.sln", RemoveProjects = new [] { "Xappy.Android", "Xappy.UWP" } } },
+		};
 
-	//	static IEnumerable<SampleTestData> GetSampleData ()
-	//	{
-	//		return GetSampleTestData (test_data, ORG, REPO, HASH, DefaultTimeout);
-	//	}
-	//}
+		static IEnumerable<SampleTestData> GetSampleData ()
+		{
+			return GetSampleTestData (test_data, ORG, REPO, HASH, DefaultTimeout);
+		}
+	}
 
 	[Category (CATEGORY)]
 	public class SmartHotelTester : SampleTester {


### PR DESCRIPTION
Most false positives are (so far) because `nuget restore` fails - both
due to network issues and a mono issue [1].

This PR allows to filter/remove some projects from a solution before
nuget is invoked. This can reduce the number of packages to download
which, beside reducing false positives, is good performance wise.

It also allows some project (e.g. Xappy.iOS) to build even if some other
projects (e.g. Xappy.UWP) in the solution can't be built.

[1] https://github.com/mono/mono/issues/15418