### PR TITLE
[msbuild] Make DeviceSpecificOutputPath an absolute path.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.Common.targets
@@ -43,15 +43,16 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<PropertyGroup>
 			<AppBundleDir Condition="'$(AppBundleDir)' == ''">$(DeviceSpecificOutputPath)$(_AppBundleName)$(AppBundleExtension)</AppBundleDir>
 			<_AppBundlePath>$(AppBundleDir)\</_AppBundlePath>
+			<_RelativeAppBundleDir>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '$(AppBundleDir)'))</_RelativeAppBundleDir>
 
 			<!-- needed for GetTargetPath/Build/Rebuild task outputs -->
-			<_AppExtensionBundlePath>$(MSBuildProjectDirectory)\$(AppBundleDir)</_AppExtensionBundlePath>
+			<_AppExtensionBundlePath>$(AppBundleDir)</_AppExtensionBundlePath>
 		</PropertyGroup>
 		<ItemGroup>
-			<_AppExtensionBundlePath Include="$(MSBuildProjectDirectory)\$(AppBundleDir)">
+			<_AppExtensionBundlePath Include="$(AppBundleDir)">
 				<!-- We need this metadata to fix the source in VS -->
 				<BuildSessionId>$(BuildSessionId)</BuildSessionId>
-				<BuildServerPath>..\..\$(BuildAppName)\$(BuildSessionId)\$(AppBundleDir)</BuildServerPath>
+				<BuildServerPath>..\..\$(BuildAppName)\$(BuildSessionId)\$(_RelativeAppBundleDir)</BuildServerPath>
 			</_AppExtensionBundlePath>
 		</ItemGroup>
 	</Target>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
@@ -41,13 +41,14 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 	<Target Name="_GetWatchAppBundlePath" DependsOnTargets="_GenerateBundleName;$(_GetWatchAppBundlePathDependsOn)">
 		<PropertyGroup>
 			<!-- needed for GetTargetPath/Build/Rebuild task outputs -->
-			<_WatchAppBundlePath>$(MSBuildProjectDirectory)\$(AppBundleDir)</_WatchAppBundlePath>
+			<_WatchAppBundlePath>$(AppBundleDir)</_WatchAppBundlePath>
+			<_RelativeAppBundleDir>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '$(AppBundleDir)'))</_RelativeAppBundleDir>
 		</PropertyGroup>
 		<ItemGroup>
-			<_WatchAppBundlePath Include="$(MSBuildProjectDirectory)\$(AppBundleDir)">
+			<_WatchAppBundlePath Include="$(AppBundleDir)">
 				<!-- We need this metadata to fix the source in VS -->
 				<BuildSessionId>$(BuildSessionId)</BuildSessionId>
-				<BuildServerPath>..\..\$(BuildAppName)\$(BuildSessionId)\$(AppBundleDir)</BuildServerPath>
+				<BuildServerPath>..\..\$(BuildAppName)\$(BuildSessionId)\$(_RelativeAppBundleDir)</BuildServerPath>
 			</_WatchAppBundlePath>
 		</ItemGroup>
 	</Target>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.Common.targets
@@ -48,15 +48,16 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<PropertyGroup>
 			<AppBundleDir Condition="'$(AppBundleDir)' == ''">$(DeviceSpecificOutputPath)$(_AppBundleName)$(AppBundleExtension)</AppBundleDir>
 			<_AppBundlePath>$(AppBundleDir)\</_AppBundlePath>
+			<_RelativeAppBundleDir>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '$(AppBundleDir)'))</_RelativeAppBundleDir>
 
 			<!-- needed for GetTargetPath/Build/Rebuild task outputs -->
-			<_AppExtensionBundlePath>$(MSBuildProjectDirectory)\$(AppBundleDir)</_AppExtensionBundlePath>
+			<_AppExtensionBundlePath>$(AppBundleDir)</_AppExtensionBundlePath>
 		</PropertyGroup>
 		<ItemGroup>
-			<_AppExtensionBundlePath Include="$(MSBuildProjectDirectory)\$(AppBundleDir)">
+			<_AppExtensionBundlePath Include="$(AppBundleDir)">
 				<!-- We need this metadata to fix the source in VS -->
 				<BuildSessionId>$(BuildSessionId)</BuildSessionId>
-				<BuildServerPath>..\..\$(BuildAppName)\$(BuildSessionId)\$(AppBundleDir)</BuildServerPath>
+				<BuildServerPath>..\..\$(BuildAppName)\$(BuildSessionId)\$(_RelativeAppBundleDir)</BuildServerPath>
 			</_AppExtensionBundlePath>
 		</ItemGroup>
 	</Target>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.Common.targets
@@ -38,15 +38,16 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<PropertyGroup>
 			<AppBundleDir Condition="'$(AppBundleDir)' == ''">$(DeviceSpecificOutputPath)$(_AppBundleName)$(AppBundleExtension)</AppBundleDir>
 			<_AppBundlePath>$(AppBundleDir)\</_AppBundlePath>
+			<_RelativeAppBundleDir>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '$(AppBundleDir)'))</_RelativeAppBundleDir>
 
 			<!-- needed for GetTargetPath/Build/Rebuild task outputs -->
-			<_AppExtensionBundlePath>$(MSBuildProjectDirectory)\$(AppBundleDir)</_AppExtensionBundlePath>
+			<_AppExtensionBundlePath>$(AppBundleDir)</_AppExtensionBundlePath>
 		</PropertyGroup>
 		<ItemGroup>
-			<_AppExtensionBundlePath Include="$(MSBuildProjectDirectory)\$(AppBundleDir)">
+			<_AppExtensionBundlePath Include="$(AppBundleDir)">
 				<!-- We need this metadata to fix the source in VS -->
 				<BuildSessionId>$(BuildSessionId)</BuildSessionId>
-				<BuildServerPath>..\..\$(BuildAppName)\$(BuildSessionId)\$(AppBundleDir)</BuildServerPath>
+				<BuildServerPath>..\..\$(BuildAppName)\$(BuildSessionId)\$(_RelativeAppBundleDir)</BuildServerPath>
 			</_AppExtensionBundlePath>
 		</ItemGroup>
 	</Target>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -134,7 +134,9 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<AppBundleExtension Condition="'$(AppBundleExtension)' == ''">.app</AppBundleExtension>
 
 		<DeviceSpecificIntermediateOutputPath>$(IntermediateOutputPath)</DeviceSpecificIntermediateOutputPath>
+		<!-- make sure DeviceSpecificOutputPath is an absolute path: when using dotnet it might be, and this way we ensure we have the same behavior when not running with dotnet as well -->
 		<DeviceSpecificOutputPath>$(OutputPath)</DeviceSpecificOutputPath>
+		<DeviceSpecificOutputPath Condition="$([System.IO.Path]::IsPathRooted ('$(DeviceSpecificOutputPath)')) != 'true'">$([MSBuild]::NormalizePath ('$(MSBuildProjectDirectory)','$(OutputPath)'))</DeviceSpecificOutputPath>
 	</PropertyGroup>
 	
 	<PropertyGroup>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.Common.targets
@@ -41,13 +41,14 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 	<Target Name="_GetWatchAppBundlePath" DependsOnTargets="_GenerateBundleName;$(_GetWatchAppBundlePathDependsOn)">
 		<PropertyGroup>
 			<!-- needed for GetTargetPath/Build/Rebuild task outputs -->
-			<_WatchAppBundlePath>$(MSBuildProjectDirectory)\$(AppBundleDir)</_WatchAppBundlePath>
+			<_WatchAppBundlePath>$(AppBundleDir)</_WatchAppBundlePath>
+			<_RelativeAppBundleDir>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '$(AppBundleDir)'))</_RelativeAppBundleDir>
 		</PropertyGroup>
 		<ItemGroup>
-			<_WatchAppBundlePath Include="$(MSBuildProjectDirectory)\$(AppBundleDir)">
+			<_WatchAppBundlePath Include="$(AppBundleDir)">
 				<!-- We need this metadata to fix the source in VS -->
 				<BuildSessionId>$(BuildSessionId)</BuildSessionId>
-				<BuildServerPath>..\..\$(BuildAppName)\$(BuildSessionId)\$(AppBundleDir)</BuildServerPath>
+				<BuildServerPath>..\..\$(BuildAppName)\$(BuildSessionId)\$(_RelativeAppBundleDir)</BuildServerPath>
 			</_WatchAppBundlePath>
 		</ItemGroup>
 	</Target>

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
@@ -407,7 +407,7 @@ namespace Xamarin.iOS.Tasks
 
 			// Now we should have an AppBundleDir
 			RunTargetOnInstance (MonoTouchProjectInstance, TargetName.GenerateBundleName);
-			Assert.AreEqual (@"bin/iPhoneSimulator/Debug/MySingleView.app", MonoTouchProjectInstance.GetPropertyValue ("AppBundleDir"), "#3");
+			Assert.AreEqual (Path.Combine (Path.GetDirectoryName (MonoTouchProjectInstance.FullPath), "bin/iPhoneSimulator/Debug/MySingleView.app"), MonoTouchProjectInstance.GetPropertyValue ("AppBundleDir"), "#3");
 		}
 
 		[Test]


### PR DESCRIPTION
It might be absolute at least sometimes when building with dotnet, and making
it always an absolute path simplifies the code.

This also had an affect on AppBundleDir, AppBundlePath, and a few other app
bundle variables, which do not need to be absolutified anymore because they're
based on DeviceSpecificOutputPath.