### PR TITLE
[Harness] Add extra labels to allow to select a smaller set of tests.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -40,6 +40,11 @@ namespace xharness
 		public bool IncludeXtro;
 		public bool IncludeCecil;
 		public bool IncludeDocs;
+		public bool IncludeNewBCL;
+		public bool IncludeOldBCL;
+		public bool IncludeMscorlib;
+		public bool IncludeXamarin = true;
+		public bool IncludeMonotouch = true;
 
 		public bool CleanSuccessfulTestRuns = true;
 		public bool UninstallTestApp = true;
@@ -219,8 +224,19 @@ namespace xharness
 		{
 			if (!project.IsExecutableProject)
 				return false;
+			
+			if (project.IsBclTest) {
+				if (!project.IsNewBclTest)
+					return IncludeBcl || IncludeOldBCL;
+				if (project.IsMscorlib) 
+					return IncludeMscorlib;
+				return IncludeBcl || IncludeNewBCL;
+			}
 
-			if (!IncludeBcl && project.IsBclTest)
+			if (!IncludeMonotouch && project.IsMonotouch)
+				return false;
+
+			if (!IncludeXamarin && !project.IsBclTest && !project.IsMonotouch)
 				return false;
 
 			if (Harness.IncludeSystemPermissionTests == false && project.Name == "introspection")
@@ -799,6 +815,9 @@ namespace xharness
 			SetEnabled (labels, "mtouch", ref IncludeMtouch);
 			SetEnabled (labels, "mmp", ref IncludeMmpTest);
 			SetEnabled (labels, "bcl", ref IncludeBcl);
+			SetEnabled (labels, "new-bcl", ref IncludeNewBCL);
+			SetEnabled (labels, "old-bcl", ref IncludeOldBCL);
+			SetEnabled (labels, "mscorlib", ref IncludeMscorlib);
 			SetEnabled (labels, "btouch", ref IncludeBtouch);
 			SetEnabled (labels, "mac-binding-project", ref IncludeMacBindingProject);
 			SetEnabled (labels, "ios-extensions", ref IncludeiOSExtensions);
@@ -817,6 +836,9 @@ namespace xharness
 			SetEnabled (labels, "mac", ref IncludeMac);
 			SetEnabled (labels, "ios-msbuild", ref IncludeiOSMSBuild);
 			SetEnabled (labels, "ios-simulator", ref IncludeSimulator);
+			SetEnabled (labels, "xamarin", ref IncludeXamarin);
+			SetEnabled (labels, "monotouch", ref IncludeMonotouch);
+
 			bool inc_permission_tests = false;
 			if (SetEnabled (labels, "system-permission", ref inc_permission_tests))
 				Harness.IncludeSystemPermissionTests = inc_permission_tests;

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -40,10 +40,10 @@ namespace xharness
 		public bool IncludeXtro;
 		public bool IncludeCecil;
 		public bool IncludeDocs;
-		public bool IncludeNewBCL;
-		public bool IncludeOldBCL;
+		public bool IncludeBCLxUnit;
+		public bool IncludeBCLNUnit;
 		public bool IncludeMscorlib;
-		public bool IncludeXamarin = true;
+		public bool IncludeNonMonotouch = true;
 		public bool IncludeMonotouch = true;
 
 		public bool CleanSuccessfulTestRuns = true;
@@ -226,17 +226,17 @@ namespace xharness
 				return false;
 			
 			if (project.IsBclTest) {
-				if (!project.IsNewBclTest)
-					return IncludeBcl || IncludeOldBCL;
+				if (!project.IsBclxUnit)
+					return IncludeBcl || IncludeBCLNUnit;
 				if (project.IsMscorlib) 
 					return IncludeMscorlib;
-				return IncludeBcl || IncludeNewBCL;
+				return IncludeBcl || IncludeBCLxUnit;
 			}
 
 			if (!IncludeMonotouch && project.IsMonotouch)
 				return false;
 
-			if (!IncludeXamarin && !project.IsBclTest && !project.IsMonotouch)
+			if (!IncludeNonMonotouch && !project.IsMonotouch)
 				return false;
 
 			if (Harness.IncludeSystemPermissionTests == false && project.Name == "introspection")
@@ -815,8 +815,8 @@ namespace xharness
 			SetEnabled (labels, "mtouch", ref IncludeMtouch);
 			SetEnabled (labels, "mmp", ref IncludeMmpTest);
 			SetEnabled (labels, "bcl", ref IncludeBcl);
-			SetEnabled (labels, "new-bcl", ref IncludeNewBCL);
-			SetEnabled (labels, "old-bcl", ref IncludeOldBCL);
+			SetEnabled (labels, "bcl-xunit", ref IncludeBCLxUnit);
+			SetEnabled (labels, "bcl-nunit", ref IncludeBCLNUnit);
 			SetEnabled (labels, "mscorlib", ref IncludeMscorlib);
 			SetEnabled (labels, "btouch", ref IncludeBtouch);
 			SetEnabled (labels, "mac-binding-project", ref IncludeMacBindingProject);
@@ -836,7 +836,7 @@ namespace xharness
 			SetEnabled (labels, "mac", ref IncludeMac);
 			SetEnabled (labels, "ios-msbuild", ref IncludeiOSMSBuild);
 			SetEnabled (labels, "ios-simulator", ref IncludeSimulator);
-			SetEnabled (labels, "xamarin", ref IncludeXamarin);
+			SetEnabled (labels, "non-monotouch", ref IncludeNonMonotouch);
 			SetEnabled (labels, "monotouch", ref IncludeMonotouch);
 
 			bool inc_permission_tests = false;

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -94,6 +94,14 @@ namespace xharness
 			}
 		}
 
+		public bool IsMonotouch => Name.Contains ("monotouch");
+
+		public bool IsNewBclTest => IsBclTest && (Name.Contains ("xUnit") || IsMscorlib);
+
+
+		public bool IsMscorlib => Name.Contains ("mscorlib");
+
+
 		public virtual TestProject Clone ()
 		{
 			TestProject rv = (TestProject) Activator.CreateInstance (GetType ());

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -96,7 +96,7 @@ namespace xharness
 
 		public bool IsMonotouch => Name.Contains ("monotouch");
 
-		public bool IsNewBclTest => IsBclTest && (Name.Contains ("xUnit") || IsMscorlib);
+		public bool IsBclxUnit => IsBclTest && (Name.Contains ("xUnit") || IsMscorlib);
 
 
 		public bool IsMscorlib => Name.Contains ("mscorlib");


### PR DESCRIPTION
It will be nice to be able to have a smaller set of tests to be ran by
xharness. In this commit we add a set of labels to be able to divide the
test in the following groups:

* Xamarin - all tests BUT monotouch.
* Monotouch - just monotouch tests.
* Old BCL - The BCL tests that are based on NUnit.
* New BCL - The BCL tests that are based on xUnit.
* mscorlib - Just the test that exercise mscorlib (and the different
groups, mscorlib 1, mscorlib 2 etc..)

This will allow to parallelize the execution of the full test suite in
different agents in VSTS.