### PR TITLE
[mtouch][mmp] Fix possible exception when logging strings with `{x}`

### DIFF
--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -226,7 +226,10 @@ namespace Xamarin.Bundler {
 			if (min_verbosity > Verbosity)
 				return;
 
-			Console.WriteLine (format, args);
+			if (args.Length > 0)
+				Console.WriteLine (format, args);
+			else
+				Console.WriteLine (format);
 		}
 
 		public const bool IsXAMCORE_4_0 = false;


### PR DESCRIPTION
We can end up with a format that has `{x}` inside it and no argument. If
this is logged (which depends on verbosity level) then we end up with an
uncaught exceptions and either `MT0000` or `MM0000` errors.

This happens in #7904 due to other, unrelated, issues (a variable is not
expanded) but this can happen in other circumstances, e.g. a file could
be named `{x}.cs`.

The easy fix is to use the right `Console.WriteLine` overload if there
are no arguments provided. This is always good since it avoid an non
required call to `String.Format`.

Fixes https://github.com/xamarin/xamarin-macios/issues/7904