### PR TITLE
[Tests] Bump language used in the mac binding tests.

### DIFF
--- a/tests/mac-binding-project/MobileBinding/MobileBinding_dynamic.csproj
+++ b/tests/mac-binding-project/MobileBinding/MobileBinding_dynamic.csproj
@@ -20,6 +20,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/mac-binding-project/MobileBinding/MobileBinding_dynamic_newstyle.csproj
+++ b/tests/mac-binding-project/MobileBinding/MobileBinding_dynamic_newstyle.csproj
@@ -20,6 +20,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/mac-binding-project/MobileBinding/MobileBinding_dynamic_spaces.csproj
+++ b/tests/mac-binding-project/MobileBinding/MobileBinding_dynamic_spaces.csproj
@@ -20,6 +20,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/mac-binding-project/MobileBinding/MobileBinding_framework.csproj
+++ b/tests/mac-binding-project/MobileBinding/MobileBinding_framework.csproj
@@ -20,6 +20,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/mac-binding-project/MobileBinding/MobileBinding_static.csproj
+++ b/tests/mac-binding-project/MobileBinding/MobileBinding_static.csproj
@@ -9,7 +9,6 @@
     <RootNamespace>MobileBinding</RootNamespace>
     <MacResourcePrefix>Resources</MacResourcePrefix>
     <AssemblyName>MobileBinding</AssemblyName>
-    <BaseIntermediateOutputPath>..\obj\Mobile-static</BaseIntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/mac-binding-project/MobileBinding/MobileBinding_static.csproj
+++ b/tests/mac-binding-project/MobileBinding/MobileBinding_static.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>MobileBinding</RootNamespace>
     <MacResourcePrefix>Resources</MacResourcePrefix>
     <AssemblyName>MobileBinding</AssemblyName>
+    <BaseIntermediateOutputPath>..\obj\Mobile-static</BaseIntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -20,6 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/mac-binding-project/MobileBinding/MobileBinding_static_newstyle.csproj
+++ b/tests/mac-binding-project/MobileBinding/MobileBinding_static_newstyle.csproj
@@ -20,6 +20,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
They broke with nullability, we need to use the latests lang version.

Fixes: https://github.com/xamarin/xamarin-macios/issues/8346