### PR TITLE
[mtouch/mmp] Use a single SdkVersions.cs in tools/common.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -191,14 +191,14 @@ Makefile-mac.inc: xharness/xharness.exe
 
 -include Makefile-mac.inc
 
-$(TOP)/tools/mtouch/SdkVersions.cs: $(TOP)/tools/common/SdkVersions.cs.in
-	@$(MAKE) -C $(TOP)/tools/mtouch SdkVersions.cs
+$(TOP)/tools/common/SdkVersions.cs: $(TOP)/tools/common/SdkVersions.cs.in
+	@$(MAKE) -C $(TOP)/tools/mtouch ../common/SdkVersions.cs
 
 .stamp-src-project-files:
 	@$(MAKE) -C $(TOP)/src project-files
 	@touch $@
 
-xharness/xharness.exe: $(wildcard xharness/*.cs) $(wildcard $(TOP)/tools/bcl-test-importer/BCLTestImporter/*.cs) xharness/xharness.csproj $(TOP)/tools/mtouch/SdkVersions.cs test.config test-system.config .stamp-src-project-files
+xharness/xharness.exe: $(wildcard xharness/*.cs) $(wildcard $(TOP)/tools/bcl-test-importer/BCLTestImporter/*.cs) xharness/xharness.csproj $(TOP)/tools/common/SdkVersions.cs test.config test-system.config .stamp-src-project-files
 	$(Q_GEN) $(SYSTEM_MSBUILD) /restore $(MSBUILD_VERBOSITY_QUIET) xharness/xharness.csproj
 
 killall:

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -110,7 +110,7 @@
     <Compile Include="src\AssemblyReferencesTests.cs" />
     <Compile Include="src\PackageReferenceTests.cs" />
     <Compile Include="src\BindingProjectNoEmbeddingTests.cs" />
-    <Compile Include="..\..\tools\mmp\SdkVersions.cs">
+    <Compile Include="..\..\tools\common\SdkVersions.cs">
       <Link>SdkVersions.cs</Link>
     </Compile>
     <Compile Include="src\TargetFrameworkMutateTests.cs" />

--- a/tests/mtouch/mtouch.csproj
+++ b/tests/mtouch/mtouch.csproj
@@ -89,7 +89,7 @@
       <Link>ErrorHelper.cs</Link>
     </Compile>
     <Compile Include="RuntimeException.cs" />
-    <Compile Include="..\..\tools\mtouch\SdkVersions.cs">
+    <Compile Include="..\..\tools\common\SdkVersions.cs">
       <Link>SdkVersions.cs</Link>
     </Compile>
     <Compile Include="..\..\tools\mtouch\Errors.Designer.cs">

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -121,7 +121,7 @@
     <Compile Include="TestTasks\Resources.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\tools\mtouch\SdkVersions.cs">
+    <Compile Include="..\..\tools\common\SdkVersions.cs">
       <Link>SdkVersions.cs</Link>
     </Compile>
   </ItemGroup>

--- a/tools/common/.gitignore
+++ b/tools/common/.gitignore
@@ -1,0 +1,1 @@
+SdkVersions.cs

--- a/tools/common/Make.common
+++ b/tools/common/Make.common
@@ -1,4 +1,4 @@
-SdkVersions.cs: ../common/SdkVersions.cs.in Makefile $(TOP)/Make.config
+../common/SdkVersions.cs: ../common/SdkVersions.cs.in Makefile $(TOP)/Make.config
 	$(Q_GEN) sed \
 		-e 's/@IOS_SDK_VERSION@/$(IOS_SDK_VERSION)/g' -e 's/@WATCHOS_SDK_VERSION@/$(WATCH_SDK_VERSION)/' -e 's/@TVOS_SDK_VERSION@/$(TVOS_SDK_VERSION)/' -e 's/@OSX_SDK_VERSION@/$(OSX_SDK_VERSION)/' \
 		-e 's/@MIN_IOS_SDK_VERSION@/$(MIN_IOS_SDK_VERSION)/g' -e 's/@MIN_WATCHOS_SDK_VERSION@/$(MIN_WATCHOS_SDK_VERSION)/' -e 's/@MIN_TVOS_SDK_VERSION@/$(MIN_TVOS_SDK_VERSION)/' -e 's/@MIN_OSX_SDK_VERSION@/$(MIN_OSX_SDK_VERSION)/' \

--- a/tools/mmp/.gitignore
+++ b/tools/mmp/.gitignore
@@ -1,4 +1,3 @@
 Xamarin.Mac.registrar.*
-SdkVersions.cs
 *.stamp
 mmp.csproj.inc

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -58,7 +58,7 @@
     <Compile Include="..\common\error.cs">
       <Link>external\error.cs</Link>
     </Compile>
-    <Compile Include="SdkVersions.cs" />
+    <Compile Include="..\common\SdkVersions.cs" />
     <Compile Include="..\..\builds\mono-ios-sdk-destdir\ios-sources\external\linker\src\tuner\Mono.Tuner\ApplyPreserveAttributeBase.cs">
       <Link>Mono.Tuner\ApplyPreserveAttributeBase.cs</Link>
     </Compile>
@@ -480,4 +480,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="..\..\packages\XliffTasks.1.0.0-beta.20060.1\build\XliffTasks.targets" Condition="Exists('..\..\packages\XliffTasks.1.0.0-beta.20060.1\build\XliffTasks.targets')" />
+  <Target Name="BuildSdkVersions" Inputs="../common/SdkVersions.cs.in" Outputs="../common/SdkVersions.cs">
+    <Exec Command="make ../common/SdkVersions.cs" />
+  </Target>
 </Project>

--- a/tools/mtouch/.gitignore
+++ b/tools/mtouch/.gitignore
@@ -1,4 +1,3 @@
-SdkVersions.cs
 *.a
 *.dylib
 *.dSYM

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -48,7 +48,7 @@
       <Link>external\error.cs</Link>
     </Compile>
     <Compile Include="mtouch.cs" />
-    <Compile Include="SdkVersions.cs" />
+    <Compile Include="..\common\SdkVersions.cs" />
     <Compile Include="Stripper.cs" />
     <Compile Include="Target.cs" />
     <Compile Include="Tuning.cs" />
@@ -496,6 +496,9 @@
       <LogicalName>Errors.mtouch.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
+  <Target Name="BuildSdkVersions" Inputs="../common/SdkVersions.cs.in" Outputs="../common/SdkVersions.cs">
+    <Exec Command="make ../common/SdkVersions.cs" />
+  </Target>
   <Target Name="AfterBuild">
     <!-- This makes sure that just building the csproj will install the updated mtouch.exe, so that tests get it without having to 'make mtouch' manually -->
     <Exec Command="make mtouch" />


### PR DESCRIPTION
No need to have two identical files around.