### PR TITLE
[Harness] Fix HTML report for NUnitTestTasks.

### DIFF
--- a/tests/xharness/Jenkins/TestTasks/NUnitExecuteTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/NUnitExecuteTask.cs
@@ -141,7 +141,7 @@ namespace Xharness.Jenkins.TestTasks
 									using (var xri = XmlReader.Create (sri)) {
 										var xslt = new System.Xml.Xsl.XslCompiledTransform ();
 										xslt.Load (xrt);
-										using (var xwo = XmlWriter.Create (output as TextWriter, xslt.OutputSettings)) // use OutputSettings of xsl, so it can be output as HTML
+										using (var xwo = XmlWriter.Create (File.Create (output.FullPath), xslt.OutputSettings)) // use OutputSettings of xsl, so it can be output as HTML
 										{
 											xslt.Transform (xri, xwo);
 										}


### PR DESCRIPTION
PR https://github.com/xamarin/xamarin-macios/pull/8184 removed the
inheritance with TextWriter, therefore the `as` will return null and we
will not generate the Html report. In this particular case, we do not
need an ILog, we just use it to get a path to the correct location,
therefore, we can create the file using the full path and pass it to the
xslt.

Fixes: https://github.com/xamarin/xamarin-macios/issues/8364