### PR TITLE
Make the smcs script obsolete, and don't use it in tests anymore.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -595,12 +595,8 @@ $(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)/bin/smcs:
 	@echo Installing smcs script
 	@echo "#!/bin/bash" > $@
 	@echo >> $@
-	@echo 'SMCS=`which mcs`' >> $@
-	@echo 'if test -z $$SMCS; then' >> $@
-	@echo "    SMCS=/Library/Frameworks/Mono.framework/Versions/Current/bin/mcs" >> $@
-	@echo "fi" >> $@
-	@echo 'unset MONO_PATH' >> $@
-	@echo "\$$SMCS -nostdlib -r:$(abspath $(IOS_TARGETDIR)/$(MONOTOUCH_PREFIX)/lib/mono/2.1/mscorlib.dll) -r:$(abspath $(IOS_TARGETDIR)/$(MONOTOUCH_PREFIX)/lib/mono/2.1/System.dll) \"\$$@\"" >> $@
+	@echo "echo 'This script ($$0) is obsolete. Use csc to compile instead."
+	@echo "exit 1"
 	@chmod +x $@
 
 install-smcs: $(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)/bin/smcs

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -406,12 +406,6 @@ namespace Xamarin.Tests
 			}
 		}
 
-		public static string SmcsPath {
-			get {
-				return Path.Combine (SdkBinDir, "smcs");
-			}
-		}
-
 		public static string BtouchPath {
 			get {
 				return Path.Combine (SdkBinDir, "btouch-native");

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -3168,9 +3168,10 @@ class Test {
 
 				File.WriteAllText (dllcs, "public class TestLib { public TestLib () { System.Console.WriteLine (typeof (UIKit.UIWindow).ToString ()); } }");
 
-				var args = new [] { dllcs, "/debug:full", "/noconfig", "/t:library", "/nologo", $"/out:{dll}", "/r:" + Configuration.XamarinIOSDll };
+				var args = new List<string> () { dllcs, "/debug:full", "/noconfig", "/t:library", "/nologo", $"/out:{dll}", "/r:" + Configuration.XamarinIOSDll };
 				File.WriteAllText (DLL + ".config", "");
-				if (ExecutionHelper.Execute (Configuration.SmcsPath, args, out output) != 0)
+				var compiler = Configuration.GetCompiler (Profile.iOS, args);
+				if (ExecutionHelper.Execute (compiler, args, out output) != 0)
 					throw new Exception (output);
 
 				var execs = @"public class TestApp { 
@@ -3185,8 +3186,9 @@ class Test {
 
 				File.WriteAllText (exeF, execs);
 
-				var cmds = new [] { exeF, "/noconfig", "/t:exe", "/nologo", $"/out:{exe}", $"/r:{dll}", $"-r:{Configuration.XamarinIOSDll}" };
-				if (ExecutionHelper.Execute (Configuration.SmcsPath, cmds, out output) != 0)
+				var cmds = new List<string> () { exeF, "/noconfig", "/t:exe", "/nologo", $"/out:{exe}", $"/r:{dll}", $"-r:{Configuration.XamarinIOSDll}" };
+				compiler = Configuration.GetCompiler (Profile.iOS, cmds);
+				if (ExecutionHelper.Execute (compiler, cmds, out output) != 0)
 					throw new Exception (output);
 
 				File.Move (dll, DLL);


### PR DESCRIPTION
Don't remove the entire script, because I believe there's code out there that
checks for the existence of the smcs script to determine whether Xamarin.iOS
is installed or not.