### PR TITLE
[mtouch/mmp] Introduce more specific helper functions for locating libxamarin*.dylib and Xamarin*.framework.

### DIFF
--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -850,6 +850,32 @@ namespace Xamarin.Bundler {
 			}
 		}
 
+		// This is the directory where the libxamarin*.[a|dylib] and libxammac*.[a|dylib] libraries are
+		public static string GetXamarinLibraryDirectory (Application app)
+		{
+			switch (app.Platform) {
+			case ApplePlatform.iOS:
+			case ApplePlatform.TVOS:
+			case ApplePlatform.WatchOS:
+				return GetProductSdkLibDirectory (app);
+			case ApplePlatform.MacOSX:
+				return FrameworkLibDirectory;
+			default:
+				throw ErrorHelper.CreateError (71, Errors.MX0071, app.Platform, PRODUCT);
+			}
+		}
+
+		// This is the directory where the Xamarin[-debug].framework frameworks are
+		public static string GetXamarinFrameworkDirectory (Application app)
+		{
+			return GetProductFrameworksDirectory (app);
+		}
+
+		public static string GetProductFrameworksDirectory (Application app)
+		{
+			return Path.Combine (GetProductSdkDirectory (app), "Frameworks");
+		}
+
 		// This is the directory where the platform assembly (Xamarin.*.dll) can be found
 		public static string GetPlatformFrameworkDirectory (Application app)
 		{

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -993,7 +993,7 @@ namespace Xamarin.Bundler {
 				throw ErrorHelper.CreateError (147, ex, Errors.MM0147, str_cflags, ex.Message);
 
 			var libmain = embed_mono ? "libxammac" : "libxammac-system";
-			var libxammac = Path.Combine (FrameworkLibDirectory, libmain + (App.EnableDebug ? "-debug" : "") + ".a");
+			var libxammac = Path.Combine (GetXamarinLibraryDirectory (App), libmain + (App.EnableDebug ? "-debug" : "") + ".a");
 
 			if (!File.Exists (libxammac))
 				throw new MonoMacException (5203, true, Errors.MM5203, libxammac);

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1888,11 +1888,11 @@ namespace Xamarin.Bundler {
 		{
 			switch (build_target) {
 			case AssemblyBuildTarget.StaticObject:
-				return Path.Combine (Driver.GetProductSdkLibDirectory (this), EnableDebug ? "libxamarin-debug.a" : "libxamarin.a");
+				return Path.Combine (Driver.GetXamarinLibraryDirectory (this), EnableDebug ? "libxamarin-debug.a" : "libxamarin.a");
 			case AssemblyBuildTarget.DynamicLibrary:
-				return Path.Combine (Driver.GetProductSdkLibDirectory (this), EnableDebug ? "libxamarin-debug.dylib" : "libxamarin.dylib");
+				return Path.Combine (Driver.GetXamarinLibraryDirectory (this), EnableDebug ? "libxamarin-debug.dylib" : "libxamarin.dylib");
 			case AssemblyBuildTarget.Framework:
-				return Path.Combine (Driver.GetProductSdkFrameworksDirectory (this), EnableDebug ? "Xamarin-debug.framework" : "Xamarin.framework");
+				return Path.Combine (Driver.GetXamarinFrameworkDirectory (this), EnableDebug ? "Xamarin-debug.framework" : "Xamarin.framework");
 			default:
 				throw ErrorHelper.CreateError (100, Errors.MT0100, build_target);
 			}


### PR DESCRIPTION
This allows a little bit more sharing between mmp and mtouch.