### PR TITLE
Make the two Equals implementations consistent

### DIFF
--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -740,7 +740,7 @@ namespace Foundation {
 				
 			bool isDirectBinding = IsDirectBinding;
 			// we can only ask `isEqual:` to test equality if both objects are direct bindings
-			return (isDirectBinding == o.IsDirectBinding) && (isDirectBinding ? IsEqual (o) : ReferenceEquals (this, obj));
+			return (isDirectBinding == o.IsDirectBinding) && (isDirectBinding ? IsEqual (o) : ReferenceEquals (this, o));
 		}
 
 		// IEquatable<T>
@@ -749,7 +749,7 @@ namespace Foundation {
 			if (obj == null)
 				return false;
 			// we'll ask the overridden Equals (if available) if one of the instances is not a direct binding
-			return (isDirectBinding == o.IsDirectBinding) && (isDirectBinding ? IsEqual (o) : ReferenceEquals (this, obj));
+			return (isDirectBinding == o.IsDirectBinding) && (isDirectBinding ? IsEqual (obj) : ReferenceEquals (this, obj));
 		}
 #endif
 

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -740,7 +740,7 @@ namespace Foundation {
 				
 			bool isDirectBinding = IsDirectBinding;
 			// is only one is a direct binding then both cannot be equals
-			if (IsDirectBinding != o.IsDirectBinding)
+			if (isDirectBinding != o.IsDirectBinding)
 				return false;
 
 			// we can only ask `isEqual:` to test equality if both objects are direct bindings

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -734,16 +734,11 @@ namespace Foundation {
 
 		public override bool Equals (object obj)
 		{
-			if (obj == null)
-				return false;
 			var o = obj as NSObject;
 			if (o == null)
 				return false;
-			// is only one is a direct binding then both cannot be equals
-			if (IsDirectBinding != o.IsDirectBinding)
-				return false;
 			// we can only ask `isEqual:` to test equality if both objects are direct bindings
-			return IsDirectBinding ? IsEqual (o) : Object.ReferenceEquals (this, obj);
+			return (IsDirectBinding && o.IsDirectBinding) ? IsEqual (o) : ReferenceEquals (this, obj);
 		}
 
 		// IEquatable<T>
@@ -752,7 +747,7 @@ namespace Foundation {
 			if (obj == null)
 				return false;
 			// we'll ask the overridden Equals (if available) if one of the instances is not a direct binding
-			return (IsDirectBinding && obj.IsDirectBinding) ? IsEqual (obj) : Equals ((object) obj);
+			return (IsDirectBinding && obj.IsDirectBinding) ? IsEqual (obj) : ReferenceEquals (this, obj);
 		}
 #endif
 

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -738,8 +738,8 @@ namespace Foundation {
 			if (o == null)
 				return false;
 				
-			bool isDirectBinding = IsDirectBinding;
 			// we can only ask `isEqual:` to test equality if both objects are direct bindings
+			bool isDirectBinding = IsDirectBinding;
 			return (isDirectBinding == o.IsDirectBinding) && (isDirectBinding ? IsEqual (o) : ReferenceEquals (this, o));
 		}
 
@@ -748,8 +748,10 @@ namespace Foundation {
 		{
 			if (obj == null)
 				return false;
+				
 			// we'll ask the overridden Equals (if available) if one of the instances is not a direct binding
-			return (isDirectBinding == o.IsDirectBinding) && (isDirectBinding ? IsEqual (obj) : ReferenceEquals (this, obj));
+			bool isDirectBinding = IsDirectBinding;
+			return (isDirectBinding == obj.IsDirectBinding) && (isDirectBinding ? IsEqual (obj) : ReferenceEquals (this, obj));
 		}
 #endif
 

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -737,8 +737,10 @@ namespace Foundation {
 			var o = obj as NSObject;
 			if (o == null)
 				return false;
+				
+			bool isDirectBinding = IsDirectBinding;
 			// we can only ask `isEqual:` to test equality if both objects are direct bindings
-			return (IsDirectBinding && o.IsDirectBinding) ? IsEqual (o) : ReferenceEquals (this, obj);
+			return (isDirectBinding == o.IsDirectBinding) && (isDirectBinding ? IsEqual (o) : ReferenceEquals (this, obj));
 		}
 
 		// IEquatable<T>
@@ -747,7 +749,7 @@ namespace Foundation {
 			if (obj == null)
 				return false;
 			// we'll ask the overridden Equals (if available) if one of the instances is not a direct binding
-			return (IsDirectBinding && obj.IsDirectBinding) ? IsEqual (obj) : ReferenceEquals (this, obj);
+			return (isDirectBinding == o.IsDirectBinding) && (isDirectBinding ? IsEqual (o) : ReferenceEquals (this, obj));
 		}
 #endif
 

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -738,9 +738,13 @@ namespace Foundation {
 			if (o == null)
 				return false;
 				
-			// we can only ask `isEqual:` to test equality if both objects are direct bindings
 			bool isDirectBinding = IsDirectBinding;
-			return (isDirectBinding == o.IsDirectBinding) && (isDirectBinding ? IsEqual (o) : ReferenceEquals (this, o));
+			// is only one is a direct binding then both cannot be equals
+			if (IsDirectBinding != o.IsDirectBinding)
+				return false;
+
+			// we can only ask `isEqual:` to test equality if both objects are direct bindings
+			return isDirectBinding ? IsEqual (o) : ReferenceEquals (this, o);
 		}
 
 		// IEquatable<T>

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -744,15 +744,7 @@ namespace Foundation {
 		}
 
 		// IEquatable<T>
-		public bool Equals (NSObject obj)
-		{
-			if (obj == null)
-				return false;
-				
-			// we'll ask the overridden Equals (if available) if one of the instances is not a direct binding
-			bool isDirectBinding = IsDirectBinding;
-			return (isDirectBinding == obj.IsDirectBinding) && (isDirectBinding ? IsEqual (obj) : ReferenceEquals (this, obj));
-		}
+		public bool Equals (NSObject obj) => Equals ((object) obj);
 #endif
 
 		public override string ToString ()


### PR DESCRIPTION
Simplify the object variant and make them use ~same code.

The object variant was querying IsDirectBinding on `this` twice and null checking obj twice.