### PR TITLE
[mac][mapkit] Allow creation of MKLocalSearchCompleter instance

### DIFF
--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -1897,7 +1897,6 @@ namespace MapKit {
 
 	[TV (9,2)][NoWatch][iOS (9,3)][Mac(10,11,4)]
 	[BaseType (typeof (NSObject))]
-	[DisableDefaultCtor]
 	interface MKLocalSearchCompleter {
 		[Export ("queryFragment")]
 		string QueryFragment { get; set; }

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -1897,9 +1897,7 @@ namespace MapKit {
 
 	[TV (9,2)][NoWatch][iOS (9,3)][Mac(10,11,4)]
 	[BaseType (typeof (NSObject))]
-#if MONOMAC || XAMCORE_3_0 // Avoid breaking change in iOS
 	[DisableDefaultCtor]
-#endif
 	interface MKLocalSearchCompleter {
 		[Export ("queryFragment")]
 		string QueryFragment { get; set; }
@@ -1953,7 +1951,7 @@ namespace MapKit {
 
 	[TV (9,2)][NoWatch][iOS (9,3)]
 	[BaseType (typeof(NSObject))]
-#if MONOMAC || XAMCORE_3_0 // Avoid breaking change in iOS
+#if MONOMAC || XAMCORE_3_0 // "You do not create instances of this class directly"
 	[DisableDefaultCtor]
 #endif
 	interface MKLocalSearchCompletion {


### PR DESCRIPTION
- Fix #8274
- Turns out that MKLocalSearchCompleter can be instanced, even on iOS
	- Tested on sim and in docs
- MKLocalSearchCompletion is still not instanced, updating comment

See:
- https://developer.apple.com/documentation/mapkit/mklocalsearchcompleter?language=objc
- https://developer.apple.com/documentation/mapkit/mklocalsearchcompletion?language=objc