### PR TITLE
[Foundation] Fix memory leak when using sync methods.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -675,9 +675,6 @@ namespace Foundation {
 				if (inflight.CancellationTokenSource.Token.IsCancellationRequested)
 					return;
 
-				if (inflight.CompletionSource.Task.IsCompleted)
-					return;
-
 				inflight.CompletionSource.TrySetResult (inflight.Response);
 			}
 


### PR DESCRIPTION
The issue is a very interesting one. When using the HttpClient in a sync
way, the memory was leaking, on the async mode it was not. The root of
the leak is the following code:

```csharp
// EVIL HACK: having TrySetResult inline was blocking the request from completing
Task.Run (() => inflight.CompletionSource.TrySetResult (httpResponse));
```

The problem with the above line is that the lambda (a closure since it
captures the context) is leaking the captured variable making the memory
grow. The main problem is that as the // HACK comment mentions, the
TrySetResult locks. The reason for that is that it is contained inside
of a not needed lock.

The correct approach to this is to remove the lock which has no used
because we can use the tcs methods to know if the value was set
(IsCompleted does that). TrySetValue is thread safe and will return
without exceptions even if we could not set the response (either we had
an exception or the value was already set).

fixes: https://github.com/xamarin/xamarin-macios/issues/8350