### PR TITLE
[Harness] Remove launchTimeout parameter from TestReporter, move factories

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -269,7 +269,6 @@ namespace Xharness {
 				harness.XmlJargon,
 				deviceName,
 				testReporterTimeout,
-				harness.LaunchTimeout,
 				buildTask?.Logs?.Directory,
 				(level, message) => harness.Log (level, message));
 

--- a/tests/xharness/DeviceLoaderFactory.cs
+++ b/tests/xharness/DeviceLoaderFactory.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
+using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 
-namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware {
+namespace Xharness {
 
 	public interface IDeviceLoaderFactory {
 		IHardwareDeviceLoader CreateLoader ();

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestReporterTests.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestReporterTests.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Listeners;
-using Microsoft.DotNet.XHarness.iOS.Shared;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests {
 
@@ -74,8 +73,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests {
 				RunMode.Sim64,
 				XmlResultJargon.NUnitV3,
 				deviceName,
-				TimeSpan.FromSeconds (2),
-				0.2);
+				TimeSpan.FromSeconds (2));
 		}
 
 		[Test]

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
@@ -38,7 +38,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared {
 		readonly string deviceName;
 
 		readonly TimeSpan timeout;
-		readonly double launchTimeout;
 		readonly Stopwatch timeoutWatch;
 
 		/// <summary>
@@ -78,7 +77,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared {
 			XmlResultJargon xmlJargon,
 			string device,
 			TimeSpan timeout,
-			double launchTimeout,
 			string additionalLogsDirectory = null,
 			ExceptionLogger exceptionLogger = null)
 		{
@@ -95,7 +93,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared {
 			this.runMode = runMode;
 			this.xmlJargon = xmlJargon;
 			this.timeout = timeout;
-			this.launchTimeout = launchTimeout;
 			this.additionalLogsDirectory = additionalLogsDirectory;
 			this.exceptionLogger = exceptionLogger;
 			this.timeoutWatch  = Stopwatch.StartNew ();
@@ -187,12 +184,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared {
 
 		// kill any process 
 		Task KillAppProcess (int pid, CancellationTokenSource cancellationSource) { 
-				var launchTimedout = cancellationSource.IsCancellationRequested;
-				var timeoutType = launchTimedout ? "Launch" : "Completion";
-				var timeoutValue = launchTimedout ? launchTimeout : timeout.TotalSeconds;
-
-				mainLog.WriteLine ($"{timeoutType} timed out after {timeoutValue} seconds");
-				return processManager.KillTreeAsync (pid, mainLog, true);
+			var launchTimedout = cancellationSource.IsCancellationRequested;
+			var timeoutType = launchTimedout ? "Launch" : "Completion";
+			mainLog.WriteLine ($"{timeoutType} timed out after {timeoutWatch.Elapsed.TotalSeconds} seconds");
+			return processManager.KillTreeAsync (pid, mainLog, true);
 		}
 
 		async Task CollectResult (Task<ProcessExecutionResult> processExecution)
@@ -231,7 +226,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared {
 				mainLog.WriteLine ("Test run started");
 			} else {
 				cancellationTokenSource.Cancel ();
-				mainLog.WriteLine ("Test launch timed out after {0} minute(s).", launchTimeout);
+				mainLog.WriteLine ("Test launch timed out after {0} minute(s).", timeoutWatch.Elapsed.TotalMinutes);
 				timedout = true;
 			}
 		}

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestReporterFactory.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestReporterFactory.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Listeners;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 
 using ExceptionLogger = System.Action<int, string>;
 
-namespace Xharness {
+namespace Microsoft.DotNet.XHarness.iOS.Shared {
 	public interface ITestReporterFactory {
 		ITestReporter Create (ILog mainLog,
 			ILog runLog,
@@ -19,9 +18,8 @@ namespace Xharness {
 			XmlResultJargon xmlJargon,
 			string device,
 			TimeSpan timeout,
-			double launchTimeout,
 			string additionalLogsDirectory = null,
-			Action<int, string> exceptionLogger = null);
+			ExceptionLogger exceptionLogger = null);
 	}
 
 	public class TestReporterFactory : ITestReporterFactory {
@@ -43,7 +41,6 @@ namespace Xharness {
 			XmlResultJargon xmlJargon,
 			string device,
 			TimeSpan timeout,
-			double launchTimeout,
 			string additionalLogsDirectory = null,
 			ExceptionLogger exceptionLogger = null)
 		{
@@ -59,7 +56,6 @@ namespace Xharness {
 				xmlJargon,
 				device,
 				timeout,
-				launchTimeout,
 				additionalLogsDirectory,
 				exceptionLogger);
 		}

--- a/tests/xharness/SimulatorLoaderFactory.cs
+++ b/tests/xharness/SimulatorLoaderFactory.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
+using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 
-namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware {
+namespace Xharness {
 
 	public interface ISimulatorLoaderFactory {
 		ISimulatorLoader CreateLoader ();

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -79,7 +79,6 @@
     <Compile Include="DeviceLogCapturerFactory.cs" />
     <Compile Include="GitHub.cs" />
     <Compile Include="Harness.cs" />
-    <Compile Include="TestReporterFactory.cs" />
     <Compile Include="Jenkins\Jenkins.cs" />
     <Compile Include="Jenkins\TestTasks\AggregatedRunSimulatorTask.cs" />
     <Compile Include="Jenkins\TestTasks\BuildProjectTask.cs" />

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -76,6 +76,7 @@
     <Compile Include="AppRunner.cs" />
     <Compile Include="BCLTestImportTargetFactory.cs" />
     <Compile Include="CrashSnapshotReporterFactory.cs" />
+    <Compile Include="DeviceLoaderFactory.cs" />
     <Compile Include="DeviceLogCapturerFactory.cs" />
     <Compile Include="GitHub.cs" />
     <Compile Include="Harness.cs" />
@@ -100,6 +101,7 @@
     <Compile Include="MonoNativeInfo.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SimulatorLoaderFactory.cs" />
     <Compile Include="SolutionGenerator.cs" />
     <Compile Include="Targets\iOSTarget.cs" />
     <Compile Include="Targets\MacTarget.cs" />


### PR DESCRIPTION
This parameter is not needed - only used for logging - and it was quite confusing with the other timeouts.

The change also moves one factory to a shared library and two from shared library back to XHarness.

No functional changes.