### PR TITLE
[Harness] Make sure we do not copy/generate the app sources more than  once.

### DIFF
--- a/tests/xharness/BCLTestImporter/Templates/Managed/XamariniOSTemplate.cs
+++ b/tests/xharness/BCLTestImporter/Templates/Managed/XamariniOSTemplate.cs
@@ -249,7 +249,7 @@ namespace Xharness.BCLTestImporter.Templates.Managed {
 					return;
 				// mk the expected directories
 				if (Directory.Exists (srcOuputPath))
-					Directory.Delete (srcOuputPath, true); // delete, we always want to add the embeded src
+					Directory.Delete (srcOuputPath, true); // delete, we always want to add the embedded src
 				BuildSrcTree (srcOuputPath);
 				// the code is simple, we are going to look for all the resources that we know are src and will write a
 				// copy of the stream in the designated output path


### PR DESCRIPTION
Threading is hard, even with async. We reached a situation in which the
src code of the test applications from the template was being generated
more than once. Ideally, we could have a nice solution with
AsyncLazy<bool> and use the lazy async to copy the code, but it was
moved to netcore 5. The fix is a little uglier but valid, lock and
enure we only generate it once. Please note that you CANNOT use a lock
statement inside a async method.

Fixes: https://github.com/xamarin/xamarin-macios/issues/8240