### PR TITLE
[msbuild] remove {GAC} from $(AssemblySearchPaths)

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
@@ -101,6 +101,12 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<AvailableItemName Include="BundleResource" />
 	</ItemGroup>
 
+	<!-- Do not resolve from the GAC under any circumstances in Mobile -->
+	<PropertyGroup>
+		<AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}',''))</AssemblySearchPaths>
+		<AssemblySearchPaths Condition="'$(MSBuildRuntimeVersion)' != ''">$(AssemblySearchPaths.Split(';'))</AssemblySearchPaths>
+	</PropertyGroup>
+
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.props"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.props')"/>
 

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectWithSpaces.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectWithSpaces.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.IO;
+using System.Linq;
 using NUnit.Framework;
 
 namespace Xamarin.iOS.Tasks
@@ -16,6 +16,14 @@ namespace Xamarin.iOS.Tasks
 		public void BasicTest ()
 		{
 			this.BuildProject ("My Spaced App", Platform, "Debug", clean: false);
+
+			// Message of the form:
+			// Property reassignment: $(AssemblySearchPaths)="..." (previous value: "...") at Xamarin.iOS.Common.props (106,3)
+			var assemblySearchPaths = Engine.Logger.MessageEvents.FirstOrDefault (m => m.Message.Contains ("Property reassignment: $(AssemblySearchPaths)=\""));
+			Assert.IsNotNull (assemblySearchPaths, "$(AssemblySearchPaths) should be modified");
+			var split = assemblySearchPaths.Message.Split ('"');
+			Assert.GreaterOrEqual (split.Length, 1, "Unexpected string contents");
+			Assert.IsFalse (split [1].Contains ("{GAC}"), "$(AssemblySearchPaths) should not contain {GAC}");
 		}
 	}
 }


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/content/problem/788505/xamarin-found-conflicts-between-different-versions.html
Fixes: http://work.azdo.io/1008385
Context: https://github.com/xamarin/xamarin-android/blob/73b93c2dc94d4af166415634b40695fa2be8c371/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L337-L341

On Windows only, Xamarin.Forms projects hit the build warning:

    Microsoft.Common.CurrentVersion.targets(2106,5): warning MSB3277: Found conflicts between different versions of "System.Numerics" that could not be resolved.
    These reference conflicts are listed in the build log when log verbosity is set to detailed.

The difference appears to be the `{GAC}` search path is used on
Windows, but not Mac.

In fact, the output of `<ResolveAssemblyReference/>` on Mac reports:

    Unused locations
        {CandidateAssemblyFiles}
        {HintPathFromItem}
        {Registry:Software/Microsoft/Xamarin.iOS,v1.0,AssemblyFoldersEx}
        {AssemblyFolders}
        {GAC}
        bin/iPhoneSimulator/Debug/
    Used locations
        {TargetFrameworkDirectory}
        {RawFileName}

Compared to Windows:

    Used locations
        {TargetFrameworkDirectory}
        {GAC}
        {RawFileName}

For now, we should just remove `{GAC}` from the list as the safest fix.

Xamarin.Mac is already doing this:

https://github.com/xamarin/xamarin-macios/blob/f85556c1e5bee7a0faf3bf7ade709c3f5f260f11/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props#L121-L125

Down the road, we could specify only the paths needed for performance
reasons. We have done this recently in Xamarin.Android:

https://github.com/xamarin/xamarin-android/blob/5945e9a77988a01ceb062dcc82bda6c6bf407e14/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L382-L386