### PR TITLE
[tests][msbuild] Update testing build engine to implement IBuildEngine4

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestEngine.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestEngine.cs
@@ -14,7 +14,7 @@ using Microsoft.Build.Utilities;
 namespace Xamarin.iOS.Tasks
 {
 
-	public class TestEngine : IBuildEngine
+	public class TestEngine : IBuildEngine, IBuildEngine2, IBuildEngine3, IBuildEngine4
 	{
 		public Logger Logger {
 			get; set;
@@ -87,6 +87,43 @@ namespace Xamarin.iOS.Tasks
 		}
 
 		public ProjectCollection ProjectCollection { get; set; }
+
+		private Dictionary<object, object> Tasks = new Dictionary<object, object> ();
+
+		void IBuildEngine4.RegisterTaskObject (object key, object obj, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection)
+		{
+			Tasks [key] = obj;
+		}
+
+		object IBuildEngine4.GetRegisteredTaskObject (object key, RegisteredTaskObjectLifetime lifetime)
+		{
+			Tasks.TryGetValue (key, out object value);
+			return value;
+		}
+
+		object IBuildEngine4.UnregisterTaskObject (object key, RegisteredTaskObjectLifetime lifetime)
+		{
+			if (Tasks.TryGetValue (key, out object value)) {
+				Tasks.Remove (key);
+			}
+			return value;
+		}
+
+		BuildEngineResult IBuildEngine3.BuildProjectFilesInParallel (string [] projectFileNames, string [] targetNames, IDictionary [] globalProperties, IList<string> [] removeGlobalProperties, string [] toolsVersion, bool returnTargetOutputs)
+		{
+			throw new NotImplementedException ();
+		}
+
+		void IBuildEngine3.Yield () { }
+
+		void IBuildEngine3.Reacquire () { }
+
+		bool IBuildEngine2.BuildProjectFile (string projectFileName, string [] targetNames, IDictionary globalProperties, IDictionary targetOutputs, string toolsVersion) => true;
+
+		bool IBuildEngine2.BuildProjectFilesInParallel (string [] projectFileNames, string [] targetNames, IDictionary [] globalProperties, IDictionary [] targetOutputsPerProject, string [] toolsVersion, bool useResultsCache, bool unloadProjectsOnCompletion) => true;
+
+		bool IBuildEngine2.IsRunningMultipleNodes => false;
+
 	}
-	
+
 }


### PR DESCRIPTION
Update the mock engine used for MSBuild tests to implement IBuildEngine4. Without these changes MSBuild tests break if we try to use BuildEngine4 features such as caching (specifically `BuildEngine4.RegisterTaskObject`). Similar changes can be found on the android test engine here:

https://github.com/xamarin/xamarin-android/blob/426630c20a483915d3c7cdcdfc83fe83d200fca7/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/MockBuildEngine.cs