### PR TITLE
[d16-6] [corenfc] Add missing enum members in NFCTagType

### DIFF
--- a/src/corenfc.cs
+++ b/src/corenfc.cs
@@ -50,6 +50,12 @@ namespace CoreNFC {
 	[Native]
 	public enum NFCTagType : ulong {
 		Iso15693 = 1,
+		[iOS (13,0)]
+		FeliCa = 2,
+		[iOS (13,0)]
+		Iso7816Compatible = 3,
+		[iOS (13,0)]
+		MiFare = 4,
 	}
 
 	//[iOS (11,0), NoTV, NoWatch, NoMac]


### PR DESCRIPTION
Fix https://github.com/xamarin/xamarin-macios/issues/8210

Backport of #8213.

/cc @spouliot 