### PR TITLE
[src] Stop using assembly identity while computing stret-ness.

### DIFF
--- a/src/ObjCRuntime/Stret.cs
+++ b/src/ObjCRuntime/Stret.cs
@@ -79,28 +79,6 @@ namespace ObjCRuntime
 			return true;
 		}
 
-		static bool IsMagicTypeOrCorlibType (Type t, Generator generator)
-		{
-			switch (t.Name) {
-			case "nint":
-			case "nuint":
-			case "nfloat":
-				if (t.Namespace != "System")
-					return false;
-#if BGENERATOR
-				return t.Assembly == generator.TypeManager.PlatformAssembly;
-#else
-				return t.Assembly == typeof (NSObject).Assembly;
-#endif
-			default:
-#if BGENERATOR
-				return t.Assembly == generator.TypeManager.CorlibAssembly;
-#else
-				return t.Assembly == typeof (object).Assembly;
-#endif
-			}
-		}
-
 		public static bool ArmNeedStret (Type returnType, Generator generator)
 		{
 			bool has32bitArm;
@@ -116,7 +94,7 @@ namespace ObjCRuntime
 
 			Type t = returnType;
 
-			if (!t.IsValueType || t.IsEnum || IsMagicTypeOrCorlibType (t, generator))
+			if (!t.IsValueType || t.IsEnum || IsBuiltInType (t))
 				return false;
 
 			var fieldTypes = new List<Type> ();
@@ -178,7 +156,7 @@ namespace ObjCRuntime
 		{
 			Type t = returnType;
 
-			if (!t.IsValueType || t.IsEnum || IsMagicTypeOrCorlibType (t, generator))
+			if (!t.IsValueType || t.IsEnum || IsBuiltInType (t))
 				return false;
 
 			var fieldTypes = new List<Type> ();
@@ -197,7 +175,7 @@ namespace ObjCRuntime
 		{
 			Type t = returnType;
 
-			if (!t.IsValueType || t.IsEnum || IsMagicTypeOrCorlibType (t, generator))
+			if (!t.IsValueType || t.IsEnum || IsBuiltInType (t))
 				return false;
 
 			var fieldTypes = new List<Type> ();
@@ -239,6 +217,55 @@ namespace ObjCRuntime
 			return size += add;
 		}
 
+		static bool IsBuiltInType (Type type)
+		{
+			return IsBuiltInType (type, true /* doesn't matter */, out var _);
+		}
+
+		static bool IsBuiltInType (Type type, bool is_64_bits, out int type_size)
+		{
+			type_size = 0;
+
+			if (type.IsNested)
+				return false;
+
+			if (type.Namespace != "System")
+				return false;
+
+			switch (type.Name) {
+			case "Char":
+			case "Boolean":
+			case "SByte":
+			case "Byte":
+				type_size = 1;
+				return true;
+			case "Int16":
+			case "UInt16":
+				type_size = 2;
+				return true;
+			case "Single":
+			case "Int32":
+			case "UInt32":
+				type_size = 4;
+				return true;
+			case "Double":
+			case "Int64":
+			case "UInt64":
+				type_size = 8;
+				return true;
+			case "IntPtr":
+			case "nfloat":
+			case "nuint":
+			case "nint":
+				type_size = is_64_bits ? 8 : 4;
+				return true;
+			case "Void":
+				return true;
+			}
+
+			return false;
+		}
+
 		static void GetValueTypeSize (Type original_type, Type type, List<Type> field_types, bool is_64_bits, ref int size, ref int max_element_size, Generator generator)
 		{
 			// FIXME:
@@ -246,37 +273,7 @@ namespace ObjCRuntime
 			// However we don't annotate those types in any way currently, so first we'd need to 
 			// add the proper attributes so that the generator can distinguish those types from other types.
 
-			var type_size = 0;
-			switch (type.FullName) {
-			case "System.Char":
-			case "System.Boolean":
-			case "System.SByte":
-			case "System.Byte":
-				type_size = 1;
-				break;
-			case "System.Int16":
-			case "System.UInt16":
-				type_size = 2;
-				break;
-			case "System.Single":
-			case "System.Int32":
-			case "System.UInt32":
-				type_size = 4;
-				break;
-			case "System.Double":
-			case "System.Int64":
-			case "System.UInt64":
-				type_size = 8;
-				break;
-			case "System.IntPtr":
-			case "System.nfloat":
-			case "System.nuint":
-			case "System.nint":
-				type_size = is_64_bits ? 8 : 4;
-				break;
-			}
-
-			if (type_size != 0) {
+			if (IsBuiltInType (type, is_64_bits, out var type_size) && type_size > 0) {
 				field_types.Add (type);
 				size = AlignAndAdd (original_type, size, type_size, ref max_element_size);
 				return;


### PR DESCRIPTION
Using assembly identity to verify that a type is the expected one becomes
complicated with .NET 5, because types move around a lot between assemblies.
There are also type forwarders all over the place which doesn't make things
better. So instead use (only) string comparisons on type names to determine
which types we're dealing with.

The only time this change can become a problem is if someone decides to
implement their own version of the built-in System types, but that would be a
very bad idea for a number of other reasons.