### PR TITLE
Create a general rule to create makefile fragments for project files.

### DIFF
--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -171,3 +171,6 @@ $(eval $(call NativeCompilationTemplate,-debug,-DDEBUG))
 
 .libs/iphoneos .libs/iphonesimulator .libs/watchos .libs/watchsimulator .libs/tvos .libs/tvsimulator .libs/iosmac:
 	$(Q) mkdir -p $@
+
+%.csproj.inc: %.csproj $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/tools/common/create-makefile-fragment.sh
+	$(Q) $(TOP)/tools/common/create-makefile-fragment.sh $(abspath $<) $(abspath $@)

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -2,10 +2,12 @@
 # Generator
 #
 
-# generator.csproj.inc contains the generator_dependencies variable used to determine if the generator needs to be rebuilt or not.
-$(BUILD_DIR)/generator.csproj.inc: Makefile.generator $(TOP)/tools/common/create-makefile-fragment.sh $(TOP)/Make.config $(TOP)/mk/mono.mk | $(BUILD_DIR)
-	$(Q_GEN) $(TOP)/tools/common/create-makefile-fragment.sh $(abspath $(CURDIR)/generator.csproj) $(abspath $@)
+# copy generator.csproj to the build dir so that we can use our shared .csproj.inc target from rules.mk to create generator.csproj.inc
+# we need any generated files in this directory to go into the build directory, and the shared target will output the csproj.inc into the same directory as the csproj
+$(BUILD_DIR)/generator.csproj: generator.csproj | $(BUILD_DIR)
+	$(Q) $(CP) $< $@
 
+# generator.csproj.inc contains the generator_dependencies variable used to determine if the generator needs to be rebuilt or not.
 -include $(BUILD_DIR)/generator.csproj.inc
 
 $(BUILD_DIR)/common/bgen.exe: $(generator_dependencies) Makefile.generator $(BUILD_DIR)/generator-frameworks.g.cs

--- a/tests/mtouch/Makefile
+++ b/tests/mtouch/Makefile
@@ -29,8 +29,6 @@ run-tests: bin/Debug/mtouch.dll test.config
 	@[[ ! -e .failed-stamp ]] 
 
 # mtouch.csproj.inc contains the mtouch_dependencies variable used to determine if mtouch.dll needs to be rebuilt or not.
-mtouch.csproj.inc: $(TOP)/tools/common/create-makefile-fragment.sh Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk
-	$(Q_GEN) $< $(CURDIR)/mtouch.csproj
 -include mtouch.csproj.inc
 
 bin/Debug/mtouch.dll: $(mtouch_dependencies)

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -12,9 +12,6 @@ MMP_DIR=bin/$(MMP_CONF)
 LOCAL_MMP=$(MMP_DIR)/mmp.exe
 
 # mmp.csproj.inc contains the mmp_dependencies variable used to determine if mmp needs to be rebuilt or not.
-mmp.csproj.inc: Makefile ../common/create-makefile-fragment.sh $(TOP)/Make.config $(TOP)/mk/mono.mk
-	$(Q_GEN) ../common/create-makefile-fragment.sh $(CURDIR)/mmp.csproj
-
 -include mmp.csproj.inc
 
 $(MMP_DIR)/mmp.exe: $(mmp_dependencies)

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -201,9 +201,6 @@ MTOUCH_DIR=bin/$(MTOUCH_CONF)
 LOCAL_MTOUCH=$(MTOUCH_DIR)/mtouch.exe
 
 # mtouch.csproj.inc contains the mtouch_dependencies variable used to determine if mtouch needs to be rebuilt or not.
-mtouch.csproj.inc: Makefile ../common/create-makefile-fragment.sh $(TOP)/Make.config $(TOP)/mk/mono.mk
-	$(Q_GEN) ../common/create-makefile-fragment.sh $(CURDIR)/mtouch.csproj
-
 -include mtouch.csproj.inc
 
 $(MTOUCH_DIR)/mtouch.exe: $(mtouch_dependencies)


### PR DESCRIPTION
The generator project file still needs some custom logic, because we can't put
the generated makefile fragment next to the csproj (that would break the
API/generator diff).