### PR TITLE
Use a GCHandle instead of WeakReference in our IntPtr->NSObject table.

### DIFF
--- a/src/ObjCRuntime/Runtime.iOS.cs
+++ b/src/ObjCRuntime/Runtime.iOS.cs
@@ -53,20 +53,22 @@ namespace ObjCRuntime {
 			UIApplication.Initialize ();
 		}
 
+#if !XAMCORE_4_0
 		// This method is documented to be for diagnostic purposes only,
 		// and should not be considered stable API.
-		[EditorBrowsable (EditorBrowsableState.Advanced)]
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		static public List<WeakReference> GetSurfacedObjects ()
 		{
 			lock (lock_obj){
 				var list = new List<WeakReference> (object_map.Count);
 
 				foreach (var kv in object_map)
-					list.Add (kv.Value);
+					list.Add (new WeakReference (kv.Value, true));
 
 				return list;
 			}
 		}
+#endif
 			
 #if TVOS || WATCH
 		[Advice ("This method is present only to help porting code.")]


### PR DESCRIPTION
A WeakReference contains a GCHandle and provides additional services on top,
but we don't need those services, so we can just use a GCHandle instead.

This should decrease memory usage somewhat, since we won't have the
WeakReference objects around.

This also prepares us for switching the native API to use GCHandle instead of
passing MonoObject* to managed code (we won't have to re-create a GCHandle
inside a WeakReference when passed a GCHandle for a managed object).