### PR TITLE
[mtouch/mmp] Pass the path to mscorlib explicitly to the partial static registrar code instead of relying on resolving it successfully.

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -402,7 +402,6 @@ namespace Xamarin.Bundler {
 			var RootAssembly = RootAssemblies [0];
 			var resolvedAssemblies = new Dictionary<string, AssemblyDefinition> ();
 			var resolver = new PlatformResolver () {
-				FrameworkDirectory = Driver.GetPlatformFrameworkDirectory (this),
 				RootDirectory = Path.GetDirectoryName (RootAssembly),
 #if MMP
 				CommandLineAssemblies = RootAssemblies,
@@ -419,7 +418,11 @@ namespace Xamarin.Bundler {
 
 			var ps = new ReaderParameters ();
 			ps.AssemblyResolver = resolver;
-			resolvedAssemblies.Add ("mscorlib", ps.AssemblyResolver.Resolve (AssemblyNameReference.Parse ("mscorlib"), new ReaderParameters ()));
+			foreach (var reference in References) {
+				var r = resolver.Load (reference);
+				if (r == null)
+					throw ErrorHelper.CreateError (2002, Errors.MT2002, reference);
+			}
 
 			var productAssembly = Driver.GetProductAssembly (this);
 			bool foundProductAssembly = false;

--- a/tools/common/CoreResolver.cs
+++ b/tools/common/CoreResolver.cs
@@ -114,6 +114,9 @@ namespace Xamarin.Bundler {
 
 		protected AssemblyDefinition SearchDirectory (string name, string directory, string extension = ".dll")
 		{
+			if (!Directory.Exists (directory))
+				return null;
+
 			var file = DirectoryGetFile (directory, name + extension);
 			if (file.Length > 0)
 				return Load (file);

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -49,11 +49,11 @@ $(MMP_DIRECTORIES):
 GENERATE_PART_REGISTRAR = $(Q_GEN) $(LOCAL_MMP_COMMAND) --xamarin-framework-directory=$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR) -q --runregistrar:$(abspath $@) --sdkroot $(XCODE_DEVELOPER_ROOT) --sdk $(OSX_SDK_VERSION) $(abspath $<) --registrar:static --arch=x86_64 --nolink
 
 Xamarin.Mac.registrar.mobile.x86_64.m: $(TOP)/src/build/mac/mobile-64/Xamarin.Mac.dll $(LOCAL_MMP)
-	$(GENERATE_PART_REGISTRAR) --target-framework Xamarin.Mac,Version=v2.0,Profile=Mobile
+	$(GENERATE_PART_REGISTRAR) --target-framework Xamarin.Mac,Version=v2.0,Profile=Mobile -a:$(MOBILE_BCL_DIR)/mscorlib.dll
 	$(Q) touch Xamarin.Mac.registrar.mobile.x86_64.m Xamarin.Mac.registrar.mobile.x86_64.h
 
 Xamarin.Mac.registrar.full.x86_64.m:   $(TOP)/src/build/mac/full-64/Xamarin.Mac.dll $(LOCAL_MMP)
-	$(GENERATE_PART_REGISTRAR) --target-framework Xamarin.Mac,Version=v4.5,Profile=Full
+	$(GENERATE_PART_REGISTRAR) --target-framework Xamarin.Mac,Version=v4.5,Profile=Full -a:$(FULL_BCL_DIR)/mscorlib.dll
 	$(Q) touch Xamarin.Mac.registrar.full.x86_64.m Xamarin.Mac.registrar.full.x86_64.h
 
 Xamarin.Mac.registrar.%.x86_64.a: Xamarin.Mac.registrar.%.x86_64.m

--- a/tools/mmp/resolver.cs
+++ b/tools/mmp/resolver.cs
@@ -69,8 +69,8 @@ namespace Xamarin.Bundler {
 			if (assembly != null)
 				return assembly;
 
-			var pclPath = Path.Combine (FrameworkDirectory, "Facades");
-			if (Directory.Exists (pclPath)) {
+			if (FrameworkDirectory != null) {
+				var pclPath = Path.Combine (FrameworkDirectory, "Facades");
 				assembly = SearchDirectory (name, pclPath);
 				if (assembly != null)
 					return assembly;

--- a/tools/mtouch/AssemblyResolver.cs
+++ b/tools/mtouch/AssemblyResolver.cs
@@ -72,7 +72,7 @@ namespace MonoTouch.Tuner {
 			if (cache.TryGetValue (aname, out assembly))
 				return assembly;
 
-			if (EnableRepl) {
+			if (EnableRepl && FrameworkDirectory != null) {
 				var replDir = Path.Combine (FrameworkDirectory, "repl");
 				if (Directory.Exists (replDir)) {
 					assembly = SearchDirectory (aname, replDir);
@@ -81,8 +81,8 @@ namespace MonoTouch.Tuner {
 				}
 			}
 
-			var facadeDir = Path.Combine (FrameworkDirectory, "Facades");
-			if (Directory.Exists (facadeDir)) {
+			if (FrameworkDirectory != null) {
+				var facadeDir = Path.Combine (FrameworkDirectory, "Facades");
 				assembly = SearchDirectory (aname, facadeDir);
 				if (assembly != null)
 					return assembly;

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -212,7 +212,7 @@ $(MTOUCH_DIR)/mtouch.exe: $(mtouch_dependencies)
 #
 define RunRegistrar
 %.registrar.$(1).$(2).m %.registrar.$(1).$(2).h: $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/$(3)bits/%.dll $(LOCAL_MTOUCH)
-	$$(Q_GEN) $$(LOCAL_MTOUCH_COMMAND) --xamarin-framework-directory=$$(IOS_DESTDIR)/$$(MONOTOUCH_PREFIX) $$(MTOUCH_VERBOSITY) --runregistrar:$$(abspath $$(basename $$@).m) --sdkroot $$(XCODE_DEVELOPER_ROOT) --sdk $(4) $$< --registrar:static --target-framework Xamarin.$(5),v1.0 --abi $(2)
+	$$(Q_GEN) $$(LOCAL_MTOUCH_COMMAND) --xamarin-framework-directory=$$(IOS_DESTDIR)/$$(MONOTOUCH_PREFIX) $$(MTOUCH_VERBOSITY) --runregistrar:$$(abspath $$(basename $$@).m) --sdkroot $$(XCODE_DEVELOPER_ROOT) --sdk $(4) $$< --registrar:static --target-framework Xamarin.$(5),v1.0 --abi $(2) -r:$(8)/mscorlib.dll
 	$$(Q) touch $$(basename $$@).m $$(basename $$@).h
 
 %.registrar.$(1).$(2).a: %.registrar.$(1).$(2).m %.registrar.$(1).$(2).h


### PR DESCRIPTION
This makes the code simpler when we have to add support for .NET.

This requires modifying the linker to accept a null FrameworkDirectory.