### PR TITLE
[Msbuild] Do not error if the localizations are out of sync.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
+++ b/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <UpdateXlfOnBuild>true</UpdateXlfOnBuild>
+    <ErrorOnOutOfDateXlf>false</ErrorOnOutOfDateXlf>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Update="MSBStrings.resx">


### PR DESCRIPTION
The translations code is quite fragile at the moment. When building a
package it is throwing errors but does not do the same when building
xamarin-macios. This has happened several times with the mono-2020-02
integration branch:

* https://jenkins.internalx.com/job/macios/job/PR-7795/24/display/redirect
* https://jenkins.internalx.com/job/macios/job/PR-7795/25/display/redirect

This change makes sure that we do not raise an error, unblocks mono
2020-02 and an issue will be added to make sure that we re-enable the
feature once the code is more stable.