### PR TITLE
[monotouch-test] Improve NWBrowserTest.TestStateChangesHandler to not assert on background threads.

### DIFF
--- a/tests/monotouch-test/Network/NWBrowserTest.cs
+++ b/tests/monotouch-test/Network/NWBrowserTest.cs
@@ -94,6 +94,7 @@ namespace MonoTouchFixtures.Network {
 			bool firstRun = true;
 			bool eventsDone = false;
 			bool listeningDone = false;
+			Exception ex = null;
 			var changesEvent = new AutoResetEvent (false);
 			var browserReady = new AutoResetEvent (false);
 			var finalEvent = new AutoResetEvent (false);
@@ -108,16 +109,21 @@ namespace MonoTouchFixtures.Network {
 				browser.SetChangesHandler ((oldResult, newResult) => {
 					// first time, listener appears, so we do not have an old result, second time
 					// listener goes, so we do not have a new result
-					if (firstRun) {
-						Assert.IsNull (oldResult, "oldResult first run.");
-						Assert.IsNotNull (newResult, "newResult first run");
-						firstRun = false;
-					} else {
-						Assert.IsNotNull (oldResult, "oldResult first run.");
-						Assert.IsNull (newResult, "newResult first run");
+					try {
+						if (firstRun) {
+							Assert.IsNull (oldResult, "oldResult first run.");
+							Assert.IsNotNull (newResult, "newResult first run");
+							firstRun = false;
+						} else {
+							Assert.IsNotNull (oldResult, "oldResult first run.");
+							Assert.IsNull (newResult, "newResult first run");
+						}
+					} catch (Exception e) {
+						ex = e;
+					} finally {
+						changesEvent.Set ();
+						eventsDone = true;
 					}
-					changesEvent.Set ();
-					eventsDone = true;
 
 				});
 				browser.Start ();
@@ -152,6 +158,7 @@ namespace MonoTouchFixtures.Network {
 			finalEvent.WaitOne (30000);
 			Assert.IsTrue (eventsDone);
 			Assert.IsTrue (listeningDone);
+			Assert.IsNull (ex, "Exception");
 			browser.Cancel ();
 		}
 	}


### PR DESCRIPTION
Asserts will throw an exception when the assert fails, which will crash the
app if it happens on a background thread. So marshal any exceptions to the
main thread.

Solves this (by turning it into a normal NUnit assert failure):

    Unhandled Exception:
    NUnit.Framework.AssertionException:   newResult first run
      Expected: null
      But was:  <Network.NWBrowseResult>
    2020-02-28 19:47:41.214499-0500 monotouchtest[46412:20292304] Unhandled managed exception:   newResult first run
      Expected: null
      But was:  <Network.NWBrowseResult>
     (NUnit.Framework.AssertionException)

    =================================================================
    	Native Crash Reporting
    =================================================================
    Got a SIGABRT while executing native code. This usually indicates
    a fatal error in the mono runtime or one of the native libraries
    used by your application.
    =================================================================

    =================================================================
    	Native stacktrace:
    =================================================================
    	0x107c028c5 - /Users/builder/Library/Developer/CoreSimulator/Devices/E7C088E5-575C-42B7-ADFB-8144438C78A5/data/Containers/Bundle/Application/E3172E17-F6D2-4BC0-8770-379689518F78/monotouchtest.app/monotouchtest : mono_dump_native_crash_info
    	0x107bf6f85 - /Users/builder/Library/Developer/CoreSimulator/Devices/E7C088E5-575C-42B7-ADFB-8144438C78A5/data/Containers/Bundle/Application/E3172E17-F6D2-4BC0-8770-379689518F78/monotouchtest.app/monotouchtest : mono_handle_native_crash
    	0x107c01f1b - /Users/builder/Library/Developer/CoreSimulator/Devices/E7C088E5-575C-42B7-ADFB-8144438C78A5/data/Containers/Bundle/Application/E3172E17-F6D2-4BC0-8770-379689518F78/monotouchtest.app/monotouchtest : sigabrt_signal_handler
    	0x7fff40be642d - /Applications/Xcode113.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_platform.dylib : _sigtramp
    	0x7ff295501cb0 - Unknown
    	0x7fff40ad6a1c - /Applications/Xcode113.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_c.dylib : abort
    	0x107e3d33f - /Users/builder/Library/Developer/CoreSimulator/Devices/E7C088E5-575C-42B7-ADFB-8144438C78A5/data/Containers/Bundle/Application/E3172E17-F6D2-4BC0-8770-379689518F78/monotouchtest.app/monotouchtest : xamarin_unhandled_exception_handler.cold.1
    	0x107e30c09 - /Users/builder/Library/Developer/CoreSimulator/Devices/E7C088E5-575C-42B7-ADFB-8144438C78A5/data/Containers/Bundle/Application/E3172E17-F6D2-4BC0-8770-379689518F78/monotouchtest.app/monotouchtest : xamarin_unhandled_exception_handler
    	0x107cb7525 - /Users/builder/Library/Developer/CoreSimulator/Devices/E7C088E5-575C-42B7-ADFB-8144438C78A5/data/Containers/Bundle/Application/E3172E17-F6D2-4BC0-8770-379689518F78/monotouchtest.app/monotouchtest : mono_invoke_unhandled_exception_hook
    	0x107bf69ea - /Users/builder/Library/Developer/CoreSimulator/Devices/E7C088E5-575C-42B7-ADFB-8144438C78A5/data/Containers/Bundle/Application/E3172E17-F6D2-4BC0-8770-379689518F78/monotouchtest.app/monotouchtest : mono_handle_exception_internal
    	0x107bf4ed9 - /Users/builder/Library/Developer/CoreSimulator/Devices/E7C088E5-575C-42B7-ADFB-8144438C78A5/data/Containers/Bundle/Application/E3172E17-F6D2-4BC0-8770-379689518F78/monotouchtest.app/monotouchtest : mono_handle_exception
    	0x107b76019 - /Users/builder/Library/Developer/CoreSimulator/Devices/E7C088E5-575C-42B7-ADFB-8144438C78A5/data/Containers/Bundle/Application/E3172E17-F6D2-4BC0-8770-379689518F78/monotouchtest.app/monotouchtest : mono_amd64_throw_exception
    	0x1085c95b0 - Unknown
    	0x107e30a25 - /Users/builder/Library/Developer/CoreSimulator/Devices/E7C088E5-575C-42B7-ADFB-8144438C78A5/data/Containers/Bundle/Application/E3172E17-F6D2-4BC0-8770-379689518F78/monotouchtest.app/monotouchtest : xamarin_process_managed_exception
    	0x107bf671e - /Users/builder/Library/Developer/CoreSimulator/Devices/E7C088E5-575C-42B7-ADFB-8144438C78A5/data/Containers/Bundle/Application/E3172E17-F6D2-4BC0-8770-379689518F78/monotouchtest.app/monotouchtest : mono_handle_exception_internal
    	0x107bf4ed9 - /Users/builder/Library/Developer/CoreSimulator/Devices/E7C088E5-575C-42B7-ADFB-8144438C78A5/data/Containers/Bundle/Application/E3172E17-F6D2-4BC0-8770-379689518F78/monotouchtest.app/monotouchtest : mono_handle_exception
    	0x107b76019 - /Users/builder/Library/Developer/CoreSimulator/Devices/E7C088E5-575C-42B7-ADFB-8144438C78A5/data/Containers/Bundle/Application/E3172E17-F6D2-4BC0-8770-379689518F78/monotouchtest.app/monotouchtest : mono_amd64_throw_exception
    	0x1085c95b0 - Unknown
    	0x11aed4ceb - Unknown
    	0x7fff3fa7ecfe - /Applications/Xcode113.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libnetwork.dylib : nw_parallel_array_apply_with_range
    	0x7fff3f975077 - /Applications/Xcode113.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libnetwork.dylib : __nw_browser_notify_browse_result_changes_locked_block_invoke.100
    	0x7fff409c9848 - /Applications/Xcode113.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libdispatch.dylib : _dispatch_call_block_and_release
    	0x7fff409ca7b9 - /Applications/Xcode113.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libdispatch.dylib : _dispatch_client_callout
    	0x7fff409d9d69 - /Applications/Xcode113.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libdispatch.dylib : _dispatch_root_queue_drain
    	0x7fff409da39b - /Applications/Xcode113.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libdispatch.dylib : _dispatch_worker_thread2
    	0x7fff40bee6b6 - /Applications/Xcode113.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_pthread.dylib : _pthread_wqthread
    	0x7fff40bed827 - /Applications/Xcode113.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_pthread.dylib : start_wqthread