### PR TITLE
[AppKit] Ignore test in earlier versions of Mac OS X.

### DIFF
--- a/tests/apitest/src/AppKit/NSScreen.cs
+++ b/tests/apitest/src/AppKit/NSScreen.cs
@@ -196,9 +196,6 @@ namespace Xamarin.Mac.Tests
 		[Test]
 		public void MaximumExtendedDynamicRangeColorComponentValueNoMainThread ()
 		{
-			// fails in earlier versions with missing selector
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 15);
-
 			if (NSScreen.MainScreen == null)
 				Assert.Inconclusive ("Could not find main screen.");
 
@@ -217,6 +214,9 @@ namespace Xamarin.Mac.Tests
 		[Test]
 		public void MaximumPotentialExtendedDynamicRangeColorComponentValueNoMainThread ()
 		{ 
+			// fails in earlier versions with missing selector
+			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 15);
+
 			if (NSScreen.MainScreen == null)
 				Assert.Inconclusive ("Could not find main screen.");
 

--- a/tests/apitest/src/AppKit/NSScreen.cs
+++ b/tests/apitest/src/AppKit/NSScreen.cs
@@ -195,7 +195,10 @@ namespace Xamarin.Mac.Tests
 
 		[Test]
 		public void MaximumExtendedDynamicRangeColorComponentValueNoMainThread ()
-		{ 
+		{
+			// fails in earlier versions with missing selector
+			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 15);
+
 			if (NSScreen.MainScreen == null)
 				Assert.Inconclusive ("Could not find main screen.");
 


### PR DESCRIPTION
The api is present since Mac OS X 10.11 but we get an exception when
executing it in earlier versions of Mac OS X, it just works on 10.15.

Fixes: https://github.com/xamarin/xamarin-macios/issues/8356