### PR TITLE
[d16-6-xcode11.4] [tests][monotouch-test] Update UrlProtocolTest

### DIFF
--- a/tests/monotouch-test/Foundation/UrlProtocolTest.cs
+++ b/tests/monotouch-test/Foundation/UrlProtocolTest.cs
@@ -98,112 +98,105 @@ namespace MonoTouchFixtures.Foundation {
 
 			Assert.IsTrue (TestRuntime.RunAsync (DateTime.Now.AddSeconds (10), () => { }, () => done.WaitOne (0)), "Timed out");
 			Assert.IsNull (ex, "Exception");
-			Assert.IsTrue (custom_url_protocol_instance.Called_DidCompleteWithError, "DidCompleteWithError");
-			// if DidReceiveChallenge is called or not seems to vary between test runs, so we can't assert it.
-			//Assert.IsFalse (custom_url_protocol_instance.Called_DidReceiveChallenge, "DidReceiveChallenge");
-			Assert.IsTrue (custom_url_protocol_instance.Called_DidReceiveData, "DidReceiveData");
-			Assert.IsTrue (custom_url_protocol_instance.Called_DidReceiveResponse, "DidReceiveResponse");
-			Assert.IsTrue (custom_url_protocol_instance.Called_StartLoading, "StartLoading");
-			Assert.IsTrue (custom_url_protocol_instance.Called_StopLoading, "StopLoading");
-			Assert.IsFalse (custom_url_protocol_instance.Called_WillPerformHttpRedirection, "WillPerformHttpRedirection");
-
-			Assert.IsTrue (CustomUrlProtocol.Called_CanInitWithRequest, "CanInitWithRequest");
-			Assert.IsTrue (CustomUrlProtocol.Called_GetCanonicalRequest, "GetCanonicalRequest");
-
+			Assert.That (CustomUrlProtocol.State, Is.EqualTo (5), "State");
 			Assert.IsTrue (success, "Success");
 		}
 
 		static CustomUrlProtocol custom_url_protocol_instance;
 
 		public class CustomUrlProtocol : NSUrlProtocol, INSUrlSessionDelegate, INSUrlSessionTaskDelegate, INSUrlSessionDataDelegate {
+
+			public static int State;
+
 			[Export ("canInitWithRequest:")]
 			public static new bool CanInitWithRequest (NSUrlRequest request)
 			{
-				Called_CanInitWithRequest = true;
+				if (State == 0)
+					State++;
 				return true;
 			}
-			public static bool Called_CanInitWithRequest;
 
 			[Export ("canonicalRequestForRequest:")]
 			public static new NSUrlRequest GetCanonicalRequest (NSUrlRequest request)
 			{
-				Called_GetCanonicalRequest = true;
+				if (State == 1)
+					State++;
 				return request;
 			}
-			public static bool Called_GetCanonicalRequest;
 
 			[Export ("initWithRequest:cachedResponse:client:")]
 			public CustomUrlProtocol (NSUrlRequest request, NSCachedUrlResponse cachedResponse, INSUrlProtocolClient client)
 			: base (request, cachedResponse, client)
 			{
+				if (State == 2)
+					State++;
 				custom_url_protocol_instance = this;
 			}
 
 			[Export ("startLoading")]
 			public override void StartLoading ()
 			{
-				Called_StartLoading = true;
-				var config = NSUrlSession.SharedSession.Configuration;
-				var session = NSUrlSession.FromConfiguration (config, this, new NSOperationQueue ());
+				if (State == 3)
+					State++;
 
-				var task = session.CreateDataTask (new NSUrlRequest (new NSUrl (NetworkResources.MicrosoftRobotsUrl)));
-				task.Resume ();
+				string file = Path.Combine (NSBundle.MainBundle.ResourcePath, "basn3p08.png");
+
+				using (var d = NSData.FromFile (file))
+				using (var response = new NSUrlResponse (Request.Url, "image/png", (nint) d.Length, null)) {
+					Client.ReceivedResponse (this, response, NSUrlCacheStoragePolicy.NotAllowed);
+					Client.DataLoaded (this, d);
+					Client.FinishedLoading (this);
+				}
 			}
-			public bool Called_StartLoading;
 
 			[Export ("stopLoading")]
 			public override void StopLoading ()
 			{
-				Called_StopLoading = true;
+				if (State == 4)
+					State++;
 			}
-			public bool Called_StopLoading;
 
 			//NSURLSessionTaskDelegate
 			[Export ("URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:")]
 			public virtual void WillPerformHttpRedirection (NSUrlSession session, NSUrlSessionTask task, NSHttpUrlResponse response, NSUrlRequest newRequest, Action<NSUrlRequest> completionHandler)
 			{
-				Called_WillPerformHttpRedirection = true;
+				State = -1;
 				completionHandler (newRequest);
 			}
-			public bool Called_WillPerformHttpRedirection;
 
 			[Export ("URLSession:task:didReceiveChallenge:completionHandler:")]
 			public virtual void DidReceiveChallenge (NSUrlSession session, NSUrlSessionTask task, NSUrlAuthenticationChallenge challenge, Action<NSUrlSessionAuthChallengeDisposition, NSUrlCredential> completionHandler)
 			{
-				Called_DidReceiveChallenge = true;
+				State = -2;
 				completionHandler (NSUrlSessionAuthChallengeDisposition.PerformDefaultHandling, null);
 			}
-			public bool Called_DidReceiveChallenge;
 
 			//NSURLSessionDataDelegate
 			[Export ("URLSession:dataTask:didReceiveResponse:completionHandler:")]
 			public virtual void DidReceiveResponse (NSUrlSession session, NSUrlSessionDataTask dataTask, NSUrlResponse response, Action<NSUrlSessionResponseDisposition> completionHandler)
 			{
-				Called_DidReceiveResponse = true;
+				State = -3;
 				completionHandler (NSUrlSessionResponseDisposition.Allow);
 				this.Client.ReceivedResponse (this, response, NSUrlCacheStoragePolicy.Allowed);
 			}
-			public bool Called_DidReceiveResponse;
 
 			[Export ("URLSession:dataTask:didReceiveData:")]
 			public virtual void DidReceiveData (NSUrlSession session, NSUrlSessionDataTask dataTask, NSData data)
 			{
-				Called_DidReceiveData = true;
+				State = -4;
 				this.Client.DataLoaded (this, data);
 			}
-			public bool Called_DidReceiveData;
 
 			[Export ("URLSession:task:didCompleteWithError:")]
 			public virtual void DidCompleteWithError (NSUrlSession session, NSUrlSessionTask task, NSError error)
 			{
-				Called_DidCompleteWithError = true;
+				State = -5;
 				if (error != null) {
 					this.Client.FailedWithError (this, error);
 				} else {
 					this.Client.FinishedLoading (this);
 				}
 			}
-			public bool Called_DidCompleteWithError;
 		}
 #endif // !__WATCHOS__
 	}


### PR DESCRIPTION
The _nice_ thing about `NSURLProtocol` is that it does not force the use
of the network - but we inflicted this upon us on tests.

So this updates the test to avoid the network, which should make it
more reliable and not so much influenced by the URL used or the OS
versions where it's executed.

This does not cover as much callback as before. However this it does
test that the NSUrlProtocol is registered correctly (what we care) and
the rest is largely only related the the OS (which is not the target
of our unit tests).

Hopefully fix https://github.com/xamarin/maccore/issues/1956

Backport of #8168.

/cc @dalexsoto @spouliot