### PR TITLE
[Foundation] Do not get in an infinite loop with empty creds.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -757,7 +757,23 @@ namespace Foundation {
 
 				if (sessionHandler.Credentials != null && TryGetAuthenticationType (challenge.ProtectionSpace, out string authType)) {
 					NetworkCredential credentialsToUse = null;
-					if (authType != RejectProtectionSpaceAuthType) {
+					// interesting situation, when we use a credential that we created that is empty, we are not getting the RejectProtectionSpaceAuthType,
+					// nevertheless, we need to check is not the first challange we will continue trusting the 
+					// TryGetAuthenticationType method, but we will also check that the status respose in no a 401
+					// look like we do get an exception from the credentials db:
+					//  TestiOSHttpClient[28769:26371051] CredStore - performQuery - Error copying matching creds.  Error=-25300, query={
+					// class = inet;
+					// "m_Limit" = "m_LimitAll";
+					// ptcl = htps;
+					// "r_Attributes" = 1;
+					// sdmn = test;
+					// srvr = "jigsaw.w3.org";
+					// sync = syna;
+					// }
+					// do remember that we ALWAYS get a challange, so the failure count has to be 1 or more for this check, 1 would be the first time
+					var nsurlRespose = challenge.FailureResponse as NSHttpUrlResponse;
+					var responseIsUnauthorized = (nsurlRespose == null) ? false : nsurlRespose.StatusCode == (int) HttpStatusCode.Unauthorized && challenge.PreviousFailureCount > 0;
+					if (authType != RejectProtectionSpaceAuthType && !responseIsUnauthorized) {
 						var uri = inflight.Request.RequestUri;
 						credentialsToUse = sessionHandler.Credentials.GetCredential (uri, authType);
 					}

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -757,25 +757,27 @@ namespace Foundation {
 
 				if (sessionHandler.Credentials != null && TryGetAuthenticationType (challenge.ProtectionSpace, out string authType)) {
 					NetworkCredential credentialsToUse = null;
-					// interesting situation, when we use a credential that we created that is empty, we are not getting the RejectProtectionSpaceAuthType,
-					// nevertheless, we need to check is not the first challange we will continue trusting the 
-					// TryGetAuthenticationType method, but we will also check that the status respose in no a 401
-					// look like we do get an exception from the credentials db:
-					//  TestiOSHttpClient[28769:26371051] CredStore - performQuery - Error copying matching creds.  Error=-25300, query={
-					// class = inet;
-					// "m_Limit" = "m_LimitAll";
-					// ptcl = htps;
-					// "r_Attributes" = 1;
-					// sdmn = test;
-					// srvr = "jigsaw.w3.org";
-					// sync = syna;
-					// }
-					// do remember that we ALWAYS get a challange, so the failure count has to be 1 or more for this check, 1 would be the first time
-					var nsurlRespose = challenge.FailureResponse as NSHttpUrlResponse;
-					var responseIsUnauthorized = (nsurlRespose == null) ? false : nsurlRespose.StatusCode == (int) HttpStatusCode.Unauthorized && challenge.PreviousFailureCount > 0;
-					if (authType != RejectProtectionSpaceAuthType && !responseIsUnauthorized) {
-						var uri = inflight.Request.RequestUri;
-						credentialsToUse = sessionHandler.Credentials.GetCredential (uri, authType);
+					if (authType != RejectProtectionSpaceAuthType) {
+						// interesting situation, when we use a credential that we created that is empty, we are not getting the RejectProtectionSpaceAuthType,
+						// nevertheless, we need to check is not the first challenge we will continue trusting the 
+						// TryGetAuthenticationType method, but we will also check that the status response in not a 401
+						// look like we do get an exception from the credentials db:
+						//  TestiOSHttpClient[28769:26371051] CredStore - performQuery - Error copying matching creds.  Error=-25300, query={
+						// class = inet;
+						// "m_Limit" = "m_LimitAll";
+						// ptcl = htps;
+						// "r_Attributes" = 1;
+						// sdmn = test;
+						// srvr = "jigsaw.w3.org";
+						// sync = syna;
+						// }
+						// do remember that we ALWAYS get a challenge, so the failure count has to be 1 or more for this check, 1 would be the first time
+						var nsurlRespose = challenge.FailureResponse as NSHttpUrlResponse;
+						var responseIsUnauthorized = (nsurlRespose == null) ? false : nsurlRespose.StatusCode == (int) HttpStatusCode.Unauthorized && challenge.PreviousFailureCount > 0;
+						if (!responseIsUnauthorized) {
+							var uri = inflight.Request.RequestUri;
+							credentialsToUse = sessionHandler.Credentials.GetCredential (uri, authType);
+						}
 					}
 
 					if (credentialsToUse != null) {


### PR DESCRIPTION
As described in the issue, when the credentials for the base auth are set
to be empty the request reaches a timeout.

The inner issue is that when we have empty credentials the query that
is performed to the credentials db of the system throws an exception.
This exception is not raised to our code, but simply prints out in stderr.

When this situation occurs we get in an infinite loop in which we keep
sending the same credentials, we get another challenge, but the OS does
not do the right thing, we believe that we have to provide the creds
again (which are the same) and we get another challenge.. this goes on
an on until we reach the timeout.

Fortunately we know the number of failed challenges and the failure
response. With this information we can deduce if we already sent the
credentials, and if we did, do not set them again. In this case, the OS
sees no credentials in out delegate, uses the default handler and
correctly returns a 401.

fixes: https://github.com/xamarin/xamarin-macios/issues/8342
fixes: https://github.com/xamarin/xamarin-macios/issues/8344

The following attached app allows you to test the following:

1. Empty creds to the url provided by the user.
2. Test basic auth works (comment the first creds, uncomment the second ones, uncomment the request to httpbin.org)
3. Test basic auth works with the wrong creds (similar to 2 but uncomment the wrong creds).
[TestiOSHttpClient.zip](https://github.com/xamarin/xamarin-macios/files/4594666/TestiOSHttpClient.zip)

