### PR TITLE
[linker] Update custom attributes that can be removed

### DIFF
--- a/tests/linker/ios/dont link/DontLinkRegressionTests.cs
+++ b/tests/linker/ios/dont link/DontLinkRegressionTests.cs
@@ -57,13 +57,8 @@ namespace DontLink {
 		public void RemovedAttributes ()
 		{
 			// since we do not link the attributes will be available - used or not by the application
-#if XAMCORE_2_0
 			var fullname = typeof (NSObject).Assembly.FullName;
 			Assert.NotNull (Type.GetType ("ObjCRuntime.ThreadSafeAttribute, " + fullname), "ThreadSafeAttribute");
-#else
-			Assert.NotNull (Type.GetType ("MonoTouch.ObjCRuntime.SinceAttribute, monotouch"), "SinceAttribute");
-			Assert.NotNull (Type.GetType ("MonoTouch.ObjCRuntime.ThreadSafeAttribute, monotouch"), "ThreadSafeAttribute");
-#endif
 		}
 
 		[Test]

--- a/tests/linker/ios/link all/LinkAllTest.cs
+++ b/tests/linker/ios/link all/LinkAllTest.cs
@@ -241,9 +241,6 @@ namespace LinkAll {
 			// since we're linking the attributes will NOT be available - even if they are used
 #if !XAMCORE_3_0
 			Assert.Null (Helper.GetType (prefix + "ObjCRuntime.AvailabilityAttribute, " + suffix), "AvailabilityAttribute");
-			Assert.Null (Helper.GetType (prefix + "ObjCRuntime.iOSAttribute, " + suffix), "AvailabilityAttribute");
-			Assert.Null (Helper.GetType (prefix + "ObjCRuntime.AvailabilityAttribute, " + suffix), "AvailabilityAttribute");
-			Assert.Null (Helper.GetType (prefix + "ObjCRuntime.SinceAttribute, " + suffix), "SinceAttribute");
 #endif
 			Assert.Null (Helper.GetType (prefix + "ObjCRuntime.IntroducedAttribute, " + suffix), "IntroducedAttribute");
 			Assert.Null (Helper.GetType (prefix + "ObjCRuntime.DeprecatedAttribute, " + suffix), "DeprecatedAttribute");

--- a/tests/mmp-regression/link-remove-attributes-1/LinkRemoveAttributes.cs
+++ b/tests/mmp-regression/link-remove-attributes-1/LinkRemoveAttributes.cs
@@ -90,10 +90,6 @@ namespace Xamarin.Mac.Linker.Test {
 				CheckPresence (type, "System.ObsoleteAttribute", false);
 				CheckPresence (type, "Foundation.AdviceAttribute", false);
 				CheckPresence (type, "ObjCRuntime.AvailabilityAttribute", false);
-				CheckPresence (type, "ObjCRuntime.LionAttribute", false);
-				CheckPresence (type, "ObjCRuntime.MountainLionAttribute", false);
-				CheckPresence (type, "ObjCRuntime.MavericksAttribute", false);
-				CheckPresence (type, "ObjCRuntime.SinceAttribute", false);
 				CheckPresence (type, "ObjCRuntime.ThreadSafeAttribute", false);
 				CheckPresence (type, "System.Diagnostics.DebuggerDisplay", debug);
 				CheckPresence (type, "System.Diagnostics.DebuggerNonUserCode", debug);

--- a/tools/linker/CoreRemoveAttributes.cs
+++ b/tools/linker/CoreRemoveAttributes.cs
@@ -30,21 +30,23 @@ namespace Xamarin.Linker {
 			case "AvailabilityBaseAttribute":
 			case "DeprecatedAttribute":
 			case "IntroducedAttribute":
-			case "iOSAttribute":
-			case "MacAttribute":
-			case "LionAttribute":
-			case "MountainLionAttribute":
-			case "MavericksAttribute":
 			case "NotImplementedAttribute":
 			case "ObsoletedAttribute":
-			case "SinceAttribute":
 			case "ThreadSafeAttribute":
 			case "UnavailableAttribute":
 			case "LinkWithAttribute":
 			case "DesignatedInitializerAttribute":
 			case "RequiresSuperAttribute":
 			case "BindingImplAttribute":
+			case "NoiOSAttribute":
+			case "NoMacAttribute":
+			case "NoTVAttribute":
+			case "NoWatchAttribute":
 				return attr_type.Namespace == Namespaces.ObjCRuntime;
+			// special subclasses of IntroducedAttribute
+			case "iOSAttribute":
+			case "MacAttribute":
+				return String.IsNullOrEmpty (attr_type.Namespace);
 			case "AdoptsAttribute":
 				return attr_type.Namespace == Namespaces.ObjCRuntime && LinkContext.App.Optimizations.RegisterProtocols == true;
 			case "ProtocolAttribute":
@@ -60,8 +62,8 @@ namespace Xamarin.Linker {
 			var attr_type = attribute.Constructor.DeclaringType;
 			if (attr_type.Namespace == Namespaces.ObjCRuntime) {
 				switch (attr_type.Name) {
-				case "AvailabilityAttribute":
-				case "AvailabilityBaseAttribute":
+				case "AvailabilityAttribute":		// obsolete (could be present in user code)
+				case "AvailabilityBaseAttribute":   // base type for IntroducedAttribute and DeprecatedAttribute (could be in user code)
 				case "DeprecatedAttribute":
 				case "IntroducedAttribute":
 					LinkContext.StoreCustomAttribute (provider, attribute, "Availability");
@@ -76,6 +78,14 @@ namespace Xamarin.Linker {
 				case "ProtocolAttribute":
 				case "ProtocolMemberAttribute":
 					LinkContext.StoreCustomAttribute (provider, attribute);
+					break;
+				}
+			} else if (String.IsNullOrEmpty (attr_type.Namespace)) {
+				switch (attr_type.Name) {
+				// they are subclasses of ObjCRuntime.IntroducedAttribute
+				case "iOSAttribute":
+				case "MacAttribute":
+					LinkContext.StoreCustomAttribute (provider, attribute, "Availability");
 					break;
 				}
 			}

--- a/tools/linker/MobileRemoveAttributes.cs
+++ b/tools/linker/MobileRemoveAttributes.cs
@@ -17,15 +17,10 @@ namespace Xamarin.Linker {
 			switch (attr_type.Name) {
 			case "ObsoleteAttribute":
 			// System.Mono*Attribute from mono/mcs/build/common/MonoTODOAttribute.cs
-			case "MonoDocumentationNoteAttribute":
-			case "MonoExtensionAttribute":
-			case "MonoInternalNoteAttribute":
 			case "MonoLimitationAttribute":
 			case "MonoNotSupportedAttribute":
 			case "MonoTODOAttribute":
 				return attr_type.Namespace == "System";
-			case "MonoFIXAttribute":
-				return attr_type.Namespace == "System.Xml";
 			// remove debugging-related attributes if we're not linking symbols (i.e. we're building release builds)
 			case "DebuggableAttribute":
 			case "DebuggerBrowsableAttribute":
@@ -53,6 +48,9 @@ namespace Xamarin.Linker {
 			case "NotNullIfNotNullAttribute":
 			case "NotNullWhenAttribute":
 				return attr_type.Namespace == "System.Diagnostics.CodeAnalysis";
+			// decorate the internalattributes (like nullability) that Roslyn inject into assemblies
+			case "EmbeddedAttribute":
+				return attr_type.Namespace == "Microsoft.CodeAnalysis";
 			default:
 				return false;
 			}


### PR DESCRIPTION
Some are no longer part of the SDK (or converted into new ones
at build time), others were new (and missing).

A full list of attributes and their usage frequency in what we ship can
be seen in https://gist.github.com/spouliot/ca03c6da7d4d75670ca77749350eb8a2

Also update tests: no need to check for removals of stuff that does not
exists anymore.