### PR TITLE
[AppKit] Ignore failing test on older OS X versions.

### DIFF
--- a/tests/apitest/src/AppKit/NSScreen.cs
+++ b/tests/apitest/src/AppKit/NSScreen.cs
@@ -196,6 +196,10 @@ namespace Xamarin.Mac.Tests
 		[Test]
 		public void MaximumExtendedDynamicRangeColorComponentValueNoMainThread ()
 		{
+			// API states that it works since 10.11 but we have exceptions thrown in the 
+			// bots stating that the selector is missing: https://github.com/xamarin/xamarin-macios/issues/8395
+			// The test seems just to work on 10.15 and fails in older versions.
+			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 15);
 			if (NSScreen.MainScreen == null)
 				Assert.Inconclusive ("Could not find main screen.");
 


### PR DESCRIPTION
The API should be present, yet we have an exception thrown when using
the selector. On 10.15 we do not have issues, so we skip in older
versions. Might be related to the fact that we use headless mac minis.

fixes: https://github.com/xamarin/xamarin-macios/issues/8395