### PR TITLE
[mmp] Make the system mono location customizable. Fixes #7923.

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -103,7 +103,6 @@ namespace Xamarin.Bundler {
 		static string resources_dir;
 		static string mmp_dir;
 		
-		static string mono_dir;
 		static string custom_bundle_name;
 
 		static string tls_provider;
@@ -121,8 +120,6 @@ namespace Xamarin.Bundler {
 		static bool frameworks_copied_to_bundle_dir;    // Have we copied any frameworks to Foo.app/Contents/Frameworks?
 		static bool dylibs_copied_to_bundle_dir => native_libraries_copied_in.Count > 0;
 
-		const string pkg_config = "/Library/Frameworks/Mono.framework/Commands/pkg-config";
-
 		static Version min_xcode_version = new Version (6, 0);
 
 		static void ShowHelp (OptionSet os) {
@@ -137,6 +134,27 @@ namespace Xamarin.Bundler {
 		public static bool IsUnifiedFullSystemFramework { get { return TargetFramework == TargetFramework.Xamarin_Mac_4_5_System; } }
 		public static bool IsUnifiedMobile { get { return TargetFramework == TargetFramework.Xamarin_Mac_2_0_Mobile; } }
 		public static bool LinkProhibitedFrameworks { get; private set; }
+
+		static string mono_prefix;
+		static string MonoPrefix {
+			get {
+				if (mono_prefix == null) {
+					mono_prefix = Environment.GetEnvironmentVariable ("MONO_PREFIX");
+					if (string.IsNullOrEmpty (mono_prefix))
+						mono_prefix = "/Library/Frameworks/Mono.framework/Versions/Current";
+				}
+				return mono_prefix;
+			}
+		}
+
+		static string PkgConfig {
+			get {
+				var pkg_config = Path.Combine (MonoPrefix, "bin", "pkg-config");
+				if (!File.Exists (pkg_config))
+					throw ErrorHelper.CreateError (5313, Errors.MX5313, pkg_config);
+				return pkg_config;
+			}
+		}
 
 		public static bool Is64Bit { 
 			get {
@@ -766,18 +784,20 @@ namespace Xamarin.Bundler {
 			Watch ("Extracted native link info", 1);
 		}
 
+		static string system_mono_directory;
+		static string SystemMonoDirectory {
+			get {
+				if (system_mono_directory == null)
+					system_mono_directory = RunPkgConfig ("--variable=prefix", force_system_mono: true);
+				return system_mono_directory;
+			}
+		}
+
 		static string MonoDirectory {
 			get {
-				if (mono_dir == null) {
-					if (IsUnifiedFullXamMacFramework || IsUnifiedMobile) {
-						mono_dir = FrameworkDirectory;
-					} else {
-						var dir = new StringBuilder ();
-						RunCommand (pkg_config, new [] { "--variable=prefix", "mono-2" }, dir);
-						mono_dir = Path.GetFullPath (dir.ToString ().Replace (Environment.NewLine, String.Empty));
-					}
-				}
-				return mono_dir;
+				if (IsUnifiedFullXamMacFramework || IsUnifiedMobile)
+					return FrameworkDirectory;
+				return SystemMonoDirectory;
 			}
 		}
 
@@ -937,7 +957,7 @@ namespace Xamarin.Bundler {
 		{
 			string mono_version;
 
-			var versionFile = "/Library/Frameworks/Mono.framework/Versions/Current/VERSION";
+			var versionFile = Path.Combine (SystemMonoDirectory, "VERSION");
 			if (File.Exists (versionFile)) {
 				mono_version = File.ReadAllText (versionFile);
 			} else {
@@ -1199,16 +1219,13 @@ namespace Xamarin.Bundler {
 		{
 			string [] env = null;
 
-			if (!File.Exists (pkg_config))
-				throw ErrorHelper.CreateError (5313, Errors.MX5313);
-
 			if (!IsUnifiedFullSystemFramework && !force_system_mono)
 				env = new [] { "PKG_CONFIG_PATH", Path.Combine (FrameworkLibDirectory, "pkgconfig") };
 
 			var sb = new StringBuilder ();
 			int rv;
 			try {
-				rv = RunCommand (pkg_config, new [] { option, "mono-2" }, env, sb);
+				rv = RunCommand (PkgConfig, new [] { option, "mono-2" }, env, sb);
 			} catch (Exception e) {
 				throw ErrorHelper.CreateError (5314, e, Errors.MX5314, e.Message);
 			}
@@ -1354,7 +1371,7 @@ namespace Xamarin.Bundler {
 			var sb = new List<string> ();
 			foreach (string library in Directory.GetFiles (mmp_dir, "*.dylib")) {
 				foreach (string lib in Xamarin.MachO.GetNativeDependencies (library)) {
-					if (lib.StartsWith ("/Library/Frameworks/Mono.framework/Versions/", StringComparison.Ordinal)) {
+					if (lib.StartsWith (Path.GetDirectoryName (MonoPrefix), StringComparison.Ordinal)) {
 						string libname = Path.GetFileName (lib);
 						string real_lib = GetRealPath (lib);
 						string real_libname	= Path.GetFileName (real_lib);

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -2667,7 +2667,7 @@
 	</data>
 
 	<data name="MX5313" xml:space="preserve">
-		<value>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+		<value>Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</value>
 		<comment>
 		</comment>

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -3027,9 +3027,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MX5313">
-        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <source>Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</source>
-        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <target state="new">Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -3027,9 +3027,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MX5313">
-        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <source>Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</source>
-        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <target state="new">Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -3027,9 +3027,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MX5313">
-        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <source>Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</source>
-        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <target state="new">Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -3027,9 +3027,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MX5313">
-        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <source>Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</source>
-        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <target state="new">Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -3027,9 +3027,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MX5313">
-        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <source>Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</source>
-        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <target state="new">Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -3027,9 +3027,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MX5313">
-        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <source>Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</source>
-        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <target state="new">Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -3027,9 +3027,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MX5313">
-        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <source>Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</source>
-        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <target state="new">Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -3027,9 +3027,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MX5313">
-        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <source>Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</source>
-        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <target state="new">Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -3027,9 +3027,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MX5313">
-        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <source>Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</source>
-        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <target state="new">Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -3027,9 +3027,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MX5313">
-        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <source>Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</source>
-        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <target state="new">Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -3027,9 +3027,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MX5313">
-        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <source>Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</source>
-        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <target state="new">Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -3027,9 +3027,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MX5313">
-        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <source>Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</source>
-        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <target state="new">Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -3027,9 +3027,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MX5313">
-        <source>Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <source>Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</source>
-        <target state="new">Could not find pkg-config. Please install the Mono.framework from https://mono-project.com/Downloads
+        <target state="new">Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</target>
         <note>
 		</note>


### PR DESCRIPTION
This also makes things a bit easier with regards to the .NET 5 work.

Fixes https://github.com/xamarin/xamarin-macios/issues/7923.