### PR TITLE
Use the correct return type for the xamarin_get_delegate_for_block_parameter function.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2165,7 +2165,7 @@ xamarin_release_block_on_main_thread (void *obj)
  *
  * Returns: the instantiated delegate.
  */
-int *
+MonoObject *
 xamarin_get_delegate_for_block_parameter (MonoMethod *method, guint32 token_ref, int par, void *nativeBlock, guint32 *exception_gchandle)
 {
 	// COOP: accesses managed memory: unsafe mode.
@@ -2204,7 +2204,7 @@ xamarin_get_delegate_for_block_parameter (MonoMethod *method, guint32 token_ref,
 	mono_gc_reference_queue_add (block_wrapper_queue, delegate, nativeBlock);
 	pthread_mutex_unlock (&wrapper_hash_lock);
 
-	return (int *) delegate;
+	return delegate;
 }
 
 id

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -181,7 +181,7 @@ MonoClass *		xamarin_get_nullable_type (MonoClass *cls, guint32 *exception_gchan
 MonoType *		xamarin_get_parameter_type (MonoMethod *managed_method, int index);
 MonoObject *	xamarin_get_nsobject_with_type_for_ptr (id self, bool owns, MonoType* type, guint32 *exception_gchandle);
 MonoObject *	xamarin_get_nsobject_with_type_for_ptr_created (id self, bool owns, MonoType *type, int32_t *created, guint32 *exception_gchandle);
-int *			xamarin_get_delegate_for_block_parameter (MonoMethod *method, guint32 token_ref, int par, void *nativeBlock, guint32 *exception_gchandle);
+MonoObject *	xamarin_get_delegate_for_block_parameter (MonoMethod *method, guint32 token_ref, int par, void *nativeBlock, guint32 *exception_gchandle);
 id              xamarin_get_block_for_delegate (MonoMethod *method, MonoObject *delegate, const char *signature /* NULL allowed, but requires the dynamic registrar at runtime to compute */, guint32 token_ref /* INVALID_TOKEN_REF allowed, but requires the dynamic registrar at runtime */, guint32 *exception_gchandle);
 id				xamarin_get_nsobject_handle (MonoObject *obj);
 void			xamarin_set_nsobject_handle (MonoObject *obj, id handle);


### PR DESCRIPTION
This code is old, and it seems the int* is a left-over from the 32-bit days.
Using the correct type makes us able to avoid a cast.

Ref: https://github.com/xamarin/maccore/commit/0f83cf16e2258f5f430e2672df199ee78d8f2c94