### PR TITLE
[CoreImage] Add missing properties found by intro tests

### DIFF
--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -2863,10 +2863,9 @@ namespace CoreImage {
 		[CoreImageFilterProperty ("outputImageNonMPS")]
 		CIImage OutputImageNonMps { get; }
 
-#if MONOMAC
+		[iOS (13,4)]
 		[CoreImageFilterProperty ("outputImageMPS")]
 		CIImage OutputImageMps { get; }
-#endif
 	}
 
 	[CoreImageFilter]
@@ -5331,10 +5330,9 @@ namespace CoreImage {
 		[CoreImageFilterProperty ("outputImageNonMPS")]
 		CIImage OutputImageNonMps { get; }
 
-#if MONOMAC
+		[iOS (13,4)]
 		[CoreImageFilterProperty ("outputImageMPS")]
 		CIImage OutputImageMps { get; }
-#endif
 	}
 
 	[CoreImageFilter]


### PR DESCRIPTION
Fixes xamarin/xamarin-macios#7956

Device intro tests found these missing properties