### PR TITLE
[Harness] Dotnet does not need to restore.

### DIFF
--- a/tests/xharness/Jenkins/TestTasks/DotNetBuildTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/DotNetBuildTask.cs
@@ -12,6 +12,8 @@ namespace Xharness.Jenkins.TestTasks {
 
 		protected override string ToolName => Harness.DOTNET;
 
+		public override bool RestoreNugets => false; // 'dotnet build' will restore
+
 		public override void SetEnvironmentVariables (Process process)
 		{
 			base.SetEnvironmentVariables (process);


### PR DESCRIPTION
Removed line due to a bad merge, re-add it.