### PR TITLE
[xcode11.3] Make the x86-64 slice we inject into binaries optional.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -370,5 +370,9 @@ MONO_MAC_SDK_DESTDIR:=$(abspath $(MONO_PATH)/sdks/out)
 MONO_BUILD_MODE=compile-mono
 endif
 
+# If we should inject an x86_64 slice into every binary that doesn't have one.
+# This is sometimes necessary to work around an Apple bug wrt notarization where Apple flags all binaries that don't have a x86_64 slice, even if they're correctly signed.
+INJECT_X86_64_SLICE=
+
 .SUFFIXES:
 MAKEFLAGS += --no-builtin-rules

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -54,9 +54,13 @@ downloads/%: downloads/%.7z
 clean-local::
 	$(Q) rm -Rf downloads .stamp-download-mono
 
+ifdef INJECT_X86_64_SLICE
 X86_64_SLICE=$(abspath $(CURDIR)/x86-64-slice.dylib)
 $(X86_64_SLICE): Makefile
 	echo "void xamarin_x86_64_function_for_notarization_workaround () {}" | $(MAC_CC) -shared -x c -o$@ -
+else
+X86_64_SLICE=
+endif
 
 ifeq ($(MONO_BUILD_FROM_SOURCE),)
 
@@ -852,10 +856,12 @@ $(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/usr/lib/%: .stamp-$(MONO_BUILD_MODE) $(X86
 $(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/Frameworks/Mono.framework/Mono: .stamp-$(MONO_BUILD_MODE) | $(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/Frameworks
 	$(Q) $(CP) -R $(MONO_IOS_SDK_DESTDIR)/ios-frameworks/ios/Mono.framework $(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/Frameworks
 	$(Q) $(CP) -R $(MONO_IOS_SDK_DESTDIR)/ios-frameworks/ios/Mono.framework.dSYM $(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/Frameworks
+ifdef INJECT_X86_64_SLICE
 	@# inject x86-64 slice
 	$(Q) mv $@ $@.tmp
 	$(Q_LIPO) lipo $@.tmp $(X86_64_SLICE) -create -output $@
 	$(Q) rm $@.tmp
+endif
 
 $(IPHONEOS_DIRECTORIES):
 	$(Q) mkdir -p $@
@@ -894,10 +900,12 @@ $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/%: .stamp-$(MONO_BUILD_MODE) $(X86_
 $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework/Mono: .stamp-$(MONO_BUILD_MODE) $(X86_64_SLICE) | $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks
 	$(Q) $(CP) -R $(MONO_IOS_SDK_DESTDIR)/ios-frameworks/watchos/Mono.framework $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks
 	$(Q) $(CP) -R $(MONO_IOS_SDK_DESTDIR)/ios-frameworks/watchos/Mono.framework.dSYM $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks
+ifdef INJECT_X86_64_SLICE
 	@# inject x86-64 slice
 	$(Q) mv $@ $@.tmp
 	$(Q_LIPO) lipo $@.tmp $(X86_64_SLICE) -create -output $@
 	$(Q) rm $@.tmp
+endif
 
 $(WATCHOS_DIRECTORIES):
 	$(Q) mkdir -p $@
@@ -936,10 +944,12 @@ $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib/%: .stamp-$(MONO_BUILD_MODE) $(X86_64_
 $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework/Mono: .stamp-$(MONO_BUILD_MODE) $(X86_64_SLICE) | $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks
 	$(Q) $(CP) -R $(MONO_IOS_SDK_DESTDIR)/ios-frameworks/tvos/Mono.framework $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks
 	$(Q) $(CP) -R $(MONO_IOS_SDK_DESTDIR)/ios-frameworks/tvos/Mono.framework.dSYM $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks
+ifdef INJECT_X86_64_SLICE
 	@# inject x86-64 slice
 	$(Q) mv $@ $@.tmp
 	$(Q_LIPO) lipo $@.tmp $(X86_64_SLICE) -create -output $@
 	$(Q) rm $@.tmp
+endif
 
 $(TVOS_DIRECTORIES):
 	$(Q) mkdir -p $@

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -30,9 +30,13 @@ SHARED_FILES = $(SHARED_SOURCES) $(SHARED_HEADERS) $(SHARED_I386_SOURCES) $(SHAR
 
 EXTRA_DEPENDENCIES = $(SHARED_HEADERS) $(TOP)/Make.config $(TOP)/mk/mono.mk
 
+ifdef INJECT_X86_64_SLICE
 X86_64_SLICE=$(abspath $(CURDIR)/x86-64-slice.dylib)
 $(X86_64_SLICE): Makefile
 	$(Q) echo "void xamarin_x86_64_function_for_notarization_workaround_v2 () {}" | $(MAC_CC) -shared -x c -o$@ -
+else
+X86_64_SLICE=
+endif
 
 xamarin/mono-runtime.h: mono-runtime.h.t4 exports.t4
 	$(Q_GEN) $(TT) $< -o $@


### PR DESCRIPTION
We inject an x86-64 slice into binaries that don't contain one, because
Apple's notarization process fails without such a slice.

But make the slice optional and opt-in, because it seems Apple has started
to fail on binaries with such a slice now...

Backport of #7891.

/cc @dalexsoto @rolfbjarne