### PR TITLE
[bgen] Don't use assembly identity to identify attributes.

### DIFF
--- a/src/Resources.Designer.cs
+++ b/src/Resources.Designer.cs
@@ -712,5 +712,11 @@ namespace bgen {
                 return ResourceManager.GetString("BI1118", resourceCulture);
             }
         }
+        
+        internal static string BI1119 {
+            get {
+                return ResourceManager.GetString("BI1119", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -893,4 +893,11 @@
 		<comment>
 		</comment>
 	</data>
+
+	<data name="BI1119" xml:space="preserve">
+		<value>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</value>
+		<comment>
+		</comment>
+	</data>
 </root>

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -463,10 +463,10 @@ public class BindingTouch {
 			Frameworks = new Frameworks (CurrentPlatform);
 
 			Assembly corlib_assembly = universe.LoadFile (LocateAssembly ("mscorlib"));
-			Assembly platform_assembly = baselib;
-			Assembly system_assembly = universe.LoadFile (LocateAssembly ("System"));
-			Assembly binding_assembly = universe.LoadFile (GetAttributeLibraryPath ());
-			TypeManager.Initialize (this, api, corlib_assembly, platform_assembly, system_assembly, binding_assembly);
+			// Explicitly load our attribute library so that IKVM doesn't try (and fail) to find it.
+			universe.LoadFile (GetAttributeLibraryPath ());
+
+			TypeManager.Initialize (this, api, corlib_assembly, baselib);
 
 			foreach (var linkWith in AttributeManager.GetCustomAttributes<LinkWithAttribute> (api)) {
 				if (!linkwith.Contains (linkWith.LibraryName)) {

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -57,6 +57,11 @@ public class BindingTouch {
 	public Frameworks Frameworks;
 	public AttributeManager AttributeManager;
 
+	readonly Dictionary<System.Type, Type> ikvm_type_lookup = new Dictionary<System.Type, Type> ();
+	internal Dictionary<System.Type, Type> IKVMTypeLookup {
+		get { return ikvm_type_lookup;  }
+	}
+
 	public TargetFramework TargetFramework {
 		get { return target_framework.Value; }
 	}

--- a/src/generator-attribute-manager.cs
+++ b/src/generator-attribute-manager.cs
@@ -199,10 +199,11 @@ public class AttributeManager
 		return rv;
 	}
 
-	static Dictionary<System.Type, Type> ikvm_type_lookup = new Dictionary<System.Type, Type> ();
 	// This method gets the IKVM.Reflection.Type for a System.Type.
 	Type ConvertType (System.Type type, ICustomAttributeProvider provider)
 	{
+		var ikvm_type_lookup = BindingTouch.IKVMTypeLookup;
+
 		if (!ikvm_type_lookup.TryGetValue (type, out var rv)) {
 			// Brute force: look everywhere.
 			// Due to how types move around between assemblies in .NET 5 it gets complicated

--- a/src/generator-attribute-manager.cs
+++ b/src/generator-attribute-manager.cs
@@ -15,58 +15,215 @@ public class AttributeManager
 		BindingTouch = binding_touch;
 	}
 
+	System.Type LookupReflectionType (string fullname, ICustomAttributeProvider provider)
+	{
+		switch (fullname) {
+		case "AbstractAttribute":
+			return typeof (AbstractAttribute);
+		case "AlignAttribute":
+			return typeof (AlignAttribute);
+		case "AppearanceAttribute":
+			return typeof (AppearanceAttribute);
+		case "AsyncAttribute":
+			return typeof (AsyncAttribute);
+		case "AutoreleaseAttribute":
+			return typeof (AutoreleaseAttribute);
+		case "BaseTypeAttribute":
+			return typeof (BaseTypeAttribute);
+		case "BindAttribute":
+			return typeof (BindAttribute);
+		case "CategoryAttribute":
+			return typeof (CategoryAttribute);
+		case "CheckDisposedAttribute":
+			return typeof (CheckDisposedAttribute);
+		case "CoreImageFilterAttribute":
+			return typeof (CoreImageFilterAttribute);
+		case "CoreImageFilterPropertyAttribute":
+			return typeof (CoreImageFilterPropertyAttribute);
+		case "DefaultCtorVisibilityAttribute":
+			return typeof (DefaultCtorVisibilityAttribute);
+		case "DefaultEnumValueAttribute":
+			return typeof (DefaultEnumValueAttribute);
+		case "DefaultValueAttribute":
+			return typeof (DefaultValueAttribute);
+		case "DefaultValueFromArgumentAttribute":
+			return typeof (DefaultValueFromArgumentAttribute);
+		case "DelegateApiNameAttribute":
+			return typeof (DelegateApiNameAttribute);
+		case "DelegateNameAttribute":
+			return typeof (DelegateNameAttribute);
+		case "DesignatedInitializerAttribute":
+			return typeof (DesignatedInitializerAttribute);
+		case "DisableDefaultCtorAttribute":
+			return typeof (DisableDefaultCtorAttribute);
+		case "DisposeAttribute":
+			return typeof (DisposeAttribute);
+		case "ErrorDomainAttribute":
+			return typeof (ErrorDomainAttribute);
+		case "EventArgsAttribute":
+			return typeof (EventArgsAttribute);
+		case "EventNameAttribute":
+			return typeof (EventNameAttribute);
+		case "ForcedTypeAttribute":
+			return typeof (ForcedTypeAttribute);
+		case "Foundation.AdviceAttribute":
+			return typeof (Foundation.AdviceAttribute);
+		case "Foundation.ExportAttribute":
+			return typeof (Foundation.ExportAttribute);
+		case "Foundation.FieldAttribute":
+			return typeof (Foundation.FieldAttribute);
+		case "Foundation.ModelAttribute":
+			return typeof (Foundation.ModelAttribute);
+		case "Foundation.NotImplementedAttribute":
+			return typeof (Foundation.NotImplementedAttribute);
+		case "Foundation.ProtocolAttribute":
+			return typeof (Foundation.ProtocolAttribute);
+		case "IgnoredInDelegateAttribute":
+			return typeof (IgnoredInDelegateAttribute);
+		case "InternalAttribute":
+			return typeof (InternalAttribute);
+		case "ManualAttribute":
+			return typeof (ManualAttribute);
+		case "MarshalDirectiveAttribute":
+			return typeof (MarshalDirectiveAttribute);
+		case "MarshalNativeExceptionsAttribute":
+			return typeof (MarshalNativeExceptionsAttribute);
+		case "NewAttribute":
+			return typeof (NewAttribute);
+		case "NoDefaultValueAttribute":
+			return typeof (NoDefaultValueAttribute);
+		case "NoMethodAttribute":
+			return typeof (NoMethodAttribute);
+		case "NotificationAttribute":
+			return typeof (NotificationAttribute);
+		case "NullAllowedAttribute":
+			return typeof (NullAllowedAttribute);
+		case "ObjCRuntime.ArgumentSemantic":
+			return typeof (ObjCRuntime.ArgumentSemantic);
+		case "ObjCRuntime.BindAsAttribute":
+			return typeof (ObjCRuntime.BindAsAttribute);
+		case "ObjCRuntime.DeprecatedAttribute":
+			return typeof (ObjCRuntime.DeprecatedAttribute);
+		case "ObjCRuntime.IntroducedAttribute":
+			return typeof (ObjCRuntime.IntroducedAttribute);
+		case "ObjCRuntime.NativeAttribute":
+			return typeof (ObjCRuntime.NativeAttribute);
+		case "ObjCRuntime.ObsoletedAttribute":
+			return typeof (ObjCRuntime.ObsoletedAttribute);
+		case "ObjCRuntime.PlatformArchitecture":
+			return typeof (ObjCRuntime.PlatformArchitecture);
+		case "ObjCRuntime.PlatformName":
+			return typeof (ObjCRuntime.PlatformName);
+		case "ObjCRuntime.RequiresSuperAttribute":
+			return typeof (ObjCRuntime.RequiresSuperAttribute);
+		case "ObjCRuntime.UnavailableAttribute":
+			return typeof (ObjCRuntime.UnavailableAttribute);
+		case "OptionalImplementationAttribute":
+			return typeof (OptionalImplementationAttribute);
+		case "OverrideAttribute":
+			return typeof (OverrideAttribute);
+		case "PostGetAttribute":
+			return typeof (PostGetAttribute);
+		case "PostSnippetAttribute":
+			return typeof (PostSnippetAttribute);
+		case "PreSnippetAttribute":
+			return typeof (PreSnippetAttribute);
+		case "PrivateDefaultCtorAttribute":
+			return typeof (PrivateDefaultCtorAttribute);
+		case "ProtectedAttribute":
+			return typeof (ProtectedAttribute);
+		case "ProtocolizeAttribute":
+			return typeof (ProtocolizeAttribute);
+		case "SealedAttribute":
+			return typeof (SealedAttribute);
+		case "StaticAttribute":
+			return typeof (StaticAttribute);
+		case "StrongDictionaryAttribute":
+			return typeof (StrongDictionaryAttribute);
+		case "System.Boolean":
+			return typeof (System.Boolean);
+		case "System.ComponentModel.EditorBrowsableAttribute":
+			return typeof (System.ComponentModel.EditorBrowsableAttribute);
+		case "System.ComponentModel.EditorBrowsableState":
+			return typeof (System.ComponentModel.EditorBrowsableState);
+		case "System.Diagnostics.DebuggerBrowsableAttribute":
+			return typeof (System.Diagnostics.DebuggerBrowsableAttribute);
+		case "System.Diagnostics.DebuggerBrowsableState":
+			return typeof (System.Diagnostics.DebuggerBrowsableState);
+		case "System.Int32":
+			return typeof (System.Int32);
+		case "System.Object":
+			return typeof (System.Object);
+		case "System.ObsoleteAttribute":
+			return typeof (System.ObsoleteAttribute);
+		case "System.Runtime.InteropServices.FieldOffsetAttribute":
+			return typeof (System.Runtime.InteropServices.FieldOffsetAttribute);
+		case "System.Runtime.InteropServices.MarshalAsAttribute":
+			return typeof (System.Runtime.InteropServices.MarshalAsAttribute);
+		case "System.Runtime.InteropServices.UnmanagedType":
+			return typeof (System.Runtime.InteropServices.UnmanagedType);
+		case "System.String":
+			return typeof (System.String);
+		case "ThreadSafeAttribute":
+			return typeof (ThreadSafeAttribute);
+		case "TransientAttribute":
+			return typeof (TransientAttribute);
+		case "UnifiedInternalAttribute":
+			return typeof (UnifiedInternalAttribute);
+		case "Visibility":
+			return typeof (Visibility);
+		case "WrapAttribute":
+			return typeof (WrapAttribute);
+		}
+
+		switch (fullname) {
+		case "ObjCRuntime.iOSAttribute":
+		case "ObjCRuntime.LionAttribute":
+		case "ObjCRuntime.AvailabilityAttribute":
+		case "ObjCRuntime.MacAttribute":
+		case "ObjCRuntime.SinceAttribute":
+		case "ObjCRuntime.MountainLionAttribute":
+		case "ObjCRuntime.MavericksAttribute":
+			throw ErrorHelper.CreateError (1061, fullname, Generator.FormatProvider (provider));
+		}
+
+		return null;
+	}
+
 	// This method gets the System.Type for a IKVM.Reflection.Type to a System.Type.
-	// It knows about our mock attribute logic, so it will return the corresponding non-mocked System.Type for a mocked IKVM.Reflection.Type.
 	System.Type ConvertType (Type type, ICustomAttributeProvider provider)
 	{
-		System.Type rv;
-		if (type.Assembly == TypeManager.CorlibAssembly) {
-			rv = typeof (int).Assembly.GetType (type.FullName);
-		} else if (type.Assembly == TypeManager.SystemAssembly) {
-			rv = typeof (System.ComponentModel.EditorBrowsableAttribute).Assembly.GetType (type.FullName);
-		} else if (type.Assembly == TypeManager.BindingAssembly) {
-			// Types (attributes) in the binding assembly are mocked in the generator itself.
-			rv = typeof (TypeManager).Assembly.GetType (type.FullName);
-		} else if (type.Assembly == TypeManager.PlatformAssembly) {
-			// Types (attributes) in the platform assemblies are mocked in the generator itself.
-
-			switch (type.FullName) {
-			case "ObjCRuntime.iOSAttribute":
-			case "ObjCRuntime.LionAttribute":
-			case "ObjCRuntime.AvailabilityAttribute":
-			case "ObjCRuntime.MacAttribute":
-			case "ObjCRuntime.SinceAttribute":
-			case "ObjCRuntime.MountainLionAttribute":
-			case "ObjCRuntime.MavericksAttribute":
-				throw ErrorHelper.CreateError (1061,type.FullName, Generator.FormatProvider (provider));
-			}
-
-			rv = typeof (TypeManager).Assembly.GetType (type.FullName);
-		} else {
-			throw ErrorHelper.CreateError (1054, type.AssemblyQualifiedName);
-		}
+		var rv = LookupReflectionType (type.FullName, provider);
 		if (rv == null)
 			throw ErrorHelper.CreateError (1055, type.AssemblyQualifiedName);
 		return rv;
 	}
 
+	static Dictionary<System.Type, Type> ikvm_type_lookup = new Dictionary<System.Type, Type> ();
 	// This method gets the IKVM.Reflection.Type for a System.Type.
-	// It knows about our mock attribute logic, so it will return the mocked IKVM.Reflection.Type for a mocked System.Type.
 	Type ConvertType (System.Type type, ICustomAttributeProvider provider)
 	{
-		Type rv;
-		if (type.Assembly == typeof (int).Assembly) {
-			rv = TypeManager.CorlibAssembly.GetType (type.FullName);
-		} else if (type.Assembly == typeof (System.ComponentModel.EditorBrowsableAttribute).Assembly) {
-			rv = TypeManager.SystemAssembly.GetType (type.FullName);
-		} else if (type.Assembly == typeof (TypeManager).Assembly) {
-			// Types (attributes) in the generator are mocked types from
-			// either the binding assembly or the platform assembly.
-			rv = TypeManager.BindingAssembly.GetType (type.FullName);
-			if (rv == null)
-				rv = TypeManager.PlatformAssembly.GetType (type.FullName);
-		} else {
-			throw ErrorHelper.CreateError (1054, type.AssemblyQualifiedName);
+		if (!ikvm_type_lookup.TryGetValue (type, out var rv)) {
+			// Brute force: look everywhere.
+			// Due to how types move around between assemblies in .NET 5 it gets complicated
+			// to figure out which assembly each type comes from, so just look in every assembly.
+			// Report a warning if we find the same type in multiple assemblies though.
+			var assemblies = BindingTouch.universe.GetAssemblies ();
+			foreach (var asm in assemblies) {
+				var lookup = asm.FindType (new TypeName (type.Namespace, type.Name));
+				if (lookup == null)
+					continue;
+				if (lookup.Assembly != asm) {
+					// Apparently looking for type X in assembly A can return type X from assembly B... ignore those.
+					continue;
+				}
+				if (rv != null) {
+					ErrorHelper.Warning (1119, /*"Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.", */type.FullName, rv.AssemblyQualifiedName, lookup.AssemblyQualifiedName);
+					break; // no need to report this more than once
+				}
+				rv = lookup;
+			}
+			ikvm_type_lookup [type] = rv;
 		}
 		if (rv == null)
 			throw ErrorHelper.CreateError (1055, type.AssemblyQualifiedName);

--- a/src/generator-attribute-manager.cs
+++ b/src/generator-attribute-manager.cs
@@ -76,8 +76,12 @@ public class AttributeManager
 			return typeof (Foundation.ModelAttribute);
 		case "Foundation.NotImplementedAttribute":
 			return typeof (Foundation.NotImplementedAttribute);
+		case "Foundation.PreserveAttribute":
+			return typeof (Foundation.PreserveAttribute);
 		case "Foundation.ProtocolAttribute":
 			return typeof (Foundation.ProtocolAttribute);
+		case "Foundation.RegisterAttribute":
+			return typeof (Foundation.RegisterAttribute);
 		case "IgnoredInDelegateAttribute":
 			return typeof (IgnoredInDelegateAttribute);
 		case "InternalAttribute":
@@ -102,6 +106,10 @@ public class AttributeManager
 			return typeof (ObjCRuntime.ArgumentSemantic);
 		case "ObjCRuntime.BindAsAttribute":
 			return typeof (ObjCRuntime.BindAsAttribute);
+		case "ObjCRuntime.BindingImplAttribute":
+			return typeof (ObjCRuntime.BindingImplAttribute);
+		case "ObjCRuntime.BindingImplOptions":
+			return typeof (ObjCRuntime.BindingImplOptions);
 		case "ObjCRuntime.DeprecatedAttribute":
 			return typeof (ObjCRuntime.DeprecatedAttribute);
 		case "ObjCRuntime.IntroducedAttribute":

--- a/src/generator-typemanager.cs
+++ b/src/generator-typemanager.cs
@@ -115,25 +115,6 @@ public class TypeManager {
 	Assembly api_assembly;
 	Assembly corlib_assembly;
 	Assembly platform_assembly;
-	Assembly system_assembly;
-	Assembly binding_assembly;
-
-	public Assembly CorlibAssembly {
-		get { return corlib_assembly; }
-	}
-
-	public Assembly PlatformAssembly {
-		get { return platform_assembly; }
-		set { platform_assembly = value; }
-	}
-
-	public Assembly SystemAssembly {
-		get { return system_assembly; }
-	}
-
-	public Assembly BindingAssembly {
-		get { return binding_assembly; }
-	}
 
 	Type Lookup (Assembly assembly, string @namespace, string @typename, bool inexistentOK = false)
 	{
@@ -179,15 +160,13 @@ public class TypeManager {
 		return type.GetEnumUnderlyingType ();
 	}
 
-	public void Initialize (BindingTouch binding_touch, Assembly api, Assembly corlib, Assembly platform, Assembly system, Assembly binding)
+	public void Initialize (BindingTouch binding_touch, Assembly api, Assembly corlib, Assembly platform)
 	{
 		BindingTouch = binding_touch;
 
 		api_assembly = api;
 		corlib_assembly = corlib;
 		platform_assembly = platform;
-		system_assembly = system;
-		binding_assembly = binding;
 
 		/* corlib */
 		System_Attribute = Lookup (corlib_assembly, "System", "Attribute");

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -879,6 +879,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="BI1119">
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -879,6 +879,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="BI1119">
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -879,6 +879,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="BI1119">
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -879,6 +879,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="BI1119">
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -879,6 +879,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="BI1119">
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -879,6 +879,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="BI1119">
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -879,6 +879,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="BI1119">
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -879,6 +879,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="BI1119">
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -879,6 +879,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="BI1119">
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -879,6 +879,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="BI1119">
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -879,6 +879,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="BI1119">
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -879,6 +879,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="BI1119">
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -879,6 +879,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="BI1119">
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>


### PR DESCRIPTION
Don't use assembly identity when converting between reflected attributes and
instantiated attributes, because types will move to different assemblies in
.NET 5, and the code to keep track of everything ends up being complicated if
we were to verify assembly identity for each attribute type.

So don't verify assembly identity anymore.

When converting from IKVM.Reflection.Type to System.Type we can just create a
big switch statement with typeof expressions as the result, and let the C#
compiler figure out where those typeof types come from.

When converting from System.Type to IKVM.Reflection.Type we now look in all
the loaded assemblies in IKVM for the type name. To try to prevent unpleasant
surprises, we verify that any particular typename is only findable once (this
seems obvious, but this check actually found a bug in IKVM when loading .NET 5
assemblies - which will be fixed in a different PR).

Also this allowed us to remove some code to manually load assemblies we needed
to know about (since now we don't need to know about those assemblies
anymore).

An additional bonus is that this seems to be slightly faster too (a clean
build in src/ takes 1m33s instead of 1m39s).