### PR TITLE
[mtouch] Fix debug with profiler on app extensions

### DIFF
--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -1570,8 +1570,7 @@ namespace Xamarin.Bundler
 				case AssemblyBuildTarget.DynamicLibrary:
 					libprofiler = Path.Combine (libmonodir, "libmono-profiler-log.dylib");
 					linker_flags.AddLinkWith (libprofiler);
-					if (App.HasFrameworksDirectory)
-						AddToBundle (libprofiler);
+					AddToBundle (libprofiler);
 					break;
 				case AssemblyBuildTarget.StaticObject:
 					libprofiler = Path.Combine (libmonodir, "libmono-profiler-log.a");


### PR DESCRIPTION
Always add `libmono-profiler-log.dylib` if profiling is enabled and we
are building with dynamic libraries. The profiler code is not (meant to
be) shipped so it can be added even without a `Frameworks` directory.

This fix debugging too (if profiler is enabled) since the library was
linked (even if it was not included).

Fix https://github.com/xamarin/xamarin-macios/issues/8470