### PR TITLE
[mtouch/mmp] Use the standard DEBUG define to determine when we're running from inside an IDE.

### DIFF
--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -799,7 +799,7 @@ namespace Xamarin.Bundler {
 					if (!string.IsNullOrEmpty (env_framework_dir)) {
 						framework_dir = env_framework_dir;
 					} else {
-#if DEV
+#if DEBUG
 						// when launched from Visual Studio, the executable is not in the final install location,
 						// so walk the directory hierarchy to find the root source directory.
 						framework_dir = WalkUpDirHierarchyLookingForLocalBuild ();

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -16,7 +16,7 @@
     <DebugType>portable</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>MONOMAC;MMP;XAMARIN_APPLETLS;DEBUG;DEV</DefineConstants>
+    <DefineConstants>MONOMAC;MMP;XAMARIN_APPLETLS;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Deterministic>True</Deterministic>

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -16,7 +16,7 @@
     <DebugType>portable</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>MONOTOUCH;MTOUCH;XAMARIN_APPLETLS;DEV</DefineConstants>
+    <DefineConstants>MONOTOUCH;MTOUCH;XAMARIN_APPLETLS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Deterministic>True</Deterministic>


### PR DESCRIPTION
We're using the Release configuration to build the mtouch and mmp binaries
that we ship, which means that we can use the Debug configuration for
debugging from an IDE, and use the standard conditional compilation symbols to
identify that case.