### PR TITLE
[VSTS] If we could not checkout, do not try to call scripts that are missing.

### DIFF
--- a/tools/devops/cleanup.sh
+++ b/tools/devops/cleanup.sh
@@ -1,6 +1,0 @@
-sudo rm -rf /Applications/Visual\ Studio*
-rm -rf ~/Library/Caches/VisualStudio
-rm -rf ~/Library/Logs/VisualStudio
-rm -rf ~/Library/VisualStudio
-rm -rf ~/Library/Preferences/Xamarin/
-rm -rf ~/Library/Caches/com.xamarin.provisionator

--- a/tools/devops/device-tests-common.yml
+++ b/tools/devops/device-tests-common.yml
@@ -196,7 +196,13 @@ jobs:
   ### Cleanup after us, not having that can lead to VSMac install issues
   ###
 
-  - bash: ./xamarin-macios/tools/devops/cleanup.sh
+  - bash: |
+      sudo rm -rf /Applications/Visual\ Studio*
+      rm -rf ~/Library/Caches/VisualStudio
+      rm -rf ~/Library/Logs/VisualStudio
+      rm -rf ~/Library/VisualStudio
+      rm -rf ~/Library/Preferences/Xamarin/
+      rm -rf ~/Library/Caches/com.xamarin.provisionator
     displayName: 'Cleanup'
     continueOnError: true
     condition: succeededOrFailed()


### PR DESCRIPTION
Some of the bots fail to do the checkout (miss configuration). The cleanup  step is always executed and assumes the presence of a script, which
will fail since the script is not there.

The script is small, there is no need to add the rm in an extra file
that needs to be checkout.

This removes an extra warning that is set in the pipeline which is noise
when monitoring.