### PR TITLE
[linker] Remove internal [NullablePublicOnly] attribute from apps

### DIFF
--- a/tools/linker/MobileRemoveAttributes.cs
+++ b/tools/linker/MobileRemoveAttributes.cs
@@ -35,6 +35,7 @@ namespace Xamarin.Linker {
 			// compiler nullability attributes are not used at runtime so they can be removed by the linker
 			case "NullableAttribute":
 			case "NullableContextAttribute":
+			case "NullablePublicOnlyAttribute":
 				return attr_type.Namespace == "System.Runtime.CompilerServices";
 			// _manual_ nullability attributes are not used at runtime so they can be removed by the linker
 			case "AllowNullAttribute":


### PR DESCRIPTION
I've only seen it with .net5 so far but it's better handled in master
and flow back into the branch