### PR TITLE
[xharness] Improve TCC database editing.

### DIFF
--- a/tests/xharness/Simulators.cs
+++ b/tests/xharness/Simulators.cs
@@ -556,6 +556,7 @@ namespace xharness
 					"kTCCServiceCalendar",
 					"kTCCServicePhotos",
 					"kTCCServiceMediaLibrary",
+					"kTCCServiceMicrophone",
 					"kTCCServiceUbiquity",
 					"kTCCServiceWillow"
 				};
@@ -589,8 +590,8 @@ namespace xharness
 							break;
 						case 3: // Xcode 10+
 							// CREATE TABLE access (    service        TEXT        NOT NULL,     client         TEXT        NOT NULL,     client_type    INTEGER     NOT NULL,     allowed        INTEGER     NOT NULL,     prompt_count   INTEGER     NOT NULL,     csreq          BLOB,     policy_id      INTEGER,     indirect_object_identifier_type    INTEGER,     indirect_object_identifier         TEXT,     indirect_object_code_identity      BLOB,     flags          INTEGER,     last_modified  INTEGER     NOT NULL DEFAULT (CAST(strftime('%s','now') AS INTEGER)),     PRIMARY KEY (service, client, client_type, indirect_object_identifier),    FOREIGN KEY (policy_id) REFERENCES policies(id) ON DELETE CASCADE ON UPDATE CASCADE)
-							sql.AppendFormat ("INSERT OR REPLACE INTO access VALUES('{0}','{1}',0,1,0,NULL,NULL,NULL,'UNUSED',NULL,NULL,1);", service, bundle_identifier);
-							sql.AppendFormat ("INSERT OR REPLACE INTO access VALUES('{0}','{1}',0,1,0,NULL,NULL,NULL,'UNUSED',NULL,NULL,1);", service, bundle_identifier + ".watchkitapp");
+							sql.AppendFormat ("INSERT OR REPLACE INTO access VALUES('{0}','{1}',0,1,0,NULL,NULL,NULL,'UNUSED',NULL,NULL,{2});", service, bundle_identifier, DateTimeOffset.Now.ToUnixTimeSeconds ());
+							sql.AppendFormat ("INSERT OR REPLACE INTO access VALUES('{0}','{1}',0,1,0,NULL,NULL,NULL,'UNUSED',NULL,NULL,{2});", service, bundle_identifier + ".watchkitapp", DateTimeOffset.Now.ToUnixTimeSeconds ());
 							break;
 						default:
 							throw new NotImplementedException ();


### PR DESCRIPTION
* Acquire permission for the microphone (the microphone permission dialog is
  not a blocking dialog, which is why things have worked so far).

* Set the last_modified field in the TCC database to now instead of 1970.
  Apparently some permissions time out (kTCCServiceMediaLibrary), which means
  that the last_modified field is important to get right.