### PR TITLE
[generator] Handle (ignore) C#8 special nullability attributes

### DIFF
--- a/src/generator-attribute-manager.cs
+++ b/src/generator-attribute-manager.cs
@@ -375,6 +375,14 @@ public class AttributeManager
 
 		List<T> list = null;
 		for (int i = 0; i < attributes.Count; i++) {
+
+			// special compiler attribtues not usable from C#
+			switch (attributes [i].AttributeType.FullName) {
+			case "System.Runtime.CompilerServices.NullableAttribute":
+			case "System.Runtime.CompilerServices.NullableContextAttribute":
+				continue;
+			}
+
 			foreach (var attrib in CreateAttributeInstance<T> (attributes [i], provider)) {
 				if (list == null)
 					list = new List<T> ();


### PR DESCRIPTION
C# 8 nullability attributes are special (injected into assemblies) and
not meant to be used from C# source code.

We do not **use** them (we generated them) so existing attributes can
be ignored (filtered) by the generator.

Fix https://github.com/xamarin/xamarin-macios/issues/8347