### PR TITLE
[corefoundation] Fix TypeInitializationException in OSLog

### DIFF
--- a/src/CoreFoundation/OSLog.cs
+++ b/src/CoreFoundation/OSLog.cs
@@ -30,15 +30,19 @@ namespace CoreFoundation {
 	[Introduced (PlatformName.MacCatalyst, 13, 0)]
 	public sealed class OSLog : NativeObject {
 
-		static IntPtr _os_log_default;
+		static OSLog _default;
 
-		static OSLog ()
-		{
-			_os_log_default = Dlfcn.dlsym (Libraries.System.Handle, "_os_log_default");
-			Default = new OSLog (_os_log_default, false);
+		public static OSLog Default {
+			get {
+				if (_default== null) {
+					var h = Dlfcn.dlsym (Libraries.System.Handle, "_os_log_default");
+					if (h == IntPtr.Zero)
+						throw new NotSupportedException ("Feature not available on this OS version");
+					_default = new OSLog (h, false);
+				}
+				return _default;
+			}
 		}
-
-		public static OSLog Default { get; private set; }
 
 		protected override void Retain ()
 		{

--- a/src/CoreFoundation/OSLog.cs
+++ b/src/CoreFoundation/OSLog.cs
@@ -34,7 +34,7 @@ namespace CoreFoundation {
 
 		public static OSLog Default {
 			get {
-				if (_default== null) {
+				if (_default == null) {
 					var h = Dlfcn.dlsym (Libraries.System.Handle, "_os_log_default");
 					if (h == IntPtr.Zero)
 						throw new NotSupportedException ("Feature not available on this OS version");

--- a/src/CoreFoundation/OSLog.cs
+++ b/src/CoreFoundation/OSLog.cs
@@ -30,8 +30,15 @@ namespace CoreFoundation {
 	[Introduced (PlatformName.MacCatalyst, 13, 0)]
 	public sealed class OSLog : NativeObject {
 
-		// initialized only once (see tests/cecil-tests/)
-		public static OSLog Default { get; } = new OSLog (IntPtr.Zero, false);
+		static IntPtr _os_log_default;
+
+		static OSLog ()
+		{
+			_os_log_default = Dlfcn.dlsym (Libraries.System.Handle, "_os_log_default");
+			Default = new OSLog (_os_log_default, false);
+		}
+
+		public static OSLog Default { get; private set; }
 
 		protected override void Retain ()
 		{

--- a/tests/monotouch-test/CoreFoundation/OSLogTest.cs
+++ b/tests/monotouch-test/CoreFoundation/OSLogTest.cs
@@ -14,6 +14,12 @@ namespace MonoTouchFixtures.CoreFoundation {
 	[Preserve (AllMembers = true)]
 	public class OSLogTest {
 
+		[TestFixtureSetUp]
+		public void SetUp ()
+		{
+			TestRuntime.AssertXcodeVersion (8,0);
+		}
+
 		[Test]
 		public void Default ()
 		{

--- a/tests/monotouch-test/CoreFoundation/OSLogTest.cs
+++ b/tests/monotouch-test/CoreFoundation/OSLogTest.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+using CoreFoundation;
+using Foundation;
+using ObjCRuntime;
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.CoreFoundation {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class OSLogTest {
+
+		[Test]
+		public void Default ()
+		{
+			OSLog.Default.Log (OSLogLevel.Default, "monotouch-test / Default / Default");
+			// this will show in the application output (e.g. inside VSfM)
+		}
+
+		[Test]
+		public void Custom ()
+		{
+			using (var log = new OSLog ("subsystem", "category")) {
+				log.Log (OSLogLevel.Error, "monotouch-test /  custom / Debug");
+				// this will show in the application output (e.g. inside VSfM)
+				// and also inside Console.app under the simulator/device
+			}
+		}
+	}
+}


### PR DESCRIPTION
`Default` property was using a nil-handle which is incorrect since
* we don't allow that (this is generally a bad sign)
* it does not map to `OS_LOG_DEFAULT`

Since `Default` was assigned in the type (static) constructor then
the whole type became unusable :(

Header `log.h` shows that the right definition requires us to load a
field and use it.

```
define OS_LOG_DEFAULT OS_OBJECT_GLOBAL_OBJECT(os_log_t, _os_log_default)
```

While `NULL` can actually be used for disabled (not exposed) by this
contradicting (nullability-wise) macro

```
define OS_LOG_DISABLED ((os_log_t _Nonnull)NULL)
```

Also adds unit tests. A more general tests for `.cctor` will be added
to introspection tests in a separate PR.

Fixes https://github.com/xamarin/xamarin-macios/issues/7959