### PR TITLE
[bgen] No need to verify that System.Nullable`1 comes from mscorlib.

### DIFF
--- a/src/generator-typemanager.cs
+++ b/src/generator-typemanager.cs
@@ -157,7 +157,7 @@ public class TypeManager {
 			return null;
 
 		var gt = type.GetGenericTypeDefinition ();
-		if (gt.Assembly != CorlibAssembly)
+		if (gt.IsNested)
 			return null;
 
 		if (gt.Namespace != "System")


### PR DESCRIPTION
Instead verify that it's not a nested type, which should be more than good
enough. If someone else defines a System.Nullable`1, they'll probably have
much bigger problems.

This solves an issue with .NET 5 where System.Nullable`1 doesn't actually come
from mscorlib.