### PR TITLE
[msbuild] Remove the net461 version of the msbuild task assemblies.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
+++ b/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Update="MSBStrings.resx">

--- a/msbuild/Xamarin.Mac.Tasks.Core/Xamarin.Mac.Tasks.Core.csproj
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Xamarin.Mac.Tasks.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IncludeMSBuildAssets Condition="'$(IncludeMSBuildAssets)' == ''">compile</IncludeMSBuildAssets>
   </PropertyGroup>

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -8,55 +8,27 @@
 
   <!--
 
-    NUnit doesn't support executing a test library built for netstandard2.0,
-    which means we need some custom logicto build the test library (this
-    csproj) for net461 while at the same time building the code we want to
-    test for netstandard2.0.
-
-    We use the configuration to distinguish between them: A
-    Debug-netstandard2.0 and Debug-net461 configuration, which indicates how
-    the code we want to test is built (not how the test library itself is
-    built).
-
-    Another problem is that the task assembly (Xamarin.iOS.Tasks.dll) is
-    ILMerged, which really confuses VSfM when using a project reference to the
-    task assembly project file, so instead use a reference to the final
-    Xamarin.iOS.Tasks.dll assembly instead. This is where we specify which
-    Xamarin.iOS.Tasks.dll we want to test (which target framework it was built
-    with), by using the TasksAssemblyTargetFramework variable. We also need to
-    map our custom configurations to the ones used in the task library project
-    file (the TasksAssemblyConfiguration variable). This approach also
-    requires us to manually build the task assembly before building the test
-    assembly (the BuildTasksAssembly target).
+    The task assembly (Xamarin.iOS.Tasks.dll) is ILMerged, which really
+    confuses VSfM when using a project reference to the task assembly project
+    file, so instead use a reference to the final Xamarin.iOS.Tasks.dll
+    assembly instead. This approach requires us to manually build the task
+    assembly before building the test assembly (the BuildTasksAssembly
+    target).
 
   -->
-
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug-netstandard2.0'">
-    <TasksAssemblyTargetFramework>netstandard2.0</TasksAssemblyTargetFramework>
-    <TasksAssemblyConfiguration>Debug</TasksAssemblyConfiguration>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug-net461'">
-    <TasksAssemblyTargetFramework>net461</TasksAssemblyTargetFramework>
-    <TasksAssemblyConfiguration>Debug</TasksAssemblyConfiguration>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- Set some default values -->
-    <TasksAssemblyTargetFramework Condition="'$(TasksAssemblyTargetFramework)' == ''">netstandard2.0</TasksAssemblyTargetFramework>
-    <TasksAssemblyConfiguration Condition="'$(TasksAssemblyConfiguration)' == ''">Debug</TasksAssemblyConfiguration>
-  </PropertyGroup>
 
   <ItemGroup>
     <Reference Include="Microsoft.Build" HintPath="$(MSBuildBinPath)\Microsoft.Build.dll" />
     <Reference Include="Microsoft.Build.Framework" HintPath="$(MSBuildBinPath)\Microsoft.Build.Framework.dll" />
     <Reference Include="Microsoft.Build.Tasks.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll" />
     <Reference Include="Microsoft.Build.Utilities.Core" HintPath="$(MSBuildBinPath)\Microsoft.Build.Utilities.Core.dll" />
-    <Reference Include="Xamarin.iOS.Tasks" HintPath="..\..\Xamarin.iOS.Tasks\bin\$(TasksAssemblyConfiguration)\$(TasksAssemblyTargetFramework)\Xamarin.iOS.Tasks.dll" />
+    <Reference Include="Xamarin.iOS.Tasks" HintPath="..\..\Xamarin.iOS.Tasks\bin\$(Configuration)\netstandard2.0\Xamarin.iOS.Tasks.dll" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />
   </ItemGroup>
 
   <Target Name="BuildTasksAssembly" AfterTargets="BeforeBuild">
-    <MSBuild Projects="..\..\Xamarin.iOS.Tasks\Xamarin.iOS.Tasks.csproj" Properties="TargetFramework=$(TasksAssemblyTargetFramework);Configuration=$(TasksAssemblyConfiguration)" />
+    <MSBuild Projects="..\..\Xamarin.iOS.Tasks\Xamarin.iOS.Tasks.csproj" />
   </Target>
 
   <ItemGroup>

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -209,11 +209,10 @@ killall:
 	@killall Touch.Server >/dev/null 2>&1 || true
 
 NUNIT_MSBUILD_DIR=$(TOP)/packages/NUnit.Runners.2.6.4/tools/lib
-test-ios-tasks: test-ios-tasks-net461 test-ios-tasks-netstandard2.0
-test-ios-tasks-%: verify-system-vsmac-xcode-match
-	$(SYSTEM_MSBUILD) $(TOP)/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj /p:Configuration=Debug-$*
-	cd $(TOP)/msbuild/tests/Xamarin.iOS.Tasks.Tests && $(SYSTEM_XIBUILD) -t -- $(abspath $(TOP)/tools/nunit3-console-3.10.0) $(abspath $(TOP)/msbuild/tests/Xamarin.iOS.Tasks.Tests/bin/Debug-$*/net461/Xamarin.iOS.Tasks.Tests.dll) "--result=$(abspath $(CURDIR)/TestResults_$*_Xamarin.iOS.Tasks.Tests.xml);format=nunit2" -labels=All $(TEST_FIXTURE) || touch .failed-stamp
-	@[[ -z "$$BUILD_REPOSITORY" ]] || ( xsltproc $(TOP)/tests/HtmlTransform.xslt $(CURDIR)/TestResults_$*_Xamarin.iOS.Tasks.Tests.xml > $(TOP)/tests/index-$*.html && echo "@MonkeyWrench: AddFile: $$PWD/index-$*.html" )
+test-ios-tasks: verify-system-vsmac-xcode-match
+	$(SYSTEM_MSBUILD) $(TOP)/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj /p:Configuration=Debug
+	cd $(TOP)/msbuild/tests/Xamarin.iOS.Tasks.Tests && $(SYSTEM_XIBUILD) -t -- $(abspath $(TOP)/tools/nunit3-console-3.10.0) $(abspath $(TOP)/msbuild/tests/Xamarin.iOS.Tasks.Tests/bin/Debug/net461/Xamarin.iOS.Tasks.Tests.dll) "--result=$(abspath $(CURDIR)/TestResults_Xamarin.iOS.Tasks.Tests.xml);format=nunit2" -labels=All $(TEST_FIXTURE) || touch .failed-stamp
+	@[[ -z "$$BUILD_REPOSITORY" ]] || ( xsltproc $(TOP)/tests/HtmlTransform.xslt $(CURDIR)/TestResults_Xamarin.iOS.Tasks.Tests.xml > $(TOP)/tests/index.html && echo "@MonkeyWrench: AddFile: $$PWD/index.html" )
 	@if test -e $(CURDIR)/.$@-failed-stamp; then rm $(CURDIR)/.$@-failed-stamp; exit 1; fi
 
 test-install-sources:

--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -978,51 +978,27 @@ namespace Xharness.Jenkins {
 
 			var crashReportSnapshotFactory = new CrashSnapshotReporterFactory (processManager);
 
-			var net461Project = new TestProject (Path.GetFullPath (Path.Combine (Harness.RootDirectory, "..", "msbuild", "tests", "Xamarin.iOS.Tasks.Tests", "Xamarin.iOS.Tasks.Tests.csproj")));
-			var buildiOSMSBuild_net461 = new MSBuildTask (jenkins: this, testProject: net461Project, processManager: processManager)
-			{
-				SpecifyPlatform = false,
-				SpecifyConfiguration = true,
-				ProjectConfiguration = "Debug-net461",
-				Platform = TestPlatform.iOS,
-				SolutionPath = Path.GetFullPath (Path.Combine (Harness.RootDirectory, "..", "msbuild", "Xamarin.MacDev.Tasks.sln")),
-				SupportsParallelExecution = false,
-			};
-			var nunitExecutioniOSMSBuild_net461 = new NUnitExecuteTask (this, buildiOSMSBuild_net461, processManager)
-			{
-				TestLibrary = Path.Combine (Harness.RootDirectory, "..", "msbuild", "tests", "Xamarin.iOS.Tasks.Tests", "bin", "Debug-net461", "net461", "Xamarin.iOS.Tasks.Tests.dll"),
-				TestProject = net461Project,
-				ProjectConfiguration = "Debug-net461",
-				Platform = TestPlatform.iOS,
-				TestName = "MSBuild tests",
-				Mode = "iOS (net461)",
-				Timeout = TimeSpan.FromMinutes (60),
-				Ignored = !IncludeiOSMSBuild,
-				SupportsParallelExecution = false,
-			};
-			Tasks.Add (nunitExecutioniOSMSBuild_net461);
-
 			var netstandard2Project = new TestProject (Path.GetFullPath (Path.Combine (Harness.RootDirectory, "..", "msbuild", "tests", "Xamarin.iOS.Tasks.Tests", "Xamarin.iOS.Tasks.Tests.csproj")));
-			var buildiOSMSBuild_netstandard2 = new MSBuildTask (jenkins: this, testProject: netstandard2Project, processManager: processManager) {
+			var buildiOSMSBuild = new MSBuildTask (jenkins: this, testProject: netstandard2Project, processManager: processManager) {
 				SpecifyPlatform = false,
 				SpecifyConfiguration = true,
-				ProjectConfiguration = "Debug-netstandard2.0",
+				ProjectConfiguration = "Debug",
 				Platform = TestPlatform.iOS,
 				SolutionPath = Path.GetFullPath (Path.Combine (Harness.RootDirectory, "..", "msbuild", "Xamarin.MacDev.Tasks.sln")),
 				SupportsParallelExecution = false,
 			};
-			var nunitExecutioniOSMSBuild_netstandard2 = new NUnitExecuteTask (this, buildiOSMSBuild_netstandard2, processManager) {
-				TestLibrary = Path.Combine (Harness.RootDirectory, "..", "msbuild", "tests", "Xamarin.iOS.Tasks.Tests", "bin", "Debug-netstandard2.0", "net461", "Xamarin.iOS.Tasks.Tests.dll"),
+			var nunitExecutioniOSMSBuild = new NUnitExecuteTask (this, buildiOSMSBuild, processManager) {
+				TestLibrary = Path.Combine (Harness.RootDirectory, "..", "msbuild", "tests", "Xamarin.iOS.Tasks.Tests", "bin", "Debug", "net461", "Xamarin.iOS.Tasks.Tests.dll"),
 				TestProject = netstandard2Project,
-				ProjectConfiguration = "Debug-netstandard2.0",
+				ProjectConfiguration = "Debug",
 				Platform = TestPlatform.iOS,
 				TestName = "MSBuild tests",
-				Mode = "iOS (netstandard2.0)",
+				Mode = "iOS",
 				Timeout = TimeSpan.FromMinutes (60),
 				Ignored = !IncludeiOSMSBuild,
 				SupportsParallelExecution = false,
 			};
-			Tasks.Add (nunitExecutioniOSMSBuild_netstandard2);
+			Tasks.Add (nunitExecutioniOSMSBuild);
 
 			var installSourcesProject = new TestProject (Path.GetFullPath (Path.Combine (Harness.RootDirectory, "..", "tools", "install-source", "InstallSourcesTests", "InstallSourcesTests.csproj")));
 			var buildInstallSources = new MSBuildTask (jenkins: this, testProject: installSourcesProject, processManager: processManager)


### PR DESCRIPTION
The netstandard2.0 version has been the default for a few weeks now, and no
problems have been found, so just delete the net461 version.

This speeds up testing a bit, since we won't be testing the net461 version
anymore.