### PR TITLE
[Harness] Ensure we do not throw an exception if we do not have tasks.

### DIFF
--- a/tests/xharness/Jenkins/TestTasks/AggregatedRunSimulatorTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/AggregatedRunSimulatorTask.cs
@@ -65,7 +65,7 @@ namespace Xharness.Jenkins.TestTasks {
 
 				var devices = executingTasks.FirstOrDefault ()?.Simulators; 
 				if (devices == null) { 
-					ExecutionResult = TestExecutingResult.Ignored;
+					ExecutionResult = TestExecutingResult.DeviceNotFound;
 					return;
 				}
 				Jenkins.MainLog.WriteLine ("Selected simulator: {0}", devices.Length > 0 ? devices [0].Name : "none");

--- a/tests/xharness/Jenkins/TestTasks/AggregatedRunSimulatorTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/AggregatedRunSimulatorTask.cs
@@ -63,7 +63,11 @@ namespace Xharness.Jenkins.TestTasks {
 					await task.SelectSimulatorAsync ();
 				}
 
-				var devices = executingTasks.First ().Simulators;
+				var devices = executingTasks.FirstOrDefault ()?.Simulators; 
+				if (devices == null) { 
+					ExecutionResult = TestExecutingResult.Ignored;
+					return;
+				}
 				Jenkins.MainLog.WriteLine ("Selected simulator: {0}", devices.Length > 0 ? devices [0].Name : "none");
 
 				foreach (var dev in devices)


### PR DESCRIPTION
The First extension will throw an exception if the list is empty. Use
FirstOrDefault, check if the devices are null and return the test as
Ignored.

fixes: https://github.com/xamarin/xamarin-macios/issues/8271