### PR TITLE
Fix API comparison. Fixes #xamarin/maccore@2176.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@ TOP=..
 include $(TOP)/Make.config
 
 BUILD_DIR=build
-DOTNET_BUILD_DIR=build/dotnet
+DOTNET_BUILD_DIR=$(BUILD_DIR)/dotnet
 PROJECT_DIR=.
 
 include $(TOP)/src/frameworks.sources

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -12,8 +12,8 @@ $(BUILD_DIR)/common/bgen.exe: $(generator_dependencies) Makefile.generator $(BUI
 	$(Q_GEN) $(SYSTEM_MSBUILD) $(XBUILD_VERBOSITY) /p:Configuration=Debug generator.csproj /p:IntermediateOutputPath=$(BUILD_DIR)/IDE/obj/common/ /p:OutputPath=$(BUILD_DIR)/common
 
 $(DOTNET_BUILD_DIR)/bgen/bgen:  $(generator_dependencies) Makefile.generator $(BUILD_DIR)/generator-frameworks.g.cs | $(DOTNET_BUILD_DIR)/bgen
-	$(Q_DOTNET_BUILD) $(DOTNET) build $(XBUILD_VERBOSITY) /p:Configuration=Debug bgen/bgen.csproj
-	$(Q) $(CP) bgen/bin/Debug/netcoreapp3.1/bgen* $(dir $@)
+	$(Q_DOTNET_BUILD) $(DOTNET) build $(XBUILD_VERBOSITY) /p:Configuration=Debug bgen/bgen.csproj /p:IntermediateOutputPath=$(abspath $(DOTNET_BUILD_DIR)/IDE/obj/common)/ /p:OutputPath=$(abspath $(DOTNET_BUILD_DIR)/IDE/bin/common)/
+	$(Q) $(CP) $(DOTNET_BUILD_DIR)/IDE/bin/common/bgen* $(dir $@)
 
 DOTNET_TARGETS += \
 	$(DOTNET_BUILD_DIR)/bgen/bgen \

--- a/tools/compare-commits.sh
+++ b/tools/compare-commits.sh
@@ -202,7 +202,7 @@ git checkout --quiet --force --detach "$BASE_HASH"
 touch "$OUTPUT_DIR/stamp"
 
 echo "${BLUE}Building src/...${CLEAR}"
-if ! make -C "$ROOT_DIR/src" BUILD_DIR=../tools/comparison/build PROJECT_DIR="$OUTPUT_DIR/project-files" "IOS_DESTDIR=$OUTPUT_DIR/_ios-build" "MAC_DESTDIR=$OUTPUT_DIR/_mac-build" -j8; then
+if ! make -C "$ROOT_DIR/src" BUILD_DIR="$ROOT_DIR/tools/comparison/build" PROJECT_DIR="$OUTPUT_DIR/project-files" "IOS_DESTDIR=$OUTPUT_DIR/_ios-build" "MAC_DESTDIR=$OUTPUT_DIR/_mac-build" -j8; then
 	EC=$?
 	report_error_line "${RED}Failed to build src/${CLEAR}"
 	exit "$EC"


### PR DESCRIPTION
* Make everything in src/ build into a directory dependent upon BUILD_DIR.
  That way the API comparison can successfully build into a different
  directory.
* Use an absolute path as the temporary build directory. This works better
  when the path is used in directories with different depth from the root.

Fixes https://github.com/xamarin/maccore/issues/2176.

The API comparison will still fail for this PR/commit, the fix won't take
effect until the next commit.