### PR TITLE
[runtime] Add asserts that gives a helpful message when a managed delegate callback doesn't exist.

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -520,3 +520,5 @@ clean-local::
 
 
 include $(TOP)/mk/rules.mk
+
+.SECONDARY: delegates.h delegates.inc

--- a/runtime/delegates.inc.t4
+++ b/runtime/delegates.inc.t4
@@ -40,10 +40,16 @@ create_linked_away_exception (const char *func)
 <#= d.CReturnType #>
 <#= d.EntryPoint #> (<#= d.CArgumentSignature #>)
 {
-	<#if (d.ExceptionHandling && d.OnlyDynamicUsage) {#>if (delegates.<#= d.EntryPoint.Substring ("xamarin_".Length) #> == NULL) {
+<#if (d.ExceptionHandling && d.OnlyDynamicUsage) {#>	if (delegates.<#= d.EntryPoint.Substring ("xamarin_".Length) #> == NULL) {
 		*exception_gchandle = create_linked_away_exception ("<#= d.EntryPoint.Substring ("xamarin_".Length) #>");
 		return<# if (d.CReturnType != "void") { #> (<#= d.CReturnType #>) 0<# } #>;
 	}
+<#} else {#>#if DEBUG
+	if (delegates.<#= d.EntryPoint.Substring ("xamarin_".Length) #> == NULL) {
+		NSLog (@PRODUCT ": The managed function <#= d.EntryPoint.Substring ("xamarin_".Length) #> could not be loaded.");
+		xamarin_assertion_message ("The managed function <#= d.EntryPoint.Substring ("xamarin_".Length) #> could not be loaded.");
+	}
+#endif
 <#}#>
 	<# if (d.CReturnType != "void") { #>return <# } #>delegates.<#= d.EntryPoint.Substring ("xamarin_".Length) #> (<#= d.CArgumentNames #>);
 }


### PR DESCRIPTION
This is restricted to debug builds.

Also tell make to not delete delegates.h and delegates.inc. That makes it much
easier to inspect them.

Example before function:

    void
    xamarin_throw_ns_exception (NSException * exc)
    {
    		delegates.throw_ns_exception (exc);
    }

The after version:

    void
    xamarin_throw_ns_exception (NSException * exc)
    {
    #if DEBUG
    	if (delegates.throw_ns_exception == NULL) {
    		NSLog (@PRODUCT ": The managed function throw_ns_exception could not be loaded.");
    		xamarin_assertion_message ("The managed function throw_ns_exception could not be loaded.");
    	}
    #endif
    	delegates.throw_ns_exception (exc);
    }