### PR TITLE
[Xharness] If we fail to install the application, report it as an test failure.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -78,6 +78,8 @@ namespace xharness
 			}
 		}
 
+		public string AppName => $"{appName} {Variation}";
+
 		public double TimeoutMultiplier { get; set; } = 1;
 
 		// For watch apps we end up with 2 simulators, the watch simulator (the main one), and the iphone simulator (the companion one).
@@ -895,7 +897,7 @@ namespace xharness
 
 	// Monitor the output from 'mlaunch --installdev' and cancel the installation if there's no output for 1 minute.
 	class AppInstallMonitorLog : Log {
-		public override string FullPath => throw new NotImplementedException ();
+		public override string FullPath => copy_to.FullPath;
 
 		Log copy_to;
 		CancellationTokenSource cancellation_source;

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -3737,6 +3737,17 @@ namespace xharness
 							if (!install_result.Succeeded) {
 								FailureMessage = $"Install failed, exit code: {install_result.ExitCode}.";
 								ExecutionResult = TestExecutingResult.Failed;
+								if (Harness.InCI) {
+									// we are in the CI, VSTS had no nice way to report that we failed to install the app, which makes
+									// the monitoring job harder, but we can write a installation failed test and that will be reported in
+									// VSTS and an install failure when the tests are uploaded
+									var installLogXmlTmp = Logs.Create ($"nunit-install-{Timestamp}.tmp", "Install Log tmp");
+									var installLogXml = Logs.Create ($"nunit-install-{Timestamp}.xml", Log.XML_LOG);
+									XmlResultParser.GenerateFailure (installLogXmlTmp.FullPath, "AppInstallation", $"Install failed, exit code: {install_result.ExitCode}", install_log.FullPath, XmlResultParser.Jargon.NUnitV3);
+									// add the required attachments and the info of the application that failed to install
+									var logs = Directory.GetFiles (Logs.Directory).Where (p => !p.Contains ("nunit")); // all logs but oursefl
+									XmlResultParser.UpdateMissingData (installLogXmlTmp.FullPath, installLogXml.FullPath, runner.AppName, logs);
+								}
 							}
 						} finally {
 							this.install_log.Dispose ();

--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -489,7 +489,7 @@ namespace xharness {
 		}
 
 		// get the file, parse it and add the attachments to the first node found
-		public static void UpdateMissingData (string source, string destination, string applicationName, List<string> attachments)
+		public static void UpdateMissingData (string source, string destination, string applicationName, IEnumerable<string> attachments)
 		{
 			// we could do this with a XmlReader and a Writer, but might be to complicated to get right, we pay with performance what we
 			// cannot pay with brain cells.


### PR DESCRIPTION
VSTS does not provide a good way to report an app installation issue,
but we can fake a failure in the test when the installation does not
happen.

In the case of the installation failure a xml test result is generated
that will expose all the required information and will attach all the
needed logs (install logs). An example of the generated result can be
seen here: https://gist.github.com/mandel-macaque/2274bcd8785eebd636b98142e228afa9