### PR TITLE
Setting an environment variable to null doesn't work in .netcore.

### DIFF
--- a/tests/xharness/Jenkins/TestTasks/AppleTestTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/AppleTestTask.cs
@@ -68,8 +68,13 @@ namespace Xharness.Jenkins.TestTasks {
 				throw new NotImplementedException ();
 			}
 
-			foreach (var kvp in Environment)
-				process.StartInfo.EnvironmentVariables [kvp.Key] = kvp.Value;
+			foreach (var kvp in Environment) {
+				if (kvp.Value == null) {
+					process.StartInfo.EnvironmentVariables.Remove (kvp.Key);
+				} else {
+					process.StartInfo.EnvironmentVariables [kvp.Key] = kvp.Value;
+				}
+			}
 		}
 
 

--- a/tests/xharness/Jenkins/TestTasks/MSBuildTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/MSBuildTask.cs
@@ -47,7 +47,7 @@ namespace Xharness.Jenkins.TestTasks {
 					xbuild.StartInfo.FileName = ToolName;
 					xbuild.StartInfo.Arguments = StringUtils.FormatArguments (ToolArguments);
 					SetEnvironmentVariables (xbuild);
-					xbuild.StartInfo.EnvironmentVariables ["MSBuildExtensionsPath"] = null;
+					xbuild.StartInfo.EnvironmentVariables.Remove ("MSBuildExtensionsPath");
 					LogEvent (BuildLog, "Building {0} ({1})", TestName, Mode);
 					if (!Harness.DryRun) {
 						var timeout = TimeSpan.FromMinutes (60);

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Execution/ProcessManager.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Execution/ProcessManager.cs
@@ -140,8 +140,13 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution {
 			process.StartInfo.UseShellExecute = false;
 
 			if (environmentVariables != null) {
-				foreach (var kvp in environmentVariables)
-					process.StartInfo.EnvironmentVariables [kvp.Key] = kvp.Value;
+				foreach (var kvp in environmentVariables) {
+					if (kvp.Value == null) {
+						process.StartInfo.EnvironmentVariables.Remove (kvp.Key);
+					} else {
+						process.StartInfo.EnvironmentVariables [kvp.Key] = kvp.Value;
+					}
+				}
 			}
 
 			process.OutputDataReceived += (sender, e) => {

--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -295,7 +295,7 @@ namespace Xamarin.Bundler {
 				// Visual Studio for Mac sets this environment variable, and it confuses the AOT compiler.
 				// So unset it.
 				// See https://github.com/mono/mono/issues/11765
-				task.ProcessStartInfo.EnvironmentVariables ["MONO_THREADS_SUSPEND"] = null;
+				task.ProcessStartInfo.EnvironmentVariables.Remove ("MONO_THREADS_SUSPEND");
 			}
 
 			aotInfo.Task = task;


### PR DESCRIPTION
There is a difference between mono and .netcore with regards to environment
variables when launching processes.

For the following example:

    process.StartInfo.EnvironmentVariables ["FOO"] = null;

.netcore will launch the process with an empty FOO variable, while mono will
launch the process with no FOO variable set.

So unstead remove the variable from the collection of environment variables
(this works fine even if the collection doesn't contain the variable).

Ref: https://github.com/dotnet/runtime/issues/34446