### PR TITLE
[Tests] Ignore failing tests in older versions of Mac OS X.

### DIFF
--- a/tests/apitest/src/AppKit/NSScreen.cs
+++ b/tests/apitest/src/AppKit/NSScreen.cs
@@ -239,6 +239,8 @@ namespace Xamarin.Mac.Tests
 		[Test]
 		public void MaximumReferenceExtendedDynamicRangeColorComponentValueNoMainThread ()
 		{ 
+			// fails in earlier versions with missing selector
+			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 15);
 			if (NSScreen.MainScreen == null)
 				Assert.Inconclusive ("Could not find main screen.");
 


### PR DESCRIPTION
Something must be different between the virtual screen created in a
headless system in older versions of Mac OS X and 10.15. Everything
works on 10.15 older versions throw an exception.

fixes: https://github.com/xamarin/xamarin-macios/issues/8408