### PR TITLE
[jenkins] Add support for specifying custom labels using a file.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -86,6 +86,35 @@ def githubGetPullRequestLabels ()
     return github_pull_request_labels
 }
 
+custom_labels = null
+def getCustomLabels ()
+{
+    if (custom_labels == null) {
+        custom_labels = []
+        def custom_labels_file = "${workspace}/xamarin-macios/jenkins/custom-labels.txt"
+        if (fileExists (custom_labels_file)) {
+            def contents = sh (script: "grep -v '^[[:space:]]*#' ${custom_labels_file} | grep -v '^[[:space:]]*\$' | tr \$'\n' ' ' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*\$//'", returnStdout: true)
+            custom_labels += contents.tokenize (' ')
+            echo ("Found labels ${custom_labels} in ${custom_labels_file}")
+        } else {
+            echo ("The custom labels file ${custom_labels_file} does not exist")
+        }
+    }
+    return custom_labels
+}
+
+labels = null
+def getLabels ()
+{
+    if (labels == null) {
+        labels = []
+        labels += githubGetPullRequestLabels ()
+        labels += getCustomLabels ()
+        echo ("Found labels: ${labels}")
+    }
+    return labels
+}
+
 def githubAddComment (url, markdown)
 {
     if (markdown.length () > 32768) {
@@ -439,8 +468,8 @@ timestamps {
                     }
 
                     if (isPr) {
-                        def hasBuildPackage = githubGetPullRequestLabels ().contains ("build-package")
-                        def hasRunInternalTests = githubGetPullRequestLabels ().contains ("run-internal-tests")
+                        def hasBuildPackage = getLabels ().contains ("build-package")
+                        def hasRunInternalTests = getLabels ().contains ("run-internal-tests")
 
                         if (!hasBuildPackage && !hasRunInternalTests) {
                             // don't add a comment to the pull request, since the public jenkins will also add comments, which ends up being too much.
@@ -448,7 +477,6 @@ timestamps {
                             echo ("Build skipped because the pull request doesn't have either of the labels 'build-package' or 'run-internal-tests'.")
                             return
                         }
-
 
                         if (!hasRunInternalTests)
                             skipLocalTestRunReason = "Not running tests here because they're run on public Jenkins."
@@ -481,70 +509,80 @@ timestamps {
                         stage ('Packaging') {
                             currentStage = "${STAGE_NAME}"
                             echo ("Building on ${env.NODE_NAME}")
-                            sh ("${workspace}/xamarin-macios/jenkins/build-package.sh")
-                            sh (script: "ls -la ${workspace}/package", returnStatus: true /* don't throw exceptions if something goes wrong */)
+                            def skipPackages = getLabels ().contains ("skip-packages")
+                            if (!skipPackages) {
+                                sh ("${workspace}/xamarin-macios/jenkins/build-package.sh")
+                                sh (script: "ls -la ${workspace}/package", returnStatus: true /* don't throw exceptions if something goes wrong */)
+                            } else {
+                                echo ("Packaging skipped because the label 'skip-packages' was found")
+                            }
                         }
 
                         stage ('Signing') {
                             def entitlements = "${workspace}/xamarin-macios/mac-entitlements.plist"
                             currentStage = "${STAGE_NAME}"
                             echo ("Building on ${env.NODE_NAME}")
-                            def xiPackages = findFiles (glob: "package/xamarin.ios-*.pkg")
-                            if (xiPackages.length > 0) {
-                                xiPackageFilename = xiPackages [0].name
-                                echo ("Created Xamarin.iOS package: ${xiPackageFilename}")
-                            }
-                            def xmPackages = findFiles (glob: "package/xamarin.mac-*.pkg")
-                            if (xmPackages.length > 0) {
-                                xmPackageFilename = xmPackages [0].name
-                                echo ("Created Xamarin.Mac package: ${xmPackageFilename}")
-                            }
-                            def msbuildZip = findFiles (glob: "package/msbuild.zip")
-                            if (msbuildZip.length > 0)
-                                msbuildZipFilename = msbuildZip [0].name
-                            def bundleZip = findFiles (glob: "package/bundle.zip")
-                            if (bundleZip.length > 0)
-                                bundleZipFilename = bundleZip [0].name
-
-                            if (isPr) {
-                              withCredentials ([string (credentialsId: 'codesign_keychain_pw', variable: 'PRODUCTSIGN_KEYCHAIN_PASSWORD')]) {
-                                sh ("${workspace}/xamarin-macios/jenkins/productsign.sh")
-                              }
-                            } else {
-                                try {
-                                    pkgs = xiPackages + xmPackages
-                                    if (fileExists('release-scripts')) {
-                                        dir('release-scripts') {
-                                            sh ('git checkout sign-and-notarized && git pull')
-                                        }
-                                    } else {
-                                        sh ('git clone git@github.com:xamarin/release-scripts -b sign-and-notarized')
-                                    }
-                                    withCredentials([string(credentialsId: 'codesign_keychain_pw', variable: 'KEYCHAIN_PASS'), string(credentialsId: 'team_id', variable: 'TEAM_ID'), string(credentialsId: 'application_id', variable: 'APP_ID'), string(credentialsId: 'installer_id', variable: 'INSTALL_ID'), usernamePassword(credentialsId: 'apple_account', passwordVariable: 'APPLE_PASS', usernameVariable: 'APPLE_ACCOUNT')]) {
-                                        sh (returnStatus: true, script: "security create-keychain -p ${env.KEYCHAIN_PASS} login.keychain") // needed to repopulate the keychain
-                                        sh ("security unlock-keychain -p ${env.KEYCHAIN_PASS} login.keychain")
-                                        timeout (time: 90, unit: 'MINUTES') {
-                                          sh ("python release-scripts/sign_and_notarize.py -a ${env.APP_ID} -i ${env.INSTALL_ID} -u ${env.APPLE_ACCOUNT} -p ${env.APPLE_PASS} -t ${env.TEAM_ID} -d package/notarized -e ${entitlements} -k login.keychain " + pkgs.flatten ().join (" "))
-                                        }
-                                    }
-
-                                    def xiNotarizedPackages = findFiles (glob: "package/notarized/xamarin.ios-*.pkg")
-                                    if (xiNotarizedPackages.length > 0) {
-                                        xiNotarizedPkgFilename = xiNotarizedPackages [0].name
-                                        echo ("Created notarized Xamarin.iOS package: ${xiNotarizedPkgFilename}")
-                                    }
-                                    def xmNotarizedPackages = findFiles (glob: "package/notarized/xamarin.mac-*.pkg")
-                                    if (xmNotarizedPackages.length > 0) {
-                                        xmNotarizedPkgFilename = xmNotarizedPackages [0].name
-                                        echo ("Created notarized Xamarin.Mac package: ${xmNotarizedPkgFilename}")
-                                    }
-                                } catch (ex) {
-                                    echo "Notarization failed:\n${ex.getMessage()}"
-                                    for (def stack : ex.getStackTrace()) {
-                                        echo "\t${stack}"
-                                    }
-                                    manager.addWarningBadge("PKGs are not notarized")
+                            def skipSigning = getLabels ().contains ("skip-signing")
+                            if (!skipSigning) {
+                                def xiPackages = findFiles (glob: "package/xamarin.ios-*.pkg")
+                                if (xiPackages.length > 0) {
+                                    xiPackageFilename = xiPackages [0].name
+                                    echo ("Created Xamarin.iOS package: ${xiPackageFilename}")
                                 }
+                                def xmPackages = findFiles (glob: "package/xamarin.mac-*.pkg")
+                                if (xmPackages.length > 0) {
+                                    xmPackageFilename = xmPackages [0].name
+                                    echo ("Created Xamarin.Mac package: ${xmPackageFilename}")
+                                }
+                                def msbuildZip = findFiles (glob: "package/msbuild.zip")
+                                if (msbuildZip.length > 0)
+                                    msbuildZipFilename = msbuildZip [0].name
+                                def bundleZip = findFiles (glob: "package/bundle.zip")
+                                if (bundleZip.length > 0)
+                                    bundleZipFilename = bundleZip [0].name
+
+                                if (isPr) {
+                                  withCredentials ([string (credentialsId: 'codesign_keychain_pw', variable: 'PRODUCTSIGN_KEYCHAIN_PASSWORD')]) {
+                                    sh ("${workspace}/xamarin-macios/jenkins/productsign.sh")
+                                  }
+                                } else {
+                                    try {
+                                        pkgs = xiPackages + xmPackages
+                                        if (fileExists('release-scripts')) {
+                                            dir('release-scripts') {
+                                                sh ('git checkout sign-and-notarized && git pull')
+                                            }
+                                        } else {
+                                            sh ('git clone git@github.com:xamarin/release-scripts -b sign-and-notarized')
+                                        }
+                                        withCredentials([string(credentialsId: 'codesign_keychain_pw', variable: 'KEYCHAIN_PASS'), string(credentialsId: 'team_id', variable: 'TEAM_ID'), string(credentialsId: 'application_id', variable: 'APP_ID'), string(credentialsId: 'installer_id', variable: 'INSTALL_ID'), usernamePassword(credentialsId: 'apple_account', passwordVariable: 'APPLE_PASS', usernameVariable: 'APPLE_ACCOUNT')]) {
+                                            sh (returnStatus: true, script: "security create-keychain -p ${env.KEYCHAIN_PASS} login.keychain") // needed to repopulate the keychain
+                                            sh ("security unlock-keychain -p ${env.KEYCHAIN_PASS} login.keychain")
+                                            timeout (time: 90, unit: 'MINUTES') {
+                                              sh ("python release-scripts/sign_and_notarize.py -a ${env.APP_ID} -i ${env.INSTALL_ID} -u ${env.APPLE_ACCOUNT} -p ${env.APPLE_PASS} -t ${env.TEAM_ID} -d package/notarized -e ${entitlements} -k login.keychain " + pkgs.flatten ().join (" "))
+                                            }
+                                        }
+
+                                        def xiNotarizedPackages = findFiles (glob: "package/notarized/xamarin.ios-*.pkg")
+                                        if (xiNotarizedPackages.length > 0) {
+                                            xiNotarizedPkgFilename = xiNotarizedPackages [0].name
+                                            echo ("Created notarized Xamarin.iOS package: ${xiNotarizedPkgFilename}")
+                                        }
+                                        def xmNotarizedPackages = findFiles (glob: "package/notarized/xamarin.mac-*.pkg")
+                                        if (xmNotarizedPackages.length > 0) {
+                                            xmNotarizedPkgFilename = xmNotarizedPackages [0].name
+                                            echo ("Created notarized Xamarin.Mac package: ${xmNotarizedPkgFilename}")
+                                        }
+                                    } catch (ex) {
+                                        echo "Notarization failed:\n${ex.getMessage()}"
+                                        for (def stack : ex.getStackTrace()) {
+                                            echo "\t${stack}"
+                                        }
+                                        manager.addWarningBadge("PKGs are not notarized")
+                                    }
+                                }
+                            } else {
+                                echo ("Signing skipped because the label 'skip-signing' was found")
                             }
                         }
 
@@ -669,8 +707,11 @@ timestamps {
                                 // Since pull requests don't create branches in the xamarin org (that VSTS sees at least),
                                 // I've created a 'pull-request' branch which we'll use for pull requests.
                                 def vsts_branch = isPr ? "pull-request" : branchName;
-                                if (isPr && !githubGetPullRequestLabels ().contains ("trigger-device-tests")) {
-                                    echo "Currently not launching external tests for pull requests"
+                                def skipExternalTests = getLabels ().contains ("skip-external-tests")
+                                if (skipExternalTests) {
+                                    echo ("Skipping external tests because the label 'skip-external-tests' was found")
+                                } else if (isPr && !getLabels ().contains ("trigger-device-tests")) {
+                                    echo ("Skipping external tests because the label 'trigger-device-tests' was not found and it's required for external tests to run for pull requests")
                                 } else {
                                     def outputFile = "${workspace}/xamarin-macios/wrench-launch-external.output.tmp"
                                     try {
@@ -686,7 +727,7 @@ timestamps {
                                     }
                                 }
 
-                                if (isPr && githubGetPullRequestLabels ().contains ("run-sample-tests")) {
+                                if (getLabels ().contains ("run-sample-tests")) {
                                     def outputFile = "${workspace}/xamarin-macios/wrench-launch-external.output.tmp"
                                     try {
                                         withCredentials ([string (credentialsId: 'macios_provisionator_pat', variable: 'PROVISIONATOR_VSTS_PAT')]) {

--- a/jenkins/custom-labels.txt
+++ b/jenkins/custom-labels.txt
@@ -1,0 +1,25 @@
+# This files contains a list of labels to select what to do when building a commit in CI.
+# Each label must go on a separate line.
+# Lines starting with a hash are comments.
+#
+# ⚠️ Important: Do not merge this file into master (or any other release branch) if it has any labels in it ⚠️
+#
+# This is used when building in CI to adjust what we build when we're building
+# a branch (since we can't apply labels to branches), but if any labels are
+# merged into master, that adjustment will be permanent, and that's most likely
+# not what we want. For this reason, replace any empty comment line with labels,
+# so that a merge attempt into master will fail with conflicts.
+#
+# ℹ️ Remove any empty comment lines with labels ℹ️ 
+#
+#
+#
+#
+#
+#
+#
+#
+#
+#
+#
+#

--- a/jenkins/fetch-pr-labels.sh
+++ b/jenkins/fetch-pr-labels.sh
@@ -48,6 +48,9 @@ else
 	grep "\"name\":" "$TMPFILE.dl" | sed -e 's/name": \"//' -e 's/.*\"\(.*\)\".*/\1/'> "$TMPFILE" || true
 fi
 
+# Find any custom labels
+grep -v '^[[:space:]]*#' custom-labels.txt | grep -v '^[[:space:]]*$' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' >> "$TMPFILE" || true
+
 if test -z "$CHECK"; then
 	echo "Labels found:"
 	sed 's/^/    /' "$TMPFILE"

--- a/tests/xharness/Jenkins/TestSelector.cs
+++ b/tests/xharness/Jenkins/TestSelector.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.IO;
 using System.Linq;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using System.Collections.Generic;
@@ -176,6 +177,20 @@ namespace Xharness.Jenkins {
 			} else {
 				MainLog.WriteLine ($"No labels were in the environment variable XHARNESS_LABELS.");
 			}
+
+			var custom_labels_file = Path.Combine (Harness.RootDirectory, "..", "jenkins", "custom-labels.txt");
+			if (File.Exists (custom_labels_file)) {
+				var custom_labels = File.ReadAllLines (custom_labels_file).Select ((v) => v.Trim ()).Where (v => v.Length > 0 && v [0] != '#');
+				if (custom_labels.Count () > 0) {
+					labels.UnionWith (custom_labels);
+					MainLog.WriteLine ($"Found {custom_labels.Count ()} label(s) in {custom_labels_file}: {string.Join (", ", custom_labels)}");
+				} else {
+					MainLog.WriteLine ($"No labels were in {custom_labels_file}.");
+				}
+			} else {
+				MainLog.WriteLine ($"The custom labels file {custom_labels_file} does not exist.");
+			}
+
 			MainLog.WriteLine ($"In total found {labels.Count ()} label(s): {string.Join (", ", labels.ToArray ())}");
 
 			// disabled by default


### PR DESCRIPTION
This makes it possible to select what should be done on CI when building a
commit on internal Jenkins (as opposed to when building a pull request, in
which case labels can be set on the pull request).

This PR is best reviewed by [ignoring whitespace](https://github.com/xamarin/xamarin-macios/pull/8549/files?diff=unified&w=1).