### PR TITLE
[devops] Fix provisioning device testing bots.

### DIFF
--- a/tools/devops/device-tests-common.yml
+++ b/tools/devops/device-tests-common.yml
@@ -77,14 +77,7 @@ jobs:
       set -x
       set -e
 
-      CONFIGURE_ARGS="--provision-xcode --provision-xamarin-studio --provision-mono --ignore-osx --ignore-autotools --ignore-cmake"
-      if grep ignore-7z xamarin-macios/system-dependencies.sh 2>&1 > /dev/null; then
-         CONFIGURE_ARGS="$CONFIGURE_ARGS --provision-7z"
-      fi
-      if grep ignore-python3 xamarin-macios/system-dependencies.sh 2>&1 > /dev/null; then
-         CONFIGURE_ARGS="$CONFIGURE_ARGS --ignore-python3"
-      fi
-      ./xamarin-macios/system-dependencies.sh $CONFIGURE_ARGS
+      ./xamarin-macios/system-dependencies.sh --ignore-all --provision-xcode --provision-xamarin-studio --provision-mono --provision-7z
     displayName: 'Provision dependencies'
     timeoutInMinutes: 240
 


### PR DESCRIPTION
It seems we only want to provision a few specific things, so modify the
selection logic to first ignore everything, then enable what we want.

This way we don't have to add new ignore flags here every time we add
something new to the provisioning script.

We also don't need to check if 7z and python3 provisioning is possible, since
we already know that (by manually checking the system-dependencies.sh script
for the current hash).