### PR TITLE
[msbuild] Unify most of the DetectSdkLocations task between Xamarin.Mac and Xamarin.iOS.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -197,111 +197,9 @@ namespace Xamarin.Localization.MSBuild {
             }
         }
         
-        public static string E0026 {
-            get {
-                return ResourceManager.GetString("E0026", resourceCulture);
-            }
-        }
-        
-        public static string E0027 {
-            get {
-                return ResourceManager.GetString("E0027", resourceCulture);
-            }
-        }
-        
-        public static string E0028 {
-            get {
-                return ResourceManager.GetString("E0028", resourceCulture);
-            }
-        }
-        
-        public static string E0029 {
-            get {
-                return ResourceManager.GetString("E0029", resourceCulture);
-            }
-        }
-        
-        public static string E0030 {
-            get {
-                return ResourceManager.GetString("E0030", resourceCulture);
-            }
-        }
-        
-        public static string E0031 {
-            get {
-                return ResourceManager.GetString("E0031", resourceCulture);
-            }
-        }
-        
         public static string E0032 {
             get {
                 return ResourceManager.GetString("E0032", resourceCulture);
-            }
-        }
-        
-        public static string E0033 {
-            get {
-                return ResourceManager.GetString("E0033", resourceCulture);
-            }
-        }
-        
-        public static string W0034 {
-            get {
-                return ResourceManager.GetString("W0034", resourceCulture);
-            }
-        }
-        
-        public static string E0035 {
-            get {
-                return ResourceManager.GetString("E0035", resourceCulture);
-            }
-        }
-        
-        public static string E0036 {
-            get {
-                return ResourceManager.GetString("E0036", resourceCulture);
-            }
-        }
-        
-        public static string E0037 {
-            get {
-                return ResourceManager.GetString("E0037", resourceCulture);
-            }
-        }
-        
-        public static string E0038 {
-            get {
-                return ResourceManager.GetString("E0038", resourceCulture);
-            }
-        }
-        
-        public static string E0039 {
-            get {
-                return ResourceManager.GetString("E0039", resourceCulture);
-            }
-        }
-        
-        public static string E0040 {
-            get {
-                return ResourceManager.GetString("E0040", resourceCulture);
-            }
-        }
-        
-        public static string E0041 {
-            get {
-                return ResourceManager.GetString("E0041", resourceCulture);
-            }
-        }
-        
-        public static string E0042 {
-            get {
-                return ResourceManager.GetString("E0042", resourceCulture);
-            }
-        }
-        
-        public static string E0043 {
-            get {
-                return ResourceManager.GetString("E0043", resourceCulture);
             }
         }
         
@@ -539,12 +437,6 @@ namespace Xamarin.Localization.MSBuild {
             }
         }
         
-        public static string E0083 {
-            get {
-                return ResourceManager.GetString("E0083", resourceCulture);
-            }
-        }
-        
         public static string E0084 {
             get {
                 return ResourceManager.GetString("E0084", resourceCulture);
@@ -560,12 +452,6 @@ namespace Xamarin.Localization.MSBuild {
         public static string E0086 {
             get {
                 return ResourceManager.GetString("E0086", resourceCulture);
-            }
-        }
-        
-        public static string E0087 {
-            get {
-                return ResourceManager.GetString("E0087", resourceCulture);
             }
         }
         
@@ -1052,6 +938,30 @@ namespace Xamarin.Localization.MSBuild {
         public static string E0169 {
             get {
                 return ResourceManager.GetString("E0169", resourceCulture);
+            }
+        }
+        
+        public static string E0170 {
+            get {
+                return ResourceManager.GetString("E0170", resourceCulture);
+            }
+        }
+        
+        public static string E0171 {
+            get {
+                return ResourceManager.GetString("E0171", resourceCulture);
+            }
+        }
+        
+        public static string E0172 {
+            get {
+                return ResourceManager.GetString("E0172", resourceCulture);
+            }
+        }
+        
+        public static string E0173 {
+            get {
+                return ResourceManager.GetString("E0173", resourceCulture);
             }
         }
         

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -138,96 +138,30 @@
         </value>
     </data>
     
-    <data name="E0026" xml:space="preserve">
-        <value>The Apple TVOS SDK is not installed.
-        </value>
-    </data>
-    
-    <data name="E0027" xml:space="preserve">
-        <value>The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </value>
-    </data>
-    
-    <data name="E0028" xml:space="preserve">
-        <value>The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </value>
-    </data>
-    
-    <data name="E0029" xml:space="preserve">
-        <value>Could not locate the TVOS platform directory at path '{0}'
-        </value>
-    </data>
-    
-    <data name="E0030" xml:space="preserve">
-        <value>Could not locate the TVOS '{0}' SDK at path '{1}'
-        </value>
-    </data>
-    
-     <data name="E0031" xml:space="preserve">
-        <value>Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </value>
-    </data>
+    <!-- E0026: not used anymore -->
+    <!-- E0027: not used anymore -->
+    <!-- E0028: not used anymore -->
+    <!-- E0029: not used anymore -->
+    <!-- E0030: not used anymore -->
+    <!-- E0031: not used anymore -->
     
     <data name="E0032" xml:space="preserve">
         <value>Could not locate SDK bin directory
         </value>
     </data>
     
-    <data name="E0033" xml:space="preserve">
-        <value>The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </value>
-    </data>
-    
-    <data name="W0034" xml:space="preserve">
-        <value>The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </value>
-    </data>
-    
-    <data name="E0035" xml:space="preserve">
-        <value>Could not locate the WatchOS platform directory at path '{0}'
-        </value>
-    </data>
-    
-    <data name="E0036" xml:space="preserve">
-        <value>Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </value>
-    </data>
-    
-    <data name="E0037" xml:space="preserve">
-        <value>Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </value>
-    </data>
-    
-    <data name="E0038" xml:space="preserve">
-        <value>The Apple iOS SDK is not installed.
-        </value>
-    </data>
-    
-    <data name="E0039" xml:space="preserve">
-        <value>The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </value>
-    </data>
-    
-    <data name="E0040" xml:space="preserve">
-        <value>The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </value>
-    </data>
-    
-    <data name="E0041" xml:space="preserve">
-        <value>Could not locate the iOS platform directory at path '{0}'
-        </value>
-    </data>
-    
-    <data name="E0042" xml:space="preserve">
-        <value>Could not locate the iOS '{0}' SDK at path '{1}'
-        </value>
-    </data>
-    
-    <data name="E0043" xml:space="preserve">
-        <value>Could not locate the iOS '{0}' SDK usr path at '{1}'
-        </value>
-    </data>
-    
+    <!-- E0033: not used anymore -->
+    <!-- E0034: not used anymore -->
+    <!-- E0035: not used anymore -->
+    <!-- E0036: not used anymore -->
+    <!-- E0037: not used anymore -->
+    <!-- E0038: not used anymore -->
+    <!-- E0039: not used anymore -->
+    <!-- E0040: not used anymore -->
+    <!-- E0041: not used anymore -->
+    <!-- E0042: not used anymore -->
+    <!-- E0043: not used anymore -->
+
     <data name="E0044" xml:space="preserve">
         <value>Could not find a valid Xcode app bundle at '{0}'. Please update your Apple SDK location in Visual Studio's preferences {1}.
         </value>
@@ -239,7 +173,7 @@
     </data>
     
     <data name="E0046" xml:space="preserve">
-        <value>Could not find 'Xamarin.iOS'
+        <value>Could not find '{0}'
         </value>
     </data>
     
@@ -423,18 +357,15 @@
         </value>
     </data>
     
-    <data name="E0083" xml:space="preserve">
-        <value>The Apple macOS SDK is not installed.
-        </value>
-    </data>
+    <!-- E0083: not used anymore -->
     
     <data name="E0084" xml:space="preserve">
-        <value>Could not locate the macOS '{0}' SDK at path '{1}'
+        <value>Could not locate the {0} '{1}' SDK at path '{}'
         </value>
     </data>
     
     <data name="E0085" xml:space="preserve">
-        <value>Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <value>Could not locate the {0} '{1}' SDK usr path at '{2}'
         </value>
     </data>
         
@@ -443,10 +374,7 @@
         </value>
     </data>
     
-    <data name="E0087" xml:space="preserve">
-        <value>Could not find 'Xamarin.Mac'
-        </value>
-    </data>
+    <!-- E0087: not used anymore -->
     
     <data name="E0088" xml:space="preserve">
         <value>Could not get native libraries: {0}
@@ -851,6 +779,26 @@
     
     <data name="E0169" xml:space="preserve">
         <value>Unknown target framework identifier: {0}.
+        </value>
+    </data>
+    
+    <data name="E0170" xml:space="preserve">
+        <value>Could not find {0} in {1}.
+        </value>
+    </data>
+    
+    <data name="E0171" xml:space="preserve">
+        <value>The {0} SDK is not installed.
+        </value>
+    </data>
+    
+    <data name="E0172" xml:space="preserve">
+        <value>The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </value>
+    </data>
+    
+    <data name="E0173" xml:space="preserve">
+        <value>The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
         </value>
     </data>
     

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
@@ -114,122 +114,10 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0026">
-        <source>The Apple TVOS SDK is not installed.
-        </source>
-        <target state="new">The Apple TVOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0027">
-        <source>The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0028">
-        <source>The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0029">
-        <source>Could not locate the TVOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the TVOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0030">
-        <source>Could not locate the TVOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0031">
-        <source>Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0032">
         <source>Could not locate SDK bin directory
         </source>
         <target state="new">Could not locate SDK bin directory
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0033">
-        <source>The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0035">
-        <source>Could not locate the WatchOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the WatchOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0036">
-        <source>Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0037">
-        <source>Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0038">
-        <source>The Apple iOS SDK is not installed.
-        </source>
-        <target state="new">The Apple iOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0039">
-        <source>The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0040">
-        <source>The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0041">
-        <source>Could not locate the iOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the iOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0042">
-        <source>Could not locate the iOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0043">
-        <source>Could not locate the iOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK usr path at '{1}'
         </target>
         <note></note>
       </trans-unit>
@@ -248,11 +136,11 @@
         <note></note>
       </trans-unit>
       <trans-unit id="E0046">
-        <source>Could not find 'Xamarin.iOS'
+        <source>Could not find '{0}'
         </source>
-        <target state="new">Could not find 'Xamarin.iOS'
+        <target state="new">Could not find '{0}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0048">
         <source>Unknown SDK platform: {0}
@@ -392,38 +280,24 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0083">
-        <source>The Apple macOS SDK is not installed.
-        </source>
-        <target state="new">The Apple macOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0084">
-        <source>Could not locate the macOS '{0}' SDK at path '{1}'
+        <source>Could not locate the {0} '{1}' SDK at path '{}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK at path '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK at path '{}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0085">
-        <source>Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <source>Could not locate the {0} '{1}' SDK usr path at '{2}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path
         </source>
         <target state="new">Could not find a valid Xcode developer path
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0087">
-        <source>Could not find 'Xamarin.Mac'
-        </source>
-        <target state="new">Could not find 'Xamarin.Mac'
         </target>
         <note></note>
       </trans-unit>
@@ -769,6 +643,34 @@
         <target state="new">Unknown target framework identifier: {0}.
         </target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="E0170">
+        <source>Could not find {0} in {1}.
+        </source>
+        <target state="new">Could not find {0} in {1}.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0171">
+        <source>The {0} SDK is not installed.
+        </source>
+        <target state="new">The {0} SDK is not installed.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0172">
+        <source>The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0173">
+        <source>The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </target>
+        <note />
       </trans-unit>
       <trans-unit id="E7001">
         <source>Could not resolve host IPs for WiFi debugger settings.
@@ -1509,13 +1411,6 @@
         <source>Supported iPad orientations are not matched pairs
         </source>
         <target state="new">Supported iPad orientations are not matched pairs
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="W0034">
-        <source>The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
         </target>
         <note></note>
       </trans-unit>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
@@ -114,122 +114,10 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0026">
-        <source>The Apple TVOS SDK is not installed.
-        </source>
-        <target state="new">The Apple TVOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0027">
-        <source>The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0028">
-        <source>The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0029">
-        <source>Could not locate the TVOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the TVOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0030">
-        <source>Could not locate the TVOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0031">
-        <source>Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0032">
         <source>Could not locate SDK bin directory
         </source>
         <target state="new">Could not locate SDK bin directory
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0033">
-        <source>The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0035">
-        <source>Could not locate the WatchOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the WatchOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0036">
-        <source>Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0037">
-        <source>Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0038">
-        <source>The Apple iOS SDK is not installed.
-        </source>
-        <target state="new">The Apple iOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0039">
-        <source>The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0040">
-        <source>The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0041">
-        <source>Could not locate the iOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the iOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0042">
-        <source>Could not locate the iOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0043">
-        <source>Could not locate the iOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK usr path at '{1}'
         </target>
         <note></note>
       </trans-unit>
@@ -248,11 +136,11 @@
         <note></note>
       </trans-unit>
       <trans-unit id="E0046">
-        <source>Could not find 'Xamarin.iOS'
+        <source>Could not find '{0}'
         </source>
-        <target state="new">Could not find 'Xamarin.iOS'
+        <target state="new">Could not find '{0}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0048">
         <source>Unknown SDK platform: {0}
@@ -392,38 +280,24 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0083">
-        <source>The Apple macOS SDK is not installed.
-        </source>
-        <target state="new">The Apple macOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0084">
-        <source>Could not locate the macOS '{0}' SDK at path '{1}'
+        <source>Could not locate the {0} '{1}' SDK at path '{}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK at path '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK at path '{}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0085">
-        <source>Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <source>Could not locate the {0} '{1}' SDK usr path at '{2}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path
         </source>
         <target state="new">Could not find a valid Xcode developer path
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0087">
-        <source>Could not find 'Xamarin.Mac'
-        </source>
-        <target state="new">Could not find 'Xamarin.Mac'
         </target>
         <note></note>
       </trans-unit>
@@ -769,6 +643,34 @@
         <target state="new">Unknown target framework identifier: {0}.
         </target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="E0170">
+        <source>Could not find {0} in {1}.
+        </source>
+        <target state="new">Could not find {0} in {1}.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0171">
+        <source>The {0} SDK is not installed.
+        </source>
+        <target state="new">The {0} SDK is not installed.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0172">
+        <source>The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0173">
+        <source>The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </target>
+        <note />
       </trans-unit>
       <trans-unit id="E7001">
         <source>Could not resolve host IPs for WiFi debugger settings.
@@ -1509,13 +1411,6 @@
         <source>Supported iPad orientations are not matched pairs
         </source>
         <target state="new">Supported iPad orientations are not matched pairs
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="W0034">
-        <source>The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
         </target>
         <note></note>
       </trans-unit>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
@@ -114,122 +114,10 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0026">
-        <source>The Apple TVOS SDK is not installed.
-        </source>
-        <target state="new">The Apple TVOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0027">
-        <source>The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0028">
-        <source>The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0029">
-        <source>Could not locate the TVOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the TVOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0030">
-        <source>Could not locate the TVOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0031">
-        <source>Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0032">
         <source>Could not locate SDK bin directory
         </source>
         <target state="new">Could not locate SDK bin directory
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0033">
-        <source>The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0035">
-        <source>Could not locate the WatchOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the WatchOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0036">
-        <source>Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0037">
-        <source>Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0038">
-        <source>The Apple iOS SDK is not installed.
-        </source>
-        <target state="new">The Apple iOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0039">
-        <source>The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0040">
-        <source>The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0041">
-        <source>Could not locate the iOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the iOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0042">
-        <source>Could not locate the iOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0043">
-        <source>Could not locate the iOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK usr path at '{1}'
         </target>
         <note></note>
       </trans-unit>
@@ -248,11 +136,11 @@
         <note></note>
       </trans-unit>
       <trans-unit id="E0046">
-        <source>Could not find 'Xamarin.iOS'
+        <source>Could not find '{0}'
         </source>
-        <target state="new">Could not find 'Xamarin.iOS'
+        <target state="new">Could not find '{0}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0048">
         <source>Unknown SDK platform: {0}
@@ -392,38 +280,24 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0083">
-        <source>The Apple macOS SDK is not installed.
-        </source>
-        <target state="new">The Apple macOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0084">
-        <source>Could not locate the macOS '{0}' SDK at path '{1}'
+        <source>Could not locate the {0} '{1}' SDK at path '{}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK at path '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK at path '{}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0085">
-        <source>Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <source>Could not locate the {0} '{1}' SDK usr path at '{2}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path
         </source>
         <target state="new">Could not find a valid Xcode developer path
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0087">
-        <source>Could not find 'Xamarin.Mac'
-        </source>
-        <target state="new">Could not find 'Xamarin.Mac'
         </target>
         <note></note>
       </trans-unit>
@@ -769,6 +643,34 @@
         <target state="new">Unknown target framework identifier: {0}.
         </target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="E0170">
+        <source>Could not find {0} in {1}.
+        </source>
+        <target state="new">Could not find {0} in {1}.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0171">
+        <source>The {0} SDK is not installed.
+        </source>
+        <target state="new">The {0} SDK is not installed.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0172">
+        <source>The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0173">
+        <source>The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </target>
+        <note />
       </trans-unit>
       <trans-unit id="E7001">
         <source>Could not resolve host IPs for WiFi debugger settings.
@@ -1509,13 +1411,6 @@
         <source>Supported iPad orientations are not matched pairs
         </source>
         <target state="new">Supported iPad orientations are not matched pairs
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="W0034">
-        <source>The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
         </target>
         <note></note>
       </trans-unit>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
@@ -114,122 +114,10 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0026">
-        <source>The Apple TVOS SDK is not installed.
-        </source>
-        <target state="new">The Apple TVOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0027">
-        <source>The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0028">
-        <source>The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0029">
-        <source>Could not locate the TVOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the TVOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0030">
-        <source>Could not locate the TVOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0031">
-        <source>Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0032">
         <source>Could not locate SDK bin directory
         </source>
         <target state="new">Could not locate SDK bin directory
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0033">
-        <source>The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0035">
-        <source>Could not locate the WatchOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the WatchOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0036">
-        <source>Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0037">
-        <source>Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0038">
-        <source>The Apple iOS SDK is not installed.
-        </source>
-        <target state="new">The Apple iOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0039">
-        <source>The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0040">
-        <source>The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0041">
-        <source>Could not locate the iOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the iOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0042">
-        <source>Could not locate the iOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0043">
-        <source>Could not locate the iOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK usr path at '{1}'
         </target>
         <note></note>
       </trans-unit>
@@ -248,11 +136,11 @@
         <note></note>
       </trans-unit>
       <trans-unit id="E0046">
-        <source>Could not find 'Xamarin.iOS'
+        <source>Could not find '{0}'
         </source>
-        <target state="new">Could not find 'Xamarin.iOS'
+        <target state="new">Could not find '{0}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0048">
         <source>Unknown SDK platform: {0}
@@ -392,38 +280,24 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0083">
-        <source>The Apple macOS SDK is not installed.
-        </source>
-        <target state="new">The Apple macOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0084">
-        <source>Could not locate the macOS '{0}' SDK at path '{1}'
+        <source>Could not locate the {0} '{1}' SDK at path '{}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK at path '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK at path '{}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0085">
-        <source>Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <source>Could not locate the {0} '{1}' SDK usr path at '{2}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path
         </source>
         <target state="new">Could not find a valid Xcode developer path
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0087">
-        <source>Could not find 'Xamarin.Mac'
-        </source>
-        <target state="new">Could not find 'Xamarin.Mac'
         </target>
         <note></note>
       </trans-unit>
@@ -769,6 +643,34 @@
         <target state="new">Unknown target framework identifier: {0}.
         </target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="E0170">
+        <source>Could not find {0} in {1}.
+        </source>
+        <target state="new">Could not find {0} in {1}.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0171">
+        <source>The {0} SDK is not installed.
+        </source>
+        <target state="new">The {0} SDK is not installed.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0172">
+        <source>The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0173">
+        <source>The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </target>
+        <note />
       </trans-unit>
       <trans-unit id="E7001">
         <source>Could not resolve host IPs for WiFi debugger settings.
@@ -1509,13 +1411,6 @@
         <source>Supported iPad orientations are not matched pairs
         </source>
         <target state="new">Supported iPad orientations are not matched pairs
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="W0034">
-        <source>The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
         </target>
         <note></note>
       </trans-unit>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
@@ -114,122 +114,10 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0026">
-        <source>The Apple TVOS SDK is not installed.
-        </source>
-        <target state="new">The Apple TVOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0027">
-        <source>The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0028">
-        <source>The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0029">
-        <source>Could not locate the TVOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the TVOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0030">
-        <source>Could not locate the TVOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0031">
-        <source>Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0032">
         <source>Could not locate SDK bin directory
         </source>
         <target state="new">Could not locate SDK bin directory
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0033">
-        <source>The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0035">
-        <source>Could not locate the WatchOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the WatchOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0036">
-        <source>Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0037">
-        <source>Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0038">
-        <source>The Apple iOS SDK is not installed.
-        </source>
-        <target state="new">The Apple iOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0039">
-        <source>The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0040">
-        <source>The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0041">
-        <source>Could not locate the iOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the iOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0042">
-        <source>Could not locate the iOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0043">
-        <source>Could not locate the iOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK usr path at '{1}'
         </target>
         <note></note>
       </trans-unit>
@@ -248,11 +136,11 @@
         <note></note>
       </trans-unit>
       <trans-unit id="E0046">
-        <source>Could not find 'Xamarin.iOS'
+        <source>Could not find '{0}'
         </source>
-        <target state="new">Could not find 'Xamarin.iOS'
+        <target state="new">Could not find '{0}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0048">
         <source>Unknown SDK platform: {0}
@@ -392,38 +280,24 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0083">
-        <source>The Apple macOS SDK is not installed.
-        </source>
-        <target state="new">The Apple macOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0084">
-        <source>Could not locate the macOS '{0}' SDK at path '{1}'
+        <source>Could not locate the {0} '{1}' SDK at path '{}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK at path '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK at path '{}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0085">
-        <source>Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <source>Could not locate the {0} '{1}' SDK usr path at '{2}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path
         </source>
         <target state="new">Could not find a valid Xcode developer path
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0087">
-        <source>Could not find 'Xamarin.Mac'
-        </source>
-        <target state="new">Could not find 'Xamarin.Mac'
         </target>
         <note></note>
       </trans-unit>
@@ -769,6 +643,34 @@
         <target state="new">Unknown target framework identifier: {0}.
         </target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="E0170">
+        <source>Could not find {0} in {1}.
+        </source>
+        <target state="new">Could not find {0} in {1}.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0171">
+        <source>The {0} SDK is not installed.
+        </source>
+        <target state="new">The {0} SDK is not installed.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0172">
+        <source>The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0173">
+        <source>The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </target>
+        <note />
       </trans-unit>
       <trans-unit id="E7001">
         <source>Could not resolve host IPs for WiFi debugger settings.
@@ -1509,13 +1411,6 @@
         <source>Supported iPad orientations are not matched pairs
         </source>
         <target state="new">Supported iPad orientations are not matched pairs
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="W0034">
-        <source>The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
         </target>
         <note></note>
       </trans-unit>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
@@ -114,122 +114,10 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0026">
-        <source>The Apple TVOS SDK is not installed.
-        </source>
-        <target state="new">The Apple TVOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0027">
-        <source>The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0028">
-        <source>The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0029">
-        <source>Could not locate the TVOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the TVOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0030">
-        <source>Could not locate the TVOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0031">
-        <source>Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0032">
         <source>Could not locate SDK bin directory
         </source>
         <target state="new">Could not locate SDK bin directory
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0033">
-        <source>The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0035">
-        <source>Could not locate the WatchOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the WatchOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0036">
-        <source>Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0037">
-        <source>Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0038">
-        <source>The Apple iOS SDK is not installed.
-        </source>
-        <target state="new">The Apple iOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0039">
-        <source>The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0040">
-        <source>The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0041">
-        <source>Could not locate the iOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the iOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0042">
-        <source>Could not locate the iOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0043">
-        <source>Could not locate the iOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK usr path at '{1}'
         </target>
         <note></note>
       </trans-unit>
@@ -248,11 +136,11 @@
         <note></note>
       </trans-unit>
       <trans-unit id="E0046">
-        <source>Could not find 'Xamarin.iOS'
+        <source>Could not find '{0}'
         </source>
-        <target state="new">Could not find 'Xamarin.iOS'
+        <target state="new">Could not find '{0}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0048">
         <source>Unknown SDK platform: {0}
@@ -392,38 +280,24 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0083">
-        <source>The Apple macOS SDK is not installed.
-        </source>
-        <target state="new">The Apple macOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0084">
-        <source>Could not locate the macOS '{0}' SDK at path '{1}'
+        <source>Could not locate the {0} '{1}' SDK at path '{}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK at path '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK at path '{}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0085">
-        <source>Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <source>Could not locate the {0} '{1}' SDK usr path at '{2}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path
         </source>
         <target state="new">Could not find a valid Xcode developer path
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0087">
-        <source>Could not find 'Xamarin.Mac'
-        </source>
-        <target state="new">Could not find 'Xamarin.Mac'
         </target>
         <note></note>
       </trans-unit>
@@ -769,6 +643,34 @@
         <target state="new">Unknown target framework identifier: {0}.
         </target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="E0170">
+        <source>Could not find {0} in {1}.
+        </source>
+        <target state="new">Could not find {0} in {1}.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0171">
+        <source>The {0} SDK is not installed.
+        </source>
+        <target state="new">The {0} SDK is not installed.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0172">
+        <source>The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0173">
+        <source>The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </target>
+        <note />
       </trans-unit>
       <trans-unit id="E7001">
         <source>Could not resolve host IPs for WiFi debugger settings.
@@ -1509,13 +1411,6 @@
         <source>Supported iPad orientations are not matched pairs
         </source>
         <target state="new">Supported iPad orientations are not matched pairs
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="W0034">
-        <source>The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
         </target>
         <note></note>
       </trans-unit>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
@@ -114,122 +114,10 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0026">
-        <source>The Apple TVOS SDK is not installed.
-        </source>
-        <target state="new">The Apple TVOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0027">
-        <source>The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0028">
-        <source>The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0029">
-        <source>Could not locate the TVOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the TVOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0030">
-        <source>Could not locate the TVOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0031">
-        <source>Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0032">
         <source>Could not locate SDK bin directory
         </source>
         <target state="new">Could not locate SDK bin directory
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0033">
-        <source>The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0035">
-        <source>Could not locate the WatchOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the WatchOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0036">
-        <source>Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0037">
-        <source>Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0038">
-        <source>The Apple iOS SDK is not installed.
-        </source>
-        <target state="new">The Apple iOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0039">
-        <source>The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0040">
-        <source>The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0041">
-        <source>Could not locate the iOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the iOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0042">
-        <source>Could not locate the iOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0043">
-        <source>Could not locate the iOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK usr path at '{1}'
         </target>
         <note></note>
       </trans-unit>
@@ -248,11 +136,11 @@
         <note></note>
       </trans-unit>
       <trans-unit id="E0046">
-        <source>Could not find 'Xamarin.iOS'
+        <source>Could not find '{0}'
         </source>
-        <target state="new">Could not find 'Xamarin.iOS'
+        <target state="new">Could not find '{0}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0048">
         <source>Unknown SDK platform: {0}
@@ -392,38 +280,24 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0083">
-        <source>The Apple macOS SDK is not installed.
-        </source>
-        <target state="new">The Apple macOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0084">
-        <source>Could not locate the macOS '{0}' SDK at path '{1}'
+        <source>Could not locate the {0} '{1}' SDK at path '{}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK at path '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK at path '{}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0085">
-        <source>Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <source>Could not locate the {0} '{1}' SDK usr path at '{2}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path
         </source>
         <target state="new">Could not find a valid Xcode developer path
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0087">
-        <source>Could not find 'Xamarin.Mac'
-        </source>
-        <target state="new">Could not find 'Xamarin.Mac'
         </target>
         <note></note>
       </trans-unit>
@@ -769,6 +643,34 @@
         <target state="new">Unknown target framework identifier: {0}.
         </target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="E0170">
+        <source>Could not find {0} in {1}.
+        </source>
+        <target state="new">Could not find {0} in {1}.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0171">
+        <source>The {0} SDK is not installed.
+        </source>
+        <target state="new">The {0} SDK is not installed.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0172">
+        <source>The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0173">
+        <source>The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </target>
+        <note />
       </trans-unit>
       <trans-unit id="E7001">
         <source>Could not resolve host IPs for WiFi debugger settings.
@@ -1509,13 +1411,6 @@
         <source>Supported iPad orientations are not matched pairs
         </source>
         <target state="new">Supported iPad orientations are not matched pairs
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="W0034">
-        <source>The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
         </target>
         <note></note>
       </trans-unit>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
@@ -114,122 +114,10 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0026">
-        <source>The Apple TVOS SDK is not installed.
-        </source>
-        <target state="new">The Apple TVOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0027">
-        <source>The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0028">
-        <source>The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0029">
-        <source>Could not locate the TVOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the TVOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0030">
-        <source>Could not locate the TVOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0031">
-        <source>Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0032">
         <source>Could not locate SDK bin directory
         </source>
         <target state="new">Could not locate SDK bin directory
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0033">
-        <source>The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0035">
-        <source>Could not locate the WatchOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the WatchOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0036">
-        <source>Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0037">
-        <source>Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0038">
-        <source>The Apple iOS SDK is not installed.
-        </source>
-        <target state="new">The Apple iOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0039">
-        <source>The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0040">
-        <source>The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0041">
-        <source>Could not locate the iOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the iOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0042">
-        <source>Could not locate the iOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0043">
-        <source>Could not locate the iOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK usr path at '{1}'
         </target>
         <note></note>
       </trans-unit>
@@ -248,11 +136,11 @@
         <note></note>
       </trans-unit>
       <trans-unit id="E0046">
-        <source>Could not find 'Xamarin.iOS'
+        <source>Could not find '{0}'
         </source>
-        <target state="new">Could not find 'Xamarin.iOS'
+        <target state="new">Could not find '{0}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0048">
         <source>Unknown SDK platform: {0}
@@ -392,38 +280,24 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0083">
-        <source>The Apple macOS SDK is not installed.
-        </source>
-        <target state="new">The Apple macOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0084">
-        <source>Could not locate the macOS '{0}' SDK at path '{1}'
+        <source>Could not locate the {0} '{1}' SDK at path '{}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK at path '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK at path '{}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0085">
-        <source>Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <source>Could not locate the {0} '{1}' SDK usr path at '{2}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path
         </source>
         <target state="new">Could not find a valid Xcode developer path
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0087">
-        <source>Could not find 'Xamarin.Mac'
-        </source>
-        <target state="new">Could not find 'Xamarin.Mac'
         </target>
         <note></note>
       </trans-unit>
@@ -769,6 +643,34 @@
         <target state="new">Unknown target framework identifier: {0}.
         </target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="E0170">
+        <source>Could not find {0} in {1}.
+        </source>
+        <target state="new">Could not find {0} in {1}.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0171">
+        <source>The {0} SDK is not installed.
+        </source>
+        <target state="new">The {0} SDK is not installed.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0172">
+        <source>The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0173">
+        <source>The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </target>
+        <note />
       </trans-unit>
       <trans-unit id="E7001">
         <source>Could not resolve host IPs for WiFi debugger settings.
@@ -1509,13 +1411,6 @@
         <source>Supported iPad orientations are not matched pairs
         </source>
         <target state="new">Supported iPad orientations are not matched pairs
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="W0034">
-        <source>The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
         </target>
         <note></note>
       </trans-unit>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
@@ -114,122 +114,10 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0026">
-        <source>The Apple TVOS SDK is not installed.
-        </source>
-        <target state="new">The Apple TVOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0027">
-        <source>The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0028">
-        <source>The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0029">
-        <source>Could not locate the TVOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the TVOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0030">
-        <source>Could not locate the TVOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0031">
-        <source>Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0032">
         <source>Could not locate SDK bin directory
         </source>
         <target state="new">Could not locate SDK bin directory
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0033">
-        <source>The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0035">
-        <source>Could not locate the WatchOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the WatchOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0036">
-        <source>Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0037">
-        <source>Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0038">
-        <source>The Apple iOS SDK is not installed.
-        </source>
-        <target state="new">The Apple iOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0039">
-        <source>The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0040">
-        <source>The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0041">
-        <source>Could not locate the iOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the iOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0042">
-        <source>Could not locate the iOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0043">
-        <source>Could not locate the iOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK usr path at '{1}'
         </target>
         <note></note>
       </trans-unit>
@@ -248,11 +136,11 @@
         <note></note>
       </trans-unit>
       <trans-unit id="E0046">
-        <source>Could not find 'Xamarin.iOS'
+        <source>Could not find '{0}'
         </source>
-        <target state="new">Could not find 'Xamarin.iOS'
+        <target state="new">Could not find '{0}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0048">
         <source>Unknown SDK platform: {0}
@@ -392,38 +280,24 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0083">
-        <source>The Apple macOS SDK is not installed.
-        </source>
-        <target state="new">The Apple macOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0084">
-        <source>Could not locate the macOS '{0}' SDK at path '{1}'
+        <source>Could not locate the {0} '{1}' SDK at path '{}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK at path '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK at path '{}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0085">
-        <source>Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <source>Could not locate the {0} '{1}' SDK usr path at '{2}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path
         </source>
         <target state="new">Could not find a valid Xcode developer path
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0087">
-        <source>Could not find 'Xamarin.Mac'
-        </source>
-        <target state="new">Could not find 'Xamarin.Mac'
         </target>
         <note></note>
       </trans-unit>
@@ -769,6 +643,34 @@
         <target state="new">Unknown target framework identifier: {0}.
         </target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="E0170">
+        <source>Could not find {0} in {1}.
+        </source>
+        <target state="new">Could not find {0} in {1}.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0171">
+        <source>The {0} SDK is not installed.
+        </source>
+        <target state="new">The {0} SDK is not installed.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0172">
+        <source>The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0173">
+        <source>The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </target>
+        <note />
       </trans-unit>
       <trans-unit id="E7001">
         <source>Could not resolve host IPs for WiFi debugger settings.
@@ -1509,13 +1411,6 @@
         <source>Supported iPad orientations are not matched pairs
         </source>
         <target state="new">Supported iPad orientations are not matched pairs
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="W0034">
-        <source>The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
         </target>
         <note></note>
       </trans-unit>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
@@ -114,122 +114,10 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0026">
-        <source>The Apple TVOS SDK is not installed.
-        </source>
-        <target state="new">The Apple TVOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0027">
-        <source>The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0028">
-        <source>The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0029">
-        <source>Could not locate the TVOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the TVOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0030">
-        <source>Could not locate the TVOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0031">
-        <source>Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0032">
         <source>Could not locate SDK bin directory
         </source>
         <target state="new">Could not locate SDK bin directory
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0033">
-        <source>The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0035">
-        <source>Could not locate the WatchOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the WatchOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0036">
-        <source>Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0037">
-        <source>Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0038">
-        <source>The Apple iOS SDK is not installed.
-        </source>
-        <target state="new">The Apple iOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0039">
-        <source>The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0040">
-        <source>The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0041">
-        <source>Could not locate the iOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the iOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0042">
-        <source>Could not locate the iOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0043">
-        <source>Could not locate the iOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK usr path at '{1}'
         </target>
         <note></note>
       </trans-unit>
@@ -248,11 +136,11 @@
         <note></note>
       </trans-unit>
       <trans-unit id="E0046">
-        <source>Could not find 'Xamarin.iOS'
+        <source>Could not find '{0}'
         </source>
-        <target state="new">Could not find 'Xamarin.iOS'
+        <target state="new">Could not find '{0}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0048">
         <source>Unknown SDK platform: {0}
@@ -392,38 +280,24 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0083">
-        <source>The Apple macOS SDK is not installed.
-        </source>
-        <target state="new">The Apple macOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0084">
-        <source>Could not locate the macOS '{0}' SDK at path '{1}'
+        <source>Could not locate the {0} '{1}' SDK at path '{}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK at path '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK at path '{}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0085">
-        <source>Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <source>Could not locate the {0} '{1}' SDK usr path at '{2}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path
         </source>
         <target state="new">Could not find a valid Xcode developer path
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0087">
-        <source>Could not find 'Xamarin.Mac'
-        </source>
-        <target state="new">Could not find 'Xamarin.Mac'
         </target>
         <note></note>
       </trans-unit>
@@ -769,6 +643,34 @@
         <target state="new">Unknown target framework identifier: {0}.
         </target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="E0170">
+        <source>Could not find {0} in {1}.
+        </source>
+        <target state="new">Could not find {0} in {1}.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0171">
+        <source>The {0} SDK is not installed.
+        </source>
+        <target state="new">The {0} SDK is not installed.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0172">
+        <source>The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0173">
+        <source>The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </target>
+        <note />
       </trans-unit>
       <trans-unit id="E7001">
         <source>Could not resolve host IPs for WiFi debugger settings.
@@ -1509,13 +1411,6 @@
         <source>Supported iPad orientations are not matched pairs
         </source>
         <target state="new">Supported iPad orientations are not matched pairs
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="W0034">
-        <source>The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
         </target>
         <note></note>
       </trans-unit>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
@@ -114,122 +114,10 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0026">
-        <source>The Apple TVOS SDK is not installed.
-        </source>
-        <target state="new">The Apple TVOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0027">
-        <source>The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0028">
-        <source>The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0029">
-        <source>Could not locate the TVOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the TVOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0030">
-        <source>Could not locate the TVOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0031">
-        <source>Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0032">
         <source>Could not locate SDK bin directory
         </source>
         <target state="new">Could not locate SDK bin directory
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0033">
-        <source>The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0035">
-        <source>Could not locate the WatchOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the WatchOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0036">
-        <source>Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0037">
-        <source>Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0038">
-        <source>The Apple iOS SDK is not installed.
-        </source>
-        <target state="new">The Apple iOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0039">
-        <source>The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0040">
-        <source>The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0041">
-        <source>Could not locate the iOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the iOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0042">
-        <source>Could not locate the iOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0043">
-        <source>Could not locate the iOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK usr path at '{1}'
         </target>
         <note></note>
       </trans-unit>
@@ -248,11 +136,11 @@
         <note></note>
       </trans-unit>
       <trans-unit id="E0046">
-        <source>Could not find 'Xamarin.iOS'
+        <source>Could not find '{0}'
         </source>
-        <target state="new">Could not find 'Xamarin.iOS'
+        <target state="new">Could not find '{0}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0048">
         <source>Unknown SDK platform: {0}
@@ -392,38 +280,24 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0083">
-        <source>The Apple macOS SDK is not installed.
-        </source>
-        <target state="new">The Apple macOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0084">
-        <source>Could not locate the macOS '{0}' SDK at path '{1}'
+        <source>Could not locate the {0} '{1}' SDK at path '{}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK at path '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK at path '{}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0085">
-        <source>Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <source>Could not locate the {0} '{1}' SDK usr path at '{2}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path
         </source>
         <target state="new">Could not find a valid Xcode developer path
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0087">
-        <source>Could not find 'Xamarin.Mac'
-        </source>
-        <target state="new">Could not find 'Xamarin.Mac'
         </target>
         <note></note>
       </trans-unit>
@@ -769,6 +643,34 @@
         <target state="new">Unknown target framework identifier: {0}.
         </target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="E0170">
+        <source>Could not find {0} in {1}.
+        </source>
+        <target state="new">Could not find {0} in {1}.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0171">
+        <source>The {0} SDK is not installed.
+        </source>
+        <target state="new">The {0} SDK is not installed.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0172">
+        <source>The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0173">
+        <source>The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </target>
+        <note />
       </trans-unit>
       <trans-unit id="E7001">
         <source>Could not resolve host IPs for WiFi debugger settings.
@@ -1509,13 +1411,6 @@
         <source>Supported iPad orientations are not matched pairs
         </source>
         <target state="new">Supported iPad orientations are not matched pairs
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="W0034">
-        <source>The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
         </target>
         <note></note>
       </trans-unit>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
@@ -114,122 +114,10 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0026">
-        <source>The Apple TVOS SDK is not installed.
-        </source>
-        <target state="new">The Apple TVOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0027">
-        <source>The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0028">
-        <source>The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0029">
-        <source>Could not locate the TVOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the TVOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0030">
-        <source>Could not locate the TVOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0031">
-        <source>Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0032">
         <source>Could not locate SDK bin directory
         </source>
         <target state="new">Could not locate SDK bin directory
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0033">
-        <source>The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0035">
-        <source>Could not locate the WatchOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the WatchOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0036">
-        <source>Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0037">
-        <source>Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0038">
-        <source>The Apple iOS SDK is not installed.
-        </source>
-        <target state="new">The Apple iOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0039">
-        <source>The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0040">
-        <source>The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0041">
-        <source>Could not locate the iOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the iOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0042">
-        <source>Could not locate the iOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0043">
-        <source>Could not locate the iOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK usr path at '{1}'
         </target>
         <note></note>
       </trans-unit>
@@ -248,11 +136,11 @@
         <note></note>
       </trans-unit>
       <trans-unit id="E0046">
-        <source>Could not find 'Xamarin.iOS'
+        <source>Could not find '{0}'
         </source>
-        <target state="new">Could not find 'Xamarin.iOS'
+        <target state="new">Could not find '{0}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0048">
         <source>Unknown SDK platform: {0}
@@ -392,38 +280,24 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0083">
-        <source>The Apple macOS SDK is not installed.
-        </source>
-        <target state="new">The Apple macOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0084">
-        <source>Could not locate the macOS '{0}' SDK at path '{1}'
+        <source>Could not locate the {0} '{1}' SDK at path '{}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK at path '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK at path '{}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0085">
-        <source>Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <source>Could not locate the {0} '{1}' SDK usr path at '{2}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path
         </source>
         <target state="new">Could not find a valid Xcode developer path
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0087">
-        <source>Could not find 'Xamarin.Mac'
-        </source>
-        <target state="new">Could not find 'Xamarin.Mac'
         </target>
         <note></note>
       </trans-unit>
@@ -769,6 +643,34 @@
         <target state="new">Unknown target framework identifier: {0}.
         </target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="E0170">
+        <source>Could not find {0} in {1}.
+        </source>
+        <target state="new">Could not find {0} in {1}.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0171">
+        <source>The {0} SDK is not installed.
+        </source>
+        <target state="new">The {0} SDK is not installed.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0172">
+        <source>The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0173">
+        <source>The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </target>
+        <note />
       </trans-unit>
       <trans-unit id="E7001">
         <source>Could not resolve host IPs for WiFi debugger settings.
@@ -1509,13 +1411,6 @@
         <source>Supported iPad orientations are not matched pairs
         </source>
         <target state="new">Supported iPad orientations are not matched pairs
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="W0034">
-        <source>The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
         </target>
         <note></note>
       </trans-unit>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
@@ -114,122 +114,10 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0026">
-        <source>The Apple TVOS SDK is not installed.
-        </source>
-        <target state="new">The Apple TVOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0027">
-        <source>The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0028">
-        <source>The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The TVOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0029">
-        <source>Could not locate the TVOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the TVOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0030">
-        <source>Could not locate the TVOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0031">
-        <source>Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the TVOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0032">
         <source>Could not locate SDK bin directory
         </source>
         <target state="new">Could not locate SDK bin directory
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0033">
-        <source>The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0035">
-        <source>Could not locate the WatchOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the WatchOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0036">
-        <source>Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0037">
-        <source>Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the WatchOS '{0}' SDK usr path at '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0038">
-        <source>The Apple iOS SDK is not installed.
-        </source>
-        <target state="new">The Apple iOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0039">
-        <source>The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed, and no newer version was found.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0040">
-        <source>The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The iOS SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0041">
-        <source>Could not locate the iOS platform directory at path '{0}'
-        </source>
-        <target state="new">Could not locate the iOS platform directory at path '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0042">
-        <source>Could not locate the iOS '{0}' SDK at path '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK at path '{1}'
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0043">
-        <source>Could not locate the iOS '{0}' SDK usr path at '{1}'
-        </source>
-        <target state="new">Could not locate the iOS '{0}' SDK usr path at '{1}'
         </target>
         <note></note>
       </trans-unit>
@@ -248,11 +136,11 @@
         <note></note>
       </trans-unit>
       <trans-unit id="E0046">
-        <source>Could not find 'Xamarin.iOS'
+        <source>Could not find '{0}'
         </source>
-        <target state="new">Could not find 'Xamarin.iOS'
+        <target state="new">Could not find '{0}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0048">
         <source>Unknown SDK platform: {0}
@@ -392,38 +280,24 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0083">
-        <source>The Apple macOS SDK is not installed.
-        </source>
-        <target state="new">The Apple macOS SDK is not installed.
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0084">
-        <source>Could not locate the macOS '{0}' SDK at path '{1}'
+        <source>Could not locate the {0} '{1}' SDK at path '{}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK at path '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK at path '{}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0085">
-        <source>Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <source>Could not locate the {0} '{1}' SDK usr path at '{2}'
         </source>
-        <target state="new">Could not locate the macOS '{0}' SDK usr path at '{1}'
+        <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path
         </source>
         <target state="new">Could not find a valid Xcode developer path
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="E0087">
-        <source>Could not find 'Xamarin.Mac'
-        </source>
-        <target state="new">Could not find 'Xamarin.Mac'
         </target>
         <note></note>
       </trans-unit>
@@ -769,6 +643,34 @@
         <target state="new">Unknown target framework identifier: {0}.
         </target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="E0170">
+        <source>Could not find {0} in {1}.
+        </source>
+        <target state="new">Could not find {0} in {1}.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0171">
+        <source>The {0} SDK is not installed.
+        </source>
+        <target state="new">The {0} SDK is not installed.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0172">
+        <source>The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed, and no newer version was found.
+        </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="E0173">
+        <source>The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </source>
+        <target state="new">The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'.
+        </target>
+        <note />
       </trans-unit>
       <trans-unit id="E7001">
         <source>Could not resolve host IPs for WiFi debugger settings.
@@ -1509,13 +1411,6 @@
         <source>Supported iPad orientations are not matched pairs
         </source>
         <target state="new">Supported iPad orientations are not matched pairs
-        </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="W0034">
-        <source>The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
-        </source>
-        <target state="new">The Watch SDK version '{0}' is not installed. Using newer version '{1}' instead'.
         </target>
         <note></note>
       </trans-unit>

--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
@@ -1,143 +1,24 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-
-using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
-
 using Xamarin.MacDev.Tasks;
 using Xamarin.MacDev;
-using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.Mac.Tasks
 {
-	public class DetectSdkLocationsTaskBase : Task
+	public abstract class DetectSdkLocationsTaskBase : DetectSdkLocationsCoreTaskBase
 	{
-		#region Inputs
-
-		public string SessionId { get; set; }
-
-		// This is also an input
-		[Output]
-		public string XamarinSdkRoot {
-			get; set;
-		}
-
-		#endregion Inputs
-
-		#region Outputs
-
-		[Output]
-		public string SdkRoot {
-			get; set;
-		}
-
-		[Output]
-		public string SdkBinPath {
-			get; set;
-		}
-
-		[Output]
-		public string SdkDevPath {
-			get; set;
-		}
-
-		[Output]
-		public string SdkUsrPath {
-			get; set;
-		}
-
-		[Output]
-		public string SdkVersion {
-			get; set;
-		}
-
-		[Output]
-		public bool IsXcode8 {
-			get; set;
-		}
-
-		#endregion Outputs
-
-		public override bool Execute ()
-		{
-			if (EnsureAppleSdkRoot ())
-				EnsureSdkPath ();
-			EnsureXamarinSdkRoot ();
-
-			IsXcode8 = AppleSdkSettings.XcodeVersion.Major >= 8;
-
-			return !Log.HasLoggedErrors;
-		}
-
-		void EnsureSdkPath ()
-		{
-			var sdkVersion = MacOSXSdkVersion.GetDefault (MacOSXSdks.Native);
-			if (!MacOSXSdks.Native.SdkIsInstalled (sdkVersion)) {
-				Log.LogError (MSBStrings.E0083);
-				return;
+		protected override IAppleSdk CurrentSdk {
+			get {
+				return MacOSXSdks.Native;
 			}
-
-			SdkVersion = sdkVersion.ToString ();
-
-			SdkRoot = MacOSXSdks.Native.GetSdkPath (sdkVersion);
-			if (string.IsNullOrEmpty (SdkRoot))
-				Log.LogError (MSBStrings.E0084, SdkVersion, SdkRoot);
-
-			SdkUsrPath = DirExists ("SDK usr directory", Path.Combine (MacOSXSdks.Native.DeveloperRoot, "usr"));
-			if (string.IsNullOrEmpty (SdkUsrPath))
-				Log.LogError (MSBStrings.E0085, SdkVersion, SdkRoot);
-
-			SdkBinPath = DirExists ("SDK bin directory", Path.Combine (SdkUsrPath, "bin"));
-			if (string.IsNullOrEmpty (SdkBinPath))
-				Log.LogError (MSBStrings.E0032);
 		}
 
-		bool EnsureAppleSdkRoot ()
+		protected override IAppleSdkVersion GetDefaultSdkVersion ()
 		{
-			if (!MacOSXSdks.Native.IsInstalled) {
-				string ideSdkPath;
-				if (string.IsNullOrEmpty(SessionId))
-					// SessionId is only and always defined on windows.
-					// We can't check 'Environment.OSVersion.Platform' since the base tasks are always executed on the Mac.
-					ideSdkPath = "(Projects > SDK Locations > Apple > Apple SDK)";
-				else
-					ideSdkPath = "(Tools > Options > Xamarin > iOS Settings > Apple SDK)";
-				Log.LogError (MSBStrings.E0044, AppleSdkSettings.InvalidDeveloperRoot, ideSdkPath);
-				return false;
-			}
-			Log.LogMessage(MessageImportance.Low, "DeveloperRoot: {0}", MacOSXSdks.Native.DeveloperRoot);
-			Log.LogMessage(MessageImportance.Low, "GetPlatformPath: {0}", MacOSXSdks.Native.GetPlatformPath());
-
-			SdkDevPath = MacOSXSdks.Native.DeveloperRoot;
-			if (string.IsNullOrEmpty(SdkDevPath)) {
-				Log.LogError(MSBStrings.E0086);
-				return false;
-			}
-			return true;
+			return MacOSXSdkVersion.GetDefault (CurrentSdk);
 		}
 
-		void EnsureXamarinSdkRoot ()
+		protected override string GetDefaultXamarinSdkRoot ()
 		{
-			if (string.IsNullOrEmpty (XamarinSdkRoot))
-				XamarinSdkRoot = MacOSXSdks.XamMac.FrameworkDirectory;
-
-			if (string.IsNullOrEmpty (XamarinSdkRoot) || !Directory.Exists (XamarinSdkRoot))
-				Log.LogError (MSBStrings.E0087);
-		}
-
-		string DirExists (string checkingFor, params string[] paths)
-		{
-			try {
-				if (paths.Any (p => string.IsNullOrEmpty (p)))
-					return null;
-
-				var path = Path.GetFullPath (Path.Combine (paths));
-				Log.LogMessage (MessageImportance.Low, MSBStrings.M0047, checkingFor, path);
-				return Directory.Exists (path) ? path : null;
-			} catch {
-				return null;
-			}
+			return MacOSXSdks.XamMac.FrameworkDirectory;
 		}
 	}
 }

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -241,7 +241,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			CompiledEntitlements="$(IntermediateOutputPath)Entitlements.xcent"
 			IsAppExtension="$(IsAppExtension)"
 			ProvisioningProfile="$(_ProvisioningProfile)"
-			SdkVersion="$(MacOSXSdkVersion)"
+			SdkVersion="$(_SdkVersion)"
 			SdkPlatform="MacOSX"
 			SdkDevPath="$(_SdkDevPath)"
 			Debug="$(DebugSymbols)"
@@ -342,7 +342,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			SdkDevPath="$(_SdkDevPath)"
 			SdkIsSimulator="false"
 			SdkRoot="$(_SdkRoot)"
-			SdkVersion="$(MacOSXSdkVersion)"
+			SdkVersion="$(_SdkVersion)"
 			SourceFile="@(Metal)">
 			<Output TaskParameter="OutputFile" ItemName="_SmeltedMetal" />
 		</Metal>
@@ -447,15 +447,20 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		</UnpackLibraryResources>
 	</Target>
 
-	<Target Name="_DetectSdkLocations">
+	<Target Name="_DetectSdkLocations" DependsOnTargets="_ComputeTargetFrameworkMoniker">
 		<DetectSdkLocations
+			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
-			SessionId="$(BuildSessionId)">
-			<Output TaskParameter="SdkVersion" PropertyName="MacOSXSdkVersion" />
+			SdkVersion="$(MacOSXSdkVersion)"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+			>
+			<Output TaskParameter="SdkVersion" PropertyName="_SdkVersion" />
 			<Output TaskParameter="SdkRoot" PropertyName="_SdkRoot" />
 			<Output TaskParameter="SdkBinPath" PropertyName="_SdkBinPath" />
 			<Output TaskParameter="SdkDevPath" PropertyName="_SdkDevPath" />
 			<Output TaskParameter="SdkUsrPath" PropertyName="_SdkUsrPath" />
+			<Output TaskParameter="SdkPlatform" PropertyName="_SdkPlatform" />
+			<Output TaskParameter="SdkIsSimulator" PropertyName="_SdkIsSimulator" />
 			<Output TaskParameter="IsXcode8" PropertyName="_IsXcode8" />
 			<Output TaskParameter="XamarinSdkRoot" PropertyName="_XamarinSdkRoot" />
 		</DetectSdkLocations>
@@ -552,7 +557,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			SdkRoot="$(_SdkDevPath)"
 			IntermediateOutputPath="$(IntermediateOutputPath)mmp-cache"
 			AppManifest="$(_AppManifest)"
-			SdkVersion="$(MacOSXSdkVersion)"
+			SdkVersion="$(_SdkVersion)"
 			IsAppExtension="$(IsAppExtension)"
 			IsXPCService="$(IsXPCService)"
 			EnableSGenConc="$(EnableSGenConc)"
@@ -590,7 +595,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			ToolPath="$(ScnToolPath)"
 			SdkRoot="$(_SdkRoot)"
 			SdkDevPath="$(_SdkDevPath)"
-			SdkVersion="$(MacOSXSdkVersion)"
+			SdkVersion="$(_SdkVersion)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			InputScene="%(_ColladaAssetWithLogicalName.Identity)"
@@ -651,7 +656,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			SdkBinPath="$(_SdkBinPath)"
 			SdkUsrPath="$(_SdkUsrPath)"
 			SdkPlatform="MacOSX"
-			SdkVersion="$(MacOSXSdkVersion)">
+			SdkVersion="$(_SdkVersion)">
 			<Output TaskParameter="PartialAppManifest" ItemName="_PartialAppManifest" />
 			<Output TaskParameter="BundleResources" ItemName="_BundleResourceWithLogicalName" />
 
@@ -685,7 +690,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			SdkPlatform="MacOSX"
 			SdkDevPath="$(_SdkDevPath)"
 			SdkRoot="$(_SdkRoot)"
-			SdkVersion="$(MacOSXSdkVersion)">
+			SdkVersion="$(_SdkVersion)">
 			<Output TaskParameter="BundleResources" ItemName="FileWrites" />
 			<Output TaskParameter="BundleResources" ItemName="_BundleResourceWithLogicalName" />
 		</CompileSceneKitAssets>
@@ -710,7 +715,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			SdkBinPath="$(_SdkBinPath)"
 			SdkUsrPath="$(_SdkUsrPath)"
 			SdkRoot="$(_SdkRoot)"
-			SdkVersion="$(MacOSXSdkVersion)">
+			SdkVersion="$(_SdkVersion)">
 			<Output TaskParameter="OutputManifests" ItemName="FileWrites" />
 			<Output TaskParameter="BundleResources" ItemName="FileWrites" />
 			<Output TaskParameter="BundleResources" ItemName="_BundleResourceWithLogicalName" />

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSdkLocationCoreTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSdkLocationCoreTaskBase.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+
+using Microsoft.Build.Framework;
+
+using Xamarin.Localization.MSBuild;
+using Xamarin.Utils;
+
+namespace Xamarin.MacDev.Tasks {
+	public abstract class DetectSdkLocationsCoreTaskBase : XamarinTask {
+		#region Outputs
+
+		[Output]
+		public string SdkRoot {
+			get; set;
+		}
+
+		[Output]
+		public string SdkBinPath {
+			get; set;
+		}
+
+		[Output]
+		public string SdkDevPath {
+			get; set;
+		}
+
+		[Output]
+		public string SdkUsrPath {
+			get; set;
+		}
+
+		[Output]
+		public bool SdkIsSimulator {
+			get; set;
+		}
+
+		[Output]
+		public string SdkPlatform {
+			get; set;
+		}
+
+		// This is also an input
+		[Output]
+		public string SdkVersion {
+			get; set;
+		}
+
+		[Output]
+		public bool IsXcode8 {
+			get; set;
+		}
+
+		// This is also an input
+		[Output]
+		public string XamarinSdkRoot {
+			get; set;
+		}
+
+		#endregion Outputs
+
+		protected abstract IAppleSdk CurrentSdk { get; }
+		protected abstract string GetDefaultXamarinSdkRoot ();
+		protected abstract IAppleSdkVersion GetDefaultSdkVersion ();
+
+		protected void EnsureSdkPath ()
+		{
+			SdkPlatform = GetSdkPlatform (SdkIsSimulator);
+
+			var currentSdk = CurrentSdk;
+			IAppleSdkVersion requestedSdkVersion;
+
+			if (string.IsNullOrEmpty (SdkVersion)) {
+				requestedSdkVersion = GetDefaultSdkVersion ();
+			} else if (!currentSdk.TryParseSdkVersion (SdkVersion, out requestedSdkVersion)) {
+				Log.LogError (MSBStrings.E0025 /* Could not parse the SDK version '{0}' */, SdkVersion);
+				return;
+			}
+
+			var sdkVersion = requestedSdkVersion.ResolveIfDefault (currentSdk, SdkIsSimulator);
+			if (!currentSdk.SdkIsInstalled (sdkVersion, SdkIsSimulator)) {
+				sdkVersion = currentSdk.GetClosestInstalledSdk (sdkVersion, SdkIsSimulator);
+
+				if (sdkVersion.IsUseDefault || !currentSdk.SdkIsInstalled (sdkVersion, SdkIsSimulator)) {
+					if (requestedSdkVersion.IsUseDefault) {
+						Log.LogError (MSBStrings.E0171 /* The {0} SDK is not installed. */, PlatformName);
+					} else {
+						Log.LogError (MSBStrings.E0172 /* The {0} SDK version '{0}' is not installed, and no newer version was found. */, PlatformName, requestedSdkVersion.ToString ());
+					}
+					return;
+				}
+				Log.LogWarning (MSBStrings.E0173 /* The {0} SDK version '{1}' is not installed. Using newer version '{2}' instead'. */, PlatformName, requestedSdkVersion, sdkVersion);
+			}
+			SdkVersion = sdkVersion.ToString ();
+
+			SdkRoot = currentSdk.GetSdkPath (SdkVersion, SdkIsSimulator);
+			if (string.IsNullOrEmpty (SdkRoot))
+				Log.LogError (MSBStrings.E0084 /* Could not locate the {0} '{1}' SDK at path '{2}' */, PlatformName, SdkVersion, SdkRoot);
+
+			SdkUsrPath = DirExists ("SDK usr directory", Path.Combine (currentSdk.DeveloperRoot, "usr"));
+			if (string.IsNullOrEmpty (SdkUsrPath))
+				Log.LogError (MSBStrings.E0085 /* Could not locate the {0} '{1}' SDK usr path at '{2}' */, PlatformName, SdkVersion, SdkRoot);
+
+			SdkBinPath = DirExists ("SDK bin directory", Path.Combine (SdkUsrPath, "bin"));
+			if (string.IsNullOrEmpty (SdkBinPath))
+				Log.LogError (MSBStrings.E0032 /* Could not locate SDK bin directory */);
+		}
+
+		void EnsureXamarinSdkRoot ()
+		{
+			if (string.IsNullOrEmpty (XamarinSdkRoot))
+				XamarinSdkRoot = GetDefaultXamarinSdkRoot ();
+
+			if (string.IsNullOrEmpty (XamarinSdkRoot))
+				Log.LogError (MSBStrings.E0046 /* Could not find '{0}' */, Product);
+			else if (!Directory.Exists (XamarinSdkRoot))
+				Log.LogError (MSBStrings.E0170 /* Could not find {0} in {1}. */, Product, XamarinSdkRoot);
+		}
+
+		public override bool Execute ()
+		{
+			if (EnsureAppleSdkRoot ())
+				EnsureSdkPath ();
+			EnsureXamarinSdkRoot ();
+			return !Log.HasLoggedErrors;
+		}
+
+		protected bool EnsureAppleSdkRoot ()
+		{
+			var currentSdk = CurrentSdk;
+			if (!currentSdk.IsInstalled) {
+				string ideSdkPath;
+				if (string.IsNullOrEmpty (SessionId))
+					// SessionId is only and always defined on windows.
+					// We can't check 'Environment.OSVersion.Platform' since the base tasks are always executed on the Mac.
+					ideSdkPath = "(Projects > SDK Locations > Apple > Apple SDK)";
+				else
+					ideSdkPath = "(Tools > Options > Xamarin > iOS Settings > Apple SDK)";
+				Log.LogError (MSBStrings.E0044, AppleSdkSettings.InvalidDeveloperRoot, ideSdkPath);
+				return false;
+			}
+			Log.LogMessage (MessageImportance.Low, "DeveloperRoot: {0}", currentSdk.DeveloperRoot);
+			Log.LogMessage (MessageImportance.Low, "GetPlatformPath: {0}", currentSdk.GetPlatformPath (SdkIsSimulator));
+
+			SdkDevPath = currentSdk.DeveloperRoot;
+			if (string.IsNullOrEmpty (SdkDevPath)) {
+				Log.LogError (MSBStrings.E0086 /* Could not find a valid Xcode developer path */);
+				return false;
+			}
+			return true;
+		}
+
+		protected string DirExists (string checkingFor, params string [] paths)
+		{
+			try {
+				if (paths.Any (p => string.IsNullOrEmpty (p)))
+					return null;
+
+				var path = Path.GetFullPath (Path.Combine (paths));
+				Log.LogMessage (MessageImportance.Low, MSBStrings.M0047 /* Searching for '{0}' in '{1}' */, checkingFor, path);
+				return Directory.Exists (path) ? path : null;
+			} catch {
+				return null;
+			}
+		}
+	}
+}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
@@ -1,0 +1,83 @@
+using System;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Utils;
+
+namespace Xamarin.MacDev.Tasks {
+	public abstract class XamarinTask : Task {
+
+		public string SessionId { get; set; }
+
+		[Required]
+		public string TargetFrameworkMoniker { get; set; }
+
+		public string Product {
+			get {
+				switch (Platform) {
+				case ApplePlatform.iOS:
+				case ApplePlatform.TVOS:
+				case ApplePlatform.WatchOS:
+					return "Xamarin.iOS";
+				case ApplePlatform.MacOSX:
+					return "Xamarin.Mac";
+				default:
+					throw new InvalidOperationException ($"Invalid platform: {Platform}");
+				}
+			}
+		}
+
+		ApplePlatform? platform;
+		public ApplePlatform Platform {
+			get {
+				if (!platform.HasValue)
+					platform = PlatformFrameworkHelper.GetFramework (TargetFrameworkMoniker);
+				return platform.Value;
+			}
+		}
+
+		TargetFramework? target_framework;
+		public TargetFramework TargetFramework {
+			get {
+				if (!target_framework.HasValue)
+					target_framework = TargetFramework.Parse (TargetFrameworkMoniker);
+				return target_framework.Value;
+			}
+		}
+
+		public string PlatformName {
+			get {
+				switch (Platform) {
+				case ApplePlatform.iOS:
+					return "iOS";
+				case ApplePlatform.TVOS:
+					return "tvOS";
+				case ApplePlatform.WatchOS:
+					return "watchOS";
+				case ApplePlatform.MacOSX:
+					return "macOS";
+				default:
+					throw new InvalidOperationException ($"Invalid platform: {Platform}");
+				}
+			}
+		}
+
+		protected string GetSdkPlatform (bool isSimulator)
+		{
+			switch (Platform) {
+			case ApplePlatform.iOS:
+				return isSimulator ? "iPhoneSimulator" : "iPhoneOS";
+			case ApplePlatform.TVOS:
+				return isSimulator ? "AppleTVSimulator" : "AppleTVOS";
+			case ApplePlatform.WatchOS:
+				return isSimulator ? "WatchSimulator" : "WatchOS";
+			case ApplePlatform.MacOSX:
+				return "MacOSX";
+			default:
+				throw new InvalidOperationException ($"Invalid platform: {Platform}");
+			}
+		}
+	}
+}
+

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
@@ -1,95 +1,30 @@
 using System;
-using System.IO;
-using System.Linq;
-
-using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 
 using Xamarin.MacDev.Tasks;
 using Xamarin.MacDev;
 using Xamarin.Utils;
-using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class DetectSdkLocationsTaskBase : Task
+	public abstract class DetectSdkLocationsTaskBase : DetectSdkLocationsCoreTaskBase
 	{
 #region Inputs
 
-		public string SessionId { get; set; }
-
-		// This is also an input
-		[Output]
-		public string SdkVersion {
-			get; set;
-		}
-
-		public TargetFramework TargetFramework { get { return TargetFramework.Parse (TargetFrameworkMoniker); } }
-
-		[Required]
-		public string TargetFrameworkMoniker {
-			get; set; 
-		}
-	
 		public string TargetArchitectures {
-			get; set;
-		}
-
-		// This is also an input
-		[Output]
-		public string XamarinSdkRoot {
 			get; set;
 		}
 
 #endregion Inputs
 
-#region Outputs
-
-		[Output]
-		public string SdkRoot {
-			get; set;
-		}
-
-		[Output]
-		public string SdkBinPath {
-			get; set;
-		}
-
-		[Output]
-		public string SdkDevPath {
-			get; set;
-		}
-
-		[Output]
-		public string SdkUsrPath {
-			get; set;
-		}
-
-		[Output]
-		public string SdkPlatform {
-			get; set; 
-		}
-
-		[Output]
-		public bool SdkIsSimulator {
-			get; set;
-		}
-
-		[Output]
-		public bool IsXcode8 {
-			get; set;
-		}
-
-#endregion Outputs
-
-		public ApplePlatform Framework {
-			get { return PlatformFrameworkHelper.GetFramework (TargetFrameworkMoniker); }
-		}
-
-		public AppleSdk CurrentSdk {
+		protected override IAppleSdk CurrentSdk {
 			get {
-				return IPhoneSdks.GetSdk (Framework);
+				return IPhoneSdks.GetSdk (Platform);
 			}
+		}
+
+		protected override IAppleSdkVersion GetDefaultSdkVersion ()
+		{
+			return IPhoneSdkVersion.UseDefault;
 		}
 
 		public override bool Execute ()
@@ -103,228 +38,12 @@ namespace Xamarin.iOS.Tasks
 
 			SdkIsSimulator = (architectures & (TargetArchitecture.i386 | TargetArchitecture.x86_64)) != 0;
 
-			IsXcode8 = AppleSdkSettings.XcodeVersion.Major >= 8;
-
-			if (EnsureAppleSdkRoot ()) {
-				switch (Framework) {
-				case ApplePlatform.iOS:
-					EnsureiOSSdkPath ();
-					break;
-				case ApplePlatform.TVOS:
-					EnsureTVOSSdkPath ();
-					break;
-				case ApplePlatform.WatchOS:
-					EnsureWatchSdkPath ();
-					break;
-				default:
-					throw new InvalidOperationException (string.Format ("Invalid framework: {0}", Framework));
-				}
-			}
-			EnsureXamarinSdkRoot ();
-
-			return !Log.HasLoggedErrors;
+			return base.Execute ();
 		}
 
-		void EnsureTVOSSdkPath ()
+		protected override string GetDefaultXamarinSdkRoot ()
 		{
-			var currentSdk = IPhoneSdks.GetSdk (Framework);
-			IPhoneSdkVersion requestedSdkVersion;
-
-			if (string.IsNullOrEmpty (SdkVersion)) {
-				requestedSdkVersion = IPhoneSdkVersion.UseDefault;
-			} else if (!IPhoneSdkVersion.TryParse (SdkVersion, out requestedSdkVersion)) {
-				Log.LogError (MSBStrings.E0025, SdkVersion);
-				return;
-			}
-
-			var sdkVersion = requestedSdkVersion.ResolveIfDefault (currentSdk, SdkIsSimulator);
-			if (!currentSdk.SdkIsInstalled (sdkVersion, SdkIsSimulator)) {
-				sdkVersion = currentSdk.GetClosestInstalledSdk (sdkVersion, SdkIsSimulator);
-
-				if (sdkVersion.IsUseDefault || !currentSdk.SdkIsInstalled (sdkVersion, SdkIsSimulator)) {
-					if (requestedSdkVersion.IsUseDefault) {
-						Log.LogError (MSBStrings.E0026);
-					} else {
-						Log.LogError (MSBStrings.E0027, requestedSdkVersion.ToString ());
-					}
-					return;
-				}
-				Log.LogWarning (MSBStrings.E0028, requestedSdkVersion, sdkVersion);
-			}
-
-			SdkVersion = sdkVersion.ToString ();
-
-			var platformDir = currentSdk.GetPlatformPath (SdkIsSimulator);
-			if (string.IsNullOrEmpty (platformDir) || !Directory.Exists (platformDir))
-				Log.LogError (MSBStrings.E0029, platformDir);
-
-			SdkRoot = currentSdk.GetSdkPath (sdkVersion, SdkIsSimulator);
-			if (string.IsNullOrEmpty (SdkRoot) || !Directory.Exists (SdkRoot))
-				Log.LogError (MSBStrings.E0030, SdkVersion, SdkRoot);
-
-			SdkUsrPath = DirExists ("SDK Usr directory", Path.Combine (currentSdk.DeveloperRoot, "usr"));
-			if (string.IsNullOrEmpty (SdkUsrPath))
-				Log.LogError (MSBStrings.E0031, SdkVersion, SdkRoot);
-
-			SdkBinPath = DirExists ("SDK bin directory", Path.Combine (SdkUsrPath, "bin"));
-			if (string.IsNullOrEmpty (SdkBinPath))
-				Log.LogError (MSBStrings.E0032);
-
-			SdkPlatform = SdkIsSimulator ? "AppleTVSimulator" : "AppleTVOS";
-		}
-
-		void EnsureWatchSdkPath ()
-		{
-			var currentSDK = IPhoneSdks.GetSdk (Framework);
-			IPhoneSdkVersion requestedSdkVersion;
-
-			if (string.IsNullOrEmpty (SdkVersion)) {
-				requestedSdkVersion = IPhoneSdkVersion.UseDefault;
-			} else if (!IPhoneSdkVersion.TryParse (SdkVersion, out requestedSdkVersion)) {
-				Log.LogError (MSBStrings.E0025, SdkVersion);
-				return;
-			}
-
-			var sdkVersion = requestedSdkVersion.ResolveIfDefault (currentSDK, SdkIsSimulator);
-			if (!currentSDK.SdkIsInstalled (sdkVersion, SdkIsSimulator)) {
-				sdkVersion = currentSDK.GetClosestInstalledSdk (sdkVersion, SdkIsSimulator);
-
-				if (sdkVersion.IsUseDefault || !currentSDK.SdkIsInstalled (sdkVersion, SdkIsSimulator)) {
-					if (requestedSdkVersion.IsUseDefault) {
-						Log.LogError (MSBStrings.E0026);
-					} else {
-						Log.LogError (MSBStrings.E0033, requestedSdkVersion.ToString ());
-					}
-					return;
-				}
-				Log.LogWarning (MSBStrings.W0034, requestedSdkVersion, sdkVersion);
-			}
-
-			SdkVersion = sdkVersion.ToString ();
-
-			var platformDir = currentSDK.GetPlatformPath (SdkIsSimulator);
-			if (string.IsNullOrEmpty (platformDir) || !Directory.Exists (platformDir))
-				Log.LogError (MSBStrings.E0035, platformDir);
-
-			SdkRoot = currentSDK.GetSdkPath (sdkVersion, SdkIsSimulator);
-			if (string.IsNullOrEmpty (SdkRoot) || !Directory.Exists (SdkRoot))
-				Log.LogError (MSBStrings.E0036, SdkVersion, SdkRoot);
-
-			SdkUsrPath = DirExists ("SDK Usr directory", Path.Combine (currentSDK.DeveloperRoot, "usr"));
-			if (string.IsNullOrEmpty (SdkUsrPath))
-				Log.LogError (MSBStrings.E0037, SdkVersion, SdkRoot);
-
-			SdkBinPath = DirExists ("SDK bin directory", Path.Combine (SdkUsrPath, "bin"));
-			if (string.IsNullOrEmpty (SdkBinPath))
-				Log.LogError (MSBStrings.E0032);
-
-			SdkPlatform = SdkIsSimulator ? "WatchSimulator" : "WatchOS";
-		}
-
-		void EnsureiOSSdkPath ()
-		{
-			var currentSDK = IPhoneSdks.GetSdk (Framework);
-			IPhoneSdkVersion requestedSdkVersion;
-
-			if (string.IsNullOrEmpty (SdkVersion)) {
-				requestedSdkVersion = IPhoneSdkVersion.UseDefault;
-			} else if (!IPhoneSdkVersion.TryParse (SdkVersion, out requestedSdkVersion)) {
-				Log.LogError (MSBStrings.E0025, SdkVersion);
-				return;
-			}
-
-			var sdkVersion = requestedSdkVersion.ResolveIfDefault (currentSDK, SdkIsSimulator);
-			if (!currentSDK.SdkIsInstalled (sdkVersion, SdkIsSimulator)) {
-				sdkVersion = currentSDK.GetClosestInstalledSdk (sdkVersion, SdkIsSimulator);
-
-				if (sdkVersion.IsUseDefault || !currentSDK.SdkIsInstalled (sdkVersion, SdkIsSimulator)) {
-					if (requestedSdkVersion.IsUseDefault) {
-						Log.LogError (MSBStrings.E0038);
-					} else {
-						Log.LogError (MSBStrings.E0039, requestedSdkVersion.ToString ());
-					}
-					return;
-				}
-				Log.LogWarning (MSBStrings.E0040, requestedSdkVersion, sdkVersion);
-			}
-
-			SdkVersion = sdkVersion.ToString ();
-
-			var platformDir = currentSDK.GetPlatformPath (SdkIsSimulator);
-			if (string.IsNullOrEmpty (platformDir) || !Directory.Exists (platformDir))
-				Log.LogError (MSBStrings.E0041, platformDir);
-
-			SdkRoot = currentSDK.GetSdkPath (sdkVersion, SdkIsSimulator);
-			if (string.IsNullOrEmpty (SdkRoot) || !Directory.Exists (SdkRoot))
-				Log.LogError (MSBStrings.E0042, SdkVersion, SdkRoot);
-			// Note: Developer/Platforms/iPhoneOS.platform/Developer/usr is a physical directory, but
-			// Developer/Platforms/iPhoneSimulator.platform/Developer/bin has always been a symlink
-			// to Developer/bin and starting with Xcode 7 Beta 2, the usr symlink no longer exists.
-			// In Xcode 10 beta 1 Developer/Platforms/iPhoneOS.platform/Developer/usr reappeared,
-			// but since it seems incomplete don't even check for it.
-			if (AppleSdkSettings.XcodeVersion.Major < 10)
-				SdkUsrPath = DirExists ("SDK Usr directory", Path.Combine (platformDir, "Developer", "usr"));
-
-			if (string.IsNullOrEmpty (SdkUsrPath)) {
-				SdkUsrPath = DirExists ("SDK Usr directory", Path.Combine (currentSDK.DeveloperRoot, "usr"));
-				if (string.IsNullOrEmpty (SdkUsrPath))
-					Log.LogError (MSBStrings.E0043, SdkVersion, SdkRoot);
-			}
-
-			SdkBinPath = DirExists ("SDK bin directory", Path.Combine (SdkUsrPath, "bin"));
-			if (string.IsNullOrEmpty (SdkBinPath))
-				Log.LogError (MSBStrings.E0032);
-
-			SdkPlatform = SdkIsSimulator ? "iPhoneSimulator" : "iPhoneOS";
-		}
-
-		bool EnsureAppleSdkRoot ()
-		{
-			if (!CurrentSdk.IsInstalled) {
-				string ideSdkPath;
-				if (string.IsNullOrEmpty(SessionId))
-					// SessionId is only and always defined on windows.
-					// We can't check 'Environment.OSVersion.Platform' since the base tasks are always executed on the Mac.
-					ideSdkPath = "(Project > SDK Locations > Apple > Apple SDK)";
-				else
-					ideSdkPath = "(Tools > Options > Xamarin > iOS Settings > Apple SDK)";
-				Log.LogError (MSBStrings.E0044, AppleSdkSettings.InvalidDeveloperRoot, ideSdkPath);
-				return false;
-			}
-			Log.LogMessage (MessageImportance.Low, "DeveloperRoot: {0}", CurrentSdk.DeveloperRoot);
-			Log.LogMessage (MessageImportance.Low, "DevicePlatform: {0}", CurrentSdk.DevicePlatform);
-			Log.LogMessage (MessageImportance.Low, "GetPlatformPath: {0}", CurrentSdk.GetPlatformPath (false));
-
-			SdkDevPath = CurrentSdk.DeveloperRoot;
-			if (string.IsNullOrEmpty (SdkDevPath)) {
-				Log.LogError ("Could not find valid a usable Xcode developer path");
-				return false;
-			}
-			return true;
-		}
-
-		void EnsureXamarinSdkRoot ()
-		{
-			if (string.IsNullOrEmpty (XamarinSdkRoot))
-				XamarinSdkRoot = IPhoneSdks.MonoTouch.SdkDir;
-
-			if (string.IsNullOrEmpty (XamarinSdkRoot) || !Directory.Exists (XamarinSdkRoot))
-				Log.LogError (MSBStrings.E0046);
-		}
-
-		string DirExists (string checkingFor, string path)
-		{
-			try {
-				if (path == null)
-					return null;
-
-				path = Path.GetFullPath (path);
-
-				Log.LogMessage (MessageImportance.Low, MSBStrings.M0047, checkingFor, path);
-				return Directory.Exists (path) ? path : null;
-			} catch {
-				return null;
-			}
+			return IPhoneSdks.MonoTouch.SdkDir;
 		}
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
@@ -56,7 +56,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<ResolveNativeWatchApp
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
-			SdkVersion="$(MtouchSdkVersion)"
+			SdkVersion="$(_SdkVersion)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -613,7 +613,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			SdkDevPath="$(_SdkDevPath)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			SdkRoot="$(_SdkRoot)"
-			SdkVersion="$(MtouchSdkVersion)"
+			SdkVersion="$(_SdkVersion)"
 			SourceFile="@(Metal)">
 			<Output TaskParameter="OutputFile" ItemName="_SmeltedMetal" />
 		</Metal>
@@ -685,7 +685,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			TargetArchitectures="$(TargetArchitectures)"
 			>
 			
-			<Output TaskParameter="SdkVersion" PropertyName="MtouchSdkVersion" />
+			<Output TaskParameter="SdkVersion" PropertyName="_SdkVersion" />
 			<Output TaskParameter="SdkRoot" PropertyName="_SdkRoot" />
 			<Output TaskParameter="SdkBinPath" PropertyName="_SdkBinPath" />
 			<Output TaskParameter="SdkDevPath" PropertyName="_SdkDevPath" />
@@ -779,7 +779,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			AssemblyName="$(AssemblyName)"
 			BundleIdentifier="$(_BundleIdentifier)"
 			Debug="$(MtouchDebug)"
-			DefaultSdkVersion="$(MtouchSdkVersion)"
+			DefaultSdkVersion="$(_SdkVersion)"
 			IsAppExtension="$(IsAppExtension)"
 			IsWatchApp="$(IsWatchApp)"
 			IsWatchExtension="$(IsWatchExtension)"
@@ -910,7 +910,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			ResponseFilePath="$(DeviceSpecificIntermediateOutputPath)response-file.rsp"
 			SdkRoot="$(_SdkDevPath)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
-			SdkVersion="$(MtouchSdkVersion)"
+			SdkVersion="$(_SdkVersion)"
 			SymbolsList="$(_MtouchSymbolsList)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			UseLlvm="$(MtouchUseLlvm)"
@@ -1261,7 +1261,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			ToolPath="$(ScnToolPath)"
 			SdkRoot="$(_SdkRoot)"
 			SdkDevPath="$(_SdkDevPath)"
-			SdkVersion="$(MtouchSdkVersion)"
+			SdkVersion="$(_SdkVersion)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
 			InputScene="%(_ColladaAssetWithLogicalName.Identity)"
@@ -1324,7 +1324,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			SdkBinPath="$(_SdkBinPath)"
 			SdkUsrPath="$(_SdkUsrPath)"
 			SdkPlatform="$(_SdkPlatform)"
-			SdkVersion="$(MtouchSdkVersion)">
+			SdkVersion="$(_SdkVersion)">
 			<Output TaskParameter="PartialAppManifest" ItemName="_PartialAppManifest" />
 			<Output TaskParameter="BundleResources" ItemName="_BundleResourceWithLogicalName" />
 
@@ -1383,7 +1383,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			SdkPlatform="$(_SdkPlatform)"
 			SdkDevPath="$(_SdkDevPath)"
 			SdkRoot="$(_SdkRoot)"
-			SdkVersion="$(MtouchSdkVersion)">
+			SdkVersion="$(_SdkVersion)">
 			<Output TaskParameter="BundleResources" ItemName="_BundleResourceWithLogicalName" />
 
 			<!-- Local items to be persisted to items files -->
@@ -1439,7 +1439,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			SdkUsrPath="$(_SdkUsrPath)"
 			SdkRoot="$(_SdkRoot)"
 			SdkPlatform="$(_SdkPlatform)"
-			SdkVersion="$(MtouchSdkVersion)">
+			SdkVersion="$(_SdkVersion)">
 			<Output TaskParameter="BundleResources" ItemName="_BundleResourceWithLogicalName" />
 
 			<!-- Local items to be persisted to items files -->
@@ -1590,7 +1590,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			ProvisioningProfile="$(_ProvisioningProfile)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			SdkPlatform="$(_SdkPlatform)"
-			SdkVersion="$(MtouchSdkVersion)"
+			SdkVersion="$(_SdkVersion)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			>
 
@@ -1611,7 +1611,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			Condition="'$(IsMacEnabled)' == 'true' And '$(CodesignResourceRules)' != '' And '$(ComputedPlatform)' == 'iPhone'"
 			AppBundleDir="$(AppBundleDir)"
 			ResourceRules="$(CodesignResourceRules)"
-			SdkVersion="$(MtouchSdkVersion)"
+			SdkVersion="$(_SdkVersion)"
 			>
 			<Output TaskParameter="PreparedResourceRules" PropertyName="_PreparedResourceRules"/>
 		</PrepareResourceRules>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.Common.targets
@@ -42,7 +42,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<ResolveNativeWatchApp
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
-			SdkVersion="$(MtouchSdkVersion)"
+			SdkVersion="$(_SdkVersion)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			>


### PR DESCRIPTION
New commits in xamarin/Xamarin.MacDev:

* xamarin/Xamarin.MacDev@45c5a68 [Xamarin.MacDev] Add interfaces to bridge Xamarin.iOS- and Xamarin.Mac-specific classes. (#72)

Diff: https://github.com/xamarin/Xamarin.MacDev/compare/a0a11aff271565bbaba029e5e428a0b9c2ca0e37..45c5a680e20a209ac846a32e0f2f0f83e843ab76