### PR TITLE
[mmp] Don't ignore failures to execute pkg-config and simplify/improve logic.

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -776,6 +776,14 @@ You can silence this warning by adding `--nowarn=5221` to the **Additional mmp a
 
 ### MM5312: pkg-config failed with an error code '{code}'. Check build log for details.
 
+<a name="MM5313" />
+
+### MM5313: Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+
+<a name="MM5314" />
+
+### MM5314: Failed to execute pkg-config: '{0}'. Check build log for details.
+
 <!-- MM6xxx: mmp internal tools -->
 <!-- MM7xxx: reserved -->
 

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -740,10 +740,7 @@ You can silence this warning by adding `--nowarn=5221` to the **Additional mmp a
 
 ### MM53xx: other tools
 
-<a name="MM5301" />
-
-#### MM5301: pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-
+<!-- 5301 used by mtouch -->
 <!-- 5302 used by mtouch -->
 <!-- 5303 used by mtouch -->
 <!-- 5304 used by mtouch -->

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -3003,6 +3003,8 @@ An error occurred when signing the application. Please review the build log to s
 <!-- 5310 is used by mmp -->
 <!-- 5311 is used by mmp -->
 <!-- 5312 is used by mmp -->
+<!-- 5313 is used by mmp -->
+<!-- 5314 is used by mmp -->
 
 ## MT6xxx: mtouch internal tools error messages
 

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1321,7 +1321,7 @@ namespace Xamarin.Bundler {
 			var sb = new StringBuilder ();
 			int rv;
 			try {
-				rv = RunCommand (pkg_config, new string [] { option, "mono-2" }, env, sb);
+				rv = RunCommand (pkg_config, new [] { option, "mono-2" }, env, sb);
 			} catch (Exception e) {
 				throw ErrorHelper.CreateError (5314, e, Errors.MX5314, e.Message);
 			}

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1041,18 +1041,36 @@ namespace Xamarin.Bundler {
 				LipoLibrary (framework, Path.Combine (name, Path.Combine (frameworks_dir, name + ".framework", name)));
 		}
 
+		static void CheckSystemMonoVersion ()
+		{
+			string mono_version;
+
+			var versionFile = "/Library/Frameworks/Mono.framework/Versions/Current/VERSION";
+			if (File.Exists (versionFile)) {
+				mono_version = File.ReadAllText (versionFile);
+			} else {
+				mono_version = RunPkgConfig ("--modversion", force_system_mono: true);
+			}
+
+			mono_version = mono_version.Trim ();
+
+			if (!Version.TryParse (mono_version, out var mono_ver))
+				return;
+
+			if (mono_ver < MonoVersions.MinimumMonoVersion)
+				throw ErrorHelper.CreateError (1, Errors.MM0001, MonoVersions.MinimumMonoVersion, mono_version);
+		}
+
 		static int Compile ()
 		{
 			int ret = 1;
 
 			string [] cflags = Array.Empty<string> ();
-			string libdir;
-			StringBuilder cflagsb = new StringBuilder ();
-			StringBuilder libdirb = new StringBuilder ();
-			StringBuilder mono_version = new StringBuilder ();
 
 			string mainSource = GenerateMain ();
 			string registrarPath = null;
+
+			CheckSystemMonoVersion ();
 
 			if (Registrar == RegistrarMode.Static) {
 				registrarPath = Path.Combine (App.Cache.Location, "registrar.m");
@@ -1063,32 +1081,11 @@ namespace Xamarin.Bundler {
 				Frameworks.Gather (App, platform_assembly, BuildTarget.Frameworks, BuildTarget.WeakFrameworks);
 			}
 
-			try {
-				string [] env = null;
-				if (!IsUnifiedFullSystemFramework)
-					env = new [] { "PKG_CONFIG_PATH", Path.Combine (FrameworkLibDirectory, "pkgconfig") };
+			var str_cflags = RunPkgConfig ("--cflags");
+			var libdir = RunPkgConfig ("--variable=libdir");
 
-				RunCommand (pkg_config, new [] { "--cflags", "mono-2" }, env, cflagsb);
-				RunCommand (pkg_config, new [] { "--variable=libdir", "mono-2" }, env, libdirb);
-				var versionFile = "/Library/Frameworks/Mono.framework/Versions/Current/VERSION";
-				if (File.Exists (versionFile)) {
-					mono_version.Append (File.ReadAllText (versionFile));
-				} else {
-					RunCommand (pkg_config, new [] { "--modversion", "mono-2" }, env, mono_version);
-				}
-			} catch (Win32Exception e) {
-				throw new MonoMacException (5301, true, e, Errors.MM5301);
-			}
-
-			Version mono_ver;
-			if (Version.TryParse (mono_version.ToString ().TrimEnd (), out mono_ver) && mono_ver < MonoVersions.MinimumMonoVersion)
-				throw new MonoMacException (1, true, Errors.MM0001, 
-					MonoVersions.MinimumMonoVersion, mono_version.ToString ().TrimEnd ());
-
-			var str_cflags = cflagsb.ToString ().Replace (Environment.NewLine, String.Empty);
 			if (!StringUtils.TryParseArguments (str_cflags, out cflags, out var ex))
 				throw ErrorHelper.CreateError (147, ex, Errors.MM0147, str_cflags, ex.Message);
-			libdir = libdirb.ToString ().Replace (Environment.NewLine, String.Empty);
 
 			var libmain = embed_mono ? "libxammac" : "libxammac-system";
 			var libxammac = Path.Combine (FrameworkLibDirectory, libmain + (App.EnableDebug ? "-debug" : "") + ".a");
@@ -1309,6 +1306,29 @@ namespace Xamarin.Bundler {
 			}
 			
 			return ret;
+		}
+
+		static string RunPkgConfig (string option, bool force_system_mono = false)
+		{
+			string [] env = null;
+
+			if (!File.Exists (pkg_config))
+				throw ErrorHelper.CreateError (5313, Errors.MX5313);
+
+			if (!IsUnifiedFullSystemFramework && !force_system_mono)
+				env = new [] { "PKG_CONFIG_PATH", Path.Combine (FrameworkLibDirectory, "pkgconfig") };
+
+			var sb = new StringBuilder ();
+			int rv;
+			try {
+				rv = RunCommand (pkg_config, new string [] { option, "mono-2" }, env, sb);
+			} catch (Exception e) {
+				throw ErrorHelper.CreateError (5314, e, Errors.MX5314, e.Message);
+			}
+			if (rv != 0)
+				throw ErrorHelper.CreateError (5312, Errors.MX5312, rv);
+
+			return sb.ToString ().Trim ();
 		}
 
 		// check that we have a reference to Xamarin.Mac.dll and not to MonoMac.dll.

--- a/tools/mtouch/errors.Designer.cs
+++ b/tools/mtouch/errors.Designer.cs
@@ -2297,6 +2297,24 @@ namespace Xamarin.Bundler {
             }
         }
         
+        internal static string MX5312 {
+            get {
+                return ResourceManager.GetString("MX5312", resourceCulture);
+            }
+        }
+        
+        internal static string MX5313 {
+            get {
+                return ResourceManager.GetString("MX5313", resourceCulture);
+            }
+        }
+        
+        internal static string MX5314 {
+            get {
+                return ResourceManager.GetString("MX5314", resourceCulture);
+            }
+        }
+        
         internal static string MT8018 {
             get {
                 return ResourceManager.GetString("MT8018", resourceCulture);

--- a/tools/mtouch/errors.resx
+++ b/tools/mtouch/errors.resx
@@ -2639,7 +2639,28 @@
 		<comment>
 		</comment>
 	</data>
-	
+
+	<data name="MX5312" xml:space="preserve">
+		<value>pkg-config failed with an error code '{0}'. Check build log for details.
+		</value>
+		<comment>
+		</comment>
+	</data>
+
+	<data name="MX5313" xml:space="preserve">
+		<value>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</value>
+		<comment>
+		</comment>
+	</data>
+
+	<data name="MX5314" xml:space="preserve">
+		<value>Failed to execute pkg-config: '{0}'. Check build log for details.
+		</value>
+		<comment>
+		</comment>
+	</data>
+
 	<data name="MT8018" xml:space="preserve">
 		<value>Internal consistency error. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new.
 		</value>

--- a/tools/mtouch/errors.resx
+++ b/tools/mtouch/errors.resx
@@ -2577,13 +2577,6 @@
 		</comment>
 	</data>
 
-	<data name="MM5301" xml:space="preserve">
-		<value>pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</value>
-		<comment>
-		</comment>
-	</data>
-
 	<data name="MT5302" xml:space="preserve">
 		<value>Missing 'dsymutil' tool. Please install Xcode 'Command-Line Tools' component
 		</value>

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -3002,6 +3002,30 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5312">
+        <source>pkg-config failed with an error code '{0}'. Check build log for details.
+		</source>
+        <target state="new">pkg-config failed with an error code '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5313">
+        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</source>
+        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5314">
+        <source>Failed to execute pkg-config: '{0}'. Check build log for details.
+		</source>
+        <target state="new">Failed to execute pkg-config: '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -338,14 +338,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MM5301">
-        <source>pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</source>
-        <target state="new">pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MM5308">
         <source>Xcode license agreement may not have been accepted.  Please launch Xcode.
 		</source>

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -3002,6 +3002,30 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5312">
+        <source>pkg-config failed with an error code '{0}'. Check build log for details.
+		</source>
+        <target state="new">pkg-config failed with an error code '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5313">
+        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</source>
+        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5314">
+        <source>Failed to execute pkg-config: '{0}'. Check build log for details.
+		</source>
+        <target state="new">Failed to execute pkg-config: '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -338,14 +338,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MM5301">
-        <source>pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</source>
-        <target state="new">pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MM5308">
         <source>Xcode license agreement may not have been accepted.  Please launch Xcode.
 		</source>

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -3002,6 +3002,30 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5312">
+        <source>pkg-config failed with an error code '{0}'. Check build log for details.
+		</source>
+        <target state="new">pkg-config failed with an error code '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5313">
+        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</source>
+        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5314">
+        <source>Failed to execute pkg-config: '{0}'. Check build log for details.
+		</source>
+        <target state="new">Failed to execute pkg-config: '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -338,14 +338,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MM5301">
-        <source>pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</source>
-        <target state="new">pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MM5308">
         <source>Xcode license agreement may not have been accepted.  Please launch Xcode.
 		</source>

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -3002,6 +3002,30 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5312">
+        <source>pkg-config failed with an error code '{0}'. Check build log for details.
+		</source>
+        <target state="new">pkg-config failed with an error code '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5313">
+        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</source>
+        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5314">
+        <source>Failed to execute pkg-config: '{0}'. Check build log for details.
+		</source>
+        <target state="new">Failed to execute pkg-config: '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -338,14 +338,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MM5301">
-        <source>pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</source>
-        <target state="new">pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MM5308">
         <source>Xcode license agreement may not have been accepted.  Please launch Xcode.
 		</source>

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -3002,6 +3002,30 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5312">
+        <source>pkg-config failed with an error code '{0}'. Check build log for details.
+		</source>
+        <target state="new">pkg-config failed with an error code '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5313">
+        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</source>
+        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5314">
+        <source>Failed to execute pkg-config: '{0}'. Check build log for details.
+		</source>
+        <target state="new">Failed to execute pkg-config: '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -338,14 +338,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MM5301">
-        <source>pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</source>
-        <target state="new">pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MM5308">
         <source>Xcode license agreement may not have been accepted.  Please launch Xcode.
 		</source>

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -3002,6 +3002,30 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5312">
+        <source>pkg-config failed with an error code '{0}'. Check build log for details.
+		</source>
+        <target state="new">pkg-config failed with an error code '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5313">
+        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</source>
+        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5314">
+        <source>Failed to execute pkg-config: '{0}'. Check build log for details.
+		</source>
+        <target state="new">Failed to execute pkg-config: '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -338,14 +338,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MM5301">
-        <source>pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</source>
-        <target state="new">pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MM5308">
         <source>Xcode license agreement may not have been accepted.  Please launch Xcode.
 		</source>

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -3002,6 +3002,30 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5312">
+        <source>pkg-config failed with an error code '{0}'. Check build log for details.
+		</source>
+        <target state="new">pkg-config failed with an error code '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5313">
+        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</source>
+        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5314">
+        <source>Failed to execute pkg-config: '{0}'. Check build log for details.
+		</source>
+        <target state="new">Failed to execute pkg-config: '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -338,14 +338,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MM5301">
-        <source>pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</source>
-        <target state="new">pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MM5308">
         <source>Xcode license agreement may not have been accepted.  Please launch Xcode.
 		</source>

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -3002,6 +3002,30 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5312">
+        <source>pkg-config failed with an error code '{0}'. Check build log for details.
+		</source>
+        <target state="new">pkg-config failed with an error code '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5313">
+        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</source>
+        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5314">
+        <source>Failed to execute pkg-config: '{0}'. Check build log for details.
+		</source>
+        <target state="new">Failed to execute pkg-config: '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -338,14 +338,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MM5301">
-        <source>pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</source>
-        <target state="new">pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MM5308">
         <source>Xcode license agreement may not have been accepted.  Please launch Xcode.
 		</source>

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -3002,6 +3002,30 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5312">
+        <source>pkg-config failed with an error code '{0}'. Check build log for details.
+		</source>
+        <target state="new">pkg-config failed with an error code '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5313">
+        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</source>
+        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5314">
+        <source>Failed to execute pkg-config: '{0}'. Check build log for details.
+		</source>
+        <target state="new">Failed to execute pkg-config: '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -338,14 +338,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MM5301">
-        <source>pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</source>
-        <target state="new">pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MM5308">
         <source>Xcode license agreement may not have been accepted.  Please launch Xcode.
 		</source>

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -3002,6 +3002,30 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5312">
+        <source>pkg-config failed with an error code '{0}'. Check build log for details.
+		</source>
+        <target state="new">pkg-config failed with an error code '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5313">
+        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</source>
+        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5314">
+        <source>Failed to execute pkg-config: '{0}'. Check build log for details.
+		</source>
+        <target state="new">Failed to execute pkg-config: '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -338,14 +338,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MM5301">
-        <source>pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</source>
-        <target state="new">pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MM5308">
         <source>Xcode license agreement may not have been accepted.  Please launch Xcode.
 		</source>

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -3002,6 +3002,30 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5312">
+        <source>pkg-config failed with an error code '{0}'. Check build log for details.
+		</source>
+        <target state="new">pkg-config failed with an error code '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5313">
+        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</source>
+        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5314">
+        <source>Failed to execute pkg-config: '{0}'. Check build log for details.
+		</source>
+        <target state="new">Failed to execute pkg-config: '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -338,14 +338,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MM5301">
-        <source>pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</source>
-        <target state="new">pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MM5308">
         <source>Xcode license agreement may not have been accepted.  Please launch Xcode.
 		</source>

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -3002,6 +3002,30 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5312">
+        <source>pkg-config failed with an error code '{0}'. Check build log for details.
+		</source>
+        <target state="new">pkg-config failed with an error code '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5313">
+        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</source>
+        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5314">
+        <source>Failed to execute pkg-config: '{0}'. Check build log for details.
+		</source>
+        <target state="new">Failed to execute pkg-config: '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -338,14 +338,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MM5301">
-        <source>pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</source>
-        <target state="new">pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MM5308">
         <source>Xcode license agreement may not have been accepted.  Please launch Xcode.
 		</source>

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -3002,6 +3002,30 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5312">
+        <source>pkg-config failed with an error code '{0}'. Check build log for details.
+		</source>
+        <target state="new">pkg-config failed with an error code '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5313">
+        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</source>
+        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX5314">
+        <source>Failed to execute pkg-config: '{0}'. Check build log for details.
+		</source>
+        <target state="new">Failed to execute pkg-config: '{0}'. Check build log for details.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -338,14 +338,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MM5301">
-        <source>pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</source>
-        <target state="new">pkg-config could not be found. Please install the Mono.framework from http://mono-project.com/Downloads
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MM5308">
         <source>Xcode license agreement may not have been accepted.  Please launch Xcode.
 		</source>


### PR DESCRIPTION
* Show proper errors if pkg-config fails to execute.
* Extract logic to verify system mono version into its own function.
* Extract logic to execute pkg-config into its own function.