### PR TITLE
[mtouch][mmp] Share TimeStampStep code in the linker pipelines

### DIFF
--- a/tools/common/Tuning.cs
+++ b/tools/common/Tuning.cs
@@ -37,6 +37,13 @@ namespace MonoMac.Tuner {
 			}
 		}
 
+		static void Append (this Pipeline self, IStep step)
+		{
+			self.AppendStep (step);
+			if (Driver.WatchLevel > 0)
+				self.AppendStep (new TimeStampStep (step));
+		}
+
 		static Exception HandlePipelineProcessException (Exception e)
 		{
 			switch (e) {
@@ -89,6 +96,20 @@ namespace MonoMac.Tuner {
 				message.Append ($"Reason: {e.Message}");
 				return new PlatformException (2001, true, e, Errors.MX2001, message);
 			}
+		}
+	}
+
+	public class TimeStampStep : IStep {
+		string message;
+
+		public TimeStampStep (IStep step)
+		{
+			message = step.ToString ();
+		}
+
+		public void Process (LinkContext context)
+		{
+			Driver.Watch (message, 2);
 		}
 	}
 }

--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -110,61 +110,62 @@ namespace MonoMac.Tuner {
 		{
 			var pipeline = new Pipeline ();
 
-			pipeline.AppendStep (options.LinkMode == LinkMode.None ? new LoadOptionalReferencesStep () : new LoadReferencesStep ());
+			pipeline.Append (options.LinkMode == LinkMode.None ? new LoadOptionalReferencesStep () : new LoadReferencesStep ());
 
 			if (options.I18nAssemblies != I18nAssemblies.None)
-				pipeline.AppendStep (new LoadI18nAssemblies (options.I18nAssemblies));
+				pipeline.Append (new LoadI18nAssemblies (options.I18nAssemblies));
 
 			// that must be done early since the XML files can "add" new assemblies [#15878]
 			// and some of the assemblies might be (directly or referenced) SDK assemblies
 			foreach (string definition in options.ExtraDefinitions)
-				pipeline.AppendStep (GetResolveStep (definition));
+				pipeline.Append (GetResolveStep (definition));
 
 			if (options.LinkMode != LinkMode.None)
-				pipeline.AppendStep (new BlacklistStep ());
+				pipeline.Append (new BlacklistStep ());
 
 			if (options.WarnOnTypeRef.Count > 0)
-				pipeline.AppendStep (new PreLinkScanTypeReferenceStep (options.WarnOnTypeRef));
+				pipeline.Append (new PreLinkScanTypeReferenceStep (options.WarnOnTypeRef));
 
-			pipeline.AppendStep (new CustomizeMacActions (options.LinkMode, options.SkippedAssemblies));
+			pipeline.Append (new CustomizeMacActions (options.LinkMode, options.SkippedAssemblies));
 
 			// We need to store the Field attribute in annotations, since it may end up removed.
-			pipeline.AppendStep (new ProcessExportedFields ());
+			pipeline.Append (new ProcessExportedFields ());
 
 			if (options.LinkMode != LinkMode.None) {
-				pipeline.AppendStep (new CoreTypeMapStep ());
+				pipeline.Append (new CoreTypeMapStep ());
 
-				pipeline.AppendStep (GetSubSteps (options));
+				pipeline.Append (GetSubSteps (options));
 
-				pipeline.AppendStep (new MonoMacPreserveCode (options));
-				pipeline.AppendStep (new PreserveCrypto ());
+				pipeline.Append (new MonoMacPreserveCode (options));
+				pipeline.Append (new PreserveCrypto ());
 
-				pipeline.AppendStep (new MonoMacMarkStep ());
-				pipeline.AppendStep (new MacRemoveResources (options));
-				pipeline.AppendStep (new CoreSweepStep (options.LinkSymbols));
-				pipeline.AppendStep (new CleanStep ());
+				pipeline.Append (new MonoMacMarkStep ());
+				pipeline.Append (new MacRemoveResources (options));
+				pipeline.Append (new CoreSweepStep (options.LinkSymbols));
+				pipeline.Append (new CleanStep ());
 
-				pipeline.AppendStep (new MonoMacNamespaces ());
-				pipeline.AppendStep (new RemoveSelectors ());
+				pipeline.Append (new MonoMacNamespaces ());
+				pipeline.Append (new RemoveSelectors ());
 
-				pipeline.AppendStep (new RegenerateGuidStep ());
+				pipeline.Append (new RegenerateGuidStep ());
 			} else {
 				SubStepDispatcher sub = new SubStepDispatcher () {
 					new RemoveUserResourcesSubStep ()
 				};
-				pipeline.AppendStep (sub);
+				pipeline.Append (sub);
 			}
 
-			pipeline.AppendStep (new ListExportedSymbols (options.MarshalNativeExceptionsState, options.SkipExportedSymbolsInSdkAssemblies));
+			pipeline.Append (new ListExportedSymbols (options.MarshalNativeExceptionsState, options.SkipExportedSymbolsInSdkAssemblies));
 
-			pipeline.AppendStep (new OutputStep ());
+			pipeline.Append (new OutputStep ());
 
 			// expect that changes can occur until it's all saved back to disk
 			if (options.WarnOnTypeRef.Count > 0)
-				pipeline.AppendStep (new PostLinkScanTypeReferenceStep (options.WarnOnTypeRef));
+				pipeline.Append (new PostLinkScanTypeReferenceStep (options.WarnOnTypeRef));
 
 			return pipeline;
 		}
+
 
 		static SubStepDispatcher GetSubSteps (LinkerOptions options)
 		{

--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -166,7 +166,6 @@ namespace MonoMac.Tuner {
 			return pipeline;
 		}
 
-
 		static SubStepDispatcher GetSubSteps (LinkerOptions options)
 		{
 			SubStepDispatcher sub = new SubStepDispatcher ();

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -174,13 +174,13 @@ namespace MonoTouch.Tuner {
 				// after the mark step. If we remove any incompatible code, we'll mark
 				// the NotSupportedException constructor we need, so we need to do this before the sweep step.
 				if (remove_incompatible_bitcode != null)
-					pipeline.AppendStep (new SubStepDispatcher { remove_incompatible_bitcode });
+					pipeline.Append (new SubStepDispatcher { remove_incompatible_bitcode });
 				
 				pipeline.Append (new MonoTouchSweepStep (options));
 				pipeline.Append (new CleanStep ());
 
 				if (!options.DebugBuild)
-					pipeline.AppendStep (GetPostLinkOptimizations (options));
+					pipeline.Append (GetPostLinkOptimizations (options));
 
 				pipeline.Append (new FixModuleFlags ());
 			} else {
@@ -201,13 +201,6 @@ namespace MonoTouch.Tuner {
 				pipeline.Append (new PostLinkScanTypeReferenceStep (options.WarnOnTypeRef));
 
 			return pipeline;
-		}
-
-		static void Append (this Pipeline self, IStep step)
-		{
-			self.AppendStep (step);
-			if (Driver.WatchLevel > 0)
-				self.AppendStep (new TimeStampStep (step));
 		}
 
 		static List<AssemblyDefinition> ListAssemblies (MonoTouchLinkContext context)
@@ -238,20 +231,6 @@ namespace MonoTouch.Tuner {
 			catch (Exception e) {
 				throw new MonoTouchException (2005, true, e, Errors.MX2005, filename);
 			}
-		}
-	}
-
-	public class TimeStampStep : IStep {
-		string message;
-
-		public TimeStampStep (IStep step)
-		{
-			message = step.ToString ();
-		}
-
-		public void Process (LinkContext context)
-		{
-			Driver.Watch (message, 2);
 		}
 	}
 


### PR DESCRIPTION
This makes the `--time` options more useful to see inside the linker's
pipeline steps.

This was used only in `mtouch` before (and missed some steps [1]).
Now it's shared between both tools.

[1] not sure why... merge issue/backport maybe ?