### PR TITLE
[appkit] Fix smartInsertForString to use nullable out strings

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -19275,12 +19275,17 @@ namespace AppKit {
 		[Export ("toggleSmartInsertDelete:")]
 		void ToggleSmartInsertDelete (NSObject sender);
 
+#if !XAMCORE_4_0
+		[Obsolete ("Use working version with out parmaters instead.")]
 		[Export ("smartInsertForString:replacingRange:beforeString:afterString:")]
-#if XAMCORE_4_0
-		void SmartInsert (string pasteString, NSRange charRangeToReplace, [NullAllowed] out string beforeString, [NullAllowed] out string afterString);
-#else
 		void SmartInsert (string pasteString, NSRange charRangeToReplace, string beforeString, string afterString);
 #endif
+
+#if !XAMCORE_4_0
+		[Sealed] // sealed until we the broken overload is gone
+#endif
+		[Export ("smartInsertForString:replacingRange:beforeString:afterString:")]
+		void SmartInsert (string pasteString, NSRange charRangeToReplace, [NullAllowed] out string beforeString, [NullAllowed] out string afterString);
 
 		[Export ("smartInsertBeforeStringForString:replacingRange:")]
 		string SmartInsertBefore (string pasteString, NSRange charRangeToReplace);

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -19276,7 +19276,11 @@ namespace AppKit {
 		void ToggleSmartInsertDelete (NSObject sender);
 
 		[Export ("smartInsertForString:replacingRange:beforeString:afterString:")]
+#if XAMCORE_4_0
+		void SmartInsert (string pasteString, NSRange charRangeToReplace, [NullAllowed] out string beforeString, [NullAllowed] out string afterString);
+#else
 		void SmartInsert (string pasteString, NSRange charRangeToReplace, string beforeString, string afterString);
+#endif
 
 		[Export ("smartInsertBeforeStringForString:replacingRange:")]
 		string SmartInsertBefore (string pasteString, NSRange charRangeToReplace);

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -19277,7 +19277,7 @@ namespace AppKit {
 
 #if !XAMCORE_4_0
 		[Obsolete ("Use 'SmartInsert(string, NSRange, out string, out string)' overload instead.")]
-		[Wrap ("throw new NotSupportedException ()")]
+		[Wrap ("throw new NotSupportedException ()", IsVirtual = true)]
 		void SmartInsert (string pasteString, NSRange charRangeToReplace, string beforeString, string afterString);
 #endif
 

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -19276,13 +19276,13 @@ namespace AppKit {
 		void ToggleSmartInsertDelete (NSObject sender);
 
 #if !XAMCORE_4_0
-		[Obsolete ("Use working version with out parmaters instead.")]
+		[Obsolete ("Use 'SmartInsert(string, NSRange, out string, out string)' overload instead.")]
 		[Export ("smartInsertForString:replacingRange:beforeString:afterString:")]
 		void SmartInsert (string pasteString, NSRange charRangeToReplace, string beforeString, string afterString);
 #endif
 
 #if !XAMCORE_4_0
-		[Sealed] // sealed until we the broken overload is gone
+		[Sealed] // sealed until the broken overload is gone
 #endif
 		[Export ("smartInsertForString:replacingRange:beforeString:afterString:")]
 		void SmartInsert (string pasteString, NSRange charRangeToReplace, [NullAllowed] out string beforeString, [NullAllowed] out string afterString);

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -19277,13 +19277,10 @@ namespace AppKit {
 
 #if !XAMCORE_4_0
 		[Obsolete ("Use 'SmartInsert(string, NSRange, out string, out string)' overload instead.")]
-		[Export ("smartInsertForString:replacingRange:beforeString:afterString:")]
+		[Wrap ("throw new NotSupportedException ()")]
 		void SmartInsert (string pasteString, NSRange charRangeToReplace, string beforeString, string afterString);
 #endif
 
-#if !XAMCORE_4_0
-		[Sealed] // sealed until the obsolete overload has been removed
-#endif
 		[Export ("smartInsertForString:replacingRange:beforeString:afterString:")]
 		void SmartInsert (string pasteString, NSRange charRangeToReplace, [NullAllowed] out string beforeString, [NullAllowed] out string afterString);
 

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -19282,7 +19282,7 @@ namespace AppKit {
 #endif
 
 #if !XAMCORE_4_0
-		[Sealed] // sealed until the broken overload is gone
+		[Sealed] // sealed until the obsolete overload has been removed
 #endif
 		[Export ("smartInsertForString:replacingRange:beforeString:afterString:")]
 		void SmartInsert (string pasteString, NSRange charRangeToReplace, [NullAllowed] out string beforeString, [NullAllowed] out string afterString);


### PR DESCRIPTION
- Sharpie outputs the correct binding, must have been ancient hand binding
- https://github.com/xamarin/xamarin-macios/issues/8349

Binding:
https://developer.apple.com/documentation/appkit/nstextview/1449544-smartinsertforstring?language=objc
```
- (void)smartInsertForString:(NSString *)pasteString 
              replacingRange:(NSRange)charRangeToReplace 
                beforeString:(NSString * _Nullable *)beforeString 
                 afterString:(NSString * _Nullable *)afterString;
```