### PR TITLE
[Harness] Refactor certain class names to simplify the extraction of the RunTestTask.

### DIFF
--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -13,8 +13,6 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Xharness.TestTasks;
-using MSBuildTask = Xharness.Jenkins.TestTasks.MSBuildTask;
-using DotNetBuildTask = Xharness.Jenkins.TestTasks.DotNetBuildTask;
 
 namespace Xharness.Jenkins {
 	public class Jenkins : IResourceManager, IErrorKnowledgeBase

--- a/tests/xharness/Jenkins/TestTasks/BuildProjectTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/BuildProjectTask.cs
@@ -7,7 +7,7 @@ using Xharness.TestTasks;
 namespace Xharness.Jenkins.TestTasks {
 	abstract class BuildProjectTask : BuildToolTask
 	{
-		Xharness.TestTasks.BuildProjectTask BuildProject => buildToolTask as Xharness.TestTasks.BuildProjectTask; 
+		BuildProject  BuildProject => buildToolTask as BuildProject; 
 
 		public string SolutionPath {
 			get => BuildProject.SolutionPath;
@@ -22,7 +22,7 @@ namespace Xharness.Jenkins.TestTasks {
 		public override bool SupportsParallelExecution => BuildProject.SupportsParallelExecution;
 
 		protected override void InitializeTool () 
-			=> buildToolTask = new Xharness.TestTasks.BuildProjectTask (ProcessManager, Jenkins, this, this);
+			=> buildToolTask = new BuildProject  (ProcessManager, Jenkins, this, this);
 
 		// This method must be called with the desktop resource acquired
 		// (which is why it takes an IAcquiredResources as a parameter without using it in the function itself).

--- a/tests/xharness/Jenkins/TestTasks/BuildProjectTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/BuildProjectTask.cs
@@ -7,7 +7,7 @@ using Xharness.TestTasks;
 namespace Xharness.Jenkins.TestTasks {
 	abstract class BuildProjectTask : BuildToolTask
 	{
-		BuildProject  BuildProject => buildToolTask as BuildProject; 
+		BuildProject BuildProject => buildToolTask as BuildProject; 
 
 		public string SolutionPath {
 			get => BuildProject.SolutionPath;
@@ -22,7 +22,7 @@ namespace Xharness.Jenkins.TestTasks {
 		public override bool SupportsParallelExecution => BuildProject.SupportsParallelExecution;
 
 		protected override void InitializeTool () 
-			=> buildToolTask = new BuildProject  (ProcessManager, Jenkins, this, this);
+			=> buildToolTask = new BuildProject (ProcessManager, Jenkins, this, this);
 
 		// This method must be called with the desktop resource acquired
 		// (which is why it takes an IAcquiredResources as a parameter without using it in the function itself).

--- a/tests/xharness/Jenkins/TestTasks/BuildToolTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/BuildToolTask.cs
@@ -6,7 +6,7 @@ namespace Xharness.Jenkins.TestTasks
 {
 	public abstract class BuildToolTask : AppleTestTask
 	{
-		protected Xharness.TestTasks.BuildToolTask buildToolTask;
+		protected Xharness.TestTasks.BuildTool buildToolTask;
 
 		public IProcessManager ProcessManager { get; }
 
@@ -54,7 +54,7 @@ namespace Xharness.Jenkins.TestTasks
 			set => buildToolTask.Mode = value;
 		}
 
-		protected virtual void InitializeTool () => buildToolTask = new Xharness.TestTasks.BuildToolTask (ProcessManager);
+		protected virtual void InitializeTool () => buildToolTask = new Xharness.TestTasks.BuildTool (ProcessManager);
 		public virtual Task CleanAsync () => buildToolTask.CleanAsync ();
 	}
 }

--- a/tests/xharness/Jenkins/TestTasks/DotNetBuildTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/DotNetBuildTask.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 
+using Xharness.TestTasks;
+
 namespace Xharness.Jenkins.TestTasks {
 	class DotNetBuildTask : MSBuildTask {
 
@@ -23,7 +25,7 @@ namespace Xharness.Jenkins.TestTasks {
 		}
 
 		protected override void InitializeTool () =>
-			buildToolTask = new Xharness.TestTasks.DotNetBuildTask (
+			buildToolTask = new DotNetBuild (
 				msbuildPath: ToolName,
 				processManager: ProcessManager,
 				resourceManager: Jenkins,

--- a/tests/xharness/Jenkins/TestTasks/MSBuildTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/MSBuildTask.cs
@@ -14,13 +14,13 @@ namespace Xharness.Jenkins.TestTasks {
 		protected virtual List<string> ToolArguments => 
 				MSBuild.GetToolArguments (ProjectPlatform, ProjectConfiguration, ProjectFile, BuildLog);
 
-		Xharness.TestTasks.MSBuildTask MSBuild => buildToolTask as Xharness.TestTasks.MSBuildTask;
+		Xharness.TestTasks.MSBuild MSBuild => buildToolTask as Xharness.TestTasks.MSBuild;
 
 		public MSBuildTask (Jenkins jenkins, TestProject testProject, IProcessManager processManager)
 			: base (jenkins, testProject, processManager) { }
 
 		protected override void InitializeTool () => 
-			buildToolTask = new Xharness.TestTasks.MSBuildTask (
+			buildToolTask = new Xharness.TestTasks.MSBuild (
 				msbuildPath: ToolName,
 				processManager: ProcessManager,
 				resourceManager: Jenkins,

--- a/tests/xharness/TestTasks/BuildProject.cs
+++ b/tests/xharness/TestTasks/BuildProject.cs
@@ -10,14 +10,14 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 
 namespace Xharness.TestTasks {
-	public class BuildProjectTask : BuildToolTask {
+	public class BuildProject : BuildTool {
 		public IResourceManager ResourceManager { get; set; }
 		public IEnvManager EnviromentManager { get; set; }
 		public IEventLogger EventLogger { get; set; }
 
 		public string SolutionPath { get; set; }
 
-		public BuildProjectTask (IProcessManager processManager, IResourceManager resourceManager, IEventLogger eventLogger, IEnvManager envManager) : base (processManager)
+		public BuildProject (IProcessManager processManager, IResourceManager resourceManager, IEventLogger eventLogger, IEnvManager envManager) : base (processManager)
 		{
 			ResourceManager = resourceManager ?? throw new ArgumentNullException (nameof (resourceManager));
 			EventLogger = eventLogger ?? throw new ArgumentNullException (nameof (eventLogger));

--- a/tests/xharness/TestTasks/BuildTool.cs
+++ b/tests/xharness/TestTasks/BuildTool.cs
@@ -4,7 +4,7 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 
 namespace Xharness.TestTasks {
 
-	public class BuildToolTask
+	public class BuildTool
 	{
 		public string TestName { get; set; }
 		public IProcessManager ProcessManager { get; }
@@ -14,12 +14,12 @@ namespace Xharness.TestTasks {
 		public bool SpecifyPlatform { get; set; } = true;
 		public bool SpecifyConfiguration { get; set; } = true;
 
-		public BuildToolTask (IProcessManager processManager)
+		public BuildTool (IProcessManager processManager)
 		{ 
 			ProcessManager = processManager ?? throw new ArgumentNullException (nameof (processManager));
 		}
 
-		public BuildToolTask (IProcessManager processManager, TestPlatform platform) : this (processManager)
+		public BuildTool (IProcessManager processManager, TestPlatform platform) : this (processManager)
 		{
 			Platform = platform;
 		}

--- a/tests/xharness/TestTasks/DotNetBuild.cs
+++ b/tests/xharness/TestTasks/DotNetBuild.cs
@@ -3,9 +3,9 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 
 namespace Xharness.TestTasks {
-	public class DotNetBuildTask : MSBuildTask {
+	public class DotNetBuild : MSBuild {
 
-		public DotNetBuildTask (string msbuildPath,
+		public DotNetBuild (string msbuildPath,
 							IProcessManager processManager,
 							IResourceManager resourceManager,
 							IEventLogger eventLogger,

--- a/tests/xharness/TestTasks/MSBuild.cs
+++ b/tests/xharness/TestTasks/MSBuild.cs
@@ -10,7 +10,7 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 
 namespace Xharness.TestTasks {
 
-	public class MSBuildTask : BuildProjectTask {
+	public class MSBuild : BuildProject {
 		readonly IErrorKnowledgeBase errorKnowledgeBase;
 		readonly string msbuildPath;
 
@@ -29,7 +29,7 @@ namespace Xharness.TestTasks {
 			return args;
 		}
 
-		public MSBuildTask (string msbuildPath,
+		public MSBuild (string msbuildPath,
 							IProcessManager processManager,
 							IResourceManager resourceManager,
 							IEventLogger eventLogger,

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -120,13 +120,13 @@
     <Compile Include="TestTasks\IAcquiredResource.cs" />
     <Compile Include="TestTasks\Resource.cs" />
     <Compile Include="TestTasks\Resources.cs" />
-    <Compile Include="TestTasks\BuildToolTask.cs" />
-    <Compile Include="TestTasks\BuildProjectTask.cs" />
+    <Compile Include="TestTasks\BuildTool.cs" />
+    <Compile Include="TestTasks\BuildProject.cs" />
     <Compile Include="TestTasks\IResourceManager.cs" />
     <Compile Include="TestTasks\IEnvManager.cs" />
-    <Compile Include="TestTasks\MSBuildTask.cs" />
+    <Compile Include="TestTasks\MSBuild.cs" />
     <Compile Include="TestTasks\IErrorKnowledgeBase.cs" />
-    <Compile Include="TestTasks\DotNetBuildTask.cs" />
+    <Compile Include="TestTasks\DotNetBuild.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\tools\common\SdkVersions.cs">


### PR DESCRIPTION
The initial idea of the refactoring looked nice but as soon as we want
to get the RunTestTask out of jenkins, we have a number of naming
issues. Move the tools to not use the *Task postfix so that it is
cleaner and we can later extra the RunTestTask better.