### PR TITLE
[tests] Remove the mcs variation of tests that run with both mcs and csc.

### DIFF
--- a/tests/common/BundlerTool.cs
+++ b/tests/common/BundlerTool.cs
@@ -335,9 +335,9 @@ namespace Xamarin.Tests
 			Assert.AreEqual (1, Execute (), message);
 		}
 
-		public abstract void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, IList<string> extraArgs = null, string extraCode = null, string usings = null, bool use_csc = true);
+		public abstract void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, IList<string> extraArgs = null, string extraCode = null, string usings = null);
 
-		public static string CompileTestAppExecutable (string targetDirectory, string code = null, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp", string extraCode = null, string usings = null, bool use_csc = true)
+		public static string CompileTestAppExecutable (string targetDirectory, string code = null, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp", string extraCode = null, string usings = null)
 		{
 			if (code == null)
 				code = "public class TestApp { static void Main () { System.Console.WriteLine (typeof (ObjCRuntime.Runtime).ToString ()); } }";
@@ -346,7 +346,7 @@ namespace Xamarin.Tests
 			if (extraCode != null)
 				code += extraCode;
 
-			return CompileTestAppCode ("exe", targetDirectory, code, extraArgs, profile, appName, use_csc);
+			return CompileTestAppCode ("exe", targetDirectory, code, extraArgs, profile, appName);
 		}
 
 		public static string CompileTestAppLibrary (string targetDirectory, string code, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp")
@@ -354,7 +354,7 @@ namespace Xamarin.Tests
 			return CompileTestAppCode ("library", targetDirectory, code, extraArgs, profile, appName);
 		}
 
-		public static string CompileTestAppCode (string target, string targetDirectory, string code, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp", bool use_csc = true)
+		public static string CompileTestAppCode (string target, string targetDirectory, string code, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp")
 		{
 			var ext = target == "exe" ? "exe" : "dll";
 			var cs = Path.Combine (targetDirectory, "testApp.cs");
@@ -365,7 +365,7 @@ namespace Xamarin.Tests
 
 			string output;
 			var args = new List<string> ();
-			string fileName = Configuration.GetCompiler (profile, args, use_csc);
+			string fileName = Configuration.GetCompiler (profile, args);
 			args.Add ("/noconfig");
 			args.Add ($"/t:{target}");
 			args.Add ("/nologo");

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -512,14 +512,10 @@ namespace Xamarin.Tests
 			}
 		}
 
-		public static string GetCompiler (Profile profile, IList<string> args, bool use_csc = true)
+		public static string GetCompiler (Profile profile, IList<string> args)
 		{
 			args.Add ($"-lib:{Path.GetDirectoryName (GetBaseLibrary (profile))}");
-			if (use_csc) {
-				return "/Library/Frameworks/Mono.framework/Commands/csc";
-			} else {
-				return "/Library/Frameworks/Mono.framework/Commands/mcs";
-			}
+			return "/Library/Frameworks/Mono.framework/Commands/csc";
 		}
 #endif // !XAMMAC_TESTS
 		

--- a/tests/mmptest/src/BindingProjectTests.cs
+++ b/tests/mmptest/src/BindingProjectTests.cs
@@ -130,7 +130,6 @@ namespace Xamarin.MMP.Tests
 
 				var logs = SetupAndBuildLinkedTestProjects (projects.Item1, projects.Item2, tmpDir, useProjectReference: false, setupDefaultNativeReference: noEmbedding);
 
-				Assert.False (logs.Item1.Contains ("mcs"), "Bindings project must not use mcs:\n" + logs.Item1);
 				Assert.True (logs.Item1.Contains ("csc"), "Bindings project must use csc:\n" + logs.Item1); 
 
 				var bgenInvocation = logs.Item1.SplitLines ().First (x => x.Contains ("bin/bgen"));

--- a/tests/mmptest/src/MmpTool.cs
+++ b/tests/mmptest/src/MmpTool.cs
@@ -53,7 +53,7 @@ namespace Xamarin
 			}
 		}
 
-		public override void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, IList<string> extraArgs = null, string extraCode = null, string usings = null, bool use_csc = true)
+		public override void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, IList<string> extraArgs = null, string extraCode = null, string usings = null)
 		{
 			if (RootAssembly == null) {
 				OutputPath = CreateTemporaryDirectory ();
@@ -64,7 +64,7 @@ namespace Xamarin
 			ApplicationName = appName;
 			var app = Path.Combine (OutputPath, appName + ".app");
 			Directory.CreateDirectory (app);
-			RootAssembly = CompileTestAppExecutable (OutputPath, code, extraArgs, profile, appName, extraCode, usings, use_csc);
+			RootAssembly = CompileTestAppExecutable (OutputPath, code, extraArgs, profile, appName, extraCode, usings);
 		}
 
 		public override string GetAppAssembliesDirectory()

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2011,14 +2011,10 @@ public class TestApp {
 			return Configuration.GetBaseLibrary (profile);
 		}
 
-		public static string GetCompiler (Profile profile, IList<string> args, bool use_csc = true)
+		public static string GetCompiler (Profile profile, IList<string> args)
 		{
 			args.Add ($"-lib:{Path.GetDirectoryName (GetBaseLibrary (profile))}");
-			if (use_csc) {
-				return "/Library/Frameworks/Mono.framework/Commands/csc";
-			} else {
-				return "/Library/Frameworks/Mono.framework/Commands/mcs";
-			}
+			return "/Library/Frameworks/Mono.framework/Commands/csc";
 		}
 
 		static string GetConfiguration (Profile profile)
@@ -3643,7 +3639,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 
 				// Create a sample exe
 				var code = "public class TestApp { static void Main () { System.Console.WriteLine (typeof (ObjCRuntime.Runtime).ToString ()); } }";
-				var exe = MTouch.CompileTestAppExecutable (tmp, code, new [] { "/debug:full" }, use_csc: false);
+				var exe = MTouch.CompileTestAppExecutable (tmp, code, new [] { "/debug:full" });
 
 				mtouch.AppPath = mtouch.CreateTemporaryDirectory ();
 				mtouch.RootAssembly = exe;
@@ -3660,7 +3656,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 
 				EnsureFilestampChange ();
 				// Recompile the exe, adding only whitespace. This will only change the debug files
-				MTouch.CompileTestAppExecutable (tmp, "\n\n" + code + "\n\n", new [] { "/debug:full" }, use_csc: false);
+				MTouch.CompileTestAppExecutable (tmp, "\n\n" + code + "\n\n", new [] { "/debug:full" });
 
 				// Rebuild the app
 				mtouch.AssertExecute (MTouchAction.BuildSim);
@@ -4013,13 +4009,11 @@ public class HandlerTest
 		}
 
 		[Test]
-		[TestCase (true)]
-		[TestCase (false)]
-		public void SymbolsOutOfDate1 (bool use_csc)
+		public void SymbolsOutOfDate1 ()
 		{
 			using (var mtouch = new MTouchTool ()) {
 				// Compile the managed executable twice, the second time without debugging symbols, which will cause the debugging symbols to become stale
-				mtouch.CreateTemporaryApp (extraArgs: new [] { "/debug:full" }, use_csc: use_csc);
+				mtouch.CreateTemporaryApp (extraArgs: new [] { "/debug:full" });
 				mtouch.CreateTemporaryApp ();
 				mtouch.Linker = MTouchLinker.DontLink; // makes the test faster
 				mtouch.Debug = true; // makes the test faster because it makes simlauncher possible
@@ -4028,16 +4022,14 @@ public class HandlerTest
 		}
 
 		[Test]
-		[TestCase (true)]
-		[TestCase (false)]
-		public void SymbolsOutOfDate2 (bool use_csc)
+		public void SymbolsOutOfDate2 ()
 		{
 			using (var mtouch = new MTouchTool ()) {
 				// Compile the managed executable twice, both times with debugging symbols, but restore the debugging symbols from the first build so that they're stale
-				mtouch.CreateTemporaryApp (extraArgs: new [] { "/debug:full" }, use_csc: use_csc);
-				var symbol_file = use_csc ? Path.ChangeExtension (mtouch.RootAssembly, "pdb") : mtouch.RootAssembly + ".mdb";
+				mtouch.CreateTemporaryApp (extraArgs: new [] { "/debug:full" });
+				var symbol_file = Path.ChangeExtension (mtouch.RootAssembly, "pdb");
 				var symbols = File.ReadAllBytes (symbol_file);
-				mtouch.CreateTemporaryApp (extraArgs: new [] { "/debug:full" }, use_csc: use_csc);
+				mtouch.CreateTemporaryApp (extraArgs: new [] { "/debug:full" });
 				File.WriteAllBytes (symbol_file, symbols);
 				mtouch.Linker = MTouchLinker.DontLink; // makes the test faster
 				mtouch.Debug = true; // makes the test faster because it makes simlauncher possible
@@ -4046,16 +4038,14 @@ public class HandlerTest
 		}
 
 		[Test]
-		[TestCase (true, true)]
-		[TestCase (false, true)]
-		[TestCase (true, false)]
-		[TestCase (false, false)]
-		public void SymbolsBroken1 (bool use_csc, bool compile_with_debug_symbols)
+		[TestCase (true)]
+		[TestCase (false)]
+		public void SymbolsBroken1 (bool compile_with_debug_symbols)
 		{
 			using (var mtouch = new MTouchTool ()) {
 				// (Over)write invalid data in the debug symbol file
-				mtouch.CreateTemporaryApp (use_csc, extraArgs: compile_with_debug_symbols ? new [] { "/debug:full" } : Array.Empty<string> ());
-				var symbol_file = use_csc ? Path.ChangeExtension (mtouch.RootAssembly, "pdb") : mtouch.RootAssembly + ".mdb";
+				mtouch.CreateTemporaryApp (extraArgs: compile_with_debug_symbols ? new [] { "/debug:full" } : Array.Empty<string> ());
+				var symbol_file = Path.ChangeExtension (mtouch.RootAssembly, "pdb");
 				File.WriteAllText (symbol_file, "invalid stuff");
 				mtouch.Linker = MTouchLinker.DontLink; // makes the test faster
 				mtouch.Debug = true; // makes the test faster because it makes simlauncher possible
@@ -4366,9 +4356,9 @@ public class Dummy {
 			ExecutionHelper.Execute ("mono", args, environmentVariables: environment_variables);
 		}
 
-		public static string CompileTestAppExecutable (string targetDirectory, string code = null, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp", string extraCode = null, string usings = null, bool use_csc = true)
+		public static string CompileTestAppExecutable (string targetDirectory, string code = null, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp", string extraCode = null, string usings = null)
 		{
-			return BundlerTool.CompileTestAppExecutable (targetDirectory, code, extraArgs, profile, appName, extraCode, usings, use_csc);
+			return BundlerTool.CompileTestAppExecutable (targetDirectory, code, extraArgs, profile, appName, extraCode, usings);
 		}
 
 		public static string CompileTestAppLibrary (string targetDirectory, string code, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp")
@@ -4376,9 +4366,9 @@ public class Dummy {
 			return BundlerTool.CompileTestAppLibrary (targetDirectory, code, extraArgs, profile, appName);
 		}
 
-		public static string CompileTestAppCode (string target, string targetDirectory, string code, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp", bool use_csc = true)
+		public static string CompileTestAppCode (string target, string targetDirectory, string code, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp")
 		{
-			return BundlerTool.CompileTestAppCode (target, targetDirectory, code, new [] { extraArg }, profile, appName, use_csc);
+			return BundlerTool.CompileTestAppCode (target, targetDirectory, code, new [] { extraArg }, profile, appName);
 		}
 
 		static string CreateBindingLibrary (string targetDirectory, string nativeCode, string bindingCode, string linkWith = null, string extraCode = "", string name = "binding", string[] references = null, string arch = "armv7")

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -487,10 +487,10 @@ namespace Xamarin
 			return MTouch.CompileTestAppLibrary (asm_dir, "class X {}", appName: Path.GetFileNameWithoutExtension (asm_name));
 		}
 
-		public override void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, IList<string> extraArgs = null, string extraCode = null, string usings = null, bool use_csc = true)
+		public override void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, IList<string> extraArgs = null, string extraCode = null, string usings = null)
 		{
 			Profile = profile;
-			CreateTemporaryApp (appName: appName, code: code, extraArgs: extraArgs, extraCode: extraCode, usings: usings, use_csc: use_csc);
+			CreateTemporaryApp (appName: appName, code: code, extraArgs: extraArgs, extraCode: extraCode, usings: usings);
 		}
 
 		public void CreateTemporaryApp ()
@@ -498,7 +498,7 @@ namespace Xamarin
 			CreateTemporaryApp (false, "testApp", null, (IList<string>) null);
 		}
 
-		public void CreateTemporaryApp (bool hasPlist = false, string appName = "testApp", string code = null, IList<string> extraArgs = null, string extraCode = null, string usings = null, bool use_csc = true)
+		public void CreateTemporaryApp (bool hasPlist = false, string appName = "testApp", string code = null, IList<string> extraArgs = null, string extraCode = null, string usings = null)
 		{
 			string testDir;
 			if (RootAssembly == null) {
@@ -510,7 +510,7 @@ namespace Xamarin
 			var app = AppPath ?? Path.Combine (testDir, appName + ".app");
 			Directory.CreateDirectory (app);
 			AppPath = app;
-			RootAssembly = CompileTestAppExecutable (testDir, code, extraArgs, Profile, appName, extraCode, usings, use_csc);
+			RootAssembly = CompileTestAppExecutable (testDir, code, extraArgs, Profile, appName, extraCode, usings);
 
 			if (hasPlist)
 				File.WriteAllText (Path.Combine (app, "Info.plist"), CreatePlist (Profile, appName));


### PR DESCRIPTION
There's no need to test mcs code anymore.