### PR TITLE
[system-dependencies] Add support for provisioning .NET 5 separately.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -376,7 +376,21 @@ DOTNET=/usr/local/share/dotnet/dotnet
 DOTNET_BCL_REF_URL=https://www.nuget.org/api/v2/package/Microsoft.NETCore.App.Ref/3.1.0
 DOTNET_BCL_REF_NAME=microsoft.netcore.app.ref.3.1.0.nupkg
 DOTNET_BCL_DIR:=$(abspath $(TOP)/builds/downloads/$(basename $(DOTNET_BCL_REF_NAME)))/ref/netcoreapp3.1
-	
+
+# Configuration for .NET 5.
+# We're using preview versions, and there will probably be many of them, so install locally (into builds/downloads) if there's no system version to
+# avoid consuming a lot of disk space (since they're never automatically deleted). The system-dependencies.sh script will install locally as long
+# as there's a TARBALL url.
+DOTNET5_VERSION=5.0.100-preview.5.20256.10
+DOTNET5_URL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-preview.5.20256.10/dotnet-sdk-5.0.100-preview.5.20256.10-osx-x64.pkg
+DOTNET5_TARBALL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-preview.5.20256.10/dotnet-sdk-5.0.100-preview.5.20256.10-osx-x64.tar.gz
+# Use the system dotnet executable if the dotnet version we need is installed, otherwise use the local version.
+ifneq ($(wildcard /usr/local/share/dotnet/sdk/$(DOTNET5_VERSION)),)
+DOTNET5=$(DOTNET)
+else
+DOTNET5=$(abspath builds/downloads/dotnet/$(DOTNET5_VERSION))/dotnet
+endif
+
 # If we should inject an x86_64 slice into every binary that doesn't have one.
 # This is sometimes necessary to work around an Apple bug wrt notarization where Apple flags all binaries that don't have a x86_64 slice, even if they're correctly signed.
 INJECT_X86_64_SLICE=

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -123,10 +123,6 @@ fi
 # Enable dotnet bits on the bots
 CONFIGURE_FLAGS="$CONFIGURE_FLAGS --enable-dotnet"
 
-make reset
-make git-clean-all
-make print-versions
-
 echo "Configuring the build with: $CONFIGURE_FLAGS"
 # shellcheck disable=SC2086
 ./configure $CONFIGURE_FLAGS

--- a/jenkins/provision-deps.sh
+++ b/jenkins/provision-deps.sh
@@ -16,6 +16,16 @@ if test -n "$ghprbPullId" && ./jenkins/fetch-pr-labels.sh --check=skip-public-je
 	exit 0
 fi
 
+# Get all our dependencies
+make reset
+
+# Make sure everything is pristine
+make git-clean-all
+
+# Print a list of our dpendencies
+make print-versions
+
+# Provision external dependencies
 ./system-dependencies.sh --provision-all
 
 sudo rm -Rf /Developer/MonoTouch

--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -1095,7 +1095,7 @@ check_dotnet ""
 check_dotnet "5"
 if test -z "$IGNORE_DOTNET"; then
 	ok "Installed .NET SDKs:"
-	(IFS=$'\n'; for i in $(dotnet --list-sdks); do log "$i"; done)
+	(IFS=$'\n'; for i in $(/usr/local/share/dotnet/dotnet --list-sdks); do log "$i"; done)
 fi
 
 if test -z $FAIL; then

--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -7,6 +7,7 @@ cd $(dirname $0)
 FAIL=
 PROVISION_DOWNLOAD_DIR=/tmp/x-provisioning
 SUDO=sudo
+VERBOSE=
 
 OPTIONAL_SHARPIE=1
 OPTIONAL_SIMULATORS=1
@@ -176,6 +177,7 @@ while ! test -z $1; do
 		-v | --verbose)
 			set -x
 			shift
+			VERBOSE=1
 			;;
 		*)
 			echo "Unknown argument: $1"
@@ -999,18 +1001,35 @@ function check_dotnet ()
 {
 	if test -n "$IGNORE_DOTNET"; then return; fi
 
+	local SUFFIX=$1
 	local DOTNET_VERSION
 	local DOTNET_INSTALL_DIR
 	local DOTNET_URL
+	local DOTNET_TARBALL
 	local DOTNET_FILENAME
+	local URL
+	local INSTALL_LOCALLY
+	local INSTALL_DIR
+	local CACHED_FILE
+	local DOWNLOADED_FILE
 
-	DOTNET_VERSION=$(grep ^DOTNET_VERSION= Make.config | sed 's/.*=//')
-	DOTNET_URL=$(grep ^DOTNET_URL= Make.config | sed 's/.*=//')
+	# If there's a TARBALL url, use that and install into builds/download, otherwise install the pkg.
+
+	DOTNET_VERSION=$(grep "^DOTNET${SUFFIX}_VERSION=" Make.config | sed 's/.*=//')
+	DOTNET_URL=$(grep "^DOTNET${SUFFIX}_URL"= Make.config | sed 's/.*=//')
+	DOTNET_TARBALL=$(grep "^DOTNET${SUFFIX}_TARBALL"= Make.config | sed 's/.*=//' || true) # this variable might not exist
 	DOTNET_INSTALL_DIR=/usr/local/share/dotnet/sdk/"$DOTNET_VERSION"
-	DOTNET_FILENAME=$(basename "$DOTNET_URL")
+	DOTNET_LOCAL_INSTALL_DIR="builds/downloads/dotnet/$DOTNET_VERSION"
+
+	if test -n "$DOTNET_TARBALL"; then
+		INSTALL_LOCALLY=1
+	fi
 
 	if test -d "$DOTNET_INSTALL_DIR"; then
-		ok "Found dotnet $DOTNET_VERSION (exactly $DOTNET_VERSION is required)."
+		ok "Found dotnet $DOTNET_VERSION in $DOTNET_INSTALL_DIR (exactly $DOTNET_VERSION is required)."
+		return
+	elif test -d "$DOTNET_LOCAL_INSTALL_DIR"; then
+		ok "Found dotnet $DOTNET_VERSION in $DOTNET_LOCAL_INSTALL_DIR (exactly $DOTNET_VERSION is required)."
 		return
 	fi
 
@@ -1020,14 +1039,43 @@ function check_dotnet ()
 		return
 	fi
 
-	log "Downloading dotnet $DOTNET_VERSION from $DOTNET_URL..."
-	mkdir -p "$PROVISION_DOWNLOAD_DIR"
-	curl -f -L "$DOTNET_URL" -o "$PROVISION_DOWNLOAD_DIR/$DOTNET_FILENAME"
+	if test -n "$INSTALL_LOCALLY"; then
+		URL=$DOTNET_TARBALL
+		INSTALL_DIR=$DOTNET_LOCAL_INSTALL_DIR
+	else
+		URL=$DOTNET_URL
+		INSTALL_DIR=$DOTNET_INSTALL_DIR
+	fi
+	DOTNET_FILENAME=$(basename "$URL")
 
-	log "Installing dotnet $DOTNET_VERSION..."
-	$SUDO installer -pkg "$PROVISION_DOWNLOAD_DIR/$DOTNET_FILENAME" -target /
+	CACHED_FILE=$HOME/Library/Caches/xamarin-macios/$DOTNET_FILENAME
+	if test -f "$CACHED_FILE"; then
+		log "Found cached version in $CACHED_FILE, will install from cache."
+		DOWNLOADED_FILE="$HOME/Library/Caches/xamarin-macios/$DOTNET_FILENAME"
+	else
+		log "Downloading dotnet $DOTNET_VERSION from $URL..."
+		mkdir -p "$PROVISION_DOWNLOAD_DIR"
+		DOWNLOADED_FILE="$PROVISION_DOWNLOAD_DIR/$DOTNET_FILENAME"
+		curl -f -L "$URL" -o "$DOWNLOADED_FILE"
+	fi
 
-	ok "Installed dotnet $DOTNET_VERSION."
+	log "Installing dotnet $DOTNET_VERSION into $INSTALL_DIR..."
+	if test -n "$INSTALL_LOCALLY"; then
+		rm -Rf "$INSTALL_DIR-tmp"
+		mkdir -p "$INSTALL_DIR-tmp"
+		local TAR_ARGS
+		if test -n "$VERBOSE"; then
+			TAR_ARGS=xvf
+		else
+			TAR_ARGS=xf
+		fi
+		tar $TAR_ARGS "$DOWNLOADED_FILE" -C "$INSTALL_DIR-tmp"
+		mv "$INSTALL_DIR-tmp" "$INSTALL_DIR"
+	else
+		$SUDO installer -pkg "$DOWNLOADED_FILE" -target /
+	fi
+
+	ok "Installed dotnet $DOTNET_VERSION into $INSTALL_DIR."
 }
 
 echo "Checking system..."
@@ -1043,7 +1091,12 @@ check_cmake
 check_7z
 check_objective_sharpie
 check_simulators
-check_dotnet
+check_dotnet ""
+check_dotnet "5"
+if test -z "$IGNORE_DOTNET"; then
+	ok "Installed .NET SDKs:"
+	(IFS=$'\n'; for i in $(dotnet --list-sdks); do log "$i"; done)
+fi
 
 if test -z $FAIL; then
 	echo "System check succeeded"


### PR DESCRIPTION
Add support for provisioning .NET 5 separately, and by default install it
locally (into builds/downloads) to avoid consuming a lot of disk space with
the various preview versions we'll need. A system install is still detected
and used if available.