### PR TITLE
[runtime] Abort if the call to Runtime.Initialize fails.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1362,8 +1362,11 @@ xamarin_initialize ()
 
 	mono_runtime_invoke (runtime_initialize, NULL, params, &exc);
 
-	if (exc)
+	if (exc) {
+		NSLog (@PRODUCT ": An exception occurred when calling Runtime.Initialize:\n%@", xamarin_print_all_exceptions (exc));
 		xamarin_process_managed_exception (exc);
+		xamarin_assertion_message ("Can't continue if Runtime.Initialize fails.");
+	}
 
 	if (!register_assembly (assembly, &exception_gchandle))
 		xamarin_process_managed_exception_gchandle (exception_gchandle);


### PR DESCRIPTION
Also print out something to the system log. In theory
xamarin_process_managed_exception should also end up terminating the process
in one way or another, but when something goes wrong it tend to go very, very
wrong, so this makes sure some info is printed somewhere.