### PR TITLE
[jenkins] Fix provisioning old macOS bots.

### DIFF
--- a/jenkins/prepare-packaged-macos-tests.sh
+++ b/jenkins/prepare-packaged-macos-tests.sh
@@ -66,7 +66,7 @@ cd mac-test-package
 COUNTER=0
 while [[ $COUNTER -lt 5 ]]; do
 	EC=0
-	./system-dependencies.sh --provision-mono --ignore-autotools --ignore-xamarin-studio --ignore-xcode --ignore-osx --ignore-cmake --ignore-simulators --ignore-7z --ignore-python3 || EC=$?
+	./system-dependencies.sh --ignore-all --provision-mono || EC=$?
 	if [[ $EC -eq 56 ]]; then
 		# Sometimes we get spurious "curl: (56) SSLRead() return error -9806" errors. Trying again usually works, so lets try again a few more times.
 		# https://github.com/xamarin/maccore/issues/1098


### PR DESCRIPTION
On old macOS bots we only want to provision Mono, so change the logic so that
we first ignore everything, then re-enable Mono.

This way we don't have to add new ignore flags here every time we add
something new to the provisioning script.

This fixes an issue where the script detects that dotnet isn't installed, and
shows an error, when trying to run tests on older macOS bots in CI.