### PR TITLE
[Haress] Completely remove the BCL prefix from the test importer.

### DIFF
--- a/tests/xharness/TestImporter/ProjectDefinition.cs
+++ b/tests/xharness/TestImporter/ProjectDefinition.cs
@@ -9,7 +9,7 @@ namespace Xharness.TestImporter {
 	/// Class that defines a bcl test project. A bcl test project by definition is the combination of the name
 	/// of the project and a set on assemblies to be tested.
 	/// </summary>
-	public class BCLTestProjectDefinition {
+	public class ProjectDefinition {
 		public string Name { get; set; }
 		public string ExtraArgs { get; private set; }
 		public IAssemblyLocator AssemblyLocator { get; set; }
@@ -24,7 +24,7 @@ namespace Xharness.TestImporter {
 			}
 		}
 
-		public BCLTestProjectDefinition (string name, IAssemblyLocator locator, ITestAssemblyDefinitionFactory factory, string [] assemblies, string extraArgs)
+		public ProjectDefinition (string name, IAssemblyLocator locator, ITestAssemblyDefinitionFactory factory, string [] assemblies, string extraArgs)
 		{
 			if (assemblies.Length == 0)
 				throw new ArgumentException ("Most provide at least an assembly.");
@@ -39,7 +39,7 @@ namespace Xharness.TestImporter {
 			}
 		}
 		
-		public BCLTestProjectDefinition (string name, IAssemblyLocator locator, ITestAssemblyDefinitionFactory factory, List<ITestAssemblyDefinition> assemblies, string extraArgs)
+		public ProjectDefinition (string name, IAssemblyLocator locator, ITestAssemblyDefinitionFactory factory, List<ITestAssemblyDefinition> assemblies, string extraArgs)
 		{
 			Name = name ?? throw new ArgumentNullException (nameof (locator));
 			AssemblyLocator = locator ?? throw new ArgumentNullException (nameof (locator));

--- a/tests/xharness/TestImporter/Templates/IProjectFilter.cs
+++ b/tests/xharness/TestImporter/Templates/IProjectFilter.cs
@@ -23,7 +23,7 @@ namespace Xharness.TestImporter.Templates {
 		/// <param name="project">The project that is being generated.</param>
 		/// <param name="platform">The target platform of the project.</param>
 		/// <returns>True if the project should be ignored, false otherwise.</returns>
-		bool ExludeProject (BCLTestProjectDefinition project, Platform platform);
+		bool ExludeProject (ProjectDefinition project, Platform platform);
 
 		/// <summary>
 		/// Returns the list of ignore files that will be added to a project so that certain tests are ignored. This

--- a/tests/xharness/TestImporter/Templates/Managed/InfoPlistGenerator.cs
+++ b/tests/xharness/TestImporter/Templates/Managed/InfoPlistGenerator.cs
@@ -2,11 +2,11 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 
-namespace Xharness.TestImporter {
+namespace Xharness.TestImporter.Templates.Managed {
 	/// <summary>
 	/// Class that knows how to generate the plist of a test project.
 	/// </summary>
-	public class BCLTestInfoPlistGenerator {
+	public class InfoPlistGenerator {
 		internal static string ApplicationNameReplacement = "%APPLICATION NAME%";
 		internal static string IndentifierReplacement = "%BUNDLE INDENTIFIER%";
 		internal static string WatchAppIndentifierReplacement = "%WATCHAPP INDENTIFIER%";

--- a/tests/xharness/TestImporter/Templates/Managed/XamariniOSTemplate.cs
+++ b/tests/xharness/TestImporter/Templates/Managed/XamariniOSTemplate.cs
@@ -391,7 +391,7 @@ namespace Xharness.TestImporter.Templates.Managed {
 				// 2. The container
 				// 3. The extensions
 				// TODO: The following is very similar to what is done in the iOS generation. Must be grouped
-				var projectDefinition = new BCLTestProjectDefinition (def.Name, AssemblyLocator, AssemblyDefinitionFactory, def.Assemblies, def.ExtraArgs);
+				var projectDefinition = new ProjectDefinition (def.Name, AssemblyLocator, AssemblyDefinitionFactory, def.Assemblies, def.ExtraArgs);
 				if (ProjectFilter != null && ProjectFilter.ExludeProject (projectDefinition, Platform.WatchOS)) // if it is ignored, continue
 					continue;
 
@@ -409,7 +409,7 @@ namespace Xharness.TestImporter.Templates.Managed {
 					var projectData = new Dictionary<WatchAppType, (string plist, string project)> ();
 					foreach (var appType in new [] { WatchAppType.Extension, WatchAppType.App }) {
 						(string plist, string project) data;
-						var plist = await BCLTestInfoPlistGenerator.GenerateCodeAsync (GetPlistTemplate (appType), projectDefinition.Name);
+						var plist = await InfoPlistGenerator.GenerateCodeAsync (GetPlistTemplate (appType), projectDefinition.Name);
 						data.plist = GetPListPath (generatedCodeDir, appType);
 						using (var file = new StreamWriter (data.plist, false)) { // false is do not append
 							await file.WriteAsync (plist);
@@ -434,7 +434,7 @@ namespace Xharness.TestImporter.Templates.Managed {
 						projectData [appType] = data;
 					} // foreach app type
 
-					var rootPlist = await BCLTestInfoPlistGenerator.GenerateCodeAsync (GetPlistTemplate (Platform.WatchOS), projectDefinition.Name);
+					var rootPlist = await InfoPlistGenerator.GenerateCodeAsync (GetPlistTemplate (Platform.WatchOS), projectDefinition.Name);
 					var infoPlistPath = GetPListPath (generatedCodeDir, Platform.WatchOS);
 					using (var file = new StreamWriter (infoPlistPath, false)) { // false is do not append
 						await file.WriteAsync (rootPlist);
@@ -517,7 +517,7 @@ namespace Xharness.TestImporter.Templates.Managed {
 			foreach (var def in projects) {
 				if (def.Assemblies.Length == 0)
 					continue;
-				var projectDefinition = new BCLTestProjectDefinition (def.Name, AssemblyLocator, AssemblyDefinitionFactory, def.Assemblies, def.ExtraArgs);
+				var projectDefinition = new ProjectDefinition (def.Name, AssemblyLocator, AssemblyDefinitionFactory, def.Assemblies, def.ExtraArgs);
 				if (ProjectFilter != null && ProjectFilter.ExludeProject (projectDefinition, Platform.WatchOS)) // if it is ignored, continue
 					continue;
 
@@ -533,7 +533,7 @@ namespace Xharness.TestImporter.Templates.Managed {
 				string projectPath = GetProjectPath (projectDefinition.Name, platform);
 				string failure = null;
 				try {
-					var plist = await BCLTestInfoPlistGenerator.GenerateCodeAsync (GetPlistTemplate (platform), projectDefinition.Name);
+					var plist = await InfoPlistGenerator.GenerateCodeAsync (GetPlistTemplate (platform), projectDefinition.Name);
 					var infoPlistPath = GetPListPath (generatedCodeDir, platform);
 					using (var file = new StreamWriter (infoPlistPath, false)) { // false is do not append
 						await file.WriteAsync (plist);
@@ -614,7 +614,7 @@ namespace Xharness.TestImporter.Templates.Managed {
 			foreach (var def in projects) {
 				if (!def.Assemblies.Any ())
 					continue;
-				var projectDefinition = new BCLTestProjectDefinition (def.Name, AssemblyLocator, AssemblyDefinitionFactory, def.Assemblies, def.ExtraArgs);
+				var projectDefinition = new ProjectDefinition (def.Name, AssemblyLocator, AssemblyDefinitionFactory, def.Assemblies, def.ExtraArgs);
 				if (ProjectFilter != null && ProjectFilter.ExludeProject (projectDefinition, platform))
 					continue;
 
@@ -635,7 +635,7 @@ namespace Xharness.TestImporter.Templates.Managed {
 				var projectPath = GetProjectPath (projectDefinition.Name, platform);
 				string failure = null;
 				try {
-					var plist = await BCLTestInfoPlistGenerator.GenerateCodeAsync (GetPlistTemplate (platform), projectDefinition.Name);
+					var plist = await InfoPlistGenerator.GenerateCodeAsync (GetPlistTemplate (platform), projectDefinition.Name);
 					var infoPlistPath = GetPListPath (generatedCodeDir, platform);
 					using (var file = new StreamWriter (infoPlistPath, false)) { // false is do not append
 						await file.WriteAsync (plist);

--- a/tests/xharness/TestImporter/Xamarin/ProjectFilter.cs
+++ b/tests/xharness/TestImporter/Xamarin/ProjectFilter.cs
@@ -93,7 +93,7 @@ namespace Xharness.TestImporter.Xamarin {
 			return false;
 		}
 
-		public bool ExludeProject (BCLTestProjectDefinition project, Platform platform)
+		public bool ExludeProject (ProjectDefinition project, Platform platform)
 		{
 			foreach (var a in project.TestAssemblies) {
 				if (CommonIgnoredAssemblies.Contains (a.Name))

--- a/tests/xharness/Xharness.Tests/TestImporter/Tests/BCLTestInfoPlistGeneratorTest.cs
+++ b/tests/xharness/Xharness.Tests/TestImporter/Tests/BCLTestInfoPlistGeneratorTest.cs
@@ -4,7 +4,7 @@ using System.IO;
 using NUnit.Framework;
 
 using System.Threading.Tasks;
-using Xharness.TestImporter;
+using Xharness.TestImporter.Templates.Managed;
 
 namespace Xharness.Tests.TestImporter.Tests {
 	public class BCLTestInfoPlistGeneratorTest {
@@ -13,7 +13,7 @@ namespace Xharness.Tests.TestImporter.Tests {
 		public void GenerateCodeNullTemplateFile ()
 		{
 			Assert.ThrowsAsync<ArgumentNullException> (() => 
-				BCLTestInfoPlistGenerator.GenerateCodeAsync (null, "Project Name"));
+				InfoPlistGenerator.GenerateCodeAsync (null, "Project Name"));
 		}
 
 		[Test]
@@ -22,7 +22,7 @@ namespace Xharness.Tests.TestImporter.Tests {
 			var tmp = Path.GetTempFileName ();
 			File.WriteAllText (tmp, "Hello");
 			using (var stream = new FileStream (tmp, FileMode.Open)) {
-				Assert.ThrowsAsync<ArgumentNullException> (() => BCLTestInfoPlistGenerator.GenerateCodeAsync (stream, null));
+				Assert.ThrowsAsync<ArgumentNullException> (() => InfoPlistGenerator.GenerateCodeAsync (stream, null));
 			}
 
 			File.Delete (tmp);
@@ -32,17 +32,17 @@ namespace Xharness.Tests.TestImporter.Tests {
 		public async Task GenerateCode ()
 		{
 			const string projectName = "MyTest";
-			var fakeTemplate = $"{BCLTestInfoPlistGenerator.ApplicationNameReplacement}-{BCLTestInfoPlistGenerator.IndentifierReplacement}";
+			var fakeTemplate = $"{InfoPlistGenerator.ApplicationNameReplacement}-{InfoPlistGenerator.IndentifierReplacement}";
 			var tmpPath = Path.GetTempPath ();
 			var templatePath = Path.Combine (tmpPath, Path.GetRandomFileName());
 			using (var file = new StreamWriter (templatePath, false)) { 
 				await file.WriteAsync (fakeTemplate);
 			}
 
-			var result = await BCLTestInfoPlistGenerator.GenerateCodeAsync (File.OpenRead (templatePath), projectName);
+			var result = await InfoPlistGenerator.GenerateCodeAsync (File.OpenRead (templatePath), projectName);
 			try {
-				StringAssert.DoesNotContain (BCLTestInfoPlistGenerator.ApplicationNameReplacement, result);
-				StringAssert.DoesNotContain (BCLTestInfoPlistGenerator.IndentifierReplacement, result);
+				StringAssert.DoesNotContain (InfoPlistGenerator.ApplicationNameReplacement, result);
+				StringAssert.DoesNotContain (InfoPlistGenerator.IndentifierReplacement, result);
 				StringAssert.Contains (projectName, result);
 			}
 			finally {

--- a/tests/xharness/Xharness.Tests/TestImporter/Tests/TestProjectDefinitionTest.cs
+++ b/tests/xharness/Xharness.Tests/TestImporter/Tests/TestProjectDefinitionTest.cs
@@ -26,7 +26,7 @@ namespace Xharness.Tests.TestImporter.Tests {
 		[Test]
 		public void GetTypeForAssembliesNullMonoPath ()
 		{
-			var projectDefinition = new Xharness.TestImporter.BCLTestProjectDefinition ("MyProject", assemblyLocator.Object, factory.Object,  new List<ITestAssemblyDefinition> (), "");	
+			var projectDefinition = new ProjectDefinition ("MyProject", assemblyLocator.Object, factory.Object,  new List<ITestAssemblyDefinition> (), "");	
 			Assert.Throws<ArgumentNullException> (() => projectDefinition.GetTypeForAssemblies (null, Platform.iOS));
 		}
 	}

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -81,8 +81,7 @@
     <Compile Include="Logging\MemoryLog.cs" />
     <Compile Include="RunMode.cs" />
     <Compile Include="TestTarget.cs" />
-    <Compile Include="TestImporter\BCLTestInfoPlistGenerator.cs" />
-    <Compile Include="TestImporter\BCLTestProjectDefinition.cs" />
+    <Compile Include="TestImporter\ProjectDefinition.cs" />
     <Compile Include="TestImporter\Platform.cs" />
     <Compile Include="Collections\BlockingEnumerableCollection.cs" />
     <Compile Include="Collections\ILoadAsync.cs" />
@@ -174,6 +173,7 @@
     <Compile Include="IAppRunner.cs" />
     <Compile Include="ITestReporter.cs" />
     <Compile Include="BCLTestImportTargetFactory.cs" />
+    <Compile Include="TestImporter\Templates\Managed\InfoPlistGenerator.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\tools\mtouch\SdkVersions.cs">


### PR DESCRIPTION
Remove the last BCLPrefix and move the InfoPlistGenerator to the managed
namespace since it is part of the managed template.