### PR TITLE
[Harness] Close message element correctly in NUnit3.

### DIFF
--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -616,12 +616,12 @@ namespace xharness {
 			writer.WriteStartElement ("failure");
 			writer.WriteStartElement ("message");
 			writer.WriteCData (message);
+			writer.WriteEndElement (); // message
 			if (stderr != null) {
 				writer.WriteStartElement ("stack-trace");
 				writer.WriteCData (stderr.ReadToEnd ());
 				writer.WriteEndElement (); //stack trace
 			}
-			writer.WriteEndElement (); // message
 			writer.WriteEndElement (); // failure
 		}
 


### PR DESCRIPTION
Xml should be:
```
<failure>
  <message>Foo</message>
  <stack-trace>Bar</stack-trace>
</failure>
```

But we generate:

```
<failure>
  <message>Foo
    <stack-trace>Bar</stack-trace>
  </message>
</failure>
```

Makes the parsing of the failures impossible.