### PR TITLE
[macOS] Add various Photo extensions that were missed

### DIFF
--- a/src/Photos/PHAssetCreationRequest.cs
+++ b/src/Photos/PHAssetCreationRequest.cs
@@ -6,8 +6,6 @@
 // Authors:
 //    Miguel de Icaza (miguel@xamarin.com)
 
-#if !MONOMAC
-
 using System;
 using Foundation;
 
@@ -26,5 +24,3 @@ namespace Photos {
 		}
 	}
 }
-
-#endif

--- a/src/Photos/PHFetchResult.cs
+++ b/src/Photos/PHFetchResult.cs
@@ -1,6 +1,4 @@
-﻿#if !MONOMAC
-
-using ObjCRuntime;
+﻿using ObjCRuntime;
 using Foundation;
 using System;
 using System.Collections;
@@ -37,5 +35,3 @@ namespace Photos
 		}
 	}
 }
-
-#endif

--- a/src/Photos/PHPhotoLibrary.cs
+++ b/src/Photos/PHPhotoLibrary.cs
@@ -6,9 +6,6 @@
 //
 // Copyright 2014 Xamarin Inc
 //
-
-#if !MONOMAC
-
 using ObjCRuntime;
 using Foundation;
 using System;
@@ -49,5 +46,3 @@ namespace Photos
 		}
 	}
 }
-
-#endif


### PR DESCRIPTION
- https://github.com/xamarin/xamarin-macios/issues/8225
- I don't see any reason why they are iOS specific, they are extensions using bound selectors