### PR TITLE
Revert "[tests] Adjust expected result of looking for 'mono_native_initialize'. Fixes xamarin/maccore#1809. (#6806)"

### DIFF
--- a/tests/mono-native/Introspection.cs
+++ b/tests/mono-native/Introspection.cs
@@ -107,9 +107,7 @@ namespace Xamarin.Tests
 
 			try {
 #if MONOTOUCH_TV || MONOTOUCH_WATCH // on tvOS/watchOS we emit a native reference for P/Invokes in all assemblies, so we'll strip away the 'mono_native_initialize' symbol when we're linking statically (since we don't need the symbol).
-				// The 'strip' tool that comes with Xcode 11 has some black magic where it removes the symbol from the executable, yet tvOS is still able to lookup the address from the symbol.
-				// So apparently we'll always be able to find the symbol. Leaving the old logic as comments for a time, since I don't quite trust the new behavior.
-				var has_symbol = true; //MonoNativeConfig.LinkMode != MonoNativeLinkMode.Static || Runtime.Arch == Arch.SIMULATOR;
+				var has_symbol = MonoNativeConfig.LinkMode != MonoNativeLinkMode.Static || Runtime.Arch == Arch.SIMULATOR;
 #else
 				var has_symbol = true;
 #endif


### PR DESCRIPTION
This reverts commit e4a926e8f28523d556a1535904e3cb8c7f12778a.

Xcode 11.4 seems to have fixed this issue so the workaround is the _new_
cause of failures.