### PR TITLE
Rename bmac-mobile-mono to mono-sgen.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -670,7 +670,7 @@ MAC_TARGETS = \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/libmono-2.0.a                        \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/pkgconfig/mono-2.pc                  \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/etc/mono/assemblies/System/System.config \
-	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/bmac-mobile-mono                     \
+	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/mono-sgen                            \
 
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/%: .stamp-$(MONO_BUILD_MODE) | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib
 	$(Q) $(CP) $(MONO_MAC_SDK_DESTDIR)/mac-libs/$(notdir $@) $@
@@ -685,7 +685,7 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/pkgconfig/mono-2.pc: .stamp-$(MON
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/etc/mono/assemblies/System/System.config: mac-System.config | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/etc/mono/assemblies/System
 	$(Q) $(CP) $< $@
 
-$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/bmac-mobile-mono: .stamp-$(MONO_BUILD_MODE) | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin
+$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/mono-sgen: .stamp-$(MONO_BUILD_MODE) | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin
 	$(Q) install -m 0755 $(MONO_MAC_SDK_DESTDIR)/mac-bin/mono-sgen $@
 
 $(MAC_DIRECTORIES):

--- a/tools/mmp/aot.cs
+++ b/tools/mmp/aot.cs
@@ -301,7 +301,7 @@ namespace Xamarin.Bundler {
 			get {
 				switch (compilerType) {
 				case AOTCompilerType.Bundled64:
-					return Path.Combine (XamarinMacPrefix, "bin/bmac-mobile-mono");
+					return Path.Combine (XamarinMacPrefix, "bin", "mono-sgen");
 				case AOTCompilerType.System64:
 					return "/Library/Frameworks/Mono.framework/Commands/mono64";
 				default:

--- a/tools/mmp/tests/aot.cs
+++ b/tools/mmp/tests/aot.cs
@@ -73,7 +73,7 @@ namespace Xamarin.MMP.Tests.Unit
 		{
 			switch (compilerType) {
 			case AOTCompilerType.Bundled64:
-				return "bmac-mobile-mono";
+				return "mono-sgen";
 			case AOTCompilerType.System64:
 				return "mono64";
 			default:


### PR DESCRIPTION
bmac-mobile-mono is an old name (when we needed a specific executable to
execute bmac) that has nothing to do with its current usage (AOT code for
Xamarin.Mac apps).

So rename the executable to reflect current usage.

This makes looking at the installed files a bit less confusing.