### PR TITLE
[linker] Make the corlib name dynamic.

### DIFF
--- a/tools/common/DerivedLinkContext.cs
+++ b/tools/common/DerivedLinkContext.cs
@@ -6,6 +6,7 @@ using Mono.Linker;
 using Mono.Collections.Generic;
 
 using Registrar;
+using Mono.Tuner;
 using Xamarin.Bundler;
 
 namespace Xamarin.Tuner
@@ -46,6 +47,18 @@ namespace Xamarin.Tuner
 			}
 		}
 
+		AssemblyDefinition corlib;
+		public AssemblyDefinition Corlib {
+			get {
+				if (corlib == null) {
+					var name = Driver.CorlibName;
+					corlib = this.GetAssembly (name);
+					if (corlib == null)
+						throw ErrorHelper.CreateError (2111, Errors.MX2111 /* Can not find the corlib assembly '{0}' in the list of loaded assemblies. */, name);
+				}
+				return corlib;
+			}
+		}
 		public HashSet<TypeDefinition> CachedIsNSObject {
 			get { return cached_isnsobject; }
 			set { cached_isnsobject = value; }

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -272,6 +272,10 @@ namespace Xamarin.Bundler {
 
 		public const bool IsXAMCORE_4_0 = false;
 
+		public static bool IsDotNet {
+			get { return TargetFramework.IsDotNet; }
+		}
+
 		static TargetFramework targetFramework;
 
 		public static TargetFramework TargetFramework {
@@ -1259,6 +1263,14 @@ namespace Xamarin.Bundler {
 		public static void RunStrip (IList<string> options)
 		{
 			RunXcodeTool ("strip", options);
+		}
+
+		public static string CorlibName {
+			get {
+				if (IsDotNet)
+					return "System.Private.CoreLib";
+				return "mscorlib";
+			}
 		}
 	}
 }

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -994,20 +994,21 @@ namespace Registrar {
 				return system_void;
 			
 			// find corlib
+			var corlib_name = Driver.CorlibName;
 			AssemblyDefinition corlib = null;
 			AssemblyDefinition first = null;
 
 			foreach (var assembly in input_assemblies) {
 				if (first == null)
 					first = assembly;
-				if (assembly.Name.Name == "mscorlib") {
+				if (assembly.Name.Name == corlib_name) {
 					corlib = assembly;
 					break;
 				}
 			}
 
 			if (corlib == null) {
-				corlib = first.MainModule.AssemblyResolver.Resolve (AssemblyNameReference.Parse ("mscorlib"), new ReaderParameters ());
+				corlib = first.MainModule.AssemblyResolver.Resolve (AssemblyNameReference.Parse (corlib_name), new ReaderParameters ());
 			}
 			foreach (var type in corlib.MainModule.Types) {
 				if (type.Namespace == "System" && type.Name == "Void")

--- a/tools/linker/CorePreserveCode.cs
+++ b/tools/linker/CorePreserveCode.cs
@@ -5,6 +5,9 @@ using Mono.Linker;
 using Mono.Linker.Steps;
 using Mono.Tuner;
 
+using Xamarin.Bundler;
+using Xamarin.Tuner;
+
 namespace Xamarin.Linker {
 
 	public class CorePreserveCode : IStep {
@@ -14,16 +17,13 @@ namespace Xamarin.Linker {
 			I18n = i18n;
 		}
 
-		protected LinkContext Context { get; private set; }
-
-		protected AssemblyDefinition Corlib { get; private set; }
+		protected DerivedLinkContext Context { get; private set; }
 
 		protected I18nAssemblies I18n { get; private set; }
 
 		public virtual void Process (LinkContext context)
 		{
-			Context = context;
-			Corlib = context.GetAssembly ("mscorlib");
+			Context = (DerivedLinkContext) context;
 
 			if (I18n.HasFlag (I18nAssemblies.MidEast)) {
 				PreserveCalendar ("UmAlQuraCalendar");
@@ -37,7 +37,7 @@ namespace Xamarin.Linker {
 
 		void PreserveCalendar (string name)
 		{
-			var calendar = Corlib.MainModule.GetType ("System.Globalization", name);
+			var calendar = Context.Corlib.MainModule.GetType ("System.Globalization", name);
 			if (calendar == null || !calendar.HasMethods)
 				return;
 
@@ -54,7 +54,7 @@ namespace Xamarin.Linker {
 
 		void PreserveResourceSet ()
 		{
-			var resource_set = Corlib.MainModule.GetType ("System.Resources", "RuntimeResourceSet");
+			var resource_set = Context.Corlib.MainModule.GetType ("System.Resources", "RuntimeResourceSet");
 			if (resource_set == null || !resource_set.HasMethods)
 				return;
 

--- a/tools/linker/MonoTouch.Tuner/PreserveCode.cs
+++ b/tools/linker/MonoTouch.Tuner/PreserveCode.cs
@@ -32,7 +32,7 @@ namespace MonoTouch.Tuner {
 
 		void PreserveDictionaryConstructor ()
 		{
-			var dictionary = Corlib.MainModule.GetType ("System.Collections.Generic", "Dictionary`2");
+			var dictionary = Context.Corlib.MainModule.GetType ("System.Collections.Generic", "Dictionary`2");
 			if (dictionary == null || !dictionary.HasMethods)
 				return;
 

--- a/tools/linker/MonoTouch.Tuner/RemoveBitcodeIncompatibleCodeStep.cs
+++ b/tools/linker/MonoTouch.Tuner/RemoveBitcodeIncompatibleCodeStep.cs
@@ -72,8 +72,7 @@ namespace MonoTouch.Tuner {
 			var il = body.GetILProcessor ();
 			il.Emit (OpCodes.Ldstr, "This method contains IL not supported when compiled to bitcode.");
 			if (nse_ctor_def == null) {
-				var corlib = context.GetAssembly ("mscorlib");
-				var nse = corlib.MainModule.GetType ("System", "NotSupportedException");
+				var nse = DerivedLinkContext.Corlib.MainModule.GetType ("System", "NotSupportedException");
 				foreach (var ctor in nse.GetConstructors ()) {
 					if (!ctor.HasParameters)
 						continue;

--- a/tools/linker/MonoTouch.Tuner/RemoveCodeBase.cs
+++ b/tools/linker/MonoTouch.Tuner/RemoveCodeBase.cs
@@ -20,7 +20,7 @@ namespace MonoTouch.Tuner {
 		{
 			// only one definition exists (in mscorlib.dll)
 			if (get_nse_def == null) {
-				var corlib = context.GetAssembly ("mscorlib");
+				var corlib = LinkContext.Corlib;
 				var nse = corlib.MainModule.GetType ("System", "NotSupportedException");
 				foreach (var m in nse.Methods) {
 					// no need to check HasMethods because we know there are (and nothing is removed at this stage)

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -1505,6 +1505,12 @@ namespace Xamarin.Bundler {
             }
         }
         
+        internal static string MX2111 {
+            get {
+                return ResourceManager.GetString("MX2111", resourceCulture);
+            }
+        }
+        
         internal static string MX3001 {
             get {
                 return ResourceManager.GetString("MX3001", resourceCulture);

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -1595,6 +1595,8 @@
 		</comment>
 	</data>
 
+	<!-- 2020 -> 2099 is used by the linker -->
+
 	<data name="MT2101" xml:space="preserve">
 		<value>Can't resolve the reference '{0}', referenced from the method '{1}' in '{2}'.
 		</value>
@@ -1716,6 +1718,13 @@
 	
 	<data name="MM2110" xml:space="preserve">
 		<value>Xamarin.Mac 'Partial Static' registrar does not support linking. Disable linking or use another registrar mode.
+		</value>
+		<comment>
+		</comment>
+	</data>
+
+	<data name="MX2111" xml:space="preserve">
+		<value>Can not find the corlib assembly '{0}' in the list of loaded assemblies.
 		</value>
 		<comment>
 		</comment>

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -2986,6 +2986,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX2111">
+        <source>Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</source>
+        <target state="new">Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX3001">
         <source>Could not {0} the assembly '{1}'
 		</source>

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -2986,6 +2986,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX2111">
+        <source>Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</source>
+        <target state="new">Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX3001">
         <source>Could not {0} the assembly '{1}'
 		</source>

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -2986,6 +2986,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX2111">
+        <source>Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</source>
+        <target state="new">Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX3001">
         <source>Could not {0} the assembly '{1}'
 		</source>

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -2986,6 +2986,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX2111">
+        <source>Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</source>
+        <target state="new">Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX3001">
         <source>Could not {0} the assembly '{1}'
 		</source>

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -2986,6 +2986,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX2111">
+        <source>Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</source>
+        <target state="new">Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX3001">
         <source>Could not {0} the assembly '{1}'
 		</source>

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -2986,6 +2986,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX2111">
+        <source>Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</source>
+        <target state="new">Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX3001">
         <source>Could not {0} the assembly '{1}'
 		</source>

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -2986,6 +2986,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX2111">
+        <source>Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</source>
+        <target state="new">Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX3001">
         <source>Could not {0} the assembly '{1}'
 		</source>

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -2986,6 +2986,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX2111">
+        <source>Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</source>
+        <target state="new">Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX3001">
         <source>Could not {0} the assembly '{1}'
 		</source>

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -2986,6 +2986,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX2111">
+        <source>Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</source>
+        <target state="new">Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX3001">
         <source>Could not {0} the assembly '{1}'
 		</source>

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -2986,6 +2986,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX2111">
+        <source>Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</source>
+        <target state="new">Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX3001">
         <source>Could not {0} the assembly '{1}'
 		</source>

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -2986,6 +2986,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX2111">
+        <source>Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</source>
+        <target state="new">Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX3001">
         <source>Could not {0} the assembly '{1}'
 		</source>

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -2986,6 +2986,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX2111">
+        <source>Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</source>
+        <target state="new">Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX3001">
         <source>Could not {0} the assembly '{1}'
 		</source>

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -2986,6 +2986,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX2111">
+        <source>Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</source>
+        <target state="new">Can not find the corlib assembly '{0}' in the list of loaded assemblies.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX3001">
         <source>Could not {0} the assembly '{1}'
 		</source>


### PR DESCRIPTION
Use the correct corlib name depending on whether we're targeting .NET or Mono,
since there's no mscorlib.dll anymore in .NET, it's System.Private.CoreLib.dll.