### PR TITLE
Bump Xamarin.MacDev.

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/MTouchTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/MTouchTaskTests.cs
@@ -306,6 +306,10 @@ namespace Xamarin.iOS.Tasks
 			{
 				SdkDir = Path.Combine (Path.GetTempPath (), Guid.NewGuid ().ToString ());
 				Directory.CreateDirectory (SdkDir);
+				Directory.CreateDirectory (Path.Combine (SdkDir, "bin"));
+				File.WriteAllText (Path.Combine (SdkDir, "Version"), "1.0.0.0"); // Fake Version file so that MonoTouchSdk detects this as a real Sdk location.
+				File.WriteAllText (Path.Combine (SdkDir, "bin", "mtouch"), "echo \"fake mtouch\""); // Fake mtouch binary so that MonoTouchSdk detects this as a real Sdk location.
+				Directory.CreateDirectory (Path.Combine (SdkDir, "lib"));
 				sdk = IPhoneSdks.MonoTouch;
 
 				IPhoneSdks.MonoTouch = new MonoTouchSdk (SdkDir);


### PR DESCRIPTION
New commits in xamarin/Xamarin.MacDev:

* xamarin/Xamarin.MacDev@a0a11af Adjust SDK validation to allow tools/bin and not allow usr/bin. (#71)
* xamarin/Xamarin.MacDev@e21e1aa Accept 'tools/buildinfo' as an alternative path to 'buildinfo' due to an nuget bug. (#70)
* xamarin/Xamarin.MacDev@ce24236 Don't look in /Developer/MonoTouch anymore, there's nothing there. (#69)

Diff: https://github.com/xamarin/Xamarin.MacDev/compare/210c664e56117d3a1a7f6dd002109eb444dbdc17..a0a11aff271565bbaba029e5e428a0b9c2ca0e37