### PR TITLE
[msbuild] The Mmp/Mtouch tasks are passed the expected TargetFrameworkMoniker, so no need to have any custom logic here.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -28,8 +28,6 @@ namespace Xamarin.Mac.Tasks
 
 		public bool IsXPCService { get; set; }
 
-		public bool UseXamMacFullFramework { get; set; }
-
 		public string ApplicationName { get; set; }
 		public string Architecture { get; set; }
 
@@ -56,8 +54,6 @@ namespace Xamarin.Mac.Tasks
 
 			if (!string.IsNullOrEmpty (ApplicationName))
 				args.AddQuotedLine ("/name:" + ApplicationName);
-
-			args.AddLine ($"/profile:{TargetFrameworkMoniker}");
 
 			XamMacArch arch;
 			if (!Enum.TryParse (Architecture, true, out arch))

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -537,7 +537,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			ApplicationName="$(_AppBundleName)"
 			MainAssembly="$(OutputPath)$(TargetName)$(TargetExt)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
-			UseXamMacFullFramework="$(UseXamMacFullFramework)"
 			Architecture="$(XamMacArch)"
 			ArchiveSymbols="$(MonoSymbolArchive)"
 			LinkMode="$(LinkMode)"

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BundlerToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BundlerToolTaskBase.cs
@@ -108,6 +108,8 @@ namespace Xamarin.MacDev.Tasks {
 			if (EnableSGenConc)
 				args.AddLine ("--sgen-conc");
 
+			args.AddLine ("/target-framework:" + TargetFrameworkMoniker);
+
 			args.AddLine (string.Format ("--http-message-handler={0}", HttpClientHandler));
 
 			if (!string.IsNullOrEmpty (I18n))

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -486,8 +486,6 @@ namespace Xamarin.iOS.Tasks
 			foreach (var ext in AppExtensionReferences)
 				args.AddQuotedLine ($"--app-extension={Path.GetFullPath (ext.ItemSpec)}");
 
-			args.AddLine ($"--target-framework={TargetFrameworkIdentifier},{TargetFrameworkVersion}");
-			
 			if (!string.IsNullOrWhiteSpace (License))
 				args.AddLine ($"--license={License}");
 


### PR DESCRIPTION
We can even move it all to the shared base class, and remove an unused variable (`UseXamMacFullFramework`).