### PR TITLE
[msbuild] Don't add newlines to command line arguments to mmp.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -242,20 +242,17 @@ namespace Xamarin.Mac.Tasks
 
 			actualArgs.AddQuoted ($"@{responseFile}");
 
-			if (!string.IsNullOrWhiteSpace (ExtraArguments)) {
-				actualArgs.Add (" ");
+			if (!string.IsNullOrWhiteSpace (ExtraArguments))
 				actualArgs.Add (ExtraArguments);
-			}
 
-			actualArgs.Add (" ");
 			var verbosity = VerbosityUtils.Merge (ExtraArguments, (LoggerVerbosity) Verbosity);
 			if (verbosity.Length > 0) {
 				foreach (var arg in verbosity) {
-					actualArgs.AddLine (arg);
+					actualArgs.Add (arg);
 				}
 			} else {
 				// for compatibility with earlier versions nothing means one /v
-				actualArgs.AddLine ("/verbose");
+				actualArgs.Add ("/verbose");
 			}
 
 			return actualArgs.ToString ();


### PR DESCRIPTION
Don't separate command-line arguments to mmp with newlines, in dotnet those
newlines are passed to mmp instead of being treated as whitespace, and that
confuses mmp.

Also remove additional and unneeded whitespace in the command line arguments,
the CommandLineArgumentBuilder class already adds whitespace when needed.