### PR TITLE
[msbuild] Compute the ComputedFrameworkMoniker later in the build. Fixes #8277.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -26,17 +26,19 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 		<_XamarinCommonPropsHasBeenImported>true</_XamarinCommonPropsHasBeenImported>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">
-		<!-- Get the TargetFrameworkMoniker and store it in our own variable so that it's overridable while only affecting the parts of the build that we care about.
-			 This is overridability is a workaround while we wait for .NET 5 to be able to give us the TFM we're supposed to get during the build. -->
-		<_ComputedTargetFrameworkMoniker>$(TargetFrameworkMoniker)</_ComputedTargetFrameworkMoniker>
-		<!-- Detect the Mobile condition and set the computed Mobile TFM our tooling expects -->
-		<_ComputedTargetFrameworkMoniker Condition="'$(_ComputedTargetFrameworkMoniker)' == 'Xamarin.Mac,Version=v2.0'">Xamarin.Mac,Version=v2.0,Profile=Mobile</_ComputedTargetFrameworkMoniker>
-		<!-- Detect the Full condition and set the computed TFM our tooling expects -->
-		<_ComputedTargetFrameworkMoniker Condition="'$(UseXamMacFullFramework)' == 'true' And $([MSBuild]::ValueOrDefault('$(_ComputedTargetFrameworkMoniker),', '').StartsWith('.NETFramework,', StringComparison.OrdinalIgnoreCase))">Xamarin.Mac,Version=v4.5,Profile=Full</_ComputedTargetFrameworkMoniker>
-		<!-- Detect the System condition and set the computed TFM our tooling expects -->
-		<_ComputedTargetFrameworkMoniker Condition="'$(UseXamMacFullFramework)' != 'true' And $([MSBuild]::ValueOrDefault('$(_ComputedTargetFrameworkMoniker),', '').StartsWith('.NETFramework,', StringComparison.OrdinalIgnoreCase))">Xamarin.Mac,Version=v4.5,Profile=System</_ComputedTargetFrameworkMoniker>
-	</PropertyGroup>
+	<Target Name="_ComputeTargetFrameworkMoniker">
+		<PropertyGroup Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">
+			<!-- Get the TargetFrameworkMoniker and store it in our own variable so that it's overridable while only affecting the parts of the build that we care about.
+				 This is overridability is a workaround while we wait for .NET 5 to be able to give us the TFM we're supposed to get during the build. -->
+			<_ComputedTargetFrameworkMoniker>$(TargetFrameworkMoniker)</_ComputedTargetFrameworkMoniker>
+			<!-- Detect the Mobile condition and set the computed Mobile TFM our tooling expects -->
+			<_ComputedTargetFrameworkMoniker Condition="'$(_ComputedTargetFrameworkMoniker)' == 'Xamarin.Mac,Version=v2.0'">Xamarin.Mac,Version=v2.0,Profile=Mobile</_ComputedTargetFrameworkMoniker>
+			<!-- Detect the Full condition and set the computed TFM our tooling expects -->
+			<_ComputedTargetFrameworkMoniker Condition="'$(UseXamMacFullFramework)' == 'true' And $([MSBuild]::ValueOrDefault('$(_ComputedTargetFrameworkMoniker),', '').StartsWith('.NETFramework,', StringComparison.OrdinalIgnoreCase))">Xamarin.Mac,Version=v4.5,Profile=Full</_ComputedTargetFrameworkMoniker>
+			<!-- Detect the System condition and set the computed TFM our tooling expects -->
+			<_ComputedTargetFrameworkMoniker Condition="'$(UseXamMacFullFramework)' != 'true' And $([MSBuild]::ValueOrDefault('$(_ComputedTargetFrameworkMoniker),', '').StartsWith('.NETFramework,', StringComparison.OrdinalIgnoreCase))">Xamarin.Mac,Version=v4.5,Profile=System</_ComputedTargetFrameworkMoniker>
+		</PropertyGroup>
+	</Target>
 
 	<!-- Story-time! MigrateToNewXMIdentifier is special because it un-does a lie we started telling from the 
 	beginning of Full (called Xamarin.Mac 4.5 back then). Back then, we released Modern (called Mobile) and 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -330,7 +330,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<Error Condition="'$(_AppManifest)' == ''" Text="Info.plist not found."/>
 	</Target>
 
-	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations">
+	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations;_ComputeTargetFrameworkMoniker">
 		<Metal
 			Condition="'$(IsMacEnabled)' == 'true' and '%(Metal.Identity)' != ''"
 			SessionId="$(BuildSessionId)"
@@ -508,6 +508,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	
 	<PropertyGroup>
 		<CompileToNativeDependsOn>
+			_ComputeTargetFrameworkMoniker;
 			_DetectAppManifest;
 			_DetectSdkLocations;
 			_GenerateBundleName;
@@ -577,7 +578,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CoreCompileColladaAssets"
-		DependsOnTargets="_CollectColladaAssets;_DetectSdkLocations"
+		DependsOnTargets="_CollectColladaAssets;_DetectSdkLocations;_ComputeTargetFrameworkMoniker"
 		Inputs="@(_ColladaAssetWithLogicalName)"
 		Outputs="$(IntermediateOutputPath)%(_ColladaAssetWithLogicalName.LogicalName)"
 		>
@@ -669,7 +670,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CompileSceneKitAssets" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_CoreCompileSceneKitAssets" />
 
-	<Target Name="_CoreCompileSceneKitAssets" DependsOnTargets="_GenerateBundleName">
+	<Target Name="_CoreCompileSceneKitAssets" DependsOnTargets="_GenerateBundleName;_ComputeTargetFrameworkMoniker">
 		<CompileSceneKitAssets
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -74,6 +74,7 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 
 	<!-- Override the CoreCompile Target to use btouch -->
 	<Target Name="_GenerateBindings"
+		DependsOnTargets="_ComputeTargetFrameworkMoniker"
 		Inputs="$(MSBuildAllProjects);@(ObjcBindingApiDefinition);@(ObjcBindingCoreSource);@(ReferencePath);@(ObjcBindingNativeLibrary)"
 		Outputs="$(_GeneratedSourcesFileList)"
 		Condition="'$(DesignTimeBuild)' != 'true'">

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
@@ -52,7 +52,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		</ItemGroup>
 	</Target>
 
-	<Target Name="_ResolveNativeWatchApp" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName">
+	<Target Name="_ResolveNativeWatchApp" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_ComputeTargetFrameworkMoniker">
 		<ResolveNativeWatchApp
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
@@ -24,10 +24,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<_XamarinCommonPropsHasBeenImported>true</_XamarinCommonPropsHasBeenImported>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<_ComputedTargetFrameworkMoniker Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">$(TargetFrameworkMoniker)</_ComputedTargetFrameworkMoniker>
-	</PropertyGroup>
-
 	<Target Name="_ComputeTargetFrameworkMoniker">
 		<PropertyGroup Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">
 			<!-- Get the TargetFrameworkMoniker and store it in our own variable so that it's overridable while only affecting the parts of the build that we care about.

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
@@ -25,10 +25,16 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<!-- Get the TargetFrameworkMoniker and store it in our own variable so that it's overridable while only affecting the parts of the build that we care about.
-			 This is overridability is a workaround while we wait for .NET 5 to be able to give us the TFM we're supposed to get during the build. -->
 		<_ComputedTargetFrameworkMoniker Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">$(TargetFrameworkMoniker)</_ComputedTargetFrameworkMoniker>
 	</PropertyGroup>
+
+	<Target Name="_ComputeTargetFrameworkMoniker">
+		<PropertyGroup Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">
+			<!-- Get the TargetFrameworkMoniker and store it in our own variable so that it's overridable while only affecting the parts of the build that we care about.
+				 This is overridability is a workaround while we wait for .NET 5 to be able to give us the TFM we're supposed to get during the build. -->
+			<_ComputedTargetFrameworkMoniker Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">$(TargetFrameworkMoniker)</_ComputedTargetFrameworkMoniker>
+		</PropertyGroup>
+	</Target>
 
 	<!-- When looking for related files to copy, look for Mono debugging files as well -->
 	<PropertyGroup>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -223,7 +223,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<Message Importance="Low" Text="Including @(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandDesignTimeFacades'" />
 	</Target>
 
-	<Target Name="_ComputeTargetArchitectures">
+	<Target Name="_ComputeTargetArchitectures" DependsOnTargets="_ComputeTargetFrameworkMoniker">
 		<ParseDeviceSpecificBuildInformation
 			SessionId="$(BuildSessionId)"
 			Condition="'$(DeviceSpecificBuild)' == 'true' And '$(TargetiOSDevice)' != '' And '$(_CanDeployToDeviceOrSimulator)' == 'true'"
@@ -421,7 +421,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</ArchiveDependsOn>
 	</PropertyGroup>
 
-	<Target Name="ValidateAppStoreBundle" DependsOnTargets="_DetectSdkLocations">
+	<Target Name="ValidateAppStoreBundle" DependsOnTargets="_DetectSdkLocations;_ComputeTargetFrameworkMoniker">
 		<ALToolValidate
 			SessionId="$(BuildSessionId)"
 			Username="$(Username)"
@@ -432,7 +432,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		/>
 	</Target>
 
-	<Target Name="UploadAppStoreBundle" DependsOnTargets="_DetectSdkLocations">
+	<Target Name="UploadAppStoreBundle" DependsOnTargets="_DetectSdkLocations;_ComputeTargetFrameworkMoniker">
 		<ALToolUpload
 			SessionId="$(BuildSessionId)"
 			Username="$(Username)"
@@ -601,7 +601,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<Error Condition="'$(_AppManifest)' == '' And '$(_CanOutputAppBundle)' == 'true'" Text="Info.plist not found."/>
 	</Target>
 
-	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations">
+	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations;_ComputeTargetFrameworkMoniker">
 		<Metal
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' and '%(Metal.Identity)' != ''"
@@ -676,7 +676,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</UnpackLibraryResources>
 	</Target>
 
-	<Target Name="_DetectSdkLocations" DependsOnTargets="_ComputeTargetArchitectures">
+	<Target Name="_DetectSdkLocations" DependsOnTargets="_ComputeTargetArchitectures;_ComputeTargetFrameworkMoniker">
 		<DetectSdkLocations
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
@@ -697,7 +697,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</DetectSdkLocations>
 	</Target>
 
-	<Target Name="_DetectSigningIdentity" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations">
+	<Target Name="_DetectSigningIdentity" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_ComputeTargetFrameworkMoniker">
 		<DetectSigningIdentity
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
@@ -767,7 +767,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="GetAppBundleDir" DependsOnTargets="_GenerateBundleName" Returns="$(AppBundleDir)"/>
 
 	<Target Name="_CompileAppManifest"
-		DependsOnTargets="_DetectSdkLocations;_DetectAppManifest;_GenerateBundleName;_DetectSigningIdentity;_PrepareResourceRules;_ResolveWatchAppReferences;_DetectDebugNetworkConfiguration"
+		DependsOnTargets="_DetectSdkLocations;_DetectAppManifest;_GenerateBundleName;_DetectSigningIdentity;_PrepareResourceRules;_ResolveWatchAppReferences;_DetectDebugNetworkConfiguration;_ComputeTargetFrameworkMoniker"
 		Inputs="$(_AppManifest);@(_PartialAppManifest)"
 		Outputs="$(_AppBundlePath)Info.plist" >
 		<CompileAppManifest
@@ -848,6 +848,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<PropertyGroup>
 		<_CompileToNativeDependsOn>
+			_ComputeTargetFrameworkMoniker;
 			_DetectAppManifest;
 			_DetectSdkLocations;
 			_GenerateBundleName;
@@ -1249,7 +1250,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CoreCompileColladaAssets"
-		DependsOnTargets="_CollectColladaAssets;_DetectSdkLocations"
+		DependsOnTargets="_CollectColladaAssets;_DetectSdkLocations;_ComputeTargetFrameworkMoniker"
 		Inputs="@(_ColladaAssetWithLogicalName)"
 		Outputs="$(DeviceSpecificIntermediateOutputPath)%(_ColladaAssetWithLogicalName.LogicalName)"
 		>
@@ -1366,7 +1367,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CoreCompileSceneKitAssets"
 		Inputs="@(SceneKitAsset)"
 		Outputs="$(_SceneKitCache)"
-		DependsOnTargets="_BeforeCoreCompileSceneKitAssets;_GenerateBundleName">
+		DependsOnTargets="_BeforeCoreCompileSceneKitAssets;_GenerateBundleName;_ComputeTargetFrameworkMoniker">
 
 		<CompileSceneKitAssets
 			SessionId="$(BuildSessionId)"
@@ -1576,7 +1577,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</EmbedMobileProvision>
 	</Target>
 
-	<Target Name="_CompileEntitlements" Condition="'$(_RequireCodeSigning)' == 'true' Or '$(CodesignEntitlements)' != ''" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectSigningIdentity"
+	<Target Name="_CompileEntitlements" Condition="'$(_RequireCodeSigning)' == 'true' Or '$(CodesignEntitlements)' != ''" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectSigningIdentity;_ComputeTargetFrameworkMoniker"
 		Outputs="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent">
 		<CompileEntitlements
 			SessionId="$(BuildSessionId)"
@@ -1725,7 +1726,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			$(_AppBundlePath)..\%(_ResolvedAppExtensionReferences.FileName)%(_ResolvedAppExtensionReferences.Extension).dSYM" />
 	</Target>
 
-	<Target Name="_ValidateAppBundle" Condition="'$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_DetectSdkLocations">
+	<Target Name="_ValidateAppBundle" Condition="'$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_DetectSdkLocations;_ComputeTargetFrameworkMoniker">
 		<ValidateAppBundleTask
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
@@ -51,6 +51,7 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 	<Target Name="_GenerateBindings"
 		Inputs="$(MSBuildAllProjects);@(ObjcBindingApiDefinition);@(ObjcBindingCoreSource);@(ReferencePath);@(ObjcBindingNativeLibrary)"
 		Outputs="$(_GeneratedSourcesFileList)"
+		DependsOnTargets="_ComputeTargetFrameworkMoniker"
 		Condition="'$(DesignTimeBuild)' != 'true'">
 
 		<PropertyGroup>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.props
@@ -24,11 +24,13 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<_XamarinCommonPropsHasBeenImported>true</_XamarinCommonPropsHasBeenImported>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<!-- Get the TargetFrameworkMoniker and store it in our own variable so that it's overridable while only affecting the parts of the build that we care about.
-			 This is overridability is a workaround while we wait for .NET 5 to be able to give us the TFM we're supposed to get during the build. -->
-		<_ComputedTargetFrameworkMoniker Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">$(TargetFrameworkMoniker)</_ComputedTargetFrameworkMoniker>
-	</PropertyGroup>
+	<Target Name="_ComputeTargetFrameworkMoniker">
+		<PropertyGroup Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">
+			<!-- Get the TargetFrameworkMoniker and store it in our own variable so that it's overridable while only affecting the parts of the build that we care about.
+				 This is overridability is a workaround while we wait for .NET 5 to be able to give us the TFM we're supposed to get during the build. -->
+			<_ComputedTargetFrameworkMoniker Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">$(TargetFrameworkMoniker)</_ComputedTargetFrameworkMoniker>
+		</PropertyGroup>
+	</Target>
 
 	<!-- This is used to determine if VS is connected to mac. -->
 	<PropertyGroup>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.Common.targets
@@ -38,7 +38,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 	<Target Name="Build"   Condition="'$(_InvalidConfigurationWarning)' != 'true'" DependsOnTargets="_GetWatchAppBundlePath;$(BuildDependsOn)" Outputs="@(_WatchAppBundlePath)" />
 	<Target Name="Rebuild" Condition="'$(_InvalidConfigurationWarning)' != 'true'" DependsOnTargets="_GetWatchAppBundlePath;$(RebuildDependsOn)" Outputs="@(_WatchAppBundlePath)" />
 
-	<Target Name="_ResolveNativeWatchApp" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName">
+	<Target Name="_ResolveNativeWatchApp" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_ComputeTargetFrameworkMoniker">
 		<ResolveNativeWatchApp
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"


### PR DESCRIPTION
It might only be necessary for Xamarin.iOS builds, but modify both XI and XM
so that the logic is identical.

Fixes https://github.com/xamarin/xamarin-macios/issues/8277.