### PR TITLE
[Harness] Create an xml crash file when we do not have a result file.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -887,6 +887,11 @@ namespace xharness
 					FailureMessage = $"Launch failure";
 					if (Harness.InCI)
 						XmlResultParser.GenerateFailure (Logs, "launch", appName, Variation, "AppLaunch", FailureMessage, main_log.FullPath, XmlResultParser.Jargon.NUnitV3);
+				} else if (!File.Exists (listener_log.FullPath) && Harness.InCI) {
+					// this happens more that what we would like on devices, the main reason most of the time is that we have had netwoking problems and the
+					// tcp connection could not be stablished. We are going to report it as an error since we have not parsed the logs, evne when the app might have
+					// not crashed.
+					XmlResultParser.GenerateFailure (Logs, "tcp-connection", appName, Variation, "TcpConnection", "Device could not reach the host over tcp.", main_log.FullPath, XmlResultParser.Jargon.NUnitV3);
 				}
 			}
 


### PR DESCRIPTION
On devices that cannot reach the host via TCP we do not have a log, this
means that in the if statement needs to have a case for it.

The main problem is that when the device cannot connect to the host, we
do not get a log OR a crash reason from the crash logs. It makes sense
not to have a crash reason, because the app did not crash. In these
sitations, we have to create a xml crash report (since we really do not
know if we can parse the file) that will tell vsts that there was an
issue. Adding the main log will let the monitoring person see the
results of the test run.