### PR TITLE
[mtouch/mmp] Remove IStaticRegistrar, it's no longer needed.

### DIFF
--- a/tools/common/DerivedLinkContext.cs
+++ b/tools/common/DerivedLinkContext.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Tuner
 {
 	public class DerivedLinkContext : LinkContext
 	{
-		internal IStaticRegistrar StaticRegistrar;
+		internal StaticRegistrar StaticRegistrar;
 		internal Target Target;
 		Symbols required_symbols;
 

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -205,23 +205,7 @@ namespace Registrar {
 		}
 	}
 
-	interface IStaticRegistrar
-	{
-		bool HasAttribute (ICustomAttributeProvider provider, string @namespace, string name, bool inherits = false);
-		bool HasProtocolAttribute (TypeReference type);
-		RegisterAttribute GetRegisterAttribute (TypeReference type);
-		ProtocolAttribute GetProtocolAttribute (TypeReference type);
-		string GetExportedTypeName (TypeReference type, RegisterAttribute register_attribute);
-		void GenerateSingleAssembly (IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, string assembly);
-		void Generate (IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path);
-		string ComputeSignature (TypeReference DeclaringType, MethodDefinition Method, Registrar.ObjCMember member = null, bool isCategoryInstance = false, bool isBlockSignature = false);
-		string ComputeSignature (TypeReference declaring_type, bool is_ctor, TypeReference return_type, TypeReference [] parameters, MethodDefinition mi = null, Registrar.ObjCMember member = null, bool isCategoryInstance = false, bool isBlockSignature = false);
-		bool MapProtocolMember (MethodDefinition method, out MethodDefinition extensionMethod);
-		string PlatformAssembly { get; }
-		Dictionary<ICustomAttribute, MethodDefinition> ProtocolMemberMethodMap { get; }
-	}
-
-	class StaticRegistrar : Registrar, IStaticRegistrar
+	class StaticRegistrar : Registrar
 	{
 		Dictionary<ICustomAttribute, MethodDefinition> protocol_member_method_map;
 

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Bundler {
 		public HashSet<string> Frameworks = new HashSet<string> ();
 		public HashSet<string> WeakFrameworks = new HashSet<string> ();
 
-		internal IStaticRegistrar StaticRegistrar { get; set; }
+		internal StaticRegistrar StaticRegistrar { get; set; }
 
 		// If we didn't link because the existing (cached) assemblyes are up-to-date.
 		bool cached_link = false;


### PR DESCRIPTION
It was created to support Xamarin.Mac/Classic, but that's not supported
anymore, so we can just remove this interface.