### PR TITLE
[Harness] Add several fixes to the crash reports.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -893,7 +893,7 @@ namespace Xharness
 					if (isTcp)
 						XmlResultParser.GenerateFailure (Logs, "tcp-connection", appName, Variation, $"TcpConnection on {device_name}", $"Device {device_name} could not reach the host over tcp.", main_log.FullPath, Harness.XmlJargon);
 				} else if (timed_out && Harness.InCI) {
-					XmlResultParser.GenerateFailure (Logs, "timeout", AppName, Variation, $"App Timeout {AppName} {Variation}", $"Test run timed out after {timeout.TotalMinutes} minute(s).", MainLog.FullPath, Harness.XmlJargon);
+					XmlResultParser.GenerateFailure (Logs, "timeout", AppName, Variation, $"App Timeout {AppName} {Variation} on bot {device_name}", $"{AppName} {Variation} Test run timed out after {timeout.TotalMinutes} minute(s) on bot {device_name}.", MainLog.FullPath, Harness.XmlJargon);
 				}
 			}
 

--- a/tests/xharness/Jenkins/TestTasks/RunTestTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/RunTestTask.cs
@@ -71,7 +71,7 @@ namespace Xharness.Jenkins.TestTasks
 				}
 				FailureMessage = BuildTask.FailureMessage;
 				if (Harness.InCI && BuildTask is MSBuildTask projectTask)
-					XmlResultParser.GenerateFailure (Logs, "build", projectTask.TestName, projectTask.Variation, "AppBuild", $"App could not be built {FailureMessage}.", projectTask.BuildLog.FullPath, Harness.XmlJargon);
+					XmlResultParser.GenerateFailure (Logs, "build", projectTask.TestName, projectTask.Variation, $"App Build {projectTask.TestName} {projectTask.Variation}", $"App could not be built {FailureMessage}.", projectTask.BuildLog.FullPath, Harness.XmlJargon);
 			} else {
 				ExecutionResult = TestExecutingResult.Built;
 			}

--- a/tests/xharness/XmlResultParser.cs
+++ b/tests/xharness/XmlResultParser.cs
@@ -601,9 +601,9 @@ namespace Xharness {
 			writer.WriteEndElement (); // test-results
 		}
 
-		static void WriteNUnitV3TestSuiteAttributes (XmlWriter writer) => WriteAttributes (writer,
+		static void WriteNUnitV3TestSuiteAttributes (XmlWriter writer, string title) => WriteAttributes (writer,
 			("id", "1"),
-			("name", "Test Crash"),
+			("name", title),
 			("testcasecount", "1"),
 			("result", "Failed"),
 			("time", "0"),
@@ -649,7 +649,7 @@ namespace Xharness {
 			);
 			writer.WriteStartElement ("test-suite");
 			writer.WriteAttributeString ("type", "Assembly");
-			WriteNUnitV3TestSuiteAttributes (writer);
+			WriteNUnitV3TestSuiteAttributes (writer, title);
 			WriteFailure (writer, "Child test failed");
 			writer.WriteStartElement ("test-suite");
 			WriteAttributes (writer,


### PR DESCRIPTION
1. The name of the tests is picked up in a more inner node than
expected. Fwd the test name to make sure that noe all
crashes/timeouts/launches have the same name.
2. Add extra information when we have a timeout. We want to know the
name and the bot used to ensure that it is easier to identify patterns.

Timeout tests now have:
- test title as: App Timeout {AppName} {Variation} on bot {device_name}
- message: AppName} {Variation} Test run timed out after {timeout.TotalMinutes} minute(s) on bot {device_name}.

Build issues now have:
- test title: App Build {projectTask.TestName} {projectTask.Variation}

That way we know the exact app that failed to build and the exact app that timeout and the device used to run it.