### PR TITLE
[Harness] If there is no BuildTask, do not add logs.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -371,7 +371,8 @@ namespace xharness
 						var logs = new List<string> ();
 						// add our logs AND the logs of the previous task, which is the build task
 						logs.AddRange (Directory.GetFiles (Logs.Directory));
-						logs.AddRange (Directory.GetFiles (BuildTask.LogDirectory));
+						if (BuildTask != null) // when using the run command, we do not have a build task, ergo, there are no logs to add.
+							logs.AddRange (Directory.GetFiles (BuildTask.LogDirectory));
 						// add the attachments and write in the new filename
 						// add a final prefix to the file name to make sure that the VSTS test uploaded just pick
 						// the final version, else we will upload tests more than once


### PR DESCRIPTION
xharness does not only allow to run tests in CI, but also helps to run
specific project. That feature is used for the mtouch tests. In that
scenario, we do not have a build task and therefore we will not have the
build logs.

fixes: https://github.com/xamarin/maccore/issues/2154