### PR TITLE
[jenkins] Add a timeout to the final tasks as well.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -848,12 +848,16 @@ timestamps {
                 reportFinalStatus ("", "${gitHash}", "${currentStage}")
             } // timeout
         } catch (err) {
-            reportFinalStatus ("${err}", "${gitHash}", "${currentStage}")
+            timeout (time: 5, unit: 'MINUTES') { // Give 5 minutes to publish results to GitHub/Slack
+                reportFinalStatus ("${err}", "${gitHash}", "${currentStage}")
+            } // timeout
         } finally {
-            stage ('Final tasks') {
-                sh (script: "${workspace}/xamarin-macios/jenkins/publish-results.sh", returnStatus: true /* don't throw exceptions if something goes wrong */)
-                sh (script: "make git-clean-all -C ${workspace}/xamarin-macios", returnStatus: true /* don't throw exceptions if something goes wrong */)
-            }
-        }
+            timeout (time: 60, unit: 'MINUTES') { // Give an hour to publish and upload stuff
+                stage ('Final tasks') {
+                    sh (script: "${workspace}/xamarin-macios/jenkins/publish-results.sh", returnStatus: true /* don't throw exceptions if something goes wrong */)
+                    sh (script: "make git-clean-all -C ${workspace}/xamarin-macios", returnStatus: true /* don't throw exceptions if something goes wrong */)
+                }
+            } // timeout
+        } // try
     } // node
 } // timestamps


### PR DESCRIPTION
This makes it so that if something goes wrong when publishing results and it
ends up stuck, the job won't stay hung for days until we realize what's
happening.