### PR TITLE
Add dotnet as a configure option and provision it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Make.config.local
 configure.inc
 _ios-build
 _mac-build
+_build
 *.userprefs
 *.user
 *.suo

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ tests/bcl-test/Mac\ OS\ X\ BCL\ \tests*.csproj
 tests/bcl-test/mscorlib*.csproj
 tests/bcl-test/SystemCoreXunit*.csproj
 tests/bcl-test/SystemXunit.csproj
+global.json
+

--- a/Make.config
+++ b/Make.config
@@ -372,5 +372,8 @@ MONO_MAC_SDK_DESTDIR:=$(abspath $(MONO_PATH)/sdks/out)
 MONO_BUILD_MODE=compile-mono
 endif
 
+DOTNET_VERSION=3.1.100
+DOTNET_URL=https://download.visualstudio.microsoft.com/download/pr/787e81f1-f0da-4e3b-a989-8a199132ed8c/61a8dba81fbf2b3d533562d7b96443ec/dotnet-sdk-3.1.100-osx-x64.pkg
+	
 .SUFFIXES:
 MAKEFLAGS += --no-builtin-rules

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ ifdef INCLUDE_IOS
 	@echo Validated file permissions for Xamarin.iOS.
 endif
 
+all-local:: global.json
+global.json: Make.config Makefile
+	$(Q) printf "{\n\t\"sdk\": {\n\t\t\"version\": \"$(DOTNET_VERSION)\"\n\t}\n}\n" > $@
+
 install-hook::
 	@$(MAKE) check-permissions
 ifdef INCLUDE_IOS

--- a/configure
+++ b/configure
@@ -29,6 +29,8 @@ Usage: configure [options]
 
     --enable-packaged-mono
     --disable-packaged-mono Enable/disable using the precompiled version of mono. If disabled mono will be compiled from source.
+
+    --enable-dotnet         Enable building .NET 5 bits.
 EOL
 }
 
@@ -101,6 +103,14 @@ while test x$1 != x; do
         ;;
     --disable-packaged-mono=no | --disable-packaged-mono=false)
         echo "MONO_BUILD_FROM_SOURCE=" >> "$CONFIGURED_FILE"
+        shift
+        ;;
+    --enable-dotnet)
+        echo "ENABLE_DOTNET=1" >> "$CONFIGURED_FILE"
+        shift
+        ;;
+    --disable-dotnet)
+        echo "ENABLE_DOTNET=" >> "$CONFIGURED_FILE"
         shift
         ;;
 	--help|-h)

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -120,6 +120,9 @@ if test -z "$ENABLE_DEVICE_BUILD"; then
 	CONFIGURE_FLAGS="$CONFIGURE_FLAGS --disable-ios-device"
 fi
 
+# Enable dotnet bits on the bots
+CONFIGURE_FLAGS="$CONFIGURE_FLAGS --enable-dotnet"
+
 make reset
 make git-clean-all
 make print-versions


### PR DESCRIPTION
Because building the .NET bits makes the build slower, and they're not very
useful quite yet, it's opt-in for developers, but enabled by default on CI.

Also provision the .NET we want to use (for everybody).