### PR TITLE
[Harness] Refactor a little the code for logging to simplify testing.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -12,6 +12,7 @@ using System.Xml;
 using System.Xml.Xsl;
 using Xamarin;
 using Xamarin.Utils;
+using xharness.Logging;
 
 namespace xharness
 {
@@ -99,15 +100,15 @@ namespace xharness
 			set { log_directory = value; }
 		}
 
-		Logs logs;
-		public Logs Logs {
+		ILogs logs;
+		public ILogs Logs {
 			get {
 				return logs ?? (logs = new Logs (LogDirectory));
 			}
 		}
 
-		Log main_log;
-		public Log MainLog {
+		ILog main_log;
+		public ILog MainLog {
 			get { return main_log; }
 			set { main_log = value; }
 		}
@@ -476,9 +477,9 @@ namespace xharness
 		public async Task<int> RunAsync ()
 		{
 			CrashReportSnapshot crash_reports;
-			Log device_system_log = null;
-			Log listener_log = null;
-			Log run_log = main_log;
+			ILog device_system_log = null;
+			ILog listener_log = null;
+			ILog run_log = main_log;
 
 			Initialize ();
 
@@ -929,7 +930,7 @@ namespace xharness
 	class AppInstallMonitorLog : Log {
 		public override string FullPath => copy_to.FullPath;
 
-		Log copy_to;
+		ILog copy_to;
 		CancellationTokenSource cancellation_source;
 		
 		public bool CopyingApp;
@@ -951,7 +952,7 @@ namespace xharness
 			}
 		}
 
-		public AppInstallMonitorLog (Log copy_to)
+		public AppInstallMonitorLog (ILog copy_to)
 				: base (copy_to.Logs, $"Watch transfer log for {copy_to.Description}")
 		{
 			this.copy_to = copy_to;

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -12,9 +12,9 @@ using System.Xml;
 using System.Xml.Xsl;
 using Xamarin;
 using Xamarin.Utils;
-using xharness.Logging;
+using Xharness.Logging;
 
-namespace xharness
+namespace Xharness
 {
 	public enum AppRunnerTarget
 	{
@@ -394,7 +394,7 @@ namespace xharness
 					File.Delete (tmpFile);
 
 					// we do not longer need the tmp file
-					Logs.AddFile (path, Log.XML_LOG);
+					Logs.AddFile (path, LogType.XmlLog.ToString ());
 					return parseResult;
 
 				} catch (Exception e) {
@@ -550,7 +550,7 @@ namespace xharness
 			args.Add ($"-argument=-app-arg:-transport:{transport}");
 			args.Add ($"-setenv=NUNIT_TRANSPORT={transport}");
 
-			listener_log = Logs.Create ($"test-{mode}-{Harness.Timestamp}.log", Log.TEST_LOG, timestamp: !useXmlOutput);
+			listener_log = Logs.Create ($"test-{mode}-{Harness.Timestamp}.log", LogType.TestLog.ToString (), timestamp: !useXmlOutput);
 
 			SimpleListener listener;
 			switch (transport) {
@@ -651,7 +651,7 @@ namespace xharness
 					var log = new CaptureLog (Logs, sim.SystemLog, entire_file: Harness.Action != HarnessAction.Jenkins)
 					{
 						Path = Path.Combine (LogDirectory, sim.Name + ".log"),
-						Description = isCompanion ? Log.COMPANION_SYSTEM_LOG : Log.SYSTEM_LOG,
+						Description = isCompanion ? LogType.CompanionSystemLog.ToString () : LogType.SystemLog.ToString (),
 					};
 					log.StartCapture ();
 					Logs.Add (log);

--- a/tests/xharness/BCLTestImporter/BCLTestImportTargetFactory.cs
+++ b/tests/xharness/BCLTestImporter/BCLTestImportTargetFactory.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Collections.Generic;
 using BCLTestImporter;
 
-namespace xharness.BCLTestImporter {
+namespace Xharness.BCLTestImporter {
 	// Class that is use as the connection between xharness and the BCLImporter
 	// This class knows about both worlds, will get the required information, 
 	// from xharness, that will then be passed to the importer to generate

--- a/tests/xharness/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tests/xharness/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Security.Cryptography;
-using xharness;
+using Xharness;
 
 namespace BCLTestImporter {
 	/// <summary>

--- a/tests/xharness/DeviceLogCapturer.cs
+++ b/tests/xharness/DeviceLogCapturer.cs
@@ -1,13 +1,13 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading;
 using Xamarin.Utils;
-using xharness.Logging;
+using Xharness.Logging;
 
-namespace xharness
+namespace Xharness
 {
 	public class DeviceLogCapturer
 	{

--- a/tests/xharness/DeviceLogCapturer.cs
+++ b/tests/xharness/DeviceLogCapturer.cs
@@ -5,13 +5,14 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using Xamarin.Utils;
+using xharness.Logging;
 
 namespace xharness
 {
 	public class DeviceLogCapturer
 	{
 		public Harness Harness;
-		public Log Log;
+		public ILog Log;
 		public string DeviceName;
 
 		Process process;

--- a/tests/xharness/Extensions.cs
+++ b/tests/xharness/Extensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace xharness
+namespace Xharness
 {
 	public static class Extensions
 	{

--- a/tests/xharness/GitHub.cs
+++ b/tests/xharness/GitHub.cs
@@ -9,7 +9,7 @@ using System.Xml;
 using System.Text;
 using Xamarin;
 
-namespace xharness
+namespace Xharness
 {
 	public static class GitHub
 	{

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -9,10 +9,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Xamarin.Utils;
-using xharness.BCLTestImporter;
-using xharness.Logging;
+using Xharness.BCLTestImporter;
+using Xharness.Logging;
 
-namespace xharness
+namespace Xharness
 {
 	public enum HarnessAction
 	{

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using Xamarin.Utils;
 using xharness.BCLTestImporter;
+using xharness.Logging;
 
 namespace xharness
 {
@@ -27,7 +28,7 @@ namespace xharness
 	{
 		public HarnessAction Action { get; set; }
 		public int Verbosity { get; set; }
-		public Log HarnessLog { get; set; }
+		public ILog HarnessLog { get; set; }
 		public bool UseSystem { get; set; } // if the system XI/XM should be used, or the locally build XI/XM.
 		public HashSet<string> Labels { get; } = new HashSet<string> ();
 		public XmlResultJargon XmlJargon { get; set; } = XmlResultJargon.NUnitV3;
@@ -776,7 +777,7 @@ namespace xharness
 			}
 		}
 
-		public Task<ProcessExecutionResult> ExecuteXcodeCommandAsync (string executable, IList<string> args, Log log, TimeSpan timeout)
+		public Task<ProcessExecutionResult> ExecuteXcodeCommandAsync (string executable, IList<string> args, ILog log, TimeSpan timeout)
 		{
 			return ProcessHelper.ExecuteCommandAsync (Path.Combine (XcodeRoot, "Contents", "Developer", "usr", "bin", executable), args, log, timeout: timeout);
 		}
@@ -786,7 +787,7 @@ namespace xharness
 			await ExecuteXcodeCommandAsync ("simctl", new [] { "list" }, log, TimeSpan.FromSeconds (10));
 		}
 
-		public async Task<LogFile> SymbolicateCrashReportAsync (Logs logs, Log log, LogFile report)
+		public async Task<ILogFile> SymbolicateCrashReportAsync (ILogs logs, ILog log, ILogFile report)
 		{
 			var symbolicatecrash = Path.Combine (XcodeRoot, "Contents/SharedFrameworks/DTDeviceKitBase.framework/Versions/A/Resources/symbolicatecrash");
 			if (!File.Exists (symbolicatecrash))
@@ -810,7 +811,7 @@ namespace xharness
 			}
 		}
 
-		public async Task<HashSet<string>> CreateCrashReportsSnapshotAsync (Log log, bool simulatorOrDesktop, string device)
+		public async Task<HashSet<string>> CreateCrashReportsSnapshotAsync (ILog log, bool simulatorOrDesktop, string device)
 		{
 			var rv = new HashSet<string> ();
 
@@ -845,8 +846,8 @@ namespace xharness
 	public class CrashReportSnapshot
 	{
 		public Harness Harness { get; set; }
-		public Log Log { get; set; }
-		public Logs Logs { get; set; }
+		public ILog Log { get; set; }
+		public ILogs Logs { get; set; }
 		public string LogDirectory { get; set; }
 		public bool Device { get; set; }
 		public string DeviceName { get; set; }
@@ -872,16 +873,16 @@ namespace xharness
 				Reports = end_crashes;
 				if (end_crashes.Count > 0) {
 					Log.WriteLine ("Found {0} new crash report(s)", end_crashes.Count);
-					List<LogFile> crash_reports;
+					List<ILogFile> crash_reports;
 					if (!Device) {
-						crash_reports = new List<LogFile> (end_crashes.Count);
+						crash_reports = new List<ILogFile> (end_crashes.Count);
 						foreach (var path in end_crashes) {
 							Logs.AddFile (path, $"Crash report: {Path.GetFileName (path)}");
 						}
 					} else {
 						// Download crash reports from the device. We put them in the project directory so that they're automatically deleted on wrench
 						// (if we put them in /tmp, they'd never be deleted).
-						var downloaded_crash_reports = new List<LogFile> ();
+						var downloaded_crash_reports = new List<ILogFile> ();
 						foreach (var file in end_crashes) {
 							var name = Path.GetFileName (file);
 							var crash_report_target = Logs.Create (name, $"Crash report: {name}", timestamp: false);

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -11,9 +11,9 @@ using System.Text;
 using Xamarin;
 using Xamarin.Utils;
 using System.Xml;
-using xharness.Logging;
+using Xharness.Logging;
 
-namespace xharness
+namespace Xharness
 {
 	public class Jenkins
 	{
@@ -2208,7 +2208,7 @@ namespace xharness
 									}
 									if (!exists) {
 										writer.WriteLine ("<a href='{0}' type='{2}' target='{3}'>{1}</a> (does not exist)<br />", LinkEncode (log.FullPath.Substring (LogDirectory.Length + 1)), log.Description, log_type, log_target);
-									} else if (log.Description == Log.BUILD_LOG) {
+									} else if (log.Description == LogType.BuildLog.ToString ()) {
 										var binlog = log.FullPath.Replace (".txt", ".binlog");
 										if (File.Exists (binlog)) {
 											var textLink = string.Format ("<a href='{0}' type='{2}' target='{3}'>{1}</a>", LinkEncode (log.FullPath.Substring (LogDirectory.Length + 1)), log.Description, log_type, log_target);
@@ -2222,7 +2222,7 @@ namespace xharness
 									}
 									if (!exists) {
 										// Don't try to parse files that don't exist
-									} else if (log.Description == Log.TEST_LOG || log.Description == Log.EXTENSION_TEST_LOG || log.Description == Log.EXECUTION_LOG) {
+									} else if (log.Description == LogType.TestLog.ToString () || log.Description ==  LogType.ExecutionLog.ToString () || log.Description == LogType.ExecutionLog.ToString ()) {
 										string summary;
 										List<string> fails;
 										try {
@@ -2262,7 +2262,7 @@ namespace xharness
 										} catch (Exception ex) {
 											writer.WriteLine ("<span style='padding-left: 15px;'>Could not parse log file: {0}</span><br />", ex.Message.AsHtml ());
 										}
-									} else if (log.Description == Log.BUILD_LOG) {
+									} else if (log.Description == LogType.BuildLog.ToString ()) {
 										HashSet<string> errors;
 										try {
 											using (var reader = log.GetReader ()) {
@@ -2298,7 +2298,7 @@ namespace xharness
 										} catch (Exception ex) {
 											writer.WriteLine ("<span style='padding-left: 15px;'>Could not parse log file: {0}</span><br />", ex.Message.AsHtml ());
 										}
-									} else if (log.Description == Log.NUNIT_RESULT || log.Description == Log.XML_LOG) {
+									} else if (log.Description == LogType.NUnitResult.ToString () || log.Description == LogType.XmlLog.ToString () ) {
 										try {
 											if (File.Exists (log.FullPath) && new FileInfo (log.FullPath).Length > 0) {
 												if (XmlResultParser.IsValidXml (log.FullPath, out var jargon)) {
@@ -2987,7 +2987,7 @@ namespace xharness
 					make.StartInfo.WorkingDirectory = WorkingDirectory;
 					make.StartInfo.Arguments = Target;
 					SetEnvironmentVariables (make);
-					var log = Logs.Create ($"make-{Platform}-{Timestamp}.txt", Log.BUILD_LOG);
+					var log = Logs.Create ($"make-{Platform}-{Timestamp}.txt", LogType.BuildLog.ToString ());
 					LogEvent (log, "Making {0} in {1}", Target, WorkingDirectory);
 					if (!Harness.DryRun) {
 						var timeout = Timeout;
@@ -3017,7 +3017,7 @@ namespace xharness
 		protected override async Task ExecuteAsync ()
 		{
 			using (var resource = await NotifyAndAcquireDesktopResourceAsync ()) {
-				BuildLog = Logs.Create ($"build-{Platform}-{Timestamp}.txt", Log.BUILD_LOG);
+				BuildLog = Logs.Create ($"build-{Platform}-{Timestamp}.txt", LogType.BuildLog.ToString ());
 				var binlogPath = BuildLog.FullPath.Replace (".txt", ".binlog");
 
 				await RestoreNugetsAsync (BuildLog, resource, useXIBuild: true);
@@ -3199,8 +3199,8 @@ namespace xharness
 		protected override async Task RunTestAsync ()
 		{
 			using (var resource = await NotifyAndAcquireDesktopResourceAsync ()) {
-				var xmlLog = Logs.CreateFile ($"log-{Timestamp}.xml", Log.XML_LOG);
-				var log = Logs.Create ($"execute-{Timestamp}.txt", Log.EXECUTION_LOG);
+				var xmlLog = Logs.CreateFile ($"log-{Timestamp}.xml", LogType.XmlLog.ToString ());
+				var log = Logs.Create ($"execute-{Timestamp}.txt", LogType.ExecutionLog.ToString ());
 				FindNUnitConsoleExecutable (log);
 				using (var proc = new Process ()) {
 
@@ -3370,14 +3370,14 @@ namespace xharness
 				using (var proc = new Process ()) {
 					proc.StartInfo.FileName = Path;
 					if (IsUnitTest) {
-						var xml = Logs.CreateFile ($"test-{Platform}-{Timestamp}.xml", Log.NUNIT_RESULT);
+						var xml = Logs.CreateFile ($"test-{Platform}-{Timestamp}.xml", LogType.NUnitResult.ToString ());
 						proc.StartInfo.Arguments = StringUtils.FormatArguments ($"-result=" + xml);
 					}
 					if (!Harness.GetIncludeSystemPermissionTests (Platform, false))
 						proc.StartInfo.EnvironmentVariables ["DISABLE_SYSTEM_PERMISSION_TESTS"] = "1";
 					proc.StartInfo.EnvironmentVariables ["MONO_DEBUG"] = "no-gdb-backtrace";
 					Jenkins.MainLog.WriteLine ("Executing {0} ({1})", TestName, Mode);
-					var log = Logs.Create ($"execute-{Platform}-{Timestamp}.txt", Log.EXECUTION_LOG);
+					var log = Logs.Create ($"execute-{Platform}-{Timestamp}.txt", LogType.ExecutionLog.ToString ());
 					if (!Harness.DryRun) {
 						ExecutionResult = TestExecutingResult.Running;
 
@@ -3431,7 +3431,7 @@ namespace xharness
 					proc.StartInfo.Arguments = $"--debug {reporter} {WorkingDirectory} {results}";
 
 					Jenkins.MainLog.WriteLine ("Executing {0} ({1})", TestName, Mode);
-					var log = Logs.Create ($"execute-xtro-{Timestamp}.txt", Log.EXECUTION_LOG);
+					var log = Logs.Create ($"execute-xtro-{Timestamp}.txt", LogType.ExecutionLog.ToString ());
 					log.WriteLine ("{0} {1}", proc.StartInfo.FileName, proc.StartInfo.Arguments);
 					if (!Harness.DryRun) {
 						ExecutionResult = TestExecutingResult.Running;

--- a/tests/xharness/Log.cs
+++ b/tests/xharness/Log.cs
@@ -3,134 +3,19 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Text;
+using xharness.Logging;
 
 namespace xharness
 {
-	public abstract class Log : TextWriter
-	{
-		public Logs Logs { get; private set; }
-		public string Description;
-		public bool Timestamp = true;
 
-		public static string XML_LOG = "XML log";
-		public static string NUNIT_RESULT = "NUnit results";
-		public static string SYSTEM_LOG = "System log";
-		public static string COMPANION_SYSTEM_LOG = "System log (companion)";
-		public static string BUILD_LOG = "Build log";
-		public static string TEST_LOG = "Test log";
-		public static string EXTENSION_TEST_LOG = "Extension test log";
-		public static string EXECUTION_LOG = "Execution log";
-
-		protected Log (Logs logs)
-		{
-			Logs = logs;
-		}
-
-		protected Log (Logs logs, string description)
-		{
-			Logs = logs;
-			Description = description;
-		}
-
-		public abstract string FullPath { get; }
-
-		internal protected virtual void WriteImpl (string value)
-		{
-			Write (Encoding.UTF8.GetBytes (value));
-		}
-
-		public virtual void Write (byte [] buffer)
-		{
-			Write (buffer, 0, buffer.Length);
-		}
-
-		public virtual void Write (byte[] buffer, int offset, int count)
-		{
-			throw new NotSupportedException ();
-		}
-
-		public virtual StreamReader GetReader ()
-		{
-			throw new NotSupportedException ();
-		}
-
-		public override void Write (char value)
-		{
-			WriteImpl (value.ToString ());
-		}
-
-		public override void Write (string value)
-		{
-			if (Timestamp)
-				value = DateTime.Now.ToString ("HH:mm:ss.fffffff") + " " + value;
-			WriteImpl (value);
-		}
-
-		public override void WriteLine (string value)
-		{
-			Write (value + "\n");
-		}
-
-		public override void WriteLine (string format, params object [] args)
-		{
-			Write (string.Format (format, args) + "\n");
-		}
-
-		public override string ToString ()
-		{
-			return Description;
-		}
-
-		public override void Flush ()
-		{
-		}
-
-		public override Encoding Encoding {
-			get {
-				return System.Text.Encoding.UTF8;
-			}
-		}
-
-		public static Log CreateAggregatedLog (params Log [] logs)
-		{
-			return new AggregatedLog (logs);
-		}
-
-		// Log that will duplicate log output to multiple other logs.
-		class AggregatedLog : Log
-		{
-			Log [] logs;
-
-			public AggregatedLog (params Log [] logs)
-				: base (null)
-			{
-				this.logs = logs;
-			}
-
-			public override string FullPath => throw new NotImplementedException ();
-
-			internal protected override void WriteImpl (string value)
-			{
-				foreach (var log in logs)
-					log.WriteImpl (value);
-			}
-
-			public override void Write (byte [] buffer, int offset, int count)
-			{
-				foreach (var log in logs)
-					log.Write (buffer, offset, count);
-			}
-		}
-	}
-
-	public class LogFile : Log
+	public class LogFile : Log, ILogFile
 	{
 		object lock_obj = new object ();
 		public string Path { get; private set; }
 		FileStream writer;
 		bool disposed;
 
-		public LogFile (Logs logs, string description, string path, bool append = true)
+		public LogFile (ILogs logs, string description, string path, bool append = true)
 			: base (logs, description)
 		{
 			Path = path;
@@ -192,71 +77,7 @@ namespace xharness
 
 			disposed = true;
 		}
-	}
 
-	public class Logs : List<Log>, IDisposable
-	{
-		public string Directory;
-
-		public Logs (string directory)
-		{
-			Directory = directory;
-		}
-
-		// Create a new log backed with a file
-		public LogFile Create (string filename, string name, bool? timestamp = null)
-		{
-			return Create (Directory, filename, name, timestamp);
-		}
-
-		LogFile Create (string directory, string filename, string name, bool? timestamp = null)
-		{
-			System.IO.Directory.CreateDirectory (directory);
-			var rv = new LogFile (this, name, Path.GetFullPath (Path.Combine (directory, filename)));
-			if (timestamp.HasValue)
-				rv.Timestamp = timestamp.Value;
-			Add (rv);
-			return rv;
-		}
-
-		// Adds an existing file to this collection of logs.
-		// If the file is not inside the log directory, then it's copied there.
-		// 'path' must be a full path to the file.
-		public LogFile AddFile (string path)
-		{
-			return AddFile (path, Path.GetFileName (path));
-		}
-
-		// Adds an existing file to this collection of logs.
-		// If the file is not inside the log directory, then it's copied there.
-		// 'path' must be a full path to the file.
-		public LogFile AddFile (string path, string name)
-		{
-			if (!path.StartsWith (Directory, StringComparison.Ordinal)) {
-				var newPath = Path.Combine (Directory, Path.GetFileNameWithoutExtension (path) + "-" + Harness.Timestamp + Path.GetExtension (path));
-				File.Copy (path, newPath, true);
-				path = newPath;
-			}
-
-			var log = new LogFile (this, name, path, true);
-			Add (log);
-			return log;
-		}
-
-		// Create an empty file in the log directory and return the full path to the file
-		public string CreateFile (string path, string description)
-		{
-			using (var rv = new LogFile (this, description, Path.Combine (Directory, path), false)) {
-				Add (rv);
-				return rv.FullPath;
-			}
-		}
-
-		public void Dispose ()
-		{
-			foreach (var log in this)
-				log.Dispose ();
-		}
 	}
 
 	// A log that writes to standard output
@@ -269,7 +90,7 @@ namespace xharness
 		{
 		}
 
-		internal protected override void WriteImpl (string value)
+		public override void WriteImpl (string value)
 		{
 			captured.Append (value);
 			Console.Write (value);
@@ -299,7 +120,7 @@ namespace xharness
 		long endPosition;
 		bool entire_file;
 
-		public CaptureLog (Logs logs, string capture_path, bool entire_file = false)
+		public CaptureLog (ILogs logs, string capture_path, bool entire_file = false)
 			: base (logs)
 		{
 			CapturePath = capture_path;
@@ -403,7 +224,7 @@ namespace xharness
 			Capture ();
 		}
 
-		internal protected override void WriteImpl (string value)
+		public override void WriteImpl (string value)
 		{
 			throw new InvalidOperationException ();
 		}
@@ -428,7 +249,7 @@ namespace xharness
 
 		public override string FullPath => throw new NotImplementedException ();
 
-		internal protected override void WriteImpl (string value)
+		public override void WriteImpl (string value)
 		{
 			OnWrite (value);
 		}

--- a/tests/xharness/Log.cs
+++ b/tests/xharness/Log.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Text;
-using xharness.Logging;
+using Xharness.Logging;
 
-namespace xharness
+namespace Xharness
 {
 
 	public class LogFile : Log, ILogFile

--- a/tests/xharness/Logging/ILog.cs
+++ b/tests/xharness/Logging/ILog.cs
@@ -2,18 +2,18 @@
 using System.IO;
 using System.Text;
 
-namespace xharness.Logging {
+namespace Xharness.Logging {
 
 	// defines common log types
 	public enum LogType {
-		XML_LOG,
-		NUNIT_RESULT,
-		SYSTEM_LOG,
-		COMPANION_SYSTEM_LOG,
-		BUILD_LOG,
-		TEST_LOG,
-		EXTENSION_TEST_LOG,
-		EXECUTION_LOG,
+		XmlLog,
+		NUnitResult,
+		SystemLog,
+		CompanionSystemLog,
+		BuildLog,
+		TestLog,
+		ExtensionTestLog,
+		ExecutionLog,
 	}
 
 	public static class LogTypeExtensions {
@@ -21,24 +21,24 @@ namespace xharness.Logging {
 		public static string ToString (this LogType type)
 		{
 			switch (type) {
-			case LogType.XML_LOG:
+			case LogType.XmlLog:
 				return "XML log";
-			case LogType.NUNIT_RESULT:
+			case LogType.NUnitResult:
 				return "NUnit results";
-			case LogType.SYSTEM_LOG:
+			case LogType.SystemLog:
 				return "System log";
-			case LogType.COMPANION_SYSTEM_LOG:
+			case LogType.CompanionSystemLog:
 				return "System log (companion)";
-			case LogType.BUILD_LOG:
+			case LogType.BuildLog:
 				return "Build log";
-			case LogType.TEST_LOG:
+			case LogType.TestLog:
 				return "Test log";
-			case LogType.EXTENSION_TEST_LOG:
+			case LogType.ExtensionTestLog:
 				return "Extension test log";
-			case LogType.EXECUTION_LOG:
+			case LogType.ExecutionLog:
 				return "Execution log";
 			default:
-				throw new ArgumentException ($"Unknoe tyme for {nameof (type)}");
+				throw new ArgumentException ($"Unknown type for {nameof (type)}");
 			}
 		}
 	}

--- a/tests/xharness/Logging/ILog.cs
+++ b/tests/xharness/Logging/ILog.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+namespace xharness.Logging {
+
+	// defines common log types
+	public enum LogType {
+		XML_LOG,
+		NUNIT_RESULT,
+		SYSTEM_LOG,
+		COMPANION_SYSTEM_LOG,
+		BUILD_LOG,
+		TEST_LOG,
+		EXTENSION_TEST_LOG,
+		EXECUTION_LOG,
+	}
+
+	public static class LogTypeExtensions {
+
+		public static string ToString (this LogType type)
+		{
+			switch (type) {
+			case LogType.XML_LOG:
+				return "XML log";
+			case LogType.NUNIT_RESULT:
+				return "NUnit results";
+			case LogType.SYSTEM_LOG:
+				return "System log";
+			case LogType.COMPANION_SYSTEM_LOG:
+				return "System log (companion)";
+			case LogType.BUILD_LOG:
+				return "Build log";
+			case LogType.TEST_LOG:
+				return "Test log";
+			case LogType.EXTENSION_TEST_LOG:
+				return "Extension test log";
+			case LogType.EXECUTION_LOG:
+				return "Execution log";
+			default:
+				throw new ArgumentException ($"Unknoe tyme for {nameof (type)}");
+			}
+		}
+	}
+	public interface ILog : IDisposable {
+		ILogs Logs { get; }
+		string Description { get; set; }
+		bool Timestamp { get; set; }
+		string FullPath { get; }
+		Encoding Encoding { get; }
+		void Write (byte [] buffer);
+		void Write (byte [] buffer, int offset, int count);
+		StreamReader GetReader ();
+		void Write (char value);
+		void Write (string value);
+		void WriteImpl (string value);
+		void WriteLine (string value);
+		void WriteLine (StringBuilder value);
+		void WriteLine (string format, params object [] args);
+		void Flush ();
+	}
+}

--- a/tests/xharness/Logging/ILogFile.cs
+++ b/tests/xharness/Logging/ILogFile.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 
-namespace xharness.Logging {
+namespace Xharness.Logging {
 	public interface ILogFile : ILog, IDisposable {
 		string Path { get; }
 	}

--- a/tests/xharness/Logging/ILogFile.cs
+++ b/tests/xharness/Logging/ILogFile.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using System.IO;
+
+namespace xharness.Logging {
+	public interface ILogFile : ILog, IDisposable {
+		string Path { get; }
+	}
+}

--- a/tests/xharness/Logging/ILogs.cs
+++ b/tests/xharness/Logging/ILogs.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace xharness.Logging {
+namespace Xharness.Logging {
 	public interface ILogs : IList<Log>, IDisposable {
 		string Directory { get; set; }
 

--- a/tests/xharness/Logging/ILogs.cs
+++ b/tests/xharness/Logging/ILogs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace xharness.Logging {
+	public interface ILogs : IList<Log>, IDisposable {
+		string Directory { get; set; }
+
+		// Create a new log backed with a file
+		ILogFile Create (string filename, string name, bool? timestamp = null);
+
+		// Adds an existing file to this collection of logs.
+		// If the file is not inside the log directory, then it's copied there.
+		// 'path' must be a full path to the file.
+		ILogFile AddFile (string path);
+
+		// Adds an existing file to this collection of logs.
+		// If the file is not inside the log directory, then it's copied there.
+		// 'path' must be a full path to the file.
+		ILogFile AddFile (string path, string name);
+
+		// Create an empty file in the log directory and return the full path to the file
+		string CreateFile (string path, string description);
+	}
+}

--- a/tests/xharness/Logging/Log.cs
+++ b/tests/xharness/Logging/Log.cs
@@ -2,21 +2,12 @@
 using System.IO;
 using System.Text;
 
-namespace xharness.Logging {
+namespace Xharness.Logging {
 
 	public abstract class Log : TextWriter, ILog {
 		public ILogs Logs { get; private set; }
 		public string Description { get; set; }
 		public bool Timestamp { get; set; } = true;
-
-		public static string XML_LOG = "XML log";
-		public static string NUNIT_RESULT = "NUnit results";
-		public static string SYSTEM_LOG = "System log";
-		public static string COMPANION_SYSTEM_LOG = "System log (companion)";
-		public static string BUILD_LOG = "Build log";
-		public static string TEST_LOG = "Test log";
-		public static string EXTENSION_TEST_LOG = "Extension test log";
-		public static string EXECUTION_LOG = "Execution log";
 
 		protected Log (ILogs logs)
 		{

--- a/tests/xharness/Logging/Log.cs
+++ b/tests/xharness/Logging/Log.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+namespace xharness.Logging {
+
+	public abstract class Log : TextWriter, ILog {
+		public ILogs Logs { get; private set; }
+		public string Description { get; set; }
+		public bool Timestamp { get; set; } = true;
+
+		public static string XML_LOG = "XML log";
+		public static string NUNIT_RESULT = "NUnit results";
+		public static string SYSTEM_LOG = "System log";
+		public static string COMPANION_SYSTEM_LOG = "System log (companion)";
+		public static string BUILD_LOG = "Build log";
+		public static string TEST_LOG = "Test log";
+		public static string EXTENSION_TEST_LOG = "Extension test log";
+		public static string EXECUTION_LOG = "Execution log";
+
+		protected Log (ILogs logs)
+		{
+			Logs = logs;
+		}
+
+		protected Log (ILogs logs, string description)
+		{
+			Logs = logs;
+			Description = description;
+		}
+
+		public abstract string FullPath { get; }
+
+		public virtual void WriteImpl (string value)
+		{
+			Write (Encoding.UTF8.GetBytes (value));
+		}
+
+		public virtual void Write (byte [] buffer)
+		{
+			Write (buffer, 0, buffer.Length);
+		}
+
+		public virtual void Write (byte [] buffer, int offset, int count)
+		{
+			throw new NotSupportedException ();
+		}
+
+		public virtual StreamReader GetReader ()
+		{
+			throw new NotSupportedException ();
+		}
+
+		public override void Write (char value)
+		{
+			WriteImpl (value.ToString ());
+		}
+
+		public override void Write (string value)
+		{
+			if (Timestamp)
+				value = DateTime.Now.ToString ("HH:mm:ss.fffffff") + " " + value;
+			WriteImpl (value);
+		}
+
+		public override void WriteLine (string value)
+		{
+			Write (value + "\n");
+		}
+
+		public void WriteLine (StringBuilder value)
+		{
+			Write (value.ToString () + "\n");
+		}
+		public override void WriteLine (string format, params object [] args)
+		{
+			Write (string.Format (format, args) + "\n");
+		}
+
+		public override string ToString ()
+		{
+			return Description;
+		}
+
+		public override void Flush ()
+		{
+		}
+
+		public override Encoding Encoding {
+			get {
+				return System.Text.Encoding.UTF8;
+			}
+		}
+
+		public static Log CreateAggregatedLog (params ILog [] logs)
+		{
+			return new AggregatedLog (logs);
+		}
+
+		// Log that will duplicate log output to multiple other logs.
+		class AggregatedLog : Log {
+			ILog [] logs;
+
+			public AggregatedLog (params ILog [] logs)
+				: base (null)
+			{
+				this.logs = logs;
+			}
+
+			public override string FullPath => throw new NotImplementedException ();
+
+			public override void WriteImpl (string value)
+			{
+				foreach (var log in logs)
+					log.WriteImpl (value);
+			}
+
+			public override void Write (byte [] buffer, int offset, int count)
+			{
+				foreach (var log in logs)
+					log.Write (buffer, offset, count);
+			}
+		}
+	}
+}

--- a/tests/xharness/Logging/Logs.cs
+++ b/tests/xharness/Logging/Logs.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 
-namespace xharness.Logging {
+namespace Xharness.Logging {
 	public class Logs : List<Log>, ILogs {
 		public string Directory { get; set; }
 

--- a/tests/xharness/Logging/Logs.cs
+++ b/tests/xharness/Logging/Logs.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace xharness.Logging {
+	public class Logs : List<Log>, ILogs {
+		public string Directory { get; set; }
+
+		public Logs (string directory)
+		{
+			Directory = directory;
+		}
+
+		// Create a new log backed with a file
+		public ILogFile Create (string filename, string name, bool? timestamp = null)
+		{
+			return Create (Directory, filename, name, timestamp);
+		}
+
+		LogFile Create (string directory, string filename, string name, bool? timestamp = null)
+		{
+			System.IO.Directory.CreateDirectory (directory);
+			var rv = new LogFile (this, name, Path.GetFullPath (Path.Combine (directory, filename)));
+			if (timestamp.HasValue)
+				rv.Timestamp = timestamp.Value;
+			Add (rv);
+			return rv;
+		}
+
+		// Adds an existing file to this collection of logs.
+		// If the file is not inside the log directory, then it's copied there.
+		// 'path' must be a full path to the file.
+		public ILogFile AddFile (string path)
+		{
+			return AddFile (path, Path.GetFileName (path));
+		}
+
+		// Adds an existing file to this collection of logs.
+		// If the file is not inside the log directory, then it's copied there.
+		// 'path' must be a full path to the file.
+		public ILogFile AddFile (string path, string name)
+		{
+			if (!path.StartsWith (Directory, StringComparison.Ordinal)) {
+				var newPath = Path.Combine (Directory, Path.GetFileNameWithoutExtension (path) + "-" + Harness.Timestamp + Path.GetExtension (path));
+				File.Copy (path, newPath, true);
+				path = newPath;
+			}
+
+			var log = new LogFile (this, name, path, true);
+			Add (log);
+			return log;
+		}
+
+		// Create an empty file in the log directory and return the full path to the file
+		public string CreateFile (string path, string description)
+		{
+			using (var rv = new LogFile (this, description, Path.Combine (Directory, path), false)) {
+				Add (rv);
+				return rv.FullPath;
+			}
+		}
+
+		public void Dispose ()
+		{
+			foreach (var log in this)
+				log.Dispose ();
+		}
+	}
+}

--- a/tests/xharness/MacTarget.cs
+++ b/tests/xharness/MacTarget.cs
@@ -5,7 +5,7 @@ using System.Xml;
 
 using Xamarin;
 
-namespace xharness
+namespace Xharness
 {
 	public class MacTarget : Target
 	{

--- a/tests/xharness/MakefileGenerator.cs
+++ b/tests/xharness/MakefileGenerator.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 
-namespace xharness
+namespace Xharness
 {
 	public static class MakefileGenerator
 	{

--- a/tests/xharness/MonoNativeInfo.cs
+++ b/tests/xharness/MonoNativeInfo.cs
@@ -29,7 +29,7 @@ using System.Xml;
 
 using Xamarin;
 
-namespace xharness
+namespace Xharness
 {
 	public enum MonoNativeFlavor
 	{

--- a/tests/xharness/Process_Extensions.cs
+++ b/tests/xharness/Process_Extensions.cs
@@ -8,9 +8,9 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Utils;
-using xharness.Logging;
+using Xharness.Logging;
 
-namespace xharness
+namespace Xharness
 {
 	public class ProcessExecutionResult
 	{

--- a/tests/xharness/Process_Extensions.cs
+++ b/tests/xharness/Process_Extensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Utils;
+using xharness.Logging;
 
 namespace xharness
 {
@@ -21,7 +22,7 @@ namespace xharness
 
 	public static class ProcessHelper
 	{
-		public static async Task<ProcessExecutionResult> ExecuteCommandAsync (string filename, IList<string> args, Log log, TimeSpan timeout, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null)
+		public static async Task<ProcessExecutionResult> ExecuteCommandAsync (string filename, IList<string> args, ILog log, TimeSpan timeout, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null)
 		{
 			using (var p = new Process ()) {
 				p.StartInfo.FileName = filename;
@@ -56,17 +57,26 @@ namespace xharness
 
 	public static class Process_Extensions
 	{
-		public static async Task<ProcessExecutionResult> RunAsync (this Process process, Log log, CancellationToken? cancellation_token = null, bool? diagnostics = null)
+		public static async Task<ProcessExecutionResult> RunAsync (this Process process, ILog log, CancellationToken? cancellation_token = null, bool? diagnostics = null)
 		{
 			return await RunAsync (process, log, log, log, cancellation_token: cancellation_token, diagnostics: diagnostics);
 		}
 
-		public static Task<ProcessExecutionResult> RunAsync (this Process process, Log log, bool append = true, TimeSpan? timeout = null, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null, bool? diagnostics = null)
+		public static Task<ProcessExecutionResult> RunAsync (this Process process, ILog log, bool append = true, TimeSpan? timeout = null, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null, bool? diagnostics = null)
 		{
 			return RunAsync (process, log, log, log, timeout, environment_variables, cancellation_token, diagnostics);
 		}
 
-		public static async Task<ProcessExecutionResult> RunAsync (this Process process, Log log, TextWriter StdoutStream, TextWriter StderrStream, TimeSpan? timeout = null, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null, bool? diagnostics = null)
+		public static Task<ProcessExecutionResult> RunAsync (this Process process, ILog log, ILog stdoutLog, ILog stderrLog, TimeSpan? timeout = null, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null, bool? diagnostics = null)
+		{
+			if (stdoutLog is TextWriter StdoutStream && stderrLog is TextWriter StderrStream) {
+				return RunAsync (process, log, StdoutStream, StderrStream, timeout, environment_variables, cancellation_token, diagnostics);
+			} else {
+				throw new ArgumentException ("Could not cast ILog to TextWriter.");
+			}
+		}
+
+		public static async Task<ProcessExecutionResult> RunAsync (this Process process, ILog log, TextWriter StdoutStream, TextWriter StderrStream, TimeSpan? timeout = null, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null, bool? diagnostics = null)
 		{
 			var stdout_completion = new TaskCompletionSource<bool> ();
 			var stderr_completion = new TaskCompletionSource<bool> ();
@@ -195,12 +205,12 @@ namespace xharness
 			}
 		}
 
-		public static Task KillTreeAsync (this Process @this, Log log, bool? diagnostics = true)
+		public static Task KillTreeAsync (this Process @this, ILog log, bool? diagnostics = true)
 		{
 			return KillTreeAsync (@this.Id, log, diagnostics);
 		}
 
-		public static async Task KillTreeAsync (int pid, Log log, bool? diagnostics = true)
+		public static async Task KillTreeAsync (int pid, ILog log, bool? diagnostics = true)
 		{
 			var pids = new List<int> ();
 			GetChildrenPS (log, pids, pid);
@@ -250,7 +260,7 @@ namespace xharness
 				ProcessHelper.kill (pids [i], 9);
 		}
 
-		static void GetChildrenPS (Log log, List<int> list, int pid)
+		static void GetChildrenPS (ILog log, List<int> list, int pid)
 		{
 			string stdout;
 

--- a/tests/xharness/Program.cs
+++ b/tests/xharness/Program.cs
@@ -2,11 +2,9 @@
 
 using Mono.Options;
 
-namespace xharness
-{
-	class MainClass
-	{
-		public static int Main (string[] args)
+namespace Xharness {
+	class MainClass {
+		public static int Main (string [] args)
 		{
 			var harness = new Harness ();
 

--- a/tests/xharness/ProjectFileExtensions.cs
+++ b/tests/xharness/ProjectFileExtensions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Xml;
 using Xamarin.Utils;
 
-namespace xharness
+namespace Xharness
 {
 	static class ProjectFileExtensions {
 		const string MSBuild_Namespace = "http://schemas.microsoft.com/developer/msbuild/2003";

--- a/tests/xharness/SimpleFileListener.cs
+++ b/tests/xharness/SimpleFileListener.cs
@@ -5,7 +5,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 
-namespace xharness
+namespace Xharness
 {
 	public class SimpleFileListener : SimpleListener
 	{

--- a/tests/xharness/SimpleHttpListener.cs
+++ b/tests/xharness/SimpleHttpListener.cs
@@ -4,7 +4,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 
-namespace xharness
+namespace Xharness
 {
 	public class SimpleHttpListener : SimpleListener
 	{

--- a/tests/xharness/SimpleListener.cs
+++ b/tests/xharness/SimpleListener.cs
@@ -4,9 +4,9 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using xharness.Logging;
+using Xharness.Logging;
 
-namespace xharness
+namespace Xharness
 {
 	public abstract class SimpleListener : IDisposable
 	{

--- a/tests/xharness/SimpleListener.cs
+++ b/tests/xharness/SimpleListener.cs
@@ -4,12 +4,13 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using xharness.Logging;
 
 namespace xharness
 {
 	public abstract class SimpleListener : IDisposable
 	{
-		Log output_writer;
+		ILog output_writer;
 		string xml_data;
 
 		TaskCompletionSource<bool> stopped = new TaskCompletionSource<bool> ();
@@ -17,8 +18,8 @@ namespace xharness
 
 		public IPAddress Address { get; set; }
 		public int Port { get; set; }
-		public Log Log { get; set; }
-		public Log TestLog { get; set; }
+		public ILog Log { get; set; }
+		public ILog TestLog { get; set; }
 		public bool AutoExit { get; set; }
 		public bool XmlOutput { get; set; }
 
@@ -30,7 +31,7 @@ namespace xharness
 		protected abstract void Start ();
 		protected abstract void Stop ();
 
-		public Log OutputWriter {
+		public ILog OutputWriter {
 			get {
 				return output_writer;
 			}

--- a/tests/xharness/SimpleTcpListener.cs
+++ b/tests/xharness/SimpleTcpListener.cs
@@ -5,7 +5,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 
-namespace xharness
+namespace Xharness
 {
 	public class SimpleTcpListener : SimpleListener
 	{

--- a/tests/xharness/Simulators.cs
+++ b/tests/xharness/Simulators.cs
@@ -10,9 +10,9 @@ using System.Threading.Tasks;
 using System.Xml;
 using Xamarin;
 using Xamarin.Utils;
-using xharness.Logging;
+using Xharness.Logging;
 
-namespace xharness
+namespace Xharness
 {
 	interface ILoadAsync {
 		Task LoadAsync (ILog log, bool include_locked, bool force);

--- a/tests/xharness/SolutionGenerator.cs
+++ b/tests/xharness/SolutionGenerator.cs
@@ -5,7 +5,7 @@ using System.Xml;
 using System.Text;
 using Xamarin;
 
-namespace xharness
+namespace Xharness
 {
 	public static class SolutionGenerator
 	{

--- a/tests/xharness/TVOSTarget.cs
+++ b/tests/xharness/TVOSTarget.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Xml;
 using Xamarin;
 
-namespace xharness
+namespace Xharness
 {
 	public class TVOSTarget : iOSTarget
 	{

--- a/tests/xharness/Target.cs
+++ b/tests/xharness/Target.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Xml;
 using Xamarin;
 
-namespace xharness
+namespace Xharness
 {
 	public abstract class Target
 	{

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using Xamarin;
 
-namespace xharness
+namespace Xharness
 {
 	public class TestProject
 	{

--- a/tests/xharness/TodayExtensionTarget.cs
+++ b/tests/xharness/TodayExtensionTarget.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Xml;
 using Xamarin;
 
-namespace xharness
+namespace Xharness
 {
 	public class TodayExtensionTarget : UnifiedTarget
 	{

--- a/tests/xharness/UnifiedTarget.cs
+++ b/tests/xharness/UnifiedTarget.cs
@@ -4,7 +4,7 @@ using System.Xml;
 
 using Xamarin;
 
-namespace xharness
+namespace Xharness
 {
 	public class UnifiedTarget : iOSTarget
 	{

--- a/tests/xharness/WatchOSTarget.cs
+++ b/tests/xharness/WatchOSTarget.cs
@@ -6,7 +6,7 @@ using System.Xml;
 using Xamarin;
 using Xamarin.Utils;
 
-namespace xharness
+namespace Xharness
 {
 	public class WatchOSTarget : iOSTarget
 	{

--- a/tests/xharness/Xharness.Tests/Tests/XmlResultParserTests.cs
+++ b/tests/xharness/Xharness.Tests/Tests/XmlResultParserTests.cs
@@ -5,9 +5,9 @@ using System.Linq;
 using System.Xml.Linq;
 using Moq;
 using NUnit.Framework;
-using xharness;
-using xharness.Logging;
-using static xharness.XmlResultParser;
+using Xharness;
+using Xharness.Logging;
+using static Xharness.XmlResultParser;
 
 namespace Xharness.Tests {
 

--- a/tests/xharness/Xharness.Tests/Tests/XmlResultParserTests.cs
+++ b/tests/xharness/Xharness.Tests/Tests/XmlResultParserTests.cs
@@ -3,15 +3,22 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using Moq;
 using NUnit.Framework;
 using xharness;
-
+using xharness.Logging;
 using static xharness.XmlResultParser;
 
 namespace Xharness.Tests {
 
 	[TestFixture]
 	public class XmlResultParserTests {
+
+		static Dictionary<XmlResultJargon, Action<string, string, string, string, string, string, string, int>> ValidationMap = new Dictionary<XmlResultJargon, Action<string, string, string, string, string, string, string, int>> {
+			[XmlResultJargon.NUnitV2] = ValidateNUnitV2Failure,
+			[XmlResultJargon.NUnitV3] = ValidateNUnitV3Failure,
+			[XmlResultJargon.xUnit] = ValidatexUnitFailure,
+		};
 
 		string CreateResultSample (XmlResultJargon jargon, bool includePing = false)
 		{
@@ -147,6 +154,146 @@ namespace Xharness.Tests {
 			var newPath = XmlResultParser.GetVSTSFilename (path);
 			StringAssert.StartsWith ("vsts-", Path.GetFileName (newPath));
 			File.Delete (path);
+		}
+
+		static void ValidateNUnitV2Failure (string src, string appName, string variation, string title, string message, string stderrMessage, string xmlPath, int _)
+		{
+			// load the doc and ensure that all the data is correct setup
+			var doc = XDocument.Load (xmlPath);
+			var testResultsNodes = doc.Descendants ().Where (e => e.Name == "test-results");
+			Assert.AreEqual (1, testResultsNodes.Count ());
+			var rootNode = testResultsNodes.FirstOrDefault ();
+			Assert.AreEqual (title, rootNode.Attribute ("name").Value, "title");
+			Assert.AreEqual ("1", rootNode.Attribute ("total").Value, "total");
+			Assert.AreEqual ("0", rootNode.Attribute ("errors").Value, "errors");
+			Assert.AreEqual ("1", rootNode.Attribute ("failures").Value, "failures");
+			// ensure we do have a test result with the failure data
+			var testResult = doc.Descendants ().Where (e => e.Name == "test-suite" && e.Attribute ("type").Value == "TestFixture");
+			Assert.AreEqual (1, testResult.Count (), "test results");
+		}
+
+		static void ValidateNUnitV3Failure (string src, string appName, string variation, string title, string message, string stderrMessage, string xmlPath, int attachemntsCount)
+		{
+			var doc = XDocument.Load (xmlPath);
+			// get test-run and verify attrs
+			var testResultNodes = doc.Descendants ().Where (e => e.Name == "test-run");
+			Assert.AreEqual (1, testResultNodes.Count (), "test-result");
+			var testResultNode = testResultNodes.FirstOrDefault ();
+			Assert.AreEqual (title, testResultNode.Attribute ("name").Value, "name");
+			Assert.AreEqual ("1", testResultNode.Attribute ("testcasecount").Value, "testcasecount");
+			Assert.AreEqual ("Failed", testResultNode.Attribute ("result").Value, "result");
+			Assert.AreEqual ("1", testResultNode.Attribute ("total").Value, "total");
+			Assert.AreEqual ("0", testResultNode.Attribute ("passed").Value, "passed");
+			Assert.AreEqual ("1", testResultNode.Attribute ("failed").Value, "failed");
+			Assert.AreEqual ("1", testResultNode.Attribute ("asserts").Value, "asserts");
+			// important attrs for the import, if they miss, we wont be able to add the files to vsts
+			Assert.IsNotNull (testResultNode.Attribute ("run-date").Value);
+			Assert.IsNotNull (testResultNode.Attribute ("start-time").Value);
+			// get the test-suite and verify the name and fullname are correct
+			var testSuite = testResultNode.Descendants ().Where (e => e.Name == "test-suite" && e.Attribute ("type").Value == "TestFixture").FirstOrDefault ();
+			Assert.IsNotNull (testSuite, "testSuite");
+			Assert.AreEqual (title, testSuite.Attribute ("name").Value, "test suite name");
+			Assert.AreEqual (title, testSuite.Attribute ("fullname").Value, "test suite full name");
+			// verify the test case
+			var testCase = testSuite.Descendants ().Where (e => e.Name == "test-case").FirstOrDefault ();
+			Assert.IsNotNull (testCase, "test case");
+			Assert.AreEqual ("Failed", testCase.Attribute ("result").Value, "test case result");
+			// validate that we do have attachments
+			var attachmentsNode = testCase.Descendants ().Where (e => e.Name == "attachments").FirstOrDefault ();
+			Assert.IsNotNull (attachmentsNode, "attachments");
+			var attachments = attachmentsNode.Descendants ().Where (e => e.Name == "attachment");
+			Assert.AreEqual (attachemntsCount, attachments.Count (), "attachments count");
+		}
+
+		static void ValidatexUnitFailure (string src, string appName, string variation, string title, string message, string stderrMessage, string xmlPath, int _)
+		{
+			var doc = XDocument.Load (xmlPath);
+			// get the assemlby and validate its attrs
+			var assemblies = doc.Descendants ().Where (e => e.Name == "assembly");
+			Assert.AreEqual (1, assemblies.Count (), "assemblies count");
+			var assemblyNode = assemblies.FirstOrDefault ();
+			Assert.AreEqual (title, assemblyNode.Attribute ("name").Value, "name");
+			Assert.AreEqual ("1", assemblyNode.Attribute ("total").Value, "total");
+			Assert.AreEqual ("1", assemblyNode.Attribute ("failed").Value, "failed");
+			Assert.AreEqual ("0", assemblyNode.Attribute ("passed").Value, "passed");
+			var collections = assemblyNode.Descendants ().Where (e => e.Name == "collection");
+			Assert.AreEqual (1, collections.Count (), "collections count");
+			var collectionNode = collections.FirstOrDefault ();
+			// assert the collection attrs
+			Assert.AreEqual ("1", collectionNode.Attribute ("failed").Value, "failed");
+			Assert.AreEqual ("0", collectionNode.Attribute ("passed").Value, "passed");
+		}
+
+		[TestCase (XmlResultJargon.NUnitV2)]
+		[TestCase (XmlResultJargon.NUnitV3)]
+		[TestCase (XmlResultJargon.xUnit)]
+		public void GenerateFailureTest (XmlResultJargon jargon)
+		{
+			var src = "test-case";
+			var appName = "MyUnitTest";
+			var variation = "Debug";
+			var title = "Testing";
+			var message = "This is a test";
+			var stderrMessage = "Something went very wrong";
+
+			var stderrPath = Path.GetTempFileName ();
+
+			// write the message in the stderrParh that should be read
+			using (var writer = new StreamWriter (stderrPath)) {
+				writer.WriteLine (stderrMessage);
+			}
+
+			// create a path with data in it
+			var logs = new Mock<ILogs> ();
+			var tmpLogMock = new Mock<ILogFile> ();
+			var xmlLogMock = new Mock<ILogFile> ();
+
+			var tmpPath = Path.GetTempFileName ();
+			var finalPath = Path.GetTempFileName ();
+
+			// create a number of fake logs to be added to the failure
+			var logsDir = Path.GetTempFileName ();
+			File.Delete (logsDir);
+			Directory.CreateDirectory (logsDir);
+			var failureLogs = new [] { "first.txt", "second.txt", "last.txt" };
+
+			foreach (var file in failureLogs) {
+				var path = Path.Combine (logsDir, file);
+				File.Create (path);
+			}
+
+			// expect the creation of the two diff xml file logs
+			_ = logs.Setup (l => l.Create (It.IsAny<string> (), "Failure Log tmp", null)).Returns (tmpLogMock.Object);
+			_ = logs.Setup (l => l.Create (It.IsAny<string> (), Log.XML_LOG, null)).Returns (xmlLogMock.Object);
+			if (jargon == XmlResultJargon.NUnitV3) {
+				_ = logs.Setup (l => l.Directory).Returns (logsDir);
+				_ = tmpLogMock.Setup (tmpLog => tmpLog.FullPath).Returns (tmpPath);
+
+			}
+
+			// return the two temp files so that we can later validate that everything is present
+			_ = xmlLogMock.Setup (xmlLog => xmlLog.FullPath).Returns (finalPath);
+
+			XmlResultParser.GenerateFailure (logs.Object, src, appName, variation, title, message, stderrPath, jargon);
+
+			// actual assertions do happen in the validation functions
+			ValidationMap [jargon] (src, appName, variation, title, message, stderrMessage, finalPath, failureLogs.Length);
+
+			// verify that we are correctly adding the logs
+			logs.Verify (l => l.Create (It.IsAny<string> (), It.IsAny<string> (), null), (jargon == XmlResultJargon.NUnitV3) ? Times.AtMost (2) : Times.AtMostOnce ());
+			if (jargon == XmlResultJargon.NUnitV3) {
+				logs.Verify (l => l.Directory, Times.Once);
+				tmpLogMock.Verify (l => l.FullPath, Times.AtLeastOnce);
+
+			}
+
+			xmlLogMock.Verify (l => l.FullPath, Times.AtLeastOnce);
+
+			// clean files
+			File.Delete (stderrPath);
+			File.Delete (tmpPath);
+			File.Delete (finalPath);
+			Directory.Delete (logsDir, true);
 		}
 	}
 }

--- a/tests/xharness/Xharness.Tests/Xharness.Tests.csproj
+++ b/tests/xharness/Xharness.Tests/Xharness.Tests.csproj
@@ -41,6 +41,12 @@
     <Reference Include="System.Threading.Tasks.Extensions">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="Castle.Core">
+      <HintPath>..\..\..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq">
+      <HintPath>..\..\..\packages\Moq.4.13.1\lib\net45\Moq.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\AppRunner.cs">
@@ -159,6 +165,21 @@
     <Compile Include="BCLTestImporter\Tests\TestAssemblyDefinitionTest.cs" />
     <Compile Include="BCLTestImporter\Tests\TestProjectDefinitionTest.cs" />
     <Compile Include="Tests\XmlResultParserTests.cs" />
+    <Compile Include="..\Logging\ILogs.cs">
+      <Link>Logging\ILogs.cs</Link>
+    </Compile>
+    <Compile Include="..\Logging\Logs.cs">
+      <Link>Logging\Logs.cs</Link>
+    </Compile>
+    <Compile Include="..\Logging\Log.cs">
+      <Link>Logging\Log.cs</Link>
+    </Compile>
+    <Compile Include="..\Logging\ILog.cs">
+      <Link>Logging\ILog.cs</Link>
+    </Compile>
+    <Compile Include="..\Logging\ILogFile.cs">
+      <Link>Logging\ILogFile.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -168,6 +189,7 @@
     <Folder Include="BCLTestImporter\Tests\" />
     <Folder Include="Tests\" />
     <Folder Include="Samples\" />
+    <Folder Include="Logging\" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Samples\NUnitV2Sample.xml" />

--- a/tests/xharness/Xharness.Tests/packages.config
+++ b/tests/xharness/Xharness.Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="4.4.0" targetFramework="net48" />
+  <package id="Moq" version="4.13.1" targetFramework="net48" />
   <package id="NUnit" version="3.12.0" targetFramework="net47" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net47" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net47" />

--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -4,9 +4,9 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
-using xharness.Logging;
+using Xharness.Logging;
 
-namespace xharness {
+namespace Xharness {
 
 	public enum XmlResultJargon {
 		TouchUnit,
@@ -743,7 +743,7 @@ namespace xharness {
 		{
 			// VSTS does not provide a nice way to report build errors, create a fake
 			// test result with a failure in the case the build did not work
-			var failureLogXml = logs.Create ($"vsts-nunit-{source}-{Harness.Timestamp}.xml", Log.XML_LOG);
+			var failureLogXml = logs.Create ($"vsts-nunit-{source}-{Harness.Timestamp}.xml", LogType.XmlLog.ToString ());
 			if (jargon == XmlResultJargon.NUnitV3) {
 				var failureXmlTmp = logs.Create ($"nunit-{source}-{Harness.Timestamp}.tmp", "Failure Log tmp");
 				GenerateFailureXml (failureXmlTmp.FullPath, title, message, stderrPath, jargon);

--- a/tests/xharness/iOSTarget.cs
+++ b/tests/xharness/iOSTarget.cs
@@ -3,7 +3,7 @@ using System.Xml;
 
 using Xamarin;
 
-namespace xharness
+namespace Xharness
 {
 	// iOS here means Xamarin.iOS, not iOS as opposed to tvOS/watchOS.
 	public class iOSTarget : Target

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -117,9 +117,15 @@
     <Compile Include="BCLTestImporter\BCLTestProjectGenerator.cs" />
     <Compile Include="BCLTestImporter\Platform.cs" />
     <Compile Include="BCLTestImporter\RegisterTypeGenerator.cs" />
+    <Compile Include="Logging\ILogs.cs" />
+    <Compile Include="Logging\Logs.cs" />
+    <Compile Include="Logging\Log.cs" />
+    <Compile Include="Logging\ILog.cs" />
+    <Compile Include="Logging\ILogFile.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="BCLTestImporter\" />
+    <Folder Include="Logging\" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="xharness.js">


### PR DESCRIPTION
Move to use interfaces, that will let us later add tests that will
verify that all the correct logging is performed. As an example, added a
test for XmlResultParser that ensures that the failures are correctly
generated. The test uses Moq to pass the different paths to be used and
later be able to verify the wirtten xml.