### PR TITLE
[mmp] Set 'disable_omit_fp' by default to provide better native stack traces in certain cases.

### DIFF
--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -372,9 +372,9 @@ update_environment (xamarin_initialize_data *data)
 	// Unfortunately the only place to set debug_options.no_gdb_backtrace is in mini_parse_debug_option
 	// So route through MONO_DEBUG
 	if (xamarin_disable_lldb_attach && xamarin_disable_omit_fp) {
-		mono_debug = "no-gdb-trace,disable-omit-fp";
+		mono_debug = "no-gdb-backtrace,disable-omit-fp";
 	} else if (xamarin_disable_lldb_attach) {
-		mono_debug = "no-gdb-trace";
+		mono_debug = "no-gdb-backtrace";
 	} else if (xamarin_disable_omit_fp) {
 		mono_debug = "disable_omit_fp";
 	}

--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -368,11 +368,18 @@ update_environment (xamarin_initialize_data *data)
 		}
 	}
 #endif
-	if (xamarin_disable_lldb_attach) {
-		// Unfortunately the only place to set debug_options.no_gdb_backtrace is in mini_parse_debug_option
-		// So route through MONO_DEBUG
-		setenv ("MONO_DEBUG", "no-gdb-backtrace", 0);
+	const char *mono_debug = NULL;
+	// Unfortunately the only place to set debug_options.no_gdb_backtrace is in mini_parse_debug_option
+	// So route through MONO_DEBUG
+	if (xamarin_disable_lldb_attach && xamarin_disable_omit_fp) {
+		mono_debug = "no-gdb-trace,disable-omit-fp";
+	} else if (xamarin_disable_lldb_attach) {
+		mono_debug = "no-gdb-trace";
+	} else if (xamarin_disable_omit_fp) {
+		mono_debug = "disable_omit_fp";
 	}
+	if (mono_debug != NULL)
+		setenv ("MONO_DEBUG", mono_debug, 0);
 
 #ifndef DYNAMIC_MONO_RUNTIME
 	setenv ("MONO_CFG_DIR", [monobundle_dir UTF8String], 0);

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -41,6 +41,7 @@ bool xamarin_mac_modern = false;
 bool xamarin_debug_mode = false;
 #endif
 bool xamarin_disable_lldb_attach = false;
+bool xamarin_disable_omit_fp = false;
 #if DEBUG
 bool xamarin_init_mono_debug = true;
 #else

--- a/runtime/xamarin/main.h
+++ b/runtime/xamarin/main.h
@@ -51,6 +51,7 @@ extern bool xamarin_gc_pump;
 #endif
 extern bool xamarin_debug_mode;
 extern bool xamarin_disable_lldb_attach;
+extern bool xamarin_disable_omit_fp;
 #if MONOMAC
 extern bool xamarin_mac_hybrid_aot;
 extern bool xamarin_mac_modern;

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -92,6 +92,7 @@ namespace Xamarin.Bundler {
 		static List<string> link_flags;
 		static LinkerOptions linker_options;
 		static bool? disable_lldb_attach = null;
+		static bool? disable_omit_fp = null;
 		static string machine_config_path = null;
 		static bool bypass_linking_checks = false;
 
@@ -302,6 +303,7 @@ namespace Xamarin.Bundler {
 				{ "allow-unsafe-gac-resolution", "Allow MSBuild to resolve from the System GAC", v => {} , true }, // Used in Xamarin.Mac.XM45.targets and must be ignored here. Hidden since it is a total hack. If you can use it, you don't need support
 				{ "force-unsupported-linker", "Bypass safety checkes preventing unsupported linking options.", v => bypass_linking_checks = true , true }, // Undocumented option for a reason, You get to keep the pieces when it breaks
 				{ "disable-lldb-attach=", "Disable automatic lldb attach on crash", v => disable_lldb_attach = ParseBool (v, "disable-lldb-attach")},
+				{ "disable-omit-fp=", "Disable a JIT optimization where the frame pointer is omitted from the stack. This is optimization is disabled by default for debug builds.", v => disable_omit_fp = ParseBool (v, "disable-omit-fp") },
 				{ "machine-config=", "Custom machine.config file to copy into MonoBundle/mono/4.5/machine.config. Pass \"\" to copy in a valid \"empty\" config file.", v => machine_config_path = v },
 				{ "runregistrar:", "Runs the registrar on the input assembly and outputs a corresponding native library.",
 					v => {
@@ -946,6 +948,8 @@ namespace Xamarin.Bundler {
 				sw.WriteLine ("\txamarin_marshal_objectivec_exception_mode = MarshalObjectiveCExceptionMode{0};", App.MarshalObjectiveCExceptions);
 				if (disable_lldb_attach.HasValue ? disable_lldb_attach.Value : !App.EnableDebug)
 					sw.WriteLine ("\txamarin_disable_lldb_attach = true;");
+				if (disable_omit_fp ?? App.EnableDebug)
+					sw.WriteLine ("\txamarin_disable_omit_fp = true;");
 				sw.WriteLine ();
 
 


### PR DESCRIPTION
This may produce better stack traces when crashes occur, which could be
helpful for tracking down issues like
https://github.com/xamarin/maccore/issues/643.

Also add an mmp option to override the default behavior (which is to set 'disable_omit_fp' for debug builds)

This is unlikely to cause any problems, because Visual Studio for Mac sets
MONO_DEBUG=disable_omit_fp at launch, which means that all processes launched
by VSMac will also have this variable set already.