### PR TITLE
[mtouch] Handle a failure to launch the native linker better by showing better error messages.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -3884,7 +3884,7 @@ public class TestApp {
 				mtouch.Abi = "x86_64";
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "first build");
-				mtouch.AssertWarningPattern (5217, "Native linking possibly failed because the linker command line was too long .[0-9]* characters..");
+				mtouch.AssertErrorPattern (5217, "Native linking failed because the linker command line was too long .[0-9]* characters..");
 
 				mtouch.CustomArguments = new string [] { "--dynamic-symbol-mode=code" };
 				mtouch.AssertExecute (MTouchAction.BuildSim, "second build");

--- a/tools/mtouch/BuildTasks.mtouch.cs
+++ b/tools/mtouch/BuildTasks.mtouch.cs
@@ -341,7 +341,7 @@ namespace Xamarin.Bundler
 							int arg_max;
 							if (int.TryParse (getconf_output.ToString ().Trim (' ', '\t', '\n', '\r'), out arg_max)) {
 								if (cmd_length > arg_max) {
-									linker_errors.Add (ErrorHelper.CreateWarning (5217, Errors.MT5217, cmd_length));
+									linker_errors.Add (ErrorHelper.CreateError (5217, Errors.MT5217, cmd_length));
 								} else {
 									Driver.Log (3, $"Linker failure is probably not due to command-line length (actual: {cmd_length} limit: {arg_max}");
 								}
@@ -355,9 +355,11 @@ namespace Xamarin.Bundler
 				}
 			} catch (System.ComponentModel.Win32Exception wex) {
 				/* This means we failed to execute the linker, not that the linker itself returned with a failure */
-				if (wex.NativeErrorCode == 7 /* E2BIG = Too many arguments */ )
-					linker_errors.Add (ErrorHelper.CreateWarning (5217, wex, Errors.MT5217, cmd_length));
-				linker_errors.Add (ErrorHelper.CreateError (5222, wex, Errors.MX5222, wex.Message));
+				if (wex.NativeErrorCode == 7 /* E2BIG = Too many arguments */ ) {
+					linker_errors.Add (ErrorHelper.CreateError (5217, wex, Errors.MT5217, cmd_length));
+				} else {
+					linker_errors.Add (ErrorHelper.CreateError (5222, wex, Errors.MX5222, wex.Message));
+				}
 			}
 
 			ErrorHelper.Show (linker_errors);

--- a/tools/mtouch/BuildTasks.mtouch.cs
+++ b/tools/mtouch/BuildTasks.mtouch.cs
@@ -307,50 +307,59 @@ namespace Xamarin.Bundler
 			// and very hard to diagnose otherwise when hidden from the build output. Ref: bug #2430
 			var linker_errors = new List<Exception> ();
 			var output = new StringBuilder ();
-			var code = await Driver.RunCommandAsync (Target.App.CompilerPath, CompilerFlags.ToArray (), null, output, suppressPrintOnErrors: true);
+			var cmd_length = Target.App.CompilerPath.Length + 1 + CompilerFlags.ToString ().Length;
 
-			Application.ProcessNativeLinkerOutput (Target, output.ToString (), CompilerFlags.AllLibraries, linker_errors, code != 0);
+			try {
+				var code = await Driver.RunCommandAsync (Target.App.CompilerPath, CompilerFlags.ToArray (), null, output, suppressPrintOnErrors: true);
 
-			if (code != 0) {
-				Console.WriteLine ($"Process exited with code {code}, command:\n{Target.App.CompilerPath} {CompilerFlags.ToString ()}\n{output} ");
-				// if the build failed - it could be because of missing frameworks / libraries we identified earlier
-				foreach (var assembly in Target.Assemblies) {
-					if (assembly.UnresolvedModuleReferences == null)
-						continue;
+				Application.ProcessNativeLinkerOutput (Target, output.ToString (), CompilerFlags.AllLibraries, linker_errors, code != 0);
 
-					foreach (var mr in assembly.UnresolvedModuleReferences) {
-						// TODO: add more diagnose information on the warnings
-						var name = Path.GetFileNameWithoutExtension (mr.Name);
-						linker_errors.Add (new MonoTouchException (5215, false, Errors.MT5215, name));
+				if (code != 0) {
+					Console.WriteLine ($"Process exited with code {code}, command:\n{Target.App.CompilerPath} {CompilerFlags.ToString ()}\n{output} ");
+					// if the build failed - it could be because of missing frameworks / libraries we identified earlier
+					foreach (var assembly in Target.Assemblies) {
+						if (assembly.UnresolvedModuleReferences == null)
+							continue;
+
+						foreach (var mr in assembly.UnresolvedModuleReferences) {
+							// TODO: add more diagnose information on the warnings
+							var name = Path.GetFileNameWithoutExtension (mr.Name);
+							linker_errors.Add (new MonoTouchException (5215, false, Errors.MT5215, name));
+						}
 					}
-				}
-				// mtouch does not validate extra parameters given to GCC when linking (--gcc_flags)
-				if (Target.App.UserGccFlags?.Count > 0)
-					linker_errors.Add (new MonoTouchException (5201, true, Errors.MT5201, StringUtils.FormatArguments (Target.App.UserGccFlags)));
-				else
-					linker_errors.Add (new MonoTouchException (5202, true, Errors.MT5202));
+					// mtouch does not validate extra parameters given to GCC when linking (--gcc_flags)
+					if (Target.App.UserGccFlags?.Count > 0)
+						linker_errors.Add (new MonoTouchException (5201, true, Errors.MT5201, StringUtils.FormatArguments (Target.App.UserGccFlags)));
+					else
+						linker_errors.Add (new MonoTouchException (5202, true, Errors.MT5202));
 
-				if (code == 255) {
-					// check command length
-					// getconf ARG_MAX
-					StringBuilder getconf_output = new StringBuilder ();
-					if (Driver.RunCommand ("getconf", new [] { "ARG_MAX" }, output: getconf_output, suppressPrintOnErrors: true) == 0) {
-						int arg_max;
-						if (int.TryParse (getconf_output.ToString ().Trim (' ', '\t', '\n', '\r'), out arg_max)) {
-							var cmd_length = Target.App.CompilerPath.Length + 1 + CompilerFlags.ToString ().Length;
-							if (cmd_length > arg_max) {
-								linker_errors.Add (ErrorHelper.CreateWarning (5217, Errors.MT5217, cmd_length));
+					if (code == 255) {
+						// check command length
+						// getconf ARG_MAX
+						StringBuilder getconf_output = new StringBuilder ();
+						if (Driver.RunCommand ("getconf", new [] { "ARG_MAX" }, output: getconf_output, suppressPrintOnErrors: true) == 0) {
+							int arg_max;
+							if (int.TryParse (getconf_output.ToString ().Trim (' ', '\t', '\n', '\r'), out arg_max)) {
+								if (cmd_length > arg_max) {
+									linker_errors.Add (ErrorHelper.CreateWarning (5217, Errors.MT5217, cmd_length));
+								} else {
+									Driver.Log (3, $"Linker failure is probably not due to command-line length (actual: {cmd_length} limit: {arg_max}");
+								}
 							} else {
-								Driver.Log (3, $"Linker failure is probably not due to command-line length (actual: {cmd_length} limit: {arg_max}");
+								Driver.Log (3, "Failed to parse 'getconf ARG_MAX' output: {0}", getconf_output);
 							}
 						} else {
-							Driver.Log (3, "Failed to parse 'getconf ARG_MAX' output: {0}", getconf_output);
+							Driver.Log (3, "Failed to execute 'getconf ARG_MAX'\n{0}", getconf_output);
 						}
-					} else {
-						Driver.Log (3, "Failed to execute 'getconf ARG_MAX'\n{0}", getconf_output);
 					}
 				}
+			} catch (System.ComponentModel.Win32Exception wex) {
+				/* This means we failed to execute the linker, not that the linker itself returned with a failure */
+				if (wex.NativeErrorCode == 7 /* E2BIG = Too many arguments */ )
+					linker_errors.Add (ErrorHelper.CreateWarning (5217, wex, Errors.MT5217, cmd_length));
+				linker_errors.Add (ErrorHelper.CreateError (5222, wex, Errors.MX5222, wex.Message));
 			}
+
 			ErrorHelper.Show (linker_errors);
 
 			// the native linker can prefer private (and existing) over public (but non-existing) framework when weak_framework are used

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -2249,6 +2249,12 @@ namespace Xamarin.Bundler {
             }
         }
         
+        internal static string MX5222 {
+            get {
+                return ResourceManager.GetString("MX5222", resourceCulture);
+            }
+        }
+        
         internal static string MT5301 {
             get {
                 return ResourceManager.GetString("MT5301", resourceCulture);

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -2590,6 +2590,13 @@
 		</comment>
 	</data>
 	
+    <data name="MX5222" xml:space="preserve">
+        <value>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </value>
+        <comment>
+        </comment>
+    </data>
+
 	<data name="MT5301" xml:space="preserve">
 		<value>Missing 'strip' tool. Please install Xcode 'Command-Line Tools' component
 		</value>

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -2556,7 +2556,7 @@
 	</data>
 
 	<data name="MT5217" xml:space="preserve">
-		<value>Native linking possibly failed because the linker command line was too long ({0} characters).
+		<value>Native linking failed because the linker command line was too long ({0} characters).
 		</value>
 		<comment>
 		</comment>

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -2994,6 +2994,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5222">
+        <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </source>
+        <target state="new">The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </target>
+        <note>
+        </note>
+      </trans-unit>
       <trans-unit id="MX5305">
         <source>Missing 'lipo' tool. Please install Xcode 'Command-Line Tools' component
 		</source>

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -2579,9 +2579,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MT5217">
-        <source>Native linking possibly failed because the linker command line was too long ({0} characters).
+        <source>Native linking failed because the linker command line was too long ({0} characters).
 		</source>
-        <target state="new">Native linking possibly failed because the linker command line was too long ({0} characters).
+        <target state="new">Native linking failed because the linker command line was too long ({0} characters).
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -2994,6 +2994,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5222">
+        <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </source>
+        <target state="new">The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </target>
+        <note>
+        </note>
+      </trans-unit>
       <trans-unit id="MX5305">
         <source>Missing 'lipo' tool. Please install Xcode 'Command-Line Tools' component
 		</source>

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -2579,9 +2579,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MT5217">
-        <source>Native linking possibly failed because the linker command line was too long ({0} characters).
+        <source>Native linking failed because the linker command line was too long ({0} characters).
 		</source>
-        <target state="new">Native linking possibly failed because the linker command line was too long ({0} characters).
+        <target state="new">Native linking failed because the linker command line was too long ({0} characters).
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -2994,6 +2994,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5222">
+        <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </source>
+        <target state="new">The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </target>
+        <note>
+        </note>
+      </trans-unit>
       <trans-unit id="MX5305">
         <source>Missing 'lipo' tool. Please install Xcode 'Command-Line Tools' component
 		</source>

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -2579,9 +2579,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MT5217">
-        <source>Native linking possibly failed because the linker command line was too long ({0} characters).
+        <source>Native linking failed because the linker command line was too long ({0} characters).
 		</source>
-        <target state="new">Native linking possibly failed because the linker command line was too long ({0} characters).
+        <target state="new">Native linking failed because the linker command line was too long ({0} characters).
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -2994,6 +2994,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5222">
+        <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </source>
+        <target state="new">The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </target>
+        <note>
+        </note>
+      </trans-unit>
       <trans-unit id="MX5305">
         <source>Missing 'lipo' tool. Please install Xcode 'Command-Line Tools' component
 		</source>

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -2579,9 +2579,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MT5217">
-        <source>Native linking possibly failed because the linker command line was too long ({0} characters).
+        <source>Native linking failed because the linker command line was too long ({0} characters).
 		</source>
-        <target state="new">Native linking possibly failed because the linker command line was too long ({0} characters).
+        <target state="new">Native linking failed because the linker command line was too long ({0} characters).
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -2994,6 +2994,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5222">
+        <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </source>
+        <target state="new">The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </target>
+        <note>
+        </note>
+      </trans-unit>
       <trans-unit id="MX5305">
         <source>Missing 'lipo' tool. Please install Xcode 'Command-Line Tools' component
 		</source>

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -2579,9 +2579,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MT5217">
-        <source>Native linking possibly failed because the linker command line was too long ({0} characters).
+        <source>Native linking failed because the linker command line was too long ({0} characters).
 		</source>
-        <target state="new">Native linking possibly failed because the linker command line was too long ({0} characters).
+        <target state="new">Native linking failed because the linker command line was too long ({0} characters).
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -2994,6 +2994,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5222">
+        <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </source>
+        <target state="new">The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </target>
+        <note>
+        </note>
+      </trans-unit>
       <trans-unit id="MX5305">
         <source>Missing 'lipo' tool. Please install Xcode 'Command-Line Tools' component
 		</source>

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -2579,9 +2579,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MT5217">
-        <source>Native linking possibly failed because the linker command line was too long ({0} characters).
+        <source>Native linking failed because the linker command line was too long ({0} characters).
 		</source>
-        <target state="new">Native linking possibly failed because the linker command line was too long ({0} characters).
+        <target state="new">Native linking failed because the linker command line was too long ({0} characters).
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -2994,6 +2994,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5222">
+        <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </source>
+        <target state="new">The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </target>
+        <note>
+        </note>
+      </trans-unit>
       <trans-unit id="MX5305">
         <source>Missing 'lipo' tool. Please install Xcode 'Command-Line Tools' component
 		</source>

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -2579,9 +2579,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MT5217">
-        <source>Native linking possibly failed because the linker command line was too long ({0} characters).
+        <source>Native linking failed because the linker command line was too long ({0} characters).
 		</source>
-        <target state="new">Native linking possibly failed because the linker command line was too long ({0} characters).
+        <target state="new">Native linking failed because the linker command line was too long ({0} characters).
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -2994,6 +2994,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5222">
+        <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </source>
+        <target state="new">The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </target>
+        <note>
+        </note>
+      </trans-unit>
       <trans-unit id="MX5305">
         <source>Missing 'lipo' tool. Please install Xcode 'Command-Line Tools' component
 		</source>

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -2579,9 +2579,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MT5217">
-        <source>Native linking possibly failed because the linker command line was too long ({0} characters).
+        <source>Native linking failed because the linker command line was too long ({0} characters).
 		</source>
-        <target state="new">Native linking possibly failed because the linker command line was too long ({0} characters).
+        <target state="new">Native linking failed because the linker command line was too long ({0} characters).
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -2994,6 +2994,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5222">
+        <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </source>
+        <target state="new">The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </target>
+        <note>
+        </note>
+      </trans-unit>
       <trans-unit id="MX5305">
         <source>Missing 'lipo' tool. Please install Xcode 'Command-Line Tools' component
 		</source>

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -2579,9 +2579,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MT5217">
-        <source>Native linking possibly failed because the linker command line was too long ({0} characters).
+        <source>Native linking failed because the linker command line was too long ({0} characters).
 		</source>
-        <target state="new">Native linking possibly failed because the linker command line was too long ({0} characters).
+        <target state="new">Native linking failed because the linker command line was too long ({0} characters).
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -2994,6 +2994,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5222">
+        <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </source>
+        <target state="new">The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </target>
+        <note>
+        </note>
+      </trans-unit>
       <trans-unit id="MX5305">
         <source>Missing 'lipo' tool. Please install Xcode 'Command-Line Tools' component
 		</source>

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -2579,9 +2579,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MT5217">
-        <source>Native linking possibly failed because the linker command line was too long ({0} characters).
+        <source>Native linking failed because the linker command line was too long ({0} characters).
 		</source>
-        <target state="new">Native linking possibly failed because the linker command line was too long ({0} characters).
+        <target state="new">Native linking failed because the linker command line was too long ({0} characters).
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -2994,6 +2994,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5222">
+        <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </source>
+        <target state="new">The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </target>
+        <note>
+        </note>
+      </trans-unit>
       <trans-unit id="MX5305">
         <source>Missing 'lipo' tool. Please install Xcode 'Command-Line Tools' component
 		</source>

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -2579,9 +2579,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MT5217">
-        <source>Native linking possibly failed because the linker command line was too long ({0} characters).
+        <source>Native linking failed because the linker command line was too long ({0} characters).
 		</source>
-        <target state="new">Native linking possibly failed because the linker command line was too long ({0} characters).
+        <target state="new">Native linking failed because the linker command line was too long ({0} characters).
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -2994,6 +2994,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5222">
+        <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </source>
+        <target state="new">The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </target>
+        <note>
+        </note>
+      </trans-unit>
       <trans-unit id="MX5305">
         <source>Missing 'lipo' tool. Please install Xcode 'Command-Line Tools' component
 		</source>

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -2579,9 +2579,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MT5217">
-        <source>Native linking possibly failed because the linker command line was too long ({0} characters).
+        <source>Native linking failed because the linker command line was too long ({0} characters).
 		</source>
-        <target state="new">Native linking possibly failed because the linker command line was too long ({0} characters).
+        <target state="new">Native linking failed because the linker command line was too long ({0} characters).
 		</target>
         <note>
 		</note>

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -2994,6 +2994,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX5222">
+        <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </source>
+        <target state="new">The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
+        </target>
+        <note>
+        </note>
+      </trans-unit>
       <trans-unit id="MX5305">
         <source>Missing 'lipo' tool. Please install Xcode 'Command-Line Tools' component
 		</source>

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -2579,9 +2579,9 @@
 		</note>
       </trans-unit>
       <trans-unit id="MT5217">
-        <source>Native linking possibly failed because the linker command line was too long ({0} characters).
+        <source>Native linking failed because the linker command line was too long ({0} characters).
 		</source>
-        <target state="new">Native linking possibly failed because the linker command line was too long ({0} characters).
+        <target state="new">Native linking failed because the linker command line was too long ({0} characters).
 		</target>
         <note>
 		</note>


### PR DESCRIPTION
dotnet will throw a Win32Exception if the command line is too long, so handle
that scenario. Also handle any other Win32Exceptions and show a better error
message.

This PR is best reviewed by [ignoring whitespace changes](https://github.com/xamarin/xamarin-macios/pull/8391/files?diff=unified&w=1).