### PR TITLE
[generator] Remove generated, 32bits specific code paths for XM

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3799,19 +3799,7 @@ public partial class Generator : IMemberGatherer {
 		int index64 = dual_enum ? 1 : 0;
 
 		if (CurrentPlatform == PlatformName.MacOSX) {
-			if (need_multi_path) {
-				print ("if (IntPtr.Size == 8) {");
-				indent++;
-				GenerateInvoke (x64_stret, supercall, mi, minfo, selector, args[index64], assign_to_temp, category_type, aligned && x64_stret, EnumMode.Bit64);
-				indent--;
-				print ("} else {");
-				indent++;
-				GenerateInvoke (x86_stret, supercall, mi, minfo, selector, args[0], assign_to_temp, category_type, aligned && x86_stret, EnumMode.Bit32);
-				indent--;
-				print ("}");
-			} else {
-				GenerateInvoke (x86_stret, supercall, mi, minfo, selector, args[0], assign_to_temp, category_type, aligned && x86_stret);
-			}
+			GenerateInvoke (x64_stret, supercall, mi, minfo, selector, args[index64], assign_to_temp, category_type, aligned && x64_stret, EnumMode.Bit64);
 			return;
 		}
 


### PR DESCRIPTION
Product now only supports 64bits but the generator was still
producing some dual 32/64 code.

Fix https://github.com/xamarin/xamarin-macios/issues/8441