### PR TITLE
[jenkins] Provide a login keychain password when installing provisioning profiles.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -705,7 +705,9 @@ timestamps {
                             stage ('Install Provisioning Profiles') {
                                 currentStage = "${STAGE_NAME}"
                                 echo ("Building on ${env.NODE_NAME}")
-                                sh ("${workspace}/maccore/tools/install-qa-provisioning-profiles.sh")
+                                withCredentials ([string (credentialsId: 'login-keychain-password', variable: "LOGIN_KEYCHAIN_PASSWORD")]) {
+                                    sh ("${workspace}/maccore/tools/install-qa-provisioning-profiles.sh")
+                                }
                             }
 
                             stage ('Publish reports') {


### PR DESCRIPTION
This seems to fix an issue where the login keychain would somehow end up
locked, which would break provisioning.