### PR TITLE
[Harness] Allow to create a process manager with the default tools paths.

### DIFF
--- a/tests/xharness/Execution/ProcessManager.cs
+++ b/tests/xharness/Execution/ProcessManager.cs
@@ -14,6 +14,9 @@ using Xharness.Utilities;
 
 namespace Xharness.Execution {
 	public class ProcessManager : IProcessManager {
+		const string xcodeDefaultPath = "/Applications/Xcode.app/";
+		const string mlaunchDefaultPath = "/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch";
+
 		public string XcodeRoot { get; }
 		public string MlaunchPath { get; }
 
@@ -28,6 +31,8 @@ namespace Xharness.Execution {
 				return xcode_version;
 			}
 		}
+
+		public ProcessManager () : this (xcodeDefaultPath, mlaunchDefaultPath) { }
 
 		public ProcessManager (string xcodeRoot, string mlaunchPath)
 		{


### PR DESCRIPTION
Allow to use the defaults. Useful if the class that is calling the
process manager is not interested in mlaunch or xcode.