### PR TITLE
[msbuild] add System.Drawing.Common ref for bindings

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -183,13 +183,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<RemoveDir Directories="$(IntermediateOutputPath)" />
 	</Target>
 
-	<Target Name="_AddExtraReferences" BeforeTargets="ResolveAssemblyReferences" Condition="'$(DisableExtraReferences)' != 'true'">
-		<ItemGroup>
-			<!-- https://github.com/mono/mono/issues/13483 -->
-			<Reference Include="System.Drawing.Common.dll" />
-		</ItemGroup>
-	</Target>
-
 	<PropertyGroup>
 		<_CollectBundleResourcesDependsOn>
 			_CompileImageAssets;

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -60,6 +60,13 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<RemoveDir Directories="$(BindingResourcePath);" />  
 	</Target>
 	
+	<Target Name="_AddExtraReferences" BeforeTargets="ResolveAssemblyReferences" Condition="'$(DisableExtraReferences)' != 'true'">
+		<ItemGroup>
+			<!-- https://github.com/mono/mono/issues/13483 -->
+			<Reference Include="System.Drawing.Common.dll" />
+		</ItemGroup>
+	</Target>
+
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
 </Project>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -502,13 +502,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="@(_IpaPackageFile)" />
 	</Target>
 
-	<Target Name="_AddExtraReferences" BeforeTargets="ResolveAssemblyReferences" Condition="'$(DisableExtraReferences)' != 'true'">
-		<ItemGroup>
-			<!-- https://github.com/mono/mono/issues/13483 -->
-			<Reference Include="System.Drawing.Common.dll" />
-		</ItemGroup>
-	</Target>
-
 	<PropertyGroup>
 		<_CollectBundleResourcesDependsOn>
 			_CompileInterfaceDefinitions;

--- a/tests/bindings-framework-test/StructsAndEnums.cs
+++ b/tests/bindings-framework-test/StructsAndEnums.cs
@@ -13,5 +13,10 @@ namespace Bindings.Test
 		[DllImport ("__Internal")]
 		public static extern int ar_theUltimateAnswer ();
 	}
+
+	// Verify that System.Drawing.Color usage compiles
+	public class Foo {
+		public void Bar (System.Drawing.Color color) { }
+	}
 }
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-macios/issues/8265

Usage of `System.Drawing` types in iOS binding projects are failing with:

    error CS1069: The type name 'Color' could not be found in the namespace 'System.Drawing'.
    This type has been forwarded to assembly 'System.Drawing.Common, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'
    Consider adding a reference to that assembly.

In 3a7bdc0, an `_AddExtraReferences` MSBuild target was added for iOS
and Mac projects, but mistakenly missing from binding projects.

I moved the `_AddExtraReferences` target to `Xamarin.Shared.targets`,
so it will be used for all project types.

I also updated a test, I could merely use `System.Drawing.Color` in
`StructsAndEnums.cs` to reproduce the failure.