### PR TITLE
[WebKit] Update bindings for Xcode 11.4 beta 3

### DIFF
--- a/src/wkwebkit.cs
+++ b/src/wkwebkit.cs
@@ -593,6 +593,7 @@ namespace WebKit
 	interface WKWebView
 #if MONOMAC
 		: NSUserInterfaceValidations
+		/* TODO , NSTextFinderClient  K_API_AVAILABLE(macos(WK_MAC_TBA)) in 11.4 beta 2 */
 #endif
 	{
 

--- a/tests/xtro-sharpie/macOS-WebKit.ignore
+++ b/tests/xtro-sharpie/macOS-WebKit.ignore
@@ -138,6 +138,8 @@
 !missing-protocol! WebDocumentView not bound
 !missing-protocol! WebEditingDelegate not bound
 !missing-protocol! WebPlugInViewFactory not bound
+# TODO WKWebView should conform to NSTextFinderClient is marked as macos(WK_MAC_TBA) as of 11.4 beta3
+!missing-protocol-conformance! WKWebView should conform to NSTextFinderClient (defined in 'WKNSTextFinderClient' category)
 !missing-protocol-member! DOMEventTarget::addEventListener::: not found
 !missing-protocol-member! DOMEventTarget::removeEventListener::: not found
 !missing-protocol-member! WebUIDelegate::webView:runOpenPanelForFileButtonWithResultListener:allowMultipleFiles: not found

--- a/tests/xtro-sharpie/macOS-WebKit.todo
+++ b/tests/xtro-sharpie/macOS-WebKit.todo
@@ -1,1 +1,0 @@
-!missing-protocol-conformance! WKWebView should conform to NSTextFinderClient (defined in 'WKNSTextFinderClient' category)


### PR DESCRIPTION
The only update is one `TBA` binding.

The previous PR which included commented-out `TBA` bindings can be found here: https://github.com/xamarin/xamarin-macios/pull/7935