### PR TITLE
[mtouch] Auto-change settings where they're honored for extensions. Fixes #7780.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1619,6 +1619,7 @@ public class B : A {}
 		[TestCase ("", "System.dll", "the interpreted assemblies are different between the container app (all assemblies) and the extension (System.dll).")]
 		[TestCase ("mscorlib.dll", "System.dll", "the interpreted assemblies are different between the container app (mscorlib.dll) and the extension (System.dll).")]
 		[TestCase ("mscorlib.dll", "mscorlib.dll,System.dll", "the interpreted assemblies are different between the container app (mscorlib.dll) and the extension (mscorlib.dll, System.dll).")]
+		[TestCase ("-all", "-all", null)]
 		public void MT0113_interpreter (string app_interpreter, string appex_interpreter, string msg)
 		{
 			using (var extension = new MTouchTool ()) {
@@ -1633,8 +1634,13 @@ public class B : A {}
 					app.CreateTemporaryCacheDirectory ();
 					app.Interpreter = app_interpreter;
 					app.WarnAsError = new int [] { 113 };
-					app.AssertExecuteFailure (MTouchAction.BuildDev, "build app");
-					app.AssertError (113, "Native code sharing has been disabled for the extension 'testServiceExtension' because " + msg); 
+					if (!string.IsNullOrEmpty (msg)) {
+						app.AssertExecuteFailure (MTouchAction.BuildDev, "build app");
+						app.AssertError (113, "Native code sharing has been disabled for the extension 'testServiceExtension' because " + msg);
+					} else {
+						app.AssertExecute (MTouchAction.BuildDev, "build app");
+						app.AssertWarningCount (0);
+					}
 				}
 			}
 		}

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1197,6 +1197,33 @@ namespace Xamarin.Bundler {
 
 		void Initialize ()
 		{
+			if (UseInterpreter) {
+				// it's confusing to use different options to get a feature to work (e.g. dynamic, SRE...) on both simulator and device
+				if (IsSimulatorBuild) {
+					ErrorHelper.Show (ErrorHelper.CreateWarning (141, "The interpreter is not supported in the simulator. Switching to REPL which provide the same extra features on the simulator."));
+					UseInterpreter = false;
+				}
+
+				// FIXME: the interpreter only supports ARM64{,_32} right now
+				// temporary - without a check here the error happens when deploying
+				if (!IsSimulatorBuild && (!IsArchEnabled (Abi.ARM64) && !IsArchEnabled (Abi.ARM64_32)))
+					throw ErrorHelper.CreateError (99, "Internal error: The interpreter is currently only available for 64 bits.");
+
+				// needs to be set after the argument validations
+				// interpreter can use some extra code (e.g. SRE) that is not shipped in the default (AOT) profile
+				EnableRepl = true;
+			} else {
+				if (Platform == ApplePlatform.WatchOS && IsArchEnabled (Abi.ARM64_32) && BitCodeMode != BitCodeMode.LLVMOnly) {
+					if (IsArchEnabled (Abi.ARMv7k)) {
+						throw ErrorHelper.CreateError (145, "Please use device specific builds on WatchOS when building for Debug.");
+					} else {
+						ErrorHelper.Warning (146, "ARM64_32 Debug mode requires --interpreter[=all], forcing it.");
+						UseInterpreter = true;
+						InterpretedAssemblies.Clear ();
+					}
+				}
+			}
+
 			if (EnableDebug && IsLLVM)
 				ErrorHelper.Warning (3003, "Debugging is not supported when building with LLVM. Debugging has been disabled.");
 

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1340,33 +1340,6 @@ namespace Xamarin.Bundler
 			if (app.EnableRepl && app.LinkMode != LinkMode.None)
 				throw new MonoTouchException (82, true, "REPL (--enable-repl) is only supported when linking is not used (--nolink).");
 
-			if (app.UseInterpreter) {
-				// it's confusing to use different options to get a feature to work (e.g. dynamic, SRE...) on both simulator and device
-				if (app.IsSimulatorBuild) {
-					ErrorHelper.Show (ErrorHelper.CreateWarning (141, "The interpreter is not supported in the simulator. Switching to REPL which provide the same extra features on the simulator."));
-					app.UseInterpreter = false;
-				}
-
-				// FIXME: the interpreter only supports ARM64{,_32} right now
-				// temporary - without a check here the error happens when deploying
-				if (!app.IsSimulatorBuild && (!app.IsArchEnabled (Abi.ARM64) && !app.IsArchEnabled (Abi.ARM64_32)))
-					throw ErrorHelper.CreateError (99, "Internal error: The interpreter is currently only available for 64 bits.");
-
-				// needs to be set after the argument validations
-				// interpreter can use some extra code (e.g. SRE) that is not shipped in the default (AOT) profile
-				app.EnableRepl = true;
-			} else {
-				if (app.Platform == ApplePlatform.WatchOS && app.IsArchEnabled (Abi.ARM64_32) && app.BitCodeMode != BitCodeMode.LLVMOnly) {
-					if (app.IsArchEnabled (Abi.ARMv7k)) {
-						throw ErrorHelper.CreateError (145, "Please use device specific builds on WatchOS when building for Debug.");
-					} else {
-						ErrorHelper.Warning (146, "ARM64_32 Debug mode requires --interpreter[=all], forcing it.");
-						app.UseInterpreter = true;
-						app.InterpretedAssemblies.Clear ();
-					}
-				}
-			}
-
 			if (cross_prefix == null)
 				cross_prefix = MonoTouchDirectory;
 


### PR DESCRIPTION
When building extensions, we first store all the mtouch arguments in a file
when msbuild builds the extension, and then when msbuild builds the main
project, we load those arguments again and actually build the extension at the
same time as we build the main app.

As such, it's important to make sure that when we reload the extension
arguments we end up with the exact same build configuration as the first time.

Unfortunately that was not the case regarding the interpreter: we
automatically set the 'EnableRepl' value in Main according to whether the
interpreter was enabled or not, but Main is not called after re-loading the
arguments when building extensions.

Fix this by moving the logic that automatically sets 'EnableRepl' to somewhere
that is executed when re-loading arguments when building extensions.

Fixes https://github.com/xamarin/xamarin-macios/issues/7780.