### PR TITLE
[generator] Remove unreachable code

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4715,20 +4715,18 @@ public partial class Generator : IMemberGatherer {
 
 		string var_name = null;
 		
-		if (wrap == null) {
-			// [Model] has properties that only throws, so there's no point in adding unused backing fields
-			if (!is_model && DoesPropertyNeedBackingField (pi) && !is_interface_impl && !minfo.is_static && !DoesPropertyNeedDirtyCheck (pi, export)) {
-				var_name = string.Format ("__mt_{0}_var{1}", pi.Name, minfo.is_static ? "_static" : "");
+		// [Model] has properties that only throws, so there's no point in adding unused backing fields
+		if (!is_model && DoesPropertyNeedBackingField (pi) && !is_interface_impl && !minfo.is_static && !DoesPropertyNeedDirtyCheck (pi, export)) {
+			var_name = string.Format ("__mt_{0}_var{1}", pi.Name, minfo.is_static ? "_static" : "");
 
-				print_generated_code ();
+			print_generated_code ();
 
-				if (minfo.is_thread_static)
-					print ("[ThreadStatic]");
-				print ("{1}object {0};", var_name, minfo.is_static ? "static " : "");
+			if (minfo.is_thread_static)
+				print ("[ThreadStatic]");
+			print ("{1}object {0};", var_name, minfo.is_static ? "static " : "");
 
-				if (!minfo.is_static && !is_interface_impl){
-					instance_fields_to_clear_on_dispose.Add (var_name);
-				}
+			if (!minfo.is_static && !is_interface_impl){
+				instance_fields_to_clear_on_dispose.Add (var_name);
 			}
 		}
 
@@ -4759,21 +4757,7 @@ public partial class Generator : IMemberGatherer {
 		       use_underscore ? "_" : "");
 		indent++;
 
-		if (wrap != null) {
-			if (pi.CanRead) {
-				PrintPlatformAttributes (pi);
-				PrintPlatformAttributes (pi.GetGetMethod ());
-				print ("get {{ return {0} as {1}; }}", wrap, FormatType (pi.DeclaringType, GetCorrectGenericType (pi.PropertyType)));
-			}
-			if (pi.CanWrite) {
-				PrintPlatformAttributes (pi);
-				PrintPlatformAttributes (pi.GetSetMethod ());
-				print ("set {{ {0} = value; }}", wrap);
-			}
-			indent--;
-			print ("}\n");
-			return;			
-		} else if (minfo.has_inner_wrap_attribute) {
+		if (minfo.has_inner_wrap_attribute) {
 			// If property getter or setter has its own WrapAttribute we let the user do whatever their heart desires
 			if (pi.CanRead) {
 				PrintAttributes (pi, platform: true);


### PR DESCRIPTION
An earlier `wrap != null` condition ends with a `return` so any check or
code assuming `wrap == null` must always be executed, while any `wrap != null`
will never be.