### PR TITLE
[msbuild] Simplify the BTouch task implementation.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -56,12 +56,7 @@ namespace Xamarin.Mac.Tasks
 			if (!string.IsNullOrEmpty (ApplicationName))
 				args.AddQuotedLine ("/name:" + ApplicationName);
 
-			if (TargetFrameworkIdentifier == "Xamarin.Mac")
-				args.AddLine ("/profile:Xamarin.Mac,Version=v2.0,Profile=Mobile");
-			else if (UseXamMacFullFramework)
-				args.AddLine ($"/profile:Xamarin.Mac,Version={TargetFrameworkVersion},Profile=Full");
-			else
-				args.AddLine ($"/profile:Xamarin.Mac,Version={TargetFrameworkVersion},Profile=System");
+			args.AddLine ($"/profile:{TargetFrameworkMoniker}");
 
 			XamMacArch arch;
 			if (!Enum.TryParse (Architecture, true, out arch))

--- a/msbuild/Xamarin.Mac.Tasks/Tasks/BTouch.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/BTouch.cs
@@ -1,70 +1,8 @@
-using System;
-using System.IO;
-using System.Linq;
-using System.Collections.Generic;
-using System.Text;
-﻿
 using Xamarin.MacDev.Tasks;
-using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 
 namespace Xamarin.Mac.Tasks
 {
 	public class BTouch : BTouchTaskBase
 	{
-		public string FrameworkRoot { get; set; }
-
-		protected override string GenerateCommandLineCommands ()
-		{
-			bool isMobile;
-			if (TargetFrameworkIdentifier != null) {
-				if (TargetFrameworkIdentifier == "Xamarin.Mac") {
-					isMobile = true; // Expected case for Mobile targetting
-				}
-				else if (TargetFrameworkIdentifier == ".NETFramework") {
-					isMobile = false; // Expected case for XM 4.5
-				}
-				else { // If it is something else, don't guess
-					Log.LogError ("BTouch doesn't know how to deal with TargetFrameworkIdentifier: " + TargetFrameworkIdentifier);
-					return string.Empty;
-				}
-			}
-			else {
-				isMobile = true; // Some older binding don't have either tag, assume mobile since it is the default
-			}
-
-			var sb = new StringBuilder ();
-			var bgen = Path.Combine (FrameworkRoot, "lib", "bgen", "bgen.exe");
-			if (!File.Exists (bgen)) {
-				EnvironmentVariables = new string[] {
-					"MONO_PATH=" + string.Format ("{0}/lib/mono/{1}", FrameworkRoot, isMobile ? "Xamarin.Mac" : "4.5")
-				};
-
-				if (isMobile) {
-					sb.Append (Path.Combine (FrameworkRoot, "lib", "bmac", "bmac-mobile.exe"));
-				} else {
-					sb.Append (Path.Combine (FrameworkRoot, "lib", "bmac", "bmac-full.exe"));
-				}
-			}
-			sb.Append (" -nostdlib ");
-			sb.Append (base.GenerateCommandLineCommands ());
-			return sb.ToString ();
-		}
-
-		protected override string GetTargetFrameworkArgument ()
-		{
-			switch (TargetFrameworkIdentifier) {
-				case null:
-				case "":
-				case "Xamarin.Mac":
-					return "/target-framework=Xamarin.Mac,Version=v2.0,Profile=Mobile";
-				case ".NETFramework":
-					return "/target-framework=Xamarin.Mac,Version=v4.5,Profile=Full";
-				default:
-					Log.LogError ($"Unknown target framework identifier: {TargetFrameworkIdentifier}.");
-					return string.Empty;
-			}
-		}
-
 	}
 }

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -26,10 +26,16 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 		<_XamarinCommonPropsHasBeenImported>true</_XamarinCommonPropsHasBeenImported>
 	</PropertyGroup>
 
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">
 		<!-- Get the TargetFrameworkMoniker and store it in our own variable so that it's overridable while only affecting the parts of the build that we care about.
 			 This is overridability is a workaround while we wait for .NET 5 to be able to give us the TFM we're supposed to get during the build. -->
-		<_ComputedTargetFrameworkMoniker Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">$(TargetFrameworkMoniker)</_ComputedTargetFrameworkMoniker>
+		<_ComputedTargetFrameworkMoniker>$(TargetFrameworkMoniker)</_ComputedTargetFrameworkMoniker>
+		<!-- Detect the Mobile condition and set the computed Mobile TFM our tooling expects -->
+		<_ComputedTargetFrameworkMoniker Condition="'$(_ComputedTargetFrameworkMoniker)' == 'Xamarin.Mac,Version=v2.0'">Xamarin.Mac,Version=v2.0,Profile=Mobile</_ComputedTargetFrameworkMoniker>
+		<!-- Detect the Full condition and set the computed TFM our tooling expects -->
+		<_ComputedTargetFrameworkMoniker Condition="'$(UseXamMacFullFramework)' == 'true' And $([MSBuild]::ValueOrDefault('$(_ComputedTargetFrameworkMoniker),', '').StartsWith('.NETFramework,', StringComparison.OrdinalIgnoreCase))">Xamarin.Mac,Version=v4.5,Profile=Full</_ComputedTargetFrameworkMoniker>
+		<!-- Detect the System condition and set the computed TFM our tooling expects -->
+		<_ComputedTargetFrameworkMoniker Condition="'$(UseXamMacFullFramework)' != 'true' And $([MSBuild]::ValueOrDefault('$(_ComputedTargetFrameworkMoniker),', '').StartsWith('.NETFramework,', StringComparison.OrdinalIgnoreCase))">Xamarin.Mac,Version=v4.5,Profile=System</_ComputedTargetFrameworkMoniker>
 	</PropertyGroup>
 
 	<!-- Story-time! MigrateToNewXMIdentifier is special because it un-does a lie we started telling from the 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -110,7 +110,6 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 			ProjectDir="$(MSBuildProjectDirectory)"
 			References="@(ReferencePath);@(BTouchReferencePath)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
-			FrameworkRoot="$(XamarinMacFrameworkRoot)"
 			BTouchToolPath="$(BTouchToolPath)"
 			BTouchToolExe="$(BTouchToolExe)"
 			StandardOutputImportance="High"

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.props
@@ -24,18 +24,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<_XamarinCommonBindingPropsHasBeenImported>true</_XamarinCommonBindingPropsHasBeenImported>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">
-		<!-- Get the TargetFrameworkMoniker and store it in our own variable so that it's overridable while only affecting the parts of the build that we care about.
-			 This is overridability is a workaround while we wait for .NET 5 to be able to give us the TFM we're supposed to get during the build. -->
-		<_ComputedTargetFrameworkMoniker>$(TargetFrameworkMoniker)</_ComputedTargetFrameworkMoniker>
-		<!-- Detect the Mobile condition and set the computed Mobile TFM our tooling expects -->
-		<_ComputedTargetFrameworkMoniker Condition="'$(_ComputedTargetFrameworkMoniker)' == 'Xamarin.Mac,v2.0'">Xamarin.Mac,Version=v2.0,Profile=Mobile</_ComputedTargetFrameworkMoniker>
-		<!-- Detect the Full condition and set the computed TFM our tooling expects -->
-		<_ComputedTargetFrameworkMoniker Condition="'$(UseXamMacFullFramework)' == 'true' And $([MSBuild]::ValueOrDefault('$(_ComputedTargetFrameworkMoniker),', '').StartsWith('.NETFramework,', StringComparison.OrdinalIgnoreCase))">Xamarin.Mac,Version=v4.5,Profile=Full</_ComputedTargetFrameworkMoniker>
-		<!-- Detect the System condition and set the computed TFM our tooling expects -->
-		<_ComputedTargetFrameworkMoniker Condition="'$(UseXamMacFullFramework)' != 'true' And $([MSBuild]::ValueOrDefault('$(_ComputedTargetFrameworkMoniker),', '').StartsWith('.NETFramework,', StringComparison.OrdinalIgnoreCase))">Xamarin.Mac,Version=v4.5,Profile=System</_ComputedTargetFrameworkMoniker>
-	</PropertyGroup>
-
 	<PropertyGroup>
 		<BaseLibDllPath>$(MacBclPath)/Xamarin.Mac.dll</BaseLibDllPath>
 		<BTouchToolPath>$(XamarinMacFrameworkRoot)/bin/</BTouchToolPath>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.props
@@ -24,10 +24,16 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<_XamarinCommonBindingPropsHasBeenImported>true</_XamarinCommonBindingPropsHasBeenImported>
 	</PropertyGroup>
 
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">
 		<!-- Get the TargetFrameworkMoniker and store it in our own variable so that it's overridable while only affecting the parts of the build that we care about.
 			 This is overridability is a workaround while we wait for .NET 5 to be able to give us the TFM we're supposed to get during the build. -->
-		<_ComputedTargetFrameworkMoniker Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">$(TargetFrameworkMoniker)</_ComputedTargetFrameworkMoniker>
+		<_ComputedTargetFrameworkMoniker>$(TargetFrameworkMoniker)</_ComputedTargetFrameworkMoniker>
+		<!-- Detect the Mobile condition and set the computed Mobile TFM our tooling expects -->
+		<_ComputedTargetFrameworkMoniker Condition="'$(_ComputedTargetFrameworkMoniker)' == 'Xamarin.Mac,v2.0'">Xamarin.Mac,Version=v2.0,Profile=Mobile</_ComputedTargetFrameworkMoniker>
+		<!-- Detect the Full condition and set the computed TFM our tooling expects -->
+		<_ComputedTargetFrameworkMoniker Condition="'$(UseXamMacFullFramework)' == 'true' And $([MSBuild]::ValueOrDefault('$(_ComputedTargetFrameworkMoniker),', '').StartsWith('.NETFramework,', StringComparison.OrdinalIgnoreCase))">Xamarin.Mac,Version=v4.5,Profile=Full</_ComputedTargetFrameworkMoniker>
+		<!-- Detect the System condition and set the computed TFM our tooling expects -->
+		<_ComputedTargetFrameworkMoniker Condition="'$(UseXamMacFullFramework)' != 'true' And $([MSBuild]::ValueOrDefault('$(_ComputedTargetFrameworkMoniker),', '').StartsWith('.NETFramework,', StringComparison.OrdinalIgnoreCase))">Xamarin.Mac,Version=v4.5,Profile=System</_ComputedTargetFrameworkMoniker>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
@@ -189,7 +189,7 @@ namespace Xamarin.MacDev.Tasks {
 			if (GeneratedSourcesFileList != null)
 				cmd.AppendSwitchIfNotNull ("/sourceonly:", Path.GetFullPath (GeneratedSourcesFileList));
 
-			cmd.AppendSwitch (GetTargetFrameworkArgument ());
+			cmd.AppendSwitch ($"/target-framework={TargetFrameworkMoniker}");
 
 			if (!string.IsNullOrEmpty (ExtraArgs)) {
 				var extraArgs = CommandLineArgumentBuilder.Parse (ExtraArgs);
@@ -237,20 +237,6 @@ namespace Xamarin.MacDev.Tasks {
 			}
 
 			return cmd.ToString ();
-		}
-
-		protected virtual string GetTargetFrameworkArgument ()
-		{
-			switch (TargetFrameworkIdentifier) {
-				case "MonoTouch":
-				case "Xamarin.iOS":
-				case "Xamarin.TVOS":
-				case "Xamarin.WatchOS":
-					return $"/target-framework={TargetFrameworkIdentifier},v1.0";
-				default:
-					Log.LogError ($"Unknown target framework identifier: {TargetFrameworkIdentifier}.");
-					return string.Empty;
-			}
 		}
 
 		public override bool Execute ()


### PR DESCRIPTION
* Don't validate the TargetFrameworkIdentifier, instead pass it along to bgen
  (which will validate it). This means less validation updates when something
  changes.
* For Xamarin.Mac's GenerateCommandLineCommands' implementation:
    * We'll always have a bgen.exe, so the code for what to do if bgen isn't
      there can be removed.
    * There's no need to compute the 'isMobile' value, because now it's not used
      anymore. So we can remove the first if block in the method completely.
    * There's no need to add the -stdlib flag, because the base implementation
      in BTouchTaskBase already adds it.
    * Now there's nothing left in the method but calling base, so the entire
      override can be removed.
    * This also removes the need for the FrameworkRoot parameter to the task,
      so remove that too.
* For Xamarin.Mac's GetTargetFrameworkArgument's implementation:
    * Move the TargetFramework logic to detect the different Xamarin.Mac
      variations to the targets file, so that it can be reused by other tasks
      and targets.
    * This means we don't need an overridable function to get the target
      framework argument, so just remove inline the entire virtual method.