### PR TITLE
[Introspection] Fix a false typo in mac modern typo tests.

### DIFF
--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -483,6 +483,7 @@ namespace Introspection
 			"Seekable",
 			"Shadable",
 			"Sharegroup",
+			"Sha", //  Secure Hash Algorithm
 			"Siemen",
 			"simd",
 			"Sinh",


### PR DESCRIPTION
Add Sha as an allowed word in the typo tests, it is a well known
acronym.