### PR TITLE
[VSTS] Ensure that certain tasks do not run when not needed.

### DIFF
--- a/tools/devops/device-tests-common.yml
+++ b/tools/devops/device-tests-common.yml
@@ -64,6 +64,11 @@ jobs:
       rm -f ~/Library/Caches/com.xamarin.provisionator/Provisions/*mobileprovision
 
       ./maccore/tools/install-qa-provisioning-profiles.sh -v
+      if [ $? -eq 0 ]; then
+        echo "##vso[task.setvariable variable=ProvisioningProfiles]success"
+      else
+        echo "##vso[task.setvariable variable=ProvisioningProfiles]failure"
+      fi
     displayName: 'Add provisioning profiles'
     env:
       LOGIN_KEYCHAIN_PASSWORD: $(OSX_KEYCHAIN_PASS)
@@ -151,7 +156,7 @@ jobs:
   - bash: ./xamarin-macios/tools/devops/add-summaries.sh
     displayName: 'Add summaries'
     continueOnError: true
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), eq(variables['ProvisioningProfiles'], 'success')) # if profiles did not succeded we do not need to do a thing since we have no summaries
 
   - task: ArchiveFiles@1
     displayName: 'Archive HtmlReport'
@@ -160,7 +165,7 @@ jobs:
       includeRootFolder: false
       archiveFile: '$(Build.ArtifactStagingDirectory)/HtmlReport-$(Build.BuildId).zip'
     continueOnError: true
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), eq(variables['ProvisioningProfiles'], 'success')) # if profiles did not succeded we do not need to do a thing since we have no summaries
 
   ###
   ### Upload the xml results to vsts. We have two types, nunit and xunit. We want both
@@ -173,7 +178,7 @@ jobs:
       testResultsFiles: '**/nunit-test-*.xml'
       failTaskOnFailedTests: true
     continueOnError: true
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), eq(variables['ProvisioningProfiles'], 'success')) # with no profiles we have no test results
 
   ###
   ### Push the HTML report to Azure DevOps (shows up in Summary tab as Build Artifact)
@@ -185,7 +190,7 @@ jobs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)/HtmlReport-$(Build.BuildId).zip'
       artifactName: HtmlReport
     continueOnError: true
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), eq(variables['ProvisioningProfiles'], 'success')) # with no profiles we have no test results
 
   ###
   ### Cleanup after us, not having that can lead to VSMac install issues


### PR DESCRIPTION
If the bot could no get the provisioning profiles installed, there is no
reason for certain tasks to run since they are all going to fail. This
adds A LOT of noise in the pipeline for the monitoring person to check
when there is no reason.