### PR TITLE
[Mono binaries] Set the mono binaries to be the ones compiled with Xcode 11.3

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -353,7 +353,8 @@ JENKINS_RESULTS_DIRECTORY ?= $(abspath $(TOP)/jenkins-results)
 # Clone files instead of copying them on APFS file systems. Much faster.
 CP:=$(shell df -t apfs / >/dev/null 2>&1 && echo "cp -c" || echo "cp")
 
-XCODE_ARCHIVE_VERSION=xcode-$(XCODE_PRODUCT_BUILD_VERSION)
+# WORKAROUND, should be  xcode-$(XCODE_PRODUCT_BUILD_VERSION) but we are stuck due to xcode 11.4 beta 1 issue: https://github.com/xamarin/xamarin-macios/issues/7872
+XCODE_ARCHIVE_VERSION=xcode-11C29
 MONO_IOS_FILENAME:=ios-release-Darwin-$(MONO_HASH).7z
 MONO_IOS_URL:=https://xamjenkinsartifact.azureedge.net/mono-sdks/$(XCODE_ARCHIVE_VERSION)/$(MONO_IOS_FILENAME)
 MONO_MAC_FILENAME:=mac-release-Darwin-$(MONO_HASH).7z


### PR DESCRIPTION
Mono is not yet built with Xcode 11.4, lets use Xcode 11.3 binary
packages to move fwd faster.

Issue created to track the revert of this change: https://github.com/xamarin/xamarin-macios/issues/7872