### PR TITLE
[Xcode11.4][Jenkins] Do not notarize on PRs. (#7836)

### DIFF
--- a/jenkins/productsign.sh
+++ b/jenkins/productsign.sh
@@ -46,7 +46,6 @@ echo 'cat (//xar/toc/signature/x:KeyInfo/x:X509Data/x:X509Certificate)[1]/text()
 
 echo Signature Verification
 for pkg in package/*.pkg; do
-	/usr/sbin/spctl -vvv --assess --type install "$pkg"
 	pkgutil --check-signature "$pkg"
 	xar -f "$pkg" --dump-toc="$pkg.toc"
 	(


### PR DESCRIPTION
It was added as a backup and has not been needed. With the updates to
catalina it makes builds fail on CI.