### PR TITLE
[Harness] Increase wait time for crash logs

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -730,7 +730,13 @@ namespace Xharness {
 			if (!success.HasValue)
 				success = false;
 
-			await crash_reports.EndCaptureAsync (TimeSpan.FromSeconds (success.Value ? 0 : 5));
+			var crashLogWaitTime = 0;
+			if (!success.Value)
+				crashLogWaitTime = 5;
+			if (crashed)
+				crashLogWaitTime = 30;
+
+			await crash_reports.EndCaptureAsync (TimeSpan.FromSeconds (crashLogWaitTime));
 
 			if (timed_out) {
 				Result = TestExecutingResult.TimedOut;


### PR DESCRIPTION
Manual testing showed that crash logs don't appear fast enough