### PR TITLE
[tests] Work around xamarin/maccore#2177 by building test-libraries as part of the build.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,5 @@
 TOP = ..
+SUBDIRS=test-libraries
 
 # disabled for now: mac-test
 


### PR DESCRIPTION
This is not a complete solution, because it doesn't work when running device
tests, because then we don't build locally. On the other hand, that bug has
never been a problem for device bots, so hopefully that won't change in the
future.

Ref: https://github.com/xamarin/maccore/issues/2177