### PR TITLE
[linker] Don't pass information to linker steps by selectively creating them or using constructors.

### DIFF
--- a/tools/linker/CoreHttpMessageHandler.cs
+++ b/tools/linker/CoreHttpMessageHandler.cs
@@ -23,12 +23,9 @@ namespace Xamarin.Linker.Steps {
 
 	public class CoreHttpMessageHandler : ExceptionalSubStep {
 		
-		public CoreHttpMessageHandler (LinkerOptions options)
+		public CoreHttpMessageHandler ()
 		{
-			Options = options;
 		}
-
-		public LinkerOptions Options { get; private set; }
 
 		public override SubStepTargets Targets {
 			get { return SubStepTargets.Type; }
@@ -39,11 +36,7 @@ namespace Xamarin.Linker.Steps {
 
 		Application App {
 			get {
-#if MONOMAC
-				return Driver.App;
-#else
-				return Options.Application;
-#endif
+				return LinkContext.App;
 			}
 		}
 
@@ -72,7 +65,7 @@ namespace Xamarin.Linker.Steps {
 			MethodDefinition method = type.Methods.First (x => x.Name == "GetHttpMessageHandler" && !x.HasParameters);
 
 			AssemblyDefinition systemNetHTTPAssembly = context.GetAssemblies ().First (x => x.Name.Name == "System.Net.Http");
-			TypeDefinition handler = RuntimeOptions.GetHttpMessageHandler (App, Options.RuntimeOptions, systemNetHTTPAssembly.MainModule, type.Module);
+			TypeDefinition handler = RuntimeOptions.GetHttpMessageHandler (App, LinkContext.Target.LinkerOptions.RuntimeOptions, systemNetHTTPAssembly.MainModule, type.Module);
 			MethodReference handler_ctor = handler.Methods.First (x => x.IsConstructor && !x.HasParameters && !x.IsStatic);
 
 			// HttpClientHandler is defined in System.Net.Http.dll so we need to import

--- a/tools/linker/CoreRemoveAttributes.cs
+++ b/tools/linker/CoreRemoveAttributes.cs
@@ -15,6 +15,13 @@ namespace Xamarin.Linker {
 			}
 		}
 
+		public override bool IsActiveFor (AssemblyDefinition assembly)
+		{
+			if (LinkContext.App.Optimizations.CustomAttributesRemoval != true)
+				return false;
+			return base.IsActiveFor (assembly);
+		}
+
 		protected override bool IsRemovedAttribute (CustomAttribute attribute)
 		{
 			// note: this also avoid calling FullName (which allocates a string)

--- a/tools/linker/CoreRemoveSecurity.cs
+++ b/tools/linker/CoreRemoveSecurity.cs
@@ -4,12 +4,27 @@ using Mono.Linker;
 
 using Mono.Cecil;
 
+using Xamarin.Bundler;
+using Xamarin.Tuner;
+
 namespace Mono.Tuner {
 
 	public class CoreRemoveSecurity : RemoveSecurity {
 
+		protected DerivedLinkContext LinkContext {
+			get {
+				return (DerivedLinkContext) base.context;
+			}
+		}
+
 		public override bool IsActiveFor (AssemblyDefinition assembly)
 		{
+#if MMP
+			// CoreRemoveSecurity can modify non-linked assemblies
+			// but the conditions for this cannot happen if only the platform assembly is linked
+			if (LinkContext.App.LinkMode == LinkMode.Platform)
+				return false;
+#endif
 			// if we run the linker then we can't ignore any assemblies since the security 
 			// declarations can refers to types that would not be marked (and preserved)
 			// leading to invalid binaries (that even Cecil won't be able to read back)

--- a/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
@@ -7,16 +7,9 @@ using Xamarin.Linker;
 using Xamarin.Bundler;
 
 namespace MonoTouch.Tuner {
-	
 	public class OptimizeGeneratedCodeSubStep : CoreOptimizeGeneratedCode {
-		
-		public OptimizeGeneratedCodeSubStep (LinkerOptions options)
-			: base (options)
-		{
-		}
-
 		public bool Device {
-			get { return Options.Device; }
+			get { return LinkContext.App.IsDeviceBuild; }
 		}
 
 		// https://app.asana.com/0/77259014252/77812690163

--- a/tools/linker/MonoTouch.Tuner/RemoveCode.cs
+++ b/tools/linker/MonoTouch.Tuner/RemoveCode.cs
@@ -11,18 +11,12 @@ namespace MonoTouch.Tuner {
 
 		bool product;
 
-		public RemoveCode (LinkerOptions options)
-		{
-			Device = options.Device;
-			Debug = options.DebugBuild;
-		}
-
 		protected override string Name { get; } = "Code Remover";
 		protected override int ErrorCode { get; } = 2050;
 
-		public bool Device { get; set; }
+		public bool Device { get { return LinkContext.App.IsDeviceBuild; } }
 
-		public bool Debug { get; set; }
+		public bool Debug { get { return LinkContext.App.EnableDebug; } }
 
 		public override SubStepTargets Targets {
 			get { return SubStepTargets.Assembly | SubStepTargets.Type; }
@@ -30,6 +24,9 @@ namespace MonoTouch.Tuner {
 
 		public override bool IsActiveFor (AssemblyDefinition assembly)
 		{
+			if (!LinkContext.Target.LinkerOptions.LinkAway)
+				return false;
+
 			switch (assembly.Name.Name) {
 			case "mscorlib":
 				product = false;

--- a/tools/linker/RemoveUserResourcesSubStep.cs
+++ b/tools/linker/RemoveUserResourcesSubStep.cs
@@ -12,11 +12,6 @@ namespace Xamarin.Linker {
 #if MTOUCH
 		const string Content = "__monotouch_content_";
 		const string Page = "__monotouch_page_";
-
-		public RemoveUserResourcesSubStep (MonoTouch.Tuner.LinkerOptions options)
-		{
-			Device = options.Device;
-		}
 #else
 		const string Content = "__xammac_content_";
 		const string Page = "__xammac_page_";
@@ -25,7 +20,7 @@ namespace Xamarin.Linker {
 			get { return SubStepTargets.Assembly; }
 		}
 
-		public bool Device { get; private set; }
+		public bool Device { get { return LinkContext.App.IsDeviceBuild; } }
 
 		protected override string Name { get; } = "Removing User Resources";
 		protected override int ErrorCode { get; } = 2030;

--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -172,8 +172,7 @@ namespace MonoMac.Tuner {
 			sub.Add (new OptimizeGeneratedCodeSubStep (options));
 			sub.Add (new RemoveUserResourcesSubStep ());
 			// OptimizeGeneratedCodeSubStep and RemoveUserResourcesSubStep needs [GeneratedCode] so it must occurs before RemoveAttributes
-			if (options.Application.Optimizations.CustomAttributesRemoval == true)
-				sub.Add (new CoreRemoveAttributes ());
+			sub.Add (new CoreRemoveAttributes ());
 
 			sub.Add (new CoreHttpMessageHandler ());
 			sub.Add (new MarkNSObjects ());

--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -133,7 +133,7 @@ namespace MonoMac.Tuner {
 			if (options.LinkMode != LinkMode.None) {
 				pipeline.Append (new CoreTypeMapStep ());
 
-				pipeline.Append (GetSubSteps (options));
+				pipeline.Append (GetSubSteps ());
 
 				pipeline.Append (new CorePreserveCode (options.I18nAssemblies));
 				pipeline.Append (new PreserveCrypto ());
@@ -165,7 +165,7 @@ namespace MonoMac.Tuner {
 			return pipeline;
 		}
 
-		static SubStepDispatcher GetSubSteps (LinkerOptions options)
+		static SubStepDispatcher GetSubSteps ()
 		{
 			SubStepDispatcher sub = new SubStepDispatcher ();
 			sub.Add (new ApplyPreserveAttribute ());

--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -169,7 +169,7 @@ namespace MonoMac.Tuner {
 		{
 			SubStepDispatcher sub = new SubStepDispatcher ();
 			sub.Add (new ApplyPreserveAttribute ());
-			sub.Add (new OptimizeGeneratedCodeSubStep (options));
+			sub.Add (new OptimizeGeneratedCodeSubStep ());
 			sub.Add (new RemoveUserResourcesSubStep ());
 			// OptimizeGeneratedCodeSubStep and RemoveUserResourcesSubStep needs [GeneratedCode] so it must occurs before RemoveAttributes
 			sub.Add (new CoreRemoveAttributes ());

--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -175,7 +175,7 @@ namespace MonoMac.Tuner {
 			if (options.Application.Optimizations.CustomAttributesRemoval == true)
 				sub.Add (new CoreRemoveAttributes ());
 
-			sub.Add (new CoreHttpMessageHandler (options));
+			sub.Add (new CoreHttpMessageHandler ());
 			sub.Add (new MarkNSObjects ());
 
 			// CoreRemoveSecurity can modify non-linked assemblies

--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -177,10 +177,7 @@ namespace MonoMac.Tuner {
 			sub.Add (new CoreHttpMessageHandler ());
 			sub.Add (new MarkNSObjects ());
 
-			// CoreRemoveSecurity can modify non-linked assemblies
-			// but the conditions for this cannot happen if only the platform assembly is linked
-			if (options.LinkMode != LinkMode.Platform)
-				sub.Add (new CoreRemoveSecurity ());
+			sub.Add (new CoreRemoveSecurity ());
 
 			return sub;
 		}

--- a/tools/mmp/linker/MonoMac.Tuner/OptimizeGeneratedCodeSubStep.cs
+++ b/tools/mmp/linker/MonoMac.Tuner/OptimizeGeneratedCodeSubStep.cs
@@ -7,12 +7,6 @@ using Mono.Tuner;
 using Xamarin.Linker;
 
 namespace MonoMac.Tuner {
-	
 	public class OptimizeGeneratedCodeSubStep : CoreOptimizeGeneratedCode {
-		
-		public OptimizeGeneratedCodeSubStep (LinkerOptions options)
-			: base (options)
-		{
-		}
 	}
 }

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -106,7 +106,7 @@ namespace MonoTouch.Tuner {
 			sub.Add (new ApplyPreserveAttribute ());
 			sub.Add (new CoreRemoveSecurity ());
 			sub.Add (new OptimizeGeneratedCodeSubStep (options));
-			sub.Add (new RemoveUserResourcesSubStep (options));
+			sub.Add (new RemoveUserResourcesSubStep ());
 			sub.Add (new RemoveAttributes ());
 			// http://bugzilla.xamarin.com/show_bug.cgi?id=1408
 			sub.Add (new RemoveCode ());
@@ -186,7 +186,7 @@ namespace MonoTouch.Tuner {
 				pipeline.Append (new FixModuleFlags ());
 			} else {
 				SubStepDispatcher sub = new SubStepDispatcher () {
-					new RemoveUserResourcesSubStep (options),
+					new RemoveUserResourcesSubStep (),
 				};
 				if (options.Application.Optimizations.ForceRejectedTypesRemoval == true)
 					sub.Add (new RemoveRejectedTypesStep ());

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -105,7 +105,7 @@ namespace MonoTouch.Tuner {
 			SubStepDispatcher sub = new SubStepDispatcher ();
 			sub.Add (new ApplyPreserveAttribute ());
 			sub.Add (new CoreRemoveSecurity ());
-			sub.Add (new OptimizeGeneratedCodeSubStep (options));
+			sub.Add (new OptimizeGeneratedCodeSubStep ());
 			sub.Add (new RemoveUserResourcesSubStep ());
 			sub.Add (new RemoveAttributes ());
 			// http://bugzilla.xamarin.com/show_bug.cgi?id=1408

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -114,7 +114,7 @@ namespace MonoTouch.Tuner {
 				sub.Add (new RemoveCode (options));
 			sub.Add (new MarkNSObjects ());
 			sub.Add (new PreserveSoapHttpClients ());
-			sub.Add (new CoreHttpMessageHandler (options));
+			sub.Add (new CoreHttpMessageHandler ());
 			sub.Add (new InlinerSubStep ());
 			sub.Add (new PreserveSmartEnumConversionsSubStep ());
 			return sub;

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -107,8 +107,7 @@ namespace MonoTouch.Tuner {
 			sub.Add (new CoreRemoveSecurity ());
 			sub.Add (new OptimizeGeneratedCodeSubStep (options));
 			sub.Add (new RemoveUserResourcesSubStep (options));
-			if (options.Application.Optimizations.CustomAttributesRemoval == true)
-				sub.Add (new RemoveAttributes ());
+			sub.Add (new RemoveAttributes ());
 			// http://bugzilla.xamarin.com/show_bug.cgi?id=1408
 			if (options.LinkAway)
 				sub.Add (new RemoveCode (options));

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -109,8 +109,7 @@ namespace MonoTouch.Tuner {
 			sub.Add (new RemoveUserResourcesSubStep (options));
 			sub.Add (new RemoveAttributes ());
 			// http://bugzilla.xamarin.com/show_bug.cgi?id=1408
-			if (options.LinkAway)
-				sub.Add (new RemoveCode (options));
+			sub.Add (new RemoveCode ());
 			sub.Add (new MarkNSObjects ());
 			sub.Add (new PreserveSoapHttpClients ());
 			sub.Add (new CoreHttpMessageHandler ());

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -100,7 +100,7 @@ namespace MonoTouch.Tuner {
 			return context;
 		}
 		
-		static SubStepDispatcher GetSubSteps (LinkerOptions options)
+		static SubStepDispatcher GetSubSteps ()
 		{
 			SubStepDispatcher sub = new SubStepDispatcher ();
 			sub.Add (new ApplyPreserveAttribute ());
@@ -164,7 +164,7 @@ namespace MonoTouch.Tuner {
 			if (options.LinkMode != LinkMode.None) {
 				pipeline.Append (new CoreTypeMapStep ());
 
-				pipeline.Append (GetSubSteps (options));
+				pipeline.Append (GetSubSteps ());
 
 				pipeline.Append (new PreserveCode (options));
 


### PR DESCRIPTION
Instead use the built-in logic to determine if a linker step should light up,
and use information available in the LinkContext to determine how steps should
behave.

This is required for .NET, where linker steps can't have custom constructors.

Several steps have not been modified, because they're not all required in .NET.

This PR is best reviewed commit-by-commit.