### PR TITLE
[mtouch] Make warning about not generating static registrar code for some simulator frameworks an actual (ignorable) warning.

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2686,7 +2686,7 @@ namespace Registrar {
 #if !MONOMAC
 				var isPlatformType = IsPlatformType (@class.Type);
 				if (isPlatformType && IsSimulatorOrDesktop && !IsTypeAllowedInSimulator (@class)) {
-					Driver.Log (5, "The static registrar won't generate code for {0} because its framework is not supported in the simulator.", @class.ExportedName);
+					ErrorHelper.Warning (4186, Errors.MX4186, /* The static registrar won't generate code for {0} because its framework is not supported in the simulator. */ @class.ExportedName);
 					continue; // Some types are not supported in the simulator.
 				}
 #else

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -2087,6 +2087,12 @@ namespace Xamarin.Bundler {
             }
         }
         
+        internal static string MX4186 {
+            get {
+                return ResourceManager.GetString("MX4186", resourceCulture);
+            }
+        }
+        
         internal static string MT5101 {
             get {
                 return ResourceManager.GetString("MT5101", resourceCulture);

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -2403,6 +2403,13 @@
 		</comment>
 	</data>
 
+	<data name="MX4186" xml:space="preserve">
+		<value>The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</value>
+		<comment>
+		</comment>
+	</data>
+
 	<data name="MT5101" xml:space="preserve">
 		<value>Missing '{0}' compiler. Please install Xcode 'Command-Line Tools' component
 		</value>

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -212,7 +212,7 @@ $(MTOUCH_DIR)/mtouch.exe: $(mtouch_dependencies)
 #
 define RunRegistrar
 %.registrar.$(1).$(2).m %.registrar.$(1).$(2).h: $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/$(3)bits/%.dll $(LOCAL_MTOUCH)
-	$$(Q_GEN) $$(LOCAL_MTOUCH_COMMAND) --xamarin-framework-directory=$$(IOS_DESTDIR)/$$(MONOTOUCH_PREFIX) $$(MTOUCH_VERBOSITY) --runregistrar:$$(abspath $$(basename $$@).m) --sdkroot $$(XCODE_DEVELOPER_ROOT) --sdk $(4) $$< --registrar:static --target-framework Xamarin.$(5),v1.0 --abi $(2) -r:$(8)/mscorlib.dll
+	$$(Q_GEN) $$(LOCAL_MTOUCH_COMMAND) --xamarin-framework-directory=$$(IOS_DESTDIR)/$$(MONOTOUCH_PREFIX) $$(MTOUCH_VERBOSITY) --runregistrar:$$(abspath $$(basename $$@).m) --sdkroot $$(XCODE_DEVELOPER_ROOT) --sdk $(4) $$< --registrar:static --target-framework Xamarin.$(5),v1.0 --abi $(2) -r:$(8)/mscorlib.dll --nowarn:4186
 	$$(Q) touch $$(basename $$@).m $$(basename $$@).h
 
 %.registrar.$(1).$(2).a: %.registrar.$(1).$(2).m %.registrar.$(1).$(2).h

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -3002,6 +3002,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX4186">
+        <source>The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</source>
+        <target state="new">The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX5222">
         <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
         </source>

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -3002,6 +3002,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX4186">
+        <source>The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</source>
+        <target state="new">The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX5222">
         <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
         </source>

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -3002,6 +3002,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX4186">
+        <source>The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</source>
+        <target state="new">The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX5222">
         <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
         </source>

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -3002,6 +3002,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX4186">
+        <source>The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</source>
+        <target state="new">The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX5222">
         <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
         </source>

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -3002,6 +3002,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX4186">
+        <source>The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</source>
+        <target state="new">The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX5222">
         <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
         </source>

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -3002,6 +3002,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX4186">
+        <source>The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</source>
+        <target state="new">The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX5222">
         <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
         </source>

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -3002,6 +3002,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX4186">
+        <source>The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</source>
+        <target state="new">The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX5222">
         <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
         </source>

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -3002,6 +3002,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX4186">
+        <source>The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</source>
+        <target state="new">The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX5222">
         <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
         </source>

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -3002,6 +3002,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX4186">
+        <source>The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</source>
+        <target state="new">The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX5222">
         <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
         </source>

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -3002,6 +3002,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX4186">
+        <source>The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</source>
+        <target state="new">The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX5222">
         <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
         </source>

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -3002,6 +3002,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX4186">
+        <source>The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</source>
+        <target state="new">The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX5222">
         <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
         </source>

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -3002,6 +3002,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX4186">
+        <source>The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</source>
+        <target state="new">The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX5222">
         <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
         </source>

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -3002,6 +3002,14 @@
         <note>
 		</note>
       </trans-unit>
+      <trans-unit id="MX4186">
+        <source>The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</source>
+        <target state="new">The static registrar won't generate code for {0} because its framework is not supported in the simulator.
+		</target>
+        <note>
+		</note>
+      </trans-unit>
       <trans-unit id="MX5222">
         <source>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
         </source>


### PR DESCRIPTION
That way we can ignore this output when generating code for the partial static registrar code:

> The static registrar won't generate code for ... because its framework is not supported in the simulator.