### PR TITLE
[msbuild] Add support for Metal in the simulator. Fixes #7392. (#7983)

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Tasks/CompileSceneKitAssets.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/CompileSceneKitAssets.cs
@@ -4,8 +4,5 @@ namespace Xamarin.Mac.Tasks
 {
 	public class CompileSceneKitAssets : CompileSceneKitAssetsTaskBase
 	{
-		protected override string OperatingSystem {
-			get { return "osx"; }
-		}
 	}
 }

--- a/msbuild/Xamarin.Mac.Tasks/Tasks/Metal.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/Metal.cs
@@ -6,10 +6,6 @@ namespace Xamarin.Mac.Tasks
 {
 	public class Metal : MetalTaskBase
 	{
-		protected override string OperatingSystem {
-			get { return "macosx"; }
-		}
-
 #if !MTOUCH_TESTS
 		protected override string MinimumDeploymentTargetKey {
 			get { return ManifestKeys.LSMinimumSystemVersion; }

--- a/msbuild/Xamarin.Mac.Tasks/Tasks/ScnTool.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/ScnTool.cs
@@ -4,8 +4,5 @@ namespace Xamarin.Mac.Tasks
 {
 	public class ScnTool : ScnToolTaskBase
 	{
-		protected override string OperatingSystem {
-			get { return "osx"; }
-		}
 	}
 }

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -340,6 +340,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			AppManifest="$(_AppManifest)"
 			ProjectDir="$(MSBuildProjectDirectory)"
+			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			ResourcePrefix="$(XamMacResourcePrefix)"
 			SdkDevPath="$(_SdkDevPath)"
 			SdkRoot="$(_SdkRoot)"
@@ -588,6 +589,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			SdkRoot="$(_SdkRoot)"
 			SdkDevPath="$(_SdkDevPath)"
 			SdkVersion="$(MacOSXSdkVersion)"
+			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			InputScene="%(_ColladaAssetWithLogicalName.Identity)"
 			OutputScene="$(IntermediateOutputPath)%(_ColladaAssetWithLogicalName.LogicalName)">
@@ -675,6 +677,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			ToolPath="$(CopySceneKitAssetsPath)"
 			SceneKitAssets="@(SceneKitAsset)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
+			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(XamMacResourcePrefix)"
 			SdkPlatform="MacOSX"

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -343,6 +343,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			ResourcePrefix="$(XamMacResourcePrefix)"
 			SdkDevPath="$(_SdkDevPath)"
+			SdkIsSimulator="false"
 			SdkRoot="$(_SdkRoot)"
 			SdkVersion="$(MacOSXSdkVersion)"
 			SourceFile="@(Metal)">

--- a/msbuild/Xamarin.MacDev.Tasks.Core/PlatformFramework.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/PlatformFramework.cs
@@ -54,5 +54,22 @@ namespace Xamarin.MacDev.Tasks
 				throw new InvalidOperationException ("Unknown TargetFrameworkIdentifier: " + targetFrameworkIdentifier);
 			}
 		}
+
+		public static string GetOperatingSystem (string targetFrameworkIdentifier)
+		{
+			var framework = PlatformFrameworkHelper.GetFramework (targetFrameworkIdentifier);
+			switch (framework) {
+			case PlatformFramework.WatchOS:
+				return "watchos";
+			case PlatformFramework.TVOS:
+				return "tvos";
+			case PlatformFramework.MacOS:
+				return "osx";
+			case PlatformFramework.iOS:
+				return "ios";
+			default:
+				throw new InvalidOperationException (string.Format ("Unknown target framework {0} for target framework identifier {2}.", framework, targetFrameworkIdentifier));
+			}
+		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
@@ -47,6 +47,9 @@ namespace Xamarin.MacDev.Tasks
 		[Required]
 		public string SdkVersion { get; set; }
 
+		[Required]
+		public string TargetFrameworkIdentifier { get; set; }
+
 		public string ToolExe {
 			get { return toolExe ?? ToolName; }
 			set { toolExe = value; }
@@ -67,8 +70,10 @@ namespace Xamarin.MacDev.Tasks
 			get { return "copySceneKitAssets"; }
 		}
 
-		protected abstract string OperatingSystem {
-			get;
+		protected virtual string OperatingSystem {
+			get {
+				return PlatformFrameworkHelper.GetOperatingSystem (TargetFrameworkIdentifier);
+			}
 		}
 
 		string DeveloperRootBinDir {

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
@@ -39,6 +39,9 @@ namespace Xamarin.MacDev.Tasks
 		[Required]
 		public ITaskItem SourceFile { get; set; }
 
+		[Required]
+		public string TargetFrameworkIdentifier { get; set; }
+
 		#endregion
 
 		[Output]
@@ -48,8 +51,22 @@ namespace Xamarin.MacDev.Tasks
 			get;
 		}
 
-		protected abstract string OperatingSystem {
-			get;
+		protected virtual string OperatingSystem {
+			get {
+				switch (PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier)) {
+				case PlatformFramework.WatchOS:
+					return "watchos";
+				case PlatformFramework.TVOS:
+					return "tvos";
+				case PlatformFramework.MacOS:
+					return "macosx";
+				case PlatformFramework.iOS:
+					return "ios";
+				default:
+					Log.LogError ($"Unknown target framework identifier: {TargetFrameworkIdentifier}.");
+					return string.Empty;
+				}
+			}
 		}
 
 		protected abstract string DevicePlatformBinDir {

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
@@ -34,6 +34,9 @@ namespace Xamarin.MacDev.Tasks
 		public string SdkVersion { get; set; }
 
 		[Required]
+		public bool SdkIsSimulator { get; set; }
+
+		[Required]
 		public string SdkRoot { get; set; }
 
 		[Required]
@@ -55,13 +58,13 @@ namespace Xamarin.MacDev.Tasks
 			get {
 				switch (PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier)) {
 				case PlatformFramework.WatchOS:
-					return "watchos";
+					return SdkIsSimulator ? "watchos-simulator" : "watchos";
 				case PlatformFramework.TVOS:
-					return "tvos";
+					return SdkIsSimulator ? "tvos-simulator" : "tvos";
 				case PlatformFramework.MacOS:
 					return "macosx";
 				case PlatformFramework.iOS:
-					return "ios";
+					return SdkIsSimulator ? "iphonesimulator" : "ios";
 				default:
 					Log.LogError ($"Unknown target framework identifier: {TargetFrameworkIdentifier}.");
 					return string.Empty;

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ScnToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ScnToolTaskBase.cs
@@ -39,14 +39,19 @@ namespace Xamarin.MacDev.Tasks
 			}
 		}
 
+		[Required]
+		public string TargetFrameworkIdentifier { get; set; }
+
 		#endregion
 
 		string DevicePlatformBinDir {
 			get { return Path.Combine (SdkDevPath, "usr", "bin"); }
 		}
 
-		protected abstract string OperatingSystem {
-			get;
+		protected virtual string OperatingSystem {
+			get {
+				return PlatformFrameworkHelper.GetOperatingSystem (TargetFrameworkIdentifier);
+			}
 		}
 
 		protected override string ToolName {

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
@@ -2,8 +2,5 @@
 {
 	public abstract class CompileSceneKitAssetsTaskBase : Xamarin.MacDev.Tasks.CompileSceneKitAssetsTaskBase
 	{
-		protected override string OperatingSystem {
-			get { return "ios"; }
-		}
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MetalTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MetalTaskBase.cs
@@ -6,10 +6,6 @@ namespace Xamarin.iOS.Tasks
 {
 	public abstract class MetalTaskBase : Xamarin.MacDev.Tasks.MetalTaskBase
 	{
-		protected override string OperatingSystem {
-			get { return "ios"; }
-		}
-
 		protected override string MinimumDeploymentTargetKey {
 			get { return ManifestKeys.MinimumOSVersion; }
 		}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ScnToolTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ScnToolTaskBase.cs
@@ -2,8 +2,5 @@
 {
 	public abstract class ScnToolTaskBase : Xamarin.MacDev.Tasks.ScnToolTaskBase
 	{
-		protected override string OperatingSystem {
-			get { return "ios"; }
-		}
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -603,6 +603,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
 			AppManifest="$(_AppManifest)"
 			ProjectDir="$(MSBuildProjectDirectory)"
+			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			ResourcePrefix="$(IPhoneResourcePrefix)"
 			SdkDevPath="$(_SdkDevPath)"
 			SdkRoot="$(_SdkRoot)"
@@ -1220,6 +1221,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			SdkRoot="$(_SdkRoot)"
 			SdkDevPath="$(_SdkDevPath)"
 			SdkVersion="$(MtouchSdkVersion)"
+			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
 			InputScene="%(_ColladaAssetWithLogicalName.Identity)"
 			OutputScene="$(DeviceSpecificIntermediateOutputPath)%(_ColladaAssetWithLogicalName.LogicalName)">
@@ -1333,6 +1335,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			ToolPath="$(CopySceneKitAssetsPath)"
 			SceneKitAssets="@(SceneKitAsset)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
+			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(IPhoneResourcePrefix)"
 			IsWatchApp="$(IsWatchApp)"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -595,8 +595,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations">
-		<Error Condition="'$(ComputedPlatform)' == 'iPhoneSimulator'" Text="The iOS Simulator does not support metal. Build for a device instead."/>
-
 		<Metal
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' and '%(Metal.Identity)' != ''"
@@ -606,6 +604,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			ResourcePrefix="$(IPhoneResourcePrefix)"
 			SdkDevPath="$(_SdkDevPath)"
+			SdkIsSimulator="$(_SdkIsSimulator)"
 			SdkRoot="$(_SdkRoot)"
 			SdkVersion="$(MtouchSdkVersion)"
 			SourceFile="@(Metal)">

--- a/msbuild/tests/MyMetalGame/MyMetalGame.sln
+++ b/msbuild/tests/MyMetalGame/MyMetalGame.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyMetalGame", "MyMetalGame.csproj", "{4598E620-3F15-4F66-B01A-B7F9E45CE659}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|iPhoneSimulator = Release|iPhoneSimulator
+		Debug|iPhone = Debug|iPhone
+		Release|iPhone = Release|iPhone
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4598E620-3F15-4F66-B01A-B7F9E45CE659}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{4598E620-3F15-4F66-B01A-B7F9E45CE659}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{4598E620-3F15-4F66-B01A-B7F9E45CE659}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{4598E620-3F15-4F66-B01A-B7F9E45CE659}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{4598E620-3F15-4F66-B01A-B7F9E45CE659}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{4598E620-3F15-4F66-B01A-B7F9E45CE659}.Debug|iPhone.Build.0 = Debug|iPhone
+		{4598E620-3F15-4F66-B01A-B7F9E45CE659}.Release|iPhone.ActiveCfg = Release|iPhone
+		{4598E620-3F15-4F66-B01A-B7F9E45CE659}.Release|iPhone.Build.0 = Release|iPhone
+	EndGlobalSection
+EndGlobal

--- a/msbuild/tests/MyTVMetalGame/AppDelegate.cs
+++ b/msbuild/tests/MyTVMetalGame/AppDelegate.cs
@@ -1,0 +1,56 @@
+using Foundation;
+using UIKit;
+
+namespace MyTVMetalGame {
+	// The UIApplicationDelegate for the application. This class is responsible for launching the
+	// User Interface of the application, as well as listening (and optionally responding) to application events from iOS.
+	[Register ("AppDelegate")]
+	public class AppDelegate : UIApplicationDelegate {
+		// class-level declarations
+
+		public override UIWindow Window {
+			get;
+			set;
+		}
+
+		public override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
+		{
+			// Override point for customization after application launch.
+			// If not required for your application you can safely delete this method
+
+			return true;
+		}
+
+		public override void OnResignActivation (UIApplication application)
+		{
+			// Invoked when the application is about to move from active to inactive state.
+			// This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) 
+			// or when the user quits the application and it begins the transition to the background state.
+			// Games should use this method to pause the game.
+		}
+
+		public override void DidEnterBackground (UIApplication application)
+		{
+			// Use this method to release shared resources, save user data, invalidate timers and store the application state.
+			// If your application supports background exection this method is called instead of WillTerminate when the user quits.
+		}
+
+		public override void WillEnterForeground (UIApplication application)
+		{
+			// Called as part of the transiton from background to active state.
+			// Here you can undo many of the changes made on entering the background.
+		}
+
+		public override void OnActivated (UIApplication application)
+		{
+			// Restart any tasks that were paused (or not yet started) while the application was inactive. 
+			// If the application was previously in the background, optionally refresh the user interface.
+		}
+
+		public override void WillTerminate (UIApplication application)
+		{
+			// Called when the application is about to terminate. Save data, if needed. See also DidEnterBackground.
+		}
+	}
+}
+

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,54 @@
+{
+  "images": [
+    {
+      "idiom": "universal"
+    },
+    {
+      "scale": "1x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "2x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "3x",
+      "idiom": "universal"
+    },
+    {
+      "idiom": "iphone"
+    },
+    {
+      "scale": "1x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "subtype": "retina4",
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "3x",
+      "idiom": "iphone"
+    },
+    {
+      "idiom": "ipad"
+    },
+    {
+      "scale": "1x",
+      "idiom": "ipad"
+    },
+    {
+      "scale": "2x",
+      "idiom": "ipad"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Back.imagestacklayer/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Back.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "layers" : [
+    {
+      "filename" : "Front.imagestacklayer"
+    },
+    {
+      "filename" : "Middle.imagestacklayer"
+    },
+    {
+      "filename" : "Back.imagestacklayer"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,54 @@
+{
+  "images": [
+    {
+      "idiom": "universal"
+    },
+    {
+      "scale": "1x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "2x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "3x",
+      "idiom": "universal"
+    },
+    {
+      "idiom": "iphone"
+    },
+    {
+      "scale": "1x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "subtype": "retina4",
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "3x",
+      "idiom": "iphone"
+    },
+    {
+      "idiom": "ipad"
+    },
+    {
+      "scale": "1x",
+      "idiom": "ipad"
+    },
+    {
+      "scale": "2x",
+      "idiom": "ipad"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Front.imagestacklayer/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Front.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,54 @@
+{
+  "images": [
+    {
+      "idiom": "universal"
+    },
+    {
+      "scale": "1x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "2x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "3x",
+      "idiom": "universal"
+    },
+    {
+      "idiom": "iphone"
+    },
+    {
+      "scale": "1x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "subtype": "retina4",
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "3x",
+      "idiom": "iphone"
+    },
+    {
+      "idiom": "ipad"
+    },
+    {
+      "scale": "1x",
+      "idiom": "ipad"
+    },
+    {
+      "scale": "2x",
+      "idiom": "ipad"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Middle.imagestacklayer/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Middle.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,54 @@
+{
+  "images": [
+    {
+      "idiom": "universal"
+    },
+    {
+      "scale": "1x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "2x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "3x",
+      "idiom": "universal"
+    },
+    {
+      "idiom": "iphone"
+    },
+    {
+      "scale": "1x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "subtype": "retina4",
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "3x",
+      "idiom": "iphone"
+    },
+    {
+      "idiom": "ipad"
+    },
+    {
+      "scale": "1x",
+      "idiom": "ipad"
+    },
+    {
+      "scale": "2x",
+      "idiom": "ipad"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Back.imagestacklayer/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Back.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "layers" : [
+    {
+      "filename" : "Front.imagestacklayer"
+    },
+    {
+      "filename" : "Middle.imagestacklayer"
+    },
+    {
+      "filename" : "Back.imagestacklayer"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,54 @@
+{
+  "images": [
+    {
+      "idiom": "universal"
+    },
+    {
+      "scale": "1x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "2x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "3x",
+      "idiom": "universal"
+    },
+    {
+      "idiom": "iphone"
+    },
+    {
+      "scale": "1x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "subtype": "retina4",
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "3x",
+      "idiom": "iphone"
+    },
+    {
+      "idiom": "ipad"
+    },
+    {
+      "scale": "1x",
+      "idiom": "ipad"
+    },
+    {
+      "scale": "2x",
+      "idiom": "ipad"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Front.imagestacklayer/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Front.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,54 @@
+{
+  "images": [
+    {
+      "idiom": "universal"
+    },
+    {
+      "scale": "1x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "2x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "3x",
+      "idiom": "universal"
+    },
+    {
+      "idiom": "iphone"
+    },
+    {
+      "scale": "1x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "subtype": "retina4",
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "3x",
+      "idiom": "iphone"
+    },
+    {
+      "idiom": "ipad"
+    },
+    {
+      "scale": "1x",
+      "idiom": "ipad"
+    },
+    {
+      "scale": "2x",
+      "idiom": "ipad"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Middle.imagestacklayer/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Middle.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Contents.json
@@ -1,0 +1,32 @@
+{
+  "assets" : [
+    {
+      "size" : "1280x768",
+      "idiom" : "tv",
+      "filename" : "App Icon - Large.imagestack",
+      "role" : "primary-app-icon"
+    },
+    {
+      "size" : "400x240",
+      "idiom" : "tv",
+      "filename" : "App Icon - Small.imagestack",
+      "role" : "primary-app-icon"
+    },
+    {
+      "size" : "2320x720",
+      "idiom" : "tv",
+      "filename" : "Top Shelf Image Wide.imageset",
+      "role" : "top-shelf-image-wide"
+    },
+    {
+      "size" : "1920x720",
+      "idiom" : "tv",
+      "filename" : "Top Shelf Image.imageset",
+      "role" : "top-shelf-image"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image Wide.imageset/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image Wide.imageset/Contents.json
@@ -1,0 +1,54 @@
+{
+  "images": [
+    {
+      "idiom": "universal"
+    },
+    {
+      "scale": "1x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "2x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "3x",
+      "idiom": "universal"
+    },
+    {
+      "idiom": "iphone"
+    },
+    {
+      "scale": "1x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "subtype": "retina4",
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "3x",
+      "idiom": "iphone"
+    },
+    {
+      "idiom": "ipad"
+    },
+    {
+      "scale": "1x",
+      "idiom": "ipad"
+    },
+    {
+      "scale": "2x",
+      "idiom": "ipad"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
@@ -1,0 +1,54 @@
+{
+  "images": [
+    {
+      "idiom": "universal"
+    },
+    {
+      "scale": "1x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "2x",
+      "idiom": "universal"
+    },
+    {
+      "scale": "3x",
+      "idiom": "universal"
+    },
+    {
+      "idiom": "iphone"
+    },
+    {
+      "scale": "1x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "subtype": "retina4",
+      "scale": "2x",
+      "idiom": "iphone"
+    },
+    {
+      "scale": "3x",
+      "idiom": "iphone"
+    },
+    {
+      "idiom": "ipad"
+    },
+    {
+      "scale": "1x",
+      "idiom": "ipad"
+    },
+    {
+      "scale": "2x",
+      "idiom": "ipad"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Assets.xcassets/Contents.json
+++ b/msbuild/tests/MyTVMetalGame/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/msbuild/tests/MyTVMetalGame/Entitlements.plist
+++ b/msbuild/tests/MyTVMetalGame/Entitlements.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/msbuild/tests/MyTVMetalGame/GameViewController.cs
+++ b/msbuild/tests/MyTVMetalGame/GameViewController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -9,12 +9,9 @@ using OpenTK;
 using Metal;
 using UIKit;
 
-namespace MyMetalGame
-{
-	public partial class GameViewController : UIViewController
-	{
-		struct Uniforms
-		{
+namespace MyTVMetalGame {
+	public partial class GameViewController : UIViewController {
+		struct Uniforms {
 			public Matrix4 ModelviewProjectionMatrix;
 			public Matrix4 NormalMatrix;
 		}
@@ -25,7 +22,7 @@ namespace MyMetalGame
 		// Max API memory buffer size
 		const int max_bytes_per_frame = 1024 * 1024;
 
-		float[] cubeVertexData = {
+		float [] cubeVertexData = {
 			// Data layout for each line below is:
 			// positionX, positionY, positionZ,     normalX, normalY, normalZ,
 			0.5f, -0.5f, 0.5f,   0.0f, -1.0f,  0.0f,
@@ -73,7 +70,6 @@ namespace MyMetalGame
 
 		// Layer
 		CAMetalLayer metalLayer;
-		bool layerSizeDidUpdate;
 		MTLRenderPassDescriptor renderPassDescriptor;
 
 		// Controller
@@ -190,7 +186,7 @@ namespace MyMetalGame
 				DepthCompareFunction = MTLCompareFunction.Less,
 				DepthWriteEnabled = true
 			};
-		
+
 			depthState = device.CreateDepthStencilState (depthStateDesc);
 		}
 
@@ -209,8 +205,7 @@ namespace MyMetalGame
 				//  Then allocate one of the proper size
 				MTLTextureDescriptor desc = MTLTextureDescriptor.CreateTexture2DDescriptor (MTLPixelFormat.Depth32Float, texture.Width, texture.Height, false);
 				if (ObjCRuntime.Runtime.Arch == ObjCRuntime.Arch.SIMULATOR)
-					desc.StorageMode = MTLStorageMode.Private;
-				depthTex = device.CreateTexture (desc);
+					desc.StorageMode = MTLStorageMode.Private; depthTex = device.CreateTexture (desc);
 				depthTex.Label = "Depth";
 
 				renderPassDescriptor.DepthAttachment.Texture = depthTex;
@@ -244,7 +239,7 @@ namespace MyMetalGame
 			renderEncoder.PushDebugGroup ("DrawCube");
 			renderEncoder.SetRenderPipelineState (pipelineState);
 			renderEncoder.SetVertexBuffer (vertexBuffer, 0, 0);
-			renderEncoder.SetVertexBuffer (dynamicConstantBuffer, (nuint)(Marshal.SizeOf (typeof(Uniforms)) * constantDataBufferIndex), 1);
+			renderEncoder.SetVertexBuffer (dynamicConstantBuffer, (nuint)(Marshal.SizeOf (typeof (Uniforms)) * constantDataBufferIndex), 1);
 
 			// Tell the render context we want to draw our primitives
 			renderEncoder.DrawPrimitives (MTLPrimitiveType.Triangle, 0, 36, 1);
@@ -258,7 +253,7 @@ namespace MyMetalGame
 				drawable.Dispose ();
 				inflightSemaphore.Release ();
 			});
-				
+
 			// Schedule a present once the framebuffer is complete
 			commandBuffer.PresentDrawable (drawable);
 
@@ -288,8 +283,8 @@ namespace MyMetalGame
 			uniformBuffer.ModelviewProjectionMatrix = Matrix4.Transpose (Matrix4.Mult (projectionMatrix, modelViewMatrix));
 
 			// Copy uniformBuffer's content into dynamicConstantBuffer.Contents
-			int rawsize = Marshal.SizeOf (typeof(Uniforms));
-			var rawdata = new byte[rawsize];
+			int rawsize = Marshal.SizeOf (typeof (Uniforms));
+			var rawdata = new byte [rawsize];
 			IntPtr ptr = Marshal.AllocHGlobal (rawsize);
 			Marshal.StructureToPtr (uniformBuffer, ptr, false);
 			Marshal.Copy (ptr, rawdata, 0, rawsize);
@@ -303,38 +298,13 @@ namespace MyMetalGame
 		// The main game loop called by the CADisplayLine timer
 		public void Gameloop ()
 		{
-			if (layerSizeDidUpdate) {
-				CGSize drawableSize = View.Bounds.Size;
-				drawableSize.Width *= View.ContentScaleFactor;
-				drawableSize.Height *= View.ContentScaleFactor;
-				metalLayer.DrawableSize = drawableSize;
-
-				Reshape ();
-				layerSizeDidUpdate = false;
-			}
-
 			Render ();
 		}
 
 		// Called whenever view changes orientation or layout is changed
 		public override void ViewDidLayoutSubviews ()
 		{
-			base.ViewDidLayoutSubviews ();
-			layerSizeDidUpdate = true;
-			metalLayer.Frame = View.Layer.Frame;
-		}
-
-		public override bool ShouldAutorotate ()
-		{
-			return true;
-		}
-
-		public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations ()
-		{
-			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone)
-				return UIInterfaceOrientationMask.AllButUpsideDown;
-
-			return UIInterfaceOrientationMask.All;
+			Reshape ();
 		}
 
 		ICAMetalDrawable GetCurrentDrawable ()

--- a/msbuild/tests/MyTVMetalGame/GameViewController.designer.cs
+++ b/msbuild/tests/MyTVMetalGame/GameViewController.designer.cs
@@ -1,0 +1,11 @@
+using Foundation;
+using System.CodeDom.Compiler;
+
+namespace MyTVMetalGame {
+	[Register ("GameViewController")]
+	partial class GameViewController {
+		void ReleaseDesignerOutlets ()
+		{
+		}
+	}
+}

--- a/msbuild/tests/MyTVMetalGame/Info.plist
+++ b/msbuild/tests/MyTVMetalGame/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>MyTVMetalGame</string>
+	<key>CFBundleName</key>
+	<string>MyTVMetalGame</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.xamarin.MyTVMetalGame</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>3</integer>
+	</array>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+	<key>GCSupportedGameControllers</key>
+	<array>
+		<dict>
+			<key>ProfileName</key>
+			<string>ExtendedGamepad</string>
+		</dict>
+		<dict>
+			<key>ProfileName</key>
+			<string>MicroGamepad</string>
+		</dict>
+	</array>
+	<key>GCSupportsControllerUserInteraction</key>
+	<true/>
+	<key>XSAppIconAssets</key>
+	<string>Assets.xcassets/App Icon &amp; Top Shelf Image.brandassets</string>
+	<key>XSLaunchImageAssets</key>
+	<string>Assets.xcassets/LaunchImages.launchimage</string>
+</dict>
+</plist>

--- a/msbuild/tests/MyTVMetalGame/Main.cs
+++ b/msbuild/tests/MyTVMetalGame/Main.cs
@@ -1,0 +1,13 @@
+using UIKit;
+
+namespace MyTVMetalGame {
+	public class Application {
+		// This is the main entry point of the application.
+		static void Main (string [] args)
+		{
+			// if you want to use a different Application Delegate class from "AppDelegate"
+			// you can specify it here.
+			UIApplication.Main (args, null, "AppDelegate");
+		}
+	}
+}

--- a/msbuild/tests/MyTVMetalGame/Main.storyboard
+++ b/msbuild/tests/MyTVMetalGame/Main.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BV1-FR-VrT">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes>
+        <!--Game View Controller-->
+        <scene sceneID="tXr-a1-R10">
+            <objects>
+                <viewController id="BV1-FR-VrT" customClass="GameViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="8aa-yV-Osq"/>
+                        <viewControllerLayoutGuide type="bottom" id="qHh-Mt-9TT"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="3se-qz-xqx">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="SZV-WD-TEh" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/msbuild/tests/MyTVMetalGame/MyTVMetalGame.csproj
+++ b/msbuild/tests/MyTVMetalGame/MyTVMetalGame.csproj
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectGuid>{CE09F37A-C1E9-488D-B72D-26269D735ECD}</ProjectGuid>
+    <ProjectTypeGuids>{06FA79CB-D6CD-4721-BB4B-1BD202089C55};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MyTVMetalGame</RootNamespace>
+    <AssemblyName>MyTVMetalGame</AssemblyName>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <MtouchFastDev>true</MtouchFastDev>
+    <IOSDebuggerPort>51092</IOSDebuggerPort>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchUseLlvm>true</MtouchUseLlvm>
+    <MtouchFloat32>true</MtouchFloat32>
+    <MtouchEnableBitcode>true</MtouchEnableBitcode>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARM64</MtouchArch>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <DeviceSpecificBuild>true</DeviceSpecificBuild>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <MtouchFastDev>true</MtouchFastDev>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <IOSDebuggerPort>39926</IOSDebuggerPort>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARM64</MtouchArch>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.TVOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Back.imagestacklayer\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Back.imagestacklayer\Content.imageset\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Front.imagestacklayer\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Front.imagestacklayer\Content.imageset\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Middle.imagestacklayer\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Middle.imagestacklayer\Content.imageset\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Back.imagestacklayer\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Back.imagestacklayer\Content.imageset\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Front.imagestacklayer\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Front.imagestacklayer\Content.imageset\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Middle.imagestacklayer\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Middle.imagestacklayer\Content.imageset\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\Top Shelf Image Wide.imageset\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\Top Shelf Image.imageset\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\Contents.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Metal Include="Shaders.metal" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+    <Compile Include="AppDelegate.cs" />
+    <Compile Include="GameViewController.cs" />
+    <Compile Include="GameViewController.designer.cs">
+      <DependentUpon>GameViewController.cs</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <InterfaceDefinition Include="Main.storyboard" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\TVOS\Xamarin.TVOS.CSharp.targets" />
+</Project>

--- a/msbuild/tests/MyTVMetalGame/MyTVMetalGame.sln
+++ b/msbuild/tests/MyTVMetalGame/MyTVMetalGame.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyTVMetalGame", "MyTVMetalGame.csproj", "{CE09F37A-C1E9-488D-B72D-26269D735ECD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|iPhone = Release|iPhone
+		Release|iPhoneSimulator = Release|iPhoneSimulator
+		Debug|iPhone = Debug|iPhone
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CE09F37A-C1E9-488D-B72D-26269D735ECD}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{CE09F37A-C1E9-488D-B72D-26269D735ECD}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{CE09F37A-C1E9-488D-B72D-26269D735ECD}.Release|iPhone.ActiveCfg = Release|iPhone
+		{CE09F37A-C1E9-488D-B72D-26269D735ECD}.Release|iPhone.Build.0 = Release|iPhone
+		{CE09F37A-C1E9-488D-B72D-26269D735ECD}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{CE09F37A-C1E9-488D-B72D-26269D735ECD}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{CE09F37A-C1E9-488D-B72D-26269D735ECD}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{CE09F37A-C1E9-488D-B72D-26269D735ECD}.Debug|iPhone.Build.0 = Debug|iPhone
+	EndGlobalSection
+EndGlobal

--- a/msbuild/tests/MyTVMetalGame/Shaders.metal
+++ b/msbuild/tests/MyTVMetalGame/Shaders.metal
@@ -1,0 +1,53 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+// Variables in constant address space
+constant float3 light_position = float3(0.0, 1.0, -1.0);
+constant float4 ambient_color  = float4(0.18, 0.24, 0.8, 1.0);
+constant float4 diffuse_color  = float4(0.4, 0.4, 1.0, 1.0);
+
+typedef struct
+{
+    float4x4 modelview_projection_matrix;
+    float4x4 normal_matrix;
+} uniforms_t;
+
+typedef struct
+{
+    packed_float3 position;
+    packed_float3 normal;
+} vertex_t;
+
+typedef struct {
+    float4 position [[position]];
+    half4  color;
+} ColorInOut;
+
+// Vertex shader function
+vertex ColorInOut lighting_vertex(device vertex_t* vertex_array [[ buffer(0) ]],
+                                  constant uniforms_t& uniforms [[ buffer(1) ]],
+                                  unsigned int vid [[ vertex_id ]])
+{
+    ColorInOut out;
+    
+    float4 in_position = float4(float3(vertex_array[vid].position), 1.0);
+    out.position = uniforms.modelview_projection_matrix * in_position;
+    
+    
+    float3 normal = vertex_array[vid].normal;
+    float4 eye_normal = normalize(uniforms.normal_matrix * float4(normal, 0.0));
+    float n_dot_l = dot(eye_normal.rgb, normalize(light_position));
+    n_dot_l = fmax(0.0, n_dot_l);
+    
+    out.color = half4(ambient_color + diffuse_color * n_dot_l);
+    
+    return out;
+}
+
+// Fragment shader function
+fragment half4 lighting_fragment(ColorInOut in [[stage_in]])
+{
+    return in.color;
+}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/CustomKeyboard.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/CustomKeyboard.cs
@@ -17,13 +17,8 @@ namespace Xamarin.iOS.Tasks {
 		[Test]
 		public void BasicTest () 
 		{
-			if (Platform == "iPhoneSimulator") {
-				// Note: we expect an error due to Metal not being supported on iPhoneSimulator
-				// Note 2: msbuild now is aware that Metal is device-only and throws an error thus this test becomes device-only for time being
-				//this.BuildExtension ("MyMetalGame", "MyKeyboardExtension", Platform, 1);
-				return;
-			}
-
+			if (Platform == "iPhoneSimulator" && Environment.OSVersion.Version.Major < 19) // Environment.OSVersion = 19.* in macOS Catalina.
+				Assert.Ignore ("Metal support is not available in the simulator until macOS 10.15.");
 			this.BuildExtension ("MyMetalGame", "MyKeyboardExtension", Platform, "Debug");
 			this.TestStoryboardC (AppBundlePath);
 		}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/TVOS/TVMetalGameTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/TVOS/TVMetalGameTests.cs
@@ -2,22 +2,20 @@ using System;
 
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks
-{
-	[TestFixture("TV", "iPhone")]
-	[TestFixture("TVSimulator", "iPhoneSimulator")]
-	public class TVAppTests : ExtensionTestBase
-	{
-		public TVAppTests (string bundlePath, string platform) : base(bundlePath, platform)
+namespace Xamarin.iOS.Tasks {
+	[TestFixture ("iPhone")]
+	[TestFixture ("iPhoneSimulator")]
+	public class TVMetalGameTests : ProjectTest {
+		public TVMetalGameTests (string platform) : base (platform)
 		{
 		}
 
 		[Test]
-		public void BasicTest()
+		public void BasicTest ()
 		{
 			if (Platform == "iPhoneSimulator" && Environment.OSVersion.Version.Major < 19) // Environment.OSVersion = 19.* in macOS Catalina.
 				Assert.Ignore ("Metal support is not available in the simulator until macOS 10.15.");
-			BuildExtension ("MyTVApp", "MyTVServicesExtension", BundlePath, Platform, "Debug");
+			BuildProject ("MyTVMetalGame", Platform, "Debug");
 		}
 
 		public override string TargetFrameworkIdentifier {

--- a/tests/mtouch/ToolTasksBinPathTest.cs
+++ b/tests/mtouch/ToolTasksBinPathTest.cs
@@ -14,8 +14,10 @@ namespace Xamarin.MacDev.Tasks {
 
 	public abstract class MetalTaskBase {
 
-		protected abstract string OperatingSystem {
-			get;
+		protected virtual string OperatingSystem {
+			get {
+				throw new NotImplementedException ();
+			}
 		}
 
 		protected abstract string DevicePlatformBinDir {
@@ -82,6 +84,7 @@ namespace Xamarin.Mac.Tasks {
 				RedirectStandardError = true,
 			};
 			psi.EnvironmentVariables.Add ("DEVELOPER_DIR", Configuration.xcode_root);
+			psi.EnvironmentVariables.Remove ("XCODE_DEVELOPER_DIR_PATH"); // VSfM sets XCODE_DEVELOPER_DIR_PATH, which confuses the command-line tools if it doesn't match xcode-select, so just unset it.
 			var proc = Process.Start (psi);
 
 			string output = proc.StandardOutput.ReadToEnd ();


### PR DESCRIPTION
This is a backport of #7983.

This also requires a backport of #7226:

[msbuild] Provide the correct value for the operating system for tvOS and
watchOS to a few tasks. Fixes #6200. (#7226)

The problem with #6200 was that we'd pass -mios-version-min=x.y to the metal
tool even for tvOS apps. This fixes it so that now pass -mtvos-version-min.

Fixes https://github.com/xamarin/xamarin-macios/issues/6200.