### PR TITLE
[devops] Use a more restricted glob to find directories with sample data in. Fixes xamarin/maccore#2202.

### DIFF
--- a/tools/devops/push-performance-data.sh
+++ b/tools/devops/push-performance-data.sh
@@ -16,7 +16,7 @@ cd "$DIR"
 # the xml from all the bots together into a single enormous xml file, because
 # it'll be close to GitHub's size limit per file (limit is 100mb, the enormous
 # xml file would be ~80mb now), and might very well pass that one day.
-for job in *-*-*-*-*; do
+for job in ????????-????-????-????-????????????; do
 {
 	echo '<?xml version="1.0" encoding="utf-8" standalone="yes"?>'
 	echo '<performance version="1.0">'


### PR DESCRIPTION
The previous pattern would match the output files we created from processing
these directories, and somehow the pattern would match such a file (even
though the pattern should only be executed before doing any processing, when
those files don't exist yet, so I don't know exactly why this is happening),
leading us to try to process those files as if they were directories with
sample data in, with the predictable (disastrous) result.

Fixes https://github.com/xamarin/maccore/issues/2202.