### PR TITLE
[d16-6][XHarness] Use static variables for common test names. (#7837)

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -371,7 +371,7 @@ namespace xharness
 					File.Delete (tmpFile);
 
 					// we do not longer need the tmp file
-					Logs.AddFile (path, "XML log");
+					Logs.AddFile (path, Log.XML_LOG);
 					return parseResult;
 
 				} catch (Exception e) {
@@ -529,7 +529,7 @@ namespace xharness
 			args.Add ($"-argument=-app-arg:-transport:{transport}");
 			args.Add ($"-setenv=NUNIT_TRANSPORT={transport}");
 
-			listener_log = Logs.Create ($"test-{mode}-{Harness.Timestamp}.log", "Test log", timestamp: !useXmlOutput);
+			listener_log = Logs.Create ($"test-{mode}-{Harness.Timestamp}.log", Log.TEST_LOG, timestamp: !useXmlOutput);
 
 			SimpleListener listener;
 			switch (transport) {
@@ -630,7 +630,7 @@ namespace xharness
 					var log = new CaptureLog (Logs, sim.SystemLog, entire_file: Harness.Action != HarnessAction.Jenkins)
 					{
 						Path = Path.Combine (LogDirectory, sim.Name + ".log"),
-						Description = isCompanion ? "System log (companion)" : "System log",
+						Description = isCompanion ? Log.COMPANION_SYSTEM_LOG : Log.SYSTEM_LOG,
 					};
 					log.StartCapture ();
 					Logs.Add (log);

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2157,7 +2157,7 @@ namespace xharness
 									}
 									if (!exists) {
 										writer.WriteLine ("<a href='{0}' type='{2}' target='{3}'>{1}</a> (does not exist)<br />", LinkEncode (log.FullPath.Substring (LogDirectory.Length + 1)), log.Description, log_type, log_target);
-									} else if (log.Description == "Build log") {
+									} else if (log.Description == Log.BUILD_LOG) {
 										var binlog = log.FullPath.Replace (".txt", ".binlog");
 										if (File.Exists (binlog)) {
 											var textLink = string.Format ("<a href='{0}' type='{2}' target='{3}'>{1}</a>", LinkEncode (log.FullPath.Substring (LogDirectory.Length + 1)), log.Description, log_type, log_target);
@@ -2171,7 +2171,7 @@ namespace xharness
 									}
 									if (!exists) {
 										// Don't try to parse files that don't exist
-									} else if (log.Description == "Test log" || log.Description == "Extension test log" || log.Description == "Execution log") {
+									} else if (log.Description == Log.TEST_LOG || log.Description == Log.EXTENSION_TEST_LOG || log.Description == Log.EXECUTION_LOG) {
 										string summary;
 										List<string> fails;
 										try {
@@ -2211,7 +2211,7 @@ namespace xharness
 										} catch (Exception ex) {
 											writer.WriteLine ("<span style='padding-left: 15px;'>Could not parse log file: {0}</span><br />", ex.Message.AsHtml ());
 										}
-									} else if (log.Description == "Build log") {
+									} else if (log.Description == Log.BUILD_LOG) {
 										HashSet<string> errors;
 										try {
 											using (var reader = log.GetReader ()) {
@@ -2247,7 +2247,7 @@ namespace xharness
 										} catch (Exception ex) {
 											writer.WriteLine ("<span style='padding-left: 15px;'>Could not parse log file: {0}</span><br />", ex.Message.AsHtml ());
 										}
-									} else if (log.Description == "NUnit results" || log.Description == "XML log") {
+									} else if (log.Description == Log.NUNIT_RESULT || log.Description == Log.XML_LOG) {
 										try {
 											if (File.Exists (log.FullPath) && new FileInfo (log.FullPath).Length > 0) {
 												if (XmlResultParser.IsValidXml (log.FullPath, out var jargon)) {
@@ -2936,7 +2936,7 @@ namespace xharness
 					make.StartInfo.WorkingDirectory = WorkingDirectory;
 					make.StartInfo.Arguments = Target;
 					SetEnvironmentVariables (make);
-					var log = Logs.Create ($"make-{Platform}-{Timestamp}.txt", "Build log");
+					var log = Logs.Create ($"make-{Platform}-{Timestamp}.txt", Log.BUILD_LOG);
 					LogEvent (log, "Making {0} in {1}", Target, WorkingDirectory);
 					if (!Harness.DryRun) {
 						var timeout = Timeout;
@@ -2965,7 +2965,7 @@ namespace xharness
 		protected override async Task ExecuteAsync ()
 		{
 			using (var resource = await NotifyAndAcquireDesktopResourceAsync ()) {
-				var log = Logs.Create ($"build-{Platform}-{Timestamp}.txt", "Build log");
+				var log = Logs.Create ($"build-{Platform}-{Timestamp}.txt", Log.BUILD_LOG);
 				var binlogPath = log.FullPath.Replace (".txt", ".binlog");
 
 				await RestoreNugetsAsync (log, resource, useXIBuild: true);
@@ -3147,8 +3147,8 @@ namespace xharness
 		protected override async Task RunTestAsync ()
 		{
 			using (var resource = await NotifyAndAcquireDesktopResourceAsync ()) {
-				var xmlLog = Logs.CreateFile ($"log-{Timestamp}.xml", "XML log");
-				var log = Logs.Create ($"execute-{Timestamp}.txt", "Execution log");
+				var xmlLog = Logs.CreateFile ($"log-{Timestamp}.xml", Log.XML_LOG);
+				var log = Logs.Create ($"execute-{Timestamp}.txt", Log.EXECUTION_LOG);
 				FindNUnitConsoleExecutable (log);
 				using (var proc = new Process ()) {
 
@@ -3318,14 +3318,14 @@ namespace xharness
 				using (var proc = new Process ()) {
 					proc.StartInfo.FileName = Path;
 					if (IsUnitTest) {
-						var xml = Logs.CreateFile ($"test-{Platform}-{Timestamp}.xml", "NUnit results");
+						var xml = Logs.CreateFile ($"test-{Platform}-{Timestamp}.xml", Log.NUNIT_RESULT);
 						proc.StartInfo.Arguments = StringUtils.FormatArguments ($"-result=" + xml);
 					}
 					if (!Harness.GetIncludeSystemPermissionTests (Platform, false))
 						proc.StartInfo.EnvironmentVariables ["DISABLE_SYSTEM_PERMISSION_TESTS"] = "1";
 					proc.StartInfo.EnvironmentVariables ["MONO_DEBUG"] = "no-gdb-backtrace";
 					Jenkins.MainLog.WriteLine ("Executing {0} ({1})", TestName, Mode);
-					var log = Logs.Create ($"execute-{Platform}-{Timestamp}.txt", "Execution log");
+					var log = Logs.Create ($"execute-{Platform}-{Timestamp}.txt", Log.EXECUTION_LOG);
 					if (!Harness.DryRun) {
 						ExecutionResult = TestExecutingResult.Running;
 
@@ -3379,7 +3379,7 @@ namespace xharness
 					proc.StartInfo.Arguments = $"--debug {reporter} {WorkingDirectory} {results}";
 
 					Jenkins.MainLog.WriteLine ("Executing {0} ({1})", TestName, Mode);
-					var log = Logs.Create ($"execute-xtro-{Timestamp}.txt", "Execution log");
+					var log = Logs.Create ($"execute-xtro-{Timestamp}.txt", Log.EXECUTION_LOG);
 					log.WriteLine ("{0} {1}", proc.StartInfo.FileName, proc.StartInfo.Arguments);
 					if (!Harness.DryRun) {
 						ExecutionResult = TestExecutingResult.Running;

--- a/tests/xharness/Log.cs
+++ b/tests/xharness/Log.cs
@@ -12,6 +12,15 @@ namespace xharness
 		public string Description;
 		public bool Timestamp = true;
 
+		public static string XML_LOG = "XML log";
+		public static string NUNIT_RESULT = "NUnit results";
+		public static string SYSTEM_LOG = "System log";
+		public static string COMPANION_SYSTEM_LOG = "System log (companion)";
+		public static string BUILD_LOG = "Build log";
+		public static string TEST_LOG = "Test log";
+		public static string EXTENSION_TEST_LOG = "Extension test log";
+		public static string EXECUTION_LOG = "Execution log";
+
 		protected Log (Logs logs)
 		{
 			Logs = logs;


### PR DESCRIPTION
One of the reason why we lost the TestReport was because the xml added
from the new code did not use the same name for the log as the expected
one (https://github.com/xamarin/xamarin-macios/pull/7835/files#diff-03773861bcef485bf343300f31b60b0eR374).

If we are going to be using the description as a way to decide what is
going to be done with it, lets use static vars so that we do not have
logs added with the wrong name.