### PR TITLE
[Harness] Rollback change to use full path.

### DIFF
--- a/tests/xharness/TestTasks/RunDevice.cs
+++ b/tests/xharness/TestTasks/RunDevice.cs
@@ -130,7 +130,6 @@ namespace Xharness.TestTasks {
 						// Install the app
 						InstallLog = new AppInstallMonitorLog (testTask.Logs.Create ($"install-{Helpers.Timestamp}.log", "Install log"));
 						try {
-							using var logReader = InstallLog.GetReader ();
 							testTask.Runner.MainLog = this.InstallLog;
 							var install_result = await testTask.Runner.InstallAsync (InstallLog.CancellationToken);
 							if (!install_result.Succeeded) {
@@ -144,7 +143,7 @@ namespace Xharness.TestTasks {
 										testTask.Variation,
 										$"AppInstallation on {testTask.Device.Name}",
 										$"Install failed on {testTask.Device.Name}, exit code: {install_result.ExitCode}",
-										logReader,
+										InstallLog.FullPath,
 										xmlResultJargon);
 							}
 						} finally {


### PR DESCRIPTION
The GetReader from the install log is broken and requires a re-eng.
Rollback to using the fullpath, not as nice, but that way we do not have
exceptions.

We are using issue #8545 to track the actual bug in the logs when we
request a Reader, if the reader cannot be created we should not be
throwing an exception, whats more, that reader should not be null since
otherwise we would not get the install logs.