### PR TITLE
[Harness] Do not use the tunnel bore in the mtouch tests.

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -706,7 +706,7 @@ namespace Xharness {
 			return new AppRunner (processManager,
 				new AppBundleInformationParser (),
 				new SimulatorLoaderFactory (processManager),
-				new SimpleListenerFactory (TunnelBore),
+				new SimpleListenerFactory (UseTcpTunnel ? TunnelBore : null),
 				new DeviceLoaderFactory (processManager),
 				new CrashSnapshotReporterFactory (processManager),
 				new CaptureLogFactory (),


### PR DESCRIPTION
The change in xamarin/xamarin-macios/@617777ae73ccefdddd5711fe9628243b399492be
forgot to ignore the use of the tunnel in some cases. Is not the root of
the exception, but is the root of the tests failing after that commit.

fixes: https://github.com/xamarin/maccore/issues/2217