### PR TITLE
[linker] Fix some strings (no effect on execution)

### DIFF
--- a/tools/linker/RemoveRejectedTypesStep.cs
+++ b/tools/linker/RemoveRejectedTypesStep.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Linker {
 			get { return SubStepTargets.Assembly; }
 		}
 
-		protected override string Name { get; } = " Removing Rejected Type";
+		protected override string Name { get; } = "Removing Rejected Type";
 		protected override int ErrorCode { get; } = 2660;
 
 		public List<(string originalFullName, string replacementTypeName)> TypeReferencesToBeRemoved = new List<(string,string)> () {

--- a/tools/linker/ScanTypeReferenceStep.cs
+++ b/tools/linker/ScanTypeReferenceStep.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Linker.Steps {
 
 		protected override void Report (string typeName, AssemblyDefinition assembly)
 		{
-			ErrorHelper.Show (new ProductException (1502, false, "One or more reference(s) to type '{0}' already exists inside '{1}' before linking", typeName, assembly));
+			ErrorHelper.Show (new ProductException (1502, false, Errors.MX1502, typeName, assembly));
 		}
 	}
 
@@ -53,7 +53,7 @@ namespace Xamarin.Linker.Steps {
 
 		protected override void Report (string typeName, AssemblyDefinition assembly)
 		{
-			ErrorHelper.Show (new ProductException (1503, false, "One or more reference(s) to type '{0}' still exists inside '{1}' after linking", typeName, assembly));
+			ErrorHelper.Show (new ProductException (1503, false, Errors.MX1503, typeName, assembly));
 		}
 	}
 }


### PR DESCRIPTION
* Extra whitespace in step name. Found by Whitney reviewing a backport;
* Two errors not using (localizable) resources strings. I likely forgot to add the file to the original PR.