### PR TITLE
[d16-7] [mmp] Fix PostLinkScanTypeReferenceStep from running two times

### DIFF
--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -162,10 +162,6 @@ namespace MonoMac.Tuner {
 			if (options.WarnOnTypeRef.Count > 0)
 				pipeline.Append (new PostLinkScanTypeReferenceStep (options.WarnOnTypeRef));
 
-			// expect that changes can occur until it's all saved back to disk
-			if (options.WarnOnTypeRef.Count > 0)
-				pipeline.AppendStep (new PostLinkScanTypeReferenceStep (options.WarnOnTypeRef));
-
 			return pipeline;
 		}
 


### PR DESCRIPTION
This came with the merge from xcode11.4 into master. Thankfully there
were unit tests to caught it, because Eyeballs Mk I did not.

Fix https://github.com/xamarin/xamarin-macios/issues/8400

Backport of #8402.

/cc @spouliot 