### PR TITLE
[Xharness] Fix all xml parsing issues and ensure that the xml can be consumed by VSTS.

### DIFF
--- a/tests/bcl-test/BCLTests-mac.csproj.in
+++ b/tests/bcl-test/BCLTests-mac.csproj.in
@@ -99,6 +99,9 @@
     <Compile Include="templates\common\TestRunner.NUnit\ClassOrNamespaceFilter.cs">
       <Link>TestRunner.NUnit\ClassOrNamespaceFilter.cs</Link>
     </Compile>
+    <Compile Include="templates\common\TestRunner.NUnit\XmlOutputWriter.cs">
+       <Link>TestRunner.NUnit\XmlOutputWriter.cs</Link>
+     </Compile>
     <Compile Include="templates\common\TestRunner.NUnit\TestMethodFilter.cs">
       <Link>TestRunner.NUnit\TestMethodFilter.cs</Link>
     </Compile>

--- a/tests/bcl-test/BCLTests-mac.csproj.in
+++ b/tests/bcl-test/BCLTests-mac.csproj.in
@@ -48,14 +48,16 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
-    <PackageReference Include="System.Memory" Version="4.5.2" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="System.Buffers" Version="4.4.0" />
+    <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
     <PackageReference Include="xunit.extensibility.core" Version="2.4.0" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.0" />
     <PackageReference Include="xunit.runner.utility" Version="2.4.0" />
+
+
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System">

--- a/tests/bcl-test/BCLTests-tv.csproj.in
+++ b/tests/bcl-test/BCLTests-tv.csproj.in
@@ -122,15 +122,15 @@
     <MtouchI18n>cjk,mideast,other,rare,west</MtouchI18n>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="System.Buffers" Version="4.4.0" />
-    <PackageReference Include="System.Memory" Version="4.5.1" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.0" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.utility" Version="2.4.0" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -175,9 +175,6 @@
     </Compile>
     <Compile Include="templates\common\TestRunner.NUnit\TestMethodFilter.cs">
       <Link>TestRunner.NUnit\TestMethodFilter.cs</Link>
-    </Compile>
-    <Compile Include="templates\common\TestRunner.NUnit\XmlOutputWriter.cs">
-      <Link>TestRunner.NUnit\XmlOutputWriter.cs</Link>
     </Compile>
     <Compile Include="templates\common\TestRunner.Core\Extensions.Bool.cs">
       <Link>TestRunner.Core\Extensions.Bool.cs</Link>

--- a/tests/bcl-test/BCLTests-tv.csproj.in
+++ b/tests/bcl-test/BCLTests-tv.csproj.in
@@ -176,6 +176,9 @@
     <Compile Include="templates\common\TestRunner.NUnit\TestMethodFilter.cs">
       <Link>TestRunner.NUnit\TestMethodFilter.cs</Link>
     </Compile>
+    <Compile Include="templates\common\TestRunner.NUnit\XmlOutputWriter.cs">
+      <Link>TestRunner.NUnit\XmlOutputWriter.cs</Link>
+    </Compile>
     <Compile Include="templates\common\TestRunner.Core\Extensions.Bool.cs">
       <Link>TestRunner.Core\Extensions.Bool.cs</Link>
     </Compile>

--- a/tests/bcl-test/BCLTests-watchos-extension.csproj.in
+++ b/tests/bcl-test/BCLTests-watchos-extension.csproj.in
@@ -128,15 +128,15 @@
     <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="System.Buffers" Version="4.4.0" />
-    <PackageReference Include="System.Memory" Version="4.5.1" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.0" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.utility" Version="2.4.0" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/bcl-test/BCLTests-watchos-extension.csproj.in
+++ b/tests/bcl-test/BCLTests-watchos-extension.csproj.in
@@ -206,6 +206,9 @@
     <Compile Include="templates\common\TestRunner.NUnit\TestMethodFilter.cs">
       <Link>TestRunner.NUnit\TestMethodFilter.cs</Link>
     </Compile>
+    <Compile Include="templates\common\TestRunner.NUnit\XmlOutputWriter.cs">
+      <Link>TestRunner.NUnit\XmlOutputWriter.cs</Link>
+    </Compile>
     <Compile Include="templates\common\TestRunner.xUnit\XUnitFilter.cs">
       <Link>TestRunner.xUnit\XUnitFilter.cs</Link>
     </Compile>

--- a/tests/bcl-test/BCLTests.csproj.in
+++ b/tests/bcl-test/BCLTests.csproj.in
@@ -189,6 +189,9 @@
     <Compile Include="templates\common\TestRunner.NUnit\TestMethodFilter.cs">
       <Link>TestRunner.NUnit\TestMethodFilter.cs</Link>
     </Compile>
+    <Compile Include="templates\common\TestRunner.NUnit\XmlOutputWriter.cs">
+      <Link>TestRunner.NUnit\XmlOutputWriter.cs</Link>
+    </Compile>
     <Compile Include="templates\common\TestRunner.Core\Extensions.Bool.cs">
       <Link>TestRunner.Core\Extensions.Bool.cs</Link>
     </Compile>

--- a/tests/bcl-test/BCLTests.csproj.in
+++ b/tests/bcl-test/BCLTests.csproj.in
@@ -135,15 +135,15 @@
     <MtouchI18n>cjk,mideast,other,rare,west</MtouchI18n>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="System.Buffers" Version="4.4.0" />
-    <PackageReference Include="System.Memory" Version="4.5.1" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.0" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.utility" Version="2.4.0" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/bcl-test/templates/common/TestRunner.NUnit/NUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.NUnit/NUnitTestRunner.cs
@@ -274,7 +274,9 @@ namespace Xamarin.iOS.UnitTests.NUnit
 			if (results == null)
 				return;
 			var resultsXml = new NUnit2XmlOutputWriter (DateTime.UtcNow);
+			writer.WriteLine ("<!--This file represents the results of running a test suite-->");
 			resultsXml.WriteResultFile (results, writer);
+			writer.WriteLine ("<!-- the end -->");
 		}
 		
 		void AppendFilter (ITestFilter filter)

--- a/tests/bcl-test/templates/common/TestRunner.NUnit/NUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.NUnit/NUnitTestRunner.cs
@@ -9,10 +9,8 @@ using System.Threading.Tasks;
 
 using Foundation;
 
-using NUnitLite.Runner;
 using NUnit.Framework.Api;
 using NUnit.Framework.Internal;
-using NUnit.Framework.Internal.WorkItems;
 using NUnit.Framework.Internal.Filters;
 
 using NUnitTest = NUnit.Framework.Internal.Test;

--- a/tests/bcl-test/templates/common/TestRunner.NUnit/NUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.NUnit/NUnitTestRunner.cs
@@ -272,9 +272,7 @@ namespace Xamarin.iOS.UnitTests.NUnit
 			if (results == null)
 				return;
 			var resultsXml = new NUnit2XmlOutputWriter (DateTime.UtcNow);
-			writer.WriteLine ("<!--This file represents the results of running a test suite-->");
 			resultsXml.WriteResultFile (results, writer);
-			writer.WriteLine ("<!-- the end -->");
 		}
 		
 		void AppendFilter (ITestFilter filter)

--- a/tests/bcl-test/templates/common/TestRunner.NUnit/XmlOutputWriter.cs
+++ b/tests/bcl-test/templates/common/TestRunner.NUnit/XmlOutputWriter.cs
@@ -1,0 +1,345 @@
+﻿// ***********************************************************************
+// Copyright (c) 2011 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Globalization;
+using System.Reflection;
+using System.Xml;
+using System.IO;
+using NUnit.Framework.Api;
+using NUnit.Framework.Internal;
+using NUnitLite.Runner;
+#if CLR_2_0 || CLR_4_0
+using System.Collections.Generic;
+#else
+using System.Collections.Specialized;
+#endif
+
+namespace Xamarin.iOS.UnitTests.NUnit {
+        /// <summary>
+        /// NUnit2XmlOutputWriter is able to create an xml file representing
+        /// the result of a test run in NUnit 2.x format.
+        /// </summary>
+        public class NUnit2XmlOutputWriter : OutputWriter {
+                private XmlWriter xmlWriter;
+                private DateTime startTime;
+
+#if CLR_2_0 || CLR_4_0
+        private static Dictionary<string, string> resultStates = new Dictionary<string, string>();
+#else
+                private static StringDictionary resultStates = new StringDictionary ();
+#endif
+
+                static NUnit2XmlOutputWriter ()
+                {
+                        resultStates ["Passed"] = "Success";
+                        resultStates ["Failed"] = "Failure";
+                        resultStates ["Failed:Error"] = "Error";
+                        resultStates ["Failed:Cancelled"] = "Cancelled";
+                        resultStates ["Inconclusive"] = "Inconclusive";
+                        resultStates ["Skipped"] = "Skipped";
+                        resultStates ["Skipped:Ignored"] = "Ignored";
+                        resultStates ["Skipped:Invalid"] = "NotRunnable";
+                }
+
+                public NUnit2XmlOutputWriter (DateTime startTime)
+                {
+                        this.startTime = startTime;
+                }
+
+                /// <summary>
+                /// Writes the result of a test run to a specified TextWriter.
+                /// </summary>
+                /// <param name="result">The test result for the run</param>
+                /// <param name="writer">The TextWriter to which the xml will be written</param>
+                public override void WriteResultFile (ITestResult result, TextWriter writer)
+                {
+                        // NOTE: Under .NET 1.1, XmlTextWriter does not implement IDisposable,
+                        // but does implement Close(). Hence we cannot use a 'using' clause.
+                        //using (XmlTextWriter xmlWriter = new XmlTextWriter(writer))
+#if SILVERLIGHT
+            XmlWriter xmlWriter = XmlWriter.Create(writer);
+#else
+                        XmlTextWriter xmlWriter = new XmlTextWriter (writer);
+                        xmlWriter.Formatting = Formatting.Indented;
+#endif
+
+                        try {
+                                WriteXmlOutput (result, xmlWriter);
+                        } finally {
+                                writer.Close ();
+                        }
+                }
+
+                private void WriteXmlOutput (ITestResult result, XmlWriter xmlWriter)
+                {
+                        this.xmlWriter = xmlWriter;
+
+                        InitializeXmlFile (result);
+                        WriteResultElement (result);
+                        TerminateXmlFile ();
+                }
+
+                private void InitializeXmlFile (ITestResult result)
+                {
+                        ResultSummary summaryResults = new ResultSummary (result);
+
+                        xmlWriter.WriteStartDocument (false);
+                        xmlWriter.WriteComment ("This file represents the results of running a test suite");
+
+                        xmlWriter.WriteStartElement ("test-results");
+
+                        xmlWriter.WriteAttributeString ("name", result.FullName);
+                        xmlWriter.WriteAttributeString ("total", summaryResults.TestCount.ToString ());
+                        xmlWriter.WriteAttributeString ("errors", summaryResults.ErrorCount.ToString ());
+                        xmlWriter.WriteAttributeString ("failures", summaryResults.FailureCount.ToString ());
+                        xmlWriter.WriteAttributeString ("not-run", summaryResults.NotRunCount.ToString ());
+                        xmlWriter.WriteAttributeString ("inconclusive", summaryResults.InconclusiveCount.ToString ());
+                        xmlWriter.WriteAttributeString ("ignored", summaryResults.IgnoreCount.ToString ());
+                        xmlWriter.WriteAttributeString ("skipped", summaryResults.SkipCount.ToString ());
+                        xmlWriter.WriteAttributeString ("invalid", summaryResults.InvalidCount.ToString ());
+
+                        xmlWriter.WriteAttributeString ("date", XmlConvert.ToString (startTime, "yyyy-MM-dd"));
+                        xmlWriter.WriteAttributeString ("time", XmlConvert.ToString (startTime, "HH:mm:ss"));
+                        WriteEnvironment ();
+                        WriteCultureInfo ();
+                }
+
+                private void WriteCultureInfo ()
+                {
+                        xmlWriter.WriteStartElement ("culture-info");
+                        xmlWriter.WriteAttributeString ("current-culture",
+                                                       CultureInfo.CurrentCulture.ToString ());
+                        xmlWriter.WriteAttributeString ("current-uiculture",
+                                                       CultureInfo.CurrentUICulture.ToString ());
+                        xmlWriter.WriteEndElement ();
+                }
+
+                private void WriteEnvironment ()
+                {
+                        xmlWriter.WriteStartElement ("environment");
+                        AssemblyName assemblyName = AssemblyHelper.GetAssemblyName (Assembly.GetExecutingAssembly ());
+                        xmlWriter.WriteAttributeString ("nunit-version",
+                                                       assemblyName.Version.ToString ());
+                        xmlWriter.WriteAttributeString ("clr-version",
+                                                       Environment.Version.ToString ());
+                        xmlWriter.WriteAttributeString ("os-version",
+                                                       Environment.OSVersion.ToString ());
+                        xmlWriter.WriteAttributeString ("platform",
+                            Environment.OSVersion.Platform.ToString ());
+#if !NETCF
+                        xmlWriter.WriteAttributeString ("cwd",
+                                                       Environment.CurrentDirectory);
+#if !SILVERLIGHT
+                        xmlWriter.WriteAttributeString ("machine-name",
+                                                       Environment.MachineName);
+                        xmlWriter.WriteAttributeString ("user",
+                                                       Environment.UserName);
+                        xmlWriter.WriteAttributeString ("user-domain",
+                                                       Environment.UserDomainName);
+#endif
+#endif
+                        xmlWriter.WriteEndElement ();
+                }
+
+                private void WriteResultElement (ITestResult result)
+                {
+                        StartTestElement (result);
+
+                        WriteProperties (result);
+
+                        switch (result.ResultState.Status) {
+                        case TestStatus.Skipped:
+                                WriteReasonElement (result.Message);
+                                break;
+                        case TestStatus.Failed:
+                                WriteFailureElement (result.Message, result.StackTrace);
+                                break;
+                        }
+
+                        if (result.Test is TestSuite)
+                                WriteChildResults (result);
+
+                        xmlWriter.WriteEndElement (); // test element
+                }
+
+                private void TerminateXmlFile ()
+                {
+                        xmlWriter.WriteEndElement (); // test-results
+                        xmlWriter.WriteEndDocument ();
+                        xmlWriter.Flush ();
+                        xmlWriter.Close ();
+                }
+
+
+                #region Element Creation Helpers
+
+                private void StartTestElement (ITestResult result)
+                {
+                        ITest test = result.Test;
+                        TestSuite suite = test as TestSuite;
+
+                        if (suite != null) {
+                                xmlWriter.WriteStartElement ("test-suite");
+                                xmlWriter.WriteAttributeString ("type", suite.TestType);
+                                xmlWriter.WriteAttributeString ("name", suite.TestType == "Assembly"
+                                    ? result.Test.FullName
+                                    : result.Test.Name);
+                        } else {
+                                xmlWriter.WriteStartElement ("test-case");
+                                xmlWriter.WriteAttributeString ("name", result.Name);
+                        }
+
+                        if (test.Properties.ContainsKey (PropertyNames.Description)) {
+                                string description = (string)test.Properties.Get (PropertyNames.Description);
+                                xmlWriter.WriteAttributeString ("description", description);
+                        }
+
+                        TestStatus status = result.ResultState.Status;
+                        string translatedResult = resultStates [result.ResultState.ToString ()];
+
+                        if (status != TestStatus.Skipped) {
+                                xmlWriter.WriteAttributeString ("executed", "True");
+                                xmlWriter.WriteAttributeString ("result", translatedResult);
+                                xmlWriter.WriteAttributeString ("success", status == TestStatus.Passed ? "True" : "False");
+                                xmlWriter.WriteAttributeString ("time", result.Duration.TotalSeconds.ToString ());
+                                xmlWriter.WriteAttributeString ("asserts", result.AssertCount.ToString ());
+                        } else {
+                                xmlWriter.WriteAttributeString ("executed", "False");
+                                xmlWriter.WriteAttributeString ("result", translatedResult);
+                        }
+                }
+
+                private void WriteProperties (ITestResult result)
+                {
+                        IPropertyBag properties = result.Test.Properties;
+                        int nprops = 0;
+
+                        foreach (string key in properties.Keys) {
+                                if (key != PropertyNames.Category) {
+                                        if (nprops++ == 0)
+                                                xmlWriter.WriteStartElement ("properties");
+
+                                        foreach (object prop in properties [key]) {
+                                                xmlWriter.WriteStartElement ("property");
+                                                xmlWriter.WriteAttributeString ("name", key);
+                                                xmlWriter.WriteAttributeString ("value", prop.ToString ());
+                                                xmlWriter.WriteEndElement ();
+                                        }
+                                }
+                        }
+
+                        if (nprops > 0)
+                                xmlWriter.WriteEndElement ();
+                }
+
+                private void WriteReasonElement (string message)
+                {
+                        xmlWriter.WriteStartElement ("reason");
+                        xmlWriter.WriteStartElement ("message");
+                        xmlWriter.WriteCData (message);
+                        xmlWriter.WriteEndElement ();
+                        xmlWriter.WriteEndElement ();
+                }
+
+                private void WriteFailureElement (string message, string stackTrace)
+                {
+                        xmlWriter.WriteStartElement ("failure");
+                        xmlWriter.WriteStartElement ("message");
+                        WriteCData (message);
+                        xmlWriter.WriteEndElement ();
+                        xmlWriter.WriteStartElement ("stack-trace");
+                        if (stackTrace != null)
+                                WriteCData (stackTrace);
+                        xmlWriter.WriteEndElement ();
+                        xmlWriter.WriteEndElement ();
+                }
+
+                private void WriteChildResults (ITestResult result)
+                {
+                        xmlWriter.WriteStartElement ("results");
+
+                        foreach (ITestResult childResult in result.Children)
+                                WriteResultElement (childResult);
+
+                        xmlWriter.WriteEndElement ();
+                }
+
+                #endregion
+
+                #region Output Helpers
+                ///// <summary>
+                ///// Makes string safe for xml parsing, replacing control chars with '?'
+                ///// </summary>
+                ///// <param name="encodedString">string to make safe</param>
+                ///// <returns>xml safe string</returnCs>
+                //private static string CharacterSafeString(string encodedString)
+                //{
+                //    /*The default code page for the system will be used.
+                //    Since all code pages use the same lower 128 bytes, this should be sufficient
+                //    for finding uprintable control characters that make the xslt processor error.
+                //    We use characters encoded by the default code page to avoid mistaking bytes as
+                //    individual characters on non-latin code pages.*/
+                //    char[] encodedChars = System.Text.Encoding.Default.GetChars(System.Text.Encoding.Default.GetBytes(encodedString));
+
+                //    System.Collections.ArrayList pos = new System.Collections.ArrayList();
+                //    for (int x = 0; x < encodedChars.Length; x++)
+                //    {
+                //        char currentChar = encodedChars[x];
+                //        //unprintable characters are below 0x20 in Unicode tables
+                //        //some control characters are acceptable. (carriage return 0x0D, line feed 0x0A, horizontal tab 0x09)
+                //        if (currentChar < 32 && (currentChar != 9 && currentChar != 10 && currentChar != 13))
+                //        {
+                //            //save the array index for later replacement.
+                //            pos.Add(x);
+                //        }
+                //    }
+                //    foreach (int index in pos)
+                //    {
+                //        encodedChars[index] = '?';//replace unprintable control characters with ?(3F)
+                //    }
+                //    return System.Text.Encoding.Default.GetString(System.Text.Encoding.Default.GetBytes(encodedChars));
+                //}
+
+                private void WriteCData (string text)
+                {
+                        int start = 0;
+                        while (true) {
+                                int illegal = text.IndexOf ("]]>", start);
+                                if (illegal < 0)
+                                        break;
+                                xmlWriter.WriteCData (text.Substring (start, illegal - start + 2));
+                                start = illegal + 2;
+                                if (start >= text.Length)
+                                        return;
+                        }
+
+                        if (start > 0)
+                                xmlWriter.WriteCData (text.Substring (start));
+                        else
+                                xmlWriter.WriteCData (text);
+                }
+
+                #endregion
+        }
+}

--- a/tests/bcl-test/templates/common/TestRunner.NUnit/XmlOutputWriter.cs
+++ b/tests/bcl-test/templates/common/TestRunner.NUnit/XmlOutputWriter.cs
@@ -36,310 +36,314 @@ using System.Collections.Specialized;
 #endif
 
 namespace Xamarin.iOS.UnitTests.NUnit {
-        /// <summary>
-        /// NUnit2XmlOutputWriter is able to create an xml file representing
-        /// the result of a test run in NUnit 2.x format.
-        /// </summary>
-        public class NUnit2XmlOutputWriter : OutputWriter {
-                private XmlWriter xmlWriter;
-                private DateTime startTime;
+	/// <summary>
+	/// NUnit2XmlOutputWriter is able to create an xml file representing
+	/// the result of a test run in NUnit 2.x format.
+	/// </summary>
+	public class NUnit2XmlOutputWriter : OutputWriter {
+		private XmlWriter xmlWriter;
+		private DateTime startTime;
 
 #if CLR_2_0 || CLR_4_0
-        private static Dictionary<string, string> resultStates = new Dictionary<string, string>();
+	private static Dictionary<string, string> resultStates = new Dictionary<string, string>();
 #else
-                private static StringDictionary resultStates = new StringDictionary ();
+		private static StringDictionary resultStates = new StringDictionary ();
 #endif
 
-                static NUnit2XmlOutputWriter ()
-                {
-                        resultStates ["Passed"] = "Success";
-                        resultStates ["Failed"] = "Failure";
-                        resultStates ["Failed:Error"] = "Error";
-                        resultStates ["Failed:Cancelled"] = "Cancelled";
-                        resultStates ["Inconclusive"] = "Inconclusive";
-                        resultStates ["Skipped"] = "Skipped";
-                        resultStates ["Skipped:Ignored"] = "Ignored";
-                        resultStates ["Skipped:Invalid"] = "NotRunnable";
-                }
+		static NUnit2XmlOutputWriter ()
+		{
+			resultStates ["Passed"] = "Success";
+			resultStates ["Failed"] = "Failure";
+			resultStates ["Failed:Error"] = "Error";
+			resultStates ["Failed:Cancelled"] = "Cancelled";
+			resultStates ["Inconclusive"] = "Inconclusive";
+			resultStates ["Skipped"] = "Skipped";
+			resultStates ["Skipped:Ignored"] = "Ignored";
+			resultStates ["Skipped:Invalid"] = "NotRunnable";
+		}
 
-                public NUnit2XmlOutputWriter (DateTime startTime)
-                {
-                        this.startTime = startTime;
-                }
+		public NUnit2XmlOutputWriter (DateTime startTime)
+		{
+			this.startTime = startTime;
+		}
 
-                /// <summary>
-                /// Writes the result of a test run to a specified TextWriter.
-                /// </summary>
-                /// <param name="result">The test result for the run</param>
-                /// <param name="writer">The TextWriter to which the xml will be written</param>
-                public override void WriteResultFile (ITestResult result, TextWriter writer)
-                {
-                        // NOTE: Under .NET 1.1, XmlTextWriter does not implement IDisposable,
-                        // but does implement Close(). Hence we cannot use a 'using' clause.
-                        //using (XmlTextWriter xmlWriter = new XmlTextWriter(writer))
+		/// <summary>
+		/// Writes the result of a test run to a specified TextWriter.
+		/// </summary>
+		/// <param name="result">The test result for the run</param>
+		/// <param name="writer">The TextWriter to which the xml will be written</param>
+		public override void WriteResultFile (ITestResult result, TextWriter writer)
+		{
+			// NOTE: Under .NET 1.1, XmlTextWriter does not implement IDisposable,
+			// but does implement Close(). Hence we cannot use a 'using' clause.
+			//using (XmlTextWriter xmlWriter = new XmlTextWriter(writer))
 #if SILVERLIGHT
-            XmlWriter xmlWriter = XmlWriter.Create(writer);
+	    XmlWriter xmlWriter = XmlWriter.Create(writer);
 #else
-                        XmlTextWriter xmlWriter = new XmlTextWriter (writer);
-                        xmlWriter.Formatting = Formatting.Indented;
+			XmlTextWriter xmlWriter = new XmlTextWriter (writer);
+			xmlWriter.Formatting = Formatting.Indented;
 #endif
 
-                        try {
-                                WriteXmlOutput (result, xmlWriter);
-                        } finally {
-                                writer.Close ();
-                        }
-                }
+			try {
+				WriteXmlOutput (result, xmlWriter);
+			} finally {
+				writer.Close ();
+			}
+		}
 
-                private void WriteXmlOutput (ITestResult result, XmlWriter xmlWriter)
-                {
-                        this.xmlWriter = xmlWriter;
+		private void WriteXmlOutput (ITestResult result, XmlWriter xmlWriter)
+		{
+			this.xmlWriter = xmlWriter;
 
-                        InitializeXmlFile (result);
-                        WriteResultElement (result);
-                        TerminateXmlFile ();
-                }
+			InitializeXmlFile (result);
+			WriteResultElement (result);
+			TerminateXmlFile ();
+		}
 
-                private void InitializeXmlFile (ITestResult result)
-                {
-                        ResultSummary summaryResults = new ResultSummary (result);
+		private void InitializeXmlFile (ITestResult result)
+		{
+			ResultSummary summaryResults = new ResultSummary (result);
 
-                        xmlWriter.WriteStartDocument (false);
-                        xmlWriter.WriteComment ("This file represents the results of running a test suite");
+			xmlWriter.WriteStartDocument (false);
+			xmlWriter.WriteComment ("This file represents the results of running a test suite");
 
-                        xmlWriter.WriteStartElement ("test-results");
+			xmlWriter.WriteStartElement ("test-results");
 
-                        xmlWriter.WriteAttributeString ("name", result.FullName);
-                        xmlWriter.WriteAttributeString ("total", summaryResults.TestCount.ToString ());
-                        xmlWriter.WriteAttributeString ("errors", summaryResults.ErrorCount.ToString ());
-                        xmlWriter.WriteAttributeString ("failures", summaryResults.FailureCount.ToString ());
-                        xmlWriter.WriteAttributeString ("not-run", summaryResults.NotRunCount.ToString ());
-                        xmlWriter.WriteAttributeString ("inconclusive", summaryResults.InconclusiveCount.ToString ());
-                        xmlWriter.WriteAttributeString ("ignored", summaryResults.IgnoreCount.ToString ());
-                        xmlWriter.WriteAttributeString ("skipped", summaryResults.SkipCount.ToString ());
-                        xmlWriter.WriteAttributeString ("invalid", summaryResults.InvalidCount.ToString ());
+			xmlWriter.WriteAttributeString ("name", result.FullName);
+			xmlWriter.WriteAttributeString ("total", summaryResults.TestCount.ToString ());
+			xmlWriter.WriteAttributeString ("errors", summaryResults.ErrorCount.ToString ());
+			xmlWriter.WriteAttributeString ("failures", summaryResults.FailureCount.ToString ());
+			xmlWriter.WriteAttributeString ("not-run", summaryResults.NotRunCount.ToString ());
+			xmlWriter.WriteAttributeString ("inconclusive", summaryResults.InconclusiveCount.ToString ());
+			xmlWriter.WriteAttributeString ("ignored", summaryResults.IgnoreCount.ToString ());
+			xmlWriter.WriteAttributeString ("skipped", summaryResults.SkipCount.ToString ());
+			xmlWriter.WriteAttributeString ("invalid", summaryResults.InvalidCount.ToString ());
 
-                        xmlWriter.WriteAttributeString ("date", XmlConvert.ToString (startTime, "yyyy-MM-dd"));
-                        xmlWriter.WriteAttributeString ("time", XmlConvert.ToString (startTime, "HH:mm:ss"));
-                        WriteEnvironment ();
-                        WriteCultureInfo ();
-                }
+			xmlWriter.WriteAttributeString ("date", XmlConvert.ToString (startTime, "yyyy-MM-dd"));
+			xmlWriter.WriteAttributeString ("time", XmlConvert.ToString (startTime, "HH:mm:ss"));
+			WriteEnvironment ();
+			WriteCultureInfo ();
+			xmlWriter.Flush ();
+		}
 
-                private void WriteCultureInfo ()
-                {
-                        xmlWriter.WriteStartElement ("culture-info");
-                        xmlWriter.WriteAttributeString ("current-culture",
-                                                       CultureInfo.CurrentCulture.ToString ());
-                        xmlWriter.WriteAttributeString ("current-uiculture",
-                                                       CultureInfo.CurrentUICulture.ToString ());
-                        xmlWriter.WriteEndElement ();
-                }
+		private void WriteCultureInfo ()
+		{
+			xmlWriter.WriteStartElement ("culture-info");
+			xmlWriter.WriteAttributeString ("current-culture",
+						       CultureInfo.CurrentCulture.ToString ());
+			xmlWriter.WriteAttributeString ("current-uiculture",
+						       CultureInfo.CurrentUICulture.ToString ());
+			xmlWriter.WriteEndElement ();
+			xmlWriter.Flush ();
+		}
 
-                private void WriteEnvironment ()
-                {
-                        xmlWriter.WriteStartElement ("environment");
-                        AssemblyName assemblyName = AssemblyHelper.GetAssemblyName (Assembly.GetExecutingAssembly ());
-                        xmlWriter.WriteAttributeString ("nunit-version",
-                                                       assemblyName.Version.ToString ());
-                        xmlWriter.WriteAttributeString ("clr-version",
-                                                       Environment.Version.ToString ());
-                        xmlWriter.WriteAttributeString ("os-version",
-                                                       Environment.OSVersion.ToString ());
-                        xmlWriter.WriteAttributeString ("platform",
-                            Environment.OSVersion.Platform.ToString ());
+		private void WriteEnvironment ()
+		{
+			xmlWriter.WriteStartElement ("environment");
+			AssemblyName assemblyName = AssemblyHelper.GetAssemblyName (Assembly.GetExecutingAssembly ());
+			xmlWriter.WriteAttributeString ("nunit-version",
+						       assemblyName.Version.ToString ());
+			xmlWriter.WriteAttributeString ("clr-version",
+						       Environment.Version.ToString ());
+			xmlWriter.WriteAttributeString ("os-version",
+						       Environment.OSVersion.ToString ());
+			xmlWriter.WriteAttributeString ("platform",
+			    Environment.OSVersion.Platform.ToString ());
 #if !NETCF
-                        xmlWriter.WriteAttributeString ("cwd",
-                                                       Environment.CurrentDirectory);
+			xmlWriter.WriteAttributeString ("cwd",
+						       Environment.CurrentDirectory);
 #if !SILVERLIGHT
-                        xmlWriter.WriteAttributeString ("machine-name",
-                                                       Environment.MachineName);
-                        xmlWriter.WriteAttributeString ("user",
-                                                       Environment.UserName);
-                        xmlWriter.WriteAttributeString ("user-domain",
-                                                       Environment.UserDomainName);
+			xmlWriter.WriteAttributeString ("machine-name",
+						       Environment.MachineName);
+			xmlWriter.WriteAttributeString ("user",
+						       Environment.UserName);
+			xmlWriter.WriteAttributeString ("user-domain",
+						       Environment.UserDomainName);
 #endif
 #endif
-                        xmlWriter.WriteEndElement ();
-                }
+			xmlWriter.WriteEndElement ();
+			xmlWriter.Flush ();
+		}
 
-                private void WriteResultElement (ITestResult result)
-                {
-                        StartTestElement (result);
+		private void WriteResultElement (ITestResult result)
+		{
+			StartTestElement (result);
 
-                        WriteProperties (result);
+			WriteProperties (result);
 
-                        switch (result.ResultState.Status) {
-                        case TestStatus.Skipped:
-                                WriteReasonElement (result.Message);
-                                break;
-                        case TestStatus.Failed:
-                                WriteFailureElement (result.Message, result.StackTrace);
-                                break;
-                        }
+			switch (result.ResultState.Status) {
+			case TestStatus.Skipped:
+				WriteReasonElement (result.Message);
+				break;
+			case TestStatus.Failed:
+				WriteFailureElement (result.Message, result.StackTrace);
+				break;
+			}
 
-                        if (result.Test is TestSuite)
-                                WriteChildResults (result);
+			if (result.Test is TestSuite)
+				WriteChildResults (result);
 
-                        xmlWriter.WriteEndElement (); // test element
-                }
+			xmlWriter.WriteEndElement (); // test element
+			xmlWriter.Flush ();
+		}
 
-                private void TerminateXmlFile ()
-                {
-                        xmlWriter.WriteEndElement (); // test-results
-                        xmlWriter.WriteEndDocument ();
-                        xmlWriter.Flush ();
-                        xmlWriter.Close ();
-                }
+		private void TerminateXmlFile ()
+		{
+			xmlWriter.WriteEndElement (); // test-results
+			xmlWriter.WriteEndDocument ();
+			xmlWriter.Flush ();
+			xmlWriter.Close ();
+		}
 
 
-                #region Element Creation Helpers
+		#region Element Creation Helpers
 
-                private void StartTestElement (ITestResult result)
-                {
-                        ITest test = result.Test;
-                        TestSuite suite = test as TestSuite;
+		private void StartTestElement (ITestResult result)
+		{
+			ITest test = result.Test;
+			TestSuite suite = test as TestSuite;
 
-                        if (suite != null) {
-                                xmlWriter.WriteStartElement ("test-suite");
-                                xmlWriter.WriteAttributeString ("type", suite.TestType);
-                                xmlWriter.WriteAttributeString ("name", suite.TestType == "Assembly"
-                                    ? result.Test.FullName
-                                    : result.Test.Name);
-                        } else {
-                                xmlWriter.WriteStartElement ("test-case");
-                                xmlWriter.WriteAttributeString ("name", result.Name);
-                        }
+			if (suite != null) {
+				xmlWriter.WriteStartElement ("test-suite");
+				xmlWriter.WriteAttributeString ("type", suite.TestType);
+				xmlWriter.WriteAttributeString ("name", suite.TestType == "Assembly"
+				    ? result.Test.FullName
+				    : result.Test.Name);
+			} else {
+				xmlWriter.WriteStartElement ("test-case");
+				xmlWriter.WriteAttributeString ("name", result.Name);
+			}
 
-                        if (test.Properties.ContainsKey (PropertyNames.Description)) {
-                                string description = (string)test.Properties.Get (PropertyNames.Description);
-                                xmlWriter.WriteAttributeString ("description", description);
-                        }
+			if (test.Properties.ContainsKey (PropertyNames.Description)) {
+				string description = (string)test.Properties.Get (PropertyNames.Description);
+				xmlWriter.WriteAttributeString ("description", description);
+			}
 
-                        TestStatus status = result.ResultState.Status;
-                        string translatedResult = resultStates [result.ResultState.ToString ()];
+			TestStatus status = result.ResultState.Status;
+			string translatedResult = resultStates [result.ResultState.ToString ()];
 
-                        if (status != TestStatus.Skipped) {
-                                xmlWriter.WriteAttributeString ("executed", "True");
-                                xmlWriter.WriteAttributeString ("result", translatedResult);
-                                xmlWriter.WriteAttributeString ("success", status == TestStatus.Passed ? "True" : "False");
-                                xmlWriter.WriteAttributeString ("time", result.Duration.TotalSeconds.ToString ());
-                                xmlWriter.WriteAttributeString ("asserts", result.AssertCount.ToString ());
-                        } else {
-                                xmlWriter.WriteAttributeString ("executed", "False");
-                                xmlWriter.WriteAttributeString ("result", translatedResult);
-                        }
-                }
+			if (status != TestStatus.Skipped) {
+				xmlWriter.WriteAttributeString ("executed", "True");
+				xmlWriter.WriteAttributeString ("result", translatedResult);
+				xmlWriter.WriteAttributeString ("success", status == TestStatus.Passed ? "True" : "False");
+				xmlWriter.WriteAttributeString ("time", result.Duration.TotalSeconds.ToString ());
+				xmlWriter.WriteAttributeString ("asserts", result.AssertCount.ToString ());
+			} else {
+				xmlWriter.WriteAttributeString ("executed", "False");
+				xmlWriter.WriteAttributeString ("result", translatedResult);
+			}
+		}
 
-                private void WriteProperties (ITestResult result)
-                {
-                        IPropertyBag properties = result.Test.Properties;
-                        int nprops = 0;
+		private void WriteProperties (ITestResult result)
+		{
+			IPropertyBag properties = result.Test.Properties;
+			int nprops = 0;
 
-                        foreach (string key in properties.Keys) {
-                                if (key != PropertyNames.Category) {
-                                        if (nprops++ == 0)
-                                                xmlWriter.WriteStartElement ("properties");
+			foreach (string key in properties.Keys) {
+				if (key != PropertyNames.Category) {
+					if (nprops++ == 0)
+						xmlWriter.WriteStartElement ("properties");
 
-                                        foreach (object prop in properties [key]) {
-                                                xmlWriter.WriteStartElement ("property");
-                                                xmlWriter.WriteAttributeString ("name", key);
-                                                xmlWriter.WriteAttributeString ("value", prop.ToString ());
-                                                xmlWriter.WriteEndElement ();
-                                        }
-                                }
-                        }
+					foreach (object prop in properties [key]) {
+						xmlWriter.WriteStartElement ("property");
+						xmlWriter.WriteAttributeString ("name", key);
+						xmlWriter.WriteAttributeString ("value", prop.ToString ());
+						xmlWriter.WriteEndElement ();
+					}
+				}
+			}
 
-                        if (nprops > 0)
-                                xmlWriter.WriteEndElement ();
-                }
+			if (nprops > 0)
+				xmlWriter.WriteEndElement ();
+		}
 
-                private void WriteReasonElement (string message)
-                {
-                        xmlWriter.WriteStartElement ("reason");
-                        xmlWriter.WriteStartElement ("message");
-                        xmlWriter.WriteCData (message);
-                        xmlWriter.WriteEndElement ();
-                        xmlWriter.WriteEndElement ();
-                }
+		private void WriteReasonElement (string message)
+		{
+			xmlWriter.WriteStartElement ("reason");
+			xmlWriter.WriteStartElement ("message");
+			xmlWriter.WriteCData (message);
+			xmlWriter.WriteEndElement ();
+			xmlWriter.WriteEndElement ();
+		}
 
-                private void WriteFailureElement (string message, string stackTrace)
-                {
-                        xmlWriter.WriteStartElement ("failure");
-                        xmlWriter.WriteStartElement ("message");
-                        WriteCData (message);
-                        xmlWriter.WriteEndElement ();
-                        xmlWriter.WriteStartElement ("stack-trace");
-                        if (stackTrace != null)
-                                WriteCData (stackTrace);
-                        xmlWriter.WriteEndElement ();
-                        xmlWriter.WriteEndElement ();
-                }
+		private void WriteFailureElement (string message, string stackTrace)
+		{
+			xmlWriter.WriteStartElement ("failure");
+			xmlWriter.WriteStartElement ("message");
+			WriteCData (message);
+			xmlWriter.WriteEndElement ();
+			xmlWriter.WriteStartElement ("stack-trace");
+			if (stackTrace != null)
+				WriteCData (stackTrace);
+			xmlWriter.WriteEndElement ();
+			xmlWriter.WriteEndElement ();
+		}
 
-                private void WriteChildResults (ITestResult result)
-                {
-                        xmlWriter.WriteStartElement ("results");
+		private void WriteChildResults (ITestResult result)
+		{
+			xmlWriter.WriteStartElement ("results");
 
-                        foreach (ITestResult childResult in result.Children)
-                                WriteResultElement (childResult);
+			foreach (ITestResult childResult in result.Children)
+				WriteResultElement (childResult);
 
-                        xmlWriter.WriteEndElement ();
-                }
+			xmlWriter.WriteEndElement ();
+		}
 
-                #endregion
+		#endregion
 
-                #region Output Helpers
-                ///// <summary>
-                ///// Makes string safe for xml parsing, replacing control chars with '?'
-                ///// </summary>
-                ///// <param name="encodedString">string to make safe</param>
-                ///// <returns>xml safe string</returnCs>
-                //private static string CharacterSafeString(string encodedString)
-                //{
-                //    /*The default code page for the system will be used.
-                //    Since all code pages use the same lower 128 bytes, this should be sufficient
-                //    for finding uprintable control characters that make the xslt processor error.
-                //    We use characters encoded by the default code page to avoid mistaking bytes as
-                //    individual characters on non-latin code pages.*/
-                //    char[] encodedChars = System.Text.Encoding.Default.GetChars(System.Text.Encoding.Default.GetBytes(encodedString));
+		#region Output Helpers
+		///// <summary>
+		///// Makes string safe for xml parsing, replacing control chars with '?'
+		///// </summary>
+		///// <param name="encodedString">string to make safe</param>
+		///// <returns>xml safe string</returnCs>
+		//private static string CharacterSafeString(string encodedString)
+		//{
+		//    /*The default code page for the system will be used.
+		//    Since all code pages use the same lower 128 bytes, this should be sufficient
+		//    for finding uprintable control characters that make the xslt processor error.
+		//    We use characters encoded by the default code page to avoid mistaking bytes as
+		//    individual characters on non-latin code pages.*/
+		//    char[] encodedChars = System.Text.Encoding.Default.GetChars(System.Text.Encoding.Default.GetBytes(encodedString));
 
-                //    System.Collections.ArrayList pos = new System.Collections.ArrayList();
-                //    for (int x = 0; x < encodedChars.Length; x++)
-                //    {
-                //        char currentChar = encodedChars[x];
-                //        //unprintable characters are below 0x20 in Unicode tables
-                //        //some control characters are acceptable. (carriage return 0x0D, line feed 0x0A, horizontal tab 0x09)
-                //        if (currentChar < 32 && (currentChar != 9 && currentChar != 10 && currentChar != 13))
-                //        {
-                //            //save the array index for later replacement.
-                //            pos.Add(x);
-                //        }
-                //    }
-                //    foreach (int index in pos)
-                //    {
-                //        encodedChars[index] = '?';//replace unprintable control characters with ?(3F)
-                //    }
-                //    return System.Text.Encoding.Default.GetString(System.Text.Encoding.Default.GetBytes(encodedChars));
-                //}
+		//    System.Collections.ArrayList pos = new System.Collections.ArrayList();
+		//    for (int x = 0; x < encodedChars.Length; x++)
+		//    {
+		//        char currentChar = encodedChars[x];
+		//        //unprintable characters are below 0x20 in Unicode tables
+		//        //some control characters are acceptable. (carriage return 0x0D, line feed 0x0A, horizontal tab 0x09)
+		//        if (currentChar < 32 && (currentChar != 9 && currentChar != 10 && currentChar != 13))
+		//        {
+		//            //save the array index for later replacement.
+		//            pos.Add(x);
+		//        }
+		//    }
+		//    foreach (int index in pos)
+		//    {
+		//        encodedChars[index] = '?';//replace unprintable control characters with ?(3F)
+		//    }
+		//    return System.Text.Encoding.Default.GetString(System.Text.Encoding.Default.GetBytes(encodedChars));
+		//}
 
-                private void WriteCData (string text)
-                {
-                        int start = 0;
-                        while (true) {
-                                int illegal = text.IndexOf ("]]>", start);
-                                if (illegal < 0)
-                                        break;
-                                xmlWriter.WriteCData (text.Substring (start, illegal - start + 2));
-                                start = illegal + 2;
-                                if (start >= text.Length)
-                                        return;
-                        }
+		private void WriteCData (string text)
+		{
+			int start = 0;
+			while (true) {
+				int illegal = text.IndexOf ("]]>", start);
+				if (illegal < 0)
+					break;
+				xmlWriter.WriteCData (text.Substring (start, illegal - start + 2));
+				start = illegal + 2;
+				if (start >= text.Length)
+					return;
+			}
 
-                        if (start > 0)
-                                xmlWriter.WriteCData (text.Substring (start));
-                        else
-                                xmlWriter.WriteCData (text);
-                }
+			if (start > 0)
+				xmlWriter.WriteCData (text.Substring (start));
+			else
+				xmlWriter.WriteCData (text);
+		}
 
-                #endregion
-        }
+		#endregion
+	}
 }

--- a/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
@@ -818,6 +818,7 @@ namespace Xamarin.iOS.UnitTests.XUnit
 		{
 			if (assembliesElement == null)
 				return;
+			writer.WriteLine ("<!--This file represents the results of running a test suite-->");
 			var settings = new XmlWriterSettings { Indent = true };
 			using (var xmlWriter = XmlWriter.Create (writer, settings)) {
 				switch (ResultFileFormat) {
@@ -836,8 +837,9 @@ namespace Xamarin.iOS.UnitTests.XUnit
 					throw new InvalidOperationException ($"Result output format '{ResultFileFormat}' is not currently supported");
 				}
 			}
+			writer.WriteLine ("<!-- the end -->");
 		}
-		
+
 		void Transform_Results (string xsltResourceName, XElement element, XmlWriter writer)
 		{
 			var xmlTransform = new System.Xml.Xsl.XslCompiledTransform ();

--- a/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
@@ -23,7 +23,7 @@ namespace Xamarin.iOS.UnitTests.XUnit
 		List<XUnitFilter> filters = new List<XUnitFilter> ();
 		bool runAssemblyByDefault;
 
-		public XUnitResultFileFormat ResultFileFormat { get; set; } = XUnitResultFileFormat.NUnit;
+		public XUnitResultFileFormat ResultFileFormat { get; set; } = XUnitResultFileFormat.XunitV2;
 		public AppDomainSupport AppDomainSupport { get; set; } = AppDomainSupport.Denied;
 		protected override string ResultsFileName { get; set; } = "TestResults.xUnit.xml";
 

--- a/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
@@ -795,9 +795,10 @@ namespace Xamarin.iOS.UnitTests.XUnit
 		{
 			if (assembliesElement == null)
 				return String.Empty;
-
+			// remove all the empty nodes
+			assembliesElement.Descendants ().Where (e => e.Name == "collection" && !e.Descendants ().Any ()).Remove ();
 			string outputFilePath = GetResultsFilePath ();
-			var settings = new XmlWriterSettings { Indent = true };
+			var settings = new XmlWriterSettings { Indent = true};
 			using (var xmlWriter = XmlWriter.Create (outputFilePath, settings)) {
 				switch (ResultFileFormat) {
 				case XUnitResultFileFormat.XunitV2:
@@ -818,6 +819,8 @@ namespace Xamarin.iOS.UnitTests.XUnit
 		{
 			if (assembliesElement == null)
 				return;
+			// remove all the empty nodes
+			assembliesElement.Descendants ().Where (e => e.Name == "collection" && !e.Descendants ().Any ()).Remove ();
 			writer.WriteLine ("<!--This file represents the results of running a test suite-->");
 			var settings = new XmlWriterSettings { Indent = true };
 			using (var xmlWriter = XmlWriter.Create (writer, settings)) {

--- a/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
@@ -821,7 +821,6 @@ namespace Xamarin.iOS.UnitTests.XUnit
 				return;
 			// remove all the empty nodes
 			assembliesElement.Descendants ().Where (e => e.Name == "collection" && !e.Descendants ().Any ()).Remove ();
-			writer.WriteLine ("<!--This file represents the results of running a test suite-->");
 			var settings = new XmlWriterSettings { Indent = true };
 			using (var xmlWriter = XmlWriter.Create (writer, settings)) {
 				switch (ResultFileFormat) {
@@ -840,7 +839,6 @@ namespace Xamarin.iOS.UnitTests.XUnit
 					throw new InvalidOperationException ($"Result output format '{ResultFileFormat}' is not currently supported");
 				}
 			}
-			writer.WriteLine ("<!-- the end -->");
 		}
 
 		void Transform_Results (string xsltResourceName, XElement element, XmlWriter writer)

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -540,11 +540,6 @@ namespace xharness
 						streamReaderTmp.DiscardBufferedData ();
 						var path = listener_log.FullPath;
 						path = Path.ChangeExtension (path, "xml");
-						var fileName = Path.GetFileName (path);
-						if (isTouchUnit)
-							path = path.Replace (fileName, "nunit-" + fileName);
-						else
-							path = path.Replace (fileName, "xunit-" + fileName);
 						// both the nunit and xunit runners are not
 						// setting the test results correctly, lets add them
 						using (var xmlWriter = new StreamWriter (path)) {
@@ -573,6 +568,7 @@ namespace xharness
 					return parseResult;
 				} catch (Exception e) {
 					main_log.WriteLine ("Could not parse xml result file: {0}", e);
+
 					if (timed_out) {
 						Harness.LogWrench ($"@MonkeyWrench: AddSummary: <b><i>{mode} timed out</i></b><br/>");
 						return parseResult;

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -638,10 +638,10 @@ namespace xharness
 						switch (xmlType) {
 						case XmlResultType.TouchUnit:
 						case XmlResultType.NUnit:
-							path.Replace (fileName, $"nunit-{fileName}");
+							path = path.Replace (fileName, $"nunit-{fileName}");
 							break;
 						case XmlResultType.xUnit:
-							path.Replace (fileName, $"xunit-{fileName}");
+							path = path.Replace (fileName, $"xunit-{fileName}");
 							break;
 						}
 						// both the nunit and xunit runners are not

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -547,6 +547,18 @@ namespace xharness
 					return parseResult;
 				} catch (Exception e) {
 					main_log.WriteLine ("Could not parse xml result file: {0}", e);
+					// print file for better debugging
+					main_log.WriteLine ("File data is:");
+					main_log.WriteLine (new string ('#', 10));
+					using (var streamReaderTmp = new StreamReader (tmpFile)) {
+						string line;
+						while ((line = streamReaderTmp.ReadLine ()) != null) {
+							main_log.WriteLine (line);
+						}
+					}
+					main_log.WriteLine (new string ('#', 10));
+					main_log.WriteLine ("End of xml results.");
+
 
 					if (timed_out) {
 						Harness.LogWrench ($"@MonkeyWrench: AddSummary: <b><i>{mode} timed out</i></b><br/>");

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -544,9 +544,11 @@ namespace xharness
 			using (var writer = new StreamWriter (destination)) {
 				string line;
 				while ((line = reader.ReadLine ()) != null) {
-					if (line.StartsWith ("ping", StringComparison.InvariantCulture)) {
+					if (line.StartsWith ("ping", StringComparison.InvariantCulture) || line.Contains ("TouchUnitTestRun") || line.Contains ("NUnitOutput") || line.Contains ("<!--")) {
 						continue;
 					}
+					if (line.Contains ("TouchUnitExtraData")) // always last node in TouchUnit
+						break;
 					writer.WriteLine (line);
 				}
 			}

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -549,7 +549,6 @@ namespace xharness
  								if (line.Contains ("<test-results")) {
 									if (line.Contains ("name=\"\"")) { // NUnit case
 										xmlWriter.WriteLine (line.Replace ("name=\"\"", $"name=\"{appName + " " + configuration}\""));
-										xmlWriter.WriteLine (line);
 									} else if (line.Contains ($"name=\"com.xamarin.bcltests.{appName}\"")) { // xunit case
 										xmlWriter.WriteLine (line.Replace ($"name=\"com.xamarin.bcltests.{appName}\"", $"name=\"{appName + " " + configuration}\""));
 									}

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -475,6 +475,9 @@ namespace xharness
 							}
 							writer.Write (reader ["name"]);
 							if (status == "Failure" || status == "Error") { //  we need to print the message
+								reader.ReadToDescendant ("message");
+								writer.Write ($" : {reader.ReadElementContentAsString ()}");
+								reader.ReadToNextSibling ("stack-trace");
 								writer.Write ($" : {reader.ReadElementContentAsString ()}");
 							}
 							// add a new line

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -358,7 +358,7 @@ namespace xharness
 			// xml, advance the reader one line.
 			var pingLine = stream.ReadLine();
 			if (!pingLine.Contains("ping"))
-				throw new InvalidDataException("Ping line is missing, unexpected format.");
+				stream.BaseStream.Position = 0;
 
 			// TouchUnitTestRun is the very first node in the TouchUnit xml result
 			// which is not preset in the xunit xml, therefore we know the runner
@@ -383,7 +383,9 @@ namespace xharness
 			long total, errors, failed, notRun, inconclusive, ignored, skipped, invalid;
 			total = errors = failed = notRun = inconclusive = ignored = skipped = invalid = 0L;
 			// ignore the first line
-			stream.ReadLine ();
+			var ping = stream.ReadLine ();
+			if (!ping.Contains ("ping"))
+				stream.BaseStream.Position = 0;
 			using (var reader = XmlReader.Create (stream)) {
 				while (reader.Read ()) {
 					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-results") {
@@ -413,7 +415,9 @@ namespace xharness
 			long total, errors, failed, notRun, inconclusive, ignored, skipped, invalid;
 			total = errors = failed = notRun = inconclusive = ignored = skipped = invalid = 0L;
 			// ignore the first line
-			stream.ReadLine();
+			var ping = stream.ReadLine();
+			if (!ping.Contains ("ping"))
+				stream.BaseStream.Position = 0;
 			using (var reader = XmlReader.Create (stream)) {
 				while (reader.Read ()) {
 					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-results") {

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -542,9 +542,11 @@ namespace xharness
 						using (var xmlWriter = new StreamWriter (path)) {
 							string line;
 							while ((line = streamReaderTmp.ReadLine ()) != null) {
-								if (line.Contains ("ping")) // ignore the ping, because VSTS is going to have issues too.
+								if (line.Contains ("ping") || line.Contains ("<TouchUnitTestRun>") || line.Contains ("<NUnitOutput>")) // ignore the ping, because VSTS is going to have issues too or the Touch unit elements
 									continue;
-								if (line.Contains ("<test-results")) {
+								if (line.Contains ("</NUnitOutput>")) // get out of the loop we are not interested in the rest of the TouchUnit data.
+									break;
+ 								if (line.Contains ("<test-results")) {
 									if (line.Contains ("name=\"\"")) { // NUnit case
 										xmlWriter.WriteLine (line.Replace ("name=\"\"", $"name=\"{appName + " " + configuration}\""));
 										xmlWriter.WriteLine (line);

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -551,6 +551,8 @@ namespace xharness
 										xmlWriter.WriteLine (line.Replace ("name=\"\"", $"name=\"{appName + " " + configuration}\""));
 									} else if (line.Contains ($"name=\"com.xamarin.bcltests.{appName}\"")) { // xunit case
 										xmlWriter.WriteLine (line.Replace ($"name=\"com.xamarin.bcltests.{appName}\"", $"name=\"{appName + " " + configuration}\""));
+									} else {
+										xmlWriter.WriteLine (line);
 									}
 								} else {
 									xmlWriter.WriteLine (line);

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -584,11 +584,14 @@ namespace xharness
 						// clean any junk we have
 						using (var xmlWriter = new StreamWriter (path)) {
 							string line;
+							string previous = null;
 							while ((line = streamReaderTmp.ReadLine ()) != null) {
 								if (line.Contains ("ping") || line.Contains ("<TouchUnitTestRun>") || line.Contains ("<NUnitOutput>") || line.StartsWith ("<!", StringComparison.Ordinal)) // ignore the ping, because VSTS is going to have issues too or the Touch unit elements
 									continue;
 								if (line.Contains ("</NUnitOutput>")) // get out of the loop we are not interested in the rest of the TouchUnit data.
 									break;
+								if (previous != null && previous.Contains ("</collection>") && line.Contains (" </collection>")) // something funny happens with the xunit results and collections that is priting twice </collection></collection>
+									continue;
 								if (line.Contains ("<test-results")) {
 									if (line.Contains ("name=\"\"")) { // NUnit case
 										xmlWriter.WriteLine (line.Replace ("name=\"\"", $"name=\"{appName + " " + configuration}\""));
@@ -600,6 +603,7 @@ namespace xharness
 								} else {
 									xmlWriter.WriteLine (line);
 								}
+								previous = line;
 							}
 						}
 					}

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -540,6 +540,11 @@ namespace xharness
 						streamReaderTmp.DiscardBufferedData ();
 						var path = listener_log.FullPath;
 						path = Path.ChangeExtension (path, "xml");
+						var fileName = Path.GetFileName (path);
+						if (isTouchUnit)
+							path = path.Replace (fileName, "nunit-" + fileName);
+						else
+							path = path.Replace (fileName, "xunit-" + fileName);
 						// both the nunit and xunit runners are not
 						// setting the test results correctly, lets add them
 						using (var xmlWriter = new StreamWriter (path)) {

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -538,6 +538,20 @@ namespace xharness
 			return (resultLine, total == 0 | errors != 0 || failed != 0);
 		}
 
+		void CleanXml (string source, string destination)
+		{
+			using (var reader = new StreamReader (source))
+			using (var writer = new StreamWriter (destination)) {
+				string line;
+				while ((line = reader.ReadLine ()) != null) {
+					if (line.StartsWith ("ping", StringComparison.InvariantCulture)) {
+						continue;
+					}
+					writer.WriteLine (line);
+				}
+			}
+		}
+
 		(string resultLine, bool failed, bool crashed) ParseResult (string test_log_path, bool timed_out, bool crashed)
 		{
 			if (!File.Exists (test_log_path))
@@ -556,7 +570,7 @@ namespace xharness
 			// from the TCP connection, we are going to fail when trying to read it and not parse it. Therefore, we are not only
 			// going to check if we are in CI, but also if the listener_log is valid.
 			var path = Path.ChangeExtension (test_log_path, "xml");
-			File.Copy (test_log_path, path);
+			CleanXml (test_log_path, path);
 
 			if (Harness.InCI && IsXml (test_log_path)) {
 				(string resultLine, bool failed, bool crashed) parseResult = (null, false, false);

--- a/tests/xharness/SimpleTcpListener.cs
+++ b/tests/xharness/SimpleTcpListener.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;

--- a/tests/xharness/SimpleTcpListener.cs
+++ b/tests/xharness/SimpleTcpListener.cs
@@ -54,6 +54,7 @@ namespace xharness
 		{
 			Connected (client.Client.RemoteEndPoint.ToString ());
 			// now simply copy what we receive
+			int i;
 			int total = 0;
 			NetworkStream stream = client.GetStream ();
 			var fs = OutputWriter;

--- a/tests/xharness/SimpleTcpListener.cs
+++ b/tests/xharness/SimpleTcpListener.cs
@@ -34,6 +34,7 @@ namespace xharness
 				do {
 					Log.WriteLine ("Test log server listening on: {0}:{1}", Address, Port);
 					using (TcpClient client = server.AcceptTcpClient ()) {
+						client.ReceiveBufferSize = buffer.Length;
 						processed = Processing (client);
 					}
 				} while (!AutoExit || !processed);


### PR DESCRIPTION
We ping the tcp listener to know that we have a tcp connection, that is
written in the xml logs, which means that parsing will not work. Ignore
the ping, parse xml, and make sure that the xml that will be consume by
vsts is valid.

Sample of the ping in CI: http://xamarin-storage/jenkins/xamarin-macios/master/a2a48c4e003b5394a9a354d1dfcd99a064103390/3422594/device-tests/jenkins-results/tests/mscorlib%20Part%201/1621/test-ios-20200128_182116.log