### PR TITLE
[Security] Don't call .Count() on an IEnumerable when we have an array we can call .Length on.

### DIFF
--- a/src/Security/SslContext.cs
+++ b/src/Security/SslContext.cs
@@ -339,7 +339,7 @@ namespace Security {
 
 			var array = ciphers.ToArray ();
 			fixed (SslCipherSuite *p = array)
-			result = SSLSetEnabledCiphers (Handle, p, ciphers.Count ());
+			result = SSLSetEnabledCiphers (Handle, p, array.Length);
 			return result;
 		}
 


### PR DESCRIPTION
Array.Length is by far the fastest.