### PR TITLE
[runtime/mmp] Put libxammac and xamarin headers for Xamarin.Mac in the same directory as the corresponding files for Xamarin.iOS.

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -484,26 +484,27 @@ RUNTIME_MAC_TARGETS_DIRS +=                                    \
 	.libs/mac                                                  \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib             \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono        \
-	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/include/xamarin \
+	$(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/lib                     \
+	$(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/include/xamarin         \
 
 RUNTIME_MAC_TARGETS +=                                                                                \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/XamMacLauncher                                     \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/XamMacLauncher                                \
-	$(foreach file,$(SHIPPED_HEADERS),$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/include/$(file))     \
-	$(foreach file,$(MAC_SHIPPED_HEADERS),$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/include/$(file)) \
-	$(foreach file,$(MAC_LIBS),$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/$(file))                \
+	$(foreach file,$(SHIPPED_HEADERS),$(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/include/$(file))             \
+	$(foreach file,$(MAC_SHIPPED_HEADERS),$(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/include/$(file))         \
+	$(foreach file,$(MAC_LIBS),$(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/lib/$(file))                        \
 
 # The XamMacLauncher file must exist for VSfM to be able to open XM/Classic projects (so that people can use the migration wizard)
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/XamMacLauncher: | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib
 	$(Q) touch $@
 
-$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/%: .libs/mac/% | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib
+$(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/lib/%: .libs/mac/% | $(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/lib
 	$(Q) $(CP) $< $@
 
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/XamMacLauncher: | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono
 	$(Q) ln -sF ../XamMacLauncher $@
 
-$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/include/%.h: %.h | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/include/xamarin
+$(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/include/%.h: %.h | $(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/include/xamarin
 	$(Q) install -m 0644 $< $@
 
 $(RUNTIME_MAC_TARGETS_DIRS):

--- a/tests/common/mac/ConsoleXM.targets
+++ b/tests/common/mac/ConsoleXM.targets
@@ -1,8 +1,8 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	
-	<Target Name="AfterBuild" Inputs="$(ProjectDir)/../../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/libxammac.dylib;$(ProjectDir)/../../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/x86_64/full/Xamarin.Mac.dll"
+	<Target Name="AfterBuild" Inputs="$(ProjectDir)/../../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/SDKs/Xamarin.macOS.sdk/lib/libxammac.dylib;$(ProjectDir)/../../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/x86_64/full/Xamarin.Mac.dll"
 		Outputs="$(OutputPath)/Stuff/libxammac.dylib;$(OutputPath)/Stuff/Xamarin.Mac.dll">
-	    <Copy SourceFiles="$(ProjectDir)/../../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/libxammac.dylib" DestinationFiles="$(OutputPath)/Stuff/libxammac.dylib" />
+	    <Copy SourceFiles="$(ProjectDir)/../../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/SDKs/Xamarin.macOS.sdk/lib/libxammac.dylib" DestinationFiles="$(OutputPath)/Stuff/libxammac.dylib" />
 	    <Copy SourceFiles="$(ProjectDir)/../../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/x86_64/full/Xamarin.Mac.dll" DestinationFiles="$(OutputPath)/Stuff/Xamarin.Mac.dll" />
 	</Target>
 </Project>

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -853,16 +853,7 @@ namespace Xamarin.Bundler {
 		// This is the directory where the libxamarin*.[a|dylib] and libxammac*.[a|dylib] libraries are
 		public static string GetXamarinLibraryDirectory (Application app)
 		{
-			switch (app.Platform) {
-			case ApplePlatform.iOS:
-			case ApplePlatform.TVOS:
-			case ApplePlatform.WatchOS:
-				return GetProductSdkLibDirectory (app);
-			case ApplePlatform.MacOSX:
-				return FrameworkLibDirectory;
-			default:
-				throw ErrorHelper.CreateError (71, Errors.MX0071, app.Platform, PRODUCT);
-			}
+			return GetProductSdkLibDirectory (app);
 		}
 
 		// This is the directory where the Xamarin[-debug].framework frameworks are

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -57,7 +57,7 @@ Xamarin.Mac.registrar.full.x86_64.m:   $(TOP)/src/build/mac/full-64/Xamarin.Mac.
 	$(Q) touch Xamarin.Mac.registrar.full.x86_64.m Xamarin.Mac.registrar.full.x86_64.h
 
 Xamarin.Mac.registrar.%.x86_64.a: Xamarin.Mac.registrar.%.x86_64.m
-	$(Q_CC) $(MAC_CC) -DDEBUG -g -gdwarf-2 -x objective-c++ -std=c++14 -o $@ -c -arch x86_64 $< -Wall -Wno-unguarded-availability-new -I$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/include -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx
+	$(Q_CC) $(MAC_CC) -DDEBUG -g -gdwarf-2 -x objective-c++ -std=c++14 -o $@ -c -arch x86_64 $< -Wall -Wno-unguarded-availability-new -I$(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/include -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx
 
 Xamarin.Mac.registrar.%.a: Xamarin.Mac.registrar.%.x86_64.a
 	$(Q) $(CP) $< $@

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1178,7 +1178,7 @@ namespace Xamarin.Bundler {
 					// Xcode 10 doesn't ship with libstdc++
 					args.Add ("-stdlib=libc++");
 				}
-				args.Add ($"-I{Path.Combine (FrameworkDirectory, "include")}");
+				args.Add ($"-I{GetProductSdkIncludeDirectory (App)}");
 				if (registrarPath != null)
 					args.Add (registrarPath);
 				args.Add ("-fno-caret-diagnostics");


### PR DESCRIPTION
That's in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/SDKs/Xamarin.macOS.sdk/[lib|include]

This allows for a bit more code share between mtouch and mmp.