### PR TITLE
[Bump VMac] Bump max version of VSMac to current stable major.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -80,7 +80,7 @@ MIN_XM_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/
 # Minimum Visual Studio version
 MIN_VISUAL_STUDIO_URL=https://bosstoragemirror.blob.core.windows.net/vsmac/3425624/release-8.4/88f89d49594ac101891944e2a6b9a0b607a6fb52/VisualStudioForMac-8.4.4.8.dmg
 MIN_VISUAL_STUDIO_VERSION=8.4.4.8
-MAX_VISUAL_STUDIO_VERSION=8.4.99
+MAX_VISUAL_STUDIO_VERSION=8.5.99
 
 # Minimum CMake version
 MIN_CMAKE_URL=https://cmake.org/files/v3.6/cmake-3.6.2-Darwin-x86_64.dmg


### PR DESCRIPTION
Current VSMac version is 8.5.1.42. Bump the max version so that we can
dogfood at least the stable channel without setting the ignore flag.