### PR TITLE
[generator] Avoid generating nearly duplicated strings in enum exceptions

### DIFF
--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -207,7 +207,7 @@ public partial class Generator {
 			}
 			// if there's no default then we throw on unknown constants
 			if (default_symbol == null)
-				print ("throw new NotSupportedException (constant + \" has no associated enum value in \" + nameof ({0}) + \" on this platform.\");", type.Name);
+				print ("throw new NotSupportedException ($\"{constant} has no associated enum value on this platform.\");");
 			else
 				print ("return {0}.{1};", type.Name, default_symbol.Item1.Name);
 			indent--;


### PR DESCRIPTION
The constant name already contains the type name (prefix) so there is no
real value in having the extra information.

**After**

```
l /Library/Frameworks/Xamarin.iOS.framework//Versions/Current/lib/64bits/Xamarin.iOS.dll
-rwxr-xr-x  1 poupou  staff  17574912 19 Feb 16:21 /Library/Frameworks/Xamarin.iOS.framework//Versions/Current/lib/64bits/Xamarin.iOS.dll
```

```
/usr/local//Cellar/binutils/2.33.1/bin/strings -e l /Library/Frameworks/Xamarin.iOS.framework//Versions/Current/lib/64bits/Xamarin.iOS.dll | grep "has no associated enum value" | wc -l
       1
```

List

```
$ /usr/local//Cellar/binutils/2.33.1/bin/strings -e l /Library/Frameworks/Xamarin.iOS.framework//Versions/Current/lib/64bits/Xamarin.iOS.dll | grep "has no associated enum value"
{0} has no associated enum value on this platform.
```

**Before**

```
l /Library/Frameworks/Xamarin.iOS.framework//Versions/Current/lib/64bits/Xamarin.iOS.dll
-rwxr-xr-x  1 poupou  staff  17587712 19 Feb 16:12 /Library/Frameworks/Xamarin.iOS.framework//Versions/Current/lib/64bits/Xamarin.iOS.dll
```

```
/usr/local//Cellar/binutils/2.33.1/bin/strings -e l /Library/Frameworks/Xamarin.iOS.framework//Versions/Current/lib/64bits/Xamarin.iOS.dll | grep "has no associated enum value" | wc -l
84
```

List

```
 has no associated enum value in PKInkType on this platform.
 has no associated enum value in CHHapticDynamicParameterId on this platform.
 has no associated enum value in CHHapticEventParameterId on this platform.
 has no associated enum value in CHHapticEventType on this platform.
 has no associated enum value in VNBarcodeSymbology on this platform.
 has no associated enum value in VSAccountProviderAuthenticationScheme on this platform.
 has no associated enum value in SKCloudServiceSetupAction on this platform.
 has no associated enum value in SKCloudServiceSetupMessageIdentifier on this platform.
 has no associated enum value in SecAuthenticationUI on this platform.
 has no associated enum value in SecKeyAlgorithm on this platform.
 has no associated enum value in SecKeyClass on this platform.
 has no associated enum value in SecKeyType on this platform.
 has no associated enum value in SecTokenID on this platform.
 has no associated enum value in SslSessionConfig on this platform.
 has no associated enum value in PdfAnnotationHighlightingMode on this platform.
 has no associated enum value in PdfAnnotationKey on this platform.
 has no associated enum value in PdfAnnotationLineEndingStyle on this platform.
 has no associated enum value in PdfAnnotationSubtype on this platform.
 has no associated enum value in PdfAnnotationTextIconType on this platform.
 has no associated enum value in PdfAnnotationWidgetSubtype on this platform.
 has no associated enum value in PKContactFields on this platform.
 has no associated enum value in NLTagScheme on this platform.
 has no associated enum value in MTKTextureLoaderCubeLayout on this platform.
 has no associated enum value in MTKTextureLoaderOrigin on this platform.
 has no associated enum value in MKPointOfInterestCategory on this platform.
 has no associated enum value in INIntentIdentifier on this platform.
 has no associated enum value in INPersonHandleLabel on this platform.
 has no associated enum value in INPersonRelationship on this platform.
 has no associated enum value in INWorkoutNameIdentifier on this platform.
 has no associated enum value in CGImageAuxiliaryDataType on this platform.
 has no associated enum value in HMAccessoryCategoryType on this platform.
 has no associated enum value in HMCharacteristicType on this platform.
 has no associated enum value in HMServiceType on this platform.
 has no associated enum value in HMSignificantEvent on this platform.
 has no associated enum value in HKCategoryTypeIdentifier on this platform.
 has no associated enum value in HKCharacteristicTypeIdentifier on this platform.
 has no associated enum value in HKClinicalTypeIdentifier on this platform.
 has no associated enum value in HKCorrelationTypeIdentifier on this platform.
 has no associated enum value in HKDataTypeIdentifier on this platform.
 has no associated enum value in HKDocumentTypeIdentifier on this platform.
 has no associated enum value in HKFhirResourceType on this platform.
 has no associated enum value in HKQuantityTypeIdentifier on this platform.
 has no associated enum value in CAContentsFormat on this platform.
 has no associated enum value in CAGradientLayerType on this platform.
 has no associated enum value in CAScroll on this platform.
 has no associated enum value in CATextLayerAlignmentMode on this platform.
 has no associated enum value in CATextLayerTruncationMode on this platform.
 has no associated enum value in CNPostalAddressKeyOption on this platform.
 has no associated enum value in CLSContextTopic on this platform.
 has no associated enum value in BCParameterName on this platform.
 has no associated enum value in ARSkeletonJointName on this platform.
 has no associated enum value in NWErrorDomain on this platform.
 has no associated enum value in UIContentSizeCategory on this platform.
 has no associated enum value in UIAccessibilityTextualContext on this platform.
 has no associated enum value in UIActivityItemsConfigurationInteraction on this platform.
 has no associated enum value in UIActivityItemsConfigurationPreviewIntent on this platform.
 has no associated enum value in UIFontTextStyle on this platform.
 has no associated enum value in UIWindowSceneSessionRole on this platform.
 has no associated enum value in NSItemDownloadingStatus on this platform.
 has no associated enum value in NSLinguisticTagScheme on this platform.
 has no associated enum value in NSLinguisticTagUnit on this platform.
 has no associated enum value in NSStringTransform on this platform.
 has no associated enum value in CVImageBufferColorPrimaries on this platform.
 has no associated enum value in CVImageBufferTransferFunction on this platform.
 has no associated enum value in CVImageBufferYCbCrMatrix on this platform.
 has no associated enum value in CMSampleBufferAttachmentKey on this platform.
 has no associated enum value in CFStringTransform on this platform.
 has no associated enum value in AVAssetDownloadedAssetEvictionPriority on this platform.
 has no associated enum value in AVAssetExportSessionPreset on this platform.
 has no associated enum value in AVAssetWriterInputMediaDataLocation on this platform.
 has no associated enum value in AVCaptureDeviceType on this platform.
 has no associated enum value in AVCaptureSystemPressureLevel on this platform.
 has no associated enum value in AVContentKeyRequestRetryReason on this platform.
 has no associated enum value in AVContentKeySystem on this platform.
 has no associated enum value in AVFileTypes on this platform.
 has no associated enum value in AVMediaCharacteristics on this platform.
 has no associated enum value in AVMediaTypes on this platform.
 has no associated enum value in AVMetadataFormat on this platform.
 has no associated enum value in AVMetadataObjectType on this platform.
 has no associated enum value in AVOutputSettingsPreset on this platform.
 has no associated enum value in AVVideoApertureMode on this platform.
 has no associated enum value in AVVideoCodecType on this platform.
 has no associated enum value in ASAuthorizationOperation on this platform.
 has no associated enum value in ASAuthorizationScope on this platform.
```