### PR TITLE
[mtouch] Always enable experimental-xforms-product-type

### DIFF
--- a/docs/website/optimizations.md
+++ b/docs/website/optimizations.md
@@ -756,20 +756,6 @@ disabling the managed linker.
 The default behavior can be overridden by passing
 `--optimize=[+|-]custom-attributes-removal` to `mtouch` or `mmp`.
 
-## Experimental Xamarin.Forms.Platform.iOS ProductType inclusion
-
-This optimization requires the linker to be enabled and is only applied
-on `Xamarin.Forms.Platform.iOS.dll`.
-
-This is **experimental** and might be removed or replaced in future 
-versions of Xamarin.iOS.
-
-This optimization consider the assembly `Xamarin.Forms.Platform.iOS` as
-a product assembly and does not automagically mark all `NSObject` 
-subclasses. This allows additional removes and optimizations to be 
-applied to the assembly, including the ability to remove `UIWebView` if
-nothing else in the application requires it.
-
 ## Force Rejected Types Removal
 
 This optimization can be enabled when it's not possible to use the 

--- a/tools/common/Optimizations.cs
+++ b/tools/common/Optimizations.cs
@@ -154,8 +154,8 @@ namespace Xamarin.Bundler
 		}
 
 		public bool? ExperimentalFormsProductType {
-			get { return values [(int) Opt.ExperimentalFormsProductType]; }
-			set { values [(int) Opt.ExperimentalFormsProductType] = value; }
+			get { return true; }
+			set { }
 		}
 
 #if MONOTOUCH

--- a/tools/linker/MarkNSObjects.cs
+++ b/tools/linker/MarkNSObjects.cs
@@ -157,7 +157,7 @@ namespace Xamarin.Linker.Steps {
 			var name = type.Module.Assembly.Name.Name;
 			switch (name) {
 			case "Xamarin.Forms.Platform.iOS":
-				return LinkContext.App.Optimizations.ExperimentalFormsProductType == true;
+				return true;
 			default:
 				return name == ProductAssembly;
 			}


### PR DESCRIPTION
Not an experiment anymore - it works as expected.

This half-remove the optimization option (it must remain there to avoid
breaking all projects that have it defined) but it will always be `true`
so `Xamarin.Forms.Platform.iOS.dll` will **always** be considered as SDK
code by the linker.

Fix https://github.com/xamarin/xamarin-macios/issues/8407