### PR TITLE
[mtouch] Add `force-rejected-types-removal` optimization (#8009)

### DIFF
--- a/docs/website/optimizations.md
+++ b/docs/website/optimizations.md
@@ -769,3 +769,24 @@ a product assembly and does not automagically mark all `NSObject`
 subclasses. This allows additional removes and optimizations to be 
 applied to the assembly, including the ability to remove `UIWebView` if
 nothing else in the application requires it.
+
+## Force Rejected Types Removal
+
+This optimization can be enabled when it's not possible to use the 
+managed linker (e.g. **Don't link**) or when the managed linker cannot
+remove references to deprecated types that would cause an application
+to be rejected by Apple.
+
+References to the existing types will be renamed, e.g. `UIWebView` to 
+`DeprecatedWebView`, in every assemblies.
+
+The type definition is also renamed (for validity) and all custom 
+attributes on the types and their members will be removed. 
+Code inside the members will be replaced with a
+`throw new NotSupportedException ();`.
+
+The default behavior can be overridden by passing
+`--optimize=[+|-]force-rejected-types-removal` to `mtouch`.
+
+The exact list of types might change over time and is best read directly from
+the [source code](https://github.com/xamarin/xamarin-macios/blob/master/tools/linker/RemoveRejectedTypesStep.cs).

--- a/msbuild/tests/MyReleaseBuild/MyReleaseBuild.csproj
+++ b/msbuild/tests/MyReleaseBuild/MyReleaseBuild.csproj
@@ -28,6 +28,7 @@
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
+    <MtouchExtraArgs>--optimize=force-rejected-types-removal</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>pdbonly</DebugType>
@@ -43,6 +44,7 @@
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
+    <MtouchExtraArgs>--optimize=force-rejected-types-removal</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>pdbonly</DebugType>
@@ -56,6 +58,7 @@
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
+    <MtouchExtraArgs>--optimize=force-rejected-types-removal</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -76,6 +79,7 @@
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
+    <MtouchExtraArgs>--optimize=force-rejected-types-removal</MtouchExtraArgs>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/msbuild/tests/MyReleaseBuild/ViewController.cs
+++ b/msbuild/tests/MyReleaseBuild/ViewController.cs
@@ -39,7 +39,25 @@ namespace MyReleaseBuild
 		public override void ViewDidLoad ()
 		{
 			base.ViewDidLoad ();
-			// Perform any additional setup after loading the view, typically from a nib.
+			try {
+				// always false - not likely to be optimized away by compilers
+				if (DateTime.UtcNow.Ticks < 0)
+					Add (new UIWebView ());
+
+				// look for non-existing type - it should be there to replace UIWebView
+				var t = Type.GetType ("UIKit.DeprecatedWebView, Xamarin.iOS");
+				if (t == null) {
+					View.BackgroundColor = UIColor.Red;
+					Console.WriteLine ("FAIL");
+				} else {
+					View.BackgroundColor = UIColor.Green;
+					Console.WriteLine ("OK");
+				}
+			} catch (NotSupportedException e) {
+				// linked away (code replaced by the linker)
+				View.BackgroundColor = UIColor.Orange;
+				Console.WriteLine ($"FAIL {e}");
+			}
 		}
 
 		public override void DidReceiveMemoryWarning ()

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ReleaseBuild.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ReleaseBuild.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading;
 
 using NUnit.Framework;
+using Xamarin.Tests;
 
 namespace Xamarin.iOS.Tasks
 {
@@ -18,6 +19,10 @@ namespace Xamarin.iOS.Tasks
 		public void BuildTest ()
 		{
 			BuildProject ("MyReleaseBuild", Platform, "Release");
+
+			var args = new List<string> { "-r", "UIWebView", AppBundlePath };
+			ExecutionHelper.Execute ("grep", args, out var output);
+			Assert.That (output.ToString (), Is.Empty, "UIWebView");
 		}
 
 		[Ignore] // requires msbuild instead of xbuild

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ReleaseBuild.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ReleaseBuild.cs
@@ -20,8 +20,7 @@ namespace Xamarin.iOS.Tasks
 		{
 			BuildProject ("MyReleaseBuild", Platform, "Release");
 
-			var args = new List<string> { "-r", "UIWebView", AppBundlePath };
-			ExecutionHelper.Execute ("grep", args, out var output);
+			ExecutionHelper.Execute ("grep", $"-r UIWebView {AppBundlePath}", out var output);
 			Assert.That (output.ToString (), Is.Empty, "UIWebView");
 		}
 

--- a/tests/introspection/ApiBaseTest.cs
+++ b/tests/introspection/ApiBaseTest.cs
@@ -184,6 +184,24 @@ namespace Introspection {
 			return property != null && SkipDueToAttribute (property);
 		}
 
+		protected bool SkipDueToRejectedTypes (Type type)
+		{
+			switch (type.FullName) {
+			case "UIKit.DeprecatedWebView+_DeprecatedWebViewDelegate":
+			case "UIKit.DeprecatedWebView+DeprecatedWebViewAppearance":
+				return true;
+			case "UIKit.IDeprecatedWebViewDelegate":
+			case "UIKit.DeprecatedWebView":
+			case "UIKit.DeprecatedWebViewDelegate":
+			case "UIKit.DeprecatedWebViewDelegate_Extensions":
+			case "UIKit.DeprecatedWebViewDelegateWrapper":
+			case "UIKit.DeprecatedWebViewNavigationType":
+				return true;
+			default:
+				return false;
+			}
+		}
+
 		/// <summary>
 		/// Gets the assembly on which the test fixture will reflect the NSObject-derived types.
 		/// The default implementation returns the assembly where NSObject is defined, e.g.

--- a/tests/introspection/ApiClassPtrTest.cs
+++ b/tests/introspection/ApiClassPtrTest.cs
@@ -38,6 +38,11 @@ namespace Introspection {
 				if (ca is ModelAttribute)
 					return true;
 			}
+
+			// skip types that we renamed / rewrite since they won't behave correctly (by design)
+			if (SkipDueToRejectedTypes (type))
+				return true;
+
 			return SkipDueToAttribute (type);
 		}
 

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -140,6 +140,9 @@ namespace Introspection {
 				return true; // WatchKit has been removed from iOS.
 			}
 #endif
+			// skip types that we renamed / rewrite since they won't behave correctly (by design)
+			if (SkipDueToRejectedTypes (type))
+				return true;
 
 			return SkipDueToAttribute (type);
 		}

--- a/tests/introspection/ApiWeakPropertyTest.cs
+++ b/tests/introspection/ApiWeakPropertyTest.cs
@@ -30,7 +30,7 @@ namespace Introspection {
 				case "LinkWithAttribute": // LinkWithAttribute.WeakFrameworks
 				return true;
 			}
-			return false;
+			return SkipDueToRejectedTypes (type);
 		}
 
 		/// <summary>

--- a/tests/linker/ios/link all/link all.csproj
+++ b/tests/linker/ios/link all/link all.csproj
@@ -25,7 +25,7 @@
     <MtouchDebug>True</MtouchDebug>
     <MtouchLink>Full</MtouchLink>
     <MtouchI18n>mideast,other</MtouchI18n>
-    <MtouchExtraArgs>--registrar=static --optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
+    <MtouchExtraArgs>--registrar=static --optimize=all,-remove-dynamic-registrar,-force-rejected-types-removal</MtouchExtraArgs>
     <MtouchArch>i386, x86_64</MtouchArch>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -39,7 +39,7 @@
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchArch>i386, x86_64</MtouchArch>
     <DefineConstants>$(DefineConstants)</DefineConstants>
-    <MtouchExtraArgs>--registrar:static --optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
+    <MtouchExtraArgs>--registrar:static --optimize=all,-remove-dynamic-registrar,-force-rejected-types-removal</MtouchExtraArgs>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
@@ -55,7 +55,7 @@
     <MtouchLink>Full</MtouchLink>
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken" --optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
+    <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken" --optimize=all,-remove-dynamic-registrar,-force-rejected-types-removal</MtouchExtraArgs>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -72,7 +72,7 @@
     <MtouchLink>Full</MtouchLink>
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchArch>ARMv7</MtouchArch>
-    <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken" --optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
+    <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken" --optimize=all,-remove-dynamic-registrar,-force-rejected-types-removal</MtouchExtraArgs>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug64|iPhone' ">
@@ -88,7 +88,7 @@
     <MtouchLink>Full</MtouchLink>
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchArch>ARM64</MtouchArch>
-    <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken" --optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
+    <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken" --optimize=all,-remove-dynamic-registrar,-force-rejected-types-removal</MtouchExtraArgs>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
@@ -102,7 +102,7 @@
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <MtouchExtraArgs>--optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
+    <MtouchExtraArgs>--optimize=all,-remove-dynamic-registrar,-force-rejected-types-removal</MtouchExtraArgs>
     <DefineConstants>$(DefineConstants)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -117,7 +117,7 @@
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchArch>ARMv7</MtouchArch>
-    <MtouchExtraArgs>--optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
+    <MtouchExtraArgs>--optimize=all,-remove-dynamic-registrar,-force-rejected-types-removal</MtouchExtraArgs>
     <DefineConstants>$(DefineConstants)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -132,7 +132,7 @@
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchArch>ARM64</MtouchArch>
-    <MtouchExtraArgs>--optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
+    <MtouchExtraArgs>--optimize=all,-remove-dynamic-registrar,-force-rejected-types-removal</MtouchExtraArgs>
     <DefineConstants>$(DefineConstants)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -147,7 +147,7 @@
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchUseLlvm>true</MtouchUseLlvm>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <MtouchExtraArgs>--bitcode:full --optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
+    <MtouchExtraArgs>--bitcode:full --optimize=all,-remove-dynamic-registrar,-force-rejected-types-removal</MtouchExtraArgs>
     <DefineConstants>$(DefineConstants)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/tests/monotouch-test/UIKit/WebViewTest.cs
+++ b/tests/monotouch-test/UIKit/WebViewTest.cs
@@ -2,6 +2,9 @@
 
 #if !__TVOS__ && !__WATCHOS__ && !MONOMAC
 
+// in release mode xharness tests with all optimizations which removes UIWebView and make this crash
+#if DEBUG
+
 using System;
 using System.Drawing;
 #if XAMCORE_2_0
@@ -53,5 +56,7 @@ namespace MonoTouchFixtures.UIKit {
 	}
 
 }
+
+#endif // DEBUG
 
 #endif // !__TVOS__ && !__WATCHOS__

--- a/tests/monotouch-test/UIKit/WebViewTest.cs
+++ b/tests/monotouch-test/UIKit/WebViewTest.cs
@@ -2,9 +2,6 @@
 
 #if !__TVOS__ && !__WATCHOS__ && !MONOMAC
 
-// in release mode xharness tests with all optimizations which removes UIWebView and make this crash
-#if DEBUG
-
 using System;
 using System.Drawing;
 #if XAMCORE_2_0
@@ -31,6 +28,13 @@ namespace MonoTouchFixtures.UIKit {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class WebViewTest {
+
+		[TestFixtureSetUp]
+		public void Setup ()
+		{
+			if (Type.GetType ("UIKit.DeprecatedWebView, Xamarin.iOS") != null)
+				Assert.Ignore ("All type references to UIWebView were removed (optimized).");
+		}
 		
 		[Test]
 		public void InitWithFrame ()
@@ -56,7 +60,5 @@ namespace MonoTouchFixtures.UIKit {
 	}
 
 }
-
-#endif // DEBUG
 
 #endif // !__TVOS__ && !__WATCHOS__

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1752,7 +1752,7 @@ public class TestApp {
 				mtouch.Linker = MTouchLinker.LinkSdk;
 				mtouch.Optimize = new string [] { "foo" };
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build");
-				mtouch.AssertWarning (132, "Unknown optimization: 'foo'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size, inline-runtime-arch, blockliteral-setupblock, register-protocols, inline-dynamic-registration-supported, static-block-to-delegate-lookup, remove-dynamic-registrar, remove-unsupported-il-for-bitcode, inline-is-arm64-calling-convention, seal-and-devirtualize, cctor-beforefieldinit, custom-attributes-removal, experimental-xforms-product-type.");
+				mtouch.AssertWarning (132, "Unknown optimization: 'foo'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size, inline-runtime-arch, blockliteral-setupblock, register-protocols, inline-dynamic-registration-supported, static-block-to-delegate-lookup, remove-dynamic-registrar, remove-unsupported-il-for-bitcode, inline-is-arm64-calling-convention, seal-and-devirtualize, cctor-beforefieldinit, custom-attributes-removal, experimental-xforms-product-type, force-rejected-types-removal.");
 			}
 		}
 
@@ -3647,7 +3647,8 @@ public partial class NotificationService : UNNotificationServiceExtension
 				mtouch.AssertWarning (2003, "Option '--optimize=cctor-beforefieldinit' will be ignored since linking is disabled");
 				mtouch.AssertWarning (2003, "Option '--optimize=custom-attributes-removal' will be ignored since linking is disabled");
 				mtouch.AssertWarning (2003, "Option '--optimize=experimental-xforms-product-type' will be ignored since linking is disabled");
-				mtouch.AssertWarningCount (15);
+				mtouch.AssertWarning (2003, "Option '--optimize=force-rejected-types-removal' will be ignored since linking is disabled");
+				mtouch.AssertWarningCount (16);
 			}
 
 			using (var mtouch = new MTouchTool ()) {

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -151,6 +151,7 @@ namespace Xamarin.Bundler {
 #else
 					"    register-protocols: Remove unneeded metadata for protocol support. Makes the app smaller and reduces memory requirements. Disabled, by default, to allow dynamic code loading.\n" +
 					"    remove-unsupported-il-for-bitcode: Remove IL that is not supported when compiling to bitcode, and replace with a NotSupportedException.\n" +
+					"    force-rejected-types-removal: Forcefully remove types that are known to cause rejections when applications are submitted to Apple. This includes: `UIWebView` and related types.\n" +
 #endif
 					"",
 					(v) => {

--- a/tools/common/Optimizations.cs
+++ b/tools/common/Optimizations.cs
@@ -43,6 +43,11 @@ namespace Xamarin.Bundler
 			"cctor-beforefieldinit",
 			"custom-attributes-removal",
 			"experimental-xforms-product-type",
+#if MONOTOUCH
+			"force-rejected-types-removal",
+#else
+			"", // dummy value to make indices match up between XM and XI
+#endif
 		};
 
 		enum Opt
@@ -64,6 +69,7 @@ namespace Xamarin.Bundler
 			StaticConstructorBeforeFieldInit,
 			CustomAttributesRemoval,
 			ExperimentalFormsProductType,
+			ForceRejectedTypesRemoval,
 		}
 
 		bool? all;
@@ -151,6 +157,13 @@ namespace Xamarin.Bundler
 			get { return values [(int) Opt.ExperimentalFormsProductType]; }
 			set { values [(int) Opt.ExperimentalFormsProductType] = value; }
 		}
+
+#if MONOTOUCH
+		public bool? ForceRejectedTypesRemoval {
+			get { return values [(int) Opt.ForceRejectedTypesRemoval]; }
+			set { values [(int) Opt.ForceRejectedTypesRemoval] = value; }
+		}
+#endif
 
 		public Optimizations ()
 		{

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3369,7 +3369,7 @@ namespace Registrar {
 				var isArray = type is ArrayType;
 				var isByRefArray = isRef && GetElementType (type) is ArrayType;
 				var isNativeEnum = false;
-				var td = type.Resolve ();
+				var td = ResolveType (type);
 				var isVariadic = i + 1 == num_arg && method.IsVariadic;
 
 				if (type != nativetype) {

--- a/tools/linker/MonoTouch.Tuner/RemoveCode.cs
+++ b/tools/linker/MonoTouch.Tuner/RemoveCode.cs
@@ -7,10 +7,8 @@ using Xamarin.Linker;
 
 namespace MonoTouch.Tuner {
 
-	public class RemoveCode : ExceptionalSubStep {
+	public class RemoveCode : RemoveCodeBase {
 
-		MethodDefinition get_nse_def;
-		MethodReference get_nse;
 		bool product;
 
 		public RemoveCode (LinkerOptions options)
@@ -47,24 +45,6 @@ namespace MonoTouch.Tuner {
 			}
 		}
 
-		protected override void Process (AssemblyDefinition assembly)
-		{
-			if (get_nse_def == null) {
-				var corlib = context.GetAssembly ("mscorlib");
-				var nse = corlib.MainModule.GetType ("System", "NotSupportedException");
-				foreach (var m in nse.Methods) {
-					// no need to check HasMethods because we know there are (and nothing is removed at this stage)
-					if (m.Name != "LinkedAway")
-						continue;
-					get_nse_def = m;
-					break;
-				}
-			}
-
-			// import the method into the current assembly
-			get_nse = assembly.MainModule.ImportReference (get_nse_def);
-		}
-
 		protected override void Process (TypeDefinition type)
 		{
 			// no code to remove in interfaces, skip processing
@@ -78,7 +58,7 @@ namespace MonoTouch.Tuner {
 					foreach (var m in type.Methods) {
 						if (m.Name == "RegisterEntryAssembly") {
 							ProcessMethod (m);
-							type.Module.ImportReference (get_nse);
+							type.Module.ImportReference (NotSupportedException);
 						}
 					}
 				}
@@ -121,46 +101,6 @@ namespace MonoTouch.Tuner {
 				ins.Operand = null;
 				break;
 			}
-		}
-
-		void ProcessMethods (TypeDefinition type)
-		{
-			if (type.HasMethods) {
-				MethodDefinition static_ctor = null;
-				foreach (MethodDefinition method in type.Methods) {
-					if (method.IsConstructor && method.IsStatic)
-						static_ctor = method;
-					else
-						ProcessMethod (method);
-				}
-				if (static_ctor != null)
-					type.Methods.Remove (static_ctor);
-			}
-		}
-
-		new void ProcessMethod (MethodDefinition method)
-		{
-			ProcessParameters (method);
-
-			if (!method.HasBody)
-				return;
-
-			var body = new MethodBody (method);
-
-			var il = body.GetILProcessor ();
-			il.Emit (OpCodes.Call, get_nse);
-			il.Emit (OpCodes.Throw);
-
-			method.Body = body;
-		}
-
-		static void ProcessParameters (MethodDefinition method)
-		{
-			if (!method.HasParameters)
-				return;
-
-			foreach (ParameterDefinition parameter in method.Parameters)
-				parameter.Name = string.Empty;
 		}
 
 		static bool IsCandidate (TypeDefinition type)

--- a/tools/linker/MonoTouch.Tuner/RemoveCodeBase.cs
+++ b/tools/linker/MonoTouch.Tuner/RemoveCodeBase.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using Mono.Linker;
+using Mono.Tuner;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xamarin.Linker;
+
+namespace MonoTouch.Tuner {
+
+	abstract public class RemoveCodeBase : ExceptionalSubStep {
+		MethodDefinition get_nse_def;
+
+		protected RemoveCodeBase ()
+		{
+		}
+
+		protected MethodReference NotSupportedException { get; private set; }
+
+		protected override void Process (AssemblyDefinition assembly)
+		{
+			// only one definition exists (in mscorlib.dll)
+			if (get_nse_def == null) {
+				var corlib = context.GetAssembly ("mscorlib");
+				var nse = corlib.MainModule.GetType ("System", "NotSupportedException");
+				foreach (var m in nse.Methods) {
+					// no need to check HasMethods because we know there are (and nothing is removed at this stage)
+					if (m.Name != "LinkedAway")
+						continue;
+					get_nse_def = m;
+					break;
+				}
+			}
+
+			// import the method into the current assembly
+			// i.e. a different reference exists (and must be used) in every assembly
+			NotSupportedException = assembly.MainModule.ImportReference (get_nse_def);
+		}
+
+		protected void ProcessMethods (TypeDefinition type)
+		{
+			if (type.HasMethods) {
+				MethodDefinition static_ctor = null;
+				foreach (MethodDefinition method in type.Methods) {
+					if (method.IsConstructor && method.IsStatic)
+						static_ctor = method;
+					else
+						ProcessMethod (method);
+				}
+				if (static_ctor != null)
+					type.Methods.Remove (static_ctor);
+			}
+		}
+
+		new protected virtual void ProcessMethod (MethodDefinition method)
+		{
+			ProcessParameters (method);
+
+			if (!method.HasBody)
+				return;
+
+			var body = new MethodBody (method);
+
+			var il = body.GetILProcessor ();
+			il.Emit (OpCodes.Call, NotSupportedException);
+			il.Emit (OpCodes.Throw);
+
+			method.Body = body;
+		}
+
+		static void ProcessParameters (MethodDefinition method)
+		{
+			if (!method.HasParameters)
+				return;
+
+			foreach (ParameterDefinition parameter in method.Parameters)
+				parameter.Name = string.Empty;
+		}
+	}
+}

--- a/tools/linker/RemoveRejectedTypesStep.cs
+++ b/tools/linker/RemoveRejectedTypesStep.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Mono.Cecil;
+using Mono.Linker;
+using Mono.Tuner;
+using MonoTouch.Tuner;
+using Xamarin.Tuner;
+
+namespace Xamarin.Linker {
+
+	// Important: This is NOT a general purpose code remover. There are a lot of
+	// cases to cover and this implementation cover only the one it requires so far.
+	// IOW additional testing is REQUIRED if you change the scope of the code.
+	public class RemoveRejectedTypesStep : RemoveCodeBase {
+
+		public RemoveRejectedTypesStep ()
+		{
+		}
+
+		public DerivedLinkContext Context {
+			get { return context as DerivedLinkContext; }
+		}
+
+		public override SubStepTargets Targets {
+			get { return SubStepTargets.Assembly; }
+		}
+
+		protected override string Name { get; } = " Removing Rejected Type";
+		protected override int ErrorCode { get; } = 2660;
+
+		public List<(string originalFullName, string replacementTypeName)> TypeReferencesToBeRemoved = new List<(string,string)> () {
+			// order is important for nested types (that's why tuples are used instead of a Dictionary)
+			( "UIKit.UIWebView/_UIWebViewDelegate", "_DeprecatedWebViewDelegate"),
+			( "UIKit.UIWebView/UIWebViewAppearance","DeprecatedWebViewAppearance"),
+			( "UIKit.IUIWebViewDelegate","IDeprecatedWebViewDelegate"),
+			( "UIKit.UIWebView","DeprecatedWebView"),
+			( "UIKit.UIWebViewDelegate","DeprecatedWebViewDelegate"),
+			( "UIKit.UIWebViewDelegate_Extensions", "DeprecatedWebViewDelegate_Extensions"),
+			( "UIKit.UIWebViewDelegateWrapper", "DeprecatedWebViewDelegateWrapper"),
+			( "UIKit.UIWebViewNavigationType", "DeprecatedWebViewNavigationType"),
+		};
+
+		protected override void Process (AssemblyDefinition assembly)
+		{
+			// this will give us a working `get_nse`
+			base.Process (assembly);
+
+			var updated = false;
+			if (Profile.IsProductAssembly (assembly)) {
+				updated = true;
+				foreach (var item in TypeReferencesToBeRemoved) {
+					var type = assembly.MainModule.GetType (item.originalFullName);
+					if (type == null)
+						continue;
+					type.Name = item.replacementTypeName;
+					Context.AddLinkedAwayType (type);
+					// we need to remove [Register], [Protocol] and [ProtocolMembers] attributes
+					// and since other attributes won't make sense anymore so we remove them all
+					type.CustomAttributes.Clear ();
+					if (!type.IsInterface) {
+						// remove IL and custom attributes (e.g. [Export])
+						ProcessMethods (type);
+					}
+				}
+			} else if (Profile.IsSdkAssembly (assembly)) {
+				// note: we know the BCL does not include references to UIWebView
+				// so we only need to care for (i.e. tweak) user code
+				return;
+			} else {
+				foreach (var module in assembly.Modules) {
+					foreach (var item in TypeReferencesToBeRemoved) {
+						if (module.TryGetTypeReference (item.originalFullName, out var tr)) {
+							tr.Name = item.replacementTypeName;
+							updated = true;
+						}
+					}
+				}
+			}
+			// we'll need to save (if we're not linking) this assembly
+			if (updated && Annotations.GetAction (assembly) != AssemblyAction.Link)
+				Annotations.SetAction (assembly, AssemblyAction.Save);
+		}
+
+		protected override void ProcessMethod (MethodDefinition method)
+		{
+			if (method.HasCustomAttributes)
+				method.CustomAttributes.Clear ();
+
+			// single special case: deal with method `EnsureUIWebViewDelegate`
+			if (method.Name == "EnsureUIWebViewDelegate")
+				method.Name = "EnsureDeprecatedWebViewDelegate";
+
+			base.ProcessMethod (method);
+		}
+	}
+}

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -34,6 +34,7 @@ namespace MonoTouch.Tuner {
 		internal PInvokeWrapperGenerator MarshalNativeExceptionsState { get; set; }
 		internal RuntimeOptions RuntimeOptions { get; set; }
 		public List<string> WarnOnTypeRef { get; set; }
+		public bool RemoveRejectedTypes { get; set; }
 
 		public MonoTouchLinkContext LinkContext { get; set; }
 		public Target Target { get; set; }
@@ -167,9 +168,13 @@ namespace MonoTouch.Tuner {
 		static SubStepDispatcher GetPostLinkOptimizations (LinkerOptions options)
 		{
 			SubStepDispatcher sub = new SubStepDispatcher ();
-			sub.Add (new MetadataReducerSubStep ());
-			if (options.Application.Optimizations.SealAndDevirtualize == true)
-				sub.Add (new SealerSubStep ());
+			if (options.Application.Optimizations.ForceRejectedTypesRemoval == true)
+				sub.Add (new RemoveRejectedTypesStep ());
+			if (!options.DebugBuild) {
+				sub.Add (new MetadataReducerSubStep ());
+				if (options.Application.Optimizations.SealAndDevirtualize == true)
+					sub.Add (new SealerSubStep ());
+			}
 			return sub;
 		}
 
@@ -223,14 +228,15 @@ namespace MonoTouch.Tuner {
 				pipeline.Append (new MonoTouchSweepStep (options));
 				pipeline.Append (new CleanStep ());
 
-				if (!options.DebugBuild)
-					pipeline.AppendStep (GetPostLinkOptimizations (options));
+				pipeline.AppendStep (GetPostLinkOptimizations (options));
 
 				pipeline.Append (new FixModuleFlags ());
 			} else {
 				SubStepDispatcher sub = new SubStepDispatcher () {
 					new RemoveUserResourcesSubStep (options),
 				};
+				if (options.Application.Optimizations.ForceRejectedTypesRemoval == true)
+					sub.Add (new RemoveRejectedTypesStep ());
 				if (remove_incompatible_bitcode != null)
 					sub.Add (remove_incompatible_bitcode);
 				pipeline.Append (sub);

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -7,7 +7,7 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>mtouch</AssemblyName>
     <RootNamespace>mtouch</RootNamespace>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -19,6 +19,7 @@
     <WarningLevel>4</WarningLevel>
     <Deterministic>True</Deterministic>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,6 +31,7 @@
     <WarningLevel>4</WarningLevel>
     <Deterministic>True</Deterministic>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -418,6 +420,12 @@
     </Compile>
     <Compile Include="..\linker\ScanTypeReferenceStep.cs">
       <Link>Xamarin.Linker\ScanTypeReferenceStep.cs</Link>
+    </Compile>
+    <Compile Include="..\linker\RemoveRejectedTypesStep.cs">
+      <Link>Xamarin.Linker\RemoveRejectedTypesStep.cs</Link>
+    </Compile>
+    <Compile Include="..\linker\MonoTouch.Tuner\RemoveCodeBase.cs">
+      <Link>MonoTouch.Tuner\RemoveCodeBase.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This optimization can be enabled when it's not possible to use the managed
linker (e.g. **Don't link**) or when the managed linker cannot remove
references to deprecated types that would cause an application to be
rejected by Apple.

References to the existing types will be renamed, e.g. `UIWebView` to
`DeprecatedWebView`, in every assemblies.

The type definition is also renamed (for validity) and all custom
attributes on the types and their members will be removed. Code inside the
members will be replaced with a
`throw new NotSupportedException ();`.

The msbuild test app `MyReleaseBuild` has been updated to test that the
optimization is working as expected (device builds are slow so reusing this
test has little impact in test time).

Basically the test ensure that `UIWebView` is used and cannot be removed by
the compiler (optimization) or the managed linker (since it's referenced).
Since the optimization is enabled then we can `grep` then final `.app`
directory to ensure there's no mention of `UIWebView` inside any of the
files that would be submitted.

The application can be run, by itself, and will turn green if OK, red if
`DeprecatedWebView` can't be found (skeleton replacement for `UIWebView`)
or orange if a `NotSupportedException` is thrown.

Finally introspection tests have been updated to skip over the deprecated
(and renamed) types. It should not be an issue right now, since this
optimization is not enabled by default, but it made testing easier.