### PR TITLE
Avoid ObjCRuntime. Runtime.GetDelegateForBlock race condition.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -243,7 +243,6 @@ namespace ObjCRuntime {
 			Runtime.options = options;
 			delegates = new List<object> ();
 			object_map = new Dictionary <IntPtr, WeakReference> (IntPtrEqualityComparer);
-			block_to_delegate_cache = new Dictionary<IntPtrTypeValueTuple, Delegate> ();
 			intptr_ctor_cache = new Dictionary<Type, ConstructorInfo> (TypeEqualityComparer);
 			intptr_bool_ctor_cache = new Dictionary<Type, ConstructorInfo> (TypeEqualityComparer);
 			lock_obj = new object ();
@@ -945,6 +944,13 @@ namespace ObjCRuntime {
 #endif
 		static Delegate GetDelegateForBlock (IntPtr methodPtr, Type type)
 		{
+			if (block_to_delegate_cache == null) {
+				lock (lock_obj) {
+					if (block_to_delegate_cache == null)
+						block_to_delegate_cache = new Dictionary<IntPtrTypeValueTuple, Delegate> ();
+				}
+			}
+
 			// We do not care if there is a race condition and we initialize two caches
 			// since the worst that can happen is that we end up with an extra
 			// delegate->function pointer.

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -243,6 +243,7 @@ namespace ObjCRuntime {
 			Runtime.options = options;
 			delegates = new List<object> ();
 			object_map = new Dictionary <IntPtr, WeakReference> (IntPtrEqualityComparer);
+			block_to_delegate_cache = new Dictionary<IntPtrTypeValueTuple, Delegate> ();
 			intptr_ctor_cache = new Dictionary<Type, ConstructorInfo> (TypeEqualityComparer);
 			intptr_bool_ctor_cache = new Dictionary<Type, ConstructorInfo> (TypeEqualityComparer);
 			lock_obj = new object ();
@@ -944,9 +945,6 @@ namespace ObjCRuntime {
 #endif
 		static Delegate GetDelegateForBlock (IntPtr methodPtr, Type type)
 		{
-			if (block_to_delegate_cache == null)
-				block_to_delegate_cache = new Dictionary<IntPtrTypeValueTuple, Delegate> ();
-
 			// We do not care if there is a race condition and we initialize two caches
 			// since the worst that can happen is that we end up with an extra
 			// delegate->function pointer.

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -944,26 +944,22 @@ namespace ObjCRuntime {
 #endif
 		static Delegate GetDelegateForBlock (IntPtr methodPtr, Type type)
 		{
-			if (block_to_delegate_cache == null) {
-				lock (lock_obj) {
-					if (block_to_delegate_cache == null)
-						block_to_delegate_cache = new Dictionary<IntPtrTypeValueTuple, Delegate> ();
-				}
-			}
-
 			// We do not care if there is a race condition and we initialize two caches
 			// since the worst that can happen is that we end up with an extra
 			// delegate->function pointer.
 			Delegate val;
 			var pair = new IntPtrTypeValueTuple (methodPtr, type);
-			lock (block_to_delegate_cache) {
+			lock (lock_obj) {
+				if (block_to_delegate_cache == null)
+					block_to_delegate_cache = new Dictionary<IntPtrTypeValueTuple, Delegate> ();
+
 				if (block_to_delegate_cache.TryGetValue (pair, out val))
 					return val;
 			}
 
 			val = Marshal.GetDelegateForFunctionPointer (methodPtr, type);
 
-			lock (block_to_delegate_cache){
+			lock (lock_obj) {
 				block_to_delegate_cache [pair] = val;
 			}
 			return val;


### PR DESCRIPTION
Fixes #8431