### PR TITLE
[tests] Ignore Xamarin.MMP.Tests.WarningTests.MM0135 on macOS 10.15+. Fixes xamarin/maccore#2035.

### DIFF
--- a/tests/mmptest/src/WarningTests.cs
+++ b/tests/mmptest/src/WarningTests.cs
@@ -15,6 +15,9 @@ namespace Xamarin.MMP.Tests
 			if (!Directory.Exists (oldXcode))
 				Assert.Ignore ("This test requires Xcode 9.4 (or updated to a newer one that still warns MM0135).");
 
+			if (PlatformHelpers.CheckSystemVersion (10, 15))
+				Assert.Ignore ("This test requires Xcode 9.4, which doesn't work on macOS 10.15+");
+
 			MMPTests.RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir);
 				var output = TI.TestUnifiedExecutable (test, environment: new string[] { "MD_APPLE_SDK_ROOT", Path.GetDirectoryName (Path.GetDirectoryName (oldXcode)) });


### PR DESCRIPTION
Ignore Xamarin.MMP.Tests.WarningTests.MM0135 on macOS 10.15+, because this
test requires Xcode 9.4, which doesn't work on macOS 10.15+.

Fixes https://github.com/xamarin/maccore/issues/2035.