### PR TITLE
[msbuild] Fix warning about CFBundleVersion in the MyWatchApp2 test project.

### DIFF
--- a/msbuild/tests/MyWatchApp2/Info.plist
+++ b/msbuild/tests/MyWatchApp2/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1.33</string>
+	<string>1.0</string>
 	<key>MinimumOSVersion</key>
 	<string>2.0</string>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
Fixes:

> /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/iOS/Xamarin.iOS.Common.targets(1726,3): warning : The Watch App 'MyWatchApp2' has a CFBundleVersion (1.33) that does not match the main app bundle's CFBundleVersion (1.0) [MyWatch2Container/MyWatch2Container.csproj]
> /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/iOS/Xamarin.iOS.Common.targets(1726,3): warning : The Watch Extension 'MyWatchKit2Extension' has a CFBundleVersion (1.0) that does not match the main app bundle's CFBundleVersion (1.33) [MyWatch2Container/MyWatch2Container.csproj]