### PR TITLE
[AppKit] NSScreen properties can be executed in non-UI threads.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -1,4 +1,4 @@
- // Copyright 2011-2012 Xamarin, Inc.
+// Copyright 2011-2012 Xamarin, Inc.
 // Copyright 2010, 2011, Novell, Inc.
 // Copyright 2010, Kenneth Pouncey
 // Coprightt 2010, James Clancey
@@ -13168,18 +13168,23 @@ namespace AppKit {
 		[Export ("deepestScreen")]
 		NSScreen DeepestScreen { get; }
 
+		[ThreadSafe]
 		[Export ("depth")]
 		NSWindowDepth Depth { get; }
 
+		[ThreadSafe]
 		[Export ("frame")]
 		CGRect Frame { get; }
 
+		[ThreadSafe]
 		[Export ("visibleFrame")]
 		CGRect VisibleFrame { get; }
 
+		[ThreadSafe]
 		[Export ("deviceDescription")]
 		NSDictionary DeviceDescription { get; }
 
+		[ThreadSafe]
 		[Export ("colorSpace")]
 		NSColorSpace ColorSpace { get; }
 
@@ -13199,9 +13204,11 @@ namespace AppKit {
 		[Export ("backingAlignedRect:options:")]
 		CGRect GetBackingAlignedRect (CGRect globalScreenCoordRect, NSAlignmentOptions options);
 
+		[ThreadSafe]
 		[Export ("backingScaleFactor")]
 		nfloat BackingScaleFactor { get; }
 
+		[ThreadSafe]
 		[Mac (10,9)]
 		[Static, Export ("screensHaveSeparateSpaces")]
 		bool ScreensHaveSeparateSpaces ();
@@ -13211,18 +13218,22 @@ namespace AppKit {
 		bool CanRepresentDisplayGamut (NSDisplayGamut displayGamut);
 
 		// Inlined from unnamed category.
+		[ThreadSafe]
 		[Mac (10,11)]
 		[Export ("maximumExtendedDynamicRangeColorComponentValue")]
 		nfloat MaximumExtendedDynamicRangeColorComponentValue { get; }
 
+		[ThreadSafe]
 		[Mac (10, 15)]
 		[Export ("maximumPotentialExtendedDynamicRangeColorComponentValue")]
 		nfloat MaximumPotentialExtendedDynamicRangeColorComponentValue { get; }
 
+		[ThreadSafe]
 		[Mac (10, 15)]
 		[Export ("maximumReferenceExtendedDynamicRangeColorComponentValue")]
 		nfloat MaximumReferenceExtendedDynamicRangeColorComponentValue { get; }
 
+		[ThreadSafe]
 		[Mac (10, 15)]
 		[Export ("localizedName", ArgumentSemantic.Copy)]
 		string LocalizedName { get; }

--- a/tests/apitest/src/AppKit/NSScreen.cs
+++ b/tests/apitest/src/AppKit/NSScreen.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Threading;
+using CoreGraphics;
 
 #if !XAMCORE_2_0
 using MonoMac.AppKit;
@@ -64,6 +65,186 @@ namespace Xamarin.Mac.Tests
 			} else {
 				Assert.Inconclusive ("Only one screen detected.");
 			}
+		}
+
+		[Test]
+		public void FrameNoMainThread ()
+		{
+			if (NSScreen.MainScreen == null)
+				Assert.Inconclusive ("Could not find main screen.");
+
+			var called = new AutoResetEvent (false);
+			CGRect? frame = null;
+
+			var backgroundThread = new Thread (() => {
+				frame = NSScreen.MainScreen.Frame;
+				called.Set ();
+			});
+			backgroundThread.Start ();
+			Assert.IsTrue (called.WaitOne (1000), "called");
+			Assert.IsTrue (frame.HasValue, "frame");
+		}
+
+		[Test]
+		public void DepthNoMainThread ()
+		{ 
+			if (NSScreen.MainScreen == null)
+				Assert.Inconclusive ("Could not find main screen.");
+
+			var called = new AutoResetEvent (false);
+			NSWindowDepth? depth = null;
+
+			var backgroundThread = new Thread (() => {
+				depth = NSScreen.MainScreen.Depth;
+				called.Set ();
+			});
+			backgroundThread.Start ();
+			Assert.IsTrue (called.WaitOne (1000), "called");
+			Assert.IsTrue (depth.HasValue, "depth");
+		}
+
+		[Test]
+		public void ColorSpaceNoMainThread ()
+		{
+			if (NSScreen.MainScreen == null)
+				Assert.Inconclusive ("Could not find main screen.");
+
+			var called = new AutoResetEvent (false);
+			NSColorSpace colorSpace = null;
+
+			var backgroundThread = new Thread (() => {
+				colorSpace = NSScreen.MainScreen.ColorSpace;
+				called.Set ();
+			});
+			backgroundThread.Start ();
+			Assert.IsTrue (called.WaitOne (1000), "called");
+			Assert.IsNotNull (colorSpace, "colorSpace");
+		}
+
+		[Test]
+		public void VisibleFrmeNoMainThread ()
+		{ 
+			if (NSScreen.MainScreen == null)
+				Assert.Inconclusive ("Could not find main screen.");
+
+			var called = new AutoResetEvent (false);
+			CGRect? frame = null;
+
+			var backgroundThread = new Thread (() => {
+				frame = NSScreen.MainScreen.VisibleFrame;
+				called.Set ();
+			});
+			backgroundThread.Start ();
+			Assert.IsTrue (called.WaitOne (1000), "called");
+			Assert.IsTrue (frame.HasValue, "frame");
+		}
+
+		[Test]
+		public void DescriptionNoMainThread ()
+		{ 
+			if (NSScreen.MainScreen == null)
+				Assert.Inconclusive ("Could not find main screen.");
+
+			var called = new AutoResetEvent (false);
+			string description = null;
+
+			var backgroundThread = new Thread (() => {
+				description = NSScreen.MainScreen.Description;
+				called.Set ();
+			});
+			backgroundThread.Start ();
+			Assert.IsTrue (called.WaitOne (1000), "called");
+			Assert.IsNotNull (description, "description");
+		}
+
+		[Test]
+		public void BackingScaleFactorNoMainThread ()
+		{ 
+			if (NSScreen.MainScreen == null)
+				Assert.Inconclusive ("Could not find main screen.");
+
+			var called = new AutoResetEvent (false);
+			nfloat? factor = null;
+
+			var backgroundThread = new Thread (() => {
+				factor = NSScreen.MainScreen.BackingScaleFactor;
+				called.Set ();
+			});
+			backgroundThread.Start ();
+			Assert.IsTrue (called.WaitOne (1000), "called");
+			Assert.IsTrue (factor.HasValue, "factor");
+		}
+
+		[Test]
+		public void NameNoMainThread ()
+		{ 
+			if (NSScreen.MainScreen == null)
+				Assert.Inconclusive ("Could not find main screen.");
+
+			var called = new AutoResetEvent (false);
+			string name = "";
+
+			var backgroundThread = new Thread (() => {
+				name = NSScreen.MainScreen.LocalizedName;
+				called.Set ();
+			});
+			backgroundThread.Start ();
+			Assert.IsTrue (called.WaitOne (1000), "called");
+			Assert.IsNotNull (name, "name");
+		}
+
+		[Test]
+		public void MaximumExtendedDynamicRangeColorComponentValueNoMainThread ()
+		{ 
+			if (NSScreen.MainScreen == null)
+				Assert.Inconclusive ("Could not find main screen.");
+
+			var called = new AutoResetEvent (false);
+			nfloat? factor = null;
+
+			var backgroundThread = new Thread (() => {
+				factor = NSScreen.MainScreen.MaximumExtendedDynamicRangeColorComponentValue;
+				called.Set ();
+			});
+			backgroundThread.Start ();
+			Assert.IsTrue (called.WaitOne (1000), "called");
+			Assert.IsTrue (factor.HasValue, "factor");
+		}
+
+		[Test]
+		public void MaximumPotentialExtendedDynamicRangeColorComponentValueNoMainThread ()
+		{ 
+			if (NSScreen.MainScreen == null)
+				Assert.Inconclusive ("Could not find main screen.");
+
+			var called = new AutoResetEvent (false);
+			nfloat? factor = null;
+
+			var backgroundThread = new Thread (() => {
+				factor = NSScreen.MainScreen.MaximumPotentialExtendedDynamicRangeColorComponentValue;
+				called.Set ();
+			});
+			backgroundThread.Start ();
+			Assert.IsTrue (called.WaitOne (1000), "called");
+			Assert.IsTrue (factor.HasValue, "factor");
+		}
+
+		[Test]
+		public void MaximumReferenceExtendedDynamicRangeColorComponentValueNoMainThread ()
+		{ 
+			if (NSScreen.MainScreen == null)
+				Assert.Inconclusive ("Could not find main screen.");
+
+			var called = new AutoResetEvent (false);
+			nfloat? factor = null;
+
+			var backgroundThread = new Thread (() => {
+				factor = NSScreen.MainScreen.MaximumReferenceExtendedDynamicRangeColorComponentValue;
+				called.Set ();
+			});
+			backgroundThread.Start ();
+			Assert.IsTrue (called.WaitOne (1000), "called");
+			Assert.IsTrue (factor.HasValue, "factor");
 		}
 	}
 }


### PR DESCRIPTION
Allow all the properties to be executed outside the UI thread. This has
been tests with Xcode using MTC.