### PR TITLE
Bump maccore (updated submission runner)

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 80ebc03ea89eb4a911bbd73ea45b308b610ab213
+NEEDED_MACCORE_VERSION := 4a09135a2d80fe671d06329ef0527141a6a79721
 NEEDED_MACCORE_BRANCH := master
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@4a09135a2d [tests][submissions] Simplify things a bit (less clicks FTW) (#2136)

Diff: https://github.com/xamarin/maccore/compare/80ebc03ea89eb4a911bbd73ea45b308b610ab213..4a09135a2d80fe671d06329ef0527141a6a79721