### PR TITLE
Extract the ApplePlatform and LinkMode enums into their own files.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -20,6 +20,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\tools\common\ApplePlatform.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
     <Compile Include="..\..\tools\common\StringUtils.cs">
       <Link>StringUtils.cs</Link>
     </Compile>

--- a/src/bgen/bgen.csproj
+++ b/src/bgen/bgen.csproj
@@ -301,6 +301,7 @@
     <Compile Include="$(RepositoryPath)\src\generator-filters.cs" />
     <Compile Include="$(RepositoryPath)\src\generator-typemanager.cs" />
     <Compile Include="$(RepositoryPath)\src\ObjCRuntime\Stret.cs" />
+    <Compile Include="$(RepositoryPath)\tools\common\ApplePlatform.cs" />
     <Compile Include="$(RepositoryPath)\tools\common\TargetFramework.cs" />
     <Compile Include="$(RepositoryPath)\tools\common\StringUtils.cs" />
     <Compile Include="$(BuildDir)\generator-frameworks.g.cs" />

--- a/src/generator.csproj
+++ b/src/generator.csproj
@@ -362,6 +362,7 @@
     <Compile Include="..\src\generator-filters.cs" />
     <Compile Include="..\src\generator-typemanager.cs" />
     <Compile Include="..\src\ObjCRuntime\Stret.cs" />
+    <Compile Include="..\tools\common\ApplePlatform.cs" />
     <Compile Include="..\tools\common\TargetFramework.cs" />
     <Compile Include="..\tools\common\StringUtils.cs" />
     <Compile Include="$(BuildDir)generator-frameworks.g.cs" />

--- a/tools/common/ApplePlatform.cs
+++ b/tools/common/ApplePlatform.cs
@@ -1,0 +1,15 @@
+//
+// ApplePlatform.cs
+//
+// Copyright 2020 Microsoft Corp. All Rights Reserved.
+
+namespace Xamarin.Utils
+{
+	public enum ApplePlatform {
+		None,
+		MacOSX,
+		iOS,
+		WatchOS,
+		TVOS,
+	}
+}

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -34,15 +34,6 @@ namespace Xamarin.Bundler {
 		Trace = 1,
 	}
 
-	public enum LinkMode {
-		None,
-		SDKOnly,
-		All,
-#if !MONOTOUCH
-		Platform,
-#endif
-	}
-
 	public partial class Application
 	{
 		public Cache Cache;

--- a/tools/common/LinkMode.cs
+++ b/tools/common/LinkMode.cs
@@ -1,0 +1,14 @@
+//
+// LinkMode.cs
+//
+// Copyright 2020 Microsoft Corp. All Rights Reserved.
+
+namespace Xamarin.Bundler {
+
+	public enum LinkMode {
+		None,
+		SDKOnly,
+		All,
+		Platform,
+	}
+}

--- a/tools/common/TargetFramework.cs
+++ b/tools/common/TargetFramework.cs
@@ -12,14 +12,6 @@ using System.Linq;
 
 namespace Xamarin.Utils
 {
-	public enum ApplePlatform {
-		None,
-		MacOSX,
-		iOS,
-		WatchOS,
-		TVOS,
-	}
-
 	public struct TargetFramework : IEquatable<TargetFramework>
 	{
 		public static readonly TargetFramework Empty = new TargetFramework ();

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -335,6 +335,9 @@
     <Compile Include="..\..\src\ObjCRuntime\Registrar.cs">
       <Link>external\Registrar.cs</Link>
     </Compile>
+    <Compile Include="..\common\ApplePlatform.cs">
+      <Link>external\ApplePlatform.cs</Link>
+    </Compile>
     <Compile Include="..\common\PListExtensions.cs">
       <Link>external\PListExtensions.cs</Link>
     </Compile>
@@ -370,6 +373,9 @@
     </Compile>
     <Compile Include="..\common\DerivedLinkContext.cs">
       <Link>external\DerivedLinkContext.cs</Link>
+    </Compile>
+    <Compile Include="..\common\LinkMode.cs">
+      <Link>external\LinkMode.cs</Link>
     </Compile>
     <Compile Include="..\common\Optimizations.cs">
       <Link>external\Optimizations.cs</Link>

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -319,6 +319,9 @@
     <Compile Include="..\linker\CoreTypeMapStep.cs">
       <Link>Xamarin.Linker\CoreTypeMapStep.cs</Link>
     </Compile>
+    <Compile Include="..\common\ApplePlatform.cs">
+      <Link>external\ApplePlatform.cs</Link>
+    </Compile>
     <Compile Include="..\common\Driver.cs">
       <Link>external\Driver.cs</Link>
     </Compile>
@@ -351,6 +354,9 @@
     </Compile>
     <Compile Include="..\common\CompilerFlags.cs">
       <Link>external\CompilerFlags.cs</Link>
+    </Compile>
+    <Compile Include="..\common\LinkMode.cs">
+      <Link>external\LinkMode.cs</Link>
     </Compile>
     <Compile Include="..\common\Tuning.cs">
       <Link>external\Tuning.cs</Link>


### PR DESCRIPTION
I also stopped excluding the LinkMode.Platform value from XI, which makes it a bit easier to write shared code.