### PR TITLE
[SystemConfiguration] Add 'IsWWAN' to XM to ease code sharing

### DIFF
--- a/src/SystemConfiguration/NetworkReachability.cs
+++ b/src/SystemConfiguration/NetworkReachability.cs
@@ -30,9 +30,8 @@ namespace SystemConfiguration {
 		ConnectionOnDemand = 1<<5,
 		IsLocalAddress = 1<<16,
 		IsDirect = 1<<17,
-#if !MONOMAC
+		[Unavailable (PlatformName.MacOSX)]
 		IsWWAN = 1<<18,
-#endif
 		ConnectionAutomatic = ConnectionOnTraffic
 	}
 	


### PR DESCRIPTION
`IsWWAN` is not available (so it won't be returned) but it's nicer to
include it anyway to make the code better looking.

The example that triggered this was
https://github.com/xamarin/Essentials/pull/653/files/0bbb51c5480f78ad549b42f7d00f7c625123a8be#r409239375