### PR TITLE
[CoreBluetooth] Update bindings to Xcode 11.4 Beta 1

### DIFF
--- a/src/CoreBluetooth/Enums.cs
+++ b/src/CoreBluetooth/Enums.cs
@@ -117,6 +117,8 @@ namespace CoreBluetooth {
 		UnknownDevice,
 		[iOS (12,0)][TV (12,0)][Mac (10,14)][Watch (5,0)]
 		OperationNotSupported,
+		PeerRemovedPairingInformation,
+		EncryptionTimedOut,
 	}
 
 	[Watch (4,0)]


### PR DESCRIPTION
diff: https://github.com/xamarin/xamarin-macios/wiki/CoreBluetooth-iOS-xcode11.4-beta1