### PR TITLE
[msbuild] Re-use tools/common/TargetFramework.cs.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Tasks/DetectSigningIdentity.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/DetectSigningIdentity.cs
@@ -7,6 +7,7 @@
 // Copyright 2014 Xamarin Inc.
 
 using Xamarin.MacDev.Tasks;
+using Xamarin.Utils;
 
 namespace Xamarin.Mac.Tasks
 {
@@ -20,7 +21,7 @@ namespace Xamarin.Mac.Tasks
 		protected override string[] DirectDistributionPrefixes { get { return directDistributionPrefixes; } }
 		protected override string[] AppStoreDistributionPrefixes { get { return appStoreDistributionPrefixes; } }
 		protected override string DeveloperRoot { get { return MacOSXSdks.Native.DeveloperRoot; } }
-		protected override PlatformFramework Framework { get { return PlatformFramework.MacOS; } }
+		protected override ApplePlatform Framework { get { return ApplePlatform.MacOSX; } }
 		protected override string PlatformName { get { return "macOS"; } }
 		protected override string ApplicationIdentifierKey { get { return "com.apple.application-identifier"; } }
 	}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/PlatformFramework.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/PlatformFramework.cs
@@ -25,31 +25,25 @@
 
 using System;
 
+using Xamarin.Utils;
+
 namespace Xamarin.MacDev.Tasks
 {
-	public enum PlatformFramework
-	{
-		MacOS,
-		iOS,
-		WatchOS,
-		TVOS,
-	}
-
 	public static class PlatformFrameworkHelper
 	{
-		public static PlatformFramework GetFramework (string targetFrameworkIdentifier)
+		public static ApplePlatform GetFramework (string targetFrameworkIdentifier)
 		{
 			switch (targetFrameworkIdentifier) {
 			case "Xamarin.Mac":
 			case "MonoMac":
-				return PlatformFramework.MacOS;
+				return ApplePlatform.MacOSX;
 			case "Xamarin.iOS":
 			case "MonoTouch":
-				return PlatformFramework.iOS;
+				return ApplePlatform.iOS;
 			case "Xamarin.WatchOS":
-				return PlatformFramework.WatchOS;
+				return ApplePlatform.WatchOS;
 			case "Xamarin.TVOS":
-				return PlatformFramework.TVOS;
+				return ApplePlatform.TVOS;
 			default:
 				throw new InvalidOperationException ("Unknown TargetFrameworkIdentifier: " + targetFrameworkIdentifier);
 			}
@@ -59,13 +53,13 @@ namespace Xamarin.MacDev.Tasks
 		{
 			var framework = PlatformFrameworkHelper.GetFramework (targetFrameworkIdentifier);
 			switch (framework) {
-			case PlatformFramework.WatchOS:
+			case ApplePlatform.WatchOS:
 				return "watchos";
-			case PlatformFramework.TVOS:
+			case ApplePlatform.TVOS:
 				return "tvos";
-			case PlatformFramework.MacOS:
+			case ApplePlatform.MacOSX:
 				return "osx";
-			case PlatformFramework.iOS:
+			case ApplePlatform.iOS:
 				return "ios";
 			default:
 				throw new InvalidOperationException (string.Format ("Unknown target framework {0} for target framework identifier {2}.", framework, targetFrameworkIdentifier));

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/AlToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/AlToolTaskBase.cs
@@ -5,6 +5,8 @@ using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 using System.Text;
 
+using Xamarin.Utils;
+
 namespace Xamarin.MacDev.Tasks
 {
 	public abstract class ALToolTaskBase : ToolTask
@@ -23,7 +25,7 @@ namespace Xamarin.MacDev.Tasks
 		[Required]
 		public string FilePath { get; set; }
 
-		protected PlatformFramework FileType {
+		protected ApplePlatform FileType {
 			get { return PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier); }
 		}
 
@@ -94,9 +96,9 @@ namespace Xamarin.MacDev.Tasks
 		string GetFileTypeValue ()
 		{
 			switch (FileType) {
-				case PlatformFramework.MacOS: return "osx";
-				case PlatformFramework.TVOS: return "appletvos";
-				case PlatformFramework.iOS: return "ios";
+				case ApplePlatform.MacOSX: return "osx";
+				case ApplePlatform.TVOS: return "appletvos";
+				case ApplePlatform.iOS: return "ios";
 				default: throw new NotSupportedException ($"Provided file type '{FileType}' is not supported by altool");
 			}
 		}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
@@ -7,6 +7,8 @@ using System.Security.Cryptography.X509Certificates;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
+using Xamarin.Utils;
+
 using SecKeychain = Xamarin.MacDev.Keychain;
 
 namespace Xamarin.MacDev.Tasks
@@ -22,8 +24,8 @@ namespace Xamarin.MacDev.Tasks
 		protected abstract string[] DevelopmentPrefixes { get; }
 		protected abstract string[] DirectDistributionPrefixes { get; }
 		protected abstract string[] AppStoreDistributionPrefixes { get; }
-		protected abstract PlatformFramework Framework { get; }
-		protected abstract string PlatformName { get ; }
+		protected abstract ApplePlatform Framework { get; }
+		protected abstract string PlatformName { get; }
 		protected abstract string ApplicationIdentifierKey { get; }
 
 		string provisioningProfileName;
@@ -456,7 +458,7 @@ namespace Xamarin.MacDev.Tasks
 				return false;
 			}
 
-			if (Framework == PlatformFramework.MacOS) {
+			if (Framework == ApplePlatform.MacOSX) {
 				if (!RequireCodeSigning) {
 					DetectedBundleId = identity.BundleId;
 					DetectedAppId = DetectedBundleId;

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
@@ -57,13 +57,13 @@ namespace Xamarin.MacDev.Tasks
 		protected virtual string OperatingSystem {
 			get {
 				switch (PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier)) {
-				case PlatformFramework.WatchOS:
+				case ApplePlatform.WatchOS:
 					return SdkIsSimulator ? "watchos-simulator" : "watchos";
-				case PlatformFramework.TVOS:
+				case ApplePlatform.TVOS:
 					return SdkIsSimulator ? "tvos-simulator" : "tvos";
-				case PlatformFramework.MacOS:
+				case ApplePlatform.MacOSX:
 					return "macosx";
-				case PlatformFramework.iOS:
+				case ApplePlatform.iOS:
 					return SdkIsSimulator ? "iphonesimulator" : "ios";
 				default:
 					Log.LogError ($"Unknown target framework identifier: {TargetFrameworkIdentifier}.");

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -26,6 +26,9 @@
     <Compile Include="..\..\tools\mtouch\errors.Designer.cs">
       <Link>errors.Designer.cs</Link>
     </Compile>
+    <Compile Include="..\..\tools\common\TargetFramework.cs">
+      <Link>TargetFramework.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\tools\mtouch\errors.resx">

--- a/msbuild/Xamarin.iOS.Tasks.Core/IPhoneSdks.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/IPhoneSdks.cs
@@ -3,6 +3,7 @@ using System.IO;
 
 using Xamarin.MacDev;
 using Xamarin.MacDev.Tasks;
+using Xamarin.Utils;
 
 namespace Xamarin.iOS.Tasks
 {
@@ -44,14 +45,14 @@ namespace Xamarin.iOS.Tasks
 			TVOS = new AppleTVOSSdk (AppleSdkSettings.DeveloperRoot, AppleSdkSettings.DeveloperRootVersionPlist);
 		}
 
-		public static AppleSdk GetSdk (PlatformFramework framework)
+		public static AppleSdk GetSdk (ApplePlatform framework)
 		{
 			switch (framework) {
-			case PlatformFramework.iOS:
+			case ApplePlatform.iOS:
 				return IPhoneSdks.Native;
-			case PlatformFramework.WatchOS:
+			case ApplePlatform.WatchOS:
 				return IPhoneSdks.Watch;
-			case PlatformFramework.TVOS:
+			case ApplePlatform.TVOS:
 				return IPhoneSdks.TVOS;
 			default:
 				throw new InvalidOperationException (string.Format ("Invalid framework: {0}", framework));

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Utilities;
 
 using Xamarin.MacDev.Tasks;
 using Xamarin.MacDev;
+using Xamarin.Utils;
 
 namespace Xamarin.iOS.Tasks
 {
@@ -42,7 +43,7 @@ namespace Xamarin.iOS.Tasks
 
 		public string ResourceRules { get; set; }
 
-		public PlatformFramework Framework {
+		public ApplePlatform Framework {
 			get { return PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier); }
 		}
 
@@ -74,12 +75,12 @@ namespace Xamarin.iOS.Tasks
 			}
 
 			switch (Framework) {
-			case PlatformFramework.iOS:
+			case ApplePlatform.iOS:
 				IsIOS = true;
 				break;
-			case PlatformFramework.WatchOS:
+			case ApplePlatform.WatchOS:
 				break;
-			case PlatformFramework.TVOS:
+			case ApplePlatform.TVOS:
 				break;
 			default:
 				throw new InvalidOperationException (string.Format ("Invalid framework: {0}", Framework));
@@ -188,7 +189,7 @@ namespace Xamarin.iOS.Tasks
 
 			if (UseFakeWatchOS4_3Sdk) {
 				// This is a workaround for https://github.com/xamarin/xamarin-macios/issues/4810
-				if (Framework == PlatformFramework.WatchOS) {
+				if (Framework == ApplePlatform.WatchOS) {
 					if (dtPlatformBuild != null)
 						dtPlatformBuild = "15T212";
 					if (dtPlatformVersion != null)
@@ -221,7 +222,7 @@ namespace Xamarin.iOS.Tasks
 
 			if (IsWatchExtension) {
 				// Note: Only watchOS1 Extensions target Xamarin.iOS
-				if (Framework == PlatformFramework.iOS) {
+				if (Framework == ApplePlatform.iOS) {
 					PObject value;
 
 					if (!plist.TryGetValue (ManifestKeys.UIRequiredDeviceCapabilities, out value)) {
@@ -350,13 +351,13 @@ namespace Xamarin.iOS.Tasks
 		void SetDeviceFamily (PDictionary plist)
 		{
 			switch (Framework) {
-			case PlatformFramework.iOS:
+			case ApplePlatform.iOS:
 				SetIOSDeviceFamily (plist);
 				break;
-			case PlatformFramework.WatchOS:
+			case ApplePlatform.WatchOS:
 				plist.SetUIDeviceFamily (IPhoneDeviceType.Watch);
 				break;
-			case PlatformFramework.TVOS:
+			case ApplePlatform.TVOS:
 				plist.SetUIDeviceFamily (IPhoneDeviceType.TV);
 				break;
 			}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Utilities;
 
 using Xamarin.MacDev.Tasks;
 using Xamarin.MacDev;
+using Xamarin.Utils;
 
 namespace Xamarin.iOS.Tasks
 {
@@ -76,7 +77,7 @@ namespace Xamarin.iOS.Tasks
 
 #endregion Outputs
 
-		public PlatformFramework Framework {
+		public ApplePlatform Framework {
 			get { return PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier); }
 		}
 
@@ -101,13 +102,13 @@ namespace Xamarin.iOS.Tasks
 
 			if (EnsureAppleSdkRoot ()) {
 				switch (Framework) {
-				case PlatformFramework.iOS:
+				case ApplePlatform.iOS:
 					EnsureiOSSdkPath ();
 					break;
-				case PlatformFramework.TVOS:
+				case ApplePlatform.TVOS:
 					EnsureTVOSSdkPath ();
 					break;
-				case PlatformFramework.WatchOS:
+				case ApplePlatform.WatchOS:
 					EnsureWatchSdkPath ();
 					break;
 				default:

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
@@ -3,6 +3,7 @@ using Microsoft.Build.Utilities;
 
 using Xamarin.MacDev;
 using Xamarin.MacDev.Tasks;
+using Xamarin.Utils;
 
 namespace Xamarin.iOS.Tasks
 {
@@ -17,17 +18,17 @@ namespace Xamarin.iOS.Tasks
 		protected override string[] DirectDistributionPrefixes { get { return directDistributionPrefixes; } }
 		protected override string[] AppStoreDistributionPrefixes { get { return IPhoneCertificate.DistributionPrefixes; } }
 		protected override string DeveloperRoot { get { return IPhoneSdks.GetSdk (TargetFrameworkIdentifier).DeveloperRoot; } }
-		protected override PlatformFramework Framework {
+		protected override ApplePlatform Framework {
 			get { return PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier); }
 		}
 		protected override string PlatformName {
 			get {
 				switch (Framework) {
-				case PlatformFramework.iOS:
+				case ApplePlatform.iOS:
 					return "iOS";
-				case PlatformFramework.WatchOS:
+				case ApplePlatform.WatchOS:
 					return "watchOS";
-				case PlatformFramework.TVOS:
+				case ApplePlatform.TVOS:
 					return "tvOS";
 				default:
 					throw new System.InvalidOperationException (string.Format ("Invalid framework: {0}", Framework));

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Utilities;
 
 using Xamarin.MacDev.Tasks;
 using Xamarin.MacDev;
+using Xamarin.Utils;
 
 namespace Xamarin.iOS.Tasks
 {
@@ -185,7 +186,7 @@ namespace Xamarin.iOS.Tasks
 
 		#endregion
 
-		public PlatformFramework Framework {
+		public ApplePlatform Framework {
 			get { return PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier); }
 		}
 
@@ -429,10 +430,10 @@ namespace Xamarin.iOS.Tasks
 
 			if (EnableBitcode) {
 				switch (Framework) {
-				case PlatformFramework.WatchOS:
+				case ApplePlatform.WatchOS:
 					args.AddLine ("--bitcode=full");
 					break;
-				case PlatformFramework.TVOS:
+				case ApplePlatform.TVOS:
 					args.AddLine ("--bitcode=asmonly");
 					break;
 				default:
@@ -658,7 +659,7 @@ namespace Xamarin.iOS.Tasks
 				}
 			} else {
 				switch (Framework) {
-				case PlatformFramework.iOS:
+				case ApplePlatform.iOS:
 					IPhoneSdkVersion sdkVersion;
 					if (!IPhoneSdkVersion.TryParse (SdkVersion, out sdkVersion)) {
 						Log.LogError (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, "Could not parse SdkVersion '{0}'", SdkVersion);
@@ -667,8 +668,8 @@ namespace Xamarin.iOS.Tasks
 
 					minimumOSVersion = sdkVersion;
 					break;
-				case PlatformFramework.WatchOS:
-				case PlatformFramework.TVOS:
+				case ApplePlatform.WatchOS:
+				case ApplePlatform.TVOS:
 					minimumOSVersion = IPhoneSdkVersion.UseDefault;
 					break;
 				default:

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ParseDeviceSpecificBuildInformationTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ParseDeviceSpecificBuildInformationTaskBase.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Framework;
 
 using Xamarin.MacDev;
 using Xamarin.MacDev.Tasks;
+using Xamarin.Utils;
 
 namespace Xamarin.iOS.Tasks
 {
@@ -59,10 +60,10 @@ namespace Xamarin.iOS.Tasks
 			PString value, os;
 
 			switch (PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier)) {
-			case PlatformFramework.WatchOS:
+			case ApplePlatform.WatchOS:
 				targetOperatingSystem = "watchOS";
 				break;
-			case PlatformFramework.TVOS:
+			case ApplePlatform.TVOS:
 				targetOperatingSystem = "tvOS";
 				break;
 			default:

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Utilities;
 
 using Xamarin.MacDev;
 using Xamarin.MacDev.Tasks;
+using Xamarin.Utils;
 
 namespace Xamarin.iOS.Tasks
 {
@@ -27,7 +28,7 @@ namespace Xamarin.iOS.Tasks
 
 		#endregion
 
-		public PlatformFramework Framework {
+		public ApplePlatform Framework {
 			get { return PlatformFrameworkHelper.GetFramework (TargetFrameworkIdentifier); }
 		}
 
@@ -402,17 +403,17 @@ namespace Xamarin.iOS.Tasks
 			AppleDeviceFamily[] validFamilies = null;
 
 			switch (Framework) {
-			case PlatformFramework.iOS:
+			case ApplePlatform.iOS:
 				validFamilies = new AppleDeviceFamily[] {
 					AppleDeviceFamily.IPhone,
 					AppleDeviceFamily.IPad,
 					AppleDeviceFamily.Watch
 				};
 				break;
-			case PlatformFramework.WatchOS:
+			case ApplePlatform.WatchOS:
 				validFamilies = new AppleDeviceFamily[] { AppleDeviceFamily.Watch };
 				break;
-			case PlatformFramework.TVOS:
+			case ApplePlatform.TVOS:
 				validFamilies = new AppleDeviceFamily[] { AppleDeviceFamily.TV };
 				break;
 			default:

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
@@ -10,13 +10,14 @@ using NUnit.Framework;
 
 using Xamarin.MacDev;
 using Xamarin.MacDev.Tasks;
+using Xamarin.Utils;
 
 namespace Xamarin.iOS.Tasks
 {
 	[TestFixture]
 	public class IBToolTaskTests
 	{
-		static IBTool CreateIBToolTask (PlatformFramework framework, string projectDir, string intermediateOutputPath)
+		static IBTool CreateIBToolTask (ApplePlatform framework, string projectDir, string intermediateOutputPath)
 		{
 			var interfaceDefinitions = new List<ITaskItem> ();
 			var sdk = IPhoneSdks.GetSdk (framework);
@@ -27,10 +28,10 @@ namespace Xamarin.iOS.Tasks
 			string platform;
 
 			switch (framework) {
-			case PlatformFramework.WatchOS:
+			case ApplePlatform.WatchOS:
 				platform = "WatchOS";
 				break;
-			case PlatformFramework.TVOS:
+			case ApplePlatform.TVOS:
 				platform = "AppleTVOS";
 				break;
 			default:
@@ -67,7 +68,7 @@ namespace Xamarin.iOS.Tasks
 			Directory.CreateDirectory (tmp);
 
 			try {
-				var ibtool = CreateIBToolTask (PlatformFramework.iOS, "../MyIBToolLinkTest", tmp);
+				var ibtool = CreateIBToolTask (ApplePlatform.iOS, "../MyIBToolLinkTest", tmp);
 				var bundleResources = new HashSet<string> ();
 
 				Assert.IsTrue (ibtool.Execute (), "Execution of IBTool task failed.");
@@ -123,7 +124,7 @@ namespace Xamarin.iOS.Tasks
 			Directory.CreateDirectory (tmp);
 
 			try {
-				ibtool = CreateIBToolTask (PlatformFramework.iOS, "../IBToolTaskTests/LinkedAndTranslated", tmp);
+				ibtool = CreateIBToolTask (ApplePlatform.iOS, "../IBToolTaskTests/LinkedAndTranslated", tmp);
 				var bundleResources = new HashSet<string> ();
 
 				// Add some ResourceTags...
@@ -194,7 +195,7 @@ namespace Xamarin.iOS.Tasks
 			}
 		}
 
-		static IBTool CreateIBToolTask (PlatformFramework framework, string projectDir, string intermediateOutputPath, params string[] fileNames)
+		static IBTool CreateIBToolTask (ApplePlatform framework, string projectDir, string intermediateOutputPath, params string[] fileNames)
 		{
 			var ibtool = CreateIBToolTask (framework, projectDir, intermediateOutputPath);
 			var interfaceDefinitions = new List<ITaskItem> ();
@@ -215,7 +216,7 @@ namespace Xamarin.iOS.Tasks
 			Directory.CreateDirectory (tmp);
 
 			try {
-				ibtool = CreateIBToolTask (PlatformFramework.iOS, "../IBToolTaskTests/GenericAndDeviceSpecific", tmp, fileNames);
+				ibtool = CreateIBToolTask (ApplePlatform.iOS, "../IBToolTaskTests/GenericAndDeviceSpecific", tmp, fileNames);
 				var bundleResources = new HashSet<string> ();
 
 				// Add some ResourceTags...


### PR DESCRIPTION
This allows us to replace Xamarin.MacDev.Tasks.PlatformFramework with
Xamarin.Utils.ApplePlatform.

It also allow for more complex target framework handling/parsing in the
future, using the TargetFramework class.