### PR TITLE
Make makefiles compatible with make 4.3.

### DIFF
--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -81,8 +81,9 @@ EXTRA_DEPENDENCIES = libtest.h $(GENERATED_FILES) rename.h
 	$$(call Q_2,LIPO   [$(1)]) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo $$^ -create -output $$@
 
 COMMON_DYLIB_ARGS=-g -dynamiclib -gdwarf-2 -fms-extensions libframework.m -o $$@ -Wall -framework Foundation -lz
-.libs/$(1)/libtest.%.dylib: libframework.m | .libs/$(1)
-	$$(call Q_2,CC,    [$(1)]) $$(XCODE_CC) $$(COMMON_DYLIB_ARGS) -arch $$(if $$(filter x86,$$*),i386,$$*) $(5) -isysroot $(XCODE_DEVELOPER_ROOT)/Platforms/$(4).platform/Developer/SDKs/$(4)$$($(6)_SDK_VERSION).sdk
+.libs/$(1)/libtest.x86.dylib: ARCH=i386
+$$(foreach arch,$(3),.libs/$(1)/libtest.$$(arch).dylib): libframework.m | .libs/$(1)
+	$$(call Q_2,CC,    [$(1)]) $$(XCODE_CC) $$(COMMON_DYLIB_ARGS) -arch $$(if $$(ARCH),i386,$$(subst libtest.,,$$(basename $$(notdir $$@)))) $(5) -isysroot $(XCODE_DEVELOPER_ROOT)/Platforms/$(4).platform/Developer/SDKs/$(4)$$($(6)_SDK_VERSION).sdk
 	$$(Q) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool -id @rpath/XTest.framework/XTest $$@
 
 .libs/$(1)/libtest.dylib: $$(foreach arch,$(3),.libs/$(1)/libtest.$$(arch).dylib)
@@ -215,3 +216,5 @@ MAC_LDFLAGS = -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -framework AppKit
 clean-local:: $(CLEAN_TARGETS)
 
 include $(TOP)/mk/rules.mk
+
+.SECONDARY:


### PR DESCRIPTION
In make 4.3 the pattern `.libs/watchos/%.arm64_32.dylib` in mk/rules.mk takes
precedence over the pattern `.libs/watchos/libtest.%.dylib` in
tests/test-libraries/Makefile when the pattern replacements are 'libtest' and
'arm64_32' respectively, because the former is shorter.

This seems to be a bug (in make 3.81) that has been fixed, because that's the
documented behavior.

Rewrite the logic to not use a pattern target in test/test-libraries/Makefile.