### PR TITLE
[Harness] Add a new known failure to help the monitoring person.

### DIFF
--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -1795,6 +1795,22 @@ namespace Xharness.Jenkins
 			}
 			return false;
 		}
+
+		public bool IsMonoMulti3Issue (ILog log) {
+			if (log == null)
+				return false;
+			if (File.Exists (log.FullPath) && new FileInfo (log.FullPath).Length > 0) {
+				using var reader = log.GetReader ();
+				while (!reader.EndOfStream) {
+					string line = reader.ReadLine ();
+					if (line == null)
+						continue;
+					if (line.Contains ("error MT5210: Native linking failed, undefined symbol: ___multi3"))
+						return true;
+				}
+			}
+			return false;
+		}
 		
 		string previous_test_runs;
 		void GenerateReportImpl (Stream stream, StreamWriter markdown_summary = null)

--- a/tests/xharness/Jenkins/TestTasks/MSBuildTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/MSBuildTask.cs
@@ -59,6 +59,9 @@ namespace Xharness.Jenkins.TestTasks
 							ExecutionResult = TestExecutingResult.Succeeded;
 						} else {
 							ExecutionResult = TestExecutingResult.Failed;
+							if (Jenkins.IsMonoMulti3Issue (BuildLog)) { 
+								KnownFailure = $"<a href='https://github.com/mono/mono/issues/18560'>Undefined symbol ___multi3 on Release Mode</a>";
+							}
 						}
 					}
 					Jenkins.MainLog.WriteLine ("Built {0} ({1})", TestName, Mode);

--- a/tests/xharness/Jenkins/TestTasks/RunTestTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/RunTestTask.cs
@@ -73,6 +73,8 @@ namespace Xharness.Jenkins.TestTasks
 					ExecutionResult = TestExecutingResult.BuildFailure;
 				}
 				FailureMessage = BuildTask.FailureMessage;
+				if (!string.IsNullOrEmpty (BuildTask.KnownFailure))
+					KnownFailure = BuildTask.KnownFailure;
 				if (Harness.InCI && BuildTask is MSBuildTask projectTask)
 					ResultParser.GenerateFailure (Logs, "build", projectTask.TestName, projectTask.Variation, $"App Build {projectTask.TestName} {projectTask.Variation}", $"App could not be built {FailureMessage}.", projectTask.BuildLog.FullPath, Harness.XmlJargon);
 			} else {


### PR DESCRIPTION
Looks like mono is not investing much time at the moment fixing
https://github.com/mono/mono/issues/18560

The above error happens always on 32b device tests. Added a new known
failure for the monitoring to use in their task so that they do not have
to goole the issue and they know that is knonw already.