### PR TITLE
[Tests] Fix AudioQueueTest.Properties test.

### DIFF
--- a/tests/monotouch-test/AudioToolbox/AudioQueueTest.cs
+++ b/tests/monotouch-test/AudioToolbox/AudioQueueTest.cs
@@ -36,9 +36,10 @@ namespace MonoTouchFixtures.AudioToolbox {
 			TestRuntime.RequestMicrophonePermission ();
 
 			var b = new InputAudioQueue (AudioStreamBasicDescription.CreateLinearPCM ());
-			b.HardwareCodecPolicy = AudioQueueHardwareCodecPolicy.PreferHardware;
+			
+			b.HardwareCodecPolicy = AudioQueueHardwareCodecPolicy.UseSoftwareOnly;
 
-			Assert.That (b.HardwareCodecPolicy, Is.EqualTo (AudioQueueHardwareCodecPolicy.PreferHardware), "#1");
+			Assert.That (b.HardwareCodecPolicy, Is.EqualTo (AudioQueueHardwareCodecPolicy.UseSoftwareOnly), "#1");
 		}
 
 		[Test]


### PR DESCRIPTION
From the documentation of
https://developer.apple.com/documentation/audiotoolbox/audio_converter_services?language=objc
I think we can deduce that we are hitting a 'hwiu' which is 'Hardware in
use' or a similar situation in which we cannot access the hardware codec implementation. Could make sense if we did not clean up properly. Switching to use
the software implementation should fix the flacky test.

fixes: https://github.com/xamarin/maccore/issues/1614