### PR TITLE
[mtouch/mmp] Build and run mtouch and mmp using dotnet.

### DIFF
--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -173,4 +173,4 @@ $(eval $(call NativeCompilationTemplate,-debug,-DDEBUG))
 	$(Q) mkdir -p $@
 
 %.csproj.inc: %.csproj $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/tools/common/create-makefile-fragment.sh
-	$(Q) $(TOP)/tools/common/create-makefile-fragment.sh $(abspath $<) $(abspath $@)
+	$(Q) export DOTNET=$(DOTNET); $(TOP)/tools/common/create-makefile-fragment.sh $(abspath $<) $(abspath $@)

--- a/tests/mmptest/CustomBuildActions.targets
+++ b/tests/mmptest/CustomBuildActions.targets
@@ -1,11 +1,11 @@
 <!-- All msbuild target logic needs to be inside a project tag -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<PropertyGroup>
-	    <BuildDependsOn>$(BuildDependsOn);CreateNativeLibs</BuildDependsOn>
-	</PropertyGroup>
-
-	<Target Name="CreateNativeLibs" Inputs="$(MSBuildThisFileDirectory)/../common/mac/SimpleClass.m" Outputs="$(MSBuildThisFileDirectory)/../mac-binding-project/bin/SimpleClassDylib.dylib;$(MSBuildThisFileDirectory)/../mac-binding-project/bin/SimpleClassStatic.a;$(MSBuildThisFileDirectory)/../mac-binding-project/bin/Mobile-static/MobileBinding.dll">
+	<Target Name="CreateNativeLibs"
+			Inputs="$(MSBuildThisFileDirectory)/../common/mac/SimpleClass.m"
+			Outputs="$(MSBuildThisFileDirectory)/../mac-binding-project/bin/SimpleClassDylib.dylib;$(MSBuildThisFileDirectory)/../mac-binding-project/bin/SimpleClassStatic.a;$(MSBuildThisFileDirectory)/../mac-binding-project/bin/Mobile-static/MobileBinding.dll"
+			BeforeTargets="Build"
+			>
 		<Exec Command="make bin/SimpleClassDylib.dylib bin/SimpleClassStatic.a bin/Mobile-static/MobileBinding.dll" WorkingDirectory="$(MSBuildThisFileDirectory)/../mac-binding-project/"/>
 	</Target>
 </Project>

--- a/tests/mmptest/Makefile
+++ b/tests/mmptest/Makefile
@@ -14,31 +14,24 @@ ifneq ($(SKIP_REGRESSION), 1)
 endif
 
 # example command to run a single test:
-#     make run TEST_FIXTURE=-test=Xamarin.MMP.Tests.MMPTests.AOT_SmokeTest
+#     make run TEST_FIXTURE="--filter Xamarin.MMP.Tests.MMPTests.AOT_SmokeTest"
 # or:
 #     make run XM_TEST_NAME=Xamarin.MMP.Tests.MMPTests.AOT_SmokeTest
 # to run multiple tests:
-#     make run TEST_FIXTURE="-test=Xamarin.MMP.Tests.MMPTests.AOT_32Bit_SmokeTest,Xamarin.MMP.Tests.MMPTests.AOT_SmokeTest"
+#     make run TEST_FIXTURE="--filter Xamarin.MMP.Tests.MMPTests.AOT_32Bit_SmokeTest --filter Xamarin.MMP.Tests.MMPTests.AOT_SmokeTest"
 #
 
 ifeq ($(TEST_FIXTURE),)
 ifneq ($(XM_TEST_NAME),)
-TEST_FIXTURE=-test=$(XM_TEST_NAME)
+TEST_FIXTURE=--filter $(XM_TEST_NAME)
 endif
 endif
 
 run: build
-	rm -f .failed-stamp
-	$(SYSTEM_MONO) --debug $(XIBUILD_EXE_PATH) -t -- $(TOP)/packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe $(abspath $(TOP)/tests/mmptest/bin/Debug/mmptest.dll) "--result=$(abspath $(CURDIR)/TestResult.xml);format=nunit2" $(TEST_FIXTURE) --labels=All || touch $(CURDIR)/.failed-stamp
-	@# Create an html file and tell MonkeyWrench to upload it (if we're running there)
-	@[[ -z "$$BUILD_REPOSITORY" ]] || \
-		( xsltproc $(TOP)/tests/HtmlTransform.xslt TestResult.xml  > index.html && \
-		echo "@MonkeyWrench: AddFile: $$PWD/index.html")
-	@[[ ! -e .failed-stamp ]]
+	$(Q) $(DOTNET) test *.csproj --results-directory:. "--logger:console;verbosity=detailed" "--logger:trx;LogFileName=$(CURDIR)/TestResult.trx" "--logger:html;LogFileName=$(CURDIR)/TestResult.html" $(TEST_FIXTURE)
 
 build:
-	$(Q_XBUILD) $(SYSTEM_XIBUILD) -t -- /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore ../tests-mac.sln
-	$(SYSTEM_XIBUILD) -- mmptest.csproj $(XBUILD_VERBOSITY)
+	$(Q) $(DOTNET) build *.csproj $(XBUILD_VERBOSITY)
 
 clean-local::
 	@rm -rf ./obj

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -1,48 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.11.0\build\NUnit.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>Xamarin.MMP.Tests</RootNamespace>
-    <AssemblyName>mmptest</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>__UNIFIED__;DEBUG;XAMCORE_2_0;MONOMAC;MMP_TEST;__MACOS__</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>0</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefineConstants>__UNIFIED__;XAMCORE_2_0;MONOMAC;MMP_TEST;__MACOS__</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>0</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.3.11.0\lib\net40\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="mmp">
-      <HintPath>..\..\_mac-build\Library\Frameworks\Xamarin.Mac.framework\Versions\git\lib\mmp\mmp.exe</HintPath>
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <ProjectReference Include="..\..\tools\mmp\mmp.csproj" />
+    <Reference Include="Mono.Cecil">
+      <HintPath>..\..\builds\mono-ios-sdk-destdir\ios-bcl\monotouch_tools\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\_mac-build\Library\Frameworks\Xamarin.Mac.framework\Versions\git\lib\mmp\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\..\_mac-build\Library\Frameworks\Xamarin.Mac.framework\Versions\git\lib\mmp\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\builds\mono-ios-sdk-destdir\ios-bcl\monotouch_tools\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -50,8 +23,6 @@
     <Folder Include="unit\" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="src\MMPTest.cs" />
-    <Compile Include="src\NativeReferencesTests.cs" />
     <Compile Include="..\common\mac\ProjectTestHelpers.cs">
       <Link>ProjectTestHelpers.cs</Link>
     </Compile>
@@ -64,20 +35,12 @@
     <Compile Include="..\..\src\ObjCRuntime\RuntimeException.cs">
       <Link>RuntimeException.cs</Link>
     </Compile>
-    <Compile Include="src\ExtensionTests.cs" />
-    <Compile Include="src\RemotingConfigurationTests.cs" />
-    <Compile Include="src\AOTTests.cs" />
     <Compile Include="..\..\tests\mmp-aot-tests\aot.cs">
       <Link>unit\aot.cs</Link>
     </Compile>
-    <Compile Include="src\FrameworkLinksTests.cs" />
-    <Compile Include="src\TargetFrameworkDetectionTests.cs" />
-    <Compile Include="src\LinkerTests.cs" />
-    <Compile Include="src\Extensions.cs" />
     <Compile Include="..\mtouch\Cache.cs">
       <Link>Cache.cs</Link>
     </Compile>
-    <Compile Include="src\NetStandardTests.cs" />
     <Compile Include="..\common\ProductTests.cs">
       <Link>ProductTests.cs</Link>
     </Compile>
@@ -93,29 +56,14 @@
     <Compile Include="..\common\Profile.cs">
       <Link>Profile.cs</Link>
     </Compile>
-    <Compile Include="src\MmpTool.cs" />
     <Compile Include="..\common\BundlerTool.cs">
       <Link>BundlerTool.cs</Link>
     </Compile>
-    <Compile Include="src\CodeStrippingTests.cs" />
     <Compile Include="..\..\tools\common\StringUtils.cs">
       <Link>StringUtils.cs</Link>
     </Compile>
-    <Compile Include="src\WarningTests.cs" />
-    <Compile Include="src\Unified45.cs" />
-    <Compile Include="src\System.ServiceModel\Net45.cs" />
-    <Compile Include="src\BindingProjectTests.cs" />
-    <Compile Include="src\SmokeTests.cs" />
-    <Compile Include="src\RegistrarTests.cs" />
-    <Compile Include="src\AssemblyReferencesTests.cs" />
-    <Compile Include="src\PackageReferenceTests.cs" />
-    <Compile Include="src\BindingProjectNoEmbeddingTests.cs" />
     <Compile Include="..\..\tools\common\SdkVersions.cs">
       <Link>SdkVersions.cs</Link>
-    </Compile>
-    <Compile Include="src\TargetFrameworkMutateTests.cs" />
-    <Compile Include="..\..\tools\common\MachO.cs">
-      <Link>MachO.cs</Link>
     </Compile>
     <Compile Include="..\..\tools\mtouch\Errors.Designer.cs">
       <Link>Errors.Designer.cs</Link>
@@ -136,6 +84,5 @@
       <Link>remoting.config</Link>
     </EmbeddedResource>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="CustomBuildActions.targets" />
 </Project>

--- a/tests/tests-mac.sln
+++ b/tests/tests-mac.sln
@@ -23,6 +23,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "link sdk-mac", "linker\mac\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bindings-test-mac", "bindings-test\bindings-test-mac.csproj", "{20BEA313-7E2D-4209-93C0-E4D99C72695A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mmp", "..\tools\mmp\mmp.csproj", "{45F62609-8E80-4674-AB7A-8DAB24319602}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,14 +35,14 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.Debug|Any CPU.Build.0 = Debug|x86
-		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.Release|Any CPU.ActiveCfg = Release|x86
-		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.Release|Any CPU.Build.0 = Release|x86
+		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.Default|Any CPU.ActiveCfg = Debug|x86
 		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.Default|Any CPU.Build.0 = Debug|x86
-		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.AppStore|Any CPU.ActiveCfg = Debug|x86
-		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.AppStore|Any CPU.Build.0 = Debug|x86
+		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.AppStore|Any CPU.Build.0 = Debug|Any CPU
 		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.Debug|x86.ActiveCfg = Debug|x86
 		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.Debug|x86.Build.0 = Debug|x86
 		{6E5405EC-1F68-4CD8-AD4B-E4CCFBE47977}.Release|x86.ActiveCfg = Release|x86
@@ -165,5 +167,17 @@ Global
 		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Debug|x86.Build.0 = Debug|Any CPU
 		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Release|x86.ActiveCfg = Release|Any CPU
 		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Release|x86.Build.0 = Release|Any CPU
+		{45F62609-8E80-4674-AB7A-8DAB24319602}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{45F62609-8E80-4674-AB7A-8DAB24319602}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{45F62609-8E80-4674-AB7A-8DAB24319602}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{45F62609-8E80-4674-AB7A-8DAB24319602}.Release|Any CPU.Build.0 = Release|Any CPU
+		{45F62609-8E80-4674-AB7A-8DAB24319602}.Default|Any CPU.ActiveCfg = Debug|Any CPU
+		{45F62609-8E80-4674-AB7A-8DAB24319602}.Default|Any CPU.Build.0 = Debug|Any CPU
+		{45F62609-8E80-4674-AB7A-8DAB24319602}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{45F62609-8E80-4674-AB7A-8DAB24319602}.AppStore|Any CPU.Build.0 = Debug|Any CPU
+		{45F62609-8E80-4674-AB7A-8DAB24319602}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{45F62609-8E80-4674-AB7A-8DAB24319602}.Debug|x86.Build.0 = Debug|Any CPU
+		{45F62609-8E80-4674-AB7A-8DAB24319602}.Release|x86.ActiveCfg = Release|Any CPU
+		{45F62609-8E80-4674-AB7A-8DAB24319602}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -281,16 +281,17 @@ namespace Xharness {
 			MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "introspection", "Mac", "introspection-mac.csproj")), targetFrameworkFlavor: MacFlavors.Modern) { Name = "introspection" });
 
 			var hard_coded_test_suites = new [] {
-				new { Directory = "mmptest", ProjectFile = "mmptest", Name = "mmptest", IsNUnit = true, Configurations = (string[]) null, Platform = "x86", Flavors = MacFlavors.Console, },
-				new { Directory = "msbuild-mac", ProjectFile = "msbuild-mac", Name = "MSBuild tests", IsNUnit = true, Configurations = (string[]) null, Platform = "x86", Flavors = MacFlavors.Console, },
-				new { Directory = "xammac_tests", ProjectFile = "xammac_tests", Name = "xammac tests", IsNUnit = false, Configurations = new string [] { "Debug", "Release" }, Platform = "AnyCPU", Flavors = MacFlavors.Modern, },
-				new { Directory = "linker/mac/link all", ProjectFile = "link all-mac", Name = "link all", IsNUnit = false, Configurations = new string [] { "Debug", "Release" }, Platform = "x86", Flavors = MacFlavors.Modern, },
-				new { Directory = "linker/mac/link sdk", ProjectFile = "link sdk-mac", Name = "link sdk", IsNUnit = false, Configurations = new string [] { "Debug", "Release" }, Platform = "x86", Flavors = MacFlavors.Modern, },
+				new { Directory = "mmptest", ProjectFile = "mmptest", Name = "mmptest", IsNUnit = true, Configurations = (string[]) null, Platform = "x86", Flavors = MacFlavors.Console, IsDotNetProject = true, },
+				new { Directory = "msbuild-mac", ProjectFile = "msbuild-mac", Name = "MSBuild tests", IsNUnit = true, Configurations = (string[]) null, Platform = "x86", Flavors = MacFlavors.Console, IsDotNetProject = false, },
+				new { Directory = "xammac_tests", ProjectFile = "xammac_tests", Name = "xammac tests", IsNUnit = false, Configurations = new string [] { "Debug", "Release" }, Platform = "AnyCPU", Flavors = MacFlavors.Modern, IsDotNetProject = false, },
+				new { Directory = "linker/mac/link all", ProjectFile = "link all-mac", Name = "link all", IsNUnit = false, Configurations = new string [] { "Debug", "Release" }, Platform = "x86", Flavors = MacFlavors.Modern, IsDotNetProject = false, },
+				new { Directory = "linker/mac/link sdk", ProjectFile = "link sdk-mac", Name = "link sdk", IsNUnit = false, Configurations = new string [] { "Debug", "Release" }, Platform = "x86", Flavors = MacFlavors.Modern, IsDotNetProject = false, },
 			};
 			foreach (var p in hard_coded_test_suites) {
 				MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p.Directory, p.ProjectFile + ".csproj")), targetFrameworkFlavor: p.Flavors) {
 					Name = p.Name,
 					IsNUnitProject = p.IsNUnit,
+					IsDotNetProject = p.IsDotNetProject,
 					SolutionPath = Path.GetFullPath (Path.Combine (RootDirectory, "tests-mac.sln")),
 					Configurations = p.Configurations,
 					Platform = p.Platform,

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs
@@ -195,7 +195,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 			// Make sure there's a top-level version too.
 			var property_group = csproj.SelectSingleNode("/*/*[local-name() = 'PropertyGroup' and not(@Condition)]");
 
-			var intermediateOutputPath = csproj.CreateElement ("IntermediateOutputPath", MSBuild_Namespace);
+			var intermediateOutputPath = csproj.CreateElement ("IntermediateOutputPath", csproj.GetNamespace ());
 			intermediateOutputPath.InnerText = value;
 			property_group.AppendChild (intermediateOutputPath);
 		}
@@ -215,7 +215,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 			}
 			else
 			{
-				var mea = csproj.CreateElement (key, MSBuild_Namespace);
+				var mea = csproj.CreateElement (key, csproj.GetNamespace ());
 				mea.InnerText = value;
 				firstPropertyGroups.AppendChild (mea);
 			}
@@ -265,11 +265,11 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 			var compile_node = csproj.SelectSingleNode ("//*[local-name() = 'Compile']");
 			var item_group = compile_node.ParentNode;
 
-			var node = csproj.CreateElement ("Compile", MSBuild_Namespace);
+			var node = csproj.CreateElement ("Compile", csproj.GetNamespace ());
 			var include_attribute = csproj.CreateAttribute ("Include");
 			include_attribute.Value = include;
 			node.Attributes.Append (include_attribute);
-			var linkElement = csproj.CreateElement ("Link", MSBuild_Namespace);
+			var linkElement = csproj.CreateElement ("Link", csproj.GetNamespace ());
 			linkElement.InnerText = link;
 			node.AppendChild (linkElement);
 			if (prepend)
@@ -286,7 +286,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 		public static void AddInterfaceDefinition (this XmlDocument csproj, string include)
 		{
 			var itemGroup = csproj.CreateItemGroup ();
-			var id = csproj.CreateElement ("InterfaceDefinition", MSBuild_Namespace);
+			var id = csproj.CreateElement ("InterfaceDefinition", csproj.GetNamespace ());
 			var attrib = csproj.CreateAttribute ("Include");
 			attrib.Value = include;
 			id.Attributes.Append (attrib);
@@ -344,7 +344,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 				if (!EvaluateCondition (pg, platform, configuration))
 					continue;
 
-				var mea = csproj.CreateElement (node, MSBuild_Namespace);
+				var mea = csproj.CreateElement (node, csproj.GetNamespace ());
 				mea.InnerText = value;
 				pg.AppendChild (mea);
 			}
@@ -397,7 +397,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 				if (!EvaluateCondition (pg, platform, configuration))
 					continue;
 
-				var mea = csproj.CreateElement (node, MSBuild_Namespace);
+				var mea = csproj.CreateElement (node, csproj.GetNamespace ());
 				mea.InnerText = value;
 				pg.AppendChild (mea);
 			}
@@ -551,11 +551,23 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 
 				var logicalName = import.SelectSingleNode ("./*[local-name() = 'LogicalName']");
 				if (logicalName == null) {
-					logicalName = csproj.CreateElement ("LogicalName", MSBuild_Namespace);
+					logicalName = csproj.CreateElement ("LogicalName", csproj.GetNamespace ());
 					import.AppendChild (logicalName);
 				}
 				logicalName.InnerText = "Info.plist";
 			}
+		}
+
+		public static string GetNamespace (this XmlDocument csproj)
+		{
+			return IsDotNetProject (csproj) ? null : MSBuild_Namespace;
+		}
+
+		public static bool IsDotNetProject (this XmlDocument csproj)
+		{
+			var project = csproj.SelectSingleNode ("./*[local-name() = 'Project']");
+			var attrib = project.Attributes ["Sdk"];
+			return attrib != null;
 		}
 
 		static XmlNode GetInfoPListNode (this XmlDocument csproj, bool throw_if_not_found = false)
@@ -634,14 +646,14 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 		public static void CreateProjectReferenceValue (this XmlDocument csproj, string existingInclude, string path, string guid, string name)
 		{
 			var referenceNode = csproj.SelectSingleNode ("//*[local-name() = 'Reference' and @Include = '" + existingInclude + "']");
-			var projectReferenceNode = csproj.CreateElement ("ProjectReference", MSBuild_Namespace);
+			var projectReferenceNode = csproj.CreateElement ("ProjectReference", csproj.GetNamespace ());
 			var includeAttribute = csproj.CreateAttribute ("Include");
 			includeAttribute.Value = path.Replace ('/', '\\');
 			projectReferenceNode.Attributes.Append (includeAttribute);
-			var projectNode = csproj.CreateElement ("Project", MSBuild_Namespace);
+			var projectNode = csproj.CreateElement ("Project", csproj.GetNamespace ());
 			projectNode.InnerText = guid;
 			projectReferenceNode.AppendChild (projectNode);
-			var nameNode = csproj.CreateElement ("Name", MSBuild_Namespace);
+			var nameNode = csproj.CreateElement ("Name", csproj.GetNamespace ());
 			nameNode.InnerText = name;
 			projectReferenceNode.AppendChild (nameNode);
 
@@ -650,7 +662,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 				itemGroup = referenceNode.ParentNode;
 				referenceNode.ParentNode.RemoveChild (referenceNode);
 			} else {
-				itemGroup = csproj.CreateElement ("ItemGroup", MSBuild_Namespace);
+				itemGroup = csproj.CreateElement ("ItemGroup", csproj.GetNamespace ());
 				csproj.SelectSingleNode ("//*[local-name() = 'Project']").AppendChild (itemGroup);
 			}
 			itemGroup.AppendChild (projectReferenceNode);
@@ -659,7 +671,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 		static XmlNode CreateItemGroup (this XmlDocument csproj)
 		{
 			var lastItemGroup = csproj.SelectSingleNode ("//*[local-name() = 'ItemGroup'][last()]");
-			var newItemGroup = csproj.CreateElement ("ItemGroup", MSBuild_Namespace);
+			var newItemGroup = csproj.CreateElement ("ItemGroup", csproj.GetNamespace ());
 			lastItemGroup.ParentNode.InsertAfter (newItemGroup, lastItemGroup);
 			return newItemGroup;
 		}
@@ -669,7 +681,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 			var mainPropertyGroup = csproj.SelectSingleNode ("//*[local-name() = 'PropertyGroup' and not(@Condition)]");
 			var mainDefine = mainPropertyGroup.SelectSingleNode ("*[local-name() = 'DefineConstants']");
 			if (mainDefine == null) {
-				mainDefine = csproj.CreateElement ("DefineConstants", MSBuild_Namespace);
+				mainDefine = csproj.CreateElement ("DefineConstants", csproj.GetNamespace ());
 				mainDefine.InnerText = value;
 				mainPropertyGroup.AppendChild (mainDefine);
 			} else {
@@ -738,7 +750,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 				if (!IsNodeApplicable (xmlnode, platform, configuration))
 					continue;
 
-				var defines = csproj.CreateElement ("DefineConstants", MSBuild_Namespace);
+				var defines = csproj.CreateElement ("DefineConstants", csproj.GetNamespace ());
 				defines.InnerText = "$(DefineConstants);" + value;
 				xmlnode.AppendChild (defines);
 				return;
@@ -817,6 +829,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 				new string [] { "None", "Include" },
 				new string [] { "Compile", "Include" },
 				new string [] { "Compile", "Exclude" },
+				new string [] { "Compile", "Remove" },
 				new string [] { "ProjectReference", "Include" },
 				new string [] { "InterfaceDefinition", "Include" },
 				new string [] { "BundleResource", "Include" },
@@ -890,11 +903,14 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 					if (!found)
 						continue;
 					
+					if (attrib == "Remove")
+						skipLogicalName = true;
+
 					// Fix any default LogicalName values (but don't change existing ones).
 					var ln = node.SelectElementNodes ("LogicalName")?.SingleOrDefault ();
 					var links = node.SelectElementNodes ("Link");
 					if (!skipLogicalName && ln == null && !links.Any ()) {
-						ln = csproj.CreateElement ("LogicalName", MSBuild_Namespace);
+						ln = csproj.CreateElement ("LogicalName", csproj.GetNamespace ());
 						node.AppendChild (ln);
 
 						string logicalName = a.Value;

--- a/tools/common/FileCopier.cs
+++ b/tools/common/FileCopier.cs
@@ -123,6 +123,12 @@ namespace Xamarin.Bundler {
 					else if (stage == CopyFileStep.Err) {
 						Log (1, "Could not copy the file '{0}' to '{1}'", source, target);
 						return CopyFileResult.Quit;
+					} else if (stage == CopyFileStep.Start) {
+						if (File.Exists (target) || Directory.Exists (target)) {
+							Log (1, "Deleted target {0}, it's not up-to-date", target);
+							// This callback won't be called for directories, but we can get here for symlinks to directories.
+							File.Delete (target);
+						}
 					}
 					return CopyFileResult.Continue;
 				} else {

--- a/tools/devops/build-samples.csx
+++ b/tools/devops/build-samples.csx
@@ -62,5 +62,7 @@ Console.WriteLine ("Provisioning provisioning profiles...");
 Exec ($"../../../maccore/tools/install-qa-provisioning-profiles.sh");
 
 // .NET core
+// mtouch/mmp need dotnet 3.1.100
+DotNetCoreSdk ("3.1.100");
 // The version number here must match the one in Xamarin.Tests.Configuration:CreateGlobalConfig (tests/sampletester/Configuration.cs).
 DotNetCoreSdk ("2.2.204");

--- a/tools/devops/device-tests-common.yml
+++ b/tools/devops/device-tests-common.yml
@@ -82,7 +82,7 @@ jobs:
 
       EC=0
 
-      ./xamarin-macios/system-dependencies.sh --ignore-all --provision-xcode --provision-xamarin-studio --provision-mono --provision-7z || EC=$?
+      ./xamarin-macios/system-dependencies.sh --ignore-all --provision-xcode --provision-xamarin-studio --provision-mono --provision-7z --provision-dotnet || EC=$?
       if [ $EC -eq 0 ]; then
         echo "##vso[task.setvariable variable=ProvisioningStatus]success"
       else

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -8,19 +8,19 @@ export DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT)
 #
 
 MMP_CONF=Release
-MMP_DIR=bin/$(MMP_CONF)
-LOCAL_MMP=$(MMP_DIR)/mmp.exe
-LOCAL_MMP_COMMAND=$(SYSTEM_MONO) --debug $(LOCAL_MMP)
+MMP_DIR=bin/$(MMP_CONF)/netcoreapp3.1/publish
+LOCAL_MMP=$(MMP_DIR)/mmp
+LOCAL_MMP_COMMAND=$(MMP_DIR)/mmp
 
 # mmp.csproj.inc contains the mmp_dependencies variable used to determine if mmp needs to be rebuilt or not.
 -include mmp.csproj.inc
 
-$(MMP_DIR)/mmp.exe: $(mmp_dependencies)
-	$(Q_GEN) $(SYSTEM_MSBUILD) $(TOP)/Xamarin.Mac.sln "/t:mmp" $(XBUILD_VERBOSITY) /p:Configuration=$(MMP_CONF)
+$(MMP_DIR)/mmp: $(mmp_dependencies)
+	$(Q_GEN) $(DOTNET) publish $(XBUILD_VERBOSITY) /p:Configuration=$(MMP_CONF)
 
 MMP_TARGETS = \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/mmp \
-	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/mmp.exe \
+	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/mmp \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/Xamarin.Mac.registrar.mobile.a \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/Xamarin.Mac.registrar.full.a \
 
@@ -31,10 +31,9 @@ MMP_DIRECTORIES = \
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/mmp: mmp | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin
 	$(Q) $(CP) $< $@
 
-$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/mmp.exe: $(MMP_DIR)/mmp.exe | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp
-	$(Q) $(CP) $(dir $<)/*.exe $(dir $@)
-	$(Q) $(CP) $(dir $<)/*.dll $(dir $@)
-	$(Q) $(CP) $(dir $<)/*.pdb $(dir $@)
+$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/mmp: $(MMP_DIR)/mmp | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp
+	$(Q) rm -Rf $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/
+	$(Q) $(CP) -r $(MMP_DIR)/ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/
 
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/Xamarin.Mac.registrar.%.a: Xamarin.Mac.registrar.%.a | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp
 	$(Q) $(CP) $<* $(dir $@)
@@ -72,7 +71,6 @@ clean-local::
 	rm -f mmp.stub.c mmp.helper.o
 	rm -rf bin obj
 	rm -f Xamarin.Mac.registrar.*
-	$(SYSTEM_MSBUILD) "/t:Clean" /p:Configuration=$(MMP_CONF) *.csproj
 
 include $(TOP)/mk/rules.mk
 include ../common/Make.common

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -619,7 +619,7 @@ namespace Xamarin.Bundler {
 					// to resolve from somewhere else). This makes it explicit that we look in the GAC, and we
 					// now also warn when using FullXamMac and finding assemblies in the GAC.
 					BuildTarget.Resolver.GlobalAssemblyCache = Path.Combine (SystemMonoDirectory, "lib", "mono", "gac");
-					var framework_dir = Path.GetDirectoryName (typeof (object).Module.FullyQualifiedName);
+					var framework_dir = Path.Combine (SystemMonoDirectory, "lib", "mono", "4.5");
 					BuildTarget.Resolver.SystemFrameworkDirectories = new [] {
 						framework_dir,
 						Path.Combine (framework_dir, "Facades")

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1218,15 +1218,20 @@ namespace Xamarin.Bundler {
 
 		static string RunPkgConfig (string option, bool force_system_mono = false)
 		{
-			string [] env = null;
+			var env = new List<string> ();
 
-			if (!IsUnifiedFullSystemFramework && !force_system_mono)
-				env = new [] { "PKG_CONFIG_PATH", Path.Combine (FrameworkLibDirectory, "pkgconfig") };
+			if (!IsUnifiedFullSystemFramework && !force_system_mono) {
+				env.Add ("PKG_CONFIG_PATH");
+				env.Add (Path.Combine (FrameworkLibDirectory, "pkgconfig"));
+			}
+			// Remove any PKG_CONFIG_LIBDIR variables that may be set.
+			env.Add ("PKG_CONFIG_LIBDIR");
+			env.Add (null);
 
 			var sb = new StringBuilder ();
 			int rv;
 			try {
-				rv = RunCommand (PkgConfig, new [] { option, "mono-2" }, env, sb);
+				rv = RunCommand (PkgConfig, new [] { option, "mono-2" }, env.ToArray (), sb);
 			} catch (Exception e) {
 				throw ErrorHelper.CreateError (5314, e, Errors.MX5314, e.Message);
 			}

--- a/tools/mmp/mmp
+++ b/tools/mmp/mmp
@@ -4,4 +4,4 @@ pushd "$(dirname "$0")" > /dev/null
 BIN_DIR=$(pwd -P)
 popd > /dev/null
 
-exec /Library/Frameworks/Mono.framework/Commands/mono --debug "$BIN_DIR/../lib/mmp/mmp.exe" "$@"
+exec "$BIN_DIR/../lib/mmp/mmp" "$@"

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -1,46 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\XliffTasks.1.0.0-beta.20060.1\build\XliffTasks.props" Condition="Exists('..\..\packages\XliffTasks.1.0.0-beta.20060.1\build\XliffTasks.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{F3232882-0FA0-4BB6-9D9C-E2CC779EAF0D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
-    <AssemblyName>mmp</AssemblyName>
-    <RootNamespace>mmp</RootNamespace>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>8.0</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>True</DebugSymbols>
-    <DebugType>portable</DebugType>
-    <Optimize>False</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>MONOMAC;MMP;XAMARIN_APPLETLS;DEBUG</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Deterministic>True</Deterministic>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>portable</DebugType>
-    <Optimize>False</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
     <DefineConstants>MONOMAC;MMP;XAMARIN_APPLETLS</DefineConstants>
-    <WarningLevel>4</WarningLevel>
-    <Deterministic>True</Deterministic>
+    <UpdateXlfOnBuild>true</UpdateXlfOnBuild>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup>
-       <UpdateXlfOnBuild>true</UpdateXlfOnBuild>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Core" />
-    <Reference Include="Mono.Security" />
+    <PackageReference Include="XliffTasks" Version="1.0.0-beta.20154.1" />
     <Reference Include="Mono.Cecil">
       <HintPath>..\..\builds\mono-ios-sdk-destdir\ios-bcl\monotouch_tools\Mono.Cecil.dll</HintPath>
     </Reference>
@@ -49,12 +19,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Application.cs" />
-    <Compile Include="driver.cs" />
-    <Compile Include="aot.cs" />
-    <Compile Include="resolver.cs" />
-    <Compile Include="Tuning.cs" />
-    <Compile Include="Assembly.cs" />
     <Compile Include="..\common\error.cs">
       <Link>external\error.cs</Link>
     </Compile>
@@ -242,21 +206,6 @@
     <Compile Include="..\..\builds\mono-ios-sdk-destdir\ios-sources\mcs\class\Mono.Options\Mono.Options\Options.cs">
       <Link>Options.cs</Link>
     </Compile>
-    <Compile Include="linker\MonoMac.Tuner\MonoMacMarkStep.cs">
-      <Link>MonoMac.Tuner\MonoMacMarkStep.cs</Link>
-    </Compile>
-    <Compile Include="linker\MonoMac.Tuner\MonoMacNamespaces.cs">
-      <Link>MonoMac.Tuner\MonoMacNamespaces.cs</Link>
-    </Compile>
-    <Compile Include="linker\MonoMac.Tuner\OptimizeGeneratedCodeSubStep.cs">
-      <Link>MonoMac.Tuner\OptimizeGeneratedCodeSubStep.cs</Link>
-    </Compile>
-    <Compile Include="linker\MonoMac.Tuner\MacRemoveResources.cs">
-      <Link>MonoMac.Tuner\MacRemoveResources.cs</Link>
-    </Compile>
-    <Compile Include="linker\MonoMac.Tuner\MacMobileProfile.cs">
-      <Link>MonoMac.Tuner\MacMobileProfile.cs</Link>
-    </Compile>
     <Compile Include="..\linker\BaseProfile.cs">
       <Link>Xamarin.Linker\BaseProfile.cs</Link>
     </Compile>
@@ -416,12 +365,6 @@
     <Compile Include="..\linker\RemoveUserResourcesSubStep.cs">
       <Link>Xamarin.Linker\RemoveUserResourcesSubStep.cs</Link>
     </Compile>
-    <Compile Include="linker\MonoMac.Tuner\XamarinMacProfile.cs">
-      <Link>MonoMac.Tuner\XamarinMacProfile.cs</Link>
-    </Compile>
-    <Compile Include="linker\MonoMac.Tuner\MacBaseProfile.cs">
-      <Link>MonoMac.Tuner\MacBaseProfile.cs</Link>
-    </Compile>
     <Compile Include="..\common\FileCopier.cs">
       <Link>external\FileCopier.cs</Link>
     </Compile>
@@ -440,7 +383,6 @@
     <Compile Include="..\linker\CustomSymbolWriter.cs">
       <Link>Xamarin.Linker\CustomSymbolWriter.cs</Link>
     </Compile>
-    <Compile Include="Target.mmp.cs" />
     <Compile Include="..\mtouch\Errors.Designer.cs">
       <Link>Errors.Designer.cs</Link>
       <DependentUpon>Errors.resx</DependentUpon>
@@ -449,7 +391,6 @@
       <Link>Xamarin.Linker\ScanTypeReferenceStep.cs</Link>
     </Compile>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <EmbeddedResource Include="config">
       <LogicalName>config</LogicalName>
@@ -485,7 +426,6 @@
     <None Include="Makefile" />
     <None Include="packages.config" />
   </ItemGroup>
-  <Import Project="..\..\packages\XliffTasks.1.0.0-beta.20060.1\build\XliffTasks.targets" Condition="Exists('..\..\packages\XliffTasks.1.0.0-beta.20060.1\build\XliffTasks.targets')" />
   <Target Name="BuildSdkVersions" Inputs="../common/SdkVersions.cs.in" Outputs="../common/SdkVersions.cs">
     <Exec Command="make ../common/SdkVersions.cs" />
   </Target>

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -197,15 +197,15 @@ $(eval $(call SimlauncherTemplate,-DXAMCORE_2_0 Xamarin.iOS.registrar.ios.simula
 #
 
 MTOUCH_CONF=Release
-MTOUCH_DIR=bin/$(MTOUCH_CONF)
-LOCAL_MTOUCH=$(MTOUCH_DIR)/mtouch.exe
-LOCAL_MTOUCH_COMMAND=$(SYSTEM_MONO) --debug $(LOCAL_MTOUCH)
+MTOUCH_DIR=bin/$(MTOUCH_CONF)/netcoreapp3.1/publish
+LOCAL_MTOUCH=$(MTOUCH_DIR)/mtouch
+LOCAL_MTOUCH_COMMAND=$(MTOUCH_DIR)/mtouch
 
 # mtouch.csproj.inc contains the mtouch_dependencies variable used to determine if mtouch needs to be rebuilt or not.
 -include mtouch.csproj.inc
 
-$(MTOUCH_DIR)/mtouch.exe: $(mtouch_dependencies)
-	$(Q_GEN) $(SYSTEM_MSBUILD) $(TOP)/Xamarin.iOS.sln "/t:mtouch" $(XBUILD_VERBOSITY) /p:Configuration=$(MTOUCH_CONF)
+$(MTOUCH_DIR)/mtouch: $(mtouch_dependencies)
+	$(Q_GEN) $(DOTNET) publish $(XBUILD_VERBOSITY) /p:Configuration=$(MTOUCH_CONF)
 
 #
 # Partial static registrar libraries
@@ -284,7 +284,7 @@ REGISTRAR_CFLAGS=-stdlib=libc++ -std=c++14
 
 TARGETS = \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/mtouch                                          \
-	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mtouch/mtouch.exe                               \
+	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mtouch/mtouch                                   \
 	$(foreach launcher,$(SIMLAUNCHERS),$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/$(launcher)) \
 	$(IOS_DESTDIR)$(MONOTOUCH_SIMULATOR_SDK)/lib/Xamarin.iOS.registrar.a                  \
 
@@ -327,10 +327,9 @@ TARGET_DIRS = \
 $(TARGET_DIRS):
 	$(Q) mkdir -p $@
 
-$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mtouch/mtouch.exe: $(MTOUCH_DIR)/mtouch.exe | $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mtouch
-	$(Q) $(CP) $(dir $<)/*.exe $(dir $@)
-	$(Q) $(CP) $(dir $<)/*.dll $(dir $@)
-	$(Q) $(CP) $(dir $<)/*.pdb $(dir $@)
+$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mtouch/mtouch: $(MTOUCH_DIR)/mtouch | $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mtouch
+	$(Q) rm -Rf $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mtouch/
+	$(Q) $(CP) -r $(MTOUCH_DIR)/ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mtouch/
 
 $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/mtouch: mtouch | $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin
 	$(Q) $(CP) $< $@
@@ -371,7 +370,6 @@ install-mtouch: \
 clean-local::
 	rm -Rf bin obj
 	rm -f $(SIMLAUNCHERS)
-	$(SYSTEM_MSBUILD) "/t:Clean" /p:Configuration=$(MTOUCH_CONF) *.csproj
 
 include $(TOP)/mk/rules.mk
 include ../common/Make.common

--- a/tools/mtouch/mtouch
+++ b/tools/mtouch/mtouch
@@ -4,4 +4,4 @@ pushd "$(dirname "$0")/.." > /dev/null
 MONOTOUCH_PREFIX=$(pwd -P)
 popd > /dev/null
 
-exec /Library/Frameworks/Mono.framework/Commands/mono64 --debug "$MONOTOUCH_PREFIX/lib/mtouch/mtouch.exe" "$@"
+exec "$MONOTOUCH_PREFIX/lib/mtouch/mtouch" "$@"

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -1,57 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
-  <Import Project="..\..\packages\XliffTasks.1.0.0-beta.20078.1\build\XliffTasks.props" Condition="Exists('..\..\packages\XliffTasks.1.0.0-beta.20078.1\build\XliffTasks.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{A737EFCC-4348-4EB1-9C14-4FDC0975388D}</ProjectGuid>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>latest</LangVersion>
+    <DefineConstants>MONOTOUCH;MTOUCH;XAMARIN_APPLETLS</DefineConstants>
+    <UpdateXlfOnBuild>true</UpdateXlfOnBuild>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
-    <AssemblyName>mtouch</AssemblyName>
-    <RootNamespace>mtouch</RootNamespace>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>True</DebugSymbols>
-    <DebugType>portable</DebugType>
-    <Optimize>False</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>MONOTOUCH;MTOUCH;XAMARIN_APPLETLS</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Deterministic>True</Deterministic>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>portable</DebugType>
-    <Optimize>False</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <DefineConstants>MONOTOUCH;MTOUCH;XAMARIN_APPLETLS</DefineConstants>
-    <WarningLevel>4</WarningLevel>
-    <Deterministic>True</Deterministic>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup>
-       <UpdateXlfOnBuild>true</UpdateXlfOnBuild>
-  </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <Compile Include="Application.cs" />
-    <Compile Include="Assembly.cs" />
-    <Compile Include="AssemblyResolver.cs" />
-    <Compile Include="BitcodeConverter.cs" />
+    <PackageReference Include="XliffTasks" Version="1.0.0-beta.20154.1" />
+    <Reference Include="Mono.Cecil">
+      <HintPath>..\..\builds\mono-ios-sdk-destdir\ios-bcl\monotouch_tools\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb">
+      <HintPath>..\..\builds\mono-ios-sdk-destdir\ios-bcl\monotouch_tools\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="..\common\error.cs">
       <Link>external\error.cs</Link>
     </Compile>
-    <Compile Include="mtouch.cs" />
     <Compile Include="..\common\SdkVersions.cs" />
-    <Compile Include="Stripper.cs" />
-    <Compile Include="Target.cs" />
-    <Compile Include="Tuning.cs" />
     <Compile Include="..\..\builds\mono-ios-sdk-destdir\ios-sources\mcs\class\Mono.Options\Mono.Options\Options.cs">
       <Link>Options.cs</Link>
     </Compile>
@@ -418,7 +389,6 @@
     <Compile Include="..\common\BuildTasks.cs">
       <Link>common\BuildTasks.cs</Link>
     </Compile>
-    <Compile Include="BuildTasks.mtouch.cs" />
     <Compile Include="..\common\Symbols.cs">
       <Link>external\Symbols.cs</Link>
     </Compile>
@@ -449,7 +419,7 @@
     <Compile Include="..\linker\CustomSymbolWriter.cs">
       <Link>Xamarin.Linker\CustomSymbolWriter.cs</Link>
     </Compile>
-    <Compile Include="Errors.Designer.cs">
+    <Compile Update="Errors.Designer.cs">
       <DependentUpon>Errors.resx</DependentUpon>
     </Compile>
     <Compile Include="..\linker\ScanTypeReferenceStep.cs">
@@ -461,18 +431,6 @@
     <Compile Include="..\linker\MonoTouch.Tuner\RemoveCodeBase.cs">
       <Link>MonoTouch.Tuner\RemoveCodeBase.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Core" />
-    <Reference Include="System" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\..\builds\mono-ios-sdk-destdir\ios-bcl\monotouch_tools\Mono.Cecil.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\builds\mono-ios-sdk-destdir\ios-bcl\monotouch_tools\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile" />
@@ -493,7 +451,7 @@
     <Folder Include="Xamarin.Linker\" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Errors.resx">
+    <EmbeddedResource Update="Errors.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <XlfSourceFormat>Resx</XlfSourceFormat>
       <XlfOutputItem>EmbeddedResource</XlfOutputItem>
@@ -509,5 +467,4 @@
     <!-- This makes sure that just building the csproj will install the updated mtouch.exe, so that tests get it without having to 'make mtouch' manually -->
     <Exec Command="make mtouch" />
   </Target>
-  <Import Project="..\..\packages\XliffTasks.1.0.0-beta.20078.1\build\XliffTasks.targets" Condition="Exists('..\..\packages\XliffTasks.1.0.0-beta.20078.1\build\XliffTasks.targets')" />
 </Project>


### PR DESCRIPTION
Compatibility: these tools now require dotnet 3.1 (or later) to be installed
before they'll work.

There are a few seemingly unrelated changes: these were required because some
of the tests would fail otherwise.