### PR TITLE
[mtouch/mmp] Share the mono native code.

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -86,6 +86,7 @@ namespace Xamarin.Bundler {
 		public Version DeploymentTarget;
 		public Version SdkVersion;
 	
+		public MonoNativeMode MonoNativeMode { get; set; }
 		List<Abi> abis;
 
 		public bool Embeddinator { get; set; }
@@ -322,8 +323,7 @@ namespace Xamarin.Bundler {
 		public void InitializeCommon ()
 		{
 			SelectRegistrar ();
-			foreach (var target in Targets)
-				target.SelectMonoNative ();
+			SelectMonoNative ();
 
 			if (RequiresXcodeHeaders && SdkVersion < SdkVersions.GetVersion (Platform)) {
 				throw ErrorHelper.CreateError (91, Errors.MX0091, ProductName, PlatformName, SdkVersions.GetVersion (Platform), SdkVersions.Xcode, Error91LinkerSuggestion);
@@ -397,6 +397,43 @@ namespace Xamarin.Bundler {
 #endif
 
 			Optimizations.Initialize (this);
+		}
+
+		void SelectMonoNative ()
+		{
+			switch (Platform) {
+			case ApplePlatform.iOS:
+			case ApplePlatform.TVOS:
+				MonoNativeMode = DeploymentTarget.Major >= 10 ? MonoNativeMode.Unified : MonoNativeMode.Compat;
+				break;
+			case ApplePlatform.WatchOS:
+				if (IsArchEnabled (Abis, Abi.ARM64_32)) {
+					MonoNativeMode = MonoNativeMode.Unified;
+				} else {
+					MonoNativeMode = DeploymentTarget.Major >= 3 ? MonoNativeMode.Unified : MonoNativeMode.Compat;
+				}
+				break;
+			case ApplePlatform.MacOSX:
+				if (DeploymentTarget >= new Version (10, 12))
+					MonoNativeMode = MonoNativeMode.Unified;
+				else
+					MonoNativeMode = MonoNativeMode.Compat;
+				break;
+			default:
+				throw ErrorHelper.CreateError (71, Errors.MX0071, Platform, ProductName);
+			}
+		}
+
+		public string GetLibNativeName ()
+		{
+			switch (MonoNativeMode) {
+			case MonoNativeMode.Unified:
+				return "libmono-native-unified";
+			case MonoNativeMode.Compat:
+				return "libmono-native-compat";
+			default:
+				throw ErrorHelper.CreateError (99, Errors.MX0099, $"Invalid mono native type: '{MonoNativeMode}'");
+			}
 		}
 
 		public void RunRegistrar ()

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -54,8 +54,6 @@ namespace Xamarin.Bundler {
 		// Note that each 'Target' can have multiple abis: armv7+armv7s for instance.
 		public List<Abi> Abis;
 
-		public MonoNativeMode MonoNativeMode { get; set; }
-
 #if MONOMAC
 		public bool Is32Build { get { return false; } }
 		public bool Is64Build { get { return true; } }

--- a/tools/mmp/Target.mmp.cs
+++ b/tools/mmp/Target.mmp.cs
@@ -6,12 +6,5 @@ namespace Xamarin.Bundler
 {
 	partial class Target
 	{
-		public void SelectMonoNative ()
-		{
-			if (App.DeploymentTarget >= new Version (10, 12))
-				MonoNativeMode = MonoNativeMode.Unified;
-			else
-				MonoNativeMode = MonoNativeMode.Compat;
-		}
 	}
 }

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -712,21 +712,12 @@ namespace Xamarin.Bundler {
 				name = "libmono-system-native";
 			} else {
 				// use modern libmono-native
-				switch (BuildTarget.MonoNativeMode) {
-				case MonoNativeMode.Unified:
-					name = "libmono-native-unified";
-					break;
-				case MonoNativeMode.Compat:
-					name = "libmono-native-compat";
-					break;
-				default:
-					throw ErrorHelper.CreateError (99, Errors.MX0099, $"Invalid mono native type: '{BuildTarget.MonoNativeMode}'");
-				}
+				name = App.GetLibNativeName ();
 			}
 
 			var src = Path.Combine (GetMonoLibraryDirectory (App), name + ".dylib");
 			var dest = Path.Combine (mmp_dir, "libmono-native.dylib");
-			Watch ($"Adding mono-native library {name} for {BuildTarget.MonoNativeMode}.", 1);
+			Watch ($"Adding mono-native library {name} for {App.MonoNativeMode}.", 1);
 
 			if (App.Optimizations.TrimArchitectures == true) {
 				// copy to temp directory and lipo there to avoid touching the final dest file if it's up to date
@@ -1114,19 +1105,7 @@ namespace Xamarin.Bundler {
 						args.Add ("_SystemNative_RealPath"); // This keeps libmono_system_native_la-pal_io.o symbols
 					} else {
 						// add modern libmono-native
-						string libmono_native_name;
-						switch (BuildTarget.MonoNativeMode) {
-						case MonoNativeMode.Unified:
-							libmono_native_name = "libmono-native-unified";
-							break;
-						case MonoNativeMode.Compat:
-							libmono_native_name = "libmono-native-compat";
-							break;
-						default:
-							throw ErrorHelper.CreateError (99, Errors.MX0099, $"Invalid mono native type: '{BuildTarget.MonoNativeMode}'");
-						}
-
-						args.Add (Path.Combine (libdir, libmono_native_name + ".a"));
+						args.Add (Path.Combine (libdir, App.GetLibNativeName () + ".a"));
 						args.Add ("-framework");
 						args.Add ("GSS");
 					}

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1453,11 +1453,11 @@ namespace Xamarin.Bundler {
 			if (require_mono_native && LibMonoNativeLinkMode == AssemblyBuildTarget.DynamicLibrary) {
 				foreach (var target in Targets) {
 					BundleFileInfo info;
-					var lib_native_name = target.GetLibNativeName () + ".dylib";
+					var lib_native_name = GetLibNativeName () + ".dylib";
 					bundle_files [lib_native_name] = info = new BundleFileInfo ();
 					var lib_native_path = Path.Combine (Driver.GetProductSdkLibDirectory (this), lib_native_name);
 					info.Sources.Add (lib_native_path);
-					Driver.Log (3, "Adding mono-native library {0} for {1}.", lib_native_name, target.MonoNativeMode);
+					Driver.Log (3, "Adding mono-native library {0} for {1}.", lib_native_name, MonoNativeMode);
 				}
 			}
 

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -98,38 +98,6 @@ namespace Xamarin.Bundler
 			}
 		}
 
-		public void SelectMonoNative ()
-		{
-			switch (App.Platform) {
-			case ApplePlatform.iOS:
-			case ApplePlatform.TVOS:
-				MonoNativeMode = App.DeploymentTarget.Major >= 10 ? MonoNativeMode.Unified : MonoNativeMode.Compat;
-				break;
-			case ApplePlatform.WatchOS:
-				if (Application.IsArchEnabled (Abis, Abi.ARM64_32)) {
-					MonoNativeMode = MonoNativeMode.Unified;
-				} else {
-					MonoNativeMode = App.DeploymentTarget.Major >= 3 ? MonoNativeMode.Unified : MonoNativeMode.Compat;
-				}
-				break;
-			default:
-				throw ErrorHelper.CreateError (71, Errors.MX0071, App.Platform, "Xamarin.iOS");
-			}
-		}
-
-		public string GetLibNativeName () 
-		{
-			switch (MonoNativeMode) {
-			case MonoNativeMode.Unified:
-				return "libmono-native-unified";
-			case MonoNativeMode.Compat:
-				return "libmono-native-compat";
-			default:
-				throw ErrorHelper.CreateError (99, Errors.MX0099, $"Invalid mono native type: '{MonoNativeMode}'");
-			}
-
-		}
-
 		List<Abi> GetArchitectures (AssemblyBuildTarget build_target)
 		{
 			switch (build_target) {
@@ -1674,11 +1642,11 @@ namespace Xamarin.Bundler
 
 		void HandleMonoNative (Application app, CompilerFlags compiler_flags)
 		{
-			if (MonoNativeMode == MonoNativeMode.None)
+			if (app.MonoNativeMode == MonoNativeMode.None)
 				return;
 			if (!MonoNative.RequireMonoNative)
 				return;
-			var libnative = GetLibNativeName ();
+			var libnative = app.GetLibNativeName ();
 			var libdir = Driver.GetMonoLibraryDirectory (app);
 			Driver.Log (3, "Adding mono-native library {0} for {1}.", libnative, app);
 			switch (app.LibMonoNativeLinkMode) {
@@ -1763,13 +1731,13 @@ namespace Xamarin.Bundler
 
 			Symlinked = true;
 
-			if (MonoNativeMode != MonoNativeMode.None) {
+			if (App.MonoNativeMode != MonoNativeMode.None) {
 				var lib_native_target = Path.Combine (TargetDirectory, "libmono-native.dylib");
 
-				var lib_native_name = GetLibNativeName () + ".dylib";
+				var lib_native_name = App.GetLibNativeName () + ".dylib";
 				var lib_native_path = Path.Combine (Driver.GetMonoLibraryDirectory (App), lib_native_name);
 				Application.UpdateFile (lib_native_path, lib_native_target);
-				Driver.Log (3, "Added mono-native library {0} for {1}.", lib_native_name, MonoNativeMode);
+				Driver.Log (3, "Added mono-native library {0} for {1}.", lib_native_name, App.MonoNativeMode);
 			}
 
 			if (Driver.Verbosity > 0)

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -469,12 +469,12 @@ namespace Xamarin.Bundler
 						}
 					}
 
-					if (target.MonoNativeMode != MonoNativeMode.None) {
+					if (app.MonoNativeMode != MonoNativeMode.None) {
 						string mono_native_lib;
 						if (app.LibMonoNativeLinkMode == AssemblyBuildTarget.StaticObject)
 							mono_native_lib = "__Internal";
 						else
-							mono_native_lib = target.GetLibNativeName () + ".dylib";
+							mono_native_lib = app.GetLibNativeName () + ".dylib";
 						sw.WriteLine ();
 						sw.WriteLine ($"\tmono_dllmap_insert (NULL, \"System.Native\", NULL, \"{mono_native_lib}\", NULL);");
 						sw.WriteLine ($"\tmono_dllmap_insert (NULL, \"System.Security.Cryptography.Native.Apple\", NULL, \"{mono_native_lib}\", NULL);");


### PR DESCRIPTION
Also move the mono native code to the Application class from the Target
class, since it's per-Application, not per-Target.