### PR TITLE
[tests] Add `.cctor` execution to introspection

### DIFF
--- a/tests/introspection/ApiTypeTest.cs
+++ b/tests/introspection/ApiTypeTest.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using NUnit.Framework;
+using Xamarin.Utils;
+
+using Foundation;
+using ObjCRuntime;
+
+namespace Introspection {
+
+	[TestFixture]
+	// we want the tests to be available because we use the linker
+	[Preserve (AllMembers = true)]
+	public class ApiTypeTest : ApiBaseTest {
+
+		[Test]
+		public void StaticCtor ()
+		{
+			ContinueOnFailure = true;
+			foreach (Type t in Assembly.GetTypes ()) {
+				var cctor = t.GetConstructor (BindingFlags.Static | BindingFlags.NonPublic, null, Type.EmptyTypes, null);
+				if (cctor == null)
+					continue;
+				// we don't skip based on availability attributes since the execution of .cctor can easily happen indirectly and
+				// we rather catch them all here *now* than trying to figure out how to replicate the specific conditions *later*
+				try {
+					RuntimeHelpers.RunClassConstructor (t.TypeHandle);
+				}
+				catch (TypeInitializationException e) {
+					ReportError ($"{t.FullName} .cctor could not execute properly: {e}");
+				}
+			}
+			AssertIfErrors ($"{Errors} execution failure(s)");
+		}
+	}
+}

--- a/tests/introspection/Mac/introspection-mac.csproj
+++ b/tests/introspection/Mac/introspection-mac.csproj
@@ -132,6 +132,9 @@
     <Compile Include="..\ApiFrameworkTest.cs">
       <Link>ApiFrameworkTest.cs</Link>
     </Compile>
+    <Compile Include="..\ApiTypeTest.cs">
+      <Link>ApiTypeTest.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">

--- a/tests/introspection/iOS/introspection-ios.csproj
+++ b/tests/introspection/iOS/introspection-ios.csproj
@@ -223,6 +223,9 @@
     <Compile Include="..\ApiFrameworkTest.cs">
       <Link>ApiFrameworkTest.cs</Link>
     </Compile>
+    <Compile Include="..\ApiTypeTest.cs">
+      <Link>ApiTypeTest.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist">


### PR DESCRIPTION
This will spot cases like https://github.com/xamarin/xamarin-macios/issues/7959
where a type (static) constructor can fail at runtime, leading to
`TypeLoadException`

Ideally it's covered by it's own tests but it's better covered twice
than never :)