### PR TITLE
[d16-7] [msbuild] Build bindings with the latest (stable) version of C#

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -61,6 +61,7 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 
 	<PropertyGroup>
 		<_GeneratedSourcesFileList>$(GeneratedSourcesDir)sources.list</_GeneratedSourcesFileList>
+		<LangVersion>latest</LangVersion>
 
 		<!-- Add our own pre and post build steps -->
 		<CompileDependsOn>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
@@ -36,6 +36,7 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 
 		<XamarinDefineConstants Condition="'$(XamarinDefineConstants)' == ''">__UNIFIED__;__MOBILE__;__IOS__</XamarinDefineConstants>
 		<DefineConstants>$(XamarinDefineConstants);$(DefineConstants)</DefineConstants>
+		<LangVersion>latest</LangVersion>
 
  		<!-- Add our own pre and post build steps --> 
 		<CompileDependsOn>


### PR DESCRIPTION
We now require C# 8 for nullability support. However we allow custom code
to be included inside binding projects and we should not support anything
(stable) that the C# compiler (installed separately) allow, so `latest`
it is.

Backport of #8387.

/cc @spouliot 