### PR TITLE
[objcruntime] Fix CS0105 warning in Registrar.cs

### DIFF
--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -43,7 +43,6 @@ using R=ObjCRuntime.Runtime;
 
 #if MONOTOUCH
 #if MTOUCH
-using Xamarin.Bundler;
 using ProductException=Xamarin.Bundler.MonoTouchException;
 #else
 #if XAMCORE_2_0
@@ -54,7 +53,6 @@ using ProductException=MonoTouch.RuntimeException;
 #endif
 #elif MONOMAC
 #if MMP
-using Xamarin.Bundler;
 using ProductException=Xamarin.Bundler.MonoMacException;
 #elif XAMCORE_2_0
 using ProductException=ObjCRuntime.RuntimeException;


### PR DESCRIPTION
```
src/ObjCRuntime/Registrar.cs(57,7): warning CS0105: The using directive for 'Xamarin.Bundler' appeared previously in this namespace
```