### PR TITLE
[xcode11.4] [Harness] Just try to generate the report when is NUnit.

### DIFF
--- a/tests/bcl-test/BCLTests-mac.csproj.in
+++ b/tests/bcl-test/BCLTests-mac.csproj.in
@@ -48,14 +48,16 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
-    <PackageReference Include="System.Memory" Version="4.5.2" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="System.Buffers" Version="4.4.0" />
+    <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
     <PackageReference Include="xunit.extensibility.core" Version="2.4.0" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.0" />
     <PackageReference Include="xunit.runner.utility" Version="2.4.0" />
+
+
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System">
@@ -99,6 +101,9 @@
     <Compile Include="templates\common\TestRunner.NUnit\ClassOrNamespaceFilter.cs">
       <Link>TestRunner.NUnit\ClassOrNamespaceFilter.cs</Link>
     </Compile>
+    <Compile Include="templates\common\TestRunner.NUnit\XmlOutputWriter.cs">
+       <Link>TestRunner.NUnit\XmlOutputWriter.cs</Link>
+     </Compile>
     <Compile Include="templates\common\TestRunner.NUnit\TestMethodFilter.cs">
       <Link>TestRunner.NUnit\TestMethodFilter.cs</Link>
     </Compile>

--- a/tests/bcl-test/BCLTests-tv.csproj.in
+++ b/tests/bcl-test/BCLTests-tv.csproj.in
@@ -122,15 +122,15 @@
     <MtouchI18n>cjk,mideast,other,rare,west</MtouchI18n>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="System.Buffers" Version="4.4.0" />
-    <PackageReference Include="System.Memory" Version="4.5.1" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.0" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.utility" Version="2.4.0" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -175,6 +175,9 @@
     </Compile>
     <Compile Include="templates\common\TestRunner.NUnit\TestMethodFilter.cs">
       <Link>TestRunner.NUnit\TestMethodFilter.cs</Link>
+    </Compile>
+    <Compile Include="templates\common\TestRunner.NUnit\XmlOutputWriter.cs">
+      <Link>TestRunner.NUnit\XmlOutputWriter.cs</Link>
     </Compile>
     <Compile Include="templates\common\TestRunner.Core\Extensions.Bool.cs">
       <Link>TestRunner.Core\Extensions.Bool.cs</Link>

--- a/tests/bcl-test/BCLTests-watchos-extension.csproj.in
+++ b/tests/bcl-test/BCLTests-watchos-extension.csproj.in
@@ -128,15 +128,15 @@
     <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="System.Buffers" Version="4.4.0" />
-    <PackageReference Include="System.Memory" Version="4.5.1" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.0" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.utility" Version="2.4.0" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -205,6 +205,9 @@
     </Compile>
     <Compile Include="templates\common\TestRunner.NUnit\TestMethodFilter.cs">
       <Link>TestRunner.NUnit\TestMethodFilter.cs</Link>
+    </Compile>
+    <Compile Include="templates\common\TestRunner.NUnit\XmlOutputWriter.cs">
+      <Link>TestRunner.NUnit\XmlOutputWriter.cs</Link>
     </Compile>
     <Compile Include="templates\common\TestRunner.xUnit\XUnitFilter.cs">
       <Link>TestRunner.xUnit\XUnitFilter.cs</Link>

--- a/tests/bcl-test/BCLTests.csproj.in
+++ b/tests/bcl-test/BCLTests.csproj.in
@@ -135,15 +135,15 @@
     <MtouchI18n>cjk,mideast,other,rare,west</MtouchI18n>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="System.Buffers" Version="4.4.0" />
-    <PackageReference Include="System.Memory" Version="4.5.1" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.0" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.utility" Version="2.4.0" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -188,6 +188,9 @@
     </Compile>
     <Compile Include="templates\common\TestRunner.NUnit\TestMethodFilter.cs">
       <Link>TestRunner.NUnit\TestMethodFilter.cs</Link>
+    </Compile>
+    <Compile Include="templates\common\TestRunner.NUnit\XmlOutputWriter.cs">
+      <Link>TestRunner.NUnit\XmlOutputWriter.cs</Link>
     </Compile>
     <Compile Include="templates\common\TestRunner.Core\Extensions.Bool.cs">
       <Link>TestRunner.Core\Extensions.Bool.cs</Link>

--- a/tests/bcl-test/templates/common/TestRunner.NUnit/NUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.NUnit/NUnitTestRunner.cs
@@ -9,10 +9,8 @@ using System.Threading.Tasks;
 
 using Foundation;
 
-using NUnitLite.Runner;
 using NUnit.Framework.Api;
 using NUnit.Framework.Internal;
-using NUnit.Framework.Internal.WorkItems;
 using NUnit.Framework.Internal.Filters;
 
 using NUnitTest = NUnit.Framework.Internal.Test;

--- a/tests/bcl-test/templates/common/TestRunner.NUnit/XmlOutputWriter.cs
+++ b/tests/bcl-test/templates/common/TestRunner.NUnit/XmlOutputWriter.cs
@@ -1,0 +1,349 @@
+﻿// ***********************************************************************
+// Copyright (c) 2011 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Globalization;
+using System.Reflection;
+using System.Xml;
+using System.IO;
+using NUnit.Framework.Api;
+using NUnit.Framework.Internal;
+using NUnitLite.Runner;
+#if CLR_2_0 || CLR_4_0
+using System.Collections.Generic;
+#else
+using System.Collections.Specialized;
+#endif
+
+namespace Xamarin.iOS.UnitTests.NUnit {
+	/// <summary>
+	/// NUnit2XmlOutputWriter is able to create an xml file representing
+	/// the result of a test run in NUnit 2.x format.
+	/// </summary>
+	public class NUnit2XmlOutputWriter : OutputWriter {
+		private XmlWriter xmlWriter;
+		private DateTime startTime;
+
+#if CLR_2_0 || CLR_4_0
+	private static Dictionary<string, string> resultStates = new Dictionary<string, string>();
+#else
+		private static StringDictionary resultStates = new StringDictionary ();
+#endif
+
+		static NUnit2XmlOutputWriter ()
+		{
+			resultStates ["Passed"] = "Success";
+			resultStates ["Failed"] = "Failure";
+			resultStates ["Failed:Error"] = "Error";
+			resultStates ["Failed:Cancelled"] = "Cancelled";
+			resultStates ["Inconclusive"] = "Inconclusive";
+			resultStates ["Skipped"] = "Skipped";
+			resultStates ["Skipped:Ignored"] = "Ignored";
+			resultStates ["Skipped:Invalid"] = "NotRunnable";
+		}
+
+		public NUnit2XmlOutputWriter (DateTime startTime)
+		{
+			this.startTime = startTime;
+		}
+
+		/// <summary>
+		/// Writes the result of a test run to a specified TextWriter.
+		/// </summary>
+		/// <param name="result">The test result for the run</param>
+		/// <param name="writer">The TextWriter to which the xml will be written</param>
+		public override void WriteResultFile (ITestResult result, TextWriter writer)
+		{
+			// NOTE: Under .NET 1.1, XmlTextWriter does not implement IDisposable,
+			// but does implement Close(). Hence we cannot use a 'using' clause.
+			//using (XmlTextWriter xmlWriter = new XmlTextWriter(writer))
+#if SILVERLIGHT
+	    XmlWriter xmlWriter = XmlWriter.Create(writer);
+#else
+			XmlTextWriter xmlWriter = new XmlTextWriter (writer);
+			xmlWriter.Formatting = Formatting.Indented;
+#endif
+
+			try {
+				WriteXmlOutput (result, xmlWriter);
+			} finally {
+				writer.Close ();
+			}
+		}
+
+		private void WriteXmlOutput (ITestResult result, XmlWriter xmlWriter)
+		{
+			this.xmlWriter = xmlWriter;
+
+			InitializeXmlFile (result);
+			WriteResultElement (result);
+			TerminateXmlFile ();
+		}
+
+		private void InitializeXmlFile (ITestResult result)
+		{
+			ResultSummary summaryResults = new ResultSummary (result);
+
+			xmlWriter.WriteStartDocument (false);
+			xmlWriter.WriteComment ("This file represents the results of running a test suite");
+
+			xmlWriter.WriteStartElement ("test-results");
+
+			xmlWriter.WriteAttributeString ("name", result.FullName);
+			xmlWriter.WriteAttributeString ("total", summaryResults.TestCount.ToString ());
+			xmlWriter.WriteAttributeString ("errors", summaryResults.ErrorCount.ToString ());
+			xmlWriter.WriteAttributeString ("failures", summaryResults.FailureCount.ToString ());
+			xmlWriter.WriteAttributeString ("not-run", summaryResults.NotRunCount.ToString ());
+			xmlWriter.WriteAttributeString ("inconclusive", summaryResults.InconclusiveCount.ToString ());
+			xmlWriter.WriteAttributeString ("ignored", summaryResults.IgnoreCount.ToString ());
+			xmlWriter.WriteAttributeString ("skipped", summaryResults.SkipCount.ToString ());
+			xmlWriter.WriteAttributeString ("invalid", summaryResults.InvalidCount.ToString ());
+
+			xmlWriter.WriteAttributeString ("date", XmlConvert.ToString (startTime, "yyyy-MM-dd"));
+			xmlWriter.WriteAttributeString ("time", XmlConvert.ToString (startTime, "HH:mm:ss"));
+			WriteEnvironment ();
+			WriteCultureInfo ();
+			xmlWriter.Flush ();
+		}
+
+		private void WriteCultureInfo ()
+		{
+			xmlWriter.WriteStartElement ("culture-info");
+			xmlWriter.WriteAttributeString ("current-culture",
+						       CultureInfo.CurrentCulture.ToString ());
+			xmlWriter.WriteAttributeString ("current-uiculture",
+						       CultureInfo.CurrentUICulture.ToString ());
+			xmlWriter.WriteEndElement ();
+			xmlWriter.Flush ();
+		}
+
+		private void WriteEnvironment ()
+		{
+			xmlWriter.WriteStartElement ("environment");
+			AssemblyName assemblyName = AssemblyHelper.GetAssemblyName (Assembly.GetExecutingAssembly ());
+			xmlWriter.WriteAttributeString ("nunit-version",
+						       assemblyName.Version.ToString ());
+			xmlWriter.WriteAttributeString ("clr-version",
+						       Environment.Version.ToString ());
+			xmlWriter.WriteAttributeString ("os-version",
+						       Environment.OSVersion.ToString ());
+			xmlWriter.WriteAttributeString ("platform",
+			    Environment.OSVersion.Platform.ToString ());
+#if !NETCF
+			xmlWriter.WriteAttributeString ("cwd",
+						       Environment.CurrentDirectory);
+#if !SILVERLIGHT
+			xmlWriter.WriteAttributeString ("machine-name",
+						       Environment.MachineName);
+			xmlWriter.WriteAttributeString ("user",
+						       Environment.UserName);
+			xmlWriter.WriteAttributeString ("user-domain",
+						       Environment.UserDomainName);
+#endif
+#endif
+			xmlWriter.WriteEndElement ();
+			xmlWriter.Flush ();
+		}
+
+		private void WriteResultElement (ITestResult result)
+		{
+			StartTestElement (result);
+
+			WriteProperties (result);
+
+			switch (result.ResultState.Status) {
+			case TestStatus.Skipped:
+				WriteReasonElement (result.Message);
+				break;
+			case TestStatus.Failed:
+				WriteFailureElement (result.Message, result.StackTrace);
+				break;
+			}
+
+			if (result.Test is TestSuite)
+				WriteChildResults (result);
+
+			xmlWriter.WriteEndElement (); // test element
+			xmlWriter.Flush ();
+		}
+
+		private void TerminateXmlFile ()
+		{
+			xmlWriter.WriteEndElement (); // test-results
+			xmlWriter.WriteEndDocument ();
+			xmlWriter.Flush ();
+			xmlWriter.Close ();
+		}
+
+
+		#region Element Creation Helpers
+
+		private void StartTestElement (ITestResult result)
+		{
+			ITest test = result.Test;
+			TestSuite suite = test as TestSuite;
+
+			if (suite != null) {
+				xmlWriter.WriteStartElement ("test-suite");
+				xmlWriter.WriteAttributeString ("type", suite.TestType);
+				xmlWriter.WriteAttributeString ("name", suite.TestType == "Assembly"
+				    ? result.Test.FullName
+				    : result.Test.Name);
+			} else {
+				xmlWriter.WriteStartElement ("test-case");
+				xmlWriter.WriteAttributeString ("name", result.Name);
+			}
+
+			if (test.Properties.ContainsKey (PropertyNames.Description)) {
+				string description = (string)test.Properties.Get (PropertyNames.Description);
+				xmlWriter.WriteAttributeString ("description", description);
+			}
+
+			TestStatus status = result.ResultState.Status;
+			string translatedResult = resultStates [result.ResultState.ToString ()];
+
+			if (status != TestStatus.Skipped) {
+				xmlWriter.WriteAttributeString ("executed", "True");
+				xmlWriter.WriteAttributeString ("result", translatedResult);
+				xmlWriter.WriteAttributeString ("success", status == TestStatus.Passed ? "True" : "False");
+				xmlWriter.WriteAttributeString ("time", result.Duration.TotalSeconds.ToString ());
+				xmlWriter.WriteAttributeString ("asserts", result.AssertCount.ToString ());
+			} else {
+				xmlWriter.WriteAttributeString ("executed", "False");
+				xmlWriter.WriteAttributeString ("result", translatedResult);
+			}
+		}
+
+		private void WriteProperties (ITestResult result)
+		{
+			IPropertyBag properties = result.Test.Properties;
+			int nprops = 0;
+
+			foreach (string key in properties.Keys) {
+				if (key != PropertyNames.Category) {
+					if (nprops++ == 0)
+						xmlWriter.WriteStartElement ("properties");
+
+					foreach (object prop in properties [key]) {
+						xmlWriter.WriteStartElement ("property");
+						xmlWriter.WriteAttributeString ("name", key);
+						xmlWriter.WriteAttributeString ("value", prop.ToString ());
+						xmlWriter.WriteEndElement ();
+					}
+				}
+			}
+
+			if (nprops > 0)
+				xmlWriter.WriteEndElement ();
+		}
+
+		private void WriteReasonElement (string message)
+		{
+			xmlWriter.WriteStartElement ("reason");
+			xmlWriter.WriteStartElement ("message");
+			xmlWriter.WriteCData (message);
+			xmlWriter.WriteEndElement ();
+			xmlWriter.WriteEndElement ();
+		}
+
+		private void WriteFailureElement (string message, string stackTrace)
+		{
+			xmlWriter.WriteStartElement ("failure");
+			xmlWriter.WriteStartElement ("message");
+			WriteCData (message);
+			xmlWriter.WriteEndElement ();
+			xmlWriter.WriteStartElement ("stack-trace");
+			if (stackTrace != null)
+				WriteCData (stackTrace);
+			xmlWriter.WriteEndElement ();
+			xmlWriter.WriteEndElement ();
+		}
+
+		private void WriteChildResults (ITestResult result)
+		{
+			xmlWriter.WriteStartElement ("results");
+
+			foreach (ITestResult childResult in result.Children)
+				WriteResultElement (childResult);
+
+			xmlWriter.WriteEndElement ();
+		}
+
+		#endregion
+
+		#region Output Helpers
+		///// <summary>
+		///// Makes string safe for xml parsing, replacing control chars with '?'
+		///// </summary>
+		///// <param name="encodedString">string to make safe</param>
+		///// <returns>xml safe string</returnCs>
+		//private static string CharacterSafeString(string encodedString)
+		//{
+		//    /*The default code page for the system will be used.
+		//    Since all code pages use the same lower 128 bytes, this should be sufficient
+		//    for finding uprintable control characters that make the xslt processor error.
+		//    We use characters encoded by the default code page to avoid mistaking bytes as
+		//    individual characters on non-latin code pages.*/
+		//    char[] encodedChars = System.Text.Encoding.Default.GetChars(System.Text.Encoding.Default.GetBytes(encodedString));
+
+		//    System.Collections.ArrayList pos = new System.Collections.ArrayList();
+		//    for (int x = 0; x < encodedChars.Length; x++)
+		//    {
+		//        char currentChar = encodedChars[x];
+		//        //unprintable characters are below 0x20 in Unicode tables
+		//        //some control characters are acceptable. (carriage return 0x0D, line feed 0x0A, horizontal tab 0x09)
+		//        if (currentChar < 32 && (currentChar != 9 && currentChar != 10 && currentChar != 13))
+		//        {
+		//            //save the array index for later replacement.
+		//            pos.Add(x);
+		//        }
+		//    }
+		//    foreach (int index in pos)
+		//    {
+		//        encodedChars[index] = '?';//replace unprintable control characters with ?(3F)
+		//    }
+		//    return System.Text.Encoding.Default.GetString(System.Text.Encoding.Default.GetBytes(encodedChars));
+		//}
+
+		private void WriteCData (string text)
+		{
+			int start = 0;
+			while (true) {
+				int illegal = text.IndexOf ("]]>", start);
+				if (illegal < 0)
+					break;
+				xmlWriter.WriteCData (text.Substring (start, illegal - start + 2));
+				start = illegal + 2;
+				if (start >= text.Length)
+					return;
+			}
+
+			if (start > 0)
+				xmlWriter.WriteCData (text.Substring (start));
+			else
+				xmlWriter.WriteCData (text);
+		}
+
+		#endregion
+	}
+}

--- a/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
@@ -23,7 +23,7 @@ namespace Xamarin.iOS.UnitTests.XUnit
 		List<XUnitFilter> filters = new List<XUnitFilter> ();
 		bool runAssemblyByDefault;
 
-		public XUnitResultFileFormat ResultFileFormat { get; set; } = XUnitResultFileFormat.NUnit;
+		public XUnitResultFileFormat ResultFileFormat { get; set; } = XUnitResultFileFormat.XunitV2;
 		public AppDomainSupport AppDomainSupport { get; set; } = AppDomainSupport.Denied;
 		protected override string ResultsFileName { get; set; } = "TestResults.xUnit.xml";
 
@@ -795,9 +795,10 @@ namespace Xamarin.iOS.UnitTests.XUnit
 		{
 			if (assembliesElement == null)
 				return String.Empty;
-
+			// remove all the empty nodes
+			assembliesElement.Descendants ().Where (e => e.Name == "collection" && !e.Descendants ().Any ()).Remove ();
 			string outputFilePath = GetResultsFilePath ();
-			var settings = new XmlWriterSettings { Indent = true };
+			var settings = new XmlWriterSettings { Indent = true};
 			using (var xmlWriter = XmlWriter.Create (outputFilePath, settings)) {
 				switch (ResultFileFormat) {
 				case XUnitResultFileFormat.XunitV2:
@@ -818,6 +819,8 @@ namespace Xamarin.iOS.UnitTests.XUnit
 		{
 			if (assembliesElement == null)
 				return;
+			// remove all the empty nodes
+			assembliesElement.Descendants ().Where (e => e.Name == "collection" && !e.Descendants ().Any ()).Remove ();
 			var settings = new XmlWriterSettings { Indent = true };
 			using (var xmlWriter = XmlWriter.Create (writer, settings)) {
 				switch (ResultFileFormat) {
@@ -837,7 +840,7 @@ namespace Xamarin.iOS.UnitTests.XUnit
 				}
 			}
 		}
-		
+
 		void Transform_Results (string xsltResourceName, XElement element, XmlWriter writer)
 		{
 			var xmlTransform = new System.Xml.Xsl.XslCompiledTransform ();

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -451,7 +451,7 @@ namespace xharness
 			// wraps the NUnit xml output with additional information, which we need to unwrap so that Jenkins understands it.
 			// 
 			// On the other hand, the nunit and xunit do not have that data and have to be parsed.
-			if (Harness.InJenkins) {
+			if (Harness.InCI) {
 				(string resultLine, bool failed, bool crashed) parseResult = (null, false, false);
 				// move the xml to a tmp path, that path will be use to read the xml
 				// in the reader, and the writer will use the stream from the logger to
@@ -606,7 +606,7 @@ namespace xharness
 			args.Append (" -argument=-app-arg:-enablenetwork");
 			args.Append (" -setenv=NUNIT_ENABLE_NETWORK=true");
 			// detect if we are using a jenkins bot.
-			var useXmlOutput = Harness.InJenkins;
+			var useXmlOutput = Harness.InCI;
 			if (useXmlOutput) {
 				args.Append (" -setenv=NUNIT_ENABLE_XML_OUTPUT=true");
 				args.Append (" -setenv=NUNIT_ENABLE_XML_MODE=wrapped");

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -328,6 +328,19 @@ namespace xharness
 			}
 		}
 
+		// test if the file is valid xml, or at least, that can be read. The reader will throw an 
+		// exception if it cannot read the file. This is not ideal :/
+		bool IsXml (string filePath)
+		{
+			if (!File.Exists (filePath))
+				return false;
+
+			using (var stream = File.OpenText (filePath)) {
+				var firstLine = stream.ReadLine ();
+				return firstLine.StartsWith ("<", StringComparison.Ordinal);
+			}
+		}
+
 		bool IsTouchUnitResult (StreamReader stream)
 		{
 			// TouchUnitTestRun is the very first node in the TouchUnit xml result
@@ -451,7 +464,12 @@ namespace xharness
 			// wraps the NUnit xml output with additional information, which we need to unwrap so that Jenkins understands it.
 			// 
 			// On the other hand, the nunit and xunit do not have that data and have to be parsed.
-			if (Harness.InCI) {
+			// 
+			// This if statement has a small trick, we found out that internet sharing in some of the bots (VSTS) does not work, in
+			// that case, we cannot do a TCP connection to xharness to get the log, this is a problem since if we did not get the xml
+			// from the TCP connection, we are going to fail when trying to read it and not parse it. Therefore, we are not only
+			// going to check if we are in CI, but also if the listener_log is valid.
+			if (Harness.InCI && IsXml (listener_log.FullPath)) {
 				(string resultLine, bool failed, bool crashed) parseResult = (null, false, false);
 				// move the xml to a tmp path, that path will be use to read the xml
 				// in the reader, and the writer will use the stream from the logger to

--- a/tests/xharness/BCLTestImporter/BCLTestImportTargetFactory.cs
+++ b/tests/xharness/BCLTestImporter/BCLTestImportTargetFactory.cs
@@ -26,7 +26,7 @@ namespace xharness.BCLTestImporter {
 				MacMonoSDKPath = Harness.MONO_MAC_SDK_DESTDIR,
 				Override = true,
 				GuidGenerator = Harness.NewStableGuid,
-				GroupTests = Harness.InJenkins || Harness.UseGroupedApps,
+				GroupTests = Harness.InCI || Harness.UseGroupedApps,
 			};
 		}
 		

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -115,7 +115,7 @@ namespace xharness
 
 		public Harness ()
 		{
-			LaunchTimeout = InWrench ? 3 : 120;
+			LaunchTimeout = InCI ? 3 : 120;
 		}
 
 		public bool GetIncludeSystemPermissionTests (TestPlatform platform, bool device)
@@ -667,24 +667,10 @@ namespace xharness
 
 		public void LogWrench (string message)
 		{
-			if (!InWrench)
+			if (!InCI)
 				return;
 
 			Console.WriteLine (message);
-		}
-
-		public bool InWrench {
-			get {
-				var buildRev = Environment.GetEnvironmentVariable ("BUILD_REVISION");
-				return !string.IsNullOrEmpty (buildRev) && buildRev != "jenkins";
-			}
-		}
-		
-		public bool InJenkins {
-			get {
-				var buildRev = Environment.GetEnvironmentVariable ("BUILD_REVISION");
-				return !string.IsNullOrEmpty (buildRev) && buildRev == "jenkins";
-			}
 		}
 		
 		public bool InCI {

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2211,26 +2211,32 @@ namespace xharness
 									} else if (log.Description == "NUnit results" || log.Description == "XML log") {
 										try {
 											if (File.Exists (log.FullPath) && new FileInfo (log.FullPath).Length > 0) {
-												var doc = new System.Xml.XmlDocument ();
-												doc.LoadWithoutNetworkAccess (log.FullPath);
-												var failures = doc.SelectNodes ("//test-case[@result='Error' or @result='Failure']").Cast<System.Xml.XmlNode> ().ToArray ();
-												if (failures.Length > 0) {
-													writer.WriteLine ("<div style='padding-left: 15px;'>");
-													writer.WriteLine ("<ul>");
-													foreach (var failure in failures) {
-														writer.WriteLine ("<li>");
-														var test_name = failure.Attributes ["name"]?.Value;
-														var message = failure.SelectSingleNode ("failure/message")?.InnerText;
-														writer.Write (HtmlFormat (test_name));
-														if (!string.IsNullOrEmpty (message)) {
-															writer.Write (": ");
-															writer.Write (HtmlFormat (message));
+												if (XmlResultParser.IsValidXml (log.FullPath, out var jargon)) {
+													if (jargon == XmlResultParser.Jargon.NUnit) {
+														var doc = new XmlDocument ();
+														doc.LoadWithoutNetworkAccess (log.FullPath);
+														var failures = doc.SelectNodes ("//test-case[@result='Error' or @result='Failure']").Cast<System.Xml.XmlNode> ().ToArray ();
+														if (failures.Length > 0) {
+															writer.WriteLine ("<div style='padding-left: 15px;'>");
+															writer.WriteLine ("<ul>");
+															foreach (var failure in failures) {
+																writer.WriteLine ("<li>");
+																var test_name = failure.Attributes ["name"]?.Value;
+																var message = failure.SelectSingleNode ("failure/message")?.InnerText;
+																writer.Write (HtmlFormat (test_name));
+																if (!string.IsNullOrEmpty (message)) {
+																	writer.Write (": ");
+																	writer.Write (HtmlFormat (message));
+																}
+																writer.WriteLine ("<br />");
+																writer.WriteLine ("</li>");
+															}
+															writer.WriteLine ("</ul>");
+															writer.WriteLine ("</div>");
 														}
-														writer.WriteLine ("<br />");
-														writer.WriteLine ("</li>");
+													} else {
+														writer.WriteLine ($"<span style='padding-left: 15px;'>Could not parse {log.Description}: Not supported format.</span><br />");
 													}
-													writer.WriteLine ("</ul>");
-													writer.WriteLine ("</div>");
 												}
 											}
 										} catch (Exception ex) {

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1143,7 +1143,7 @@ namespace xharness
 			try {
 				Directory.CreateDirectory (LogDirectory);
 				Log log = Logs.Create ($"Harness-{Harness.Timestamp}.log", "Harness log");
-				if (Harness.InWrench)
+				if (Harness.InCI)
 					log = Log.CreateAggregatedLog (log, new ConsoleLog ());
 				Harness.HarnessLog = MainLog = log;
 
@@ -1151,7 +1151,7 @@ namespace xharness
 				if (IsServerMode)
 					tasks.Add (RunTestServer ());
 
-				if (Harness.InJenkins) {
+				if (Harness.InCI) {
 					Task.Factory.StartNew (async () => {
 						while (true) {
 							await Task.Delay (TimeSpan.FromMinutes (10));
@@ -3733,7 +3733,7 @@ namespace xharness
 					}
 
 					// Also clean up after us locally.
-					if (Harness.InJenkins || Harness.InWrench || (Jenkins.CleanSuccessfulTestRuns && Succeeded))
+					if (Harness.InCI || (Jenkins.CleanSuccessfulTestRuns && Succeeded))
 						await BuildTask.CleanAsync ();
 				}
 			}

--- a/tests/xharness/MakefileGenerator.cs
+++ b/tests/xharness/MakefileGenerator.cs
@@ -211,7 +211,7 @@ namespace xharness
 
 		public static void CreateMakefile (Harness harness, IEnumerable<UnifiedTarget> unified_targets, IEnumerable<TVOSTarget> tvos_targets, IEnumerable<WatchOSTarget> watchos_targets, IEnumerable<TodayExtensionTarget> today_targets)
 		{
-			var executeSim32 = !harness.InWrench; // Waiting for iOS 10.3 simulator to be installed on wrench
+			var executeSim32 = !harness.InCI; // Waiting for iOS 10.3 simulator to be installed on wrench
 			var makefile = Path.Combine (Harness.RootDirectory, "Makefile.inc");
 			using (var writer = new StreamWriter (makefile, false, new UTF8Encoding (false))) {
 				writer.WriteLine (".stamp-configure-projects: Makefile xharness/xharness.exe");

--- a/tests/xharness/SimpleTcpListener.cs
+++ b/tests/xharness/SimpleTcpListener.cs
@@ -34,6 +34,7 @@ namespace xharness
 				do {
 					Log.WriteLine ("Test log server listening on: {0}:{1}", Address, Port);
 					using (TcpClient client = server.AcceptTcpClient ()) {
+						client.ReceiveBufferSize = buffer.Length;
 						processed = Processing (client);
 					}
 				} while (!AutoExit || !processed);

--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -1,0 +1,258 @@
+﻿using System;
+using System.IO;
+using System.Xml;
+
+namespace xharness {
+	public static class XmlResultParser {
+
+		public enum Jargon {
+			TouchUnit,
+			NUnit,
+			xUnit,
+			Missing,
+		}
+
+		// test if the file is valid xml, or at least, that can be read it.
+		public static bool IsValidXml (string path, out Jargon type)
+		{
+			type = Jargon.Missing;
+			if (!File.Exists (path))
+				return false;
+
+			using (var stream = File.OpenText (path)) {
+				string line;
+				while ((line = stream.ReadLine ()) != null) { // special case when get got the tcp connection
+					if (line.Contains ("ping"))
+						continue;
+					if (line.Contains ("TouchUnitTestRun")) {
+						type = Jargon.TouchUnit;
+						return true;
+					}
+					if (line.Contains ("nunit-version")) {
+						type = Jargon.NUnit;
+						return true;
+					}
+					if (line.Contains ("xUnit")) {
+						type = Jargon.xUnit;
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
+		static (string resultLine, bool failed) ParseTouchUnitXml (StreamReader stream, StreamWriter writer)
+		{
+			long total, errors, failed, notRun, inconclusive, ignored, skipped, invalid;
+			total = errors = failed = notRun = inconclusive = ignored = skipped = invalid = 0L;
+
+			using (var reader = XmlReader.Create (stream)) {
+				while (reader.Read ()) {
+					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-results") {
+						long.TryParse (reader ["total"], out total);
+						long.TryParse (reader ["errors"], out errors);
+						long.TryParse (reader ["failures"], out failed);
+						long.TryParse (reader ["not-run"], out notRun);
+						long.TryParse (reader ["inconclusive"], out inconclusive);
+						long.TryParse (reader ["ignored"], out ignored);
+						long.TryParse (reader ["skipped"], out skipped );
+						long.TryParse (reader ["invalid"], out invalid);
+					}
+					if (reader.NodeType == XmlNodeType.Element && reader.Name == "TouchUnitExtraData") {
+						// move fwd to get to the CData
+						if (reader.Read ())
+							writer.Write (reader.Value);
+					}
+				}
+			}
+			var passed = total - errors - failed - notRun - inconclusive - ignored - skipped - invalid;
+			var resultLine = $"Tests run: {total} Passed: {passed} Inconclusive: {inconclusive} Failed: {failed + errors} Ignored: {ignored + skipped + invalid}";
+			return (resultLine, total == 0 || errors != 0 || failed != 0);
+		}
+
+		static (string resultLine, bool failed) ParseNUnitXml (StreamReader stream, StreamWriter writer)
+		{
+			long total, errors, failed, notRun, inconclusive, ignored, skipped, invalid;
+			total = errors = failed = notRun = inconclusive = ignored = skipped = invalid = 0L;
+			XmlReaderSettings settings = new XmlReaderSettings ();
+			settings.ValidationType = ValidationType.None;
+			using (var reader = XmlReader.Create (stream, settings)) {
+				while (reader.Read ()) {
+					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-results") {
+						long.TryParse (reader ["total"], out total);
+						long.TryParse (reader ["errors"], out errors);
+						long.TryParse (reader ["failures"], out failed);
+						long.TryParse (reader ["not-run"], out notRun);
+						long.TryParse (reader ["inconclusive"], out inconclusive);
+						long.TryParse (reader ["ignored"], out ignored);
+						long.TryParse (reader ["skipped"], out skipped);
+						long.TryParse (reader ["invalid"], out invalid);
+					}
+					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-suite" && (reader ["type"] == "TestFixture" || reader ["type"] == "TestCollection")) {
+						var testCaseName = reader ["name"];
+						writer.WriteLine (testCaseName);
+						var time = reader.GetAttribute ("time") ?? "0"; // some nodes might not have the time :/
+												// get the first node and then move in the siblings of the same type
+						reader.ReadToDescendant ("test-case");
+						do {
+							if (reader.Name != "test-case")
+								break;
+							// read the test cases in the current node
+							var status = reader ["result"];
+							switch (status) {
+							case "Success":
+								writer.Write ("\t[PASS] ");
+								break;
+							case "Ignored":
+								writer.Write ("\t[IGNORED] ");
+								break;
+							case "Error":
+							case "Failure":
+								writer.Write ("\t[FAIL] ");
+								break;
+							case "Inconclusive":
+								writer.Write ("\t[INCONCLUSIVE] ");
+								break;
+							default:
+								writer.Write ("\t[INFO] ");
+								break;
+							}
+							writer.Write (reader ["name"]);
+							if (status == "Failure" || status == "Error") { //  we need to print the message
+								reader.ReadToDescendant ("message");
+								writer.Write ($" : {reader.ReadElementContentAsString ()}");
+								reader.ReadToNextSibling ("stack-trace");
+								writer.Write ($" : {reader.ReadElementContentAsString ()}");
+							}
+							// add a new line
+							writer.WriteLine ();
+						} while (reader.ReadToNextSibling ("test-case"));
+						writer.WriteLine ($"{testCaseName} {time} ms");
+					}
+				}
+			}
+			var passed = total - errors - failed - notRun - inconclusive - ignored - skipped - invalid;
+			string resultLine = $"Tests run: {total} Passed: {passed} Inconclusive: {inconclusive} Failed: {failed + errors} Ignored: {ignored + skipped + invalid}";
+			writer.WriteLine (resultLine);
+
+			return (resultLine, total == 0 | errors != 0 || failed != 0);
+		}
+
+		static (string resultLine, bool failed) ParsexUnitXml (StreamReader stream, StreamWriter writer)
+		{
+			long total, errors, failed, notRun, inconclusive, ignored, skipped, invalid;
+			total = errors = failed = notRun = inconclusive = ignored = skipped = invalid = 0L;
+			using (var reader = XmlReader.Create (stream)) {
+				while (reader.Read ()) {
+					if (reader.NodeType == XmlNodeType.Element && reader.Name == "assembly") {
+						long.TryParse (reader ["total"], out var assemblyCount);
+						total += assemblyCount;
+						long.TryParse (reader ["errors"], out var assemblyErrors);
+						errors += assemblyErrors;
+						long.TryParse (reader ["failed"], out var assemblyFailures);
+						failed += assemblyFailures;
+						long.TryParse (reader ["skipped"], out var assemblySkipped);
+						skipped += assemblySkipped;
+					}
+					if (reader.NodeType == XmlNodeType.Element && reader.Name == "collection") {
+						var testCaseName = reader ["name"].Replace ("Test collection for ", "");
+						writer.WriteLine (testCaseName);
+						var time = reader.GetAttribute ("time") ?? "0"; // some nodes might not have the time :/
+												// get the first node and then move in the siblings of the same type
+						reader.ReadToDescendant ("test");
+						do {
+							if (reader.Name != "test")
+								break;
+							// read the test cases in the current node
+							var status = reader ["result"];
+							switch (status) {
+							case "Pass":
+								writer.Write ("\t[PASS] ");
+								break;
+							case "Skip":
+								writer.Write ("\t[IGNORED] ");
+								break;
+							case "Fail":
+								writer.Write ("\t[FAIL] ");
+								break;
+							default:
+								writer.Write ("\t[FAIL] ");
+								break;
+							}
+							writer.Write (reader ["name"]);
+							if (status == "Fail") { //  we need to print the message
+								reader.ReadToDescendant ("message");
+								writer.Write ($" : {reader.ReadElementContentAsString ()}");
+								reader.ReadToNextSibling ("stack-trace");
+								writer.Write ($" : {reader.ReadElementContentAsString ()}");
+							}
+							// add a new line
+							writer.WriteLine ();
+						} while (reader.ReadToNextSibling ("test"));
+						writer.WriteLine ($"{testCaseName} {time} ms");
+					}
+				}
+			}
+			var passed = total - errors - failed - notRun - inconclusive - ignored - skipped - invalid;
+			string resultLine = $"Tests run: {total} Passed: {passed} Inconclusive: {inconclusive} Failed: {failed + errors} Ignored: {ignored + skipped + invalid}";
+			writer.WriteLine (resultLine);
+
+			return (resultLine, total == 0 | errors != 0 || failed != 0);
+		}
+
+		public static string GetXmlFilePath (string path, Jargon xmlType)
+		{
+			var fileName = Path.GetFileName (path);
+			switch (xmlType) {
+			case Jargon.TouchUnit:
+			case Jargon.NUnit:
+				return path.Replace (fileName, $"nunit-{fileName}");
+			case Jargon.xUnit:
+				return path.Replace (fileName, $"xunit-{fileName}");
+			default:
+				return path;
+			}
+		}
+
+		public static void CleanXml (string source, string destination)
+		{
+			using (var reader = new StreamReader (source))
+			using (var writer = new StreamWriter (destination)) {
+				string line;
+				while ((line = reader.ReadLine ()) != null) {
+					if (line.StartsWith ("ping", StringComparison.Ordinal) || line.Contains ("TouchUnitTestRun") || line.Contains ("NUnitOutput") || line.Contains ("<!--")) {
+						continue;
+					}
+					if (line == "") // remove white lines, some files have them
+						continue;
+					if (line.Contains ("TouchUnitExtraData")) // always last node in TouchUnit
+						break;
+					writer.WriteLine (line);
+				}
+			}
+		}
+
+		public static (string resultLine, bool failed) GenerateHumanReadableResults (string source, string destination, Jargon xmlType)
+		{
+			(string resultLine, bool failed) parseData;
+			using (var reader = new StreamReader (source)) 
+			using (var writer = new StreamWriter (destination, true)) {
+				switch (xmlType) {
+				case Jargon.TouchUnit:
+					parseData = ParseTouchUnitXml (reader, writer);
+					break;
+				case Jargon.NUnit:
+					parseData = ParseNUnitXml (reader, writer);
+					break;
+				case Jargon.xUnit:
+					parseData = ParsexUnitXml (reader, writer);
+					break;
+				default:
+					parseData = ("", true);
+					break;
+				}
+			}
+			return parseData;
+		}
+	}
+}

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -128,6 +128,7 @@
     <Compile Include="..\..\tools\bcl-test-importer\BCLTestImporter\BCLTestInfoPlistGenerator.cs">
       <Link>BCLTestImporter\BCLTestInfoPlistGenerator.cs</Link>
     </Compile>
+    <Compile Include="XmlResultParser.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="BCLTestImporter\" />


### PR DESCRIPTION
Use the xml parsing helper methods to decide if the xml can be parsed
and if we will be able to generate the report. That way we avoid an
exception that makes the CI noise.

Backport of #7824.

/cc @mandel-macaque 