### PR TITLE
[d16-7] [AppKit] Allow static properties to execute on non-UI threads.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -13152,14 +13152,18 @@ namespace AppKit {
 
 	[BaseType (typeof (NSObject))]
 	partial interface NSScreen {
+
+		[ThreadSafe]
 		[Static]
 		[Export ("screens", ArgumentSemantic.Copy)]
 		NSScreen [] Screens { get; }
 
+		[ThreadSafe]
 		[Static]
 		[Export ("mainScreen")]
 		NSScreen MainScreen { get; }
 
+		[ThreadSafe]
 		[Static]
 		[Export ("deepestScreen")]
 		NSScreen DeepestScreen { get; }

--- a/tests/apitest/apitest.csproj
+++ b/tests/apitest/apitest.csproj
@@ -156,6 +156,7 @@
     <Compile Include="..\common\TestRuntime.cs">
       <Link>shared\TestRuntime.cs</Link>
     </Compile>
+    <Compile Include="src\AppKit\NSScreen.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">

--- a/tests/apitest/src/AppKit/NSScreen.cs
+++ b/tests/apitest/src/AppKit/NSScreen.cs
@@ -1,0 +1,69 @@
+﻿using NUnit.Framework;
+using System;
+using System.Threading;
+
+#if !XAMCORE_2_0
+using MonoMac.AppKit;
+using MonoMac.ObjCRuntime;
+using MonoMac.Foundation;
+#else
+using AppKit;
+using ObjCRuntime;
+using Foundation;
+#endif
+
+namespace Xamarin.Mac.Tests
+{
+	[TestFixture]
+	public class NSSCreenTests
+	{
+		[Test]
+		public void ScreensNotMainThread ()
+		{
+			var called = new AutoResetEvent (false);
+			var screensCount = 0;
+			var backgroundThread = new Thread (() => {
+				screensCount = NSScreen.Screens.Length;
+				called.Set ();
+			});
+			backgroundThread.Start ();
+			Assert.IsTrue (called.WaitOne (1000), "called");
+			Assert.IsTrue (screensCount > 0, "screens count");
+		}
+
+		[Test]
+		public void MainScreenNotMainThread ()
+		{ 
+			var called = new AutoResetEvent (false);
+			NSScreen main = null;
+			var backgroundThread = new Thread (() => {
+				main = NSScreen.MainScreen;
+				called.Set ();
+			});
+			backgroundThread.Start ();
+			Assert.IsTrue (called.WaitOne (1000), "called");
+			Assert.IsNotNull (main, "main screen");
+		}
+
+		[Test]
+		public void DeepScreenNotMainThread ()
+		{ 
+			var called = new AutoResetEvent (false);
+			NSScreen deepScreen = null;
+			var screenCount = 0;
+
+			var backgroundThread = new Thread (() => {
+				screenCount = NSScreen.Screens.Length;
+				deepScreen = NSScreen.DeepestScreen;
+				called.Set ();
+			});
+			backgroundThread.Start ();
+			Assert.IsTrue (called.WaitOne (1000), "called");
+			if (screenCount > 1) {
+				Assert.IsNotNull (deepScreen, "deep screen");
+			} else {
+				Assert.Inconclusive ("Only one screen detected.");
+			}
+		}
+	}
+}


### PR DESCRIPTION
VSMac has failing tests when they query the NSScrees.Screens property
which the following swift code shows that it can be executed in a diff
thread:

```swift
import Cocoa
import AppKit

DispatchQueue.global(qos: .background).async {
    print("This is run on the background queue")

    print(Thread.current)
    var screens = NSScreen.screens
    print (screens.count)
}
```

Fixes: https://github.com/xamarin/xamarin-macios/issues/8329

Backport of #8330.

/cc @mandel-macaque 