### PR TITLE
[VSTS] Propagate debug to the make rules

### DIFF
--- a/tools/devops/run-tests.sh
+++ b/tools/devops/run-tests.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -ex
 
-make -C xamarin-macios/builds download -j
-make -C xamarin-macios/builds .stamp-mono-ios-sdk-destdir -j
-make -C xamarin-macios/tests vsts-device-tests
+
+if [[ "$SYSTEM_DEBUG" == "true" ]]; then
+  DEBUG="-d"
+else
+  DEBUG=""
+fi
+make -C $DEBUG xamarin-macios/builds download -j
+make -C $DEBUG xamarin-macios/builds .stamp-mono-ios-sdk-destdir -j
+make -C $DEBUG xamarin-macios/tests vsts-device-tests


### PR DESCRIPTION
If the pipeline is set on debug, to be able to see any issues, propagate
that to the make calls so that we can also get the information there,
else debugging issues with the pipelines + make is really hard.