### PR TITLE
[tests] Simulator dylibs can either have min OS version 7.0 or 8.0. Fixes xamarin/maccore#2153.

### DIFF
--- a/tests/common/ProductTests.cs
+++ b/tests/common/ProductTests.cs
@@ -122,7 +122,8 @@ namespace Xamarin.Tests
 							} else if (slice.Architecture == MachO.Architectures.ARM64) {
 								alternate_version = new Version (7, 0, 0); // our arm64 slices has min iOS 7.0.
 							} else if (slice.IsDynamicLibrary && !device) {
-								version = new Version (7, 0, 0);
+								version = new Version (8, 0, 0);
+								alternate_version = new Version (7, 0, 0);
 							}
 							mono_native_compat_version = version;
 							mono_native_unified_version = new Version (10, 0, 0);


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/2153.