### PR TITLE
[XHarness] Do write the TestReport when we have xUnit results.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -371,7 +371,7 @@ namespace xharness
 					File.Delete (tmpFile);
 
 					// we do not longer need the tmp file
-					Logs.AddFile (path, "Test xml");
+					Logs.AddFile (path, "XML log");
 					return parseResult;
 
 				} catch (Exception e) {

--- a/tests/xharness/Extensions.cs
+++ b/tests/xharness/Extensions.cs
@@ -126,5 +126,11 @@ namespace xharness
 			var rnd = new Random ((int) DateTime.Now.Ticks);
 			return collection.OrderBy (v => rnd.Next ());
 		}
+
+		public static string AsHtmlFormat (this string inString)
+		{
+			var rv = System.Web.HttpUtility.HtmlEncode (inString);
+			return rv.Replace ("\t", "&nbsp;&nbsp;&nbsp;&nbsp;").Replace ("\n", "<br/>\n");
+		}
 	}
 }

--- a/tests/xharness/Extensions.cs
+++ b/tests/xharness/Extensions.cs
@@ -127,7 +127,7 @@ namespace xharness
 			return collection.OrderBy (v => rnd.Next ());
 		}
 
-		public static string AsHtmlFormat (this string inString)
+		public static string AsHtml (this string inString)
 		{
 			var rv = System.Web.HttpUtility.HtmlEncode (inString);
 			return rv.Replace ("\t", "&nbsp;&nbsp;&nbsp;&nbsp;").Replace ("\n", "<br/>\n");

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2100,7 +2100,7 @@ namespace xharness
 								writer.WriteLine ($"Known failure: {test.KnownFailure} <br />");
 
 							if (!string.IsNullOrEmpty (test.FailureMessage)) {
-								var msg = HtmlFormat (test.FailureMessage);
+								var msg = test.FailureMessage.AsHtmlFormat ();
 								var prefix = test.Ignored ? "Ignored" : "Failure";
 								if (test.FailureMessage.Contains ('\n')) {
 									writer.WriteLine ($"{prefix}:<br /> <div style='margin-left: 20px;'>{msg}</div>");
@@ -2110,7 +2110,7 @@ namespace xharness
 							}
 							var progressMessage = test.ProgressMessage;
 							if (!string.IsNullOrEmpty (progressMessage))
-								writer.WriteLine (HtmlFormat (progressMessage) + " <br />");
+								writer.WriteLine (progressMessage.AsHtmlFormat () + " <br />");
 
 							if (runTest != null) {
 								if (runTest.BuildTask.Duration.Ticks > 0) {
@@ -2203,13 +2203,13 @@ namespace xharness
 											if (fails.Count > 0) {
 												writer.WriteLine ("<div style='padding-left: 15px;'>");
 												foreach (var fail in fails)
-													writer.WriteLine ("{0} <br />", HtmlFormat (fail));
+													writer.WriteLine ("{0} <br />", fail.AsHtmlFormat ());
 												writer.WriteLine ("</div>");
 											}
 											if (!string.IsNullOrEmpty (summary))
 												writer.WriteLine ("<span style='padding-left: 15px;'>{0}</span><br />", summary);
 										} catch (Exception ex) {
-											writer.WriteLine ("<span style='padding-left: 15px;'>Could not parse log file: {0}</span><br />", HtmlFormat (ex.Message));
+											writer.WriteLine ("<span style='padding-left: 15px;'>Could not parse log file: {0}</span><br />", ex.Message.AsHtmlFormat ());
 										}
 									} else if (log.Description == "Build log") {
 										HashSet<string> errors;
@@ -2241,45 +2241,21 @@ namespace xharness
 											if (errors.Count > 0) {
 												writer.WriteLine ("<div style='padding-left: 15px;'>");
 												foreach (var error in errors)
-													writer.WriteLine ("{0} <br />", HtmlFormat (error));
+													writer.WriteLine ("{0} <br />",  error.AsHtmlFormat ());
 												writer.WriteLine ("</div>");
 											}
 										} catch (Exception ex) {
-											writer.WriteLine ("<span style='padding-left: 15px;'>Could not parse log file: {0}</span><br />", HtmlFormat (ex.Message));
+											writer.WriteLine ("<span style='padding-left: 15px;'>Could not parse log file: {0}</span><br />", ex.Message.AsHtmlFormat ());
 										}
 									} else if (log.Description == "NUnit results" || log.Description == "XML log") {
 										try {
 											if (File.Exists (log.FullPath) && new FileInfo (log.FullPath).Length > 0) {
 												if (XmlResultParser.IsValidXml (log.FullPath, out var jargon)) {
-													if (jargon == XmlResultParser.Jargon.NUnit) {
-														var doc = new XmlDocument ();
-														doc.LoadWithoutNetworkAccess (log.FullPath);
-														var failures = doc.SelectNodes ("//test-case[@result='Error' or @result='Failure']").Cast<System.Xml.XmlNode> ().ToArray ();
-														if (failures.Length > 0) {
-															writer.WriteLine ("<div style='padding-left: 15px;'>");
-															writer.WriteLine ("<ul>");
-															foreach (var failure in failures) {
-																writer.WriteLine ("<li>");
-																var test_name = failure.Attributes ["name"]?.Value;
-																var message = failure.SelectSingleNode ("failure/message")?.InnerText;
-																writer.Write (HtmlFormat (test_name));
-																if (!string.IsNullOrEmpty (message)) {
-																	writer.Write (": ");
-																	writer.Write (HtmlFormat (message));
-																}
-																writer.WriteLine ("<br />");
-																writer.WriteLine ("</li>");
-															}
-															writer.WriteLine ("</ul>");
-															writer.WriteLine ("</div>");
-														}
-													} else {
-														writer.WriteLine ($"<span style='padding-left: 15px;'>Could not parse {log.Description}: Not supported format.</span><br />");
-													}
+													XmlResultParser.GenerateTestReport (writer, log.FullPath, jargon);
 												}
 											}
 										} catch (Exception ex) {
-											writer.WriteLine ($"<span style='padding-left: 15px;'>Could not parse {log.Description}: {HtmlFormat (ex.Message)}</span><br />");
+											writer.WriteLine ($"<span style='padding-left: 15px;'>Could not parse {log.Description}: {ex.Message.AsHtmlFormat ()}</span><br />");
 										}
 									}
 								}
@@ -2321,7 +2297,7 @@ namespace xharness
 					if (runningTests.Any ()) {
 						writer.WriteLine ($"<h3>{runningTests.Count ()} running tests:</h3>");
 						foreach (var test in runningTests) {
-							writer.WriteLine ($"<a href='#test_{test.TestName}'>{test.TestName} ({test.Mode})</a> {test.Duration.ToString ()} {HtmlFormat ("\n\t" + test.ProgressMessage)}<br />");
+							writer.WriteLine ($"<a href='#test_{test.TestName}'>{test.TestName} ({test.Mode})</a> {test.Duration.ToString ()} {"\n\t" + test.ProgressMessage.AsHtmlFormat ()}<br />");
 						}
 					}
 
@@ -2354,12 +2330,6 @@ namespace xharness
 			}
 		}
 		Dictionary<Log, Tuple<long, object>> log_data = new Dictionary<Log, Tuple<long, object>> ();
-
-		static string HtmlFormat (string value)
-		{
-			var rv = System.Web.HttpUtility.HtmlEncode (value);
-			return rv.Replace ("\t", "&nbsp;&nbsp;&nbsp;&nbsp;").Replace ("\n", "<br/>\n");
-		}
 
 		static string LinkEncode (string path)
 		{

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2100,7 +2100,7 @@ namespace xharness
 								writer.WriteLine ($"Known failure: {test.KnownFailure} <br />");
 
 							if (!string.IsNullOrEmpty (test.FailureMessage)) {
-								var msg = test.FailureMessage.AsHtmlFormat ();
+								var msg = test.FailureMessage.AsHtml ();
 								var prefix = test.Ignored ? "Ignored" : "Failure";
 								if (test.FailureMessage.Contains ('\n')) {
 									writer.WriteLine ($"{prefix}:<br /> <div style='margin-left: 20px;'>{msg}</div>");
@@ -2110,7 +2110,7 @@ namespace xharness
 							}
 							var progressMessage = test.ProgressMessage;
 							if (!string.IsNullOrEmpty (progressMessage))
-								writer.WriteLine (progressMessage.AsHtmlFormat () + " <br />");
+								writer.WriteLine (progressMessage.AsHtml () + " <br />");
 
 							if (runTest != null) {
 								if (runTest.BuildTask.Duration.Ticks > 0) {
@@ -2203,13 +2203,13 @@ namespace xharness
 											if (fails.Count > 0) {
 												writer.WriteLine ("<div style='padding-left: 15px;'>");
 												foreach (var fail in fails)
-													writer.WriteLine ("{0} <br />", fail.AsHtmlFormat ());
+													writer.WriteLine ("{0} <br />", fail.AsHtml ());
 												writer.WriteLine ("</div>");
 											}
 											if (!string.IsNullOrEmpty (summary))
 												writer.WriteLine ("<span style='padding-left: 15px;'>{0}</span><br />", summary);
 										} catch (Exception ex) {
-											writer.WriteLine ("<span style='padding-left: 15px;'>Could not parse log file: {0}</span><br />", ex.Message.AsHtmlFormat ());
+											writer.WriteLine ("<span style='padding-left: 15px;'>Could not parse log file: {0}</span><br />", ex.Message.AsHtml ());
 										}
 									} else if (log.Description == "Build log") {
 										HashSet<string> errors;
@@ -2241,11 +2241,11 @@ namespace xharness
 											if (errors.Count > 0) {
 												writer.WriteLine ("<div style='padding-left: 15px;'>");
 												foreach (var error in errors)
-													writer.WriteLine ("{0} <br />",  error.AsHtmlFormat ());
+													writer.WriteLine ("{0} <br />",  error.AsHtml ());
 												writer.WriteLine ("</div>");
 											}
 										} catch (Exception ex) {
-											writer.WriteLine ("<span style='padding-left: 15px;'>Could not parse log file: {0}</span><br />", ex.Message.AsHtmlFormat ());
+											writer.WriteLine ("<span style='padding-left: 15px;'>Could not parse log file: {0}</span><br />", ex.Message.AsHtml ());
 										}
 									} else if (log.Description == "NUnit results" || log.Description == "XML log") {
 										try {
@@ -2255,7 +2255,7 @@ namespace xharness
 												}
 											}
 										} catch (Exception ex) {
-											writer.WriteLine ($"<span style='padding-left: 15px;'>Could not parse {log.Description}: {ex.Message.AsHtmlFormat ()}</span><br />");
+											writer.WriteLine ($"<span style='padding-left: 15px;'>Could not parse {log.Description}: {ex.Message.AsHtml ()}</span><br />");
 										}
 									}
 								}
@@ -2297,7 +2297,7 @@ namespace xharness
 					if (runningTests.Any ()) {
 						writer.WriteLine ($"<h3>{runningTests.Count ()} running tests:</h3>");
 						foreach (var test in runningTests) {
-							writer.WriteLine ($"<a href='#test_{test.TestName}'>{test.TestName} ({test.Mode})</a> {test.Duration.ToString ()} {"\n\t" + test.ProgressMessage.AsHtmlFormat ()}<br />");
+							writer.WriteLine ($"<a href='#test_{test.TestName}'>{test.TestName} ({test.Mode})</a> {test.Duration.ToString ()} {("\n\t" + test.ProgressMessage).AsHtml ()}<br />");
 						}
 					}
 

--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -303,7 +303,7 @@ namespace xharness {
 		{
 			var failedTests = new List<(string name, string message)> ();
 			// xUnit is not as nice and does not provide the final result in a top node,
-			// we need to look in all the collections and find all the failed thests, this is really bad :/
+			// we need to look in all the collections and find all the failed tests, this is really bad :/
 			while (reader.Read ()) {
 				if (reader.NodeType == XmlNodeType.Element && reader.Name == "collection") {
 					reader.ReadToDescendant ("test");

--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -282,13 +282,13 @@ namespace xharness {
 						case "Failure":
 							writer.WriteLine ("<li>");
 							var test_name = reader ["name"];
-							writer.Write (test_name.AsHtmlFormat ());
+							writer.Write (test_name.AsHtml ());
 							// read to the message of the error and get it
 							reader.ReadToDescendant ("message");
 							var message = reader.ReadElementContentAsString ();
 							if (!string.IsNullOrEmpty (message)) {
 								writer.Write (": ");
-								writer.Write (message.AsHtmlFormat ());
+								writer.Write (message.AsHtml ());
 							}
 							writer.WriteLine ("<br />");
 							writer.WriteLine ("</li>");
@@ -328,10 +328,10 @@ namespace xharness {
 				writer.WriteLine ("<ul>");
 				foreach (var (name, message) in failedTests) {
 					writer.WriteLine ("<li>");
-					writer.Write (name.AsHtmlFormat ());
+					writer.Write (name.AsHtml ());
 					if (!string.IsNullOrEmpty (message)) {
 						writer.Write (": ");
-						writer.Write (message.AsHtmlFormat ());
+						writer.Write (message.AsHtml ());
 					}
 				}
 				writer.WriteLine ("<br />");


### PR DESCRIPTION
Add code to write the TestReport when we have xunit results. Also
refactored code for the NUnit format to not use LINQ, it will use less
memory and in the future we can move to async (not now since it might
raise other problems).

fixes: https://github.com/xamarin/xamarin-macios/issues/7826