### PR TITLE
[Harness] Use readers over paths.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/IResultParser.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/IResultParser.cs
@@ -11,6 +11,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared {
 		// generates a xml result that will consider to be an error by the CI. Allows to catch errors in cases in which we are not talking about a test
 		// failure perse but the situation in which the app could not be built, timeout or crashed.
 		void GenerateFailure (ILogs logs, string source, string appName, string variation, string title, string message, string stderrPath, XmlResultJargon jargon);
+		
+		void GenerateFailure (ILogs logs, string source, string appName, string variation, string title, string message, StreamReader stderrReader, XmlResultJargon jargon);
 
 		// updates a given xml result to contain a list of attachments. This is useful for CI to be able to add logs as part of the attachments of a failing test.
 		void UpdateMissingData (string source, string destination, string applicationName, IEnumerable<string> attachments);

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
@@ -391,6 +391,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared {
 		// generate all the xml failures that will help the integration with the CI and return the failure reason
 		async Task GenerateXmlFailures (string failureMessage, bool crashed, string crashReason)
 		{
+			using var mainLogReader = mainLog.GetReader ();
 			if (!ResultsUseXml) // nothing to do
 				return;
 			if (!string.IsNullOrEmpty (crashReason)) {
@@ -401,7 +402,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared {
 					appInfo.Variation,
 					$"App Crash {appInfo.AppName} {appInfo.Variation}",
 					$"App crashed: {failureMessage}",
-					mainLog.FullPath,
+					mainLogReader,
 					xmlJargon);
 			} else if (launchFailure) {
 				resultParser.GenerateFailure (
@@ -411,7 +412,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared {
 					appInfo.Variation,
 					$"App Launch {appInfo.AppName} {appInfo.Variation} on {deviceName}",
 					$"{failureMessage} on {deviceName}",
-					mainLog.FullPath,
+					mainLogReader,
 					xmlJargon);
 			} else if (!isSimulatorTest && crashed && string.IsNullOrEmpty (crashReason)) {
 				// this happens more that what we would like on devices, the main reason most of the time is that we have had netwoking problems and the
@@ -425,7 +426,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared {
 						appInfo.Variation,
 						$"TcpConnection on {deviceName}",
 						$"Device {deviceName} could not reach the host over tcp.",
-						mainLog.FullPath,
+						mainLogReader,
 						xmlJargon);
 				}
 			} else if (timedout) {
@@ -436,7 +437,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared {
 					appInfo.Variation,
 					$"App Timeout {appInfo.AppName} {appInfo.Variation} on bot {deviceName}",
 					$"{appInfo.AppName} {appInfo.Variation} Test run timed out after {timeout.TotalMinutes} minute(s) on bot {deviceName}.",
-					mainLog.FullPath,
+					mainLogReader,
 					xmlJargon);
 			}
 		}

--- a/tests/xharness/TestTasks/RunDevice.cs
+++ b/tests/xharness/TestTasks/RunDevice.cs
@@ -130,6 +130,7 @@ namespace Xharness.TestTasks {
 						// Install the app
 						InstallLog = new AppInstallMonitorLog (testTask.Logs.Create ($"install-{Helpers.Timestamp}.log", "Install log"));
 						try {
+							using var logReader = InstallLog.GetReader ();
 							testTask.Runner.MainLog = this.InstallLog;
 							var install_result = await testTask.Runner.InstallAsync (InstallLog.CancellationToken);
 							if (!install_result.Succeeded) {
@@ -143,7 +144,8 @@ namespace Xharness.TestTasks {
 										testTask.Variation,
 										$"AppInstallation on {testTask.Device.Name}",
 										$"Install failed on {testTask.Device.Name}, exit code: {install_result.ExitCode}",
-										InstallLog.FullPath, xmlResultJargon);
+										logReader,
+										xmlResultJargon);
 							}
 						} finally {
 							InstallLog.Dispose ();

--- a/tests/xharness/TestTasks/RunTest.cs
+++ b/tests/xharness/TestTasks/RunTest.cs
@@ -67,16 +67,18 @@ namespace Xharness.TestTasks {
 				testTask.FailureMessage = BuildTask.FailureMessage;
 				if (!string.IsNullOrEmpty (BuildTask.KnownFailure))
 					testTask.KnownFailure = BuildTask.KnownFailure;
-				if (generateXmlFailures)
+				if (generateXmlFailures) {
+					var logReader = BuildTask.BuildLog.GetReader ();
 					ResultParser.GenerateFailure (
-						logs: testTask.Logs, 
+						logs: testTask.Logs,
 						source: "build",
 						appName: testTask.TestName,
 						variation: testTask.Variation,
 						title: $"App Build {testTask.TestName} {testTask.Variation}",
 						message: $"App could not be built {testTask.FailureMessage}.",
-						stderrPath: BuildTask.BuildLog.FullPath,
+						stderrReader: logReader,
 						jargon: xmlResultJargon);
+				}
 			} else {
 				testTask.ExecutionResult = TestExecutingResult.Built;
 			}


### PR DESCRIPTION
As issue https://github.com/xamarin/xamarin-macios/issues/8533 states,
not all loggers support the FullPath property, all of them do support
the GetReader one. We move the creation of the failures to use the
readers and reduce the chances of getting an exception.

fixes: https://github.com/xamarin/xamarin-macios/issues/8533