### PR TITLE
[d16-5-xcode11.4] Wrap mono_gc_init_finalizer_thread() call with now-needed coop GC state transition

### DIFF
--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -203,7 +203,9 @@ extern void mono_gc_init_finalizer_thread (void);
 {
 	// COOP: ?
 #if defined (__arm__) || defined(__aarch64__)
+	MONO_ENTER_GC_UNSAFE;
 	mono_gc_init_finalizer_thread ();
+	MONO_EXIT_GC_UNSAFE;
 #endif
 }
 


### PR DESCRIPTION
Should fix https://github.com/mono/mono/issues/19372

Backport of #8242.

/cc @dalexsoto @alexischr