### PR TITLE
[d16-6][maccore] Bump maccore to get AzDo script changes

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := f6b975c6241bb30372022b62a7924660564ad2b5
+NEEDED_MACCORE_VERSION := 9bb38d4059307cf1cfddbc3f52eae16ecea8c8c5
 NEEDED_MACCORE_BRANCH := d16-6
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@9bb38d4059 Update external-deps.csx (#2192)

Diff: https://github.com/xamarin/maccore/compare/f6b975c6241bb30372022b62a7924660564ad2b5..9bb38d4059307cf1cfddbc3f52eae16ecea8c8c5

Needed by our internal build to pick Xcode 11.4