### PR TITLE
[generator] Add C#8 nullability into generated code (#7570)

### DIFF
--- a/msbuild/tests/MyBindingsReferences/LibraryA/LibraryA.csproj
+++ b/msbuild/tests/MyBindingsReferences/LibraryA/LibraryA.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>LibraryA</AssemblyName>
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/msbuild/tests/MyBindingsReferences/LibraryB/LibraryB.csproj
+++ b/msbuild/tests/MyBindingsReferences/LibraryB/LibraryB.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>LibraryB</AssemblyName>
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/msbuild/tests/MySatelliteAssembliesBug/iOSBinding/iOSBinding.csproj
+++ b/msbuild/tests/MySatelliteAssembliesBug/iOSBinding/iOSBinding.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>iOSBinding</RootNamespace>
     <AssemblyName>iOSBinding</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/msbuild/tests/MyiOSAppWithBinding/MyiOSAppWithBinding.csproj
+++ b/msbuild/tests/MyiOSAppWithBinding/MyiOSAppWithBinding.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>MyiOSAppWithBinding</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>MyiOSAppWithBinding</AssemblyName>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/msbuild/tests/MyiOSFrameworkBinding/MyiOSFrameworkBinding.csproj
+++ b/msbuild/tests/MyiOSFrameworkBinding/MyiOSFrameworkBinding.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MyiOSFrameworkBinding</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>MyiOSFrameworkBinding</AssemblyName>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Foundation/DictionaryContainer.cs
+++ b/src/Foundation/DictionaryContainer.cs
@@ -40,6 +40,8 @@ using CoreMedia;
 #endif // !WATCH
 #endif
 
+#nullable enable
+
 namespace Foundation {
 
 	public abstract class DictionaryContainer
@@ -50,16 +52,14 @@ namespace Foundation {
 			Dictionary = new NSMutableDictionary ();
 		}
 
-		protected DictionaryContainer (NSDictionary dictionary)
+		protected DictionaryContainer (NSDictionary? dictionary)
 		{
-			if (dictionary == null)
-				throw new ArgumentNullException ("dictionary");
-			Dictionary = dictionary;
+			Dictionary = dictionary ?? new NSMutableDictionary ();
 		}
 		
 		public NSDictionary Dictionary { get; private set; }
 
-		protected T[] GetArray<T> (NSString key) where T : NSObject
+		protected T[]? GetArray<T> (NSString key) where T : NSObject
 		{
 			if (key == null)
 				throw new ArgumentNullException ("key");
@@ -71,7 +71,7 @@ namespace Foundation {
 			return NSArray.ArrayFromHandle<T> (value);
 		}
 
-		protected T[] GetArray<T> (NSString key, Func<IntPtr, T> creator)
+		protected T[]? GetArray<T> (NSString key, Func<IntPtr, T> creator)
 		{
 			if (key == null)
 				throw new ArgumentNullException ("key");
@@ -199,7 +199,7 @@ namespace Foundation {
 			return CFBoolean.GetValue (value);
 		}
 
-		protected T GetNativeValue<T> (NSString key) where T : class, INativeObject
+		protected T? GetNativeValue<T> (NSString key) where T : class, INativeObject
 		{
 			if (key == null)
 				throw new ArgumentNullException ("key");
@@ -207,7 +207,7 @@ namespace Foundation {
 			return Runtime.GetINativeObject<T> (Dictionary.LowlevelObjectForKey (key.Handle), false);
 		}
 
-		protected NSDictionary GetNSDictionary (NSString key)
+		protected NSDictionary? GetNSDictionary (NSString key)
 		{
 			if (key == null)
 				throw new ArgumentNullException ("key");
@@ -218,7 +218,7 @@ namespace Foundation {
 		}
 		
 #if XAMCORE_2_0
-		protected NSDictionary <TKey, TValue> GetNSDictionary <TKey, TValue> (NSString key)
+		protected NSDictionary <TKey, TValue>? GetNSDictionary <TKey, TValue> (NSString key)
 			where TKey : class, INativeObject
 			where TValue : class, INativeObject
 		{
@@ -231,7 +231,7 @@ namespace Foundation {
 		}
 #endif
 
-		protected T GetStrongDictionary<T> (NSString key) where T : DictionaryContainer
+		protected T? GetStrongDictionary<T> (NSString key) where T : DictionaryContainer
 		{
 			if (key == null)
 				throw new ArgumentNullException ("key");
@@ -239,14 +239,12 @@ namespace Foundation {
 			var dict = GetNSDictionary (key);
 			if (dict == null)
 				return null;
-			T value = (T)Activator.CreateInstance (typeof(T),
+			return (T?) Activator.CreateInstance (typeof(T),
 				new object[] { dict }
 			);
-
-			return value;
 		}
 
-		protected NSString GetNSStringValue (NSString key)
+		protected NSString? GetNSStringValue (NSString key)
 		{
 			if (key == null)
 				throw new ArgumentNullException ("key");
@@ -256,7 +254,7 @@ namespace Foundation {
 			return value as NSString;
 		}
 
-		protected string GetStringValue (NSString key)
+		protected string? GetStringValue (NSString key)
 		{
 			if (key == null)
 				throw new ArgumentNullException ("key");
@@ -268,7 +266,7 @@ namespace Foundation {
 			return CFString.FetchString (value.Handle);
 		}
 
-		protected string GetStringValue (string key)
+		protected string? GetStringValue (string key)
 		{
 			if (key == null)
 				throw new ArgumentNullException ("key");
@@ -330,28 +328,28 @@ namespace Foundation {
 			return !removeEntry;
 		}
 
-		protected void SetArrayValue (NSString key, NSNumber[] values)
+		protected void SetArrayValue (NSString key, NSNumber[]? values)
 		{
 			if (NullCheckAndRemoveKey (key, values == null))
 				Dictionary [key] = NSArray.FromNSObjects (values);
 		}
 
-		protected void SetArrayValue<T> (NSString key, T[] values)
+		protected void SetArrayValue<T> (NSString key, T[]? values)
 		{
 			if (NullCheckAndRemoveKey (key, values == null))
 				Dictionary [key] = NSArray.FromNSObjects (values.Select (x => NSObject.FromObject (x)).ToArray ());
 		}
 
-		protected void SetArrayValue (NSString key, string[] values)
+		protected void SetArrayValue (NSString key, string[]? values)
 		{
 			if (NullCheckAndRemoveKey (key, values == null))
-				Dictionary [key] = NSArray.FromStrings (values);
+				Dictionary [key!] = NSArray.FromStrings (values);
 		}
 
-		protected void SetArrayValue (NSString key, INativeObject[] values)
+		protected void SetArrayValue (NSString key, INativeObject[]? values)
 		{
 			if (NullCheckAndRemoveKey (key, values == null))
-				CFMutableDictionary.SetValue (Dictionary.Handle, key.Handle, CFArray.FromNativeObjects (values).Handle);
+				CFMutableDictionary.SetValue (Dictionary.Handle, key!.Handle, CFArray.FromNativeObjects (values).Handle);
 		}
 
 		#region Sets CFBoolean value
@@ -359,7 +357,7 @@ namespace Foundation {
 		protected void SetBooleanValue (NSString key, bool? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				CFMutableDictionary.SetValue (Dictionary.Handle, key.Handle, value.Value ? CFBoolean.TrueHandle : CFBoolean.FalseHandle);			
+				CFMutableDictionary.SetValue (Dictionary.Handle, key!.Handle, value!.Value ? CFBoolean.TrueHandle : CFBoolean.FalseHandle);			
 		}
 
 		#endregion
@@ -369,67 +367,67 @@ namespace Foundation {
 		protected void SetNumberValue (NSString key, int? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key] = new NSNumber (value.Value);				
+				Dictionary [key!] = new NSNumber (value!.Value);				
 		}
 
 		protected void SetNumberValue (NSString key, uint? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key] = new NSNumber (value.Value);				
+				Dictionary [key!] = new NSNumber (value!.Value);				
 		}
 
 #if XAMCORE_2_0
 		protected void SetNumberValue (NSString key, nint? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key] = new NSNumber (value.Value);	
+				Dictionary [key!] = new NSNumber (value!.Value);	
 		}
 
 		protected void SetNumberValue (NSString key, nuint? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key] = new NSNumber (value.Value);	
+				Dictionary [key!] = new NSNumber (value!.Value);	
 		}
 #endif
 
 		protected void SetNumberValue (NSString key, long? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key] = new NSNumber (value.Value);				
+				Dictionary [key!] = new NSNumber (value!.Value);				
 		}
 
 		protected void SetNumberValue (NSString key, float? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key] = new NSNumber (value.Value);				
+				Dictionary [key!] = new NSNumber (value!.Value);				
 		}
 
 		protected void SetNumberValue (NSString key, double? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key] = new NSNumber (value.Value);				
+				Dictionary [key!] = new NSNumber (value!.Value);				
 		}
 
 		#endregion
 
 		#region Sets NSString value
 
-		protected void SetStringValue (NSString key, string value)
+		protected void SetStringValue (NSString key, string? value)
 		{
-			SetStringValue (key, value == null ? (NSString) null : new NSString (value));
+			SetStringValue (key, value == null ? (NSString) null! : new NSString (value));
 		}
 
-		protected void SetStringValue (NSString key, NSString value)
+		protected void SetStringValue (NSString key, NSString? value)
 		{
 			if (NullCheckAndRemoveKey (key, value == null))
-				Dictionary [key] = value;
+				Dictionary [key!] = value;
 		}
 
 		#endregion
 
 		#region Sets Native value
 
-		protected void SetNativeValue (NSString key, INativeObject value, bool removeNullValue = true)
+		protected void SetNativeValue (NSString key, INativeObject? value, bool removeNullValue = true)
 		{
 			if (NullCheckAndRemoveKey (key, removeNullValue && value == null))
 				CFMutableDictionary.SetValue (Dictionary.Handle, key.Handle, value == null ? IntPtr.Zero : value.Handle);
@@ -451,26 +449,26 @@ namespace Foundation {
 		protected void SetCGRectValue (NSString key, CGRect? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key] = value.Value.ToDictionary ();
+				Dictionary [key!] = value!.Value.ToDictionary ();
 		}
 
 		protected void SetCGSizeValue (NSString key, CGSize? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key] = value.Value.ToDictionary ();
+				Dictionary [key!] = value!.Value.ToDictionary ();
 		}
 
 		protected void SetCGPointValue (NSString key, CGPoint? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key] = value.Value.ToDictionary ();
+				Dictionary [key!] = value!.Value.ToDictionary ();
 		}
 #endif // XAMCORE_2_0
 #if !WATCH
 		protected void SetCMTimeValue (NSString key, CMTime? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key] = value.Value.ToDictionary ();
+				Dictionary [key!] = value!.Value.ToDictionary ();
 		}
 #endif //!WATCH
 		#endregion
@@ -482,14 +480,14 @@ namespace Foundation {
 
 		// helper to avoid the (common pattern)
 		// 	var p = x == null ? IntPtr.Zero : h.Dictionary.Handle;
-		static public IntPtr GetHandle (this DictionaryContainer self)
+		static public IntPtr GetHandle (this DictionaryContainer? self)
 		{
 			return self == null ? IntPtr.Zero : self.Dictionary.Handle;
 		}
 
 		// helper to avoid the (common pattern)
 		// 	var p = x == null ? null : x.Dictionary;
-		static public NSDictionary GetDictionary (this DictionaryContainer self)
+		static public NSDictionary? GetDictionary (this DictionaryContainer? self)
 		{
 			return self == null ? null : self.Dictionary;
 		}

--- a/src/Foundation/ProtocolAttribute.cs
+++ b/src/Foundation/ProtocolAttribute.cs
@@ -24,6 +24,8 @@ using System;
 
 using ObjCRuntime;
 
+#nullable enable
+
 namespace Foundation {
 
 	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Interface)]
@@ -31,13 +33,13 @@ namespace Foundation {
 		
 		public ProtocolAttribute () {}
 
-		public Type WrapperType { get; set; }
-		public string Name { get; set; }
+		public Type? WrapperType { get; set; }
+		public string? Name { get; set; }
 		public bool IsInformal { get; set; }
 		// In which SDK version this protocol switched from being informal (i.e. a category) to a formal protocol.
 		// System.Version is not a valid type for attributes, so we're using a string instead.
-		string informal_until;
-		public string FormalSince {
+		string? informal_until;
+		public string? FormalSince {
 			get {
 				return informal_until;
 			}
@@ -56,18 +58,18 @@ namespace Foundation {
 		public bool IsRequired { get; set; }
 		public bool IsProperty { get; set; }
 		public bool IsStatic { get; set; }
-		public string Name { get; set; }
-		public string Selector { get; set; }
-		public Type ReturnType { get; set; }
-		public Type ReturnTypeDelegateProxy { get; set; }
-		public Type[] ParameterType { get; set; }
-		public bool[] ParameterByRef { get; set; }
-		public Type[] ParameterBlockProxy { get; set; }
+		public string? Name { get; set; }
+		public string? Selector { get; set; }
+		public Type? ReturnType { get; set; }
+		public Type? ReturnTypeDelegateProxy { get; set; }
+		public Type[]? ParameterType { get; set; }
+		public bool[]? ParameterByRef { get; set; }
+		public Type?[]? ParameterBlockProxy { get; set; }
 		public bool IsVariadic { get; set; }
 
-		public Type PropertyType { get; set; }
-		public string GetterSelector { get; set; }
-		public string SetterSelector { get; set; }
+		public Type? PropertyType { get; set; }
+		public string? GetterSelector { get; set; }
+		public string? SetterSelector { get; set; }
 		public ArgumentSemantic ArgumentSemantic { get; set; }
 	}
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -68,7 +68,9 @@ include $(TOP)/opentk/Makefile.include
 # It takes a comma separated list, but an empty list means
 # reporting all warnings as errors.
 #
-GENERATOR_WARNASERROR=
+# https://cezarypiatek.github.io/post/non-nullable-references-in-dotnet-core/
+NULLABILITY_WARNINGS=8073,8597,8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8610,87611,8612,8613,8614,8615,8616,8617,8618,8619,8620,8621,8622,8624,8625,8626,8629,8631,8632,8633,8634,8638,8343,8644,8645,8653,8654,8655,8667,8714
+GENERATOR_WARNASERROR=$(NULLABILITY_WARNINGS)
 IOS_GENERATOR_WARNASERROR=$(GENERATOR_WARNASERROR)
 WATCH_GENERATOR_WARNASERROR=$(GENERATOR_WARNASERROR)
 TVOS_GENERATOR_WARNASERROR=$(GENERATOR_WARNASERROR)
@@ -202,6 +204,7 @@ $(IOS_BUILD_DIR)/native-$(1)%Xamarin.iOS.dll $(IOS_BUILD_DIR)/native-$(1)%Xamari
 		$$(ARGS_$(1)) \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) $$(IOS_DEFINES) \
 		-nowarn:219,618,114,414,1635,3021,$$(IOS_WARNINGS_THAT_YOU_SHOULD_FIX) \
+		-warnaserror:$(NULLABILITY_WARNINGS) \
 		$$(IOS_CSC_FLAGS_XI) \
 		$$(IOS_SOURCES) @$(IOS_BUILD_DIR)/native/generated_sources
 
@@ -498,6 +501,7 @@ $(MAC_BUILD_DIR)/$(1)-64/Xamarin.Mac.dll: $(MAC_BUILD_DIR)/$(1)/generated-source
 		$$(ARGS_64) \
 		-publicsign -keyfile:$(SN_KEY) \
 		-nowarn:3021,1635,612,618,0219,0414,$(MAC_WARNINGS_TO_FIX) \
+		-warnaserror:$(NULLABILITY_WARNINGS) \
 		$$(MAC_CSC_FLAGS_XM) \
 		$(MAC_CFNETWORK_SOURCES) $(MAC_HTTP_SOURCES) \
 		$(2) \
@@ -775,6 +779,7 @@ $(WATCHOS_DOTNET_BUILD_DIR)/32/Xamarin.WatchOS.dll: $(WATCHOS_DOTNET_BUILD_DIR)/
 		$(WATCH_DEFINES) \
 		$(ARGS_32) \
 		$(WATCHOS_WARNINGS_TO_FIX) \
+		-warnaserror:$(NULLABILITY_WARNINGS) \
 		$(IOS_CSC_FLAGS_XI) \
 		$(WATCHOS_SOURCES) \
 		@$<
@@ -991,6 +996,7 @@ $(TVOS_DOTNET_BUILD_DIR)/64/Xamarin.TVOS.dll: $(TVOS_DOTNET_BUILD_DIR)/tvos-gene
 		$(TVOS_DEFINES) \
 		$(ARGS_64) \
 		$(TVOS_WARNINGS_TO_FIX) \
+		-warnaserror:$(NULLABILITY_WARNINGS) \
 		$(IOS_CSC_FLAGS_XI) \
 		$(TVOS_SOURCES) \
 		@$<

--- a/src/accounts.cs
+++ b/src/accounts.cs
@@ -100,7 +100,7 @@ namespace Accounts {
 		[Async]
 		void RequestAccess (ACAccountType accountType, [NullAllowed] NSDictionary options, ACRequestCompletionHandler completion);
 
-		[Wrap ("RequestAccess (accountType, options == null ? null : options.Dictionary, completion)")]
+		[Wrap ("RequestAccess (accountType, options.GetDictionary (), completion)")]
 		[Async]
 		void RequestAccess (ACAccountType accountType, [NullAllowed] AccountStoreOptions options, ACRequestCompletionHandler completion);
 

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -567,7 +567,7 @@ namespace AppKit {
 #endif
 
 		// NSEventMask must be casted to nuint to preserve the NSEventMask.Any special value on 64 bit systems. NSEventMask is not [Native].
-		[Wrap ("NextEvent (mask, expiration, runLoopMode.GetConstant (), deqFlag)")]
+		[Wrap ("NextEvent (mask, expiration, runLoopMode.GetConstant ()!, deqFlag)")]
 		NSEvent NextEvent (NSEventMask mask, NSDate expiration, NSRunLoopMode runLoopMode, bool deqFlag);
 
 		[Export ("discardEventsMatchingMask:beforeEvent:"), Protected]
@@ -8822,7 +8822,7 @@ namespace AppKit {
 		bool ShouldEnableUrl (NSSavePanel panel, NSUrl url);
 
 		[Export ("panel:validateURL:error:"), DelegateName ("NSOpenSavePanelValidate"), DefaultValue (true)]
-		bool ValidateUrl (NSSavePanel panel, NSUrl url, out NSError outError);
+		bool ValidateUrl (NSSavePanel panel, NSUrl url, [NullAllowed] out NSError outError);
 
 		[Export ("panel:didChangeToDirectoryURL:"), EventArgs ("NSOpenSavePanelUrl")]
 		void DidChangeToDirectory (NSSavePanel panel, NSUrl newDirectoryUrl);
@@ -9837,19 +9837,19 @@ namespace AppKit {
 		[Export ("sizeWithAttributes:")]
 		CGSize StringSize (NSDictionary attributes);
 
-		[Wrap ("This.StringSize (attributes == null ? null : attributes.Dictionary)")]
+		[Wrap ("This.StringSize (attributes.GetDictionary ()!)")]
 		CGSize StringSize (AppKit.NSStringAttributes attributes);
 
 		[Export ("drawAtPoint:withAttributes:")]
 		void DrawAtPoint (CGPoint point, NSDictionary attributes);
 
-		[Wrap ("This.DrawAtPoint (point, attributes == null ? null : attributes.Dictionary)")]
+		[Wrap ("This.DrawAtPoint (point, attributes.GetDictionary ()!)")]
 		void DrawAtPoint (CGPoint point, AppKit.NSStringAttributes attributes);
 
 		[Export ("drawInRect:withAttributes:")]
 		void DrawInRect (CGRect rect, NSDictionary attributes);
 
-		[Wrap ("This.DrawInRect (rect, attributes == null ? null : attributes.Dictionary)")]
+		[Wrap ("This.DrawInRect (rect, attributes.GetDictionary ()!)")]
 		void DrawInRect (CGRect rect, AppKit.NSStringAttributes attributes);
 	}
 
@@ -9874,7 +9874,7 @@ namespace AppKit {
 		void WeakDrawString (CGRect rect, NSStringDrawingOptions options, [NullAllowed] NSDictionary attributes, [NullAllowed] NSStringDrawingContext context);
 
 		[Mac (10,11)]
-		[Wrap ("WeakDrawString (This, rect, options, attributes == null ? null : attributes.Dictionary, context)")]
+		[Wrap ("WeakDrawString (This, rect, options, attributes.GetDictionary (), context)")]
 		void DrawString (CGRect rect, NSStringDrawingOptions options, [NullAllowed] NSStringAttributes attributes, [NullAllowed] NSStringDrawingContext context);
 
 		[Mac (10,11)]
@@ -9882,7 +9882,7 @@ namespace AppKit {
 		CGRect WeakGetBoundingRect (CGSize size, NSStringDrawingOptions options, [NullAllowed] NSDictionary attributes, [NullAllowed] NSStringDrawingContext context);
 
 		[Mac (10,11)]
-		[Wrap ("WeakGetBoundingRect (This, size, options, attributes == null ? null : attributes.Dictionary, context)")]
+		[Wrap ("WeakGetBoundingRect (This, size, options, attributes.GetDictionary (), context)")]
 		CGRect GetBoundingRect (CGSize size, NSStringDrawingOptions options, [NullAllowed] NSStringAttributes attributes, [NullAllowed] NSStringDrawingContext context);
 	}
 
@@ -9908,25 +9908,25 @@ namespace AppKit {
 		[Export ("readFromURL:options:documentAttributes:error:")]
 		bool ReadFromURL (NSUrl url, NSDictionary options, out NSDictionary returnOptions, out NSError error);
 
-		[Wrap ("This.ReadFromURL (url, options == null ? null : options.Dictionary, out returnOptions, out error)")]
+		[Wrap ("This.ReadFromURL (url, options.GetDictionary ()!, out returnOptions, out error)")]
 		bool ReadFromURL (NSUrl url, NSAttributedStringDocumentAttributes options, out NSDictionary returnOptions, out NSError error);
 
 		[Export ("readFromURL:options:documentAttributes:")]
 		bool ReadFromURL (NSUrl url, NSDictionary options, out NSDictionary returnOptions);
 
-		[Wrap ("This.ReadFromURL (url, options == null ? null : options.Dictionary, out returnOptions)")]
+		[Wrap ("This.ReadFromURL (url, options.GetDictionary ()!, out returnOptions)")]
 		bool ReadFromURL (NSUrl url, NSAttributedStringDocumentAttributes options, out NSDictionary returnOptions);
 
 		[Export ("readFromData:options:documentAttributes:error:")]
 		bool ReadFromData (NSData data, NSDictionary options, out NSDictionary returnOptions, out NSError error);
 
-		[Wrap ("This.ReadFromData (data, options == null ? null : options.Dictionary, out returnOptions, out error)")]
+		[Wrap ("This.ReadFromData (data, options.GetDictionary ()!, out returnOptions, out error)")]
 		bool ReadFromData (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary returnOptions, out NSError error);
 
 		[Export ("readFromData:options:documentAttributes:")]
 		bool ReadFromData (NSData data, NSDictionary options, out NSDictionary dict);
 
-		[Wrap ("This.ReadFromData (data, options == null ? null : options.Dictionary, out returnOptions)")]
+		[Wrap ("This.ReadFromData (data, options.GetDictionary ()!, out returnOptions)")]
 		bool ReadFromData (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary returnOptions);
 
 		[Export ("superscriptRange:")]
@@ -14265,19 +14265,19 @@ namespace AppKit {
 		[Export ("checkString:range:types:options:inSpellDocumentWithTag:orthography:wordCount:")]
 		NSTextCheckingResult [] CheckString (string stringToCheck, NSRange range, NSTextCheckingTypes checkingTypes, [NullAllowed] NSDictionary options, nint tag, out NSOrthography orthography, out nint wordCount);
 
-		[Wrap ("CheckString (stringToCheck, range, checkingTypes, options == null ? null : options.Dictionary, tag, out orthography, out wordCount)")]
+		[Wrap ("CheckString (stringToCheck, range, checkingTypes, options.GetDictionary (), tag, out orthography, out wordCount)")]
 		NSTextCheckingResult [] CheckString (string stringToCheck, NSRange range, NSTextCheckingTypes checkingTypes, NSTextCheckingOptions options, nint tag, out NSOrthography orthography, out nint wordCount);
 
 		[Export ("requestCheckingOfString:range:types:options:inSpellDocumentWithTag:completionHandler:")]
 		nint RequestChecking (string stringToCheck, NSRange range, NSTextCheckingTypes checkingTypes, [NullAllowed] NSDictionary options, nint tag, Action<nint, NSTextCheckingResult [], NSOrthography, nint> completionHandler);
 
-		[Wrap ("RequestChecking (stringToCheck, range, checkingTypes, options == null ? null : options.Dictionary, tag, completionHandler)")]
+		[Wrap ("RequestChecking (stringToCheck, range, checkingTypes, options.GetDictionary (), tag, completionHandler)")]
 		nint RequestChecking (string stringToCheck, NSRange range, NSTextCheckingTypes checkingTypes, NSTextCheckingOptions options, nint tag, Action<nint, NSTextCheckingResult [], NSOrthography, nint> completionHandler);
 		
 		[Export ("menuForResult:string:options:atLocation:inView:")]
 		NSMenu MenuForResults (NSTextCheckingResult result, string checkedString, NSDictionary options, CGPoint location, NSView view);
 
-		[Wrap ("MenuForResults (result, checkedString, options == null ? null : options.Dictionary, location, view)")]
+		[Wrap ("MenuForResults (result, checkedString, options.GetDictionary ()!, location, view)")]
 		NSMenu MenuForResults (NSTextCheckingResult result, string checkedString, NSTextCheckingOptions options, CGPoint location, NSView view);
 
 		[Export ("userQuotesArrayForLanguage:")]
@@ -27756,7 +27756,7 @@ namespace AppKit {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		void CheckText (NSRange range, NSTextCheckingTypes checkingTypes, NSDictionary options);
 
-		[Wrap ("CheckText (range, checkingTypes, options?.Dictionary)")]
+		[Wrap ("CheckText (range, checkingTypes, options.GetDictionary ()!)")]
 		void CheckText (NSRange range, NSTextCheckingTypes checkingTypes, NSTextCheckingOptions options);
 
 		[Export ("checkTextInSelection:")]

--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -1364,7 +1364,7 @@ namespace ARKit {
 		[Export ("initWithBlendShapes:")]
 		IntPtr Constructor (NSDictionary blendShapes);
 
-		[Wrap ("this ((NSDictionary)blendShapes?.Dictionary)")]
+		[Wrap ("this (blendShapes.GetDictionary ()!)")]
 		IntPtr Constructor (ARBlendShapeLocationOptions blendShapes);
 
 		[Export ("vertexCount")]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -1137,13 +1137,13 @@ namespace AVFoundation {
 		[Export ("initForWriting:settings:error:"), Internal]
 		IntPtr Constructor (NSUrl fileUrl, NSDictionary settings, out NSError outError);
 
-		[Wrap ("this (fileUrl, settings == null ? null : settings.Dictionary, out outError)")]
+		[Wrap ("this (fileUrl, settings.GetDictionary ()!, out outError)")]
 		IntPtr Constructor (NSUrl fileUrl, AudioSettings settings, out NSError outError);
 
 		[Export ("initForWriting:settings:commonFormat:interleaved:error:"), Internal]
 		IntPtr Constructor (NSUrl fileUrl, NSDictionary settings, AVAudioCommonFormat format, bool interleaved, out NSError outError);
 		
-		[Wrap ("this (fileUrl, settings == null ? null : settings.Dictionary, format, interleaved, out outError)")]
+		[Wrap ("this (fileUrl, settings.GetDictionary ()!, format, interleaved, out outError)")]
 		IntPtr Constructor (NSUrl fileUrl, AudioSettings settings, AVAudioCommonFormat format, bool interleaved, out NSError outError);
 
 		[Export ("url")]
@@ -1196,7 +1196,7 @@ namespace AVFoundation {
 		[Export ("initWithSettings:")]
 		IntPtr Constructor (NSDictionary settings);
 
-		[Wrap ("this (settings.Dictionary)")]
+		[Wrap ("this (settings.GetDictionary ()!)")]
 		IntPtr Constructor (AudioSettings settings);
 
 		[iOS (9,0)][Mac (10,11)][Watch (6,0)]
@@ -2918,7 +2918,7 @@ namespace AVFoundation {
 		[Export ("metadataForFormat:")]
 		AVMetadataItem [] GetMetadataForFormat (NSString format);
 
-		[Wrap ("GetMetadataForFormat (format.GetConstant ())")]
+		[Wrap ("GetMetadataForFormat (format.GetConstant ()!)")]
 		AVMetadataItem [] GetMetadataForFormat (AVMetadataFormat format);
 
 		[Export ("hasProtectedContent")]
@@ -2964,7 +2964,8 @@ namespace AVFoundation {
 		[Export ("mediaSelectionGroupForMediaCharacteristic:")]
 		AVMediaSelectionGroup MediaSelectionGroupForMediaCharacteristic (string avMediaCharacteristic);
 
-		[Wrap ("MediaSelectionGroupForMediaCharacteristic (avMediaCharacteristic.GetConstant ())")]
+		[Wrap ("MediaSelectionGroupForMediaCharacteristic (avMediaCharacteristic.GetConstant ()!)")]
+		[return: NullAllowed]
 		AVMediaSelectionGroup GetMediaSelectionGroupForMediaCharacteristic (AVMediaCharacteristics avMediaCharacteristic);
 
 		[Export ("statusOfValueForKey:error:")]
@@ -3172,6 +3173,7 @@ namespace AVFoundation {
 #if !XAMCORE_4_0
 		[Obsolete ("Use 'GetSynchronizedData' instead.")]
 		[Wrap ("GetSynchronizedData (captureOutput)", isVirtual: true)]
+		[return: NullAllowed]
 		AVCaptureSynchronizedData From (AVCaptureOutput captureOutput);
 
 		// This is not reexposed because it is not needed you can use 'GetSynchronizedData' instead, also from docs:
@@ -3477,6 +3479,7 @@ namespace AVFoundation {
 		IntPtr Constructor (AVAsset asset);
 
 		[Export ("copyCGImageAtTime:actualTime:error:")]
+		[return: NullAllowed]
 		[return: Release ()]
 		CGImage CopyCGImageAtTime (CMTime requestedTime, out CMTime actualTime, out NSError outError);
 
@@ -3636,20 +3639,20 @@ namespace AVFoundation {
 		[Static, Export ("assetReaderTrackOutputWithTrack:outputSettings:")]
 		AVAssetReaderTrackOutput FromTrack (AVAssetTrack track, [NullAllowed] NSDictionary outputSettings);
 
-		[Static, Wrap ("FromTrack (track, settings == null ? null : settings.Dictionary)")]
+		[Static, Wrap ("FromTrack (track, settings.GetDictionary ())")]
 		AVAssetReaderTrackOutput Create (AVAssetTrack track, [NullAllowed] AudioSettings settings);
 
-		[Static, Wrap ("FromTrack (track, settings == null ? null : settings.Dictionary)")]
+		[Static, Wrap ("FromTrack (track, settings.GetDictionary ())")]
 		AVAssetReaderTrackOutput Create (AVAssetTrack track, [NullAllowed] AVVideoSettingsUncompressed settings);		
 
 		[DesignatedInitializer]
 		[Export ("initWithTrack:outputSettings:")]
 		IntPtr Constructor (AVAssetTrack track, [NullAllowed] NSDictionary outputSettings);
 
-		[Wrap ("this (track, settings == null ? null : settings.Dictionary)")]		
+		[Wrap ("this (track, settings.GetDictionary ())")]		
 		IntPtr Constructor (AVAssetTrack track, [NullAllowed] AudioSettings settings);
 
-		[Wrap ("this (track, settings == null ? null : settings.Dictionary)")]		
+		[Wrap ("this (track, settings.GetDictionary ())")]		
 		IntPtr Constructor (AVAssetTrack track, [NullAllowed] AVVideoSettingsUncompressed settings);
 
 		[Export ("outputSettings"), NullAllowed]
@@ -3680,14 +3683,14 @@ namespace AVFoundation {
 		[Static, Export ("assetReaderAudioMixOutputWithAudioTracks:audioSettings:")]
 		AVAssetReaderAudioMixOutput FromTracks (AVAssetTrack [] audioTracks, [NullAllowed] NSDictionary audioSettings);
 
-		[Wrap ("FromTracks (audioTracks, settings == null ? null : settings.Dictionary)")]
+		[Wrap ("FromTracks (audioTracks, settings.GetDictionary ())")]
 		AVAssetReaderAudioMixOutput Create (AVAssetTrack [] audioTracks, [NullAllowed] AudioSettings settings);
 
 		[DesignatedInitializer]
 		[Export ("initWithAudioTracks:audioSettings:")]
 		IntPtr Constructor (AVAssetTrack [] audioTracks, [NullAllowed] NSDictionary audioSettings);
 
-		[Wrap ("this (audioTracks, settings == null ? null : settings.Dictionary)")]
+		[Wrap ("this (audioTracks, settings.GetDictionary ())")]
 		IntPtr Constructor (AVAssetTrack [] audioTracks, [NullAllowed] AudioSettings settings);
 
 #if XAMCORE_2_0
@@ -3726,7 +3729,7 @@ namespace AVFoundation {
 		[Export ("assetReaderVideoCompositionOutputWithVideoTracks:videoSettings:")]
 		AVAssetReaderVideoCompositionOutput WeakFromTracks (AVAssetTrack [] videoTracks, [NullAllowed] NSDictionary videoSettings);
 
-		[Wrap ("WeakFromTracks (videoTracks, settings == null ? null : settings.Dictionary)")]
+		[Wrap ("WeakFromTracks (videoTracks, settings.GetDictionary ())")]
 		[Static]
 		AVAssetReaderVideoCompositionOutput Create (AVAssetTrack [] videoTracks, [NullAllowed] CVPixelBufferAttributes settings);
 
@@ -3734,7 +3737,7 @@ namespace AVFoundation {
 		[Export ("initWithVideoTracks:videoSettings:")]
 		IntPtr Constructor (AVAssetTrack [] videoTracks, [NullAllowed] NSDictionary videoSettings);
 
-		[Wrap ("this (videoTracks, settings == null ? null : settings.Dictionary)")]
+		[Wrap ("this (videoTracks, settings.GetDictionary ())")]
 		IntPtr Constructor (AVAssetTrack [] videoTracks, [NullAllowed] CVPixelBufferAttributes settings);		
 
 		[Export ("videoSettings"), NullAllowed]
@@ -3967,10 +3970,10 @@ namespace AVFoundation {
 		[Export ("canApplyOutputSettings:forMediaType:")]
 		bool CanApplyOutputSettings ([NullAllowed] NSDictionary outputSettings, string mediaType);
 
-		[Wrap ("CanApplyOutputSettings (outputSettings == null ? null : outputSettings.Dictionary, mediaType)")]
+		[Wrap ("CanApplyOutputSettings (outputSettings.GetDictionary (), mediaType)")]
 		bool CanApplyOutputSettings (AudioSettings outputSettings, string mediaType);
 
-		[Wrap ("CanApplyOutputSettings (outputSettings == null ? null : outputSettings.Dictionary, mediaType)")]
+		[Wrap ("CanApplyOutputSettings (outputSettings.GetDictionary (), mediaType)")]
 		bool CanApplyOutputSettings (AVVideoSettingsCompressed outputSettings, string mediaType);
 
 		[Export ("canAddInput:")]
@@ -4033,10 +4036,10 @@ namespace AVFoundation {
 		[Export ("initWithMediaType:outputSettings:sourceFormatHint:")]
 		IntPtr Constructor (string mediaType, [NullAllowed] NSDictionary outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
-		[Wrap ("this (mediaType, outputSettings == null ? null : outputSettings.Dictionary, sourceFormatHint)")]
+		[Wrap ("this (mediaType, outputSettings.GetDictionary (), sourceFormatHint)")]
 		IntPtr Constructor (string mediaType, [NullAllowed] AudioSettings outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
-		[Wrap ("this (mediaType, outputSettings == null ? null : outputSettings.Dictionary, sourceFormatHint)")]
+		[Wrap ("this (mediaType, outputSettings.GetDictionary (), sourceFormatHint)")]
 		IntPtr Constructor (string mediaType, [NullAllowed] AVVideoSettingsCompressed outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
 		[Static, Internal]
@@ -4044,11 +4047,11 @@ namespace AVFoundation {
 		AVAssetWriterInput Create (string mediaType, [NullAllowed] NSDictionary outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
 		[Static]
-		[Wrap ("Create(mediaType, outputSettings == null ? null : outputSettings.Dictionary, sourceFormatHint)")]
+		[Wrap ("Create(mediaType, outputSettings.GetDictionary (), sourceFormatHint)")]
 		AVAssetWriterInput Create (string mediaType, [NullAllowed] AudioSettings outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
 		[Static]
-		[Wrap ("Create(mediaType, outputSettings == null ? null : outputSettings.Dictionary, sourceFormatHint)")]
+		[Wrap ("Create(mediaType, outputSettings.GetDictionary (), sourceFormatHint)")]
 		AVAssetWriterInput Create (string mediaType, [NullAllowed] AVVideoSettingsCompressed outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
 		[Export ("mediaType")]
@@ -4076,10 +4079,10 @@ namespace AVFoundation {
 		[Static, Export ("assetWriterInputWithMediaType:outputSettings:")]
 		AVAssetWriterInput FromType (string mediaType, [NullAllowed] NSDictionary outputSettings);
 
-		[Static, Wrap ("FromType (mediaType, outputSettings == null ? null : outputSettings.Dictionary)")]
+		[Static, Wrap ("FromType (mediaType, outputSettings.GetDictionary ())")]
 		AVAssetWriterInput Create (string mediaType, [NullAllowed] AudioSettings outputSettings);
 
-		[Static, Wrap ("FromType (mediaType, outputSettings == null ? null : outputSettings.Dictionary)")]
+		[Static, Wrap ("FromType (mediaType, outputSettings.GetDictionary ())")]
 		AVAssetWriterInput Create (string mediaType, [NullAllowed] AVVideoSettingsCompressed outputSettings);
 
 #if XAMCORE_2_0
@@ -4089,10 +4092,10 @@ namespace AVFoundation {
 		[Export ("initWithMediaType:outputSettings:")]
 		IntPtr Constructor (string mediaType, [NullAllowed] NSDictionary outputSettings);
 
-		[Wrap ("this (mediaType, outputSettings == null ? null : outputSettings.Dictionary)")]		
+		[Wrap ("this (mediaType, outputSettings.GetDictionary ())")]		
 		IntPtr Constructor (string mediaType, [NullAllowed] AudioSettings outputSettings);
 
-		[Wrap ("this (mediaType, outputSettings == null ? null : outputSettings.Dictionary)")]		
+		[Wrap ("this (mediaType, outputSettings.GetDictionary ())")]		
 		IntPtr Constructor (string mediaType, [NullAllowed] AVVideoSettingsCompressed outputSettings);
 
 		[Export ("requestMediaDataWhenReadyOnQueue:usingBlock:")]
@@ -4252,14 +4255,14 @@ namespace AVFoundation {
 		[Static, Export ("assetWriterInputPixelBufferAdaptorWithAssetWriterInput:sourcePixelBufferAttributes:")]
 		AVAssetWriterInputPixelBufferAdaptor FromInput (AVAssetWriterInput input, [NullAllowed] NSDictionary sourcePixelBufferAttributes);
 
-		[Static, Wrap ("FromInput (input, attributes == null ? null : attributes.Dictionary)")]
+		[Static, Wrap ("FromInput (input, attributes.GetDictionary ())")]
 		AVAssetWriterInputPixelBufferAdaptor Create (AVAssetWriterInput input, [NullAllowed] CVPixelBufferAttributes attributes);
 
 		[DesignatedInitializer]
 		[Export ("initWithAssetWriterInput:sourcePixelBufferAttributes:")]
 		IntPtr Constructor (AVAssetWriterInput input, [NullAllowed] NSDictionary sourcePixelBufferAttributes);
 
-		[Wrap ("this (input, attributes == null ? null : attributes.Dictionary)")]
+		[Wrap ("this (input, attributes.GetDictionary ())")]
 		IntPtr Constructor (AVAssetWriterInput input, [NullAllowed] CVPixelBufferAttributes attributes);		
 
 		[Export ("appendPixelBuffer:withPresentationTime:")]
@@ -4299,21 +4302,21 @@ namespace AVFoundation {
 		AVUrlAsset FromUrl (NSUrl url, [NullAllowed] NSDictionary options);
 
 		[Static]
-		[Wrap ("FromUrl (url, options == null ? null : options.Dictionary)")]
+		[Wrap ("FromUrl (url, options.GetDictionary ())")]
 		AVUrlAsset Create (NSUrl url, [NullAllowed] AVUrlAssetOptions options);
 
 		[Static]
-		[Wrap ("FromUrl (url, (NSDictionary) null)")]
+		[Wrap ("FromUrl (url, (NSDictionary) null!)")]
 		AVUrlAsset Create (NSUrl url);
 
 		[DesignatedInitializer]
 		[Export ("initWithURL:options:")]
 		IntPtr Constructor (NSUrl url, [NullAllowed] NSDictionary options);
 
-		[Wrap ("this (url, options == null ? null : options.Dictionary)")]
+		[Wrap ("this (url, options.GetDictionary ())")]
 		IntPtr Constructor (NSUrl url, [NullAllowed] AVUrlAssetOptions options);
 
-		[Wrap ("this (url, (NSDictionary) null)")]
+		[Wrap ("this (url, (NSDictionary) null!)")]
 		IntPtr Constructor (NSUrl url);
 
 		[return: NullAllowed]
@@ -7925,6 +7928,7 @@ namespace AVFoundation {
 		bool GetVolumeRamp (CMTime forTime, ref float /* defined as 'float*' */ startVolume, ref float /* defined as 'float*' */ endVolume, ref CMTimeRange timeRange);
 
 		[Mac (10,9), NoWatch]
+		[NullAllowed]
 		[Export ("audioTapProcessor", ArgumentSemantic.Retain)]
 		MTAudioProcessingTap AudioTapProcessor { get; [NotImplemented] set;}
 
@@ -8186,6 +8190,7 @@ namespace AVFoundation {
 		}
 
 		[NoWatch]
+		[NullAllowed]
 		[Export ("layerInstructions", ArgumentSemantic.Copy)]
 		AVVideoCompositionLayerInstruction [] LayerInstructions { get; [NotImplemented ("Not available on AVVideoCompositionInstruction, only available on AVMutableVideoCompositionInstruction")]set; }
 
@@ -9042,7 +9047,8 @@ namespace AVFoundation {
 		NSDictionary GetWeakRecommendedVideoSettings (string videoCodecType, string outputFileType);
 
 		[iOS (11,0), Mac (10,15)]
-		[Wrap ("new AVPlayerItemVideoOutputSettings (GetWeakRecommendedVideoSettings (videoCodecType, outputFileType))")]
+		[Wrap ("new AVPlayerItemVideoOutputSettings (GetWeakRecommendedVideoSettings (videoCodecType, outputFileType)!)")]
+		[return: NullAllowed]
 		AVPlayerItemVideoOutputSettings GetRecommendedVideoSettings (string videoCodecType, string outputFileType);
 
 		[NoWatch, NoTV, NoMac, iOS (13,0)]
@@ -10049,7 +10055,7 @@ namespace AVFoundation {
 
 		[NoWatch]
 		[Static]
-		[Wrap ("GetDefaultDevice (mediaType.GetConstant ())")]
+		[Wrap ("GetDefaultDevice (mediaType.GetConstant ()!)")]
 		AVCaptureDevice GetDefaultDevice (AVMediaTypes mediaType);
 
 #if !XAMCORE_4_0
@@ -10255,7 +10261,7 @@ namespace AVFoundation {
 		// Either AVMediaTypeVideo or AVMediaTypeAudio.
 		[iOS (7,0), NoWatch]
 		[Static]
-		[Wrap ("RequestAccessForMediaType (mediaType == AVAuthorizationMediaType.Video ? AVMediaTypes.Video.GetConstant () : AVMediaTypes.Audio.GetConstant (), completion)")]
+		[Wrap ("RequestAccessForMediaType (mediaType == AVAuthorizationMediaType.Video ? AVMediaTypes.Video.GetConstant ()! : AVMediaTypes.Audio.GetConstant ()!, completion)")]
 		[Async]
 		void RequestAccessForMediaType (AVAuthorizationMediaType mediaType, AVRequestAccessStatus completion);
 
@@ -10271,7 +10277,7 @@ namespace AVFoundation {
 		[iOS (7,0)]
 		[Mac (10,14)]
 		[Static]
-		[Wrap ("GetAuthorizationStatus (mediaType == AVAuthorizationMediaType.Video ? AVMediaTypes.Video.GetConstant () : AVMediaTypes.Audio.GetConstant ())")]
+		[Wrap ("GetAuthorizationStatus (mediaType == AVAuthorizationMediaType.Video ? AVMediaTypes.Video.GetConstant ()! : AVMediaTypes.Audio.GetConstant ()!)")]
 		AVAuthorizationStatus GetAuthorizationStatus (AVAuthorizationMediaType mediaType);
 
 		[NoWatch]
@@ -10377,7 +10383,7 @@ namespace AVFoundation {
 
 		[iOS (10,0), Mac (10,15), NoWatch]
 		[Static]
-		[Wrap ("AVCaptureDevice._DefaultDeviceWithDeviceType (deviceType.GetConstant (), mediaType, position)")]
+		[Wrap ("AVCaptureDevice._DefaultDeviceWithDeviceType (deviceType.GetConstant ()!, mediaType, position)")]
 		AVCaptureDevice GetDefaultDevice (AVCaptureDeviceType deviceType, string mediaType, AVCaptureDevicePosition position);
 
 		//
@@ -11008,7 +11014,7 @@ namespace AVFoundation {
 
 		[return: NullAllowed]
 		[Static]
-		[Wrap ("FromTextMarkupAttributes (textMarkupAttributes == null ? null : textMarkupAttributes.Dictionary)")]
+		[Wrap ("FromTextMarkupAttributes (textMarkupAttributes.GetDictionary ()!)")]
 		AVTextStyleRule FromTextMarkupAttributes (CMTextMarkupAttributes textMarkupAttributes);
 
 		[return: NullAllowed]
@@ -11018,14 +11024,14 @@ namespace AVFoundation {
 
 		[return: NullAllowed]
 		[Static]
-		[Wrap ("FromTextMarkupAttributes (textMarkupAttributes == null ? null : textMarkupAttributes.Dictionary, textSelector)")]
+		[Wrap ("FromTextMarkupAttributes (textMarkupAttributes.GetDictionary ()!, textSelector)")]
 		AVTextStyleRule FromTextMarkupAttributes (CMTextMarkupAttributes textMarkupAttributes, [NullAllowed] string textSelector);
 
 		[Export ("initWithTextMarkupAttributes:")]
 		[Protected]
 		IntPtr Constructor (NSDictionary textMarkupAttributes);
 
-		[Wrap ("this (attributes == null ? null : attributes.Dictionary)")]
+		[Wrap ("this (attributes.GetDictionary ()!)")]
 		IntPtr Constructor (CMTextMarkupAttributes attributes);
 
 		[DesignatedInitializer]
@@ -11033,7 +11039,7 @@ namespace AVFoundation {
 		[Protected]
 		IntPtr Constructor (NSDictionary textMarkupAttributes, [NullAllowed] string textSelector);
 	
-		[Wrap ("this (attributes == null ? null : attributes.Dictionary, textSelector)")]
+		[Wrap ("this (attributes.GetDictionary ()!, textSelector)")]
 		IntPtr Constructor (CMTextMarkupAttributes attributes, string textSelector);
 	}
 
@@ -11081,7 +11087,7 @@ namespace AVFoundation {
 	[Watch (6,0)]
 	[BaseType (typeof (AVTimedMetadataGroup))]
 	interface AVMutableTimedMetadataGroup {
-		[NullAllowed] // by default this property is null
+
 		[Export ("items", ArgumentSemantic.Copy)]
 		[Override]
 		AVMetadataItem [] Items { get; set;  }
@@ -11734,12 +11740,12 @@ namespace AVFoundation {
 		IntPtr _FromOutputSettings ([NullAllowed] NSDictionary outputSettings);
 
 		[DesignatedInitializer]
-		[Wrap ("this (attributes == null ? null : attributes.Dictionary, AVPlayerItemVideoOutput.InitMode.PixelAttributes)")]
+		[Wrap ("this (attributes.GetDictionary (), AVPlayerItemVideoOutput.InitMode.PixelAttributes)")]
 		IntPtr Constructor (CVPixelBufferAttributes attributes);
 		
 		[DesignatedInitializer]
 		[iOS (10,0), TV (10,0), Mac (10,12)]
-		[Wrap ("this (settings == null ? null : settings.Dictionary, AVPlayerItemVideoOutput.InitMode.OutputSettings)")]
+		[Wrap ("this (settings.GetDictionary (), AVPlayerItemVideoOutput.InitMode.OutputSettings)")]
 		IntPtr Constructor (AVPlayerItemVideoOutputSettings settings);
 
 		[Export ("hasNewPixelBufferForItemTime:")]
@@ -12640,7 +12646,8 @@ namespace AVFoundation {
 		[return: NullAllowed]
 		AVAssetDownloadTask GetAssetDownloadTask (AVUrlAsset urlAsset, NSUrl destinationUrl, [NullAllowed] NSDictionary options);
 
-		[Wrap ("GetAssetDownloadTask (urlAsset, destinationUrl, options != null ? options.Dictionary : null)")]
+		[Wrap ("GetAssetDownloadTask (urlAsset, destinationUrl, options.GetDictionary ())")]
+		[return: NullAllowed]
 		AVAssetDownloadTask GetAssetDownloadTask (AVUrlAsset urlAsset, NSUrl destinationUrl, AVAssetDownloadOptions options);
 
 		[iOS (10,0)]
@@ -12649,7 +12656,8 @@ namespace AVFoundation {
 		AVAssetDownloadTask GetAssetDownloadTask (AVUrlAsset urlAsset, string title, [NullAllowed] NSData artworkData, [NullAllowed] NSDictionary options);
 
 		[iOS (10,0)]
-		[Wrap ("GetAssetDownloadTask (urlAsset, title, artworkData, options != null ? options.Dictionary : null)")]
+		[Wrap ("GetAssetDownloadTask (urlAsset, title, artworkData, options.GetDictionary ())")]
+		[return: NullAllowed]
 		AVAssetDownloadTask GetAssetDownloadTask (AVUrlAsset urlAsset, string title, [NullAllowed] NSData artworkData, AVAssetDownloadOptions options);
 
 		[NoMac, NoTV, NoWatch, iOS (11,0)]
@@ -13186,7 +13194,7 @@ namespace AVFoundation {
 		AVContentKeySession Create (NSString keySystem, [NullAllowed] NSUrl storageUrl);
 
 		[Static]
-		[Wrap ("Create (keySystem.GetConstant (), storageUrl)")]
+		[Wrap ("Create (keySystem.GetConstant ()!, storageUrl)")]
 		AVContentKeySession Create (AVContentKeySystem keySystem, [NullAllowed] NSUrl storageUrl);
 
 		[Export ("setDelegate:queue:")]
@@ -13232,7 +13240,7 @@ namespace AVFoundation {
 
 		[Async]
 		[NoTV, NoMac, iOS (12, 2)]
-		[Wrap ("InvalidatePersistableContentKey (persistableContentKeyData, options?.Dictionary, handler)")]
+		[Wrap ("InvalidatePersistableContentKey (persistableContentKeyData, options.GetDictionary (), handler)")]
 		void InvalidatePersistableContentKey (NSData persistableContentKeyData, [NullAllowed] AVContentKeySessionServerPlaybackContextOptions options, Action<NSData, NSError> handler);
 
 		[Async]
@@ -13242,7 +13250,7 @@ namespace AVFoundation {
 
 		[Async]
 		[NoTV, NoMac, iOS (12, 2)]
-		[Wrap ("InvalidateAllPersistableContentKeys (appIdentifier, options?.Dictionary, handler)")]
+		[Wrap ("InvalidateAllPersistableContentKeys (appIdentifier, options.GetDictionary (), handler)")]
 		void InvalidateAllPersistableContentKeys (NSData appIdentifier, [NullAllowed] AVContentKeySessionServerPlaybackContextOptions options, Action<NSData, NSError> handler);
 
 		#region AVContentKeySession_AVContentKeySessionPendingExpiredSessionReports
@@ -13488,7 +13496,7 @@ namespace AVFoundation {
 		[NullAllowed, Export ("sourceDeviceType")]
 		NSString WeakSourceDeviceType { get; }
 
-		[Wrap ("AVCaptureDeviceTypeExtensions.GetValue (WeakSourceDeviceType)")]
+		[Wrap ("AVCaptureDeviceTypeExtensions.GetValue (WeakSourceDeviceType!)")]
 		AVCaptureDeviceType SourceDeviceType { get; }
 
 		// From @interface AVCapturePhotoBracketedCapture (AVCapturePhoto)

--- a/src/contacts.cs
+++ b/src/contacts.cs
@@ -1596,7 +1596,7 @@ namespace Contacts {
 #if XAMCORE_4_0
 		[Export ("predicateForContainersWithIdentifiers:")]
 #else
-		[Wrap ("(null as CNContainer).GetPredicateForContainers (identifiers)")]
+		[Wrap ("CNContainer_PredicatesExtension.GetPredicateForContainers (null!, identifiers)")]
 #endif
 		NSPredicate CreatePredicateForContainers (string [] identifiers);
 
@@ -1604,7 +1604,7 @@ namespace Contacts {
 #if XAMCORE_4_0
 		[Export ("predicateForContainerOfContactWithIdentifier:")]
 #else
-		[Wrap ("(null as CNContainer).GetPredicateForContainerOfContact (contactIdentifier)")]
+		[Wrap ("CNContainer_PredicatesExtension.GetPredicateForContainerOfContact (null!, contactIdentifier)")]
 #endif
 		NSPredicate CreatePredicateForContainerOfContact (string contactIdentifier);
 
@@ -1612,7 +1612,7 @@ namespace Contacts {
 #if XAMCORE_4_0
 		[Export ("predicateForContainerOfGroupWithIdentifier:")]
 #else
-		[Wrap ("(null as CNContainer).GetPredicateForContainerOfGroup (groupIdentifier)")]
+		[Wrap ("CNContainer_PredicatesExtension.GetPredicateForContainerOfGroup (null!, groupIdentifier)")]
 #endif
 		NSPredicate CreatePredicateForContainerOfGroup (string groupIdentifier);
 #endregion
@@ -1690,7 +1690,7 @@ namespace Contacts {
 #if XAMCORE_4_0
 		[Export ("predicateForGroupsWithIdentifiers:")]
 #else
-		[Wrap ("(null as CNGroup).GetPredicateForGroups (identifiers)")]
+		[Wrap ("CNGroup_PredicatesExtension.GetPredicateForGroups (null!, identifiers)")]
 #endif
 		NSPredicate CreatePredicateForGroups (string [] identifiers);
 
@@ -1699,7 +1699,7 @@ namespace Contacts {
 #if XAMCORE_4_0
 		[Export ("predicateForSubgroupsInGroupWithIdentifier:")]
 #else
-		[Wrap ("(null as CNGroup).GetPredicateForSubgroupsInGroup (parentGroupIdentifier)")]
+		[Wrap ("CNGroup_PredicatesExtension.GetPredicateForSubgroupsInGroup (null!, parentGroupIdentifier)")]
 #endif
 		NSPredicate CreatePredicateForSubgroupsInGroup (string parentGroupIdentifier);
 
@@ -1707,7 +1707,7 @@ namespace Contacts {
 #if XAMCORE_4_0
 		[Export ("predicateForGroupsInContainerWithIdentifier:")]
 #else
-		[Wrap ("(null as CNGroup).GetPredicateForGroupsInContainer (containerIdentifier)")]
+		[Wrap ("CNGroup_PredicatesExtension.GetPredicateForGroupsInContainer (null!, containerIdentifier)")]
 #endif
 		NSPredicate CreatePredicateForGroupsInContainer (string containerIdentifier);
 #endregion
@@ -2109,7 +2109,7 @@ namespace Contacts {
 		string LocalizeProperty (NSString property);
 
 		[Static]
-		[Wrap ("LocalizeProperty (option.GetConstant ())")]
+		[Wrap ("LocalizeProperty (option.GetConstant ()!)")]
 		string LocalizeProperty (CNPostalAddressKeyOption option);
 	}
 
@@ -2267,7 +2267,7 @@ namespace Contacts {
 		string LocalizeProperty (NSString key);
 
 		[Static]
-		[Wrap ("LocalizeProperty (key.GetConstant ())")]
+		[Wrap ("LocalizeProperty (key.GetConstant ()!)")]
 		string LocalizeProperty (CNPostalAddressKeyOption key);
 
 		[Static]

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -1888,7 +1888,7 @@ namespace CoreAnimation {
 
 		[Mac (10,13)]
 		[Static]
-		[Wrap ("Create (tex, options?.Dictionary)")]
+		[Wrap ("Create (tex, options.GetDictionary ())")]
 		CARenderer Create (IMTLTexture tex, [NullAllowed] CARendererOptions options);
 
 		[NullAllowed, Export ("layer", ArgumentSemantic.Strong)]

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -137,7 +137,7 @@ namespace CoreBluetooth {
 		IntPtr Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue, [NullAllowed] NSDictionary options);
 
 		[iOS (7,0), Mac (10,9)]
-		[Wrap ("this (centralDelegate, queue, options == null ? null : options.Dictionary)")]
+		[Wrap ("this (centralDelegate, queue, options.GetDictionary ())")]
 		IntPtr Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue, CBCentralInitOptions options);
 
 		[NoTV]
@@ -162,7 +162,7 @@ namespace CoreBluetooth {
 		[Export ("connectPeripheral:options:")]
 		void ConnectPeripheral (CBPeripheral peripheral, [NullAllowed] NSDictionary options);
 
-		[Wrap ("ConnectPeripheral (peripheral, options?.Dictionary)")]
+		[Wrap ("ConnectPeripheral (peripheral, options.GetDictionary ())")]
 		void ConnectPeripheral (CBPeripheral peripheral, [NullAllowed] CBConnectPeripheralOptions options);
 
 		[Export ("cancelPeripheralConnection:")]
@@ -242,7 +242,7 @@ namespace CoreBluetooth {
 		void RegisterForConnectionEvents ([NullAllowed] NSDictionary options);
 
 		[iOS (13,0), TV (13,0), Watch (6,0), NoMac]
-		[Wrap ("RegisterForConnectionEvents (options?.Dictionary)")]
+		[Wrap ("RegisterForConnectionEvents (options.GetDictionary ())")]
 		void RegisterForConnectionEvents ([NullAllowed] CBConnectionEventMatchingOptions options);
 	}
 
@@ -411,9 +411,11 @@ namespace CoreBluetooth {
 		[Export ("properties")]
 		CBCharacteristicProperties Properties { get; [NotImplemented ("Not available on CBCharacteristic, only available on CBMutableCharacteristic")] set; }
 
+		[NullAllowed]
 		[Export ("value", ArgumentSemantic.Retain)]
 		NSData Value { get; [NotImplemented ("Not available on CBCharacteristic, only available on CBMutableCharacteristic")] set;  }
 
+		[NullAllowed]
 		[Export ("descriptors", ArgumentSemantic.Retain)]
 		CBDescriptor [] Descriptors { get; [NotImplemented ("Not available on CBCharacteristic, only available on CBMutableCharacteristic")] set; }
 
@@ -915,7 +917,7 @@ namespace CoreBluetooth {
 		[Export ("startAdvertising:")]
 		void StartAdvertising ([NullAllowed] NSDictionary options);
 
-		[Wrap ("StartAdvertising (options == null ? null : options.Dictionary)")]
+		[Wrap ("StartAdvertising (options.GetDictionary ())")]
 		void StartAdvertising ([NullAllowed] StartAdvertisingOptions options);
 
 		[Export ("stopAdvertising")]

--- a/src/corehaptics.cs
+++ b/src/corehaptics.cs
@@ -391,7 +391,7 @@ namespace CoreHaptics {
 		[Export ("initWithDictionary:error:")]
 		IntPtr Constructor (NSDictionary patternDict, [NullAllowed] out NSError outError);
 
-		[Wrap ("this (patternDefinition?.Dictionary, out outError)")]
+		[Wrap ("this (patternDefinition.GetDictionary ()!, out outError)")]
 		IntPtr Constructor (CHHapticPatternDefinition patternDefinition, [NullAllowed] out NSError outError);
 
 		[Internal]
@@ -399,7 +399,8 @@ namespace CoreHaptics {
 		[return: NullAllowed]
 		NSDictionary<NSString, NSObject> _ExportDictionary ([NullAllowed] out NSError outError);
 
-		[Wrap ("new CHHapticPatternDefinition (_ExportDictionary (out outError))")]
+		[Wrap ("new CHHapticPatternDefinition (_ExportDictionary (out outError)!)")]
+		[return: NullAllowed]
 		CHHapticPatternDefinition Export ([NullAllowed] out NSError outError);
 	}
 }

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -298,15 +298,18 @@ namespace CoreImage {
 
 		[Export ("createCGImage:fromRect:")]
 		[return: Release ()]
+		[return: NullAllowed]
 		CGImage CreateCGImage (CIImage image, CGRect fromRectangle);
 
 		[Export ("createCGImage:fromRect:format:colorSpace:")]
 		[return: Release ()]
+		[return: NullAllowed]
 		CGImage CreateCGImage (CIImage image, CGRect fromRect, int /* CIFormat = int */ ciImageFormat, [NullAllowed] CGColorSpace colorSpace);
 
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10,0)]
 		[Export ("createCGImage:fromRect:format:colorSpace:deferred:")]
+		[return: Release]
 		[return: NullAllowed]
 		CGImage CreateCGImage (CIImage image, CGRect fromRect, CIFormat format, [NullAllowed] CGColorSpace colorSpace, bool deferred);
 
@@ -413,7 +416,7 @@ namespace CoreImage {
 		NSData GetTiffRepresentation (CIImage image, CIFormat format, CGColorSpace colorSpace, NSDictionary options);
 
 		[iOS (10,0)][Mac (10,12)]
-		[Wrap ("GetTiffRepresentation (This, image, format, colorSpace, options?.Dictionary)")]
+		[Wrap ("GetTiffRepresentation (This, image, format, colorSpace, options.GetDictionary ()!)")]
 		[return: NullAllowed]
 		NSData GetTiffRepresentation (CIImage image, CIFormat format, CGColorSpace colorSpace, CIImageRepresentationOptions options);
 
@@ -423,7 +426,7 @@ namespace CoreImage {
 		NSData GetJpegRepresentation (CIImage image, CGColorSpace colorSpace, NSDictionary options);
 
 		[iOS (10,0)][Mac (10,12)]
-		[Wrap ("GetJpegRepresentation (This, image, colorSpace, options?.Dictionary)")]
+		[Wrap ("GetJpegRepresentation (This, image, colorSpace, options.GetDictionary ()!)")]
 		[return: NullAllowed]
 		NSData GetJpegRepresentation (CIImage image, CGColorSpace colorSpace, CIImageRepresentationOptions options);
 
@@ -433,7 +436,7 @@ namespace CoreImage {
 		NSData GetHeifRepresentation (CIImage image, CIFormat format, CGColorSpace colorSpace, NSDictionary options);
 
 		[iOS (11,0)][TV (11,0)][Mac (10,13)]
-		[Wrap ("GetHeifRepresentation (This, image, format, colorSpace, options?.Dictionary)")]
+		[Wrap ("GetHeifRepresentation (This, image, format, colorSpace, options.GetDictionary ()!)")]
 		[return: NullAllowed]
 		NSData GetHeifRepresentation (CIImage image, CIFormat format, CGColorSpace colorSpace, CIImageRepresentationOptions options);
 
@@ -443,7 +446,7 @@ namespace CoreImage {
 		NSData GetPngRepresentation (CIImage image, CIFormat format, CGColorSpace colorSpace, NSDictionary options);
 
 		[iOS (11,0)][TV (11,0)][Mac (10,13)]
-		[Wrap ("GetPngRepresentation (This, image, format, colorSpace, options?.Dictionary)")]
+		[Wrap ("GetPngRepresentation (This, image, format, colorSpace, options.GetDictionary ()!)")]
 		[return: NullAllowed]
 		NSData GetPngRepresentation (CIImage image, CIFormat format, CGColorSpace colorSpace, CIImageRepresentationOptions options);
 
@@ -452,7 +455,7 @@ namespace CoreImage {
 		bool WriteTiffRepresentation (CIImage image, NSUrl url, CIFormat format, CGColorSpace colorSpace, NSDictionary options, out NSError error);
 
 		[iOS (10,0)][Mac (10,12)]
-		[Wrap ("WriteTiffRepresentation (This, image, url, format, colorSpace, options?.Dictionary, out error)")]
+		[Wrap ("WriteTiffRepresentation (This, image, url, format, colorSpace, options.GetDictionary ()!, out error)")]
 		bool WriteTiffRepresentation (CIImage image, NSUrl url, CIFormat format, CGColorSpace colorSpace, CIImageRepresentationOptions options, out NSError error);
 
 		[iOS (10,0)][Mac (10,12)]
@@ -460,7 +463,7 @@ namespace CoreImage {
 		bool WriteJpegRepresentation (CIImage image, NSUrl url, CGColorSpace colorSpace, NSDictionary options, [NullAllowed] out NSError error);
 
 		[iOS (10,0)][Mac (10,12)]
-		[Wrap ("WriteJpegRepresentation (This, image, url, colorSpace, options?.Dictionary, out error)")]
+		[Wrap ("WriteJpegRepresentation (This, image, url, colorSpace, options.GetDictionary ()!, out error)")]
 		bool WriteJpegRepresentation (CIImage image, NSUrl url, CGColorSpace colorSpace, CIImageRepresentationOptions options, [NullAllowed] out NSError error);
 
 		[iOS (11,0)][TV (11,0)][Mac (10,13,4)]
@@ -468,7 +471,7 @@ namespace CoreImage {
 		bool WriteHeifRepresentation (CIImage image, NSUrl url, CIFormat format, CGColorSpace colorSpace, NSDictionary options, [NullAllowed] out NSError error);
 
 		[iOS (11,0)][TV (11,0)][Mac (10,13)]
-		[Wrap ("WriteHeifRepresentation (This, image, url, format, colorSpace, options?.Dictionary, out error)")]
+		[Wrap ("WriteHeifRepresentation (This, image, url, format, colorSpace, options.GetDictionary ()!, out error)")]
 		bool WriteHeifRepresentation (CIImage image, NSUrl url, CIFormat format, CGColorSpace colorSpace, CIImageRepresentationOptions options, [NullAllowed] out NSError error);
 
 		[iOS (11,0)][TV (11,0)][Mac (10,13)]
@@ -476,7 +479,7 @@ namespace CoreImage {
 		bool WritePngRepresentation (CIImage image, NSUrl url, CIFormat format, CGColorSpace colorSpace, NSDictionary options, [NullAllowed] out NSError error);
 
 		[iOS (11,0)][TV (11,0)][Mac (10,13)]
-		[Wrap ("WritePngRepresentation (This, image, url, format, colorSpace, options?.Dictionary, out error)")]
+		[Wrap ("WritePngRepresentation (This, image, url, format, colorSpace, options.GetDictionary ()!, out error)")]
 		bool WritePngRepresentation (CIImage image, NSUrl url, CIFormat format, CGColorSpace colorSpace, CIImageRepresentationOptions options, [NullAllowed] out NSError error);
 	}
 
@@ -620,7 +623,7 @@ namespace CoreImage {
 		[iOS (10,0)]
 		[TV (10,0)]
 		[Static]
-		[Wrap ("CreateRawFilter (url, options?.Dictionary)")]
+		[Wrap ("CreateRawFilter (url, options.GetDictionary ()!)")]
 		CIFilter CreateRawFilter (NSUrl url, CIRawFilterOptions options);
 
 		[iOS (10,0)]
@@ -632,7 +635,7 @@ namespace CoreImage {
 		[iOS (10,0)]
 		[TV (10,0)]
 		[Static]
-		[Wrap ("CreateRawFilter (data, options?.Dictionary)")]
+		[Wrap ("CreateRawFilter (data, options.GetDictionary ()!)")]
 		CIFilter CreateRawFilter (NSData data, CIRawFilterOptions options);
 
 		[iOS (10,0)][Mac (10,12)]
@@ -644,7 +647,7 @@ namespace CoreImage {
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10,0)]
 		[Static]
-		[Wrap ("CreateRawFilter (pixelBuffer, properties, options?.Dictionary)")]
+		[Wrap ("CreateRawFilter (pixelBuffer, properties, options.GetDictionary ()!)")]
 		CIFilter CreateRawFilter (CVPixelBuffer pixelBuffer, NSDictionary properties, CIRawFilterOptions options);
 	}
 
@@ -1385,7 +1388,7 @@ namespace CoreImage {
 		CIImage FromCGImage (CGImage image, [NullAllowed] NSDictionary d);
 
 		[Static]
-		[Wrap ("FromCGImage (image, options?.Dictionary)")]
+		[Wrap ("FromCGImage (image, options.GetDictionary ())")]
 		CIImage FromCGImage (CGImage image, [NullAllowed] CIImageInitializationOptionsWithMetadata options);
 
 		[iOS (13,0)][TV (13,0)][Mac (10,15)]
@@ -1396,7 +1399,7 @@ namespace CoreImage {
 
 		[iOS (13,0)][TV (13,0)][Mac (10,15)]
 		[Static]
-		[Wrap ("FromCGImageSource (source, index, options?.Dictionary)")]
+		[Wrap ("FromCGImageSource (source, index, options.GetDictionary ())")]
 		CIImage FromCGImageSource (CGImageSource source, nuint index, [NullAllowed] CIImageInitializationOptionsWithMetadata options);
 
 #if MONOMAC
@@ -1436,7 +1439,7 @@ namespace CoreImage {
 		CIImage FromUrl (NSUrl url, [NullAllowed] NSDictionary d);
 
 		[Static]
-		[Wrap ("FromUrl (url, options?.Dictionary)")]
+		[Wrap ("FromUrl (url, options.GetDictionary ())")]
 		CIImage FromUrl (NSUrl url, [NullAllowed] CIImageInitializationOptions options);
 
 		[Static]
@@ -1449,7 +1452,7 @@ namespace CoreImage {
 		CIImage FromData (NSData data, [NullAllowed] NSDictionary d);
 
 		[Static]
-		[Wrap ("FromData (data, options?.Dictionary)")]
+		[Wrap ("FromData (data, options.GetDictionary ())")]
 		CIImage FromData (NSData data, [NullAllowed] CIImageInitializationOptionsWithMetadata options);
 
 		[Static]
@@ -1479,7 +1482,7 @@ namespace CoreImage {
 #endif
 
 		[Static][iOS(9,0)]
-		[Wrap ("FromImageBuffer (imageBuffer, options?.Dictionary)")]
+		[Wrap ("FromImageBuffer (imageBuffer, options.GetDictionary ())")]
 		CIImage FromImageBuffer (CVImageBuffer imageBuffer, CIImageInitializationOptions options);
 		
 #if !MONOMAC
@@ -1493,7 +1496,7 @@ namespace CoreImage {
 		CIImage FromImageBuffer (CVPixelBuffer buffer, [NullAllowed] NSDictionary dict);
 
 		[Static]
-		[Wrap ("FromImageBuffer (buffer, options?.Dictionary)")]
+		[Wrap ("FromImageBuffer (buffer, options.GetDictionary ())")]
 		CIImage FromImageBuffer (CVPixelBuffer buffer, [NullAllowed] CIImageInitializationOptions options);
 #endif
 		[iOS (11,0)]
@@ -1515,7 +1518,7 @@ namespace CoreImage {
 		[TV (11,0)]
 		[Mac (10,13)]
 		[Static]
-		[Wrap ("FromSurface (surface, options?.Dictionary)")]
+		[Wrap ("FromSurface (surface, options.GetDictionary ()!)")]
 		CIImage FromSurface (IOSurface.IOSurface surface, CIImageInitializationOptions options);
 
 		[Static]
@@ -1533,7 +1536,7 @@ namespace CoreImage {
 		[Export ("initWithCGImage:options:")]
 		IntPtr Constructor (CGImage image, [NullAllowed] NSDictionary d);
 
-		[Wrap ("this (image, options?.Dictionary)")]
+		[Wrap ("this (image, options.GetDictionary ())")]
 		IntPtr Constructor (CGImage image, [NullAllowed] CIImageInitializationOptionsWithMetadata options);
 
 		[iOS (13,0)][TV (13,0)][Mac (10,15)]
@@ -1542,7 +1545,7 @@ namespace CoreImage {
 		IntPtr Constructor (CGImageSource source, nuint index, [NullAllowed] NSDictionary options);
 
 		[iOS (13,0)][TV (13,0)][Mac (10,15)]
-		[Wrap ("this (source, index, options?.Dictionary)")]
+		[Wrap ("this (source, index, options.GetDictionary ())")]
 		IntPtr Constructor (CGImageSource source, nuint index, CIImageInitializationOptionsWithMetadata options);
 
 #if MONOMAC
@@ -1555,7 +1558,7 @@ namespace CoreImage {
 		[Export ("initWithCGLayer:options:")]
 		IntPtr Constructor (CGLayer layer, [NullAllowed] NSDictionary d);
 
-		[Wrap ("this (layer, options?.Dictionary)")]
+		[Wrap ("this (layer, options.GetDictionary ())")]
 		IntPtr Constructor (CGLayer layer, [NullAllowed] CIImageInitializationOptions options);
 #endif
 
@@ -1565,7 +1568,7 @@ namespace CoreImage {
 		[Export ("initWithData:options:")]
 		IntPtr Constructor (NSData data, [NullAllowed] NSDictionary d);
 
-		[Wrap ("this (data, options?.Dictionary)")]
+		[Wrap ("this (data, options.GetDictionary ())")]
 		IntPtr Constructor (NSData data, [NullAllowed] CIImageInitializationOptionsWithMetadata options);
 
 		[Export ("initWithBitmapData:bytesPerRow:size:format:colorSpace:")]
@@ -1582,7 +1585,7 @@ namespace CoreImage {
 		[Export ("initWithContentsOfURL:options:")]
 		IntPtr Constructor (NSUrl url, [NullAllowed] NSDictionary d);
 
-		[Wrap ("this (url, options?.Dictionary)")]
+		[Wrap ("this (url, options.GetDictionary ())")]
 		IntPtr Constructor (NSUrl url, [NullAllowed] CIImageInitializationOptions options);
 
 		[iOS (11,0)] // IOSurface was not exposed before Xcode 9
@@ -1600,7 +1603,7 @@ namespace CoreImage {
 		[iOS (11,0)] // IOSurface was not exposed before Xcode 9
 		[TV (11,0)]
 		[Mac (10,13)]
-		[Wrap ("this (surface, options?.Dictionary)")]
+		[Wrap ("this (surface, options.GetDictionary ())")]
 		IntPtr Constructor (IOSurface.IOSurface surface, [NullAllowed] CIImageInitializationOptions options);
 
 		[iOS(9,0)]
@@ -1625,7 +1628,7 @@ namespace CoreImage {
 #endif
 
 		[iOS(9,0)]
-		[Wrap ("this (imageBuffer, options?.Dictionary)")]
+		[Wrap ("this (imageBuffer, options.GetDictionary ())")]
 		IntPtr Constructor (CVImageBuffer imageBuffer, [NullAllowed] CIImageInitializationOptions options);
 
 		[Mac (10,11)]
@@ -1637,7 +1640,7 @@ namespace CoreImage {
 		IntPtr Constructor (CVPixelBuffer buffer, [NullAllowed] NSDictionary dict);
 
 		[Mac (10,11)]
-		[Wrap ("this (buffer, options?.Dictionary)")]
+		[Wrap ("this (buffer, options.GetDictionary ())")]
 		IntPtr Constructor (CVPixelBuffer buffer, [NullAllowed] CIImageInitializationOptions options);
 
 		[Export ("initWithColor:")]
@@ -1795,7 +1798,7 @@ namespace CoreImage {
 		[Export ("initWithImage:options:")]
 		IntPtr Constructor (UIImage image, [NullAllowed] NSDictionary options);
 
-		[Wrap ("this (image, options?.Dictionary)")]
+		[Wrap ("this (image, options.GetDictionary ())")]
 		IntPtr Constructor (UIImage image, [NullAllowed] CIImageInitializationOptions options);
 #endif
 	

--- a/src/coreml.cs
+++ b/src/coreml.cs
@@ -247,7 +247,7 @@ namespace CoreML {
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[Static]
-		[Wrap ("Create (url, pixelsWide, pixelsHigh, pixelFormatType, imageOptions?.Dictionary, out error)")]
+		[Wrap ("Create (url, pixelsWide, pixelsHigh, pixelFormatType, imageOptions.GetDictionary (), out error)")]
 		[return: NullAllowed]
 		MLFeatureValue Create (NSUrl url, nint pixelsWide, nint pixelsHigh, CVPixelFormatType pixelFormatType, [NullAllowed] MLFeatureValueImageOption imageOptions, [NullAllowed] out NSError error);
 
@@ -259,7 +259,7 @@ namespace CoreML {
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[Static]
-		[Wrap ("Create (url, constraint, imageOptions?.Dictionary, out error)")]
+		[Wrap ("Create (url, constraint, imageOptions.GetDictionary (), out error)")]
 		[return: NullAllowed]
 		MLFeatureValue Create (NSUrl url, MLImageConstraint constraint, [NullAllowed] MLFeatureValueImageOption imageOptions, [NullAllowed] out NSError error);
 
@@ -271,7 +271,7 @@ namespace CoreML {
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[Static]
-		[Wrap ("Create (image, pixelsWide, pixelsHigh, pixelFormatType, imageOptions?.Dictionary, out error)")]
+		[Wrap ("Create (image, pixelsWide, pixelsHigh, pixelFormatType, imageOptions.GetDictionary (), out error)")]
 		[return: NullAllowed]
 		MLFeatureValue Create (CGImage image, nint pixelsWide, nint pixelsHigh, CVPixelFormatType pixelFormatType, [NullAllowed] MLFeatureValueImageOption imageOptions, [NullAllowed] out NSError error);
 
@@ -283,7 +283,7 @@ namespace CoreML {
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[Static]
-		[Wrap ("Create (image, constraint, imageOptions?.Dictionary, out error)")]
+		[Wrap ("Create (image, constraint, imageOptions.GetDictionary (), out error)")]
 		[return: NullAllowed]
 		MLFeatureValue Create (CGImage image, MLImageConstraint constraint, [NullAllowed] MLFeatureValueImageOption imageOptions, [NullAllowed] out NSError error);
 
@@ -295,7 +295,7 @@ namespace CoreML {
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[Static]
-		[Wrap ("Create (url, orientation, pixelsWide, pixelsHigh, pixelFormatType, imageOptions?.Dictionary, out error)")]
+		[Wrap ("Create (url, orientation, pixelsWide, pixelsHigh, pixelFormatType, imageOptions.GetDictionary (), out error)")]
 		[return: NullAllowed]
 		MLFeatureValue Create (NSUrl url, CGImagePropertyOrientation orientation, nint pixelsWide, nint pixelsHigh, CVPixelFormatType pixelFormatType, [NullAllowed] MLFeatureValueImageOption imageOptions, [NullAllowed] out NSError error);
 
@@ -307,7 +307,7 @@ namespace CoreML {
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[Static]
-		[Wrap ("Create (url, orientation, constraint, imageOptions?.Dictionary, out error)")]
+		[Wrap ("Create (url, orientation, constraint, imageOptions.GetDictionary (), out error)")]
 		[return: NullAllowed]
 		MLFeatureValue Create (NSUrl url, CGImagePropertyOrientation orientation, MLImageConstraint constraint, [NullAllowed] MLFeatureValueImageOption imageOptions, [NullAllowed] out NSError error);
 
@@ -319,7 +319,7 @@ namespace CoreML {
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[Static]
-		[Wrap ("Create (image, orientation, pixelsWide, pixelsHigh, pixelFormatType, imageOptions?.Dictionary, out error)")]
+		[Wrap ("Create (image, orientation, pixelsWide, pixelsHigh, pixelFormatType, imageOptions.GetDictionary (), out error)")]
 		[return: NullAllowed]
 		MLFeatureValue Create (CGImage image, CGImagePropertyOrientation orientation, nint pixelsWide, nint pixelsHigh, CVPixelFormatType pixelFormatType, [NullAllowed] MLFeatureValueImageOption imageOptions, [NullAllowed] out NSError error);
 
@@ -331,7 +331,7 @@ namespace CoreML {
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[Static]
-		[Wrap ("Create (image, orientation, constraint, imageOptions?.Dictionary, out error)")]
+		[Wrap ("Create (image, orientation, constraint, imageOptions.GetDictionary (), out error)")]
 		[return: NullAllowed]
 		MLFeatureValue Create (CGImage image, CGImagePropertyOrientation orientation, MLImageConstraint constraint, [NullAllowed] MLFeatureValueImageOption imageOptions, [NullAllowed] out NSError error);
 	}

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -275,7 +275,7 @@ namespace Foundation
 #endif
 
 		[iOS (7,0)]
-		[Wrap ("this (url, options == null ? null : options.Dictionary, out resultDocumentAttributes, ref error)")]
+		[Wrap ("this (url, options.GetDictionary (), out resultDocumentAttributes, ref error)")]
 		IntPtr Constructor (NSUrl url, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, ref NSError error);
 
 		[iOS (7,0)]
@@ -283,7 +283,7 @@ namespace Foundation
 		IntPtr Constructor (NSData data, [NullAllowed] NSDictionary options, out NSDictionary resultDocumentAttributes, ref NSError error);
 
 		[iOS (7,0)]
-		[Wrap ("this (data, options == null ? null : options.Dictionary, out resultDocumentAttributes, ref error)")]
+		[Wrap ("this (data, options.GetDictionary (), out resultDocumentAttributes, ref error)")]
 		IntPtr Constructor (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, ref NSError error);
 
 		[iOS (7,0)]
@@ -291,7 +291,7 @@ namespace Foundation
 		NSData GetDataFromRange (NSRange range, NSDictionary attributes, ref NSError error);
 
 		[iOS (7,0)]
-		[Wrap ("GetDataFromRange (range, documentAttributes == null ? null : documentAttributes.Dictionary, ref error)")]
+		[Wrap ("GetDataFromRange (range, documentAttributes.GetDictionary ()!, ref error)")]
 		NSData GetDataFromRange (NSRange range, NSAttributedStringDocumentAttributes documentAttributes, ref NSError error);
 
 		[iOS (7,0)]
@@ -299,7 +299,7 @@ namespace Foundation
 		NSFileWrapper GetFileWrapperFromRange (NSRange range, NSDictionary attributes, ref NSError error);
 
 		[iOS (7,0)]
-		[Wrap ("GetFileWrapperFromRange (range, documentAttributes == null ? null : documentAttributes.Dictionary, ref error)")]
+		[Wrap ("GetFileWrapperFromRange (range, documentAttributes.GetDictionary ()!, ref error)")]
 		NSFileWrapper GetFileWrapperFromRange (NSRange range, NSAttributedStringDocumentAttributes documentAttributes, ref NSError error);
 
 #endif
@@ -417,10 +417,10 @@ namespace Foundation
 		[Export ("initWithURL:options:documentAttributes:error:")]
 		IntPtr Constructor (NSUrl url, [NullAllowed] NSDictionary options, out NSDictionary resultDocumentAttributes, out NSError error);
 
-		[Wrap ("this (url, options == null ? null : options.Dictionary, out resultDocumentAttributes, out error)")]
+		[Wrap ("this (url, options.GetDictionary (), out resultDocumentAttributes, out error)")]
 		IntPtr Constructor (NSUrl url, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, out NSError error);
 
-		[Wrap ("this (data, options == null ? null : options.Dictionary, out resultDocumentAttributes, out error)")]
+		[Wrap ("this (data, options.GetDictionary (), out resultDocumentAttributes, out error)")]
 		IntPtr Constructor (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, out NSError error);
 
 		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSAttributedString (NSUrl, NSDictionary, out NSDictionary, ref NSError)' instead.")]
@@ -443,7 +443,7 @@ namespace Foundation
 		[Export ("initWithHTML:options:documentAttributes:")]
 		IntPtr Constructor (NSData data, [NullAllowed]  NSDictionary options, out NSDictionary resultDocumentAttributes);
 
-		[Wrap ("this (data, options == null ? null : options.Dictionary, out resultDocumentAttributes)")]
+		[Wrap ("this (data, options.GetDictionary (), out resultDocumentAttributes)")]
 		IntPtr Constructor (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes);
 
 		[Export ("initWithRTFDFileWrapper:documentAttributes:")]
@@ -489,37 +489,37 @@ namespace Foundation
 		[Export ("dataFromRange:documentAttributes:error:")]
 		NSData GetData (NSRange range, [NullAllowed] NSDictionary options, out NSError error);
 
-		[Wrap ("this.GetData (range, options == null ? null : options.Dictionary, out error)")]
+		[Wrap ("this.GetData (range, options.GetDictionary (), out error)")]
 		NSData GetData (NSRange range, NSAttributedStringDocumentAttributes options, out NSError error);
 
 		[Export ("fileWrapperFromRange:documentAttributes:error:")]
 		NSFileWrapper GetFileWrapper (NSRange range, [NullAllowed] NSDictionary options, out NSError error);
 
-		[Wrap ("this.GetFileWrapper (range, options == null ? null : options.Dictionary, out error)")]
+		[Wrap ("this.GetFileWrapper (range, options.GetDictionary (), out error)")]
 		NSFileWrapper GetFileWrapper (NSRange range, NSAttributedStringDocumentAttributes options, out NSError error);
 
 		[Export ("RTFFromRange:documentAttributes:")]
 		NSData GetRtf (NSRange range, [NullAllowed] NSDictionary options);
 
-		[Wrap ("this.GetRtf (range, options == null ? null : options.Dictionary)")]
+		[Wrap ("this.GetRtf (range, options.GetDictionary ())")]
 		NSData GetRtf (NSRange range, NSAttributedStringDocumentAttributes options);
 
 		[Export ("RTFDFromRange:documentAttributes:")]
 		NSData GetRtfd (NSRange range, [NullAllowed] NSDictionary options);
 
-		[Wrap ("this.GetRtfd (range, options == null ? null : options.Dictionary)")]
+		[Wrap ("this.GetRtfd (range, options.GetDictionary ())")]
 		NSData GetRtfd (NSRange range, NSAttributedStringDocumentAttributes options);
 
 		[Export ("RTFDFileWrapperFromRange:documentAttributes:")]
 		NSFileWrapper GetRtfdFileWrapper (NSRange range, [NullAllowed] NSDictionary options);
 
-		[Wrap ("this.GetRtfdFileWrapper (range, options == null ? null : options.Dictionary)")]
+		[Wrap ("this.GetRtfdFileWrapper (range, options.GetDictionary ())")]
 		NSFileWrapper GetRtfdFileWrapper (NSRange range, NSAttributedStringDocumentAttributes options);
 
 		[Export ("docFormatFromRange:documentAttributes:")]
 		NSData GetDocFormat (NSRange range, [NullAllowed] NSDictionary options);
 
-		[Wrap ("this.GetDocFormat (range, options == null ? null : options.Dictionary)")]
+		[Wrap ("this.GetDocFormat (range, options.GetDictionary ())")]
 		NSData GetDocFormat (NSRange range, NSAttributedStringDocumentAttributes options);
 #else
 		[Export ("size")]
@@ -558,7 +558,7 @@ namespace Foundation
 		[Mac (10,15), iOS (13,0)]
 		[Static]
 		[Async (ResultTypeName = "NSLoadFromHtmlResult")]
-		[Wrap ("LoadFromHtml (request, options == null ? null : options.Dictionary, completionHandler)")]
+		[Wrap ("LoadFromHtml (request, options.GetDictionary ()!, completionHandler)")]
 		void LoadFromHtml (NSUrlRequest request, NSAttributedStringDocumentAttributes options, NSAttributedStringCompletionHandler completionHandler);
 
 		[NoWatch][NoTV] // really inside WKWebKit
@@ -574,7 +574,7 @@ namespace Foundation
 		[Mac (10,15), iOS (13,0)]
 		[Static]
 		[Async (ResultTypeName = "NSLoadFromHtmlResult")]
-		[Wrap ("LoadFromHtml (fileUrl, options == null ? null : options.Dictionary, completionHandler)")]
+		[Wrap ("LoadFromHtml (fileUrl, options.GetDictionary ()!, completionHandler)")]
 		void LoadFromHtml (NSUrl fileUrl, NSAttributedStringDocumentAttributes options, NSAttributedStringCompletionHandler completionHandler);
 
 		[NoWatch][NoTV] // really inside WKWebKit
@@ -590,7 +590,7 @@ namespace Foundation
 		[Mac (10,15), iOS (13,0)]
 		[Static]
 		[Async (ResultTypeName = "NSLoadFromHtmlResult")]
-		[Wrap ("LoadFromHtml (@string, options == null ? null : options.Dictionary, completionHandler)")]
+		[Wrap ("LoadFromHtml (@string, options.GetDictionary ()!, completionHandler)")]
 		void LoadFromHtml (string @string, NSAttributedStringDocumentAttributes options, NSAttributedStringCompletionHandler completionHandler);
 
 		[NoWatch][NoTV] // really inside WKWebKit
@@ -606,7 +606,7 @@ namespace Foundation
 		[Mac (10,15), iOS (13,0)]
 		[Static]
 		[Async (ResultTypeName = "NSLoadFromHtmlResult")]
-		[Wrap ("LoadFromHtml (data, options == null ? null : options.Dictionary, completionHandler)")]
+		[Wrap ("LoadFromHtml (data, options.GetDictionary ()!, completionHandler)")]
 		void LoadFromHtml (NSData data, NSAttributedStringDocumentAttributes options, NSAttributedStringCompletionHandler completionHandler);
 	}
 
@@ -2323,7 +2323,7 @@ namespace Foundation
 		[Export ("attributedStringForObjectValue:withDefaultAttributes:")]
 		NSAttributedString GetAttributedString (NSObject obj, NSDictionary<NSString, NSObject> defaultAttributes);
 
-		[Wrap ("GetAttributedString (obj, defaultAttributes == null ? null : defaultAttributes.Dictionary)")]
+		[Wrap ("GetAttributedString (obj, defaultAttributes.GetDictionary ()!)")]
 #if MONOMAC
 		NSAttributedString GetAttributedString (NSObject obj, NSStringAttributes defaultAttributes);
 #else
@@ -2598,6 +2598,7 @@ namespace Foundation
 		void SetClass (Class kls, string codedName);
 
 		[Export ("classForClassName:")]
+		[return: NullAllowed]
 		Class GetClass (string codedName);
 
 		[Export ("setRequiresSecureCoding:")]
@@ -3647,7 +3648,7 @@ namespace Foundation
 		void AddAttributes (NSDictionary attrs, NSRange range);
 
 #if MONOMAC
-		[Wrap ("AddAttributes (attributes == null ? null : attributes.Dictionary, range)")]
+		[Wrap ("AddAttributes (attributes.GetDictionary ()!, range)")]
 		void AddAttributes (NSStringAttributes attributes, NSRange range);
 #endif
 		[Export ("removeAttribute:range:")]
@@ -3683,14 +3684,14 @@ namespace Foundation
 
 		[NoTV]
 		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'ReadFromUrl' instead.")]
-		[Wrap ("ReadFromFile (url, options == null ? null : options.Dictionary, ref returnOptions, ref error)")]
+		[Wrap ("ReadFromFile (url, options.GetDictionary ()!, ref returnOptions, ref error)")]
 		bool ReadFromFile (NSUrl url, NSAttributedStringDocumentAttributes options, ref NSDictionary returnOptions, ref NSError error);
 
 		[iOS (7,0)]
 		[Export ("readFromData:options:documentAttributes:error:")]
 		bool ReadFromData (NSData data, NSDictionary options, ref NSDictionary returnOptions, ref NSError error);
 		
-		[Wrap ("ReadFromData (data, options == null ? null : options.Dictionary, ref returnOptions, ref error)")]
+		[Wrap ("ReadFromData (data, options.GetDictionary ()!, ref returnOptions, ref error)")]
 		bool ReadFromData (NSData data, NSAttributedStringDocumentAttributes options, ref NSDictionary returnOptions, ref NSError error);
 
 #endif
@@ -3708,7 +3709,7 @@ namespace Foundation
 		bool ReadFromUrl (NSUrl url, NSDictionary<NSString, NSObject> options, ref NSDictionary<NSString, NSObject> returnOptions, ref NSError error);
 
 		[iOS(9,0), Mac(10,11)]
-		[Wrap ("ReadFromUrl (url, options.Dictionary, ref returnOptions, ref error)")]
+		[Wrap ("ReadFromUrl (url, options.GetDictionary ()!, ref returnOptions, ref error)")]
 		bool ReadFromUrl (NSUrl url, NSAttributedStringDocumentAttributes options, ref NSDictionary<NSString, NSObject> returnOptions, ref NSError error);
 	}
 
@@ -4886,19 +4887,19 @@ namespace Foundation
 		[Export ("addTimer:forMode:")]
 		void AddTimer (NSTimer timer, NSString forMode);
 
-		[Wrap ("AddTimer (timer, forMode.GetConstant ())")]
+		[Wrap ("AddTimer (timer, forMode.GetConstant ()!)")]
 		void AddTimer (NSTimer timer, NSRunLoopMode forMode);
 
 		[Export ("limitDateForMode:")]
 		NSDate LimitDateForMode (NSString mode);
 
-		[Wrap ("LimitDateForMode (mode.GetConstant ())")]
+		[Wrap ("LimitDateForMode (mode.GetConstant ()!)")]
 		NSDate LimitDateForMode (NSRunLoopMode mode);
 
 		[Export ("acceptInputForMode:beforeDate:")]
 		void AcceptInputForMode (NSString mode, NSDate limitDate);
 
-		[Wrap ("AcceptInputForMode (mode.GetConstant (), limitDate)")]
+		[Wrap ("AcceptInputForMode (mode.GetConstant ()!, limitDate)")]
 		void AcceptInputForMode (NSRunLoopMode mode, NSDate limitDate);
 
 		[Export ("run")]
@@ -4910,7 +4911,7 @@ namespace Foundation
 		[Export ("runMode:beforeDate:")]
 		bool RunUntil (NSString runLoopMode, NSDate limitdate);
 
-		[Wrap ("RunUntil (runLoopMode.GetConstant (), limitDate)")]
+		[Wrap ("RunUntil (runLoopMode.GetConstant ()!, limitDate)")]
 		bool RunUntil (NSRunLoopMode runLoopMode, NSDate limitDate);
 
 		[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -4922,7 +4923,7 @@ namespace Foundation
 		void Perform (NSString[] modes, Action block);
 
 		[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
-		[Wrap ("Perform (modes.GetConstants (), block)")]
+		[Wrap ("Perform (modes.GetConstants ()!, block)")]
 		void Perform (NSRunLoopMode[] modes, Action block);
 
 #if !XAMCORE_4_0
@@ -6723,13 +6724,13 @@ namespace Foundation
 		[Export ("scheduleInRunLoop:forMode:")]
 		void Schedule (NSRunLoop aRunLoop, NSString forMode);
 
-		[Wrap ("Schedule (aRunLoop, forMode.GetConstant ())")]
+		[Wrap ("Schedule (aRunLoop, forMode.GetConstant ()!)")]
 		void Schedule (NSRunLoop aRunLoop, NSRunLoopMode forMode);
 	
 		[Export ("unscheduleFromRunLoop:forMode:")]
 		void Unschedule (NSRunLoop aRunLoop, NSString forMode);
 
-		[Wrap ("Unschedule (aRunLoop, forMode.GetConstant ())")]
+		[Wrap ("Unschedule (aRunLoop, forMode.GetConstant ()!)")]
 		void Unschedule (NSRunLoop aRunLoop, NSRunLoopMode forMode);
 
 #if !MONOMAC
@@ -7464,9 +7465,9 @@ namespace Foundation
 
 		[NoWatch]
 		ProxyConfigurationDictionary StrongConnectionProxyDictionary {
-			[Wrap ("new ProxyConfigurationDictionary (ConnectionProxyDictionary)")]
+			[Wrap ("new ProxyConfigurationDictionary (ConnectionProxyDictionary!)")]
 			get;
-			[Wrap ("ConnectionProxyDictionary = value?.Dictionary")]
+			[Wrap ("ConnectionProxyDictionary = value.GetDictionary ()")]
 			set;
 		}
 	
@@ -8479,7 +8480,7 @@ namespace Foundation
 		nuint DetectStringEncoding (NSData rawData, NSDictionary options, out string convertedString, out bool usedLossyConversion);
 
 		[iOS (8,0), Mac(10,10)]
-		[Static, Wrap ("DetectStringEncoding(rawData,options == null ? null : options.Dictionary, out convertedString, out usedLossyConversion)")]
+		[Static, Wrap ("DetectStringEncoding(rawData,options.GetDictionary ()!, out convertedString, out usedLossyConversion)")]
 		nuint DetectStringEncoding (NSData rawData, EncodingDetectionOptions options, out string convertedString, out bool usedLossyConversion);
 
 		[iOS (8,0),Mac(10,10)]
@@ -8639,7 +8640,7 @@ namespace Foundation
 		bool ApplyTransform (NSString transform, bool reverse, NSRange range, out NSRange resultingRange);
 
 		[iOS (9,0)][Mac (10,11)]
-		[Wrap ("ApplyTransform (transform.GetConstant (), reverse, range, out resultingRange)")]
+		[Wrap ("ApplyTransform (transform.GetConstant ()!, reverse, range, out resultingRange)")]
 		bool ApplyTransform (NSStringTransform transform, bool reverse, NSRange range, out NSRange resultingRange);
 
 		[Export ("replaceCharactersInRange:withString:")]
@@ -8747,7 +8748,7 @@ namespace Foundation
 		[Export ("linguisticTagsInRange:scheme:options:orthography:tokenRanges:")]
 		NSString[] GetLinguisticTags (NSRange range, NSString scheme, NSLinguisticTaggerOptions options, [NullAllowed] NSOrthography orthography, [NullAllowed] out NSValue[] tokenRanges);
 
-		[Wrap ("GetLinguisticTags (This, range, scheme.GetConstant (), options, orthography, out tokenRanges)")]
+		[Wrap ("GetLinguisticTags (This, range, scheme.GetConstant ()!, options, orthography, out tokenRanges)")]
 #if XAMCORE_4_0
 		NSLinguisticTag[] GetLinguisticTags (NSRange range, NSLinguisticTagScheme scheme, NSLinguisticTaggerOptions options, [NullAllowed] NSOrthography orthography, [NullAllowed] out NSValue[] tokenRanges);
 #else
@@ -8758,7 +8759,7 @@ namespace Foundation
 		[Export ("enumerateLinguisticTagsInRange:scheme:options:orthography:usingBlock:")]
 		void EnumerateLinguisticTags (NSRange range, NSString scheme, NSLinguisticTaggerOptions options, [NullAllowed] NSOrthography orthography, NSEnumerateLinguisticTagsEnumerator handler);
 
-		[Wrap ("EnumerateLinguisticTags (This, range, scheme.GetConstant (), options, orthography, handler)")]
+		[Wrap ("EnumerateLinguisticTags (This, range, scheme.GetConstant ()!, options, orthography, handler)")]
 		void EnumerateLinguisticTags (NSRange range, NSLinguisticTagScheme scheme, NSLinguisticTaggerOptions options, [NullAllowed] NSOrthography orthography, NSEnumerateLinguisticTagsEnumerator handler);
 	}
 
@@ -10593,10 +10594,10 @@ namespace Foundation
 		[Export ("removeFromRunLoop:forMode:")]
 		void Unschedule (NSRunLoop aRunLoop, string forMode);
 #endif
-		[Wrap ("Schedule (aRunLoop, forMode.GetConstant ())")]
+		[Wrap ("Schedule (aRunLoop, forMode.GetConstant ()!)")]
 		void Schedule (NSRunLoop aRunLoop, NSRunLoopMode forMode);
 
-		[Wrap ("Unschedule (aRunLoop, forMode.GetConstant ())")]
+		[Wrap ("Unschedule (aRunLoop, forMode.GetConstant ()!)")]
 		void Unschedule (NSRunLoop aRunLoop, NSRunLoopMode forMode);
 
 		[Export ("domain", ArgumentSemantic.Copy)]
@@ -11849,13 +11850,13 @@ namespace Foundation
 		[Export ("scheduleInRunLoop:forMode:")]
 		void ScheduleInRunLoop (NSRunLoop runLoop, NSString runLoopMode);
 
-		[Wrap ("ScheduleInRunLoop (runLoop, runLoopMode.GetConstant ())")]
+		[Wrap ("ScheduleInRunLoop (runLoop, runLoopMode.GetConstant ()!)")]
 		void ScheduleInRunLoop (NSRunLoop runLoop, NSRunLoopMode runLoopMode);
 
 		[Export ("removeFromRunLoop:forMode:")]
 		void RemoveFromRunLoop (NSRunLoop runLoop, NSString runLoopMode);
 
-		[Wrap ("RemoveFromRunLoop (runLoop, runLoopMode.GetConstant ())")]
+		[Wrap ("RemoveFromRunLoop (runLoop, runLoopMode.GetConstant ()!)")]
 		void RemoveFromRunLoop (NSRunLoop runLoop, NSRunLoopMode runLoopMode);
 
 		// Disable warning for NSMutableArray
@@ -12345,7 +12346,7 @@ namespace Foundation
 
 #if !XAMCORE_4_0
 		[Obsolete ("Use '.ctor(INSFilePresenter)' instead.")]
-		[Wrap ("this ((INSFilePresenter) filePresenterOrNil)")]
+		[Wrap ("this (filePresenterOrNil as INSFilePresenter)")]
 		IntPtr Constructor ([NullAllowed] NSFilePresenter filePresenterOrNil);
 #endif
 
@@ -12523,6 +12524,7 @@ namespace Foundation
 
 		[Wrap ("WeakDelegate")]
 		[Protocolize]
+		[NullAllowed]
 		NSFileManagerDelegate Delegate { get; set; }
 
 		[Export ("setAttributes:ofItemAtPath:error:")]
@@ -13565,7 +13567,7 @@ namespace Foundation
 		NSTextCheckingResult AddressCheckingResult (NSRange range, NSDictionary components);
 
 		[Static]
-		[Wrap ("AddressCheckingResult (range, components != null ? components.Dictionary : null)")]
+		[Wrap ("AddressCheckingResult (range, components.GetDictionary ()!)")]
 		NSTextCheckingResult AddressCheckingResult (NSRange range, NSTextCheckingAddressComponents components);
 
 		[Static]
@@ -13609,7 +13611,7 @@ namespace Foundation
 		NSTextCheckingResult TransitInformationCheckingResult (NSRange range, NSDictionary components);
 
 		[Static]
-		[Wrap ("TransitInformationCheckingResult (range, components != null ? components.Dictionary : null)")]
+		[Wrap ("TransitInformationCheckingResult (range, components.GetDictionary ()!)")]
 		NSTextCheckingResult TransitInformationCheckingResult (NSRange range, NSTextCheckingTransitComponents components);
 
 		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -1262,9 +1262,11 @@ namespace GameKit {
 		[Export ("initWithNibName:bundle:")]
 		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 		
+		[NullAllowed]
 		[Export ("matchmakerDelegate", ArgumentSemantic.Assign)]
 		NSObject WeakMatchmakerDelegate { get; set; }
 		
+		[NullAllowed]
 		[Wrap ("WeakMatchmakerDelegate")]
 		[Protocolize]
 		GKMatchmakerViewControllerDelegate MatchmakerDelegate { get; set;  }
@@ -1391,7 +1393,7 @@ namespace GameKit {
 		void ResetAchivements ([NullAllowed] GKNotificationHandler completionHandler);
 #endif
 
-		[Wrap ("this ((string) null)")]
+		[Wrap ("this ((string) null!)")]
 		IntPtr Constructor ();
 
 		[Export ("initWithIdentifier:")]

--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -114,9 +114,9 @@ public partial class Generator {
 		if (error != null) {
 			// this attribute is important for our tests
 			print ("[Field (\"{0}\", \"{1}\")]", error.ErrorDomain, library_name);
-			print ("static NSString _domain;");
+			print ("static NSString? _domain;");
 			print ("");
-			print ("public static NSString GetDomain (this {0} self)", type.Name);
+			print ("public static NSString? GetDomain (this {0} self)", type.Name);
 			print ("{");
 			indent++;
 			print ("if (_domain == null)");
@@ -161,7 +161,7 @@ public partial class Generator {
 				print ("");
 			}
 			
-			print ("public static NSString GetConstant (this {0} self)", type.Name);
+			print ("public static NSString? GetConstant (this {0} self)", type.Name);
 			print ("{");
 			indent++;
 			print ("IntPtr ptr = IntPtr.Zero;");
@@ -187,14 +187,15 @@ public partial class Generator {
 			print ("}");
 			
 			print ("");
-			
-			print ("public static {0} GetValue (NSString constant)", type.Name);
+
+			var nullable = null_field != null;
+			print ("public static {0} GetValue (NSString{1} constant)", type.Name, nullable ? "?" : "");
 			print ("{");
 			indent++;
 			print ("if (constant == null)");
 			indent++;
 			// if we do not have a enum value that maps to a null field then we throw
-			if (null_field == null)
+			if (!nullable)
 				print ("throw new ArgumentNullException (nameof (constant));");
 			else
 				print ("return {0}.{1};", type.Name, null_field.Item1.Name);

--- a/src/generator-filters.cs
+++ b/src/generator-filters.cs
@@ -86,6 +86,10 @@ public partial class Generator {
 		print ("public {0} (NSCoder coder) : base (NSObjectFlag.Empty)", type_name);
 		print ("{");
 		indent++;
+		print ("if (coder == null)");
+		indent++;
+		print ("throw new ArgumentNullException (nameof (coder));");
+		indent--;
 		print ("IntPtr h;");
 		print ("if (IsDirectBinding) {");
 		indent++;
@@ -142,14 +146,14 @@ public partial class Generator {
 
 			print ("");
 			print ($"// {pname} protocol members ");
-			GenerateProperties (i);
+			GenerateProperties (i, fromProtocol: true);
 
 			// also include base interfaces/protocols
 			GenerateProtocolProperties (i, processed);
 		}
 	}
 
-	void GenerateProperties (Type type)
+	void GenerateProperties (Type type, bool fromProtocol = false)
 	{
 		foreach (var p in type.GetProperties (BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)) {
 			if (p.IsUnavailable (this))
@@ -162,6 +166,7 @@ public partial class Generator {
 			print_generated_code ();
 
 			var ptype = p.PropertyType.Name;
+			var nullable = false;
 			// keep C# names as they are reserved keywords (e.g. Boolean also exists in OpenGL for Mac)
 			switch (ptype) {
 			case "Boolean":
@@ -180,8 +185,17 @@ public partial class Generator {
 			case "CGImageMetadata":
 				ptype = "ImageIO.CGImageMetadata";
 				break;
+			case "CIVector":
+			case "CIColor":
+			case "CIImage":
+				// protocol-based bindings have annotations - but the older, key-based, versions did not
+				if (!fromProtocol)
+					nullable = true;
+				break;
 			}
-			print ("public {0} {1} {{", ptype, p.Name);
+			if (AttributeManager.HasAttribute<NullAllowedAttribute> (p))
+				nullable = true;
+			print ("public {0}{1} {2} {{", ptype, nullable ? "?" : "", p.Name);
 			indent++;
 
 			// an export will be present (only) if it's defined in a protocol
@@ -262,7 +276,8 @@ public partial class Generator {
 		case "CIColor":
 		case "CIImage":
 		case "CIVector":
-			print ($"return ValueForKey (\"{propertyName}\") as {propertyType};");
+			// `!` -> assume the method/property signature is correct (since it's based on headers)
+			print ($"return (ValueForKey (\"{propertyName}\") as {propertyType})!;");
 			break;
 		case "CGPoint":
 			print ("return GetPoint (\"{0}\");", propertyName);

--- a/src/generator.csproj
+++ b/src/generator.csproj
@@ -11,6 +11,8 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <BuildDir Condition="'$(BUILD_DIR)' != ''">$(BUILD_DIR)\</BuildDir>
     <BuildDir Condition="'$(BUILD_DIR)' == ''">build\</BuildDir>
+    <LangVersion>latest</LangVersion>
+    <NoWarn>8601,8618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -271,7 +271,7 @@ namespace HealthKit {
 		HKCategorySample FromType (HKCategoryType type, nint value, NSDate startDate, NSDate endDate, [NullAllowed] NSDictionary metadata);
 
 		[Static]
-		[Wrap ("FromType (type, value, startDate, endDate, metadata != null ? metadata.Dictionary : null)")]
+		[Wrap ("FromType (type, value, startDate, endDate, metadata.GetDictionary ())")]
 		HKCategorySample FromType (HKCategoryType type, nint value, NSDate startDate, NSDate endDate, HKMetadata metadata);
 
 		[Static]
@@ -309,7 +309,8 @@ namespace HealthKit {
 		[return: NullAllowed]
 		HKCdaDocumentSample Create (NSData documentData, NSDate startDate, NSDate endDate, [NullAllowed] NSDictionary metadata, out NSError validationError);
 
-		[Static, Wrap ("Create (documentData, startDate, endDate, metadata != null ? metadata.Dictionary : null, out validationError)")]
+		[Static, Wrap ("Create (documentData, startDate, endDate, metadata.GetDictionary (), out validationError)")]
+		[return: NullAllowed]
 		HKCdaDocumentSample Create (NSData documentData, NSDate startDate, NSDate endDate, HKMetadata metadata, out NSError validationError);
 	}
 
@@ -353,7 +354,7 @@ namespace HealthKit {
 		[EditorBrowsable (EditorBrowsableState.Advanced)] // this is not the one we want to be seen (compat only)
 		HKCorrelation Create (HKCorrelationType correlationType, NSDate startDate, NSDate endDate, NSSet objects, [NullAllowed] NSDictionary metadata);
 
-		[Static, Wrap ("Create (correlationType, startDate, endDate, objects, metadata != null ? metadata.Dictionary : null)")]
+		[Static, Wrap ("Create (correlationType, startDate, endDate, objects, metadata.GetDictionary ())")]
 		HKCorrelation Create (HKCorrelationType correlationType, NSDate startDate, NSDate endDate, NSSet objects, HKMetadata metadata);
 
 		[Static, Export ("correlationWithType:startDate:endDate:objects:")]
@@ -1017,7 +1018,8 @@ namespace HealthKit {
 
 		[Watch (5,0), iOS (12,0)]
 		[Static]
-		[Wrap ("GetClinicalType (identifier.GetConstant ())")]
+		[Wrap ("GetClinicalType (identifier.GetConstant ()!)")]
+		[return: NullAllowed]
 		HKClinicalType GetClinicalType (HKClinicalTypeIdentifier identifier);
 
 		[Watch (6, 0), iOS (13, 0)]
@@ -1154,7 +1156,7 @@ namespace HealthKit {
 		HKQuantitySample FromType (HKQuantityType quantityType, HKQuantity quantity, NSDate startDate, NSDate endDate, [NullAllowed] NSDictionary metadata);
 
 		[Static]
-		[Wrap ("FromType (quantityType, quantity, startDate, endDate, metadata != null ? metadata.Dictionary : null)")]
+		[Wrap ("FromType (quantityType, quantity, startDate, endDate, metadata.GetDictionary ())")]
 		HKQuantitySample FromType (HKQuantityType quantityType, HKQuantity quantity, NSDate startDate, NSDate endDate, HKMetadata metadata);
 
 		[iOS (9,0)]
@@ -1301,7 +1303,7 @@ namespace HealthKit {
 
 		[NoWatch, iOS (12,0)]
 		[Static]
-		[Wrap ("GetPredicateForClinicalRecords (resourceType.GetConstant ())")]
+		[Wrap ("GetPredicateForClinicalRecords (resourceType.GetConstant ()!)")]
 		NSPredicate GetPredicateForClinicalRecords (HKFhirResourceType resourceType);
 
 		[NoWatch, iOS (12,0)]
@@ -2211,14 +2213,14 @@ namespace HealthKit {
 		[EditorBrowsable (EditorBrowsableState.Advanced)] // this is not the one we want to be seen (compat only)
 		HKWorkout Create (HKWorkoutActivityType workoutActivityType, NSDate startDate, NSDate endDate, [NullAllowed] HKWorkoutEvent [] workoutEvents, [NullAllowed] HKQuantity totalEnergyBurned, [NullAllowed] HKQuantity totalDistance, [NullAllowed] NSDictionary metadata);
 
-		[Static, Wrap ("Create (workoutActivityType, startDate, endDate, workoutEvents, totalEnergyBurned, totalDistance, metadata == null ? null : metadata.Dictionary)")]
+		[Static, Wrap ("Create (workoutActivityType, startDate, endDate, workoutEvents, totalEnergyBurned, totalDistance, metadata.GetDictionary ())")]
 		HKWorkout Create (HKWorkoutActivityType workoutActivityType, NSDate startDate, NSDate endDate, HKWorkoutEvent [] workoutEvents, HKQuantity totalEnergyBurned, HKQuantity totalDistance, HKMetadata metadata);
 		
 		[Static, Export ("workoutWithActivityType:startDate:endDate:duration:totalEnergyBurned:totalDistance:metadata:")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)] // this is not the one we want to be seen (compat only)
 		HKWorkout Create (HKWorkoutActivityType workoutActivityType, NSDate startDate, NSDate endDate, double duration, [NullAllowed] HKQuantity totalEnergyBurned, [NullAllowed] HKQuantity totalDistance, [NullAllowed] NSDictionary metadata);
 
-		[Static, Wrap ("Create (workoutActivityType, startDate, endDate, duration, totalEnergyBurned, totalDistance, metadata == null ? null : metadata.Dictionary)")]
+		[Static, Wrap ("Create (workoutActivityType, startDate, endDate, duration, totalEnergyBurned, totalDistance, metadata.GetDictionary ())")]
 		HKWorkout Create (HKWorkoutActivityType workoutActivityType, NSDate startDate, NSDate endDate, double duration, HKQuantity totalEnergyBurned, HKQuantity totalDistance, HKMetadata metadata);
 
 		[iOS (9,0)]
@@ -2228,7 +2230,7 @@ namespace HealthKit {
 
 		[iOS (9,0)]
 		[Static]
-		[Wrap ("Create (workoutActivityType, startDate, endDate, workoutEvents, totalEnergyBurned, totalDistance, device, metadata == null ? null : metadata.Dictionary)")]
+		[Wrap ("Create (workoutActivityType, startDate, endDate, workoutEvents, totalEnergyBurned, totalDistance, device, metadata.GetDictionary ())")]
 		HKWorkout Create (HKWorkoutActivityType workoutActivityType, NSDate startDate, NSDate endDate, HKWorkoutEvent[] workoutEvents, HKQuantity totalEnergyBurned, HKQuantity totalDistance, HKDevice device, HKMetadata metadata);
 
 		[iOS (9,0)]
@@ -2238,7 +2240,7 @@ namespace HealthKit {
 
 		[iOS (9,0)]
 		[Static]
-		[Wrap ("Create (workoutActivityType, startDate, endDate, duration, totalEnergyBurned, totalDistance, device, metadata == null ? null : metadata.Dictionary)")]
+		[Wrap ("Create (workoutActivityType, startDate, endDate, duration, totalEnergyBurned, totalDistance, device, metadata.GetDictionary ())")]
 		HKWorkout Create (HKWorkoutActivityType workoutActivityType, NSDate startDate, NSDate endDate, double duration, HKQuantity totalEnergyBurned, HKQuantity totalDistance, HKDevice device, HKMetadata metadata);
 
 		[Watch (3,0), iOS (10,0)]
@@ -2248,7 +2250,7 @@ namespace HealthKit {
 
 		[Watch (3,0), iOS (10,0)]
 		[Static]
-		[Wrap ("Create (workoutActivityType, startDate, endDate, workoutEvents, totalEnergyBurned, totalDistance, totalSwimmingStrokeCount, device, metadata == null ? null : metadata.Dictionary)")]
+		[Wrap ("Create (workoutActivityType, startDate, endDate, workoutEvents, totalEnergyBurned, totalDistance, totalSwimmingStrokeCount, device, metadata.GetDictionary ())")]
 		HKWorkout Create (HKWorkoutActivityType workoutActivityType, NSDate startDate, NSDate endDate, HKWorkoutEvent[] workoutEvents, HKQuantity totalEnergyBurned, HKQuantity totalDistance, HKQuantity totalSwimmingStrokeCount, HKDevice device, HKMetadata metadata);
 
 		[Watch (4, 0), iOS (11, 0)]
@@ -2258,7 +2260,7 @@ namespace HealthKit {
 
 		[Watch (4, 0), iOS (11, 0)]
 		[Static]
-		[Wrap ("CreateFlightsClimbedWorkout (workoutActivityType, startDate, endDate, workoutEvents, totalEnergyBurned, totalDistance, totalFlightsClimbed, device, metadata == null ? null : metadata.Dictionary)")]
+		[Wrap ("CreateFlightsClimbedWorkout (workoutActivityType, startDate, endDate, workoutEvents, totalEnergyBurned, totalDistance, totalFlightsClimbed, device, metadata.GetDictionary ())")]
 		HKWorkout CreateFlightsClimbedWorkout (HKWorkoutActivityType workoutActivityType, NSDate startDate, NSDate endDate, [NullAllowed] HKWorkoutEvent [] workoutEvents, [NullAllowed] HKQuantity totalEnergyBurned, [NullAllowed] HKQuantity totalDistance, [NullAllowed] HKQuantity totalFlightsClimbed, [NullAllowed] HKDevice device, [NullAllowed] HKMetadata metadata);
 
 		// TODO: where is this thing used?
@@ -2324,7 +2326,7 @@ namespace HealthKit {
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
 		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
 		[Static]
-		[Wrap ("Create (type, date, metadata != null ? metadata.Dictionary : null)")]
+		[Wrap ("Create (type, date, metadata.GetDictionary ()!)")]
 		HKWorkoutEvent Create (HKWorkoutEventType type, NSDate date, HKMetadata metadata);
 
 		[Watch (4, 0), iOS (11, 0)]
@@ -2334,7 +2336,7 @@ namespace HealthKit {
 
 		[Watch (4, 0), iOS (11, 0)]
 		[Static]
-		[Wrap ("Create (type, dateInterval, metadata != null ? metadata.Dictionary : null)")]
+		[Wrap ("Create (type, dateInterval, metadata.GetDictionary ())")]
 		HKWorkoutEvent Create (HKWorkoutEventType type, NSDateInterval dateInterval, HKMetadata metadata);
 
 		[Watch (4, 0), iOS (11, 0)]
@@ -2734,7 +2736,7 @@ namespace HealthKit {
 		[Async, Protected, Export ("finishRouteWithWorkout:metadata:completion:")]
 		void FinishRoute (HKWorkout workout, [NullAllowed] NSDictionary metadata, Action<HKWorkoutRoute, NSError> completion);
 
-		[Async, Wrap ("FinishRoute (workout, metadata != null ? metadata.Dictionary : null, completion)")]
+		[Async, Wrap ("FinishRoute (workout, metadata.GetDictionary (), completion)")]
 		void FinishRoute (HKWorkout workout, HKMetadata metadata, Action<HKWorkoutRoute, NSError> completion);
 
 		[Watch (5, 0), iOS (12, 0)]
@@ -2743,7 +2745,7 @@ namespace HealthKit {
 		void AddMetadata (NSDictionary metadata, HKWorkoutRouteBuilderAddMetadataHandler completion);
 
 		[Watch (5, 0), iOS (12, 0)]
-		[Async, Wrap ("AddMetadata (metadata != null ? metadata.Dictionary : null, completion)")]
+		[Async, Wrap ("AddMetadata (metadata.GetDictionary ()!, completion)")]
 		void AddMetadata (HKMetadata metadata, HKWorkoutRouteBuilderAddMetadataHandler completion);
 	}
 
@@ -2803,7 +2805,7 @@ namespace HealthKit {
 		void Add (NSDictionary metadata, HKWorkoutBuilderCompletionHandler completionHandler);
 
 		[Async]
-		[Wrap ("Add (metadata.Dictionary, completionHandler)")]
+		[Wrap ("Add (metadata.GetDictionary ()!, completionHandler)")]
 		void Add (HKMetadata metadata, HKWorkoutBuilderCompletionHandler completionHandler);
 
 		[Async]
@@ -2880,7 +2882,7 @@ namespace HealthKit {
 		void FinishSeries ([NullAllowed] NSDictionary metadata, HKQuantitySeriesSampleBuilderFinishSeriesDelegate completionHandler);
 
 		[Async]
-		[Wrap ("FinishSeries (metadata?.Dictionary, completionHandler)")]
+		[Wrap ("FinishSeries (metadata.GetDictionary (), completionHandler)")]
 		void FinishSeries ([NullAllowed] HKMetadata metadata, HKQuantitySeriesSampleBuilderFinishSeriesDelegate completionHandler);
 
 		[Watch (6,0), iOS (13,0)]
@@ -2890,7 +2892,7 @@ namespace HealthKit {
 
 		[Watch (6,0), iOS (13,0)]
 		[Async]
-		[Wrap ("FinishSeries (metadata?.Dictionary, endDate, completionHandler)")]
+		[Wrap ("FinishSeries (metadata.GetDictionary (), endDate, completionHandler)")]
 		void FinishSeries ([NullAllowed] HKMetadata metadata, [NullAllowed] NSDate endDate, HKQuantitySeriesSampleBuilderFinishSeriesDelegate completionHandler);
 
 

--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -1808,7 +1808,7 @@ namespace HomeKit {
 		[Export ("initWithSignificantEvent:offset:")]
 		IntPtr Constructor (NSString significantEvent, [NullAllowed] NSDateComponents offset);
 
-		[Wrap ("this (HMSignificantEventExtensions.GetConstant (significantEvent), offset)")]
+		[Wrap ("this (HMSignificantEventExtensions.GetConstant (significantEvent)!, offset)")]
 		IntPtr Constructor (HMSignificantEvent significantEvent, [NullAllowed] NSDateComponents offset);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
@@ -1822,7 +1822,8 @@ namespace HomeKit {
 			set;
 		}
 
-		[NullAllowed, Export ("offset", ArgumentSemantic.Strong)]
+		// subclass does not allow null
+		[Export ("offset", ArgumentSemantic.Strong)]
 		NSDateComponents Offset { get; [NotImplemented] set; }
 	}
 
@@ -1834,7 +1835,7 @@ namespace HomeKit {
 		[Export ("initWithSignificantEvent:offset:")]
 		IntPtr Constructor (NSString significantEvent, [NullAllowed] NSDateComponents offset);
 
-		[Wrap ("this (HMSignificantEventExtensions.GetConstant (significantEvent), offset)")]
+		[Wrap ("this (HMSignificantEventExtensions.GetConstant (significantEvent)!, offset)")]
 		IntPtr Constructor (HMSignificantEvent significantEvent, [NullAllowed] NSDateComponents offset);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
@@ -1848,7 +1849,7 @@ namespace HomeKit {
 		HMSignificantEvent SignificantEvent {
 			[Wrap ("HMSignificantEventExtensions.GetValue (WeakSignificantEvent)")]
 			get;
-			[Wrap ("WeakSignificantEvent = HMSignificantEventExtensions.GetConstant (value)")]
+			[Wrap ("WeakSignificantEvent = HMSignificantEventExtensions.GetConstant (value)!")]
 			set;
 		}
 

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -1839,6 +1839,9 @@ namespace Intents {
 	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	public enum INIntentIdentifier {
+		[Field (null)]
+		None = -1,
+
 		[Unavailable (PlatformName.MacOSX)]
 		[Field ("INStartAudioCallIntentIdentifier")]
 		StartAudioCall,
@@ -3493,6 +3496,7 @@ namespace Intents {
 
 		[Unavailable (PlatformName.MacOSX)]
 		[Wrap ("INIntentIdentifierExtensions.GetValue (IdentifierString)")]
+		[NullAllowed]
 		INIntentIdentifier? Identifier { get; }
 
 		[Watch (4,0), Mac (10,13), iOS (11,0)]
@@ -6388,7 +6392,7 @@ namespace Intents {
 	interface INSpeakable {
 
 		[Abstract]
-		[NullAllowed, Export ("spokenPhrase")]
+		[Export ("spokenPhrase")]
 		string SpokenPhrase { get; }
 
 		[Abstract]

--- a/src/iosurface.cs
+++ b/src/iosurface.cs
@@ -125,7 +125,7 @@ namespace IOSurface {
 		[Internal, Export ("initWithProperties:")]
 		IntPtr Constructor (NSDictionary properties);
 
-		[Wrap ("this (properties == null ? null : properties.Dictionary)")]
+		[Wrap ("this (properties.GetDictionary ()!)")]
 		IntPtr Constructor (IOSurfaceOptions properties);
 	
 		[Internal, Export ("lockWithOptions:seed:")]

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -927,7 +927,7 @@ namespace MapKit {
 
 #if IOS
 		// This requires the AddressBook framework, which afaict isn't bound on Mac, tvOS and watchOS yet
-		[Wrap ("this (coordinate, addressDictionary == null ? null : addressDictionary.Dictionary)")]
+		[Wrap ("this (coordinate, addressDictionary.GetDictionary ())")]
 		IntPtr Constructor (CLLocationCoordinate2D coordinate, MKPlacemarkAddress addressDictionary);
 #endif // !MONOMAC && !WATCH
 

--- a/src/metalkit.cs
+++ b/src/metalkit.cs
@@ -243,21 +243,21 @@ namespace MetalKit {
 		[Export ("newTextureWithContentsOfURL:options:completionHandler:"), Internal]
 		void FromUrl (NSUrl url, [NullAllowed] NSDictionary options, MTKTextureLoaderCallback completionHandler);
 
-		[Wrap ("FromUrl (url, options == null ? null : options.Dictionary, completionHandler)")]
+		[Wrap ("FromUrl (url, options.GetDictionary (), completionHandler)")]
 		[Async]
 		void FromUrl (NSUrl url, [NullAllowed] MTKTextureLoaderOptions options, MTKTextureLoaderCallback completionHandler);
 
 		[Export ("newTextureWithData:options:completionHandler:"), Internal]
 		void FromData (NSData data, [NullAllowed] NSDictionary options, MTKTextureLoaderCallback completionHandler);
 
-		[Wrap ("FromData (data, options == null ? null : options.Dictionary, completionHandler)")]
+		[Wrap ("FromData (data, options.GetDictionary (), completionHandler)")]
 		[Async]
 		void FromData (NSData data, [NullAllowed] MTKTextureLoaderOptions options, MTKTextureLoaderCallback completionHandler);
 
 		[Export ("newTextureWithCGImage:options:completionHandler:"), Internal]
 		void FromCGImage (CGImage cgImage, [NullAllowed] NSDictionary options, MTKTextureLoaderCallback completionHandler);
 
-		[Wrap ("FromCGImage (cgImage, options == null ? null : options.Dictionary, completionHandler)")]
+		[Wrap ("FromCGImage (cgImage, options.GetDictionary (), completionHandler)")]
 		[Async]
 		void FromCGImage (CGImage cgImage, [NullAllowed] MTKTextureLoaderOptions options, MTKTextureLoaderCallback completionHandler);
 
@@ -265,7 +265,7 @@ namespace MetalKit {
 		[return: NullAllowed]
 		IMTLTexture FromUrl (NSUrl url, [NullAllowed] NSDictionary options, out NSError error);
 
-		[Wrap ("FromUrl (url, options == null ? null : options.Dictionary, out error)")]
+		[Wrap ("FromUrl (url, options.GetDictionary (), out error)")]
 		[return: NullAllowed]
 		IMTLTexture FromUrl (NSUrl url, [NullAllowed] MTKTextureLoaderOptions options, out NSError error);
 
@@ -275,7 +275,7 @@ namespace MetalKit {
 		void FromUrls (NSUrl[] urls, [NullAllowed] NSDictionary options, MTKTextureLoaderArrayCallback completionHandler);
 
 		[iOS (10,0)][Mac (10,12)]
-		[Wrap ("FromUrls (urls, options == null ? null : options.Dictionary, completionHandler)")]
+		[Wrap ("FromUrls (urls, options.GetDictionary (), completionHandler)")]
 		[Async]
 		void FromUrls (NSUrl[] urls, [NullAllowed] MTKTextureLoaderOptions options, MTKTextureLoaderArrayCallback completionHandler);
 
@@ -284,14 +284,14 @@ namespace MetalKit {
 		IMTLTexture[] FromUrls (NSUrl[] urls, [NullAllowed] NSDictionary options, out NSError error);
 
 		[iOS (10,0)][Mac (10,12)]
-		[Wrap ("FromUrls (urls, options == null ? null : options.Dictionary, out error)")]
+		[Wrap ("FromUrls (urls, options.GetDictionary (), out error)")]
 		IMTLTexture[] FromUrls (NSUrl[] urls, [NullAllowed] MTKTextureLoaderOptions options, out NSError error);
 
 		[Export ("newTextureWithData:options:error:"), Internal]
 		[return: NullAllowed]
 		IMTLTexture FromData (NSData data, [NullAllowed] NSDictionary options, out NSError error);
 
-		[Wrap ("FromData (data, options == null ? null : options.Dictionary, out error)")]
+		[Wrap ("FromData (data, options.GetDictionary (), out error)")]
 		[return: NullAllowed]
 		IMTLTexture FromData (NSData data, [NullAllowed] MTKTextureLoaderOptions options, out NSError error);
 
@@ -299,7 +299,7 @@ namespace MetalKit {
 		[return: NullAllowed]
 		IMTLTexture FromCGImage (CGImage cgImage, [NullAllowed] NSDictionary options, out NSError error);
 
-		[Wrap ("FromCGImage (cgImage, options == null ? null : options.Dictionary, out error)")]
+		[Wrap ("FromCGImage (cgImage, options.GetDictionary (), out error)")]
 		[return: NullAllowed]
 		IMTLTexture FromCGImage (CGImage cgImage, [NullAllowed] MTKTextureLoaderOptions options, out NSError error);
 
@@ -309,7 +309,7 @@ namespace MetalKit {
 		void FromName (string name, nfloat scaleFactor, [NullAllowed] NSBundle bundle, [NullAllowed] NSDictionary options, MTKTextureLoaderCallback completionHandler);
 
 		[iOS (10,0)][Mac (10,12)]
-		[Wrap ("FromName (name, scaleFactor, bundle, options == null ? null : options.Dictionary, completionHandler)")]
+		[Wrap ("FromName (name, scaleFactor, bundle, options.GetDictionary (), completionHandler)")]
 		[Async]
 		void FromName (string name, nfloat scaleFactor, [NullAllowed] NSBundle bundle, [NullAllowed] MTKTextureLoaderOptions options, MTKTextureLoaderCallback completionHandler);
 
@@ -323,7 +323,7 @@ namespace MetalKit {
 		[NoiOS]
 		[NoTV]
 		[Mac (10,12)]
-		[Wrap ("FromName (name, scaleFactor, displayGamut, bundle, options == null ? null : options.Dictionary, completionHandler)")]
+		[Wrap ("FromName (name, scaleFactor, displayGamut, bundle, options.GetDictionary (), completionHandler)")]
 		[Async]
 		void FromName (string name, nfloat scaleFactor, NSDisplayGamut displayGamut, [NullAllowed] NSBundle bundle, [NullAllowed] MTKTextureLoaderOptions options, MTKTextureLoaderCallback completionHandler);
 
@@ -333,7 +333,7 @@ namespace MetalKit {
 		void FromNames (string[] names, nfloat scaleFactor, [NullAllowed] NSBundle bundle, [NullAllowed] NSDictionary options, MTKTextureLoaderArrayCallback completionHandler);
 
 		[iOS (10,0)][Mac (10,12)]
-		[Wrap ("FromNames (names, scaleFactor, bundle, options == null ? null : options.Dictionary, completionHandler)")]
+		[Wrap ("FromNames (names, scaleFactor, bundle, options.GetDictionary (), completionHandler)")]
 		[Async]
 		void FromNames (string[] names, nfloat scaleFactor, [NullAllowed] NSBundle bundle, [NullAllowed] MTKTextureLoaderOptions options, MTKTextureLoaderArrayCallback completionHandler);
 
@@ -347,7 +347,7 @@ namespace MetalKit {
 		[NoiOS]
 		[NoTV]
 		[Mac (10,12)]
-		[Wrap ("FromNames (names, scaleFactor, displayGamut, bundle, options == null ? null : options.Dictionary, completionHandler)")]
+		[Wrap ("FromNames (names, scaleFactor, displayGamut, bundle, options.GetDictionary (), completionHandler)")]
 		[Async]
 		void FromNames (string[] names, nfloat scaleFactor, NSDisplayGamut displayGamut, [NullAllowed] NSBundle bundle, [NullAllowed] MTKTextureLoaderOptions options, MTKTextureLoaderArrayCallback completionHandler);
 
@@ -357,7 +357,7 @@ namespace MetalKit {
 		void FromTexture (MDLTexture texture, [NullAllowed] NSDictionary options, MTKTextureLoaderCallback completionHandler);
 
 		[iOS (10,0)][Mac (10,12)]
-		[Wrap ("FromTexture (texture, options == null ? null : options.Dictionary, completionHandler)")]
+		[Wrap ("FromTexture (texture, options.GetDictionary (), completionHandler)")]
 		[Async]
 		void FromTexture (MDLTexture texture, [NullAllowed] MTKTextureLoaderOptions options, MTKTextureLoaderCallback completionHandler);
 
@@ -367,7 +367,7 @@ namespace MetalKit {
 		IMTLTexture FromTexture (MDLTexture texture, [NullAllowed] NSDictionary options, out NSError error);
 
 		[iOS (10,0)][Mac (10,12)]
-		[Wrap ("FromTexture (texture, options == null ? null : options.Dictionary, out error)")]
+		[Wrap ("FromTexture (texture, options.GetDictionary (), out error)")]
 		[return: NullAllowed]
 		IMTLTexture FromTexture (MDLTexture texture, [NullAllowed] MTKTextureLoaderOptions options, out NSError error);
 
@@ -377,7 +377,7 @@ namespace MetalKit {
 		IMTLTexture FromName (string name, nfloat scaleFactor, [NullAllowed] NSBundle bundle, [NullAllowed] NSDictionary options, out NSError error);
 
 		[iOS (10,0)][Mac (10,12)]
-		[Wrap ("FromName (name, scaleFactor, bundle, options == null ? null : options.Dictionary, out error)")]
+		[Wrap ("FromName (name, scaleFactor, bundle, options.GetDictionary (), out error)")]
 		[return: NullAllowed]
 		IMTLTexture FromName (string name, nfloat scaleFactor, [NullAllowed] NSBundle bundle, [NullAllowed] MTKTextureLoaderOptions options, out NSError error);
 
@@ -391,7 +391,7 @@ namespace MetalKit {
 		[NoiOS]
 		[NoTV]
 		[Mac (10,12)]
-		[Wrap ("FromName (name, scaleFactor, displayGamut, bundle, options == null ? null : options.Dictionary, out error)")]
+		[Wrap ("FromName (name, scaleFactor, displayGamut, bundle, options.GetDictionary (), out error)")]
 		[return: NullAllowed]
 		IMTLTexture FromName (string name, nfloat scaleFactor, NSDisplayGamut displayGamut, [NullAllowed] NSBundle bundle, [NullAllowed] MTKTextureLoaderOptions options, [NullAllowed] out NSError error);
 	}

--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -156,7 +156,8 @@ namespace ModelIO {
 		IMDLComponent GetComponent (Protocol protocol);
 
 		[iOS (10,3), TV (10,2), Mac (10,12,4)]
-		[Wrap ("GetComponent (new Protocol (type))")]
+		[Wrap ("GetComponent (new Protocol (type!))")]
+		[return: NullAllowed]
 		IMDLComponent GetComponent (Type type);
 
 		[iOS (10,0)]
@@ -1181,7 +1182,7 @@ namespace ModelIO {
 		[Export ("setComponent:forProtocol:")]
 		void SetComponent (IMDLComponent component, Protocol protocol);
 
-		[Wrap ("SetComponent (component, new Protocol (type))")]
+		[Wrap ("SetComponent (component, new Protocol (type!))")]
 		void SetComponent (IMDLComponent component, Type type);
 
 #if XAMCORE_4_0
@@ -1193,10 +1194,12 @@ namespace ModelIO {
 		IMDLComponent IsComponentConforming (Protocol protocol);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
-		[Wrap ("IsComponentConforming (protocol)")]
+		[Wrap ("IsComponentConforming (protocol!)")]
+		[return: NullAllowed]
 		IMDLComponent GetComponent (Protocol protocol);
 
-		[Wrap ("GetComponent (new Protocol (type))")]
+		[Wrap ("GetComponent (new Protocol (type!))")]
+		[return: NullAllowed]
 		IMDLComponent GetComponent (Type type);
 
 		[NullAllowed, Export ("parent", ArgumentSemantic.Weak)]

--- a/src/naturallanguage.cs
+++ b/src/naturallanguage.cs
@@ -73,7 +73,7 @@ namespace NaturalLanguage {
 		NLLanguage[] LanguageConstraints {
 			[Wrap ("Array.ConvertAll (_LanguageConstraints, e => NLLanguageExtensions.GetValue (e))")]
 			get;
-			[Wrap ("_LanguageConstraints = Array.ConvertAll (value, e => NLLanguageExtensions.GetConstant (e))")]
+			[Wrap ("_LanguageConstraints = Array.ConvertAll (value, e => NLLanguageExtensions.GetConstant (e)!)")]
 			set;
 		}
 	}
@@ -148,7 +148,7 @@ namespace NaturalLanguage {
 		[Export ("setLanguage:")]
 		void _SetLanguage (NSString language);
 
-		[Wrap ("_SetLanguage (language.GetConstant ())")]
+		[Wrap ("_SetLanguage (language.GetConstant ()!)")]
 		void SetLanguage (NLLanguage language);
 
 		[Export ("tokenRangeAtIndex:")]
@@ -173,7 +173,7 @@ namespace NaturalLanguage {
 		[DesignatedInitializer]
 		IntPtr Constructor ([Params] NSString[] tagSchemes);
 
-		[Wrap ("this (Array.ConvertAll (tagSchemes, e => e.GetConstant ()))")]
+		[Wrap ("this (Array.ConvertAll (tagSchemes, e => e.GetConstant ()!))")]
 		IntPtr Constructor ([Params] NLTagScheme[] tagSchemes);
 
 		[Internal]
@@ -192,7 +192,7 @@ namespace NaturalLanguage {
 		NSString[] GetAvailableTagSchemes (NLTokenUnit unit, NSString language);
 
 		[Static]
-		[Wrap ("Array.ConvertAll (GetAvailableTagSchemes (unit, language.GetConstant()), e => NLTagSchemeExtensions.GetValue (e))")]
+		[Wrap ("Array.ConvertAll (GetAvailableTagSchemes (unit, language.GetConstant()!), e => NLTagSchemeExtensions.GetValue (e))")]
 		NLTagScheme[] GetAvailableTagSchemes (NLTokenUnit unit, NLLanguage language);
 
 		[Export ("tokenRangeAtIndex:unit:")]
@@ -209,7 +209,7 @@ namespace NaturalLanguage {
 		[Export ("enumerateTagsInRange:unit:scheme:options:usingBlock:")]
 		void EnumerateTags (NSRange range, NLTokenUnit unit, NSString scheme, NLTaggerOptions options, NLTaggerEnumerateTagsContinuationHandler handler);
 
-		[Wrap ("EnumerateTags (range, unit, scheme.GetConstant (), options, handler)")]
+		[Wrap ("EnumerateTags (range, unit, scheme.GetConstant ()!, options, handler)")]
 		void EnumerateTags (NSRange range, NLTokenUnit unit, NLTagScheme scheme, NLTaggerOptions options, NLTaggerEnumerateTagsContinuationHandler handler);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
@@ -218,21 +218,21 @@ namespace NaturalLanguage {
 		NSString GetTag (nuint characterIndex, NLTokenUnit unit, NSString scheme, out NSRange tokenRange);
 
 		[return: NullAllowed]
-		[Wrap ("GetTag (characterIndex, unit, scheme.GetConstant (), out tokenRange)")]
+		[Wrap ("GetTag (characterIndex, unit, scheme.GetConstant ()!, out tokenRange)")]
 		NSString GetTag (nuint characterIndex, NLTokenUnit unit, NLTagScheme scheme, out NSRange tokenRange);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("tagsInRange:unit:scheme:options:tokenRanges:")]
 		NSString[] GetTags (NSRange range, NLTokenUnit unit, NSString scheme, NLTaggerOptions options, [NullAllowed] out NSValue[] tokenRanges);
 
-		[Wrap ("GetTags (range, unit, scheme.GetConstant (), options, out tokenRanges)")]
+		[Wrap ("GetTags (range, unit, scheme.GetConstant ()!, options, out tokenRanges)")]
 		NSString[] GetTags (NSRange range, NLTokenUnit unit, NLTagScheme scheme, NLTaggerOptions options, [NullAllowed] out NSValue[] tokenRanges);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("setLanguage:range:")]
 		void SetLanguage (NSString language, NSRange range);
 
-		[Wrap ("SetLanguage (language.GetConstant (), range)")]
+		[Wrap ("SetLanguage (language.GetConstant ()!, range)")]
 		void SetLanguage (NLLanguage language, NSRange range);
 
 		[Export ("setOrthography:range:")]
@@ -242,14 +242,14 @@ namespace NaturalLanguage {
 		[Export ("setModels:forTagScheme:")]
 		void SetModels (NLModel[] models, NSString tagScheme);
 
-		[Wrap ("SetModels (models, tagScheme.GetConstant ())")]
+		[Wrap ("SetModels (models, tagScheme.GetConstant ()!)")]
 		void SetModels (NLModel[] models, NLTagScheme tagScheme);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("modelsForTagScheme:")]
 		NLModel[] GetModels (NSString tagScheme);
 
-		[Wrap ("GetModels (tagScheme.GetConstant ())")]
+		[Wrap ("GetModels (tagScheme.GetConstant ()!)")]
 		NLModel[] GetModels (NLTagScheme tagScheme);
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
@@ -258,7 +258,7 @@ namespace NaturalLanguage {
 		void SetGazetteers (NLGazetteer[] gazetteers, NSString tagScheme);
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
-		[Wrap ("SetGazetteers (gazetteers, tagScheme.GetConstant ())")]
+		[Wrap ("SetGazetteers (gazetteers, tagScheme.GetConstant ()!)")]
 		void SetGazetteers (NLGazetteer[] gazetteers, NLTagScheme tagScheme);
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
@@ -267,7 +267,7 @@ namespace NaturalLanguage {
 		NLGazetteer[] GetGazetteers (NSString tagScheme);
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
-		[Wrap ("GetGazetteers (tagScheme.GetConstant ())")]
+		[Wrap ("GetGazetteers (tagScheme.GetConstant ()!)")]
 		NLGazetteer[] GetGazetteers (NLTagScheme tagScheme);
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
@@ -280,7 +280,7 @@ namespace NaturalLanguage {
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[Static]
 		[Async]
-		[Wrap ("RequestAssets (language.GetConstant (), tagScheme.GetConstant (), completionHandler)")]
+		[Wrap ("RequestAssets (language.GetConstant ()!, tagScheme.GetConstant ()!, completionHandler)")]
 		void RequestAssets (NLLanguage language, NLTagScheme tagScheme, Action<NLTaggerAssetsResult, NSError> completionHandler);
 	}
 
@@ -380,7 +380,7 @@ namespace NaturalLanguage {
 		NLEmbedding GetWordEmbedding (NSString language);
 
 		[Static]
-		[Wrap ("GetWordEmbedding (language.GetConstant ())")]
+		[Wrap ("GetWordEmbedding (language.GetConstant ()!)")]
 		[return: NullAllowed]
 		NLEmbedding GetWordEmbedding (NLLanguage language);
 
@@ -391,7 +391,7 @@ namespace NaturalLanguage {
 		NLEmbedding GetWordEmbedding (NSString language, nuint revision);
 
 		[Static]
-		[Wrap ("GetWordEmbedding (language.GetConstant ())")]
+		[Wrap ("GetWordEmbedding (language.GetConstant ()!)")]
 		[return: NullAllowed]
 		NLEmbedding GetWordEmbedding (NLLanguage language, nuint revision);
 
@@ -460,7 +460,7 @@ namespace NaturalLanguage {
 		NSIndexSet GetSupportedRevisions (NSString language);
 
 		[Static]
-		[Wrap ("GetSupportedRevisions (language.GetConstant ())")]
+		[Wrap ("GetSupportedRevisions (language.GetConstant ()!)")]
 		NSIndexSet GetSupportedRevisions (NLLanguage language);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
@@ -469,7 +469,7 @@ namespace NaturalLanguage {
 		nuint GetCurrentRevision (NSString language);
 
 		[Static]
-		[Wrap ("GetCurrentRevision (language.GetConstant ())")]
+		[Wrap ("GetCurrentRevision (language.GetConstant ()!)")]
 		nuint GetCurrentRevision (NLLanguage language);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
@@ -478,7 +478,7 @@ namespace NaturalLanguage {
 		bool Write (NSDictionary dictionary, [NullAllowed] NSString language, nuint revision, NSUrl url, [NullAllowed] out NSError error);
 
 		[Static]
-		[Wrap ("Write (dictionary.GetDictionary (), language.HasValue ? language.Value.GetConstant () : null, revision, url, out error)")]
+		[Wrap ("Write (dictionary.GetDictionary ()!, language.HasValue ? language.Value.GetConstant () : null, revision, url, out error)")]
 		bool Write (NLVectorDictionary dictionary, NLLanguage? language, nuint revision, NSUrl url, [NullAllowed] out NSError error);
 	}
 
@@ -507,7 +507,7 @@ namespace NaturalLanguage {
 
 		// sadly `language?.GetConstant ()` does not cut it :(
 		// error CS1929: 'NLLanguage?' does not contain a definition for 'GetConstant' and the best extension method overload 'NLLanguageExtensions.GetConstant(NLLanguage)' requires a receiver of type 'NLLanguage'
-		[Wrap ("this (dictionary.GetDictionary (), language.HasValue ? language.Value.GetConstant () : null, out error)")]
+		[Wrap ("this (dictionary.GetDictionary ()!, language.HasValue ? language.Value.GetConstant () : null, out error)")]
 		IntPtr Constructor (NLStrongDictionary dictionary, NLLanguage? language, [NullAllowed] out NSError error);
 
 		[Export ("labelForString:")]
@@ -527,7 +527,7 @@ namespace NaturalLanguage {
 		bool Write (NSDictionary dictionary, [NullAllowed] NSString language, NSUrl url, [NullAllowed] out NSError error);
 
 		[Static]
-		[Wrap ("Write (dictionary.GetDictionary (), language.HasValue ? language.Value.GetConstant () : null, url, out error)")]
+		[Wrap ("Write (dictionary.GetDictionary ()!, language.HasValue ? language.Value.GetConstant () : null, url, out error)")]
 		bool Write (NLStrongDictionary dictionary, NLLanguage? language, NSUrl url, [NullAllowed] out NSError error);
 	}
 }

--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -695,7 +695,7 @@ namespace NetworkExtension {
 		bool Register ([NullAllowed] NSDictionary options, DispatchQueue queue, NEHotspotHelperHandler handler);
 
 		[Static]
-		[Wrap ("Register (options == null ? null : options.Dictionary, queue, handler)")]
+		[Wrap ("Register (options.GetDictionary (), queue, handler)")]
 		bool Register ([NullAllowed] NEHotspotHelperOptions options, DispatchQueue queue, NEHotspotHelperHandler handler);
 
 		[Static]
@@ -1038,7 +1038,7 @@ namespace NetworkExtension {
 		NEAppRule[] AppRules { get; set; }
 #else
 		[Obsolete ("Use 'CopyAppRules' instead, this property will be removed in the future.")]
-		NEAppRule[] AppRules { [Wrap ("CopyAppRules ()", IsVirtual = true)] get; }
+		NEAppRule[] AppRules { [Wrap ("CopyAppRules ()!", IsVirtual = true)] get; }
 #endif
 
 		[Export ("routingMethod")]
@@ -1149,7 +1149,7 @@ namespace NetworkExtension {
 		bool StartVpnTunnel ([NullAllowed] NSDictionary options, out NSError error);
 
 		[iOS (9,0)][Mac (10,11)]
-		[Wrap ("StartVpnTunnel (options == null ? null : options.Dictionary, out error);")]
+		[Wrap ("StartVpnTunnel (options.GetDictionary (), out error);")]
 		bool StartVpnTunnel ([NullAllowed] NEVpnConnectionStartOptions options, out NSError error);
 
 		[Export ("stopVPNTunnel")]

--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -483,7 +483,7 @@ namespace PassKit {
 
 		[Watch (4,0)][iOS (11,0)]
 		[Static]
-		[Wrap ("CreatePaymentContactInvalidError (contactField.GetConstant (), localizedDescription)")]
+		[Wrap ("CreatePaymentContactInvalidError (contactField.GetConstant ()!, localizedDescription)")]
 		NSError CreatePaymentContactInvalidError (PKContactFields contactField, [NullAllowed] string localizedDescription);
 
 		[Watch (4,0)][iOS (11,0)]
@@ -495,7 +495,7 @@ namespace PassKit {
 #if XAMCORE_2_0
 		[Watch (4,0)][iOS (11,0)]
 		[Static]
-		[Wrap ("CreatePaymentShippingAddressInvalidError (postalAddress.GetConstant (), localizedDescription)")]
+		[Wrap ("CreatePaymentShippingAddressInvalidError (postalAddress.GetConstant ()!, localizedDescription)")]
 		NSError CreatePaymentShippingAddressInvalidError (CNPostalAddressKeyOption postalAddress, [NullAllowed] string localizedDescription);
 #endif
 
@@ -508,7 +508,7 @@ namespace PassKit {
 #if XAMCORE_2_0
 		[Watch (4,0)][iOS (11,0)]
 		[Static]
-		[Wrap ("CreatePaymentBillingAddressInvalidError (postalAddress.GetConstant (), localizedDescription)")]
+		[Wrap ("CreatePaymentBillingAddressInvalidError (postalAddress.GetConstant ()!, localizedDescription)")]
 		NSError CreatePaymentBillingAddressInvalidError (CNPostalAddressKeyOption postalAddress, [NullAllowed] string localizedDescription);
 #endif
 

--- a/src/pdfkit.cs
+++ b/src/pdfkit.cs
@@ -547,7 +547,7 @@ namespace PdfKit {
 		IntPtr Constructor (CGRect bounds, NSString annotationType, [NullAllowed] NSDictionary properties);
 
 		[Mac (10,13)]
-		[Wrap ("this (bounds, annotationType.GetConstant (), properties)")]
+		[Wrap ("this (bounds, annotationType.GetConstant ()!, properties)")]
 		IntPtr Constructor (CGRect bounds, PdfAnnotationKey annotationType, [NullAllowed] NSDictionary properties);
 
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use '.ctor (CGRect, PDFAnnotationKey, NSDictionary)' instead.")]
@@ -648,7 +648,7 @@ namespace PdfKit {
 		bool SetValue (bool boolean, NSString key);
 
 		[Mac (10,12)]
-		[Wrap ("SetValue (boolean, key.GetConstant ())")]
+		[Wrap ("SetValue (boolean, key.GetConstant ()!)")]
 		bool SetValue (bool boolean, PdfAnnotationKey key);
 
 		[Protected]
@@ -657,7 +657,7 @@ namespace PdfKit {
 		bool SetValue (CGRect rect, NSString key);
 
 		[Mac (10,12)]
-		[Wrap ("SetValue (rect, key.GetConstant ())")]
+		[Wrap ("SetValue (rect, key.GetConstant ()!)")]
 		bool SetValue (CGRect rect, PdfAnnotationKey key);
 
 		[Mac (10,13)]
@@ -670,7 +670,7 @@ namespace PdfKit {
 		void RemoveValue (NSString key);
 
 		[Mac (10,12)]
-		[Wrap ("RemoveValue (key.GetConstant ())")]
+		[Wrap ("RemoveValue (key.GetConstant ()!)")]
 		void RemoveValue (PdfAnnotationKey key);
 
 		// PDFAnnotation (PDFAnnotationUtilities) Category
@@ -1179,7 +1179,7 @@ namespace PdfKit {
 		[Wrap ("new PdfDocumentAttributes (DocumentAttributes)")]
 		PdfDocumentAttributes GetDocumentAttributes ();
 
-		[Wrap ("DocumentAttributes = attributes?.Dictionary")]
+		[Wrap ("DocumentAttributes = attributes.GetDictionary ()!")]
 		void SetDocumentAttributes (PdfDocumentAttributes attributes);
 
 #if XAMCORE_4_0 || IOS
@@ -1257,7 +1257,7 @@ namespace PdfKit {
 		bool Write (string path, NSDictionary options);
 
 		[Mac (10,13)]
-		[Wrap ("Write (path, options.Dictionary)")]
+		[Wrap ("Write (path, options.GetDictionary ()!)")]
 		bool Write (string path, PdfDocumentWriteOptions options);
 
 		[Export ("writeToURL:")]
@@ -1267,7 +1267,7 @@ namespace PdfKit {
 		bool Write (NSUrl url, NSDictionary options);
 
 		[Mac (10,13)]
-		[Wrap ("Write (url, options?.Dictionary)")]
+		[Wrap ("Write (url, options.GetDictionary ()!)")]
 		bool Write (NSUrl url, PdfDocumentWriteOptions options);
 
 		[NullAllowed]

--- a/src/photos.cs
+++ b/src/photos.cs
@@ -1229,14 +1229,14 @@ namespace Photos
 		void PrepareLivePhotoForPlayback (CGSize targetSize, Action<PHLivePhoto, NSError> handler);
 
 		[Async]
-		[Wrap ("_PrepareLivePhotoForPlayback (targetSize, (NSDictionary)options, handler)", IsVirtual = true)]
+		[Wrap ("_PrepareLivePhotoForPlayback (targetSize, (options as NSDictionary), handler)", IsVirtual = true)]
 		void PrepareLivePhotoForPlayback (CGSize targetSize, [NullAllowed] NSDictionary<NSString, NSObject> options, Action<PHLivePhoto, NSError> handler);
 
 #if XAMCORE_2_0
 		// the API existed earlier but the key needed to create the strong dictionary did not work
 		[iOS (11,0)][TV (11,0)][Mac (10,12)]
 		[Async]
-		[Wrap ("_PrepareLivePhotoForPlayback (targetSize, options?.Dictionary, handler)")]
+		[Wrap ("_PrepareLivePhotoForPlayback (targetSize, options.GetDictionary (), handler)")]
 		void PrepareLivePhotoForPlayback (CGSize targetSize, [NullAllowed] PHLivePhotoEditingOption options, Action<PHLivePhoto, NSError> handler);
 #endif
 
@@ -1256,7 +1256,7 @@ namespace Photos
 		// the API existed earlier but the key needed to create the strong dictionary did not work
 		[iOS (11,0)][TV (11,0)][Mac (10,12)]
 		[Async]
-		[Wrap ("_SaveLivePhoto (output, options?.Dictionary, handler)")]
+		[Wrap ("_SaveLivePhoto (output, options.GetDictionary (), handler)")]
 		void SaveLivePhoto (PHContentEditingOutput output, [NullAllowed] PHLivePhotoEditingOption options, Action<bool, NSError> handler);
 #endif
 

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -229,7 +229,6 @@ namespace SceneKit {
 #if XAMCORE_4_0
 		[Abstract]
 #endif
-		[return: NullAllowed]
 		[iOS (11,0), TV (11,0), Watch (4,0), Mac (10,13)]
 		[Export ("removeAnimationForKey:blendOutDuration:")]
 		void RemoveAnimationUsingBlendOutDuration (NSString key, nfloat blendOutDuration);
@@ -1759,6 +1758,7 @@ namespace SceneKit {
 		bool BoundingBoxOnly { get; set; }
 		bool IgnoreChildNodes { get; set; }
 		bool IgnoreHiddenNodes { get; set; }
+		[NullAllowed]
 		SCNNode RootNode { get; set; }
 		SCNHitTestSearchMode SearchMode { get; set; }
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
@@ -1962,7 +1962,7 @@ namespace SceneKit {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		SCNHitTestResult [] HitTest (SCNVector3 pointA, SCNVector3 pointB, [NullAllowed] NSDictionary options);
 
-		[Wrap ("HitTest (pointA, pointB, options == null ? null : options.Dictionary)")]
+		[Wrap ("HitTest (pointA, pointB, options.GetDictionary ())")]
 		SCNHitTestResult [] HitTest (SCNVector3 pointA, SCNVector3 pointB, SCNHitTestOptions options);
 
 		[Mac (10,10)]
@@ -2442,7 +2442,7 @@ namespace SceneKit {
 
 #if !WATCH
 		[NoWatch]
-		[Wrap ("SetSemantic (geometrySourceSemantic, symbol, options == null ? null : options.Dictionary)")]
+		[Wrap ("SetSemantic (geometrySourceSemantic, symbol, options.GetDictionary ())")]
 		void SetSemantic (NSString geometrySourceSemantic, string symbol, SCNProgramSemanticOptions options);
 #endif
 
@@ -2652,7 +2652,7 @@ namespace SceneKit {
 		SCNScene FromUrl (NSUrl url, [NullAllowed] NSDictionary options, out NSError error);
 
 		[Static]
-		[Wrap ("FromUrl (url, options == null ? null : options.Dictionary, out error)")]
+		[Wrap ("FromUrl (url, options.GetDictionary (), out error)")]
 		SCNScene FromUrl (NSUrl url, [NullAllowed] SCNSceneLoadingOptions options, out NSError error);
 
 		
@@ -2703,7 +2703,7 @@ namespace SceneKit {
 		SCNScene FromFile (string name, [NullAllowed] string directory, [NullAllowed] NSDictionary options);
 
 		[Mac (10,10), iOS (8,0)]
-		[Static, Wrap ("FromFile (name, directory, options == null ? null : options.Dictionary)")]
+		[Static, Wrap ("FromFile (name, directory, options.GetDictionary ())")]
 		SCNScene FromFile (string name, string directory, SCNSceneLoadingOptions options);
 
 		// Keeping here the same name WriteToUrl for iOS and friends because it is how it was bound
@@ -2717,7 +2717,7 @@ namespace SceneKit {
 			[NullAllowed] SCNSceneExportProgressHandler exportProgressHandler);
 
 		[TV (10, 0), NoWatch, Mac (10, 9), iOS (10, 0)]
-		[Wrap ("WriteToUrl (url, options == null ? null : options.Dictionary, handler, exportProgressHandler)")]
+		[Wrap ("WriteToUrl (url, options.GetDictionary (), handler, exportProgressHandler)")]
 		bool WriteToUrl (NSUrl url, SCNSceneLoadingOptions options, ISCNSceneExportDelegate handler, SCNSceneExportProgressHandler exportProgressHandler);
 
 		#region SCNParticleSystemSupport (SCNNode) category
@@ -2805,7 +2805,7 @@ namespace SceneKit {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		SCNSceneSource FromUrl (NSUrl url, [NullAllowed] NSDictionary options);
 
-		[Wrap ("FromUrl (url, options == null ? null : options.Dictionary)")]
+		[Wrap ("FromUrl (url, options.GetDictionary ())")]
 		SCNSceneSource FromUrl (NSUrl url, SCNSceneLoadingOptions options);
 
 		[Static]
@@ -2814,35 +2814,35 @@ namespace SceneKit {
 		SCNSceneSource FromData (NSData data, [NullAllowed] NSDictionary options);
 
 		[Static]
-		[Wrap ("FromData (data, options == null ? null : options.Dictionary)")]
+		[Wrap ("FromData (data, options.GetDictionary ())")]
 		SCNSceneSource FromData (NSData data, SCNSceneLoadingOptions options);
 
 		[Export ("initWithURL:options:")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		IntPtr Constructor (NSUrl url, [NullAllowed] NSDictionary options);
 
-		[Wrap ("this (url, options == null ? null : options.Dictionary)")]
+		[Wrap ("this (url, options.GetDictionary ())")]
 		IntPtr Constructor (NSUrl url, SCNSceneLoadingOptions options);
 
 		[Export ("initWithData:options:")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		IntPtr Constructor (NSData data, [NullAllowed] NSDictionary options);
 
-		[Wrap ("this (data, options == null ? null : options.Dictionary)")]
+		[Wrap ("this (data, options.GetDictionary ())")]
 		IntPtr Constructor (NSData data, SCNSceneLoadingOptions options);
 		
 		[Export ("sceneWithOptions:statusHandler:")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		SCNScene SceneFromOptions ([NullAllowed] NSDictionary options, SCNSceneSourceStatusHandler statusHandler);
 
-		[Wrap ("SceneFromOptions (options == null ? null : options.Dictionary, statusHandler)")]
+		[Wrap ("SceneFromOptions (options.GetDictionary (), statusHandler)")]
 		SCNScene SceneFromOptions (SCNSceneLoadingOptions options, SCNSceneSourceStatusHandler statusHandler);
 
 		[Export ("sceneWithOptions:error:")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		SCNScene SceneWithOption ([NullAllowed] NSDictionary options, out NSError error);
 
-		[Wrap ("SceneWithOption (options == null ? null : options.Dictionary, out error)")]
+		[Wrap ("SceneWithOption (options.GetDictionary (), out error)")]
 		SCNScene SceneWithOption (SCNSceneLoadingOptions options, out NSError error);
 
 		[Export ("propertyForKey:")]
@@ -3060,7 +3060,7 @@ namespace SceneKit {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		SCNHitTestResult [] HitTest (CGPoint thePoint, [NullAllowed] NSDictionary options);
 
-		[Wrap ("HitTest (thePoint, options == null ? null : options.Dictionary)")]
+		[Wrap ("HitTest (thePoint, options.GetDictionary ())")]
 		SCNHitTestResult [] HitTest (CGPoint thePoint, SCNHitTestOptions options);
 
 #if XAMCORE_2_0
@@ -3527,7 +3527,7 @@ namespace SceneKit {
 
 #if !WATCH
 		[iOS (9,0)][Mac (10,11)]
-		[Wrap ("this (frame, options != null ? options.Dictionary : null)")]
+		[Wrap ("this (frame, options.GetDictionary ())")]
 		IntPtr Constructor (CGRect frame, [NullAllowed] SCNRenderingOptions options);
 #endif
 
@@ -4031,6 +4031,7 @@ namespace SceneKit {
 		NSDictionary WeakShaderModifiers { get; set; }
 
 		[Mac (10,9)] // Not marked, but crashes 32-bit - 17695192
+		[NullAllowed] // by default this property is null
 		[Wrap ("WeakShaderModifiers")]
 		SCNShaderModifiers ShaderModifiers { get; set; }
 
@@ -4378,28 +4379,28 @@ namespace SceneKit {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		SCNHitTestResult [] RayTestWithSegmentFromPoint (SCNVector3 origin, SCNVector3 dest, [NullAllowed] NSDictionary options);
 
-		[Wrap ("RayTestWithSegmentFromPoint (origin, dest, options != null ? options.Dictionary : null)")]
+		[Wrap ("RayTestWithSegmentFromPoint (origin, dest, options.GetDictionary ())")]
 		SCNHitTestResult [] RayTestWithSegmentFromPoint (SCNVector3 origin, SCNVector3 dest, [NullAllowed] SCNPhysicsTest options);
 
 		[Export ("contactTestBetweenBody:andBody:options:")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		SCNPhysicsContact [] ContactTest (SCNPhysicsBody bodyA, SCNPhysicsBody bodyB, [NullAllowed] NSDictionary options);
 
-		[Wrap ("ContactTest (bodyA, bodyB, options != null ? options.Dictionary : null)")]
+		[Wrap ("ContactTest (bodyA, bodyB, options.GetDictionary ())")]
 		SCNPhysicsContact [] ContactTest (SCNPhysicsBody bodyA, SCNPhysicsBody bodyB, [NullAllowed] SCNPhysicsTest options);
 
 		[Export ("contactTestWithBody:options:")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		SCNPhysicsContact [] ContactTest (SCNPhysicsBody body, [NullAllowed] NSDictionary options);
 
-		[Wrap ("ContactTest (body, options != null ? options.Dictionary : null)")]
+		[Wrap ("ContactTest (body, options.GetDictionary ())")]
 		SCNPhysicsContact [] ContactTest (SCNPhysicsBody body, [NullAllowed] SCNPhysicsTest options);
 
 		[Export ("convexSweepTestWithShape:fromTransform:toTransform:options:")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		SCNPhysicsContact [] ConvexSweepTest (SCNPhysicsShape shape, SCNMatrix4 from, SCNMatrix4 to, [NullAllowed] NSDictionary options);
 
-		[Wrap ("ConvexSweepTest (shape, from, to, options != null ? options.Dictionary : null)")]
+		[Wrap ("ConvexSweepTest (shape, from, to, options.GetDictionary ())")]
 		SCNPhysicsContact [] ConvexSweepTest (SCNPhysicsShape shape, SCNMatrix4 from, SCNMatrix4 to, [NullAllowed] SCNPhysicsTest options);
 
 		[Export ("updateCollisionPairs")]

--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -108,7 +108,7 @@ namespace SpriteKit {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		SCNHitTestResult [] HitTest (CGPoint thePoint, [NullAllowed] NSDictionary options);
 
-		[Wrap ("HitTest (thePoint, options == null ? null : options.Dictionary)")]
+		[Wrap ("HitTest (thePoint, options.GetDictionary ())")]
 		SCNHitTestResult [] HitTest (CGPoint thePoint, SCNHitTestOptions options);
 
 		[Export ("projectPoint:")]

--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -110,6 +110,7 @@ namespace StoreKit {
 		string ProductIdentifier { get; }
 
 		[Export ("requestData", ArgumentSemantic.Copy)]
+		[NullAllowed]
 		NSData RequestData { get; [NotImplemented ("Not available on SKPayment, only available on SKMutablePayment")] set;  }
 
 		[Export ("quantity")]
@@ -420,7 +421,7 @@ namespace StoreKit {
 		[Export ("initWithReceiptProperties:")]
 		IntPtr Constructor ([NullAllowed] NSDictionary properties);
 
-		[Wrap ("this (receiptProperties == null ? null : receiptProperties.Dictionary)")]
+		[Wrap ("this (receiptProperties.GetDictionary ())")]
 		IntPtr Constructor ([NullAllowed] SKReceiptProperties receiptProperties);
 
 		[Export ("receiptProperties")]
@@ -503,7 +504,7 @@ namespace StoreKit {
 		[Async]
 		void LoadProduct (NSDictionary parameters, [NullAllowed] Action<bool,NSError> callback);
 
-		[Wrap ("LoadProduct (parameters == null ? null : parameters.Dictionary, callback)")]
+		[Wrap ("LoadProduct (parameters.GetDictionary ()!, callback)")]
 		[Async]
 		void LoadProduct (StoreProductParameters parameters, [NullAllowed] Action<bool,NSError> callback);
 	}
@@ -664,7 +665,7 @@ namespace StoreKit {
 		void Load (NSDictionary options, [NullAllowed] Action<bool, NSError> completionHandler);
 
 		[Async]
-		[Wrap ("Load (options == null ? null : options.Dictionary, completionHandler)")]
+		[Wrap ("Load (options.GetDictionary ()!, completionHandler)")]
 		void Load (SKCloudServiceSetupOptions options, Action<bool, NSError> completionHandler);
 	}
 

--- a/src/tvmlkit.cs
+++ b/src/tvmlkit.cs
@@ -979,7 +979,7 @@ namespace TVMLKit {
 		[NullAllowed, Export ("type", ArgumentSemantic.Strong)]
 		NSString /* NS_TYPED_EXTENSIBLE_ENUM */ WeakType { get; }
 
-		[Wrap ("TVMediaItemTypeExtensions.GetValue (WeakType)")]
+		[Wrap ("TVMediaItemTypeExtensions.GetValue (WeakType!)")]
 		TVMediaItemType Type { get; }
 
 		[NullAllowed, Export ("url", ArgumentSemantic.Strong)]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -2514,7 +2514,7 @@ namespace UIKit {
 		void OpenUrl (NSUrl url, NSDictionary options, [NullAllowed] Action<bool> completion);
 
 		[iOS (10,0), TV (10,0)]
-		[Wrap ("OpenUrl (url, options?.Dictionary, completion)")]
+		[Wrap ("OpenUrl (url, options.GetDictionary ()!, completion)")]
 		[Async]
 		void OpenUrl (NSUrl url, UIApplicationOpenUrlOptions options, [NullAllowed] Action<bool> completion);
 
@@ -3419,7 +3419,7 @@ namespace UIKit {
 		bool OpenUrl (UIApplication app, NSUrl url, NSDictionary options);
 
 		[iOS (9,0)]
-		[Wrap ("OpenUrl(app, url, options.Dictionary)")]
+		[Wrap ("OpenUrl(app, url, options.GetDictionary ())")]
 		bool OpenUrl (UIApplication app, NSUrl url, UIApplicationOpenUrlOptions options);
 		
 		[Export ("window", ArgumentSemantic.Retain), NullAllowed]
@@ -3591,9 +3591,11 @@ namespace UIKit {
 		[Export ("enabled")][Abstract]
 		bool Enabled { [Bind ("isEnabled")] get; set; }
 
+		[NullAllowed]
 		[Export ("title", ArgumentSemantic.Copy)][Abstract]
 		string Title { get;set; }
 
+		[NullAllowed]
 		[Export ("image", ArgumentSemantic.Retain)][Abstract]
 		UIImage Image { get; set; }
 
@@ -5789,7 +5791,7 @@ namespace UIKit {
 		[Static, Export ("fontDescriptorWithFontAttributes:")]
 		UIFontDescriptor FromAttributes (NSDictionary attributes);
 
-		[Static, Wrap ("FromAttributes (attributes == null ? null : attributes.Dictionary)")]
+		[Static, Wrap ("FromAttributes (attributes.GetDictionary ()!)")]
 		UIFontDescriptor FromAttributes (UIFontAttributes attributes);
 	
 		[Static, Export ("fontDescriptorWithName:size:")]
@@ -5802,7 +5804,7 @@ namespace UIKit {
 		UIFontDescriptor GetPreferredDescriptorForTextStyle (NSString uiFontTextStyle);
 
 		[Static]
-		[Wrap ("GetPreferredDescriptorForTextStyle (uiFontTextStyle.GetConstant ())")]
+		[Wrap ("GetPreferredDescriptorForTextStyle (uiFontTextStyle.GetConstant ()!)")]
 		UIFontDescriptor GetPreferredDescriptorForTextStyle (UIFontTextStyle uiFontTextStyle);
 
 		// FIXME [Watch (3,0)] the API is present but UITraitCollection is not exposed / rdar #27785753
@@ -5814,7 +5816,7 @@ namespace UIKit {
 
 		[iOS (10,0), TV (10,0)]
 		[Static]
-		[Wrap ("GetPreferredDescriptorForTextStyle (uiFontTextStyle.GetConstant (), traitCollection)")]
+		[Wrap ("GetPreferredDescriptorForTextStyle (uiFontTextStyle.GetConstant ()!, traitCollection)")]
 		UIFontDescriptor GetPreferredDescriptorForTextStyle (UIFontTextStyle uiFontTextStyle, [NullAllowed] UITraitCollection traitCollection);
 #endif
 	
@@ -5823,13 +5825,13 @@ namespace UIKit {
 		IntPtr Constructor (NSDictionary attributes);
 		
 		[DesignatedInitializer]
-		[Wrap ("this (attributes == null ? null : attributes.Dictionary)")]
+		[Wrap ("this (attributes.GetDictionary ()!)")]
 		IntPtr Constructor (UIFontAttributes attributes);
 
 		[Export ("fontDescriptorByAddingAttributes:")]
 		UIFontDescriptor CreateWithAttributes (NSDictionary attributes);
 		
-		[Wrap ("CreateWithAttributes (attributes == null ? null : attributes.Dictionary)")]
+		[Wrap ("CreateWithAttributes (attributes.GetDictionary ()!)")]
 		UIFontDescriptor CreateWithAttributes (UIFontAttributes attributes);
 
 		[Export ("fontDescriptorWithSymbolicTraits:")]
@@ -5845,7 +5847,7 @@ namespace UIKit {
 		[iOS (13,0), TV (13,0)]
 		[Watch (5,2)]
 		[return: NullAllowed]
-		[Wrap ("CreateWithDesign (design.GetConstant ())")]
+		[Wrap ("CreateWithDesign (design.GetConstant ()!)")]
 		UIFontDescriptor CreateWithDesign (UIFontDescriptorSystemDesign design);
 
 		[Export ("fontDescriptorWithSize:")]
@@ -7437,6 +7439,7 @@ namespace UIKit {
 
 		[Export ("CGImage")]
 		[ThreadSafe]
+		[NullAllowed]
 		CGImage CGImage { get; }
 
 		[Export ("imageOrientation")]
@@ -9289,6 +9292,7 @@ namespace UIKit {
 		[NoTV]
 		[iOS (11,0)]
 		[Wrap ("_LargeTitleTextAttributes")]
+		[NullAllowed]
 		[Appearance]
 		UIStringAttributes LargeTitleTextAttributes { get; set; }
 	}
@@ -9875,7 +9879,7 @@ namespace UIKit {
 		
 #if !TVOS
 		[iOS (10,0)]
-		[Wrap ("SetItems (items, pasteboardOptions?.Dictionary)")]
+		[Wrap ("SetItems (items, pasteboardOptions.GetDictionary ()!)")]
 		void SetItems (NSDictionary<NSString, NSObject> [] items, UIPasteboardOptions pasteboardOptions);
 #endif
 		[NoWatch, NoTV, iOS (10, 0)]
@@ -12079,7 +12083,7 @@ namespace UIKit {
 		void SetBadgeTextAttributes ([NullAllowed] NSDictionary textAttributes, UIControlState state);
 
 		[iOS (10,0), TV (10,0)]
-		[Wrap ("SetBadgeTextAttributes (textAttributes == null ? null : textAttributes.Dictionary, state)")]
+		[Wrap ("SetBadgeTextAttributes (textAttributes.GetDictionary (), state)")]
 		void SetBadgeTextAttributes (UIStringAttributes textAttributes, UIControlState state);
 
 		[iOS (10,0), TV (10,0)]
@@ -16195,6 +16199,7 @@ namespace UIKit {
 		[Export ("initWithPresentedViewController:presentingViewController:")]
 		IntPtr Constructor (UIViewController presentedViewController, [NullAllowed] UIViewController presentingViewController);
 
+		[NullAllowed]
 		[Export ("delegate", ArgumentSemantic.UnsafeUnretained)]
 		NSObject WeakDelegate { get; set; }
 
@@ -16205,6 +16210,7 @@ namespace UIKit {
 #endif
 		
 		[Wrap ("WeakDelegate")]
+		[NullAllowed]
 		[Protocolize]
 		UIPopoverPresentationControllerDelegate Delegate { get; set; }
 	
@@ -16934,26 +16940,26 @@ namespace UIKit {
 	interface NSStringDrawing {
 		[iOS (7,0)]
 		[Export ("sizeWithAttributes:")]
-		CGSize WeakGetSizeUsingAttributes (NSDictionary attributes);
+		CGSize WeakGetSizeUsingAttributes ([NullAllowed] NSDictionary attributes);
 
 		[iOS (7,0)]
-		[Wrap ("WeakGetSizeUsingAttributes (This, attributes.Dictionary)")]
+		[Wrap ("WeakGetSizeUsingAttributes (This, attributes.GetDictionary ())")]
 		CGSize GetSizeUsingAttributes (UIStringAttributes attributes);
 
 		[iOS (7,0)]
 		[Export ("drawAtPoint:withAttributes:")]
-		void WeakDrawString (CGPoint point, NSDictionary attributes);
+		void WeakDrawString (CGPoint point, [NullAllowed] NSDictionary attributes);
 
 		[iOS (7,0)]
-		[Wrap ("WeakDrawString (This, point, attributes.Dictionary)")]
+		[Wrap ("WeakDrawString (This, point, attributes.GetDictionary ())")]
 		void DrawString (CGPoint point, UIStringAttributes attributes);
 
 		[iOS (7,0)]
 		[Export ("drawInRect:withAttributes:")]
-		void WeakDrawString (CGRect rect, NSDictionary attributes);
+		void WeakDrawString (CGRect rect, [NullAllowed] NSDictionary attributes);
 
 		[iOS (7,0)]
-		[Wrap ("WeakDrawString (This, rect, attributes.Dictionary)")]
+		[Wrap ("WeakDrawString (This, rect, attributes.GetDictionary ())")]
 		void DrawString (CGRect rect, UIStringAttributes attributes);
 	}
 
@@ -16961,18 +16967,18 @@ namespace UIKit {
 	interface NSExtendedStringDrawing {
 		[iOS (7,0)]
 		[Export ("drawWithRect:options:attributes:context:")]
-		void WeakDrawString (CGRect rect, NSStringDrawingOptions options, NSDictionary attributes, [NullAllowed] NSStringDrawingContext context);
+		void WeakDrawString (CGRect rect, NSStringDrawingOptions options, [NullAllowed] NSDictionary attributes, [NullAllowed] NSStringDrawingContext context);
 
 		[iOS (7,0)]
-		[Wrap ("WeakDrawString (This, rect, options, attributes == null ? null : attributes.Dictionary, context)")]
+		[Wrap ("WeakDrawString (This, rect, options, attributes.GetDictionary (), context)")]
 		void DrawString (CGRect rect, NSStringDrawingOptions options, UIStringAttributes attributes, [NullAllowed] NSStringDrawingContext context);
 		
 		[iOS (7,0)]
 		[Export ("boundingRectWithSize:options:attributes:context:")]
-		CGRect WeakGetBoundingRect (CGSize size, NSStringDrawingOptions options, NSDictionary attributes, [NullAllowed] NSStringDrawingContext context);
+		CGRect WeakGetBoundingRect (CGSize size, NSStringDrawingOptions options, [NullAllowed] NSDictionary attributes, [NullAllowed] NSStringDrawingContext context);
 
 		[iOS (7,0)]
-		[Wrap ("WeakGetBoundingRect (This, size, options, attributes == null ? null : attributes.Dictionary, context)")]
+		[Wrap ("WeakGetBoundingRect (This, size, options, attributes.GetDictionary (), context)")]
 		CGRect GetBoundingRect (CGSize size, NSStringDrawingOptions options, UIStringAttributes attributes, [NullAllowed] NSStringDrawingContext context);
 	}
 

--- a/src/vision.cs
+++ b/src/vision.cs
@@ -784,121 +784,121 @@ namespace Vision {
 		[Export ("initWithTargetedCVPixelBuffer:options:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
 
-		[Wrap ("this (pixelBuffer, options?.Dictionary)")]
+		[Wrap ("this (pixelBuffer, options.GetDictionary ()!)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:options:completionHandler:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (pixelBuffer, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (pixelBuffer, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (pixelBuffer, orientation, options?.Dictionary)")]
+		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:completionHandler:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (pixelBuffer, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:options:")]
 		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict);
 
-		[Wrap ("this (cgImage, options?.Dictionary)")]
+		[Wrap ("this (cgImage, options.GetDictionary ()!)")]
 		IntPtr Constructor (CGImage cgImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:options:completionHandler:")]
 		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (cgImage, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (cgImage, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:orientation:options:")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (cgImage, orientation, options?.Dictionary)")]
+		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:orientation:options:completionHandler:")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (cgImage, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:options:")]
 		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict);
 
-		[Wrap ("this (ciImage, options?.Dictionary)")]
+		[Wrap ("this (ciImage, options.GetDictionary ()!)")]
 		IntPtr Constructor (CIImage ciImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:options:completionHandler:")]
 		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (ciImage, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (ciImage, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:orientation:options:")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (ciImage, orientation, options?.Dictionary)")]
+		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:orientation:options:completionHandler:")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (ciImage, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:options:")]
 		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict);
 
-		[Wrap ("this (imageUrl, options?.Dictionary)")]
+		[Wrap ("this (imageUrl, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:options:completionHandler:")]
 		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageUrl, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageUrl, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:orientation:options:")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (imageUrl, orientation, options?.Dictionary)")]
+		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:orientation:options:completionHandler:")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageUrl, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:options:")]
 		IntPtr Constructor (NSData imageData, NSDictionary optionsDict);
 
-		[Wrap ("this (imageData, options?.Dictionary)")]
+		[Wrap ("this (imageData, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSData imageData, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:options:completionHandler:")]
 		IntPtr Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageData, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageData, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:orientation:options:")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (imageData, orientation, options?.Dictionary)")]
+		[Wrap ("this (imageData, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:orientation:options:completionHandler:")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageData, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageData, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 	}
 
@@ -911,121 +911,121 @@ namespace Vision {
 		[Export ("initWithTargetedCVPixelBuffer:options:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
 
-		[Wrap ("this (pixelBuffer, options?.Dictionary)")]
+		[Wrap ("this (pixelBuffer, options.GetDictionary ()!)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:options:completionHandler:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (pixelBuffer, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (pixelBuffer, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (pixelBuffer, orientation, options?.Dictionary)")]
+		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:completionHandler:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (pixelBuffer, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:options:")]
 		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict);
 
-		[Wrap ("this (cgImage, options?.Dictionary)")]
+		[Wrap ("this (cgImage, options.GetDictionary ()!)")]
 		IntPtr Constructor (CGImage cgImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:options:completionHandler:")]
 		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (cgImage, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (cgImage, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:orientation:options:")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (cgImage, orientation, options?.Dictionary)")]
+		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:orientation:options:completionHandler:")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (cgImage, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:options:")]
 		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict);
 
-		[Wrap ("this (ciImage, options?.Dictionary)")]
+		[Wrap ("this (ciImage, options.GetDictionary ()!)")]
 		IntPtr Constructor (CIImage ciImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:options:completionHandler:")]
 		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (ciImage, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (ciImage, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:orientation:options:")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (ciImage, orientation, options?.Dictionary)")]
+		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:orientation:options:completionHandler:")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (ciImage, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:options:")]
 		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict);
 
-		[Wrap ("this (imageUrl, options?.Dictionary)")]
+		[Wrap ("this (imageUrl, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:options:completionHandler:")]
 		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageUrl, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageUrl, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:orientation:options:")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (imageUrl, orientation, options?.Dictionary)")]
+		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:orientation:options:completionHandler:")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageUrl, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:options:")]
 		IntPtr Constructor (NSData imageData, NSDictionary optionsDict);
 
-		[Wrap ("this (imageData, options?.Dictionary)")]
+		[Wrap ("this (imageData, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSData imageData, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:options:completionHandler:")]
 		IntPtr Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageData, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageData, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:orientation:options:")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (imageData, orientation, options?.Dictionary)")]
+		[Wrap ("this (imageData, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:orientation:options:completionHandler:")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageData, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageData, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		// into subclasses so the correct class_ptr is used.
@@ -1059,121 +1059,121 @@ namespace Vision {
 		[Export ("initWithTargetedCVPixelBuffer:options:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
 
-		[Wrap ("this (pixelBuffer, options?.Dictionary)")]
+		[Wrap ("this (pixelBuffer, options.GetDictionary ()!)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:options:completionHandler:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (pixelBuffer, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (pixelBuffer, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (pixelBuffer, orientation, options?.Dictionary)")]
+		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:completionHandler:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (pixelBuffer, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:options:")]
 		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict);
 
-		[Wrap ("this (cgImage, options?.Dictionary)")]
+		[Wrap ("this (cgImage, options.GetDictionary ()!)")]
 		IntPtr Constructor (CGImage cgImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:options:completionHandler:")]
 		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (cgImage, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (cgImage, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:orientation:options:")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (cgImage, orientation, options?.Dictionary)")]
+		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:orientation:options:completionHandler:")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (cgImage, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:options:")]
 		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict);
 
-		[Wrap ("this (ciImage, options?.Dictionary)")]
+		[Wrap ("this (ciImage, options.GetDictionary ()!)")]
 		IntPtr Constructor (CIImage ciImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:options:completionHandler:")]
 		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (ciImage, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (ciImage, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:orientation:options:")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (ciImage, orientation, options?.Dictionary)")]
+		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:orientation:options:completionHandler:")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (ciImage, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:options:")]
 		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict);
 
-		[Wrap ("this (imageUrl, options?.Dictionary)")]
+		[Wrap ("this (imageUrl, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:options:completionHandler:")]
 		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageUrl, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageUrl, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:orientation:options:")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (imageUrl, orientation, options?.Dictionary)")]
+		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:orientation:options:completionHandler:")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageUrl, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:options:")]
 		IntPtr Constructor (NSData imageData, NSDictionary optionsDict);
 
-		[Wrap ("this (imageData, options?.Dictionary)")]
+		[Wrap ("this (imageData, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSData imageData, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:options:completionHandler:")]
 		IntPtr Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageData, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageData, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:orientation:options:")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (imageData, orientation, options?.Dictionary)")]
+		[Wrap ("this (imageData, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:orientation:options:completionHandler:")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageData, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageData, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		// We must inline the following 5 properties
@@ -1572,61 +1572,61 @@ namespace Vision {
 		[Export ("initWithCVPixelBuffer:options:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary options);
 
-		[Wrap ("this (pixelBuffer, imageOptions?.Dictionary)")]
+		[Wrap ("this (pixelBuffer, imageOptions.GetDictionary ()!)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions imageOptions);
 
 		[Export ("initWithCVPixelBuffer:orientation:options:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary options);
 
-		[Wrap ("this (pixelBuffer, orientation, imageOptions?.Dictionary)")]
+		[Wrap ("this (pixelBuffer, orientation, imageOptions.GetDictionary ()!)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[Export ("initWithCGImage:options:")]
 		IntPtr Constructor (CGImage image, NSDictionary options);
 
-		[Wrap ("this (image, imageOptions?.Dictionary)")]
+		[Wrap ("this (image, imageOptions.GetDictionary ()!)")]
 		IntPtr Constructor (CGImage image, VNImageOptions imageOptions);
 
 		[Export ("initWithCGImage:orientation:options:")]
 		IntPtr Constructor (CGImage image, CGImagePropertyOrientation orientation, NSDictionary options);
 
-		[Wrap ("this (image, orientation, imageOptions?.Dictionary)")]
+		[Wrap ("this (image, orientation, imageOptions.GetDictionary ()!)")]
 		IntPtr Constructor (CGImage image, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[Export ("initWithCIImage:options:")]
 		IntPtr Constructor (CIImage image, NSDictionary options);
 
-		[Wrap ("this (image, imageOptions?.Dictionary)")]
+		[Wrap ("this (image, imageOptions.GetDictionary ()!)")]
 		IntPtr Constructor (CIImage image, VNImageOptions imageOptions);
 
 		[Export ("initWithCIImage:orientation:options:")]
 		IntPtr Constructor (CIImage image, CGImagePropertyOrientation orientation, NSDictionary options);
 
-		[Wrap ("this (image, orientation, imageOptions?.Dictionary)")]
+		[Wrap ("this (image, orientation, imageOptions.GetDictionary ()!)")]
 		IntPtr Constructor (CIImage image, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[Export ("initWithURL:options:")]
 		IntPtr Constructor (NSUrl imageUrl, NSDictionary options);
 
-		[Wrap ("this (imageUrl, imageOptions?.Dictionary)")]
+		[Wrap ("this (imageUrl, imageOptions.GetDictionary ()!)")]
 		IntPtr Constructor (NSUrl imageUrl, VNImageOptions imageOptions);
 
 		[Export ("initWithURL:orientation:options:")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary options);
 
-		[Wrap ("this (imageUrl, orientation, imageOptions?.Dictionary)")]
+		[Wrap ("this (imageUrl, orientation, imageOptions.GetDictionary ()!)")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[Export ("initWithData:options:")]
 		IntPtr Constructor (NSData imageData, NSDictionary options);
 
-		[Wrap ("this (imageData, imageOptions?.Dictionary)")]
+		[Wrap ("this (imageData, imageOptions.GetDictionary ()!)")]
 		IntPtr Constructor (NSData imageData, VNImageOptions imageOptions);
 
 		[Export ("initWithData:orientation:options:")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary options);
 
-		[Wrap ("this (imageData, orientation, imageOptions?.Dictionary)")]
+		[Wrap ("this (imageData, orientation, imageOptions.GetDictionary ()!)")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[Export ("performRequests:error:")]
@@ -1682,121 +1682,121 @@ namespace Vision {
 		[Export ("initWithTargetedCVPixelBuffer:options:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
 
-		[Wrap ("this (pixelBuffer, options?.Dictionary)")]
+		[Wrap ("this (pixelBuffer, options.GetDictionary ()!)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:options:completionHandler:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (pixelBuffer, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (pixelBuffer, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (pixelBuffer, orientation, options?.Dictionary)")]
+		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:completionHandler:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (pixelBuffer, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:options:")]
 		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict);
 
-		[Wrap ("this (cgImage, options?.Dictionary)")]
+		[Wrap ("this (cgImage, options.GetDictionary ()!)")]
 		IntPtr Constructor (CGImage cgImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:options:completionHandler:")]
 		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (cgImage, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (cgImage, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:orientation:options:")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (cgImage, orientation, options?.Dictionary)")]
+		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:orientation:options:completionHandler:")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (cgImage, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:options:")]
 		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict);
 
-		[Wrap ("this (ciImage, options?.Dictionary)")]
+		[Wrap ("this (ciImage, options.GetDictionary ()!)")]
 		IntPtr Constructor (CIImage ciImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:options:completionHandler:")]
 		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (ciImage, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (ciImage, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:orientation:options:")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (ciImage, orientation, options?.Dictionary)")]
+		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:orientation:options:completionHandler:")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (ciImage, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:options:")]
 		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict);
 
-		[Wrap ("this (imageUrl, options?.Dictionary)")]
+		[Wrap ("this (imageUrl, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:options:completionHandler:")]
 		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageUrl, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageUrl, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:orientation:options:")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (imageUrl, orientation, options?.Dictionary)")]
+		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:orientation:options:completionHandler:")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageUrl, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:options:")]
 		IntPtr Constructor (NSData imageData, NSDictionary optionsDict);
 
-		[Wrap ("this (imageData, options?.Dictionary)")]
+		[Wrap ("this (imageData, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSData imageData, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:options:completionHandler:")]
 		IntPtr Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageData, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageData, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:orientation:options:")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Wrap ("this (imageData, orientation, options?.Dictionary)")]
+		[Wrap ("this (imageData, orientation, options.GetDictionary ()!)")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:orientation:options:completionHandler:")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Wrap ("this (imageData, orientation, options?.Dictionary, completionHandler)")]
+		[Wrap ("this (imageData, orientation, options.GetDictionary ()!, completionHandler)")]
 		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 	}
 

--- a/tests/BundledResources/BundledResources.csproj
+++ b/tests/BundledResources/BundledResources.csproj
@@ -14,6 +14,7 @@
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants>XAMCORE_2_0</DefineConstants>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Debug32' Or '$(Configuration)' == 'Debug64' Or '$(Configuration)' == 'Debug64_32' ">
     <DebugSymbols>True</DebugSymbols>

--- a/tests/EmbeddedResources/EmbeddedResources.csproj
+++ b/tests/EmbeddedResources/EmbeddedResources.csproj
@@ -16,6 +16,7 @@
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants>XAMCORE_2_0</DefineConstants>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Debug32' Or '$(Configuration)' == 'Debug64' Or '$(Configuration)' == 'Debug64_32' ">
     <DebugSymbols>True</DebugSymbols>

--- a/tests/bindings-framework-test/bindings-framework-test.csproj
+++ b/tests/bindings-framework-test/bindings-framework-test.csproj
@@ -16,6 +16,7 @@
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants>XAMCORE_2_0</DefineConstants>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Debug32' Or '$(Configuration)' == 'Debug64' Or '$(Configuration)' == 'Debug64_32' ">
     <DebugSymbols>True</DebugSymbols>

--- a/tests/bindings-test/bindings-test-mac.csproj
+++ b/tests/bindings-test/bindings-test-mac.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>bindingstestmac</RootNamespace>
     <AssemblyName>bindings-test-mac</AssemblyName>
     <MacResourcePrefix>Resources</MacResourcePrefix>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/bindings-test/bindings-test.csproj
+++ b/tests/bindings-test/bindings-test.csproj
@@ -16,6 +16,7 @@
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants>XAMCORE_2_0</DefineConstants>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Debug32' Or '$(Configuration)' == 'Debug64' Or '$(Configuration)' == 'Debug64_32' ">
     <DebugSymbols>True</DebugSymbols>

--- a/tests/bindings-test2/bindings-test2.csproj
+++ b/tests/bindings-test2/bindings-test2.csproj
@@ -16,6 +16,7 @@
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants>XAMCORE_2_0</DefineConstants>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Debug32' Or '$(Configuration)' == 'Debug64' Or '$(Configuration)' == 'Debug64_32' ">
     <DebugSymbols>True</DebugSymbols>

--- a/tests/cecil-tests/cecil-tests.csproj
+++ b/tests/cecil-tests/cecil-tests.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>ceciltests</RootNamespace>
     <AssemblyName>cecil-tests</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -20,14 +21,12 @@
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/common/mac/BindingProjectWithNoTag.csproj
+++ b/tests/common/mac/BindingProjectWithNoTag.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>BindingProjectWithNoTag</RootNamespace>
     <MacResourcePrefix>Resources</MacResourcePrefix>
     <AssemblyName>BindingProjectWithNoTag</AssemblyName>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/common/mac/ClassicExample.csproj
+++ b/tests/common/mac/ClassicExample.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>ClassicExample</RootNamespace>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
     <AssemblyName>ClassicExample</AssemblyName>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/common/mac/ConsoleXMApp.csproj
+++ b/tests/common/mac/ConsoleXMApp.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>ConsoleXMApp</RootNamespace>
     <AssemblyName>ConsoleXMApp</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/common/mac/MobileBinding.csproj
+++ b/tests/common/mac/MobileBinding.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>MobileBinding</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/common/mac/SystemMonoExample.csproj
+++ b/tests/common/mac/SystemMonoExample.csproj
@@ -12,6 +12,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <OutputPath>bin\$(Configuration)</OutputPath>
+    <LangVersion>latest</LangVersion>
 %TARGETFRAMEWORKVERSION%
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/common/mac/UnifiedExample.csproj
+++ b/tests/common/mac/UnifiedExample.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>%NAME%</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/common/mac/UnifiedLibrary.csproj
+++ b/tests/common/mac/UnifiedLibrary.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>%NAME%</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/common/mac/XM45Binding.csproj
+++ b/tests/common/mac/XM45Binding.csproj
@@ -10,6 +10,7 @@
     <MacResourcePrefix>Resources</MacResourcePrefix>
     <AssemblyName>XM45Binding</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/common/mac/XM45Example.csproj
+++ b/tests/common/mac/XM45Example.csproj
@@ -13,6 +13,7 @@
     <SchemaVersion>2.0</SchemaVersion>
 %TARGET_FRAMEWORK_VERSION%
     <UseXamMacFullFramework>true</UseXamMacFullFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/common/mac/XM45Library.csproj
+++ b/tests/common/mac/XM45Library.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>XM45Library</RootNamespace>
     <AssemblyName>%NAME%</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/framework-test/framework-test.csproj
+++ b/tests/framework-test/framework-test.csproj
@@ -14,6 +14,7 @@
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants>XAMCORE_2_0</DefineConstants>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/introspection/iOS/introspection-ios.csproj
+++ b/tests/introspection/iOS/introspection-ios.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants>XAMCORE_2_0</DefineConstants>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>True</DebugSymbols>

--- a/tests/linker/ios/link all/link all.csproj
+++ b/tests/linker/ios/link all/link all.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants>XAMCORE_2_0</DefineConstants>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>True</DebugSymbols>

--- a/tests/linker/ios/link sdk/link sdk.csproj
+++ b/tests/linker/ios/link sdk/link sdk.csproj
@@ -27,6 +27,7 @@
     <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchLink>SdkOnly</MtouchLink>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ExternalConsole>false</ExternalConsole>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>

--- a/tests/linker/mac/dont link/dont link-mac.csproj
+++ b/tests/linker/mac/dont link/dont link-mac.csproj
@@ -14,6 +14,7 @@
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <XamMacArch>x86_64</XamMacArch>
     <DefineConstants>XAMCORE_2_0</DefineConstants>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/linker/mac/link all/link all-mac.csproj
+++ b/tests/linker/mac/link all/link all-mac.csproj
@@ -11,6 +11,7 @@
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/linker/mac/link sdk/link sdk-mac.csproj
+++ b/tests/linker/mac/link sdk/link sdk-mac.csproj
@@ -11,6 +11,7 @@
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/monotouch-test/CoreFoundation/DispatchTests.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchTests.cs
@@ -67,7 +67,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 			bool hit = false;
 			// We need to check the UIKitThreadAccessException, but there are very few API
 			// with that check on WatchOS. NSStringDrawing.WeakDrawString is one example, here we pass
-			// it null for the parameter so that it immediately returns with an ArgumentNullException
+			// it null for the parameter so that it immediately returns with a NullReferenceException
 			// instead of trying to load an image (which is not what we're testing). There
 			// is also a test to ensure UIKitThreadAccessException is thrown if not on
 			// the UI thread (so that we'll notice if the UIKitThreadAccessException is ever
@@ -106,7 +106,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		        NSRunLoop.Current.RunUntil (NSDate.FromTimeIntervalSinceNow (0.5));
 		    }
 			Assert.IsNotNull (ex, "main ex");
-			Assert.That (ex.GetType (), Is.SameAs (typeof (ArgumentNullException)), "no thread check hit");
+			Assert.That (ex.GetType (), Is.SameAs (typeof (NullReferenceException)), "no thread check hit");
 			Assert.IsNotNull (queue_ex, "queue ex");
 			Assert.That (queue_ex.GetType (), Is.SameAs (typeof (UIKitThreadAccessException)), "thread check hit");
 			Assert.That (uiThread, Is.EqualTo (mainQthread), "mainq thread is equal to uithread");
@@ -125,7 +125,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 			bool hit = false;
 			// We need to check the UIKitThreadAccessException, but there are very few API
 			// with that check on WatchOS. NSStringDrawing.WeakDrawString is one example, here we pass
-			// it null for the parameter so that it immediately returns with an ArgumentNullException
+			// it null for the parameter so that it immediately returns with a NullReferenceException
 			// instead of trying to load an image (which is not what we're testing). There
 			// is also a test to ensure UIKitThreadAccessException is thrown if not on
 			// the UI thread (so that we'll notice if the UIKitThreadAccessException is ever
@@ -164,7 +164,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		        NSRunLoop.Current.RunUntil (NSDate.FromTimeIntervalSinceNow (0.5));
 		    }
 			Assert.IsNotNull (ex, "main ex");
-			Assert.That (ex.GetType (), Is.SameAs (typeof (ArgumentNullException)), "no thread check hit");
+			Assert.That (ex.GetType (), Is.SameAs (typeof (NullReferenceException)), "no thread check hit");
 			Assert.IsNotNull (queue_ex, "queue ex");
 			Assert.That (queue_ex.GetType (), Is.SameAs (typeof (UIKitThreadAccessException)), "thread check hit");
 			Assert.That (uiThread, Is.EqualTo (mainQthread), "mainq thread is equal to uithread");
@@ -285,7 +285,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 			bool hit = false;
 			// We need to check the UIKitThreadAccessException, but there are very few API
 			// with that check on WatchOS. NSStringDrawing.WeakDrawString is one example, here we pass
-			// it null for the parameter so that it immediately returns with an ArgumentNullException
+			// it null for the parameter so that it immediately returns with a NullReferenceException
 			// instead of trying to load an image (which is not what we're testing). There
 			// is also a test to ensure UIKitThreadAccessException is thrown if not on
 			// the UI thread (so that we'll notice if the UIKitThreadAccessException is ever
@@ -323,7 +323,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 				NSRunLoop.Current.RunUntil (NSDate.FromTimeIntervalSinceNow (0.5));
 			}
 			Assert.IsNotNull (ex, "main ex");
-			Assert.That (ex.GetType (), Is.SameAs (typeof (ArgumentNullException)), "no thread check hit");
+			Assert.That (ex.GetType (), Is.SameAs (typeof (NullReferenceException)), "no thread check hit");
 			Assert.IsNotNull (queue_ex, "queue ex");
 			Assert.That (queue_ex.GetType (), Is.SameAs (typeof (UIKitThreadAccessException)), "thread check hit");
 			Assert.That (uiThread, Is.EqualTo (mainQthread), "mainq thread is equal to uithread");
@@ -342,7 +342,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 			bool hit = false;
 			// We need to check the UIKitThreadAccessException, but there are very few API
 			// with that check on WatchOS. NSStringDrawing.WeakDrawString is one example, here we pass
-			// it null for the parameter so that it immediately returns with an ArgumentNullException
+			// it null for the parameter so that it immediately returns with a NullReferenceException
 			// instead of trying to load an image (which is not what we're testing). There
 			// is also a test to ensure UIKitThreadAccessException is thrown if not on
 			// the UI thread (so that we'll notice if the UIKitThreadAccessException is ever
@@ -380,7 +380,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 				NSRunLoop.Current.RunUntil (NSDate.FromTimeIntervalSinceNow (0.5));
 			}
 			Assert.IsNotNull (ex, "main ex");
-			Assert.That (ex.GetType (), Is.SameAs (typeof (ArgumentNullException)), "no thread check hit");
+			Assert.That (ex.GetType (), Is.SameAs (typeof (NullReferenceException)), "no thread check hit");
 			Assert.IsNotNull (queue_ex, "queue ex");
 			Assert.That (queue_ex.GetType (), Is.SameAs (typeof (UIKitThreadAccessException)), "thread check hit");
 			Assert.That (uiThread, Is.EqualTo (mainQthread), "mainq thread is equal to uithread");

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -15,6 +15,7 @@
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants>XAMCORE_2_0</DefineConstants>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>True</DebugSymbols>

--- a/tests/mtouch/mtouch.csproj
+++ b/tests/mtouch/mtouch.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MTouchTests</RootNamespace>
     <AssemblyName>mtouch</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/tests/sampletester/sampletester.csproj
+++ b/tests/sampletester/sampletester.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>sampletester</RootNamespace>
     <AssemblyName>sampletester</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/test-libraries/testgenerator.csproj
+++ b/tests/test-libraries/testgenerator.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>testgenerator</RootNamespace>
     <AssemblyName>testgenerator</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -11,6 +11,7 @@
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tools/linker/MobileMarkStep.cs
+++ b/tools/linker/MobileMarkStep.cs
@@ -48,6 +48,14 @@ namespace Xamarin.Linker.Steps {
 			}
 		}
 
+		protected override void EnqueueMethod (MethodDefinition method)
+		{
+			// workaround, this can be re-introduced into the queue and keep the processing going forever
+			if ((_methods.Count == 0) && (method.IsConstructor && method.DeclaringType.FullName == "System.Runtime.CompilerServices.NullableAttribute"))
+				return;
+			base.EnqueueMethod (method);
+		}
+
 		protected AssemblyDefinition GetAssembly (string assemblyName)
 		{
 			AssemblyDefinition ad;


### PR DESCRIPTION
Goals
* Reflect Apple nullability annotations in our bindings using C#8
* No warnings when building bindings

Non-Goals
* Update (add or fix) `[NullAllowed]` to match Apple headers (next phase)
* Make the generator or internal code fully nullable aware (`nowarn` is used)

Notes
* Apple's own annotations are not 100% accurate :(
* Where known issue exists we have _fixed_ our attributes to match reality :)
* We also do additional null-checks internally that might seems not required (better safe than sorry).