### PR TITLE
[Harness] Attach build logs to NUnit V3 xml results.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -34,13 +34,13 @@ namespace xharness
 		TodayExtension,
 	}
 
-	public class AppRunner
+	class AppRunner
 	{
 		public Harness Harness;
 		public string ProjectFile;
 		public string AppPath;
 		public string Variation;
-		public int BuildTaskID;
+		public BuildToolTask BuildTask;
 
 		public TestExecutingResult Result { get; private set; }
 		public string FailureMessage { get; private set; }
@@ -369,8 +369,7 @@ namespace xharness
 						var logs = new List<string> ();
 						// add our logs AND the logs of the previous task, which is the build task
 						logs.AddRange (Directory.GetFiles (Logs.Directory));
-						var previousLogsDir = Path.Combine (Directory.GetParent (Logs.Directory).FullName, BuildTaskID.ToString ());
-						logs.AddRange (Directory.GetFiles (previousLogsDir));
+						logs.AddRange (Directory.GetFiles (BuildTask.LogDirectory));
 						// add the attachments and write in the new filename
 						XmlResultParser.UpdateMissingData (path, newFilename, testRunName, logs);
 					} else {

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -40,6 +40,7 @@ namespace xharness
 		public string ProjectFile;
 		public string AppPath;
 		public string Variation;
+		public int BuildTaskID;
 
 		public TestExecutingResult Result { get; private set; }
 		public string FailureMessage { get; private set; }
@@ -365,8 +366,13 @@ namespace xharness
 					// the right one (NUnitV3) add the nodes. ATM only TouchUnit uses V3.
 					var testRunName = $"{appName} {Variation}";
 					if (xmlType == XmlResultParser.Jargon.NUnitV3) {
+						var logs = new List<string> ();
+						// add our logs AND the logs of the previous task, which is the build task
+						logs.AddRange (Directory.GetFiles (Logs.Directory));
+						var previousLogsDir = Path.Combine (Directory.GetParent (Logs.Directory).FullName, BuildTaskID.ToString ());
+						logs.AddRange (Directory.GetFiles (previousLogsDir));
 						// add the attachments and write in the new filename
-						XmlResultParser.UpdateMissingData (path, newFilename, testRunName, Directory.GetFiles (Logs.Directory));
+						XmlResultParser.UpdateMissingData (path, newFilename, testRunName, logs);
 					} else {
 						// rename the path to the correct value
 						File.Move (path, newFilename);

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -3715,6 +3715,7 @@ namespace xharness
 						Configuration = ProjectConfiguration,
 						TimeoutMultiplier = TimeoutMultiplier,
 						Variation = Variation,
+						BuildTaskID = BuildTask.ID,
 					};
 
 					// Sometimes devices can't upgrade (depending on what has changed), so make sure to uninstall any existing apps first.

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -3715,7 +3715,7 @@ namespace xharness
 						Configuration = ProjectConfiguration,
 						TimeoutMultiplier = TimeoutMultiplier,
 						Variation = Variation,
-						BuildTaskID = BuildTask.ID,
+						BuildTask = BuildTask,
 					};
 
 					// Sometimes devices can't upgrade (depending on what has changed), so make sure to uninstall any existing apps first.
@@ -3771,6 +3771,7 @@ namespace xharness
 								CompanionDeviceName = CompanionDevice?.Name,
 								Configuration = ProjectConfiguration,
 								Variation = Variation,
+								BuildTask = BuildTask,
 							};
 							additional_runner = todayRunner;
 							await todayRunner.RunAsync ();
@@ -3881,7 +3882,8 @@ namespace xharness
 				MainLog = Logs.Create ($"run-{Device.UDID}-{Timestamp}.log", "Run log"),
 				Configuration = ProjectConfiguration,
 				TimeoutMultiplier = TimeoutMultiplier,
-				Variation = Variation
+				Variation = Variation,
+				BuildTask = BuildTask,
 			};
 			runner.Simulators = Simulators;
 			runner.Initialize ();

--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -489,7 +489,7 @@ namespace xharness {
 		}
 
 		// get the file, parse it and add the attachments to the first node found
-		public static void UpdateMissingData (string source, string destination, string applicationName, params string [] attachments)
+		public static void UpdateMissingData (string source, string destination, string applicationName, List<string> attachments)
 		{
 			// we could do this with a XmlReader and a Writer, but might be to complicated to get right, we pay with performance what we
 			// cannot pay with brain cells.


### PR DESCRIPTION
Get the previous task ID and use it to build the log directory of the
builds, then add all the combined files as attachments.

Fixes: https://github.com/xamarin/xamarin-macios/issues/7854