### PR TITLE
[mtouch] Add -d:DEBUG to .csproj Debug configuration

### DIFF
--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -16,7 +16,7 @@
     <DebugType>portable</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>MONOTOUCH;MTOUCH</DefineConstants>
+    <DefineConstants>MONOTOUCH;MTOUCH;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Deterministic>True</Deterministic>


### PR DESCRIPTION
otherwise debug won't work and you'll get a weird error

```
Using Xcode 11.4 (11E146) found in /Applications/Xcode114.app/Contents/Developer
Xamarin.iOS 13.21.0.154 (master): 296eabd9a using framework: /Applications/Xcode114.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS13.4.sdk
A full rebuild will be performed because the cache is either incomplete or entirely missing.
A full rebuild has been forced because the cache for linker is not valid.
error MT2006: Can not load mscorlib.dll from: '/Users/poupou/git/master/xamarin-macios/tools/mtouch/lib/mono/Xamarin.iOS/mscorlib.dll'. Please reinstall Xamarin.iOS.

  at Xamarin.Bundler.Target.Initialize (System.Boolean show_warnings) [0x0002c] in /Users/poupou/git/master/xamarin-macios/tools/mtouch/Target.cs:275
  at Xamarin.Bundler.Application.Initialize () [0x007c2] in /Users/poupou/git/master/xamarin-macios/tools/mtouch/Application.cs:1104
  at Xamarin.Bundler.Application.BuildInitialize () [0x00008] in /Users/poupou/git/master/xamarin-macios/tools/mtouch/Application.cs:684
  at Xamarin.Bundler.Application+<>c.<BuildAll>b__135_0 (Xamarin.Bundler.Application v) [0x00000] in /Users/poupou/git/master/xamarin-macios/tools/mtouch/Application.cs:638
  at System.Collections.Generic.List`1[T].ForEach (System.Action`1[T] action) [0x0001e] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/external/corefx/src/Common/src/CoreLib/System/Collections/Generic/List.cs:578
  at Xamarin.Bundler.Application.BuildAll () [0x00023] in /Users/poupou/git/master/xamarin-macios/tools/mtouch/Application.cs:638
  at Xamarin.Bundler.Driver.Main2 (System.String[] args) [0x0041c] in /Users/poupou/git/master/xamarin-macios/tools/mtouch/mtouch.cs:1154
  at Xamarin.Bundler.Driver.Main (System.String[] args) [0x00015] in /Users/poupou/git/master/xamarin-macios/tools/common/Driver.cs:35
```