### PR TITLE
[d16-6] [Jenkins] Do not notarize on PRs.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -501,11 +501,7 @@ timestamps {
                             if (bundleZip.length > 0)
                                 bundleZipFilename = bundleZip [0].name
 
-                            if (isPr) {
-                              withCredentials ([string (credentialsId: 'codesign_keychain_pw', variable: 'PRODUCTSIGN_KEYCHAIN_PASSWORD')]) {
-                                sh ("${workspace}/xamarin-macios/jenkins/productsign.sh")
-                              }
-                            } else {
+                            if (!isPr) {
                                 try {
                                     pkgs = xiPackages + xmPackages
                                     if (fileExists('release-scripts')) {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -501,7 +501,11 @@ timestamps {
                             if (bundleZip.length > 0)
                                 bundleZipFilename = bundleZip [0].name
 
-                            if (!isPr) {
+                            if (isPr) {
+                              withCredentials ([string (credentialsId: 'codesign_keychain_pw', variable: 'PRODUCTSIGN_KEYCHAIN_PASSWORD')]) {
+                                sh ("${workspace}/xamarin-macios/jenkins/productsign.sh")
+                              }
+                            } else {
                                 try {
                                     pkgs = xiPackages + xmPackages
                                     if (fileExists('release-scripts')) {

--- a/jenkins/productsign.sh
+++ b/jenkins/productsign.sh
@@ -46,7 +46,6 @@ echo 'cat (//xar/toc/signature/x:KeyInfo/x:X509Data/x:X509Certificate)[1]/text()
 
 echo Signature Verification
 for pkg in package/*.pkg; do
-	/usr/sbin/spctl -vvv --assess --type install "$pkg"
 	pkgutil --check-signature "$pkg"
 	xar -f "$pkg" --dump-toc="$pkg.toc"
 	(


### PR DESCRIPTION
It was added as a backup and has not been needed. With the updates to
catalina it makes builds fail on CI.

Backport of #7836.

/cc @mandel-macaque 