### PR TITLE
[Harness] Fix the generation of the sources.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/XamariniOSTemplate.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/XamariniOSTemplate.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.TestImporter.Templates.Managed {
 		internal static readonly string TestingFrameworksKey = "%TESTING FRAMEWORKS%";
 
 		// resource related static vars used to copy the embedded src to the hd
-		static string srcResourcePrefix = "Xharness.TestImporter.Templates.Managed.Resources.src.";
+		static string srcResourcePrefix = "Microsoft.DotNet.XHarness.iOS.Shared.TestImporter.Templates.Managed.Resources.src.";
 		static string registerTemplateResourceName = "RegisterType.cs";
 		static string [] [] srcDirectories = new [] {
 			new [] { "common", },


### PR DESCRIPTION
The name of the dll changed, ergo the prefix changed.