### PR TITLE
[d16-6] [XHarness] Add logs to VSTS test runs.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -366,7 +366,7 @@ namespace xharness
 					var testRunName = $"{appName} {Variation}";
 					if (xmlType == XmlResultParser.Jargon.NUnitV3) {
 						// add the attachments and write in the new filename
-						XmlResultParser.UpdateMissingData (path, newFilename, testRunName, Directory.GetFiles(Logs.Directory));
+						XmlResultParser.UpdateMissingData (path, newFilename, testRunName, Directory.GetFiles (Logs.Directory));
 					} else {
 						// rename the path to the correct value
 						File.Move (path, newFilename);

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -360,8 +360,16 @@ namespace xharness
 				try {
 					var newFilename = XmlResultParser.GetXmlFilePath (path, xmlType);
 
-					// rename the path to the correct value
-					File.Move (path, newFilename);
+					// at this point, we have the test results, but we want to be able to have attachments in vsts, so if the format is
+					// the right one (NUnitV3) add the nodes. ATM only TouchUnit uses V3.
+					var testRunName = $"{appName} ({configuration})";
+					if (xmlType == XmlResultParser.Jargon.NUnitV3) {
+						// add the attachments and write in the new filename
+						XmlResultParser.UpdateMissingData (path, newFilename, testRunName, Directory.GetFiles(Logs.Directory));
+					} else {
+						// rename the path to the correct value
+						File.Move (path, newFilename);
+					}
 					path = newFilename;
 
 					// write the human readable results in a tmp file, which we later use to step on the logs

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -503,6 +503,7 @@ namespace xharness
 			if (useXmlOutput) {
 				args.Add ("-setenv=NUNIT_ENABLE_XML_OUTPUT=true");
 				args.Add ("-setenv=NUNIT_ENABLE_XML_MODE=wrapped");
+				args.Add ("-setenv=NUNIT_XML_VERSION=nunitv3");
 			}
 
 			if (Harness.InCI) {

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -39,6 +39,7 @@ namespace xharness
 		public Harness Harness;
 		public string ProjectFile;
 		public string AppPath;
+		public string Variation;
 
 		public TestExecutingResult Result { get; private set; }
 		public string FailureMessage { get; private set; }
@@ -362,7 +363,7 @@ namespace xharness
 
 					// at this point, we have the test results, but we want to be able to have attachments in vsts, so if the format is
 					// the right one (NUnitV3) add the nodes. ATM only TouchUnit uses V3.
-					var testRunName = $"{appName} ({configuration})";
+					var testRunName = $"{appName} {Variation}";
 					if (xmlType == XmlResultParser.Jargon.NUnitV3) {
 						// add the attachments and write in the new filename
 						XmlResultParser.UpdateMissingData (path, newFilename, testRunName, Directory.GetFiles(Logs.Directory));

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -3686,6 +3686,7 @@ namespace xharness
 						CompanionDeviceName = CompanionDevice?.Name,
 						Configuration = ProjectConfiguration,
 						TimeoutMultiplier = TimeoutMultiplier,
+						Variation = Variation,
 					};
 
 					// Sometimes devices can't upgrade (depending on what has changed), so make sure to uninstall any existing apps first.
@@ -3740,6 +3741,7 @@ namespace xharness
 								DeviceName = Device.Name,
 								CompanionDeviceName = CompanionDevice?.Name,
 								Configuration = ProjectConfiguration,
+								Variation = Variation,
 							};
 							additional_runner = todayRunner;
 							await todayRunner.RunAsync ();
@@ -3850,6 +3852,7 @@ namespace xharness
 				MainLog = Logs.Create ($"run-{Device.UDID}-{Timestamp}.log", "Run log"),
 				Configuration = ProjectConfiguration,
 				TimeoutMultiplier = TimeoutMultiplier,
+				Variation = Variation
 			};
 			runner.Simulators = Simulators;
 			runner.Initialize ();

--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -63,14 +63,7 @@ namespace xharness {
 						long.TryParse (reader ["failed"], out failed);
 						long.TryParse (reader ["inconclusive"], out inconclusive);
 						long.TryParse (reader ["skipped"], out skipped);
-						switch (reader["result"]) {
-						case "Failed":
-							failedTestRun = true;
-							break;
-						default:
-							failedTestRun = false;
-							break;
-						}
+						failedTestRun = failed != 0;
 					}
 					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-suite" && (reader ["type"] == "TestFixture" || reader ["type"] == "ParameterizedFixture")) {
 						var testCaseName = reader ["fullname"];

--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -1,14 +1,17 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Xml;
+using System.Xml.Linq;
 
 namespace xharness {
 	public static class XmlResultParser {
 
 		public enum Jargon {
 			TouchUnit,
-			NUnit,
+			NUnitV2,
+			NUnitV3,
 			xUnit,
 			Missing,
 		}
@@ -25,21 +28,101 @@ namespace xharness {
 				while ((line = stream.ReadLine ()) != null) { // special case when get got the tcp connection
 					if (line.Contains ("ping"))
 						continue;
+					if (line.Contains ("test-run")) { // first element of the NUnitV3 test collection
+						type = Jargon.NUnitV3;
+						return true;
+					}
 					if (line.Contains ("TouchUnitTestRun")) {
 						type = Jargon.TouchUnit;
 						return true;
 					}
-					if (line.Contains ("nunit-version")) {
-						type = Jargon.NUnit;
+					if (line.Contains ("test-results")) { // first element of the NUnitV3 test collection
+						type = Jargon.NUnitV2;
 						return true;
 					}
-					if (line.Contains ("xUnit")) {
+					if (line.Contains ("<assemblies>")) { // first element of the xUnit test collection
 						type = Jargon.xUnit;
 						return true;
 					}
 				}
 			}
 			return false;
+		}
+
+		static (string resultLine, bool failed) ParseNUnitV3Xml (StreamReader stream, StreamWriter writer)
+		{
+			long testcasecount, passed, failed, inconclusive, skipped;
+			bool failedTestRun = false; // result = "Failed"
+			testcasecount = passed = failed = inconclusive = skipped = 0L;
+
+			using (var reader = XmlReader.Create (stream)) {
+				while (reader.Read ()) {
+					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-run") {
+						long.TryParse (reader ["testcasecount"], out testcasecount);
+						long.TryParse (reader ["passed"], out passed);
+						long.TryParse (reader ["failed"], out failed);
+						long.TryParse (reader ["inconclusive"], out inconclusive);
+						long.TryParse (reader ["skipped"], out skipped);
+						switch (reader["result"]) {
+						case "Failed":
+							failedTestRun = true;
+							break;
+						default:
+							failedTestRun = false;
+							break;
+						}
+					}
+					if (reader.NodeType == XmlNodeType.Element && reader.Name == "test-suite" && (reader ["type"] == "TestFixture" || reader ["type"] == "ParameterizedFixture")) {
+						var testCaseName = reader ["fullname"];
+						writer.WriteLine (testCaseName);
+						var time = reader.GetAttribute ("time") ?? "0"; // some nodes might not have the time :/
+												// get the first node and then move in the siblings of the same type
+						reader.ReadToDescendant ("test-case");
+						do {
+							if (reader.Name != "test-case")
+								break;
+							// read the test cases in the current node
+							var status = reader ["result"];
+							switch (status) {
+							case "Passed":
+								writer.Write ("\t[PASS] ");
+								break;
+							case "Skipped":
+								writer.Write ("\t[IGNORED] ");
+								break;
+							case "Error":
+							case "Failed":
+								writer.Write ("\t[FAIL] ");
+								break;
+							case "Inconclusive":
+								writer.Write ("\t[INCONCLUSIVE] ");
+								break;
+							default:
+								writer.Write ("\t[INFO] ");
+								break;
+							}
+							writer.Write (reader ["name"]);
+							if (status == "Failed") { //  we need to print the message
+								reader.ReadToDescendant ("failure");
+								reader.ReadToDescendant ("message");
+								writer.Write ($" : {reader.ReadElementContentAsString ()}");
+								reader.ReadToNextSibling ("stack-trace");
+								writer.Write ($" : {reader.ReadElementContentAsString ()}");
+							}
+							if (status == "Skipped") { // nice to have the skip reason
+								reader.ReadToDescendant ("reason");
+								reader.ReadToDescendant ("message");
+								writer.Write ($" : {reader.ReadElementContentAsString ()}");
+							}
+							// add a new line
+							writer.WriteLine ();
+						} while (reader.ReadToNextSibling ("test-case"));
+						writer.WriteLine ($"{testCaseName} {time} ms");
+					}
+				}
+			}
+			var resultLine = $"Tests run: {testcasecount} Passed: {passed} Inconclusive: {inconclusive} Failed: {failed} Ignored: {skipped + inconclusive}";
+			return (resultLine, failedTestRun);
 		}
 
 		static (string resultLine, bool failed) ParseTouchUnitXml (StreamReader stream, StreamWriter writer)
@@ -206,7 +289,8 @@ namespace xharness {
 			var fileName = Path.GetFileName (path);
 			switch (xmlType) {
 			case Jargon.TouchUnit:
-			case Jargon.NUnit:
+			case Jargon.NUnitV2:
+			case Jargon.NUnitV3:
 				return path.Replace (fileName, $"nunit-{fileName}");
 			case Jargon.xUnit:
 				return path.Replace (fileName, $"xunit-{fileName}");
@@ -242,8 +326,11 @@ namespace xharness {
 				case Jargon.TouchUnit:
 					parseData = ParseTouchUnitXml (reader, writer);
 					break;
-				case Jargon.NUnit:
+				case Jargon.NUnitV2:
 					parseData = ParseNUnitXml (reader, writer);
+					break;
+				case Jargon.NUnitV3:
+					parseData = ParseNUnitV3Xml (reader, writer);
 					break;
 				case Jargon.xUnit:
 					parseData = ParsexUnitXml (reader, writer);
@@ -344,7 +431,7 @@ namespace xharness {
 			using (var stream = new StreamReader (resultsPath))
 			using (var reader = XmlReader.Create (stream)) {
 				switch (xmlType) {
-				case Jargon.NUnit:
+				case Jargon.NUnitV2:
 				case Jargon.TouchUnit:
 					GenerateNUnitTestReport (writer, reader);
 					break;
@@ -356,6 +443,41 @@ namespace xharness {
 					break;
 				}
 			}
+		}
+
+		// get the file, parse it and add the attachments to the first node found
+		public static void UpdateMissingData (string source, string destination, string applicationName, params string [] attachments)
+		{
+			// we could do this with a XmlReader and a Writer, but might be to complicated to get right, we pay with performance what we
+			// cannot pay with brain cells.
+			var doc = XDocument.Load (source);
+			var attachmentsElement = new XElement ("attachments");
+			foreach (var path in attachments) {
+				// we do not add a description, VSTS ignores that :/
+				attachmentsElement.Add (new XElement ("attachment",
+					new XElement ("filePath", path)));
+			}
+
+			var testSuitesElements = doc.Descendants ().Where (e => e.Name == "test-suite" && e.Attribute ("type")?.Value == "Assembly");
+			if (!testSuitesElements.Any ())
+				return;
+
+			// add the attachments to the first test-suite, this will add the attachmnets to it, which will be added to the test-run, the pipeline
+			// SHOULD NOT merge runs, else this upload will be really hard to use. Also, just to one of them, else we have duplicated logs.
+			testSuitesElements.FirstOrDefault ().Add (attachmentsElement);
+
+			foreach (var suite in testSuitesElements) {
+				suite.SetAttributeValue ("name", applicationName);
+				suite.SetAttributeValue ("fullname", applicationName); // docs say just name, but I've seen the fullname instead, docs usually lie
+				// add also the attachments to all the failing tests, this will make the life of the person monitoring easier, since
+				// he will see the logs directly from the attachment page
+				var tests = suite.Descendants ().Where (e => e.Name == "test-case" && e.Attribute ("result").Value == "Failed");
+				foreach (var t in tests) {
+					t.Add (attachmentsElement);
+				}
+			}
+
+			doc.Save (destination);
 		}
 	}
 }

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -64,6 +64,7 @@
     <Reference Include="Mono.Posix" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="mscorlib" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />


### PR DESCRIPTION
As per the documentation of the VSTS test uploader (https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/publish-test-results?view=azure-devops&tabs=yaml#attachments-support)
the tests support the addition of attachments. We want to be able to
access the logs of the different tests runs, this is achieved the
following way:

1. Move TouchUnit to use NUnit V3 which allows to add attachments.
2. Once the tests are ran, add the attachments to the following nodes:
   1. The very first test-suite. This will allow to have the logs for
   succesul tests.
   2. Add logs to failing tests. Reduces the number of clicks to be done
   to access to the logs when a test case fails.
3. Modify the assembly name of the test-suit to match the name of the
application. This ensures two things.
   1. We have a consistent name for the file column in VSTS, that can be
   used to see recurrent failing tests.
   2. The name is more readable, since if not, it will contain the UUID
   of the device.

Logs are not added to succesful tests because it will have the following
problems:

* Larger data storage usage.
* Longer upload time. The addtion of the logs per tests (succesful or
failed) was tested and resulted in an upload time LONGER than 6 hours
for all TouchUnit, NUnit blc tests and xUnit bcl tests.

In order for this to be useful, the task in the pipeline SHOULD NOT
merge test runs. We should have a test run PER application so that we do
not mix the logs.

Backport of #7844.

/cc @mandel-macaque 