### PR TITLE
[Harness] Do not add the variation two times to failure messages.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -78,7 +78,7 @@ namespace xharness
 			}
 		}
 
-		public string AppName => $"{appName} {Variation}";
+		public string AppName => appName;
 
 		public double TimeoutMultiplier { get; set; } = 1;
 


### PR DESCRIPTION
AppName should only be the app name since we are passing the varation as
a parameter too. Else we end up with $"{appname} {variation} {variation}".