### PR TITLE
[DDFun|VSTS] Add a URL to a more interesting view.

### DIFF
--- a/jenkins/vsts-device-tests-set-status.sh
+++ b/jenkins/vsts-device-tests-set-status.sh
@@ -44,7 +44,7 @@ if test -z "$DEVICE_TYPE"; then
 	DEVICE_TYPE="iOS/tvOS"
 fi
 
-VSTS_BUILD_URL="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECT}/_build/index?buildId=${BUILD_BUILDID}"
+VSTS_BUILD_URL="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECT}/_build/index?buildId=${BUILD_BUILDID}&view=ms.vss-test-web.test-result-details"
 
 # Add a GitHub status to the commit we're testing
 GH_STATE=failure


### PR DESCRIPTION
Since we now have test being imported in DDFun, lets use the test
results view so that the monitoring person just need to click once.