### PR TITLE
[XHarness] Add ids to the xunit to nunit transformed tests.

### DIFF
--- a/tests/bcl-test/templates/common/TestRunner.xUnit/NUnit3Xml.xslt
+++ b/tests/bcl-test/templates/common/TestRunner.xUnit/NUnit3Xml.xslt
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:myGenerator="urn:hash-generator">
   <xsl:output cdata-section-elements="message stack-trace"/>
 
   <xsl:template match="/">
@@ -7,7 +7,7 @@
   </xsl:template>
 
   <xsl:template match="assemblies">
-    <test-run name="Test results" inconclusive="0" asserts="0" > 
+    <test-run name="Test results" inconclusive="0" asserts="0" id="2"> 
       <!-- test-run attributes -->
       <xsl:attribute name="testcasecount">
         <xsl:value-of select="sum(assembly/@total)"/>
@@ -138,9 +138,13 @@
   <!-- Map test to test-case -->
 
   <xsl:template match="test">
+    <xsl:param name="hash_source" select="@name"/>
     <test-case>
       <xsl:attribute name="name">
         <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="id">
+        <xsl:value-of select="myGenerator:GenerateHash($hash_source)"/>
       </xsl:attribute>
       <xsl:attribute name="result">
         <xsl:if test="@result='Fail'">Failed</xsl:if>

--- a/tests/bcl-test/templates/common/TestRunner.xUnit/NUnit3Xml.xslt
+++ b/tests/bcl-test/templates/common/TestRunner.xUnit/NUnit3Xml.xslt
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:myGenerator="urn:hash-generator">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:testIdGenerator="urn:hash-generator">
   <xsl:output cdata-section-elements="message stack-trace"/>
 
   <xsl:template match="/">
@@ -98,9 +98,13 @@
 
   <!-- Map colection to test-case name="TestFixture" -->
   <xsl:template match="collection">
+    <xsl:param name="hash_source" select="@name"/>
     <test-suite type="TestFixture" inconclusive="0">
       <xsl:attribute name="name">
         <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="id">
+        <xsl:value-of select="testIdGenerator:GenerateHash($hash_source)"/>
       </xsl:attribute>
       <xsl:attribute name="testcasecount">
         <xsl:value-of select="@total"/>
@@ -144,7 +148,7 @@
         <xsl:value-of select="@name"/>
       </xsl:attribute>
       <xsl:attribute name="id">
-        <xsl:value-of select="myGenerator:GenerateHash($hash_source)"/>
+        <xsl:value-of select="testIdGenerator:GenerateHash($hash_source)"/>
       </xsl:attribute>
       <xsl:attribute name="result">
         <xsl:if test="@result='Fail'">Failed</xsl:if>

--- a/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
@@ -8,13 +8,24 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
-
-
+using System.Xml.Xsl;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Xamarin.iOS.UnitTests.XUnit
 {
+	public class XsltIdGenerator
+	{
+		public int GenerateHash (string name)
+		{
+			var sum = 0;
+			foreach (var c in name) {
+				sum += c;
+			}
+			return sum;
+		}
+	}
+
 	public class XUnitTestRunner : TestRunner
 	{
 		readonly TestMessageSink messageSink;
@@ -854,10 +865,17 @@ namespace Xamarin.iOS.UnitTests.XUnit
 				if (xsltStream == null) {
 					throw new Exception ($"Stream with name {name} cannot be found! We have {GetType ().Assembly.GetManifestResourceNames ()[0]}");
 				}
+				// add the extension so that we can get the hash from the name of the test
+				// Create an XsltArgumentList.
+				XsltArgumentList xslArg = new XsltArgumentList ();
+
+				var generator = new XsltIdGenerator ();
+				xslArg.AddExtensionObject ("urn:hash-generator", generator);
+
 				using (var xsltReader = XmlReader.Create (xsltStream))
 				using (var xmlReader = element.CreateReader ()) {
 					xmlTransform.Load (xsltReader);
-					xmlTransform.Transform (xmlReader, writer);
+					xmlTransform.Transform (xmlReader, xslArg, writer);
 				}
 			}
 		}

--- a/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
@@ -16,14 +16,9 @@ namespace Xamarin.iOS.UnitTests.XUnit
 {
 	public class XsltIdGenerator
 	{
-		public int GenerateHash (string name)
-		{
-			var sum = 0;
-			foreach (var c in name) {
-				sum += c;
-			}
-			return sum;
-		}
+		// NUnit3 xml does not have schema, there is no much info about it, most examples just have incremental IDs.
+		int seed = 1000;
+		public int GenerateHash (string name) => seed++;
 	}
 
 	public class XUnitTestRunner : TestRunner


### PR DESCRIPTION
The NUnit3 xml requires an id for the tests, but xunit does not provide
one. Add an extension object to the xslt that will return a very lame id
so that the test uploader does not complain.

fixes: https://github.com/xamarin/xamarin-macios/issues/7888