### PR TITLE
[msbuild] Fix MT4174 warning for the MyWatchKit2IntentsExtension test project.

### DIFF
--- a/msbuild/tests/MyWatchKit2IntentsExtension/IntentHandler.cs
+++ b/msbuild/tests/MyWatchKit2IntentsExtension/IntentHandler.cs
@@ -32,7 +32,7 @@ namespace MyWatchKit2IntentsExtension
 
 		// Implement resolution methods to provide additional information about your intent (optional).
 		[Export ("resolveRecipientsForSearchForMessages:withCompletion:")]
-		public void ResolveRecipients (INSendMessageIntent intent, Action<INPersonResolutionResult[]> completion)
+		public void ResolveRecipients (INSearchForMessagesIntent intent, Action<INPersonResolutionResult[]> completion)
 		{
 			var recipients = intent.Recipients;
 			// If no recipients were provided we'll need to prompt for a value.


### PR DESCRIPTION
Fixes:

> MyWatchKit2IntentsExtension/IntentHandler.cs(36): warning MT4174: Unable to locate the block to delegate conversion method for the method MyWatchKit2IntentsExtension.IntentHandler.ResolveRecipients's parameter #2. [MyWatchKit2Extension/MyWatchKit2Extension.csproj]

The method signature probably changed from a beta release to the corresponding
stable release, and this method was never updated.