### PR TITLE
Fix generator diff after .NET modifications.

### DIFF
--- a/jenkins/.gitignore
+++ b/jenkins/.gitignore
@@ -1,3 +1,4 @@
+failure-stamp
 pr-comments.md
 build-failure.md
 .tmp-labels*

--- a/tools/compare-commits.sh
+++ b/tools/compare-commits.sh
@@ -232,7 +232,19 @@ fi
 # affecting that build.
 $CP -R "$ROOT_DIR/src/build" "$OUTPUT_DIR/build-new"
 cd "$OUTPUT_DIR"
-find build build-new '(' -name '*.dll' -or -name '*.pdb' -or -name 'generated-sources' -or -name 'generated_sources' -or -name '*.exe' -or -name '*.rsp' -or -name 'AssemblyInfo.cs' -or -name 'Constants.cs' -or -name 'generator.csproj.*' ')' -delete
+find build build-new '(' \
+	-name '*.dll' -or \
+	-name '*.pdb' -or \
+	-name '*generated-sources' -or \
+	-name 'generated_sources' -or \
+	-name '*.exe' -or \
+	-name '*.rsp' -or \
+	-name 'AssemblyInfo.cs' -or \
+	-name 'Constants.cs' -or \
+	-name 'generator.csproj.*' -or \
+	-name 'bgen.csproj.*' -or \
+	-name '*.cache' \
+	')' -delete
 mkdir -p "$OUTPUT_DIR/generator-diff"
 GENERATOR_DIFF_FILE="$OUTPUT_DIR/generator-diff/index.html"
 git diff --no-index build build-new > "$OUTPUT_DIR/generator-diff/generator.diff" || true
@@ -245,6 +257,7 @@ MODIFIED_FILES=$(find \
 	"$ROOT_DIR/src" \
 	"$ROOT_DIR/tools/apidiff" \
 	-type f \
+	-not -name '*.xlf' \
 	-newer "$OUTPUT_DIR/stamp")
 
 if test -n "$MODIFIED_FILES"; then


### PR DESCRIPTION
* Some files were renamed after the .NET support was implemented, so the list
  of files to ignore for the diff had to be updated.
* Update .gitignore.

This will only take effect in the next commit (the generator diff for this PR will still show extraneous differences)