### PR TITLE
[msbuild] Fixes translations out of date issue

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
+++ b/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup>
-    <UpdateXlfOnBuild>true</UpdateXlfOnBuild>
-  </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Update="MSBStrings.resx">
       <XlfSourceFormat>Resx</XlfSourceFormat>
@@ -22,4 +19,7 @@
   <ItemGroup>
     <PackageReference Include="XliffTasks" Version="1.0.0-beta.20154.1" />
   </ItemGroup>
+  <Target Name="BuildLocalization" BeforeTargets="BeforeBuild">
+    <CallTarget Targets="UpdateXlf" />
+  </Target>
 </Project>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -38,7 +38,4 @@
       <Link>errors.resx</Link>
     </None>
   </ItemGroup>
-  <Target Name="BuildLocalization" BeforeTargets="BeforeBuild">
-    <MSBuild Projects="../Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj" Targets="UpdateXlf" />
-  </Target>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/8140. The UpdateXlf target generates a set of *.lastrun files under ./obj/. The .lastrun files are used by the xliff-tasks nuget package as a first step to check if the translation files (files with *.xlf extension) are out of date with the *.resx file. The .lastrun files are wiped out on a git clean so xliff-tasks complains about translations being out of date even when they aren't. The UpdateXlfOnBuild property (provided by xliff-tasks) was set to true so that it calls the UpdateXlf target on every build to generate the .lastrun files. However, there is a bug with xliff-tasks and it seems to ignore UpdateXlfOnBuild in projects with multiple target frameworks. To workaround the multiple target frameworks bug, Xamarin.Localization.MSBuild.csproj is modified so  that the UpdateXlf target is explicitly called before the BeforeBuild msbuild target.

.lastrun file paths:
./obj/Debug/netstandard2.0/Xamarin.Localization.MSBuild.xlf/UpdateXlf.lastrun
./obj/Debug/net461/Xamarin.Localization.MSBuild.xlf/UpdateXlf.lastrun