### PR TITLE
[d16-5-xcode11.4][mtouch/mmp] Only use stdout from xcrun as the path of the file that was found. Fixes #8147. (#8150)

### DIFF
--- a/tests/mmptest/src/System.ServiceModel/Net45.cs
+++ b/tests/mmptest/src/System.ServiceModel/Net45.cs
@@ -24,7 +24,7 @@ namespace MonoTouchFixtures.ServiceModel {
 		public void ShouldIncludeSystemServiceModel ()
 		{
 			StringBuilder output = new StringBuilder ();
-			int result = Driver.RunCommand ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", new [] { "--refs", $"-r:{TI.FindRootDirectory ()}/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/4.5/System.ServiceModel.dll" }, null, output);
+			int result = Driver.RunCommand ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", new [] { "--refs", $"-r:{TI.FindRootDirectory ()}/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/4.5/System.ServiceModel.dll" }, output);
 			Assert.That (result, Is.EqualTo (0));
 			Assert.That (output.ToString (), Contains.Substring ("System.Web.Services, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"));
 		}
@@ -33,7 +33,7 @@ namespace MonoTouchFixtures.ServiceModel {
 		public void ShouldNotIncludeSystemDrawing ()
 		{
 			StringBuilder output = new StringBuilder ();
-			int result = Driver.RunCommand ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", new [] { "--refs", $"-r:{TI.FindRootDirectory ()}/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/4.5/System.ServiceModel.dll" }, null, output);
+			int result = Driver.RunCommand ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/monop", new [] { "--refs", $"-r:{TI.FindRootDirectory ()}/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/4.5/System.ServiceModel.dll" }, output);
 			Assert.That (result, Is.EqualTo (0));
 			Assert.That (output.ToString (), !Contains.Substring ("System.Drawing"));
 		}

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -225,36 +225,79 @@ namespace Xamarin.Bundler {
 
 		public static int RunCommand (string path, params string [] args)
 		{
-			return RunCommand (path, args, null, (Action<string>) null);
+			return RunCommand (path, args, null, (Action<string>) null, (Action<string>) null, false);
 		}
 
 		public static int RunCommand (string path, IList<string> args)
 		{
-			return RunCommand (path, args, null, (Action<string>) null);
+			return RunCommand (path, args, null, (Action<string>) null, (Action<string>) null, false);
 		}
 
-		public static int RunCommand (string path, IList<string> args, string [] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
+		public static int RunCommand (string path, IList<string> args, StringBuilder output)
 		{
-			if (output != null)
-				return RunCommand (path, args, env, (v) => { if (v != null) output.AppendLine (v); }, suppressPrintOnErrors);
-			return RunCommand (path, args, env, (Action<string>) null, suppressPrintOnErrors);
+			return RunCommand (path, args, null, output, output, false);
 		}
 
-		public static int RunCommand (string path, IList<string> args, string [] env = null, Action<string> output_received = null, bool suppressPrintOnErrors = false)
+		public static int RunCommand (string path, IList<string> args, StringBuilder output, bool suppressPrintOnErrors)
 		{
-			return RunCommand (path, StringUtils.FormatArguments (args), env, output_received, suppressPrintOnErrors);
+			return RunCommand (path, args, null, output, output, suppressPrintOnErrors);
 		}
 
-		static int RunCommand (string path, string args, string[] env = null, Action<string> output_received = null, bool suppressPrintOnErrors = false)
+		public static int RunCommand (string path, IList<string> args, string [] env, StringBuilder output)
+		{
+			return RunCommand (path, args, env, output, output, false);
+		}
+
+		public static int RunCommand (string path, IList<string> args, string [] env, StringBuilder output, bool suppressPrintOnErrors)
+		{
+			return RunCommand (path, args, env, output, output, suppressPrintOnErrors);
+		}
+
+		public static int RunCommand (string path, IList<string> args, string [] env, StringBuilder output, StringBuilder error)
+		{
+			return RunCommand (path, args, env, output, error, false);
+		}
+
+		public static int RunCommand (string path, IList<string> args, StringBuilder output, StringBuilder error)
+		{
+			return RunCommand (path, args, null, output, error, false);
+		}
+
+		public static int RunCommand (string path, IList<string> args, StringBuilder output, StringBuilder error, bool suppressPrintOnErrors)
+		{
+			return RunCommand (path, args, null, output, error, suppressPrintOnErrors);
+		}
+
+		public static int RunCommand (string path, IList<string> args, string [] env, StringBuilder output, StringBuilder error, bool suppressPrintOnErrors)
+		{
+			var output_received = output == null ? null : new Action<string> ((v) => { if (v != null) output.AppendLine (v); });
+			var error_received = error == null ? null : new Action<string> ((v) => { if (v != null) error.AppendLine (v); });
+			return RunCommand (path, args, env, output_received, error_received, suppressPrintOnErrors);
+		}
+
+		static int RunCommand (string path, IList<string> args, string [] env, Action<string> output_received, bool suppressPrintOnErrors)
+		{
+			return RunCommand (path, args, env, output_received, output_received, suppressPrintOnErrors);
+		}
+
+		static int RunCommand (string path, IList<string> args, string [] env, Action<string> output_received, Action<string> error_received)
+		{
+			return RunCommand (path, args, env, output_received, error_received, false);
+		}
+
+		static int RunCommand (string path, IList<string> args, string[] env, Action<string> output_received, Action<string> error_received, bool suppressPrintOnErrors)
 		{
 			Exception stdin_exc = null;
-			var info = new ProcessStartInfo (path, args);
+			var info = new ProcessStartInfo (path, StringUtils.FormatArguments (args));
 			info.UseShellExecute = false;
 			info.RedirectStandardInput = false;
 			info.RedirectStandardOutput = true;
 			info.RedirectStandardError = true;
 			System.Threading.ManualResetEvent stdout_completed = new System.Threading.ManualResetEvent (false);
 			System.Threading.ManualResetEvent stderr_completed = new System.Threading.ManualResetEvent (false);
+
+			if (output_received == null ^ error_received == null)
+				throw new ArgumentException ("Either both or neither of 'output_received' and 'error_received' can be specified.");
 
 			var lockobj = new object ();
 			StringBuilder output = null;
@@ -264,6 +307,7 @@ namespace Xamarin.Bundler {
 					if (line != null)
 						output.AppendLine (line);
 				};
+				error_received = output_received;
 			}
 
 			if (env != null){
@@ -279,8 +323,7 @@ namespace Xamarin.Bundler {
 				}
 			}
 
-			if (verbose > 0)
-				Console.WriteLine ("{0} {1}", path, args);
+			Log (1, "{0} {1}", info.FileName, info.Arguments);
 
 			using (var p = Process.Start (info)) {
 
@@ -296,7 +339,7 @@ namespace Xamarin.Bundler {
 				p.ErrorDataReceived += (s, e) => {
 					if (e.Data != null) {
 						lock (lockobj)
-							output_received (e.Data);
+							error_received (e.Data);
 					} else {
 						stderr_completed.Set ();
 					}
@@ -760,13 +803,31 @@ namespace Xamarin.Bundler {
 			args.Add ("-f");
 			args.Add (tool);
 
-			var output = new StringBuilder ();
-			int ret = RunCommand ("xcrun", args, env.ToArray (), output);
+			var stdout = new StringBuilder ();
+			var stderr = new StringBuilder ();
+			var both = new StringBuilder ();
+			// xcrun can write unrelated stuff to stderr even if it succeeds, so we need to separate stdout and stderr.
+			// We also want to print out what happened if something went wrong, and in that case we don't want stdout
+			// and stderr captured separately, because related lines could end up printed far from eachother in time,
+			// and that's confusing. So capture stdout and stderr by themselves, and also capture both together.
+			int ret = RunCommand ("xcrun", args, env.ToArray (),
+				(v) => {
+					lock (both) {
+						both.AppendLine (v);
+						stdout.AppendLine (v);
+					}
+				},
+				(v) => {
+					lock (both) {
+						both.AppendLine (v);
+						stderr.AppendLine (v);
+					}
+				});
 
 			if (ret == 0) {
-				path = output.ToString ().Trim ();
+				path = stdout.ToString ().Trim ();
 			} else {
-				Log (1, "Failed to locate the developer tool '{0}', 'xcrun {1}' returned with the exit code {2}:\n{3}", tool, string.Join (" ", args), ret, output.ToString ());
+				Log (1, "Failed to locate the developer tool '{0}', 'xcrun {1}' returned with the exit code {2}:\n{3}", tool, string.Join (" ", args), ret, both.ToString ());
 			}
 
 			return ret == 0;

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -909,7 +909,7 @@ namespace Xamarin.Bundler {
 						mono_dir = GetXamMacPrefix ();
 					} else {
 						var dir = new StringBuilder ();
-						RunCommand (pkg_config, new [] { "--variable=prefix", "mono-2" }, null, dir);
+						RunCommand (pkg_config, new [] { "--variable=prefix", "mono-2" }, dir);
 						mono_dir = Path.GetFullPath (dir.ToString ().Replace (Environment.NewLine, String.Empty));
 					}
 				}


### PR DESCRIPTION
xcrun can print stuff to stderr even if it succeeds and prints what it found
to stdout, which means we have to separate stdout and stderr when capturing
xcrun's output.

This also means that we need a few changes to our RunCommand API:

* Add support for capturing stdout and stderr separately by providing
  different callbacks/StringBuilder instances.
* Use overloads instead of default arguments, because with default arguments
  we end up with ambiguous matches in a lot of places with the new overloads.

Fixes https://github.com/xamarin/xamarin-macios/issues/8147.

Backport of #8150.