### PR TITLE
[linker] Directly use Annotations in BaseStep subclasses

### DIFF
--- a/tools/linker/CoreTypeMapStep.cs
+++ b/tools/linker/CoreTypeMapStep.cs
@@ -51,7 +51,7 @@ namespace MonoTouch.Tuner {
 
 			// The product assembly itself is safe as long as it's linked
 			if (Profile.IsProductAssembly (assembly))
-				return LinkContext.Annotations.GetAction (assembly) != Mono.Linker.AssemblyAction.Link;
+				return Annotations.GetAction (assembly) != Mono.Linker.AssemblyAction.Link;
 
 			// Can't touch the forbidden fruit in the product assembly unless there's a reference to it
 			var hasProductReference = false;
@@ -112,7 +112,7 @@ namespace MonoTouch.Tuner {
 							// Fortunately the linker is able to rewrite calls to SetupBlock[Unsafe] to call
 							// SetupBlockImpl (which doesn't need the dynamic registrar), which means we only have
 							// to look in assemblies that aren't linked.
-							if (LinkContext.Annotations.GetAction (assembly) == Mono.Linker.AssemblyAction.Link && LinkContext.App.Optimizations.OptimizeBlockLiteralSetupBlock == true)
+							if (Annotations.GetAction (assembly) == Mono.Linker.AssemblyAction.Link && LinkContext.App.Optimizations.OptimizeBlockLiteralSetupBlock == true)
 								break;
 
 							if (warnIfRequired)

--- a/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
+++ b/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
@@ -33,7 +33,7 @@ namespace MonoTouch.Tuner
 		{
 			base.ProcessAssembly (assembly);
 
-			if (Context.Annotations.GetAction (assembly) == AssemblyAction.Delete)
+			if (Annotations.GetAction (assembly) == AssemblyAction.Delete)
 				return;
 
 			if (skip_sdk_assemblies && Profile.IsSdkAssembly (assembly))
@@ -129,7 +129,7 @@ namespace MonoTouch.Tuner
 				var property = method.GetProperty ();
 				object symbol;
 				// The Field attribute may have been linked away, but we've stored it in an annotation.
-				if (property != null && Context.Annotations.GetCustomAnnotations ("ExportedFields").TryGetValue (property, out symbol)) {
+				if (property != null && Annotations.GetCustomAnnotations ("ExportedFields").TryGetValue (property, out symbol)) {
 					DerivedLinkContext.RequiredSymbols.AddField ((string) symbol).AddMember (property);
 				}
 			}

--- a/tools/linker/MonoTouch.Tuner/ProcessExportedFields.cs
+++ b/tools/linker/MonoTouch.Tuner/ProcessExportedFields.cs
@@ -57,7 +57,7 @@ namespace MonoTouch.Tuner {
 			if (symbol == null)
 				return;
 
-			Context.Annotations.GetCustomAnnotations ("ExportedFields").Add (property, symbol);
+			Annotations.GetCustomAnnotations ("ExportedFields").Add (property, symbol);
 		}
 
 		internal static string GetFieldSymbol (PropertyDefinition property)


### PR DESCRIPTION
It's exposed directly in `BaseStep` and makes porting code easier to net5