### PR TITLE
[Harness] When on device, check if we got a tcp exception on a crash.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -887,11 +887,22 @@ namespace xharness
 					FailureMessage = $"Launch failure";
 					if (Harness.InCI)
 						XmlResultParser.GenerateFailure (Logs, "launch", appName, Variation, $"AppLaunch on {device_name}", $"{FailureMessage} on {device_name}", main_log.FullPath, XmlResultJargon.NUnitV3);
-				} else if (crashed && (!File.Exists (listener_log.FullPath) || string.IsNullOrEmpty (crash_reason)) && Harness.InCI) {
+				} else if (!isSimulator && crashed && string.IsNullOrEmpty (crash_reason) && Harness.InCI) {
 					// this happens more that what we would like on devices, the main reason most of the time is that we have had netwoking problems and the
 					// tcp connection could not be stablished. We are going to report it as an error since we have not parsed the logs, evne when the app might have
-					// not crashed.
-					XmlResultParser.GenerateFailure (Logs, "tcp-connection", appName, Variation, $"TcpConnection on {device_name}", $"Device {device_name} could not reach the host over tcp.", main_log.FullPath, Harness.XmlJargon);
+					// not crashed. We need to check the main_log to see if we do have an tcp issue or not
+					var isTcp = false;
+					using (var reader = new StreamReader (main_log.FullPath)) {
+						string line;
+						while ((line = reader.ReadLine ()) != null) {
+							if (line.Contains ("Couldn't establish a TCP connection with any of the hostnames")) {
+								isTcp = true;
+								break;
+							}
+						}
+					}
+					if (isTcp)
+						XmlResultParser.GenerateFailure (Logs, "tcp-connection", appName, Variation, $"TcpConnection on {device_name}", $"Device {device_name} could not reach the host over tcp.", main_log.FullPath, Harness.XmlJargon);
 				} else if (timed_out && Harness.InCI) {
 					XmlResultParser.GenerateFailure (Logs, "timeout", appName, Variation, "AppTimeout", $"Test run timed out after {timeout.TotalMinutes} minute(s).", main_log.FullPath, Harness.XmlJargon);
 				}


### PR DESCRIPTION
Some crashes are reported as tcp connection issues because they happen
before the app haad the chance to write anything in the log. In that
case, we checked for the presence of the file, and if not present we
decided it was a tcp issue when it is not the case.

In this commit, we check for the tcp erorr message in the main_log so
that we are certain that the issue was with the connection and not
anyother.

Testingis simple, ran tests without the phone being part of the same
network and test with a branch that has a crash. For example the one in
https://github.com/xamarin/xamarin-macios/pull/8009 hash 83240612e8c0b2f7ed20547b92dd42a112b24d7c