### PR TITLE
[d16-6] [appkit] Fix `NSApplication` with custom initialization

### DIFF
--- a/src/AppKit/NSApplication.cs
+++ b/src/AppKit/NSApplication.cs
@@ -70,8 +70,21 @@ namespace AppKit {
 			// But can affect child xbuild processes, so unset
 			Environment.SetEnvironmentVariable ("MONO_CFG_DIR", "");
 
+			// custom initialization might have happened before native NSApplication code was full ready to be queried
+			// as such it's possible that `class_ptr` might be empty and that will make things fails later
+			// reference: https://github.com/xamarin/xamarin-macios/issues/7932
+			if (class_ptr == IntPtr.Zero)
+				ResetHandle ();
+
 			// TODO:
 			//   Install hook to register dynamically loaded assemblies
+		}
+
+		// separate method so it can be invoked without `Init` (if needed)
+		static void ResetHandle ()
+		{
+				// `class_ptr` is `readonly` so one can't simply do `class_ptr = Class.GetHandle ("NSApplication");`
+				typeof (NSApplication).GetField ("class_ptr", BindingFlags.Static | BindingFlags.NonPublic).SetValue (null, Class.GetHandle ("NSApplication"));
 		}
 
 		public static void InitDrawingBridge ()

--- a/src/AppKit/NSApplication.cs
+++ b/src/AppKit/NSApplication.cs
@@ -83,8 +83,8 @@ namespace AppKit {
 		// separate method so it can be invoked without `Init` (if needed)
 		static void ResetHandle ()
 		{
-				// `class_ptr` is `readonly` so one can't simply do `class_ptr = Class.GetHandle ("NSApplication");`
-				typeof (NSApplication).GetField ("class_ptr", BindingFlags.Static | BindingFlags.NonPublic).SetValue (null, Class.GetHandle ("NSApplication"));
+			// `class_ptr` is `readonly` so one can't simply do `class_ptr = Class.GetHandle ("NSApplication");`
+			typeof (NSApplication).GetField ("class_ptr", BindingFlags.Static | BindingFlags.NonPublic).SetValue (null, Class.GetHandle ("NSApplication"));
 		}
 
 		public static void InitDrawingBridge ()


### PR DESCRIPTION
Custom initialization of Xamarin.Mac is tricky. You can easily start
using ObjC features before everything is ready / loaded into memory.

In contrast a _normal_ XM application, from an app bundle, already has a
lot of things loaded into memory when it starts to initialize.

This means that some things can work _by chance_ due to timing and that
semi-related (and correct) changes could affect your _lucky_ timings.

Such a semi-related change was https://github.com/xamarin/xamarin-macios/commit/a239fa9ebd5071d9e72b1d3b72633e5b2864425e#diff-4aa19167162888aec0ccc2261a7ddbd3

In #7932 the attached code
```csharp
NSApplication.IgnoreMissingAssembliesDuringRegistration = false;
```
triggers the `.cctor` which means that `class_ptr` is initialized.

Note: That's not fully correct/safe since `Init` is not been called
but that's a different issue...

Anyway the dual calls that existed before was enough to hide the first
(which failed but triggered the rest of the native initialization).
That extra call made older XM version works (with attached code).

So in this (#7932) case our generated code
```csharp
static readonly IntPtr class_ptr = Class.GetHandle ("NSApplication");
```
happens too early. Now that cannot be changed because

* it's how .net `readonly` works
* existing/correct code depends on this
* it depends on native side (being loaded/initialized/ready)

but we can **add** to this and make `Init` safer to use by duplicating
the call _only if_ the original call had failed.

Of course the generated code has the `class_ptr` field as `readonly`...
```
error CS0198: A static readonly field cannot be assigned to (except in a static constructor or a variable initializer)
```
so we need to use reflection to achieve this (but that cost will occur
if the original initialization failed)

Fix https://github.com/xamarin/xamarin-macios/issues/7932

Backport of #7954.

/cc @spouliot 