### PR TITLE
[Harness] Increase the timeout on iOS32b devices.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -3729,6 +3729,11 @@ namespace Xharness
 						CompanionDevice = Jenkins.Devices.FindCompanionDevice (Jenkins.DeviceLoadLog, Device);
 					Jenkins.MainLog.WriteLine ("Acquired device '{0}' for '{1}'", Device.Name, ProjectFile);
 
+					var multiplier = TimeoutMultiplier;
+					// ios 32b is slow and we need more time to run the tests.
+					if (BuildTask.Platform == TestPlatform.iOS_Unified32)
+						multiplier *= 2;
+
 					runner = new AppRunner
 					{
 						Harness = Harness,
@@ -3739,7 +3744,7 @@ namespace Xharness
 						DeviceName = Device.Name,
 						CompanionDeviceName = CompanionDevice?.Name,
 						Configuration = ProjectConfiguration,
-						TimeoutMultiplier = TimeoutMultiplier,
+						TimeoutMultiplier = multiplier,
 						Variation = Variation,
 						BuildTask = BuildTask,
 					};


### PR DESCRIPTION
Double the timeout (via a multiplier) when running tests on a iOS 32b
device. This is done because devices are slow and test keep timing out.