### PR TITLE
[master] [siminstaller] Update parsing xml because Apple changed their schema.

### DIFF
--- a/tools/siminstaller/Program.cs
+++ b/tools/siminstaller/Program.cs
@@ -171,7 +171,7 @@ namespace xsiminstaller {
 				var versionNode = downloadable.SelectSingleNode ("key[text()='version']/following-sibling::string");
 				var sourceNode = downloadable.SelectSingleNode ("key[text()='source']/following-sibling::string");
 				var identifierNode = downloadable.SelectSingleNode ("key[text()='identifier']/following-sibling::string");
-				var fileSizeNode = downloadable.SelectSingleNode ("key[text()='fileSize']/following-sibling::integer");
+				var fileSizeNode = downloadable.SelectSingleNode ("key[text()='fileSize']/following-sibling::integer|key[text()='fileSize']/following-sibling::real");
 				var installPrefixNode = downloadable.SelectSingleNode ("key[text()='userInfo']/following-sibling::dict/key[text()='InstallPrefix']/following-sibling::string");
 
 				var version = versionNode.InnerText;
@@ -191,7 +191,8 @@ namespace xsiminstaller {
 				var name = Replace (nameNode.InnerText, dict);
 				var source = Replace (sourceNode.InnerText, dict);
 				var installPrefix = Replace (installPrefixNode.InnerText, dict);
-				var fileSize = long.Parse (fileSizeNode.InnerText);
+				double.TryParse (fileSizeNode?.InnerText, out var parsedFileSize);
+				var fileSize = (long) parsedFileSize;
 
 				var installed = false;
 				var updateAvailable = false;


### PR DESCRIPTION
Apparently file sizes can be real numbers now, because in the manifest of
downloadable simulators there's one entry where the fileSize is a real:

    <key>fileSize</key>
    <real>2049324382</real>

when every other file size in the manifest is an integer.

So handle real file sizes too, and fix file size parsing to not throw
exceptions if the number can't be parsed. Maybe we'll get imaginary file sizes
too one day...

Fixes this exception:

    Unhandled Exception:
    System.NullReferenceException: Object reference not set to an instance of an object
      at xsiminstaller.MainClass.Main (System.String[] args) [0x00617] in /Users/rolf/work/maccore/d16-6/xamarin-macios/tools/siminstaller/Program.cs:194

Backport of #8209.

/cc @rolfbjarne 