### PR TITLE
Remove XAMARIN_APPLETLS, it seems like it's always defined, which means it's not needed.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -143,13 +143,6 @@ ifdef ENABLE_CCACHE
 CCACHE=ccache 
 endif
 
-#DISABLE_APPLETLS=1
-ifdef DISABLE_APPLETLS
-APPLETLS_DEFINES = -d:XAMARIN_NO_TLS
-else
-APPLETLS_DEFINES = -d:XAMARIN_APPLETLS
-endif
-
 XCODE_MAC_SDKROOT=$(XCODE_DEVELOPER_ROOT)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
 
 # The MAC_* variables do not contain the -mmacosx-version-min flag on purpose: each usage must specify it separately.

--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -28,7 +28,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if (XAMARIN_APPLETLS || WATCH) && !NET
+#if !NET
 #define NATIVE_APPLE_CERTIFICATE
 #endif
 
@@ -91,13 +91,6 @@ namespace Security {
 				throw new ArgumentNullException ("certificate");
 
 #if NATIVE_APPLE_CERTIFICATE
-			/*
-			 * This requires a recent Mono runtime which has the lazily-initialized
-			 * certifciates in mscorlib.dll, so we can't use it on XM classic.
-			 *
-			 * Using 'XAMARIN_APPLETLS' as a conditional because 'XAMCORE_2_0' is
-			 * defined for tvos and watch, which have a recent-enough runtime.
-			 */
 			handle = certificate.Impl.GetNativeAppleCertificate ();
 			if (handle != IntPtr.Zero) {
 				CFObject.CFRetain (handle);

--- a/tests/linker/ios/link sdk/link sdk.csproj
+++ b/tests/linker/ios/link sdk/link sdk.csproj
@@ -45,7 +45,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DEBUG;XAMARIN_APPLETLS;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <MtouchDebug>True</MtouchDebug>
@@ -60,7 +60,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DEBUG;XAMARIN_APPLETLS;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <MtouchDebug>True</MtouchDebug>
@@ -75,7 +75,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DEBUG;XAMARIN_APPLETLS;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <MtouchDebug>True</MtouchDebug>
@@ -95,7 +95,7 @@
     <MtouchExtraArgs>-v -v -xml=${ProjectDir}/extra-linker-defs.xml "--dlsym:-link sdk"</MtouchExtraArgs>
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <DefineConstants>DO_NOT_REMOVE;XAMARIN_APPLETLS;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DO_NOT_REMOVE;$(DefineConstants)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release32|iPhone' ">
@@ -108,7 +108,7 @@
     <MtouchExtraArgs>-v -v -xml=${ProjectDir}/extra-linker-defs.xml "--dlsym:-link sdk"</MtouchExtraArgs>
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchArch>ARMv7</MtouchArch>
-    <DefineConstants>DO_NOT_REMOVE;XAMARIN_APPLETLS;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DO_NOT_REMOVE;$(DefineConstants)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release64|iPhone' ">
@@ -121,7 +121,7 @@
     <MtouchExtraArgs>-v -v -xml=${ProjectDir}/extra-linker-defs.xml "--dlsym:-link sdk"</MtouchExtraArgs>
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchArch>ARM64</MtouchArch>
-    <DefineConstants>DO_NOT_REMOVE;XAMARIN_APPLETLS;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DO_NOT_REMOVE;$(DefineConstants)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-bitcode|iPhone' ">
@@ -134,7 +134,7 @@
     <MtouchExtraArgs>-v -v -xml=${ProjectDir}/extra-linker-defs.xml "--dlsym:-link sdk" --bitcode:full</MtouchExtraArgs>
     <MtouchUseLlvm>true</MtouchUseLlvm>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <DefineConstants>DO_NOT_REMOVE;XAMARIN_APPLETLS;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DO_NOT_REMOVE;$(DefineConstants)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -16,7 +16,7 @@
     <DebugType>portable</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>MONOMAC;MMP;XAMARIN_APPLETLS;DEBUG</DefineConstants>
+    <DefineConstants>MONOMAC;MMP;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Deterministic>True</Deterministic>
@@ -28,7 +28,7 @@
     <Optimize>False</Optimize>
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
-    <DefineConstants>MONOMAC;MMP;XAMARIN_APPLETLS</DefineConstants>
+    <DefineConstants>MONOMAC;MMP</DefineConstants>
     <WarningLevel>4</WarningLevel>
     <Deterministic>True</Deterministic>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -16,7 +16,7 @@
     <DebugType>portable</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>MONOTOUCH;MTOUCH;XAMARIN_APPLETLS</DefineConstants>
+    <DefineConstants>MONOTOUCH;MTOUCH</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Deterministic>True</Deterministic>
@@ -29,7 +29,7 @@
     <Optimize>False</Optimize>
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
-    <DefineConstants>MONOTOUCH;MTOUCH;XAMARIN_APPLETLS</DefineConstants>
+    <DefineConstants>MONOTOUCH;MTOUCH</DefineConstants>
     <WarningLevel>4</WarningLevel>
     <Deterministic>True</Deterministic>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Also remove outdated comment about Xamarin.Mac/Classic, since XM/Classic is dead.