### PR TITLE
[xharness] Don't overwrite variations.

### DIFF
--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -1076,7 +1076,7 @@ namespace Xharness.Jenkins {
 					}
 
 					foreach (var e in execs)
-						e.Variation = config;
+						e.Variation = string.IsNullOrEmpty (e.Variation) ? config : e.Variation;
 
 					Tasks.AddRange (execs);
 				}


### PR DESCRIPTION
This means different variations of tests won't show up as identical in the
html report.

Before:

<img width="282" alt="Before" src="https://user-images.githubusercontent.com/249268/78767634-26683500-798b-11ea-80cc-e1fdf66327c3.png">

After:

<img width="392" alt="After" src="https://user-images.githubusercontent.com/249268/78767645-29fbbc00-798b-11ea-8b54-998b69ee8766.png">
