### PR TITLE
[tests] NugetRestore should only restore, not build.

### DIFF
--- a/tests/common/mac/ProjectTestHelpers.cs
+++ b/tests/common/mac/ProjectTestHelpers.cs
@@ -588,7 +588,7 @@ namespace TestCase
 			Environment.SetEnvironmentVariable ("XAMMAC_FRAMEWORK_PATH", rootDirectory + "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current");
 			Environment.SetEnvironmentVariable ("XamarinMacFrameworkRoot", rootDirectory + "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current");
 
-			var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, new [] { $"--", "/restore", project}, out var output);
+			var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, new [] { $"--", "/t:Restore", project}, out var output);
 			if (rv != 0) {
 				Console.WriteLine ("nuget restore failed:");
 				Console.WriteLine (output);


### PR DESCRIPTION
"msbuild /restore" will run nuget restore, then build. "msbuild /t:Restore"
will just run the Restore target, which should just restore.

This becomes significant when we later try to do "msbuild", and expect
warnings to show up. If we previously built the project unintentionally, those
warnings won't show up because nothing will actually be built.