### PR TITLE
[AVFoundation] AVPlayerItemMetadataCollector is now 10.12+

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -11993,7 +11993,7 @@ namespace AVFoundation {
 	}
 
 	[Watch (6,0)]
-	[iOS (9,3), Mac (10,11,3)]
+	[iOS (9,3), Mac (10,12)]
 	[TV (9,2)]
 	[BaseType (typeof(AVPlayerItemMediaDataCollector))]
 	interface AVPlayerItemMetadataCollector


### PR DESCRIPTION
- Runs on older macOS show the type is not as documented, nm confirms.
	1) ApiCtorInitTest.DefaultCtorAllowed (Introspection.MacApiCtorInitTest.ApiCtorInitTest.DefaultCtorAllowed)
		1 potential errors found in 1143 default ctor validated:
		Default constructor not allowed for AVFoundation.AVPlayerItemMetadataCollector : Could not create an native instance of the type 'AVFoundation.AVPlayerItemMetadataCollector': the native class hasn't been loaded.