### PR TITLE
[d16-6] [mtouch] Fix looking up satellites for root assemblies without a path.

### DIFF
--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -622,6 +622,8 @@ namespace Xamarin.Bundler {
 				// they will be copied (at build time) into the destination directory (making them work at runtime)
 				// but they won't be side-by-side the original assembly (which breaks our build time assumptions)
 				path = Path.GetDirectoryName (App.RootAssemblies [0]);
+				if (string.IsNullOrEmpty (path))
+					path = Environment.CurrentDirectory;
 				ComputeSatellites (satellite_name, path);
 			}
 		}


### PR DESCRIPTION
This may happen when a root assembly is in the current directory.

This fixes the bug-13945 test in the scripted tests.

Backport of #7871.

/cc @dalexsoto @rolfbjarne