### PR TITLE
[d16-7] [BGTasks] Do not make BGTask abstract.

### DIFF
--- a/src/backgroundtasks.cs
+++ b/src/backgroundtasks.cs
@@ -48,7 +48,6 @@ namespace BackgroundTasks {
 		NSDate EarliestBeginDate { get; set; }
 	}
 
-	[Abstract]
 	[TV (13,0), NoWatch, NoMac, iOS (13,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]


### PR DESCRIPTION
The class in the API is abstract, the problem is that when the
application goes to the background, when it gets back we try to
instantiate an abstract class probably because Apple returns a internal
type that we do not know about.

fixes: https://github.com/xamarin/xamarin-macios/issues/7456

Backport of #8513.

/cc @mandel-macaque 