### PR TITLE
Bump maccore to get msbuild.zip fix.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := a1ad303faf4c066e50dfed810a01a4f4c6a8d221
+NEEDED_MACCORE_VERSION := ad1696d6f33badd34f930e4ce1be9185b5a36dd7
 NEEDED_MACCORE_BRANCH := master
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@ad1696d6f3 Restore Xamarin.iOS.Tasks project for msbuild.zip (#2198)

Diff: https://github.com/xamarin/maccore/compare/a1ad303faf4c066e50dfed810a01a4f4c6a8d221..ad1696d6f33badd34f930e4ce1be9185b5a36dd7