### PR TITLE
[mtouch/mmp] Improve target framework code.

### DIFF
--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -199,7 +199,7 @@ public class BindingTouch {
 			throw ErrorHelper.CreateError (68, fx);
 		target_framework = tf;
 
-		if (Array.IndexOf (TargetFramework.ValidFrameworks, target_framework.Value) == -1)
+		if (!TargetFramework.IsValidFramework (target_framework.Value))
 			throw ErrorHelper.CreateError (70, target_framework.Value, string.Join (" ", TargetFramework.ValidFrameworks.Select ((v) => v.ToString ()).ToArray ()));
 	}
 

--- a/tests/common/BundlerTool.cs
+++ b/tests/common/BundlerTool.cs
@@ -256,23 +256,18 @@ namespace Xamarin.Tests
 			} else if (!string.IsNullOrEmpty (TargetFramework)) {
 				sb.Add ("--target-framework");
 				sb.Add (TargetFramework);
-			} else if (!NoPlatformAssemblyReference) {
-				// make the implicit default the way tests have been running until now, and at the same time the very minimum to make apps build.
+			} else {
 				switch (Profile) {
 				case Profile.iOS:
-					sb.Add ($"-r:" + Configuration.XamarinIOSDll);
-					break;
 				case Profile.tvOS:
 				case Profile.watchOS:
-					sb.Add ("--target-framework");
-					sb.Add (Configuration.GetTargetFramework (Profile));
-					sb.Add ("-r:" + Configuration.GetBaseLibrary (Profile));
-					break;
 				case Profile.macOSFull:
 				case Profile.macOSMobile:
 				case Profile.macOSSystem:
 					sb.Add ("--target-framework");
 					sb.Add (Configuration.GetTargetFramework (Profile));
+					if (!NoPlatformAssemblyReference)
+						sb.Add ("-r:" + Configuration.GetBaseLibrary (Profile));
 					break;
 				default:
 					throw new NotImplementedException ();

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -447,7 +447,7 @@ namespace Xamarin.MMP.Tests
 			RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { XM45 = true };
 				var output = TI.TestUnifiedExecutable (test);
-				Assert.That (output.BuildOutput, Contains.Substring ("Selected target framework: .NETFramework,Version=v4.5; API: Unified"));
+				Assert.That (output.BuildOutput, Contains.Substring ("Selected target framework: Xamarin.Mac,Version=v4.5,Profile=Full; API: Unified"));
 			});
 		}
 

--- a/tests/mmptest/src/MmpTool.cs
+++ b/tests/mmptest/src/MmpTool.cs
@@ -37,6 +37,8 @@ namespace Xamarin
 				sb.Add ($"--output={OutputPath}");
 
 			switch (Profile) {
+			case Profile.None:
+				break;
 			case Profile.macOSMobile:
 				sb.Add ("--profile=Xamarin.Mac,Version=v2.0,Profile=Mobile");
 				break;

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1048,7 +1048,7 @@ public class B : A {}
 
 		[Test]
 		[TestCase (Profile.tvOS)]
-		//[TestCase (Profile.WatchOS)] MT0077 interferring.
+		[TestCase (Profile.watchOS)]
 		[TestCase (Profile.iOS)]
 		public void MT0085 (Profile profile)
 		{
@@ -1056,8 +1056,11 @@ public class B : A {}
 				mtouch.Profile = profile;
 				mtouch.CreateTemporaryApp ();
 				mtouch.TargetFramework = GetTargetFramework (profile);
-				Assert.AreEqual (0, mtouch.Execute (MTouchAction.BuildSim));
+				mtouch.WarnAsError = new int [] { 85 };
+				mtouch.AssertExecuteFailure (MTouchAction.BuildSim);
 				mtouch.AssertError (85, string.Format ("No reference to '{0}' was found. It will be added automatically.", Path.GetFileName (GetBaseLibrary (profile))));
+				mtouch.AssertErrorCount (1);
+				mtouch.AssertWarningCount (0);
 			}
 		}
 
@@ -1067,10 +1070,11 @@ public class B : A {}
 		public void MT0086 (Profile profile)
 		{
 			using (var mtouch = new MTouchTool ()) {
+				mtouch.TargetFramework = BundlerTool.None;
 				mtouch.CreateTemporaryApp ();
 				mtouch.References = new string [] { GetBaseLibrary (profile) };
 				Assert.AreEqual (1, mtouch.Execute (MTouchAction.BuildSim));
-				mtouch.AssertError (86, "A target framework (--target-framework) must be specified when building for TVOS or WatchOS.");
+				mtouch.AssertError (86, "A target framework (--target-framework) must be specified.");
 			}
 		}
 

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1181,17 +1181,6 @@ public class B : A {}
 			}
 		}
 		
-		[Test]
-		public void MT0096 ()
-		{
-			using (var mtouch = new MTouchTool ()) {
-				mtouch.CreateTemporaryApp ();
-				mtouch.NoPlatformAssemblyReference = true;
-				Assert.AreEqual (1, mtouch.Execute (MTouchAction.BuildSim));
-				mtouch.AssertError (96, "No reference to Xamarin.iOS.dll was found.");
-			}
-		}
-
 		/* MT0100 is a consistency check, and should never be seen (and as such can never be tested either, since there's no known test cases that would produce it) */
 
 		[Test]

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -19,6 +19,12 @@ using Xamarin.MacDev;
 using Xamarin.Utils;
 using ObjCRuntime;
 
+#if MTOUCH
+using ProductException = Xamarin.Bundler.MonoTouchException;
+#else
+using ProductException=Xamarin.Bundler.MonoMacException;
+#endif
+
 namespace Xamarin.Bundler {
 	public partial class Driver {
 		public static int Main (string [] args)
@@ -35,11 +41,17 @@ namespace Xamarin.Bundler {
 			return 0;
 		}
 
-		static void AddSharedOptions (Application app, Mono.Options.OptionSet options)
+		// Returns true if the process should exit (with a 0 exit code; failures are propagated using exceptions)
+		static bool ParseOptions (Application app, Mono.Options.OptionSet options, string[] args, ref Action action)
 		{
+			Action a = Action.None; // Need a temporary local variable, since anonymous functions can't write directly to ref/out arguments.
+
+			options.Add ("h|?|help", "Displays the help", v => a = Action.Help);
+			options.Add ("version", "Output version information and exit.", v => a = Action.Version);
 			options.Add ("v|verbose", "Specify how verbose the output should be. This can be passed multiple times to increase the verbosity.", v => Verbosity++);
 			options.Add ("q|quiet", "Specify how quiet the output should be. This can be passed multiple times to increase the silence.", v => Verbosity--);
 			options.Add ("sdkroot=", "Specify the location of Apple SDKs, default to 'xcode-select' value.", v => sdk_root = v);
+			options.Add ("target-framework=", "Specify target framework to use. Currently supported: '" + string.Join ("', '", TargetFramework.ValidFrameworks.Select ((v) => v.ToString ())) + "'.", v => SetTargetFramework (v));
 			options.Add ("no-xcode-version-check", "Ignores the Xcode version check.", v => { min_xcode_version = null; }, true /* This is a non-documented option. Please discuss any customers running into the xcode version check on the maciosdev@ list before giving this option out to customers. */);
 			options.Add ("warnaserror:", "An optional comma-separated list of warning codes that should be reported as errors (if no warnings are specified all warnings are reported as errors).", v =>
 			{
@@ -174,6 +186,31 @@ namespace Xamarin.Bundler {
 						app.Optimizations.Parse (v);
 					});
 			options.Add (new Mono.Options.ResponseFileSource ());
+
+			try {
+				app.RootAssemblies.AddRange (options.Parse (args));
+			} catch (ProductException) {
+				throw;
+			} catch (Exception e) {
+				throw ErrorHelper.CreateError (10, e, Errors.MX0010, e);
+			}
+
+			if (a != Action.None)
+				action = a;
+
+			if (action == Action.Help || args.Length == 0) {
+				ShowHelp (options);
+				return true;
+			} else if (action == Action.Version) {
+				Console.WriteLine (NAME + " {0}.{1}", Constants.Version, Constants.Revision);
+				return true;
+			}
+
+			LogArguments (args);
+
+			ValidateTargetFramework ();
+
+			return false;
 		}
 
 		static int Jobs;
@@ -235,54 +272,110 @@ namespace Xamarin.Bundler {
 
 		public const bool IsXAMCORE_4_0 = false;
 
-#if MONOMAC
-#pragma warning disable 0414
-		static string userTargetFramework = TargetFramework.Default.ToString ();
-#pragma warning restore 0414
-#endif
-
-		static TargetFramework? targetFramework;
-		public static bool HasTargetFramework {
-			get { return targetFramework.HasValue; }
-		}
+		static TargetFramework targetFramework;
 
 		public static TargetFramework TargetFramework {
-			get { return targetFramework.Value; }
+			get { return targetFramework; }
 			set { targetFramework = value; }
 		}
 
-		static void SetTargetFramework (string fx)
+		// We need to delay validating the target framework until we've parsed all the command line arguments,
+		// so first store it here, and then we call ValidateTargetFramework when we're done parsing the command
+		// line arguments.
+		static string target_framework;
+		static void SetTargetFramework (string value)
 		{
-#if MONOMAC
-			userTargetFramework = fx;
-#endif
+			target_framework = value;
+		}
 
+		static void ValidateTargetFramework ()
+		{
+			if (string.IsNullOrEmpty (target_framework))
+				throw ErrorHelper.CreateError (86, Errors.MX0086 /* A target framework (--target-framework) must be specified */);
+
+			var fx = target_framework;
 			switch (fx.Trim ().ToLowerInvariant ()) {
-#if MONOMAC
 			case "xammac":
 			case "mobile":
 			case "xamarin.mac":
-				targetFramework = TargetFramework.Xamarin_Mac_2_0;
-				break;
-#endif
+				targetFramework = TargetFramework.Xamarin_Mac_2_0_Mobile;
+				ErrorHelper.Warning (90, Errors.MX0090, /* The target framework '{0}' is deprecated. Use '{1}' instead. */ fx, targetFramework);
+				return;
 			default:
 				TargetFramework parsedFramework;
-				if (!Xamarin.Utils.TargetFramework.TryParse (fx, out parsedFramework))
+				if (!TargetFramework.TryParse (fx, out parsedFramework))
 					throw ErrorHelper.CreateError (68, Errors.MX0068, fx);
-#if MONOMAC
-				if (parsedFramework == TargetFramework.Net_3_0 || parsedFramework == TargetFramework.Net_3_5)
-					parsedFramework = TargetFramework.Net_2_0;
-#endif
 
 				targetFramework = parsedFramework;
 
 				break;
 			}
 
-#if MTOUCH
-			if (Array.IndexOf (TargetFramework.ValidFrameworks, targetFramework.Value) == -1)
-				throw ErrorHelper.CreateError (70, Errors.MT0070, targetFramework.Value, string.Join (" ", TargetFramework.ValidFrameworks.Select ((v) => v.ToString ()).ToArray ()));
+			bool show_0090 = false;
+#if MONOMAC
+			if (!TargetFramework.IsValidFramework (targetFramework)) {
+				// For historic reasons this is messy.
+				// If the TargetFramework we got isn't any of the one we accept, we have to do some fudging.
+				bool force45From40UnifiedSystemFull = false;
+
+				if (references.Any ((v) => Path.GetFileName (v) == "XamMac.dll"))
+					throw ErrorHelper.CreateError (143, Errors.MM0143);
+
+				if (targetFramework == TargetFramework.Net_2_0
+					|| targetFramework == TargetFramework.Net_3_0
+					|| targetFramework == TargetFramework.Net_3_5
+					|| targetFramework == TargetFramework.Net_4_0
+					|| targetFramework == TargetFramework.Net_4_5) {
+					// .NETFramework,v2.0 => Xamarin.Mac,Version=v4.5,Profile=Full
+					// .NETFramework,v3.0 => Xamarin.Mac,Version=v4.5,Profile=Full
+					// .NETFramework,v3.5 => Xamarin.Mac,Version=v4.5,Profile=Full
+					// .NETFramework,v4.0 => Xamarin.Mac,Version=v4.5,Profile=Full
+					// .NETFramework,v4.5 => Xamarin.Mac,Version=v4.5,Profile=Full
+					TargetFramework = TargetFramework.Xamarin_Mac_4_5_Full;
+				} else if (TargetFramework.Identifier == TargetFramework.Xamarin_Mac_2_0_Mobile.Identifier
+					&& TargetFramework.Version == TargetFramework.Xamarin_Mac_2_0_Mobile.Version) {
+					// At least once instance of a TargetFramework of Xamarin.Mac,v2.0,(null) was found already. Assume any v2.0 implies a desire for Modern.
+					TargetFramework = TargetFramework.Xamarin_Mac_2_0_Mobile;
+				} else if (TargetFramework.Identifier == TargetFramework.Xamarin_Mac_4_5_Full.Identifier
+						 && TargetFramework.Profile == TargetFramework.Xamarin_Mac_4_5_Full.Profile) {
+					// Xamarin.Mac,Version=vX.Y,Profile=Full => Xamarin.Mac,Version=v4.5,Profile=Full
+					TargetFramework = TargetFramework.Xamarin_Mac_4_5_Full;
+				} else if (TargetFramework.Identifier == TargetFramework.Xamarin_Mac_4_5_System.Identifier
+						 && TargetFramework.Profile == TargetFramework.Xamarin_Mac_4_5_System.Profile) {
+					// Xamarin.Mac,Version=vX.Y,Profile=System => Xamarin.Mac,Version=v4.5,Profile=System
+					TargetFramework = TargetFramework.Xamarin_Mac_4_5_System;
+				} else {
+					// This is a total hack. Instead of passing in an argument, we walk the references looking for
+					// the "right" Xamarin.Mac and assume you are doing something
+					// Skip it if xamarin-full-framework or xamarin-system-framework passed in 
+					foreach (var asm in references) {
+						if (asm.EndsWith ("reference/full/Xamarin.Mac.dll", StringComparison.Ordinal)) {
+							force45From40UnifiedSystemFull = TargetFramework == TargetFramework.Net_4_0;
+							TargetFramework = TargetFramework.Xamarin_Mac_4_5_System;
+							break;
+						} else if (asm.EndsWith ("mono/4.5/Xamarin.Mac.dll", StringComparison.Ordinal)) {
+							TargetFramework = TargetFramework.Xamarin_Mac_4_5_Full;
+							break;
+						}
+					}
+				}
+
+				if (force45From40UnifiedSystemFull) {
+					// Xamarin.Mac Unified Full System profile requires .NET 4.5, not .NET 4.0.
+					FixReferences (x => x.Contains ("lib/mono/4.0"), x => x.Replace ("lib/mono/4.0", "lib/mono/4.5"));
+				}
+
+				show_0090 = true;
+			}
 #endif
+
+			// Verify that our TargetFramework is our limited list of valid target frameworks.
+			if (!TargetFramework.IsValidFramework (TargetFramework))
+				throw ErrorHelper.CreateError (70, Errors.MX0070, fx, "'" + string.Join ("', '", TargetFramework.ValidFrameworks.Select ((v) => v.ToString ()).ToArray ()) + "'");
+
+			// Only show the warning if no errors were shown.
+			if (show_0090)
+				ErrorHelper.Warning (90, Errors.MX0090, /* The target framework '{0}' is deprecated. Use '{1}' instead. */ fx, TargetFramework);
 		}
 
 		public static int RunCommand (string path, params string [] args)

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -318,8 +318,9 @@ namespace Xamarin.Bundler {
 				// If the TargetFramework we got isn't any of the one we accept, we have to do some fudging.
 				bool force45From40UnifiedSystemFull = false;
 
+				// Detect Classic usage, and show an error.
 				if (references.Any ((v) => Path.GetFileName (v) == "XamMac.dll"))
-					throw ErrorHelper.CreateError (143, Errors.MM0143);
+					throw ErrorHelper.CreateError (143, Errors.MM0143 /* Projects using the Classic API are not supported anymore. Please migrate the project to the Unified API. */);
 
 				if (targetFramework == TargetFramework.Net_2_0
 					|| targetFramework == TargetFramework.Net_3_0
@@ -347,7 +348,6 @@ namespace Xamarin.Bundler {
 				} else {
 					// This is a total hack. Instead of passing in an argument, we walk the references looking for
 					// the "right" Xamarin.Mac and assume you are doing something
-					// Skip it if xamarin-full-framework or xamarin-system-framework passed in 
 					foreach (var asm in references) {
 						if (asm.EndsWith ("reference/full/Xamarin.Mac.dll", StringComparison.Ordinal)) {
 							force45From40UnifiedSystemFull = TargetFramework == TargetFramework.Net_4_0;

--- a/tools/common/TargetFramework.cs
+++ b/tools/common/TargetFramework.cs
@@ -7,6 +7,8 @@
 // Copyright 2014 Xamarin Inc. All Rights Reserved.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Xamarin.Utils
 {
@@ -21,12 +23,6 @@ namespace Xamarin.Utils
 	public struct TargetFramework : IEquatable<TargetFramework>
 	{
 		public static readonly TargetFramework Empty = new TargetFramework ();
-		public static readonly TargetFramework Default = 
-#if MONOMAC
-			Parse ("4.0");
-#else
-			Parse ("Xamarin.iOS,v1.0");
-#endif
 		public static readonly TargetFramework Net_2_0 = Parse ("2.0");
 		public static readonly TargetFramework Net_3_0 = Parse ("3.0");
 		public static readonly TargetFramework Net_3_5 = Parse ("3.5");
@@ -46,16 +42,36 @@ namespace Xamarin.Utils
 		public static readonly TargetFramework DotNet_5_0_tvOS = Parse (".NETCoreApp,Version=5.0,Profile=tvos"); // Short form: net5.0-tvos
 		public static readonly TargetFramework DotNet_5_0_watchOS = Parse (".NETCoreApp,Version=5.0,Profile=watchos"); // Short form: net5.0-watchos
 		public static readonly TargetFramework DotNet_5_0_macOS = Parse (".NETCoreApp,Version=5.0,Profile=macos"); // Short form: net5.0-macos
-#if MTOUCH
-		public static readonly TargetFramework [] ValidFrameworks = new TargetFramework[] { Xamarin_iOS_1_0, Xamarin_WatchOS_1_0, Xamarin_TVOS_1_0 };
-#elif BGENERATOR
-		public static readonly TargetFramework [] ValidFrameworks = new TargetFramework[]
-		{
-			Xamarin_iOS_1_0, Xamarin_TVOS_1_0, Xamarin_WatchOS_1_0,
+
+		public static readonly TargetFramework [] ValidFrameworksMac = new [] {
 			Xamarin_Mac_2_0_Mobile, Xamarin_Mac_4_5_Full, Xamarin_Mac_4_5_System,
-			DotNet_5_0_iOS, DotNet_5_0_macOS, DotNet_5_0_tvOS, DotNet_5_0_watchOS,
+			DotNet_5_0_macOS,
 		};
+
+		public static readonly TargetFramework [] ValidFrameworksiOS = new [] {
+			Xamarin_iOS_1_0, Xamarin_WatchOS_1_0, Xamarin_TVOS_1_0,
+			DotNet_5_0_iOS, DotNet_5_0_tvOS, DotNet_5_0_watchOS,
+		};
+
+		public static IEnumerable<TargetFramework> AllValidFrameworks {
+			get { return ValidFrameworksMac.Union (ValidFrameworksiOS); }
+		}
+
+#if MTOUCH
+		public static IEnumerable<TargetFramework> ValidFrameworks { get { return ValidFrameworksiOS; } }
+#elif MMP
+		public static IEnumerable<TargetFramework> ValidFrameworks { get { return ValidFrameworksMac; } }
+#else
+		public static IEnumerable<TargetFramework> ValidFrameworks { get { return AllValidFrameworks; } }
 #endif
+
+		public static bool IsValidFramework (TargetFramework framework)
+		{
+			foreach (var tf in ValidFrameworks)
+				if (tf == framework)
+					return true;
+			return false;
+		}
 
 		public bool IsDotNet {
 			get { return Identifier == ".NETCoreApp" && Version.Major >= 5; }
@@ -195,18 +211,6 @@ namespace Xamarin.Utils
 				id = "Xamarin.Mac";
 
 			return String.Format ("{0},Version=v{1}{2}", id, Version == null ? "0.0" : Version.ToString (), Profile == null ? string.Empty : (",Profile=" + Profile));
-		}
-
-		public string MonoFrameworkDirectory {
-			get {
-				if (Identifier == "Xamarin.Mac")
-					return Identifier;
-
-				if (Version == null)
-					return null;
-
-				return Version.ToString ();
-			}
 		}
 
 		public ApplePlatform Platform {

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -55,7 +55,7 @@ Xamarin.Mac.registrar.mobile.x86_64.m: $(TOP)/src/build/mac/mobile-64/Xamarin.Ma
 	$(Q) touch Xamarin.Mac.registrar.mobile.x86_64.m Xamarin.Mac.registrar.mobile.x86_64.h
 
 Xamarin.Mac.registrar.full.x86_64.m:   $(TOP)/src/build/mac/full-64/Xamarin.Mac.dll $(LOCAL_MMP)
-	$(GENERATE_PART_REGISTRAR) --target-framework 4.5 --arch=x86_64 --xamarin-full-framework --nolink
+	$(GENERATE_PART_REGISTRAR) --target-framework Xamarin.Mac,Version=v4.5,Profile=Full --arch=x86_64 --xamarin-full-framework --nolink
 	$(Q) touch Xamarin.Mac.registrar.full.x86_64.m Xamarin.Mac.registrar.full.x86_64.h
 
 Xamarin.Mac.registrar.%.x86_64.a: Xamarin.Mac.registrar.%.x86_64.m

--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -29,7 +29,6 @@ namespace MonoMac.Tuner {
 		public IEnumerable<string> SkippedAssemblies { get; set; }
 		public I18nAssemblies I18nAssemblies { get; set; }
 		public IList<string> ExtraDefinitions { get; set; }
-		public TargetFramework TargetFramework { get; set; }
 		public string Architecture { get; set; }
 		internal PInvokeWrapperGenerator MarshalNativeExceptionsState { get; set; }
 		internal RuntimeOptions RuntimeOptions { get; set; }

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -133,11 +133,9 @@ namespace Xamarin.Bundler {
 			os.WriteOptionDescriptions (Console.Out);
 		}
 
-		public static bool IsUnifiedFullXamMacFramework { get; private set; }
-		public static bool IsUnifiedFullSystemFramework { get; private set; }
-		public static bool IsUnifiedMobile { get; private set; }
-		public static bool IsUnified { get { return IsUnifiedFullSystemFramework || IsUnifiedMobile || IsUnifiedFullXamMacFramework; } }
-		public static bool IsClassic { get { return !IsUnified; } }
+		public static bool IsUnifiedFullXamMacFramework { get { return TargetFramework == TargetFramework.Xamarin_Mac_4_5_Full; } }
+		public static bool IsUnifiedFullSystemFramework { get { return TargetFramework == TargetFramework.Xamarin_Mac_4_5_System; } }
+		public static bool IsUnifiedMobile { get { return TargetFramework == TargetFramework.Xamarin_Mac_2_0_Mobile; } }
 		public static bool LinkProhibitedFrameworks { get; private set; }
 
 		public static bool Is64Bit { 
@@ -184,8 +182,6 @@ namespace Xamarin.Bundler {
 		static int Main2 (string [] args)
 		{
 			var os = new OptionSet () {
-				{ "h|?|help", "Displays the help", v => action = Action.Help },
-				{ "version", "Output version information and exit.", v => action = Action.Version },
 				{ "f|force", "Forces the recompilation of code, regardless of timestamps", v=> Force = true },
 				{ "cache=", "Specify the directory where temporary build files will be cached", v => App.Cache.Location = v },
 				{ "a|assembly=", "Add an assembly to be processed", v => references.Add (v) },
@@ -234,8 +230,7 @@ namespace Xamarin.Bundler {
 				{ "xml=", "Provide an extra XML definition file to the linker", v => App.Definitions.Add (v) },
 				{ "time", v => WatchLevel++ },
 				{ "arch=", "Specify the architecture ('x86_64') of the native runtime (default to 'x86_64', which is the only valid value)", v => { arch = v; } },
-				{ "profile=", "(Obsoleted in favor of --target-framework) Specify the .NET profile to use (defaults to '" + Xamarin.Utils.TargetFramework.Default + "')", v => SetTargetFramework (v) },
-				{ "target-framework=", "Specify the .NET target framework to use (defaults to '" + Xamarin.Utils.TargetFramework.Default + "')", v => SetTargetFramework (v) },
+				{ "profile=", "(Obsoleted in favor of --target-framework) Specify the .NET profile to use", v => SetTargetFramework (v), true },
 				{ "force-thread-check", "Keep UI thread checks inside (even release) builds [DEPRECATED, use --optimize=-remove-uithread-checks instead]", v => { App.Optimizations.RemoveUIThreadChecks = false; }, true},
 				{ "disable-thread-check", "Remove UI thread checks inside (even debug) builds [DEPRECATED, use --optimize=remove-uithread-checks instead]", v => { App.Optimizations.RemoveUIThreadChecks = true; }, true},
 				{ "registrar:", "Specify the registrar to use (dynamic [default], static, partial)", v => {
@@ -313,8 +308,8 @@ namespace Xamarin.Bundler {
 					true /* this is an internal option */
 				},
 				{ "xamarin-framework-directory=", "The framework directory", v => { framework_dir = v; }, true },
-				{ "xamarin-full-framework", "Used with --target-framework=4.5 to select XM Full Target Framework", v => { IsUnifiedFullXamMacFramework = true; } },
-				{ "xamarin-system-framework", "Used with --target-framework=4.5 to select XM Full Target Framework", v => { IsUnifiedFullSystemFramework = true; } },
+				{ "xamarin-full-framework", "Used with --target-framework=4.5 to select XM Full Target Framework. Deprecated, use --target-framework=Xamarin.Mac,Version=v4.0,Profile=Full instead.", v => { TargetFramework = TargetFramework.Xamarin_Mac_4_5_Full; }, true },
+				{ "xamarin-system-framework", "Used with --target-framework=4.5 to select XM Full Target Framework. Deprecated, use --target-framework=Xamarin.Mac,Version=v4.0,Profile=System instead.", v => { TargetFramework = TargetFramework.Xamarin_Mac_4_5_System; }, true },
 				{ "aot:", "Specify assemblies that should be AOT compiled\n- none - No AOT (default)\n- all - Every assembly in MonoBundle\n- core - Xamarin.Mac, System, mscorlib\n- sdk - Xamarin.Mac.dll and BCL assemblies\n- |hybrid after option enables hybrid AOT which allows IL stripping but is slower (only valid for 'all')\n - Individual files can be included for AOT via +FileName.dll and excluded via -FileName.dll\n\nExamples:\n  --aot:all,-MyAssembly.dll\n  --aot:core,+MyOtherAssembly.dll,-mscorlib.dll",
 					v => {
 						aotOptions = new AOTOptions (v);
@@ -327,8 +322,6 @@ namespace Xamarin.Bundler {
 				},
 			};
 
-			AddSharedOptions (App, os);
-
 			var extra_args = Environment.GetEnvironmentVariable ("MMP_ENV_OPTIONS");
 			if (!string.IsNullOrEmpty (extra_args)) {
 				var l = new List<string> (args);
@@ -336,17 +329,8 @@ namespace Xamarin.Bundler {
 				args = l.ToArray ();
 			}
 
-			try {
-				App.RootAssemblies.AddRange (os.Parse (args));
-			}
-			catch (MonoMacException) {
-				throw;
-			}
-			catch (Exception e) {
-				throw new MonoMacException (10, true, Errors.MX0010, e.Message);
-			}
-
-			Driver.LogArguments (args);
+			if (ParseOptions (App, os, args, ref action))
+				return 0;
 
 			if (aotOptions == null) {
 				string forceAotVariable = Environment.GetEnvironmentVariable ("XM_FORCE_AOT");
@@ -354,63 +338,8 @@ namespace Xamarin.Bundler {
 					aotOptions = new AOTOptions (forceAotVariable);
 			}
 
-			if (!targetFramework.HasValue)
-				targetFramework = TargetFramework.Default;
-
 			App.RuntimeOptions = RuntimeOptions.Create (App, http_message_provider, tls_provider);
 
-			if (action == Action.Help || (args.Length == 0)) {
-				ShowHelp (os);
-				return 0;
-			} else if (action == Action.Version) {
-				Console.Write ("mmp {0}.{1}", Constants.Version, Constants.Revision);
-				Console.WriteLine ();
-				return 0;
-			}
-
-			bool force45From40UnifiedSystemFull = false;
-
-			// At least once instance of a TargetFramework of Xamarin.Mac,v2.0,(null) was found already. Assume any v2.0 implies a desire for Modern.
-			if (TargetFramework == TargetFramework.Xamarin_Mac_2_0_Mobile || TargetFramework.Version == TargetFramework.Xamarin_Mac_2_0_Mobile.Version) {
-				IsUnifiedMobile = true;
-			} else if (TargetFramework.Identifier == TargetFramework.Xamarin_Mac_4_5_Full.Identifier 
-			         && TargetFramework.Profile == TargetFramework.Xamarin_Mac_4_5_Full.Profile) {
-				IsUnifiedFullXamMacFramework = true;
-				TargetFramework = TargetFramework.Net_4_5;
-			} else if (TargetFramework.Identifier == TargetFramework.Xamarin_Mac_4_5_System.Identifier
-			         && TargetFramework.Profile == TargetFramework.Xamarin_Mac_4_5_System.Profile) {
-				IsUnifiedFullSystemFramework = true;
-				TargetFramework = TargetFramework.Net_4_5;
-			} else if (!IsUnifiedFullXamMacFramework && !IsUnifiedFullSystemFramework) {
-				// This is a total hack. Instead of passing in an argument, we walk the refernces looking for
-				// the "right" Xamarin.Mac and assume you are doing something
-				// Skip it if xamarin-full-framework or xamarin-system-framework passed in 
-				foreach (var asm in references) {
-					if (asm.EndsWith ("reference/full/Xamarin.Mac.dll", StringComparison.Ordinal)) {
-						IsUnifiedFullSystemFramework = true;
-						force45From40UnifiedSystemFull = targetFramework == TargetFramework.Net_4_0;
-						break;
-					}
-					if (asm.EndsWith ("mono/4.5/Xamarin.Mac.dll", StringComparison.Ordinal)) {
-						IsUnifiedFullXamMacFramework = true;
-						break;
-					}
-				}
-			}
-
-			if (IsUnifiedFullXamMacFramework) {
-				if (TargetFramework.Identifier != TargetFramework.Net_4_5.Identifier)
-					throw new MonoMacException (1405, true, Errors.MM1405, userTargetFramework);
-			}
-			if (IsUnifiedFullSystemFramework)
-			{
-				if (force45From40UnifiedSystemFull) {
-					Console.WriteLine ("Xamarin.Mac Unified Full System profile requires .NET 4.5, not .NET 4.0.");
-					FixReferences (x => x.Contains ("lib/mono/4.0"), x => x.Replace("lib/mono/4.0", "lib/mono/4.5"));
-					targetFramework = TargetFramework.Net_4_5;
-				}
-
-			}
 
 			if (IsUnifiedFullSystemFramework) {
 				// With newer Mono builds, the system assemblies passed to us by msbuild are
@@ -421,14 +350,8 @@ namespace Xamarin.Bundler {
 				FixReferences (x => monoAPIRegex.IsMatch (x) && !monoAPIFacadesRegex.IsMatch (x), x => x.Replace(monoAPIRegex.Match(x).Value, "lib/mono/4.5/"));
 			}
 
-			if (targetFramework == TargetFramework.Empty)
-				throw new MonoMacException (1404, true, Errors.MM1404, userTargetFramework);
-
 			if (Registrar == RegistrarMode.PartialStatic && App.LinkMode != LinkMode.None)
 				throw new MonoMacException (2110, true, Errors.MM2110);
-
-			if (IsClassic)
-				throw ErrorHelper.CreateError (143, Errors.MM0143);
 
 			// sanity check as this should never happen: we start out by not setting any
 			// Unified/Classic properties, and only IsUnifiedMobile if we are are on the
@@ -666,14 +589,18 @@ namespace Xamarin.Bundler {
 				if (references.Exists (a => Path.GetFileNameWithoutExtension (a).Equals (root_wo_ext)))
 					throw new MonoMacException (23, true, Errors.MM0023, root_wo_ext);
 
-				string monoFrameworkDirectory = TargetFramework.MonoFrameworkDirectory;
-				if (IsUnifiedFullXamMacFramework || IsUnifiedFullSystemFramework)
+				string monoFrameworkDirectory;
+
+				if (TargetFramework == TargetFramework.Xamarin_Mac_2_0_Mobile) {
+					monoFrameworkDirectory = TargetFramework.Identifier;
+				} else {
 					monoFrameworkDirectory = "4.5";
+				}
 
 				fx_dir = Path.Combine (MonoDirectory, "lib", "mono", monoFrameworkDirectory);
 
 				if (!Directory.Exists (fx_dir))
-					throw new MonoMacException (1403, true, Errors.MM1403, "Directory", fx_dir, userTargetFramework);
+					throw new MonoMacException (1403, true, Errors.MM1403, "Directory", fx_dir, TargetFramework);
 
 				references.Add (root_assembly);
 				BuildTarget.Resolver.CommandLineAssemblies = references;
@@ -1353,7 +1280,6 @@ namespace Xamarin.Bundler {
 				SkippedAssemblies = App.LinkSkipped,
 				I18nAssemblies = App.I18n,
 				ExtraDefinitions = App.Definitions,
-				TargetFramework = TargetFramework,
 				Architecture = arch,
 				RuntimeOptions = App.RuntimeOptions,
 				MarshalNativeExceptionsState = !App.RequiresPInvokeWrappers ? null : new PInvokeWrapperGenerator ()
@@ -1709,7 +1635,7 @@ namespace Xamarin.Bundler {
 					string machine_config = Path.Combine (MonoDirectory, "etc", "mono", "4.5", "machine.config");
 
 					if (!File.Exists (machine_config))
-						throw new MonoMacException (1403, true, Errors.MM1403, "File", machine_config, userTargetFramework);
+						throw new MonoMacException (1403, true, Errors.MM1403, "File", machine_config, TargetFramework);
 
 					File.Copy (machine_config, Path.Combine (mmp_dir, "machine.config"), true);
 				}

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -950,35 +950,6 @@ namespace Xamarin.Bundler {
 			Console.WriteLine ("{0} built successfully.", AppDirectory);
 		}
 
-		bool no_framework;
-		public void SetDefaultFramework ()
-		{
-			// If no target framework was specified, check if we're referencing Xamarin.iOS.dll.
-			// It's an error if neither target framework nor Xamarin.iOS.dll is not specified
-			if (!Driver.HasTargetFramework) {
-				foreach (var reference in References) {
-					var name = Path.GetFileName (reference);
-					switch (name) {
-					case "Xamarin.iOS.dll":
-						Driver.TargetFramework = TargetFramework.Xamarin_iOS_1_0;
-						break;
-					case "Xamarin.TVOS.dll":
-					case "Xamarin.WatchOS.dll":
-						throw ErrorHelper.CreateError (86, Errors.MT0086);
-					}
-
-					if (Driver.HasTargetFramework)
-						break;
-				}
-			}
-
-			if (!Driver.HasTargetFramework) {
-				// Set a default target framework to show errors in the least confusing order.
-				Driver.TargetFramework = TargetFramework.Xamarin_iOS_1_0;
-				no_framework = true;
-			}
-		}
-
 		string FormatAssemblyBuildTargets ()
 		{
 			var sb = new StringBuilder ();
@@ -1260,10 +1231,6 @@ namespace Xamarin.Bundler {
 			}
 			if (exceptions?.Count > 0)
 				throw new AggregateException (exceptions);
-
-
-			if (no_framework)
-				throw ErrorHelper.CreateError (96, Errors.MT0096);
 
 			// Add a reference to the platform assembly if none has been added, and check that we're not referencing
 			// any platform assemblies from another platform.

--- a/tools/mtouch/errors.Designer.cs
+++ b/tools/mtouch/errors.Designer.cs
@@ -467,9 +467,9 @@ namespace Xamarin.Bundler {
             }
         }
         
-        internal static string MT0070 {
+        internal static string MX0070 {
             get {
-                return ResourceManager.GetString("MT0070", resourceCulture);
+                return ResourceManager.GetString("MX0070", resourceCulture);
             }
         }
         
@@ -569,9 +569,9 @@ namespace Xamarin.Bundler {
             }
         }
         
-        internal static string MT0086 {
+        internal static string MX0086 {
             get {
-                return ResourceManager.GetString("MT0086", resourceCulture);
+                return ResourceManager.GetString("MX0086", resourceCulture);
             }
         }
         
@@ -590,6 +590,12 @@ namespace Xamarin.Bundler {
         internal static string MT0089 {
             get {
                 return ResourceManager.GetString("MT0089", resourceCulture);
+            }
+        }
+        
+        internal static string MX0090 {
+            get {
+                return ResourceManager.GetString("MX0090", resourceCulture);
             }
         }
         
@@ -2240,12 +2246,6 @@ namespace Xamarin.Bundler {
         internal static string MT5301 {
             get {
                 return ResourceManager.GetString("MT5301", resourceCulture);
-            }
-        }
-        
-        internal static string MM5301 {
-            get {
-                return ResourceManager.GetString("MM5301", resourceCulture);
             }
         }
         

--- a/tools/mtouch/errors.resx
+++ b/tools/mtouch/errors.resx
@@ -503,7 +503,7 @@
 		</comment>
 	</data>
 
-	<data name="MT0070" xml:space="preserve">
+	<data name="MX0070" xml:space="preserve">
 		<value>Invalid target framework: {0}. Valid target frameworks are: {1}.
 		</value>
 		<comment>
@@ -623,8 +623,8 @@
 		</comment>
 	</data>
 
-	<data name="MT0086" xml:space="preserve">
-		<value>A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
+	<data name="MX0086" xml:space="preserve">
+		<value>A target framework (--target-framework) must be specified.
 		</value>
 		<comment>
 		</comment>
@@ -651,6 +651,13 @@
 		</comment>
 	</data>
 
+	<data name="MX0090" xml:space="preserve">
+		<value>The target framework '{0}' is deprecated. Use '{1}' instead.
+		</value>
+		<comment>
+		</comment>
+	</data>
+
 	<data name="MX0091" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
 		</value>
@@ -658,12 +665,16 @@
 		</comment>
 	</data>
 
+	<!-- MT0092 has been used in the past -->
+
 	<data name="MT0093" xml:space="preserve">
 		<value>Could not find 'mlaunch'.
 		</value>
 		<comment>
 		</comment>
 	</data>
+
+	<!-- MT0094 has been used in the past -->
 
 	<data name="MT0095" xml:space="preserve">
 		<value>Aot files could not be copied to the destination directory {0}: {1}
@@ -699,6 +710,8 @@
 		<comment>
 		</comment>
 	</data>
+
+	<!-- MM0098 has been used in the past -->
 
 	<data name="MX0099" xml:space="preserve">
 		<value>Internal error: {0}. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -762,14 +762,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT0072">
         <source>Extensions are not supported for the platform '{0}'.
 		</source>
@@ -862,14 +854,6 @@
         <source>No reference to '{0}' was found. It will be added automatically.
 		</source>
         <target state="new">No reference to '{0}' was found. It will be added automatically.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT0086">
-        <source>A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
 		</target>
         <note>
 		</note>
@@ -2794,6 +2778,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX0070">
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX0071">
         <source>Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.
 		</source>
@@ -2814,6 +2806,22 @@
         <source>Disabling the new refcount logic is deprecated.
 		</source>
         <target state="new">Disabling the new refcount logic is deprecated.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0086">
+        <source>A target framework (--target-framework) must be specified.
+		</source>
+        <target state="new">A target framework (--target-framework) must be specified.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0090">
+        <source>The target framework '{0}' is deprecated. Use '{1}' instead.
+		</source>
+        <target state="new">The target framework '{0}' is deprecated. Use '{1}' instead.
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -762,14 +762,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT0072">
         <source>Extensions are not supported for the platform '{0}'.
 		</source>
@@ -862,14 +854,6 @@
         <source>No reference to '{0}' was found. It will be added automatically.
 		</source>
         <target state="new">No reference to '{0}' was found. It will be added automatically.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT0086">
-        <source>A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
 		</target>
         <note>
 		</note>
@@ -2794,6 +2778,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX0070">
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX0071">
         <source>Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.
 		</source>
@@ -2814,6 +2806,22 @@
         <source>Disabling the new refcount logic is deprecated.
 		</source>
         <target state="new">Disabling the new refcount logic is deprecated.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0086">
+        <source>A target framework (--target-framework) must be specified.
+		</source>
+        <target state="new">A target framework (--target-framework) must be specified.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0090">
+        <source>The target framework '{0}' is deprecated. Use '{1}' instead.
+		</source>
+        <target state="new">The target framework '{0}' is deprecated. Use '{1}' instead.
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -762,14 +762,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT0072">
         <source>Extensions are not supported for the platform '{0}'.
 		</source>
@@ -862,14 +854,6 @@
         <source>No reference to '{0}' was found. It will be added automatically.
 		</source>
         <target state="new">No reference to '{0}' was found. It will be added automatically.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT0086">
-        <source>A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
 		</target>
         <note>
 		</note>
@@ -2794,6 +2778,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX0070">
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX0071">
         <source>Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.
 		</source>
@@ -2814,6 +2806,22 @@
         <source>Disabling the new refcount logic is deprecated.
 		</source>
         <target state="new">Disabling the new refcount logic is deprecated.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0086">
+        <source>A target framework (--target-framework) must be specified.
+		</source>
+        <target state="new">A target framework (--target-framework) must be specified.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0090">
+        <source>The target framework '{0}' is deprecated. Use '{1}' instead.
+		</source>
+        <target state="new">The target framework '{0}' is deprecated. Use '{1}' instead.
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -762,14 +762,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT0072">
         <source>Extensions are not supported for the platform '{0}'.
 		</source>
@@ -862,14 +854,6 @@
         <source>No reference to '{0}' was found. It will be added automatically.
 		</source>
         <target state="new">No reference to '{0}' was found. It will be added automatically.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT0086">
-        <source>A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
 		</target>
         <note>
 		</note>
@@ -2794,6 +2778,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX0070">
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX0071">
         <source>Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.
 		</source>
@@ -2814,6 +2806,22 @@
         <source>Disabling the new refcount logic is deprecated.
 		</source>
         <target state="new">Disabling the new refcount logic is deprecated.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0086">
+        <source>A target framework (--target-framework) must be specified.
+		</source>
+        <target state="new">A target framework (--target-framework) must be specified.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0090">
+        <source>The target framework '{0}' is deprecated. Use '{1}' instead.
+		</source>
+        <target state="new">The target framework '{0}' is deprecated. Use '{1}' instead.
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -762,14 +762,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT0072">
         <source>Extensions are not supported for the platform '{0}'.
 		</source>
@@ -862,14 +854,6 @@
         <source>No reference to '{0}' was found. It will be added automatically.
 		</source>
         <target state="new">No reference to '{0}' was found. It will be added automatically.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT0086">
-        <source>A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
 		</target>
         <note>
 		</note>
@@ -2794,6 +2778,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX0070">
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX0071">
         <source>Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.
 		</source>
@@ -2814,6 +2806,22 @@
         <source>Disabling the new refcount logic is deprecated.
 		</source>
         <target state="new">Disabling the new refcount logic is deprecated.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0086">
+        <source>A target framework (--target-framework) must be specified.
+		</source>
+        <target state="new">A target framework (--target-framework) must be specified.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0090">
+        <source>The target framework '{0}' is deprecated. Use '{1}' instead.
+		</source>
+        <target state="new">The target framework '{0}' is deprecated. Use '{1}' instead.
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -762,14 +762,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT0072">
         <source>Extensions are not supported for the platform '{0}'.
 		</source>
@@ -862,14 +854,6 @@
         <source>No reference to '{0}' was found. It will be added automatically.
 		</source>
         <target state="new">No reference to '{0}' was found. It will be added automatically.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT0086">
-        <source>A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
 		</target>
         <note>
 		</note>
@@ -2794,6 +2778,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX0070">
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX0071">
         <source>Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.
 		</source>
@@ -2814,6 +2806,22 @@
         <source>Disabling the new refcount logic is deprecated.
 		</source>
         <target state="new">Disabling the new refcount logic is deprecated.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0086">
+        <source>A target framework (--target-framework) must be specified.
+		</source>
+        <target state="new">A target framework (--target-framework) must be specified.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0090">
+        <source>The target framework '{0}' is deprecated. Use '{1}' instead.
+		</source>
+        <target state="new">The target framework '{0}' is deprecated. Use '{1}' instead.
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -762,14 +762,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT0072">
         <source>Extensions are not supported for the platform '{0}'.
 		</source>
@@ -862,14 +854,6 @@
         <source>No reference to '{0}' was found. It will be added automatically.
 		</source>
         <target state="new">No reference to '{0}' was found. It will be added automatically.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT0086">
-        <source>A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
 		</target>
         <note>
 		</note>
@@ -2794,6 +2778,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX0070">
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX0071">
         <source>Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.
 		</source>
@@ -2814,6 +2806,22 @@
         <source>Disabling the new refcount logic is deprecated.
 		</source>
         <target state="new">Disabling the new refcount logic is deprecated.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0086">
+        <source>A target framework (--target-framework) must be specified.
+		</source>
+        <target state="new">A target framework (--target-framework) must be specified.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0090">
+        <source>The target framework '{0}' is deprecated. Use '{1}' instead.
+		</source>
+        <target state="new">The target framework '{0}' is deprecated. Use '{1}' instead.
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -762,14 +762,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT0072">
         <source>Extensions are not supported for the platform '{0}'.
 		</source>
@@ -862,14 +854,6 @@
         <source>No reference to '{0}' was found. It will be added automatically.
 		</source>
         <target state="new">No reference to '{0}' was found. It will be added automatically.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT0086">
-        <source>A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
 		</target>
         <note>
 		</note>
@@ -2794,6 +2778,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX0070">
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX0071">
         <source>Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.
 		</source>
@@ -2814,6 +2806,22 @@
         <source>Disabling the new refcount logic is deprecated.
 		</source>
         <target state="new">Disabling the new refcount logic is deprecated.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0086">
+        <source>A target framework (--target-framework) must be specified.
+		</source>
+        <target state="new">A target framework (--target-framework) must be specified.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0090">
+        <source>The target framework '{0}' is deprecated. Use '{1}' instead.
+		</source>
+        <target state="new">The target framework '{0}' is deprecated. Use '{1}' instead.
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -762,14 +762,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT0072">
         <source>Extensions are not supported for the platform '{0}'.
 		</source>
@@ -862,14 +854,6 @@
         <source>No reference to '{0}' was found. It will be added automatically.
 		</source>
         <target state="new">No reference to '{0}' was found. It will be added automatically.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT0086">
-        <source>A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
 		</target>
         <note>
 		</note>
@@ -2794,6 +2778,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX0070">
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX0071">
         <source>Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.
 		</source>
@@ -2814,6 +2806,22 @@
         <source>Disabling the new refcount logic is deprecated.
 		</source>
         <target state="new">Disabling the new refcount logic is deprecated.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0086">
+        <source>A target framework (--target-framework) must be specified.
+		</source>
+        <target state="new">A target framework (--target-framework) must be specified.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0090">
+        <source>The target framework '{0}' is deprecated. Use '{1}' instead.
+		</source>
+        <target state="new">The target framework '{0}' is deprecated. Use '{1}' instead.
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -762,14 +762,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT0072">
         <source>Extensions are not supported for the platform '{0}'.
 		</source>
@@ -862,14 +854,6 @@
         <source>No reference to '{0}' was found. It will be added automatically.
 		</source>
         <target state="new">No reference to '{0}' was found. It will be added automatically.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT0086">
-        <source>A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
 		</target>
         <note>
 		</note>
@@ -2794,6 +2778,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX0070">
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX0071">
         <source>Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.
 		</source>
@@ -2814,6 +2806,22 @@
         <source>Disabling the new refcount logic is deprecated.
 		</source>
         <target state="new">Disabling the new refcount logic is deprecated.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0086">
+        <source>A target framework (--target-framework) must be specified.
+		</source>
+        <target state="new">A target framework (--target-framework) must be specified.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0090">
+        <source>The target framework '{0}' is deprecated. Use '{1}' instead.
+		</source>
+        <target state="new">The target framework '{0}' is deprecated. Use '{1}' instead.
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -762,14 +762,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT0072">
         <source>Extensions are not supported for the platform '{0}'.
 		</source>
@@ -862,14 +854,6 @@
         <source>No reference to '{0}' was found. It will be added automatically.
 		</source>
         <target state="new">No reference to '{0}' was found. It will be added automatically.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT0086">
-        <source>A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
 		</target>
         <note>
 		</note>
@@ -2794,6 +2778,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX0070">
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX0071">
         <source>Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.
 		</source>
@@ -2814,6 +2806,22 @@
         <source>Disabling the new refcount logic is deprecated.
 		</source>
         <target state="new">Disabling the new refcount logic is deprecated.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0086">
+        <source>A target framework (--target-framework) must be specified.
+		</source>
+        <target state="new">A target framework (--target-framework) must be specified.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0090">
+        <source>The target framework '{0}' is deprecated. Use '{1}' instead.
+		</source>
+        <target state="new">The target framework '{0}' is deprecated. Use '{1}' instead.
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -762,14 +762,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT0072">
         <source>Extensions are not supported for the platform '{0}'.
 		</source>
@@ -862,14 +854,6 @@
         <source>No reference to '{0}' was found. It will be added automatically.
 		</source>
         <target state="new">No reference to '{0}' was found. It will be added automatically.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT0086">
-        <source>A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
 		</target>
         <note>
 		</note>
@@ -2794,6 +2778,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX0070">
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX0071">
         <source>Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.
 		</source>
@@ -2814,6 +2806,22 @@
         <source>Disabling the new refcount logic is deprecated.
 		</source>
         <target state="new">Disabling the new refcount logic is deprecated.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0086">
+        <source>A target framework (--target-framework) must be specified.
+		</source>
+        <target state="new">A target framework (--target-framework) must be specified.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0090">
+        <source>The target framework '{0}' is deprecated. Use '{1}' instead.
+		</source>
+        <target state="new">The target framework '{0}' is deprecated. Use '{1}' instead.
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -762,14 +762,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT0072">
         <source>Extensions are not supported for the platform '{0}'.
 		</source>
@@ -862,14 +854,6 @@
         <source>No reference to '{0}' was found. It will be added automatically.
 		</source>
         <target state="new">No reference to '{0}' was found. It will be added automatically.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT0086">
-        <source>A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified when building for TVOS or WatchOS.
 		</target>
         <note>
 		</note>
@@ -2794,6 +2778,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX0070">
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX0071">
         <source>Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.
 		</source>
@@ -2814,6 +2806,22 @@
         <source>Disabling the new refcount logic is deprecated.
 		</source>
         <target state="new">Disabling the new refcount logic is deprecated.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0086">
+        <source>A target framework (--target-framework) must be specified.
+		</source>
+        <target state="new">A target framework (--target-framework) must be specified.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MX0090">
+        <source>The target framework '{0}' is deprecated. Use '{1}' instead.
+		</source>
+        <target state="new">The target framework '{0}' is deprecated. Use '{1}' instead.
 		</target>
         <note>
 		</note>


### PR DESCRIPTION
* Unify target framework code between mtouch and mmp.
* Simplify the code in mmp: have three possible valid target frameworks for
  most of code, and add special code to handle setting any other valid target
  frameworks to redirect to one of those three valid target frameworks (and
  warn if given any of those valid, but not "main", target frameworks). Any
  other code can then depend on the target framework having exactly one of
  those specific values, which means we can make IsUnified* variables
  convenience properties instead.
* Unify a bit more of the argument parsing code between mtouch and mmp, since
  that made a few other things easier.
* Add TargetFramework.IsValidFramework to have one validation implementation.
* Move the implementation of TargetFramework.MonoFrameworkDirectory to mmp
  itself, it's not really related to the target framework.
* Remove Driver.IsUnified and IsClassic from mmp, they're not used anymore.
* Formally deprecate --xamarin-[full|system]-framework in mmp, they've really been deprecated for many years.
* Remove LinkerOptions.TargetFramework, it's not used anymore.
* Get rid of mmp's userTargetFramework fried, it's duplicated with the
  targetFramework field.
* Add a few tests, and tweak others a bit.

Breaking changes:

* Both mtouch and mmp require --target-framework now. The only direct
  consumers should be the MSBuild tasks, which already pass --target-framework
  all the time. This simplifies code, and removes assumptions.