### PR TITLE
[Harness] Add start-time to work around a bug in the publishing tool.

### DIFF
--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -627,6 +627,7 @@ namespace xharness {
 
 		static void GenerateNUnitV3Failure (XmlWriter writer, string title, string message, StreamReader stderr)
 		{
+			var date = DateTime.Now;
 			writer.WriteStartElement ("test-run");
 			// defualt values for the crash
 			WriteAttributes (writer,
@@ -640,8 +641,8 @@ namespace xharness {
 				("inconclusive", "0"),
 				("skipped", "0"),
 				("asserts", "1"),
-				("run-date", XmlConvert.ToString (DateTime.Now, "yyyy-MM-dd")),
-				("start-time", DateTime.Now.ToString ("HH:mm:ss"))
+				("run-date", XmlConvert.ToString (date, "yyyy-MM-dd")),
+				("start-time", date.ToString ("HH:mm:ss"))
 			);
 			writer.WriteStartElement ("test-suite");
 			writer.WriteAttributeString ("type", "Assembly");

--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -640,7 +640,8 @@ namespace xharness {
 				("inconclusive", "0"),
 				("skipped", "0"),
 				("asserts", "1"),
-				("date", XmlConvert.ToString (DateTime.Now, "yyyy-MM-dd"))
+				("run-date", XmlConvert.ToString (DateTime.Now, "yyyy-MM-dd")),
+				("start-time", DateTime.Now.ToString ("HH:mm:ss"))
 			);
 			writer.WriteStartElement ("test-suite");
 			writer.WriteAttributeString ("type", "Assembly");


### PR DESCRIPTION
The publishing tool is a little fragile. In run
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3490479&view=logs&j=67d14776-f827-5fe4-2625-2db4b5987fd1&t=fa262eec-9d97-5ba4-b4cc-a9292beecd8f
I noticed that valid test runs with a failing test (launch issues) were
not being uploaded.

I found out that the reason is a flaw in the logic on the parser of the
publishing tool. The tool assumes, that if there is no start-time, there
are no test results (do remember that NUnitV3 is schemaless we don't
know exactly what attrs are compulsory).

The culprint is line: https://dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps?path=%2FTa%2FTasks%2FPublishTestResults%2FParser%2FNUnitResultParser.cs&version=GBmaster&line=473&lineEnd=473&lineStartColumn=63&lineEndColumn=64&lineStyle=plain

Basically:

```csharp
 if (testRunNode?.Attributes?["start-time"] != null) {
   // import test data
 }

 // do nothing interesting since there is no data
```

This commit fixes it by setting the start time as the current one, we
dont care since it is a failure xml result.