### PR TITLE
[msbuild] Make the DeleteBase task inherit from the Delete task.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/MsBuildTasks/DeleteBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/MsBuildTasks/DeleteBase.cs
@@ -1,38 +1,8 @@
-﻿using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
-
 namespace Microsoft.Build.Tasks
 {
-	public abstract class DeleteBase : Task
+	public abstract class DeleteBase : Delete
 	{
-		readonly Delete delete = new Delete();
-
 		public string SessionId { get; set; }
-
-		[Required]
-		public ITaskItem[] Files
-		{
-			get { return delete.Files; }
-			set { delete.Files = value; }
-		}
-
-		public bool TreatErrorsAsWarnings
-		{
-			get { return delete.TreatErrorsAsWarnings; }
-			set { delete.TreatErrorsAsWarnings = value; }
-		}
-
-		[Output]
-		public ITaskItem[] DeletedFiles
-		{
-			get { return delete.DeletedFiles; }
-			set { delete.DeletedFiles = value; }
-		}
-
-		public override bool Execute ()
-		{
-			delete.BuildEngine = this.BuildEngine;
-			return delete.Execute ();
-		}
 	}
 }
+


### PR DESCRIPTION
Once upon a time the Delete task was sealed [1], so we couldn't subclass it as
we wanted. That time is long in the past, so we can now do what we wanted back
then.

[1]: https://github.com/xamarin/maccore/commit/5c49171303e056b2fc7763c9c14e60e7e677a6ca