### PR TITLE
[tests][monotouch-test] Tweak UIWebView tests to work in every case

### DIFF
--- a/tests/monotouch-test/UIKit/WebViewTest.cs
+++ b/tests/monotouch-test/UIKit/WebViewTest.cs
@@ -2,9 +2,6 @@
 
 #if !__TVOS__ && !__WATCHOS__ && !MONOMAC
 
-// in release mode xharness tests with all optimizations which removes UIWebView and make this crash
-#if DEBUG
-
 using System;
 using System.Drawing;
 #if XAMCORE_2_0
@@ -31,6 +28,13 @@ namespace MonoTouchFixtures.UIKit {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class WebViewTest {
+
+		[TestFixtureSetUp]
+		public void Setup ()
+		{
+			if (Type.GetType ("UIKit.DeprecatedWebView, Xamarin.iOS") != null)
+				Assert.Ignore ("All type references to UIWebView were removed (optimized).");
+		}
 		
 		[Test]
 		public void InitWithFrame ()
@@ -56,7 +60,5 @@ namespace MonoTouchFixtures.UIKit {
 	}
 
 }
-
-#endif // DEBUG
 
 #endif // !__TVOS__ && !__WATCHOS__


### PR DESCRIPTION
so if we optimize (to remove references) the tests will be ignored.
Doing this based on define was wrong since we have different (and more)
configurations executed on devices,