### PR TITLE
Remove the LaunchProfiles capability for the CPS integration

### DIFF
--- a/msbuild/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/msbuild/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -28,6 +28,10 @@
 	<ItemGroup>
 		<ProjectCapability Include="Apple" />
 		<ProjectCapability Include="Mobile" />
+
+		// See https://work.azdo.io/1112733
+		<!-- Conflicts with our targets generator in VS+CPS -->
+		<ProjectCapability Remove="LaunchProfiles" />
 	</ItemGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
Implements https://work.azdo.io/1112733 as a workaround for the conflicts between
the built-in launchsettings.json-based .NET Core debugger and our Mono debugger.