### PR TITLE
[src] Fix output name of Xamarin.iOS.dll.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -125,7 +125,7 @@ define IOS_TARGETS_template
 # Xamarin.iOS.dll
 $(IOS_BUILD_DIR)/native-$(1)%Xamarin.iOS.dll $(IOS_BUILD_DIR)/native-$(1)%Xamarin.iOS.pdb: $$(IOS_SOURCES) $(IOS_BUILD_DIR)/native/generated_sources $(PRODUCT_KEY_PATH)
 	@mkdir -p $(IOS_BUILD_DIR)/native-$(1)
-	$$(call Q_PROF_CSC,ios/$(1) bit) $$(IOS_CSC) -nologo -out:$$@ -target:library -debug -unsafe -optimize \
+	$$(call Q_PROF_CSC,ios/$(1) bit) $$(IOS_CSC) -nologo -out:$$(basename $$@).dll -target:library -debug -unsafe -optimize \
 		-deterministic \
 		$$(ARGS_$(1)) \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) $$(IOS_DEFINES) \


### PR DESCRIPTION
The make target names both Xamarin.iOS.dll and Xamarin.iOS.pdb. Depending on
ordering, make might want to ask the target to make the .pdb, in which case
we'd use that as the output name of the compilation. So instead explicitly
make the output assembly a .dll.