### PR TITLE
[tests] Don't assume test assemblies are at a specific distance from the root directory.

### DIFF
--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -303,13 +303,8 @@ namespace Xamarin.Tests
 
 		public static string SourceRoot {
 			get {
-				// might need tweaking.
 				if (mt_src_root == null)
-#if MONOMAC
 					mt_src_root = RootPath;
-#else
-					mt_src_root = Path.GetFullPath (Path.Combine (TestAssemblyDirectory, "../../../.."));
-#endif
 				return mt_src_root;
 			}
 		}


### PR DESCRIPTION
The RootPath finds the top '.git' directory, which should be good enough
always, so use that implementation instead.