### PR TITLE
[XHarness] Refactor xml code to make the AppRunner class cleaner.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -34,13 +34,6 @@ namespace xharness
 		TodayExtension,
 	}
 
-	public enum XmlResultType
-	{
-		TouchUnit,
-		NUnit,
-		xUnit,
-	}
-
 	public class AppRunner
 	{
 		public Harness Harness;
@@ -364,7 +357,6 @@ namespace xharness
 			if (Harness.InCI && XmlResultParser.IsXml (path)) {
 				(string resultLine, bool failed, bool crashed) parseResult = (null, false, false);
 				crashed = false;
-				XmlResultType xmlType;
 				try {
 					XmlResultParser.XmlResultType xmlType = XmlResultParser.GetXmlType (path);
 					var newFilename = XmlResultParser.GetXmlFilePath (path, xmlType);

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -353,9 +353,8 @@ namespace xharness
 			// going to check if we are in CI, but also if the listener_log is valid.
 			var path = Path.ChangeExtension (test_log_path, "xml");
 			XmlResultParser.CleanXml (test_log_path, path);
-			XmlResultParser.Jargon xmlType;
 
-			if (Harness.InCI && XmlResultParser.IsValidXml (path, out xmlType)) {
+			if (Harness.InCI && XmlResultParser.IsValidXml (path, out var xmlType)) {
 				(string resultLine, bool failed, bool crashed) parseResult = (null, false, false);
 				crashed = false;
 				try {
@@ -369,6 +368,7 @@ namespace xharness
 					var tmpFile = Path.Combine (Path.GetTempPath (), Guid.NewGuid ().ToString ());
 					(parseResult.resultLine, parseResult.failed) = XmlResultParser.GenerateHumanReadableResults (path, tmpFile, xmlType);
 					File.Copy (tmpFile, test_log_path, true);
+					File.Delete (tmpFile);
 
 					// we do not longer need the tmp file
 					Logs.AddFile (path, "Test xml");

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -341,219 +341,6 @@ namespace xharness
 			}
 		}
 
-		// test if the file is valid xml, or at least, that can be read. The reader will throw an 
-		// exception if it cannot read the file. This is not ideal :/
-		bool IsXml (string filePath)
-		{
-			if (!File.Exists (filePath))
-				return false;
-
-			using (var stream = File.OpenText (filePath)) {
-				string line;
-				while ((line = stream.ReadLine ()) != null) {
-					if (line.Contains ("ping"))
-						continue;
-					return line.StartsWith ("<", StringComparison.Ordinal);
-				}
-			}
-			return false;
-		}
-
-		XmlResultType GetXmlType (StreamReader stream)
-		{
-			var resultType = XmlResultType.TouchUnit; // default
-			// more fun, the first like of the stream, is a ping from the application to the tcp server, and that will not be parsable as
-			// xml, advance the reader one line.
-			string line;
-			while ((line = stream.ReadLine ()) != null) {
-				if (line.Contains ("TouchUnitTestRun")) {
-					resultType = XmlResultType.TouchUnit;
-					break;
-				}
-				if (line.Contains ("nunit-version"))
-					resultType = XmlResultType.NUnit;
-				if (line.Contains ("xUnit")) {
-					resultType = XmlResultType.xUnit;
-					break;
-				}
-			}
-			
-			// we want to reuse the stream (and we are sync)
-			stream.BaseStream.Position = 0;
-			stream.DiscardBufferedData ();
-			return resultType;
-		}
-
-		(string resultLine, bool failed) ParseTouchUnitXml (StreamReader stream, StreamWriter writer)
-		{
-			long total, errors, failed, notRun, inconclusive, ignored, skipped, invalid;
-			total = errors = failed = notRun = inconclusive = ignored = skipped = invalid = 0L;
-			
-			using (var reader = XmlReader.Create (stream)) {
-				while (reader.Read ()) {
-					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-results") {
-						total = long.Parse (reader ["total"]);
-						errors = long.Parse (reader ["errors"]);
-						failed = long.Parse (reader ["failures"]);
-						notRun = long.Parse (reader ["not-run"]);
-						inconclusive = long.Parse (reader ["inconclusive"]);
-						ignored = long.Parse (reader ["ignored"]);
-						skipped = long.Parse (reader ["skipped"]);
-						invalid = long.Parse (reader ["invalid"]);
-					}
-					if (reader.NodeType == XmlNodeType.Element && reader.Name == "TouchUnitExtraData") {
-						// move fwd to get to the CData
-						if (reader.Read ())
-							writer.Write (reader.Value);
-					}
-				}
-			}
-			var passed = total - errors - failed - notRun - inconclusive - ignored - skipped - invalid;
-			var resultLine = $"Tests run: {total} Passed: {passed} Inconclusive: {inconclusive} Failed: {failed + errors} Ignored: {ignored + skipped + invalid}";
-			return (resultLine, total == 0 || errors != 0 || failed != 0);
-		}
-
-		(string resultLine, bool failed) ParseNUnitXml (StreamReader stream, StreamWriter writer)
-		{
-			long total, errors, failed, notRun, inconclusive, ignored, skipped, invalid;
-			total = errors = failed = notRun = inconclusive = ignored = skipped = invalid = 0L;
-			XmlReaderSettings settings = new XmlReaderSettings ();
-			settings.ValidationType = ValidationType.None;
-			using (var reader = XmlReader.Create (stream, settings)) {
-				while (reader.Read ()) {
-					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-results") {
-						total = long.Parse (reader ["total"]);
-						errors = long.Parse (reader ["errors"]);
-						failed = long.Parse (reader ["failures"]);
-						notRun = long.Parse (reader ["not-run"]);
-						inconclusive = long.Parse (reader ["inconclusive"]);
-						ignored = long.Parse (reader ["ignored"]);
-						skipped = long.Parse (reader ["skipped"]);
-						invalid = long.Parse (reader ["invalid"]);
-					}
-					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-suite" && (reader["type"] == "TestFixture" || reader["type"] == "TestCollection")) {
-						var testCaseName = reader ["name"];
-						writer.WriteLine (testCaseName);
-						var time = reader.GetAttribute ("time") ?? "0"; // some nodes might not have the time :/
-						// get the first node and then move in the siblings of the same type
-						reader.ReadToDescendant ("test-case");
-						do {
-							if (reader.Name != "test-case")
-								break;
-							// read the test cases in the current node
-							var status = reader ["result"];
-							switch (status) {
-							case "Success":
-								writer.Write ("\t[PASS] ");
-								break;
-							case "Ignored":
-								writer.Write ("\t[IGNORED] ");
-								break;
-							case "Error":
-							case "Failure":
-								writer.Write ("\t[FAIL] ");
-								break;
-							case "Inconclusive":
-								writer.Write ("\t[INCONCLUSIVE] ");
-								break;
-							default:
-								writer.Write ("\t[INFO] ");
-								break;
-							}
-							writer.Write (reader ["name"]);
-							if (status == "Failure" || status == "Error") { //  we need to print the message
-								reader.ReadToDescendant ("message");
-								writer.Write ($" : {reader.ReadElementContentAsString ()}");
-								reader.ReadToNextSibling ("stack-trace");
-								writer.Write ($" : {reader.ReadElementContentAsString ()}");
-							}
-							// add a new line
-							writer.WriteLine ();
-						} while (reader.ReadToNextSibling ("test-case"));
-						writer.WriteLine ($"{testCaseName} {time} ms");
-					}
-				}
-			}
-			var passed = total - errors - failed - notRun - inconclusive - ignored - skipped - invalid;
-			string resultLine = $"Tests run: {total} Passed: {passed} Inconclusive: {inconclusive} Failed: {failed + errors} Ignored: {ignored + skipped + invalid}";
-			writer.WriteLine (resultLine);
-			
-			return (resultLine, total == 0 | errors != 0 || failed != 0);
-		}
-
-		(string resultLine, bool failed) ParsexUnitXml (StreamReader stream, StreamWriter writer) {
-			long total, errors, failed, notRun, inconclusive, ignored, skipped, invalid;
-			total = errors = failed = notRun = inconclusive = ignored = skipped = invalid = 0L;
-			using (var reader = XmlReader.Create (stream)) {
-				while (reader.Read ()) {
-					if (reader.NodeType == XmlNodeType.Element && reader.Name == "assembly") {
-						total += long.Parse (reader ["total"]);
-						errors += long.Parse (reader ["errors"]);
-						failed += long.Parse (reader ["failed"]);
-						skipped += long.Parse (reader ["skipped"]);
-					}
-					if (reader.NodeType == XmlNodeType.Element && reader.Name == "collection") {
-						var testCaseName = reader ["name"].Replace ("Test collection for ", "");
-						writer.WriteLine (testCaseName);
-						var time = reader.GetAttribute ("time") ?? "0"; // some nodes might not have the time :/
-												// get the first node and then move in the siblings of the same type
-						reader.ReadToDescendant ("test");
-						do {
-							if (reader.Name != "test")
-								break;
-							// read the test cases in the current node
-							var status = reader ["result"];
-							switch (status) {
-							case "Pass":
-								writer.Write ("\t[PASS] ");
-								break;
-							case "Skip":
-								writer.Write ("\t[IGNORED] ");
-								break;
-							case "Fail":
-								writer.Write ("\t[FAIL] ");
-								break;
-							default:
-								writer.Write ("\t[FAIL] ");
-								break;
-							}
-							writer.Write (reader ["name"]);
-							if (status == "Fail") { //  we need to print the message
-								reader.ReadToDescendant ("message"); 
-								writer.Write ($" : {reader.ReadElementContentAsString ()}");
-								reader.ReadToNextSibling ("stack-trace");
-								writer.Write ($" : {reader.ReadElementContentAsString ()}");
-							}
-							// add a new line
-							writer.WriteLine ();
-						} while (reader.ReadToNextSibling ("test"));
-						writer.WriteLine ($"{testCaseName} {time} ms");
-					}
-				}
-			}
-			var passed = total - errors - failed - notRun - inconclusive - ignored - skipped - invalid;
-			string resultLine = $"Tests run: {total} Passed: {passed} Inconclusive: {inconclusive} Failed: {failed + errors} Ignored: {ignored + skipped + invalid}";
-			writer.WriteLine (resultLine);
-
-			return (resultLine, total == 0 | errors != 0 || failed != 0);
-		}
-
-		void CleanXml (string source, string destination)
-		{
-			using (var reader = new StreamReader (source))
-			using (var writer = new StreamWriter (destination)) {
-				string line;
-				while ((line = reader.ReadLine ()) != null) {
-					if (line.StartsWith ("ping", StringComparison.InvariantCulture) || line.Contains ("TouchUnitTestRun") || line.Contains ("NUnitOutput") || line.Contains ("<!--")) {
-						continue;
-					}
-					if (line.Contains ("TouchUnitExtraData")) // always last node in TouchUnit
-						break;
-					writer.WriteLine (line);
-				}
-			}
-		}
-
 		(string resultLine, bool failed, bool crashed) ParseResult (string test_log_path, bool timed_out, bool crashed)
 		{
 			if (!File.Exists (test_log_path))
@@ -572,57 +359,29 @@ namespace xharness
 			// from the TCP connection, we are going to fail when trying to read it and not parse it. Therefore, we are not only
 			// going to check if we are in CI, but also if the listener_log is valid.
 			var path = Path.ChangeExtension (test_log_path, "xml");
-			CleanXml (test_log_path, path);
+			XmlResultParser.CleanXml (test_log_path, path);
 
-			if (Harness.InCI && IsXml (test_log_path)) {
+			if (Harness.InCI && XmlResultParser.IsXml (path)) {
 				(string resultLine, bool failed, bool crashed) parseResult = (null, false, false);
 				crashed = false;
 				XmlResultType xmlType;
 				try {
-					using (var streamReaderTmp = new StreamReader (path)) {
-						xmlType = GetXmlType (streamReaderTmp);
-						var fileName = Path.GetFileName (path);
-						var newFilename = "";
-						switch (xmlType) {
-						case XmlResultType.TouchUnit:
-						case XmlResultType.NUnit:
-							newFilename = path.Replace (fileName, $"nunit-{fileName}");
-							break;
-						case XmlResultType.xUnit:
-							newFilename = path.Replace (fileName, $"xunit-{fileName}");
-							break;
-						}
-						// rename the path to the correct value
-						File.Move (path, newFilename);
-						path = newFilename;
-						
-					}
-					using (var reader = new StreamReader (path)) {
-						var tmpFile = Path.Combine (Path.GetTempPath (), Guid.NewGuid ().ToString ());
-						using (var writer = new StreamWriter (tmpFile, true)) { // write the human result to the log file
-							(string resultLine, bool failed) parseData;
-							switch (xmlType) {
-							case XmlResultType.TouchUnit:
-								parseData = ParseTouchUnitXml (reader, writer);
-								break;
-							case XmlResultType.NUnit:
-								parseData = ParseNUnitXml (reader, writer);
-								break;
-							case XmlResultType.xUnit:
-								parseData = ParsexUnitXml (reader, writer);
-								break;
-							default:
-								parseData = ("", true);
-								break;
-							}
-							parseResult.resultLine = parseData.resultLine;
-							parseResult.failed = parseData.failed;
-						}
-						File.Copy (tmpFile, test_log_path, true);
-					}
+					XmlResultParser.XmlResultType xmlType = XmlResultParser.GetXmlType (path);
+					var newFilename = XmlResultParser.GetXmlFilePath (path, xmlType);
+
+					// rename the path to the correct value
+					File.Move (path, newFilename);
+					path = newFilename;
+
+					// write the human readable results in a tmp file, which we later use to step on the logs
+					var tmpFile = Path.Combine (Path.GetTempPath (), Guid.NewGuid ().ToString ());
+					(parseResult.resultLine, parseResult.failed) = XmlResultParser.GenerateHumanReadableResults (path, tmpFile, xmlType);
+					File.Copy (tmpFile, test_log_path, true);
+
 					// we do not longer need the tmp file
 					Logs.AddFile (path, "Test xml");
 					return parseResult;
+
 				} catch (Exception e) {
 					main_log.WriteLine ("Could not parse xml result file: {0}", e);
 					// print file for better debugging

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -353,12 +353,12 @@ namespace xharness
 			// going to check if we are in CI, but also if the listener_log is valid.
 			var path = Path.ChangeExtension (test_log_path, "xml");
 			XmlResultParser.CleanXml (test_log_path, path);
+			XmlResultParser.Jargon xmlType;
 
-			if (Harness.InCI && XmlResultParser.IsXml (path)) {
+			if (Harness.InCI && XmlResultParser.IsValidXml (path, out xmlType)) {
 				(string resultLine, bool failed, bool crashed) parseResult = (null, false, false);
 				crashed = false;
 				try {
-					XmlResultParser.XmlResultType xmlType = XmlResultParser.GetXmlType (path);
 					var newFilename = XmlResultParser.GetXmlFilePath (path, xmlType);
 
 					// rename the path to the correct value

--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -145,8 +145,8 @@ namespace xharness {
 			using (var reader = XmlReader.Create (stream)) {
 				while (reader.Read ()) {
 					if (reader.NodeType == XmlNodeType.Element && reader.Name == "assembly") {
-						long.TryParse (reader ["total"], out var asseblyCount);
-						total += asseblyCount;
+						long.TryParse (reader ["total"], out var assemblyCount);
+						total += assemblyCount;
 						long.TryParse (reader ["errors"], out var assemblyErrors);
 						errors += assemblyErrors;
 						long.TryParse (reader ["failed"], out var assemblyFailures);

--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -1,0 +1,267 @@
+﻿using System;
+using System.IO;
+using System.Xml;
+
+namespace xharness {
+	public static class XmlResultParser {
+
+		public enum XmlResultType {
+			TouchUnit,
+			NUnit,
+			xUnit,
+		}
+
+		// test if the file is valid xml, or at least, that can be read it.
+		public static bool IsXml (string filePath)
+		{
+			if (!File.Exists (filePath))
+				return false;
+
+			using (var stream = File.OpenText (filePath)) {
+				string line;
+				while ((line = stream.ReadLine ()) != null) { // special case when get got the tcp connection
+					if (line.Contains ("ping"))
+						continue;
+					return line.StartsWith ("<", StringComparison.Ordinal);
+				}
+			}
+			return false;
+		}
+
+		public static XmlResultType GetXmlType (string filePath)
+		{
+			using (var stream = new StreamReader (filePath)) {
+				var resultType = XmlResultType.TouchUnit; // default
+									  // more fun, the first like of the stream, is a ping from the application to the tcp server, and that will not be parsable as
+									  // xml, advance the reader one line.
+				string line;
+				while ((line = stream.ReadLine ()) != null) {
+					if (line.Contains ("TouchUnitTestRun")) {
+						resultType = XmlResultType.TouchUnit;
+						break;
+					}
+					if (line.Contains ("nunit-version"))
+						resultType = XmlResultType.NUnit;
+					if (line.Contains ("xUnit")) {
+						resultType = XmlResultType.xUnit;
+						break;
+					}
+				}
+				return resultType;
+			}
+		}
+
+		static (string resultLine, bool failed) ParseTouchUnitXml (StreamReader stream, StreamWriter writer)
+		{
+			long total, errors, failed, notRun, inconclusive, ignored, skipped, invalid;
+			total = errors = failed = notRun = inconclusive = ignored = skipped = invalid = 0L;
+
+			using (var reader = XmlReader.Create (stream)) {
+				while (reader.Read ()) {
+					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-results") {
+						total = long.Parse (reader ["total"]);
+						errors = long.Parse (reader ["errors"]);
+						failed = long.Parse (reader ["failures"]);
+						notRun = long.Parse (reader ["not-run"]);
+						inconclusive = long.Parse (reader ["inconclusive"]);
+						ignored = long.Parse (reader ["ignored"]);
+						skipped = long.Parse (reader ["skipped"]);
+						invalid = long.Parse (reader ["invalid"]);
+					}
+					if (reader.NodeType == XmlNodeType.Element && reader.Name == "TouchUnitExtraData") {
+						// move fwd to get to the CData
+						if (reader.Read ())
+							writer.Write (reader.Value);
+					}
+				}
+			}
+			var passed = total - errors - failed - notRun - inconclusive - ignored - skipped - invalid;
+			var resultLine = $"Tests run: {total} Passed: {passed} Inconclusive: {inconclusive} Failed: {failed + errors} Ignored: {ignored + skipped + invalid}";
+			return (resultLine, total == 0 || errors != 0 || failed != 0);
+		}
+
+		static (string resultLine, bool failed) ParseNUnitXml (StreamReader stream, StreamWriter writer)
+		{
+			long total, errors, failed, notRun, inconclusive, ignored, skipped, invalid;
+			total = errors = failed = notRun = inconclusive = ignored = skipped = invalid = 0L;
+			XmlReaderSettings settings = new XmlReaderSettings ();
+			settings.ValidationType = ValidationType.None;
+			using (var reader = XmlReader.Create (stream, settings)) {
+				while (reader.Read ()) {
+					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-results") {
+						total = long.Parse (reader ["total"]);
+						errors = long.Parse (reader ["errors"]);
+						failed = long.Parse (reader ["failures"]);
+						notRun = long.Parse (reader ["not-run"]);
+						inconclusive = long.Parse (reader ["inconclusive"]);
+						ignored = long.Parse (reader ["ignored"]);
+						skipped = long.Parse (reader ["skipped"]);
+						invalid = long.Parse (reader ["invalid"]);
+					}
+					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-suite" && (reader ["type"] == "TestFixture" || reader ["type"] == "TestCollection")) {
+						var testCaseName = reader ["name"];
+						writer.WriteLine (testCaseName);
+						var time = reader.GetAttribute ("time") ?? "0"; // some nodes might not have the time :/
+												// get the first node and then move in the siblings of the same type
+						reader.ReadToDescendant ("test-case");
+						do {
+							if (reader.Name != "test-case")
+								break;
+							// read the test cases in the current node
+							var status = reader ["result"];
+							switch (status) {
+							case "Success":
+								writer.Write ("\t[PASS] ");
+								break;
+							case "Ignored":
+								writer.Write ("\t[IGNORED] ");
+								break;
+							case "Error":
+							case "Failure":
+								writer.Write ("\t[FAIL] ");
+								break;
+							case "Inconclusive":
+								writer.Write ("\t[INCONCLUSIVE] ");
+								break;
+							default:
+								writer.Write ("\t[INFO] ");
+								break;
+							}
+							writer.Write (reader ["name"]);
+							if (status == "Failure" || status == "Error") { //  we need to print the message
+								reader.ReadToDescendant ("message");
+								writer.Write ($" : {reader.ReadElementContentAsString ()}");
+								reader.ReadToNextSibling ("stack-trace");
+								writer.Write ($" : {reader.ReadElementContentAsString ()}");
+							}
+							// add a new line
+							writer.WriteLine ();
+						} while (reader.ReadToNextSibling ("test-case"));
+						writer.WriteLine ($"{testCaseName} {time} ms");
+					}
+				}
+			}
+			var passed = total - errors - failed - notRun - inconclusive - ignored - skipped - invalid;
+			string resultLine = $"Tests run: {total} Passed: {passed} Inconclusive: {inconclusive} Failed: {failed + errors} Ignored: {ignored + skipped + invalid}";
+			writer.WriteLine (resultLine);
+
+			return (resultLine, total == 0 | errors != 0 || failed != 0);
+		}
+
+		static (string resultLine, bool failed) ParsexUnitXml (StreamReader stream, StreamWriter writer)
+		{
+			long total, errors, failed, notRun, inconclusive, ignored, skipped, invalid;
+			total = errors = failed = notRun = inconclusive = ignored = skipped = invalid = 0L;
+			using (var reader = XmlReader.Create (stream)) {
+				while (reader.Read ()) {
+					if (reader.NodeType == XmlNodeType.Element && reader.Name == "assembly") {
+						total += long.Parse (reader ["total"]);
+						errors += long.Parse (reader ["errors"]);
+						failed += long.Parse (reader ["failed"]);
+						skipped += long.Parse (reader ["skipped"]);
+					}
+					if (reader.NodeType == XmlNodeType.Element && reader.Name == "collection") {
+						var testCaseName = reader ["name"].Replace ("Test collection for ", "");
+						writer.WriteLine (testCaseName);
+						var time = reader.GetAttribute ("time") ?? "0"; // some nodes might not have the time :/
+												// get the first node and then move in the siblings of the same type
+						reader.ReadToDescendant ("test");
+						do {
+							if (reader.Name != "test")
+								break;
+							// read the test cases in the current node
+							var status = reader ["result"];
+							switch (status) {
+							case "Pass":
+								writer.Write ("\t[PASS] ");
+								break;
+							case "Skip":
+								writer.Write ("\t[IGNORED] ");
+								break;
+							case "Fail":
+								writer.Write ("\t[FAIL] ");
+								break;
+							default:
+								writer.Write ("\t[FAIL] ");
+								break;
+							}
+							writer.Write (reader ["name"]);
+							if (status == "Fail") { //  we need to print the message
+								reader.ReadToDescendant ("message");
+								writer.Write ($" : {reader.ReadElementContentAsString ()}");
+								reader.ReadToNextSibling ("stack-trace");
+								writer.Write ($" : {reader.ReadElementContentAsString ()}");
+							}
+							// add a new line
+							writer.WriteLine ();
+						} while (reader.ReadToNextSibling ("test"));
+						writer.WriteLine ($"{testCaseName} {time} ms");
+					}
+				}
+			}
+			var passed = total - errors - failed - notRun - inconclusive - ignored - skipped - invalid;
+			string resultLine = $"Tests run: {total} Passed: {passed} Inconclusive: {inconclusive} Failed: {failed + errors} Ignored: {ignored + skipped + invalid}";
+			writer.WriteLine (resultLine);
+
+			return (resultLine, total == 0 | errors != 0 || failed != 0);
+		}
+
+		public static string GetXmlFilePath (string path, XmlResultType xmlType)
+		{
+
+			using (var streamReaderTmp = new StreamReader (path)) {
+				var fileName = Path.GetFileName (path);
+				var newFilename = "";
+				switch (xmlType) {
+				case XmlResultType.TouchUnit:
+				case XmlResultType.NUnit:
+					newFilename = path.Replace (fileName, $"nunit-{fileName}");
+					break;
+				case XmlResultType.xUnit:
+					newFilename = path.Replace (fileName, $"xunit-{fileName}");
+					break;
+				}
+				return newFilename;
+			}
+		}
+
+		public static void CleanXml (string source, string destination)
+		{
+			using (var reader = new StreamReader (source))
+			using (var writer = new StreamWriter (destination)) {
+				string line;
+				while ((line = reader.ReadLine ()) != null) {
+					if (line.StartsWith ("ping", StringComparison.InvariantCulture) || line.Contains ("TouchUnitTestRun") || line.Contains ("NUnitOutput") || line.Contains ("<!--")) {
+						continue;
+					}
+					if (line.Contains ("TouchUnitExtraData")) // always last node in TouchUnit
+						break;
+					writer.WriteLine (line);
+				}
+			}
+		}
+
+		public static (string resultLine, bool failed) GenerateHumanReadableResults (string source, string destination, XmlResultType xmlType)
+		{
+			(string resultLine, bool failed) parseData;
+			using (var reader = new StreamReader (source)) 
+			using (var writer = new StreamWriter (destination, true)) {
+				switch (xmlType) {
+				case XmlResultType.TouchUnit:
+					parseData = ParseTouchUnitXml (reader, writer);
+					break;
+				case XmlResultType.NUnit:
+					parseData = ParseNUnitXml (reader, writer);
+					break;
+				case XmlResultType.xUnit:
+					parseData = ParsexUnitXml (reader, writer);
+					break;
+				default:
+					parseData = ("", true);
+					break;
+				}
+			}
+			return parseData;
+		}
+	}
+}

--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -9,13 +9,13 @@ namespace xharness {
 			TouchUnit,
 			NUnit,
 			xUnit,
-			Text,
+			Missing,
 		}
 
 		// test if the file is valid xml, or at least, that can be read it.
 		public static bool IsValidXml (string path, out Jargon type)
 		{
-			type = Jargon.Text;
+			type = Jargon.Missing;
 			if (!File.Exists (path))
 				return false;
 
@@ -52,14 +52,14 @@ namespace xharness {
 			using (var reader = XmlReader.Create (stream)) {
 				while (reader.Read ()) {
 					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-results") {
-						total = long.Parse (reader ["total"]);
-						errors = long.Parse (reader ["errors"]);
-						failed = long.Parse (reader ["failures"]);
-						notRun = long.Parse (reader ["not-run"]);
-						inconclusive = long.Parse (reader ["inconclusive"]);
-						ignored = long.Parse (reader ["ignored"]);
-						skipped = long.Parse (reader ["skipped"]);
-						invalid = long.Parse (reader ["invalid"]);
+						long.TryParse (reader ["total"], out total);
+						long.TryParse (reader ["errors"], out errors);
+						long.TryParse (reader ["failures"], out failed);
+						long.TryParse (reader ["not-run"], out notRun);
+						long.TryParse (reader ["inconclusive"], out inconclusive);
+						long.TryParse (reader ["ignored"], out ignored);
+						long.TryParse (reader ["skipped"], out skipped );
+						long.TryParse (reader ["invalid"], out invalid);
 					}
 					if (reader.NodeType == XmlNodeType.Element && reader.Name == "TouchUnitExtraData") {
 						// move fwd to get to the CData
@@ -82,14 +82,14 @@ namespace xharness {
 			using (var reader = XmlReader.Create (stream, settings)) {
 				while (reader.Read ()) {
 					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-results") {
-						total = long.Parse (reader ["total"]);
-						errors = long.Parse (reader ["errors"]);
-						failed = long.Parse (reader ["failures"]);
-						notRun = long.Parse (reader ["not-run"]);
-						inconclusive = long.Parse (reader ["inconclusive"]);
-						ignored = long.Parse (reader ["ignored"]);
-						skipped = long.Parse (reader ["skipped"]);
-						invalid = long.Parse (reader ["invalid"]);
+						long.TryParse (reader ["total"], out total);
+						long.TryParse (reader ["errors"], out errors);
+						long.TryParse (reader ["failures"], out failed);
+						long.TryParse (reader ["not-run"], out notRun);
+						long.TryParse (reader ["inconclusive"], out inconclusive);
+						long.TryParse (reader ["ignored"], out ignored);
+						long.TryParse (reader ["skipped"], out skipped);
+						long.TryParse (reader ["invalid"], out invalid);
 					}
 					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-suite" && (reader ["type"] == "TestFixture" || reader ["type"] == "TestCollection")) {
 						var testCaseName = reader ["name"];
@@ -148,10 +148,14 @@ namespace xharness {
 			using (var reader = XmlReader.Create (stream)) {
 				while (reader.Read ()) {
 					if (reader.NodeType == XmlNodeType.Element && reader.Name == "assembly") {
-						total += long.Parse (reader ["total"]);
-						errors += long.Parse (reader ["errors"]);
-						failed += long.Parse (reader ["failed"]);
-						skipped += long.Parse (reader ["skipped"]);
+						long.TryParse (reader ["total"], out var asseblyCount);
+						total += asseblyCount;
+						long.TryParse (reader ["errors"], out var assemblyErrors);
+						errors += assemblyErrors;
+						long.TryParse (reader ["failed"], out var assemblyFailures);
+						failed += assemblyFailures;
+						long.TryParse (reader ["skipped"], out var assemblySkipped);
+						skipped += assemblySkipped;
 					}
 					if (reader.NodeType == XmlNodeType.Element && reader.Name == "collection") {
 						var testCaseName = reader ["name"].Replace ("Test collection for ", "");
@@ -219,7 +223,7 @@ namespace xharness {
 			using (var writer = new StreamWriter (destination)) {
 				string line;
 				while ((line = reader.ReadLine ()) != null) {
-					if (line.StartsWith ("ping", StringComparison.InvariantCulture) || line.Contains ("TouchUnitTestRun") || line.Contains ("NUnitOutput") || line.Contains ("<!--")) {
+					if (line.StartsWith ("ping", StringComparison.Ordinal) || line.Contains ("TouchUnitTestRun") || line.Contains ("NUnitOutput") || line.Contains ("<!--")) {
 						continue;
 					}
 					if (line == "") // remove white lines, some files have them

--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -19,7 +19,6 @@ namespace xharness {
 			if (!File.Exists (path))
 				return false;
 
-			bool isXml = false;
 			using (var stream = File.OpenText (path)) {
 				string line;
 				while ((line = stream.ReadLine ()) != null) { // special case when get got the tcp connection
@@ -27,21 +26,19 @@ namespace xharness {
 						continue;
 					if (line.Contains ("TouchUnitTestRun")) {
 						type = Jargon.TouchUnit;
-						isXml = true;
-						break;
+						return true;
 					}
 					if (line.Contains ("nunit-version")) {
 						type = Jargon.NUnit;
-						isXml = true;
+						return true;
 					}
 					if (line.Contains ("xUnit")) {
 						type = Jargon.xUnit;
-						isXml = true;
-						break;
+						return true;
 					}
 				}
 			}
-			return isXml;
+			return false;
 		}
 
 		static (string resultLine, bool failed) ParseTouchUnitXml (StreamReader stream, StreamWriter writer)

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -128,6 +128,7 @@
     <Compile Include="..\..\tools\bcl-test-importer\BCLTestImporter\BCLTestInfoPlistGenerator.cs">
       <Link>BCLTestImporter\BCLTestInfoPlistGenerator.cs</Link>
     </Compile>
+    <Compile Include="XmlResultParser.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="BCLTestImporter\" />


### PR DESCRIPTION
There is a lot of logic related to xml in the AppRunner making it more
complicated than needed. Move the methods to a hlper class.