### PR TITLE
[devops] Fix provision-xcode unhandled exception

### DIFF
--- a/tools/devops/provision-xcode.csx
+++ b/tools/devops/provision-xcode.csx
@@ -27,8 +27,14 @@ string FindConfigurationVariable (string variable, string hash = "HEAD")
 	if (!string.IsNullOrEmpty (value))
 		return value;
 
-	if (make_config == null)
-		make_config = Exec ("git", "show", $"{hash}:Make.config");
+	if (make_config == null) {
+		try {
+			make_config = Exec ("git", "show", $"{hash}:Make.config");
+		} catch {
+			Console.WriteLine ("Could not find a Make.config");
+			return null;	
+		}
+	}
 	foreach (var line in make_config) {
 		if (line.StartsWith (variable + "=", StringComparison.Ordinal))
 			return line.Substring (variable.Length + 1);


### PR DESCRIPTION
In cases where a `Make.config` doesn't exist, there's an unhandled exception and the user friendly one cannot be reached.

Arguably, an edge case not applicable to xamarin-macios I discovered when using that code in an other context (where obviously I don't have a Make.config :P). Still this is making the code more robust (;