### PR TITLE
[msbuild] Inherit from Xamarin[Tool]Task instead of [Tool]Task in a most tasks.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/EmbedProvisionProfileTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/EmbedProvisionProfileTaskBase.cs
@@ -11,11 +11,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.Mac.Tasks
 {
-	public class EmbedProvisionProfileTaskBase : Task
+	public class EmbedProvisionProfileTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string AppBundleDir { get; set; }

--- a/msbuild/Xamarin.Mac.Tasks/Tasks/DetectSigningIdentity.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/DetectSigningIdentity.cs
@@ -21,8 +21,6 @@ namespace Xamarin.Mac.Tasks
 		protected override string[] DirectDistributionPrefixes { get { return directDistributionPrefixes; } }
 		protected override string[] AppStoreDistributionPrefixes { get { return appStoreDistributionPrefixes; } }
 		protected override string DeveloperRoot { get { return MacOSXSdks.Native.DeveloperRoot; } }
-		protected override ApplePlatform Framework { get { return ApplePlatform.MacOSX; } }
-		protected override string PlatformName { get { return "macOS"; } }
 		protected override string ApplicationIdentifierKey { get { return "com.apple.application-identifier"; } }
 	}
 }

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -459,7 +459,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		</DetectSdkLocations>
 	</Target>
 
-	<Target Name="_DetectSigningIdentity" DependsOnTargets="_DetectAppManifest">
+	<Target Name="_DetectSigningIdentity" DependsOnTargets="_DetectAppManifest;_ComputeTargetFrameworkMoniker">
 		<DetectSigningIdentity
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
@@ -470,7 +470,9 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			RequireProvisioningProfile="$(_RequireProvisioningProfile)"
 			SdkPlatform="MacOSX"
 			ProvisioningProfile="$(CodeSignProvision)"
-			SigningKey="$(CodeSigningKey)">
+			SigningKey="$(CodeSigningKey)"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+			>
 			<Output TaskParameter="DetectedAppId" PropertyName="_AppIdentifier" />
 			<Output TaskParameter="DetectedBundleId" PropertyName="_BundleIdentifier" />
 			<Output TaskParameter="DetectedCodeSigningKey" PropertyName="_CodeSigningKey" />

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/AlToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/AlToolTaskBase.cs
@@ -10,12 +10,10 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class ALToolTaskBase : ToolTask
+	public abstract class ALToolTaskBase : XamarinToolTask
 	{
 		string sdkDevPath;
 		StringBuilder toolOutput;
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string Username { get ; set; }
@@ -25,15 +23,6 @@ namespace Xamarin.MacDev.Tasks
 
 		[Required]
 		public string FilePath { get; set; }
-
-		protected ApplePlatform FileType {
-			get { return PlatformFrameworkHelper.GetFramework (TargetFrameworkMoniker); }
-		}
-
-		public TargetFramework TargetFramework { get { return TargetFramework.Parse (TargetFrameworkMoniker); } }
-
-		[Required]
-		public string TargetFrameworkMoniker { get; set; }
 
 		protected override string ToolName {
 			get { return "altool"; }
@@ -98,11 +87,11 @@ namespace Xamarin.MacDev.Tasks
 
 		string GetFileTypeValue ()
 		{
-			switch (FileType) {
+			switch (Platform) {
 				case ApplePlatform.MacOSX: return "osx";
 				case ApplePlatform.TVOS: return "appletvos";
 				case ApplePlatform.iOS: return "ios";
-				default: throw new NotSupportedException ($"Provided file type '{FileType}' is not supported by altool");
+				default: throw new NotSupportedException ($"Provided file type '{Platform}' is not supported by altool");
 			}
 		}
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ArToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ArToolTaskBase.cs
@@ -8,11 +8,9 @@ using Xamarin.MacDev;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class ArToolTaskBase : ToolTask
+	public abstract class ArToolTaskBase : XamarinToolTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public ITaskItem Archive { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ArchiveTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ArchiveTaskBase.cs
@@ -9,13 +9,11 @@ using Xamarin.MacDev;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class ArchiveTaskBase : Task
+	public abstract class ArchiveTaskBase : XamarinTask
 	{
 		protected readonly DateTime Now = DateTime.Now;
 
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public ITaskItem AppBundleDir { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
@@ -11,9 +11,7 @@ using Xamarin.Utils;
 using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks {
-	public abstract class BTouchTaskBase : ToolTask {
-
-		public string SessionId { get; set; }
+	public abstract class BTouchTaskBase : XamarinToolTask {
 
 		public string OutputPath { get; set; }
 
@@ -65,13 +63,6 @@ namespace Xamarin.MacDev.Tasks {
 		public ITaskItem[] Resources { get; set; }
 
 		public ITaskItem[] Sources { get; set; }
-
-		public string TargetFrameworkIdentifier { get { return TargetFramework.Identifier; } }
-
-		public TargetFramework TargetFramework { get { return TargetFramework.Parse (TargetFrameworkMoniker); } }
-
-		[Required]
-		public string TargetFrameworkMoniker { get; set; }
 
 		protected override string ToolName {
 			get { return Path.GetFileNameWithoutExtension (ToolExe); }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BundlerToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BundlerToolTaskBase.cs
@@ -10,11 +10,9 @@ using Xamarin.Utils;
 
 namespace Xamarin.MacDev.Tasks {
 	// A class to express what's shared/common between mtouch and mmp.
-	public abstract class BundlerToolTaskBase : ToolTask {
+	public abstract class BundlerToolTaskBase : XamarinToolTask {
 
 		#region Inputs
-		public string SessionId { get; set; }
-
 		[Required]
 		public string AppBundleDir { get; set; }
 
@@ -67,24 +65,11 @@ namespace Xamarin.MacDev.Tasks {
 		[Required]
 		public string SdkVersion { get; set; }
 
-		[Required]
-		public string TargetFrameworkMoniker { get; set; }
-
 		public int Verbosity { get; set; }
 
 		[Required]
 		public string XamarinSdkRoot { get; set; }
 		#endregion
-
-		public ApplePlatform Framework {
-			get { return PlatformFrameworkHelper.GetFramework (TargetFrameworkMoniker); }
-		}
-
-		public string TargetFrameworkIdentifier { get { return TargetFramework.Identifier; } }
-
-		public TargetFramework TargetFramework { get { return TargetFramework.Parse (TargetFrameworkMoniker); } }
-
-		public string TargetFrameworkVersion { get { return TargetFramework.Version.ToString (); } }
 
 		protected override string GenerateFullPathToTool ()
 		{

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -14,7 +14,7 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class CodesignTaskBase : Task
+	public abstract class CodesignTaskBase : XamarinTask
 	{
 		const string ToolName = "codesign";
 		const string MacOSDirName = "MacOS";
@@ -22,8 +22,6 @@ namespace Xamarin.MacDev.Tasks
 		string toolExe;
 
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string CodesignAllocate { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignVerifyTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignVerifyTaskBase.cs
@@ -9,11 +9,9 @@ using Xamarin.MacDev;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class CodesignVerifyTaskBase : ToolTask
+	public abstract class CodesignVerifyTaskBase : XamarinToolTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string CodesignAllocate { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CollectBundleResourcesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CollectBundleResourcesTaskBase.cs
@@ -8,11 +8,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class CollectBundleResourcesTaskBase : Task
+	public abstract class CollectBundleResourcesTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		public ITaskItem[] BundleResources { get; set; }
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CollectFrameworksBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CollectFrameworksBase.cs
@@ -9,11 +9,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.iOS.Tasks
 {
-	public class CollectFrameworksBase : Task
+	public class CollectFrameworksBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string AppBundlePath { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -9,11 +9,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class CompileAppManifestTaskBase : Task
+	public abstract class CompileAppManifestTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string AppBundleName { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
@@ -10,7 +10,7 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class CompileEntitlementsTaskBase : Task
+	public abstract class CompileEntitlementsTaskBase : XamarinTask
 	{
 		static readonly byte[] XcentMagic = { 0xfa, 0xde, 0x71, 0x71 };
 
@@ -18,8 +18,6 @@ namespace Xamarin.MacDev.Tasks
 		bool warnedAppIdentifierPrefix;
 
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string AppBundleDir { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
@@ -12,13 +12,11 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class CompileSceneKitAssetsTaskBase : Task
+	public abstract class CompileSceneKitAssetsTaskBase : XamarinTask
 	{
 		string toolExe;
 
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string AppBundleName { get; set; }
@@ -48,11 +46,6 @@ namespace Xamarin.MacDev.Tasks
 
 		[Required]
 		public string SdkVersion { get; set; }
-
-		public TargetFramework TargetFramework { get { return TargetFramework.Parse (TargetFrameworkMoniker); } }
-
-		[Required]
-		public string TargetFrameworkMoniker { get; set; }
 
 		public string ToolExe {
 			get { return toolExe ?? ToolName; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ComputeBundleResourceOutputPathsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ComputeBundleResourceOutputPathsTaskBase.cs
@@ -9,10 +9,8 @@ using Xamarin.MacDev;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class ComputeBundleResourceOutputPathsTaskBase : Task
+	public abstract class ComputeBundleResourceOutputPathsTaskBase : XamarinTask
 	{
-		public string SessionId { get; set; }
-
 		[Required]
 		public ITaskItem AppBundleDir { get; set; }
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CoreMLCompilerTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CoreMLCompilerTaskBase.cs
@@ -11,15 +11,13 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class CoreMLCompilerTaskBase : Task
+	public abstract class CoreMLCompilerTaskBase : XamarinTask
 	{
 		string toolExe;
 
 		public string ToolName { get { return "coremlc"; } }
 
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		public bool EnableOnDemandResources { get; set; }
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateAssetPackManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateAssetPackManifestTaskBase.cs
@@ -11,12 +11,10 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class CreateAssetPackManifestTaskBase : Task
+	public abstract class CreateAssetPackManifestTaskBase : XamarinTask
 	{
 		const double DownloadPriorityInterval = 0.90;
 		const double TopDownloadPriority = 0.95;
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public ITaskItem AppBundleDir { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateBindingResourcePackageBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateBindingResourcePackageBase.cs
@@ -10,9 +10,7 @@ using Microsoft.Build.Utilities;
 using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks {
-	public abstract class CreateBindingResourcePackageBase : Task {
-		public string SessionId { get; set; }
-		
+	public abstract class CreateBindingResourcePackageBase : XamarinTask {
 		[Required]
 		public string OutputPath { get; set; }
 		

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateInstallerPackageTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateInstallerPackageTaskBase.cs
@@ -13,11 +13,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public class CreateInstallerPackageTaskBase : ToolTask
+	public class CreateInstallerPackageTaskBase : XamarinToolTask
 	{
 		#region Inputs
-		public string SessionId { get; set; }
-
 		[Required]
 		public string OutputDirectory { get; set; }
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreatePkgInfoTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreatePkgInfoTaskBase.cs
@@ -6,12 +6,10 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class CreatePkgInfoTaskBase : Task
+	public abstract class CreatePkgInfoTaskBase : XamarinTask
 	{
 		static readonly byte[] PkgInfoData = { 0X41, 0X50, 0X50, 0X4C, 0x3f, 0x3f, 0x3f, 0x3f };
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string OutputPath { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
@@ -7,11 +7,9 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class DSymUtilTaskBase : ToolTask
+	public abstract class DSymUtilTaskBase : XamarinToolTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string AppBundleDir { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
@@ -14,7 +14,7 @@ using SecKeychain = Xamarin.MacDev.Keychain;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class DetectSigningIdentityTaskBase : Task
+	public abstract class DetectSigningIdentityTaskBase : XamarinTask
 	{
 		const string AutomaticProvision = "Automatic";
 		const string AutomaticAdHocProvision = "Automatic:AdHoc";
@@ -25,16 +25,12 @@ namespace Xamarin.MacDev.Tasks
 		protected abstract string[] DevelopmentPrefixes { get; }
 		protected abstract string[] DirectDistributionPrefixes { get; }
 		protected abstract string[] AppStoreDistributionPrefixes { get; }
-		protected abstract ApplePlatform Framework { get; }
-		protected abstract string PlatformName { get; }
 		protected abstract string ApplicationIdentifierKey { get; }
 
 		string provisioningProfileName;
 		string codesignCommonName;
 
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string AppBundleName { get; set; }
@@ -459,7 +455,7 @@ namespace Xamarin.MacDev.Tasks
 				return false;
 			}
 
-			if (Framework == ApplePlatform.MacOSX) {
+			if (Platform == ApplePlatform.MacOSX) {
 				if (!RequireCodeSigning) {
 					DetectedBundleId = identity.BundleId;
 					DetectedAppId = DetectedBundleId;

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
@@ -6,11 +6,9 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class DittoTaskBase : ToolTask
+	public abstract class DittoTaskBase : XamarinToolTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public ITaskItem Source { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindItemWithLogicalNameTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindItemWithLogicalNameTaskBase.cs
@@ -6,11 +6,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class FindItemWithLogicalNameTaskBase : Task
+	public abstract class FindItemWithLogicalNameTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string ProjectDir { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/GenerateBundleNameTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/GenerateBundleNameTaskBase.cs
@@ -7,10 +7,8 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class GenerateBundleNameTaskBase : Task
+	public abstract class GenerateBundleNameTaskBase : XamarinTask
 	{
-		public string SessionId { get; set; }
-
 		[Required]
 		public string ProjectName { get; set; }
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/GetNativeExecutableNameTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/GetNativeExecutableNameTaskBase.cs
@@ -8,11 +8,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class GetNativeExecutableNameTaskBase : Task
+	public abstract class GetNativeExecutableNameTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string AppManifest { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalLibTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalLibTaskBase.cs
@@ -8,11 +8,9 @@ using Xamarin.Utils;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class MetalLibTaskBase : ToolTask
+	public abstract class MetalLibTaskBase : XamarinToolTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public ITaskItem[] Items { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
@@ -12,11 +12,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class MetalTaskBase : ToolTask
+	public abstract class MetalTaskBase : XamarinToolTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		public ITaskItem AppManifest { get; set; }
 
@@ -44,11 +42,6 @@ namespace Xamarin.MacDev.Tasks
 		[Required]
 		public ITaskItem SourceFile { get; set; }
 
-		public TargetFramework TargetFramework { get { return TargetFramework.Parse (TargetFrameworkMoniker); } }
-
-		[Required]
-		public string TargetFrameworkMoniker { get; set; }
-
 		#endregion
 
 		[Output]
@@ -60,7 +53,7 @@ namespace Xamarin.MacDev.Tasks
 
 		protected virtual string OperatingSystem {
 			get {
-				switch (PlatformFrameworkHelper.GetFramework (TargetFrameworkMoniker)) {
+				switch (Platform) {
 				case ApplePlatform.WatchOS:
 					return SdkIsSimulator ? "watchos-simulator" : "watchos";
 				case ApplePlatform.TVOS:

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/OptimizePropertyListTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/OptimizePropertyListTaskBase.cs
@@ -6,11 +6,9 @@ using Microsoft.Build.Framework;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class OptimizePropertyListTaskBase : ToolTask
+	public abstract class OptimizePropertyListTaskBase : XamarinToolTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public ITaskItem Input { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/PackLibraryResourcesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/PackLibraryResourcesTaskBase.cs
@@ -8,11 +8,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class PackLibraryResourcesTaskBase : Task
+	public abstract class PackLibraryResourcesTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string Prefix { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/PrepareNativeReferencesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/PrepareNativeReferencesTaskBase.cs
@@ -8,10 +8,8 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class PrepareNativeReferencesTaskBase : Task
+	public abstract class PrepareNativeReferencesTaskBase : XamarinTask
 	{
-		public string SessionId { get; set; }
-
 		[Required]
 		public string IntermediateOutputPath { get; set; }
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ReadItemsFromFileBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ReadItemsFromFileBase.cs
@@ -10,7 +10,7 @@ using System.Xml.Linq;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class ReadItemsFromFileBase : Task
+	public abstract class ReadItemsFromFileBase : XamarinTask
 	{
 		static readonly XNamespace XmlNs = XNamespace.Get("http://schemas.microsoft.com/developer/msbuild/2003");
 
@@ -18,8 +18,6 @@ namespace Xamarin.MacDev.Tasks
 		const string IncludeAttributeName = "Include";
 
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Output]
 		[Required]

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ScnToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ScnToolTaskBase.cs
@@ -6,13 +6,11 @@ using Microsoft.Build.Framework;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class ScnToolTaskBase : ToolTask
+	public abstract class ScnToolTaskBase : XamarinToolTask
 	{
 		string sdkDevPath;
 
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string IntermediateOutputPath { get; set; }
@@ -38,9 +36,6 @@ namespace Xamarin.MacDev.Tasks
 				SetEnvironmentVariable ("DEVELOPER_DIR", sdkDevPath);
 			}
 		}
-
-		[Required]
-		public string TargetFrameworkMoniker { get; set; }
 
 		#endregion
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/SmartCopyTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/SmartCopyTaskBase.cs
@@ -9,13 +9,11 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class SmartCopyTaskBase : Task
+	public abstract class SmartCopyTaskBase : XamarinTask
 	{
 		readonly List<ITaskItem> copied = new List<ITaskItem> ();
 
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		public ITaskItem[] DestinationFiles { get; set; }
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/SpotlightIndexerTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/SpotlightIndexerTaskBase.cs
@@ -6,11 +6,9 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class SpotlightIndexerTaskBase : ToolTask
+	public abstract class SpotlightIndexerTaskBase : XamarinToolTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string Input { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/SymbolStripTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/SymbolStripTaskBase.cs
@@ -6,11 +6,9 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class SymbolStripTaskBase : ToolTask
+	public abstract class SymbolStripTaskBase : XamarinToolTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string Executable { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/UnpackLibraryResourcesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/UnpackLibraryResourcesTaskBase.cs
@@ -9,13 +9,11 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class UnpackLibraryResourcesTaskBase : Task
+	public abstract class UnpackLibraryResourcesTaskBase : XamarinTask
 	{
 		List<ITaskItem> unpackedResources = new List<ITaskItem> ();
 		
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string Prefix { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/WriteItemsToFileBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/WriteItemsToFileBase.cs
@@ -10,7 +10,7 @@ using System.Xml.Linq;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class WriteItemsToFileBase : Task
+	public abstract class WriteItemsToFileBase : XamarinTask
 	{
 		static readonly XNamespace XmlNs = XNamespace.Get("http://schemas.microsoft.com/developer/msbuild/2003");
 
@@ -19,8 +19,6 @@ namespace Xamarin.MacDev.Tasks
 		const string IncludeAttributeName = "Include";
 
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		public ITaskItem[] Items { get; set; }
         

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinToolTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinToolTask.cs
@@ -6,8 +6,8 @@ using Microsoft.Build.Utilities;
 using Xamarin.Utils;
 
 namespace Xamarin.MacDev.Tasks {
-	// This is the same as XamarinToolTask, except that it subclasses Task instead.
-	public abstract class XamarinTask : Task {
+	// This is the same as XamarinTask, except that it subclasses ToolTask instead.
+	public abstract class XamarinToolTask : ToolTask {
 
 		public string SessionId { get; set; }
 
@@ -38,10 +38,8 @@ namespace Xamarin.MacDev.Tasks {
 		ApplePlatform? platform;
 		public ApplePlatform Platform {
 			get {
-				if (!platform.HasValue) {
-					VerifyTargetFrameworkMoniker ();
+				if (!platform.HasValue)
 					platform = PlatformFrameworkHelper.GetFramework (TargetFrameworkMoniker);
-				}
 				return platform.Value;
 			}
 		}
@@ -71,22 +69,6 @@ namespace Xamarin.MacDev.Tasks {
 				default:
 					throw new InvalidOperationException ($"Invalid platform: {Platform}");
 				}
-			}
-		}
-
-		protected string GetSdkPlatform (bool isSimulator)
-		{
-			switch (Platform) {
-			case ApplePlatform.iOS:
-				return isSimulator ? "iPhoneSimulator" : "iPhoneOS";
-			case ApplePlatform.TVOS:
-				return isSimulator ? "AppleTVSimulator" : "AppleTVOS";
-			case ApplePlatform.WatchOS:
-				return isSimulator ? "WatchSimulator" : "WatchOS";
-			case ApplePlatform.MacOSX:
-				return "MacOSX";
-			default:
-				throw new InvalidOperationException ($"Invalid platform: {Platform}");
 			}
 		}
 	}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
@@ -13,15 +13,13 @@ using Xamarin.MacDev;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class XcodeCompilerToolTask : Task
+	public abstract class XcodeCompilerToolTask : XamarinTask
 	{
 		protected bool Link { get; set; }
 		IList<string> prefixes;
 		string toolExe;
 
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		public ITaskItem AppManifest { get; set; }
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeToolTaskBase.cs
@@ -12,13 +12,11 @@ using Xamarin.MacDev;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class XcodeToolTaskBase : Task
+	public abstract class XcodeToolTaskBase : XamarinTask
 	{
 		string toolExe;
 
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string IntermediateOutputPath { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ZipTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ZipTaskBase.cs
@@ -6,11 +6,9 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public abstract class ZipTaskBase : ToolTask
+	public abstract class ZipTaskBase : XamarinToolTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Output]
 		[Required]

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CodesignNativeLibrariesTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CodesignNativeLibrariesTaskBase.cs
@@ -16,14 +16,12 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class CodesignNativeLibrariesTaskBase : Task
+	public abstract class CodesignNativeLibrariesTaskBase : XamarinTask
 	{
 		const string ToolName = "codesign";
 		string toolExe;
 
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string AppBundleDir { get; set; }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CollectAssetPacksTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CollectAssetPacksTaskBase.cs
@@ -9,11 +9,9 @@ using Xamarin.MacDev.Tasks;
 
 namespace Xamarin.iOS.Tasks
 {
-	public class CollectAssetPacksTaskBase : Task
+	public class CollectAssetPacksTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string OnDemandResourcesPath { get; set; }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CollectITunesArtworkTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CollectITunesArtworkTaskBase.cs
@@ -12,11 +12,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class CollectITunesArtworkTaskBase : Task
+	public abstract class CollectITunesArtworkTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		public ITaskItem[] ITunesArtwork { get; set; }
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CollectITunesSourceFilesTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CollectITunesSourceFilesTaskBase.cs
@@ -9,13 +9,11 @@ using Xamarin.MacDev.Tasks;
 
 namespace Xamarin.iOS.Tasks
 {
-	public class CollectITunesSourceFilesTaskBase : Task
+	public class CollectITunesSourceFilesTaskBase : XamarinTask
 	{
 		static readonly string[] iTunesFileNames = { "iTunesMetadata.plist", "iTunesArtwork@2x", "iTunesArtwork" };
 
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string OutputPath { get; set; }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -32,11 +32,6 @@ namespace Xamarin.iOS.Tasks
 
 		public string TargetArchitectures { get; set; }
 
-		public TargetFramework TargetFramework { get { return TargetFramework.Parse (TargetFrameworkMoniker); } }
-
-		[Required]
-		public string TargetFrameworkMoniker { get; set; }
-
 		[Required]
 		public bool Debug { get; set; }
 
@@ -45,10 +40,6 @@ namespace Xamarin.iOS.Tasks
 		public string DebugIPAddresses { get; set; }
 
 		public string ResourceRules { get; set; }
-
-		public ApplePlatform Framework {
-			get { return PlatformFrameworkHelper.GetFramework (TargetFrameworkMoniker); }
-		}
 
 		TargetArchitecture architectures;
 		IPhoneDeviceType supportedDevices;
@@ -77,7 +68,7 @@ namespace Xamarin.iOS.Tasks
 				return false;
 			}
 
-			switch (Framework) {
+			switch (Platform) {
 			case ApplePlatform.iOS:
 				IsIOS = true;
 				break;
@@ -86,7 +77,7 @@ namespace Xamarin.iOS.Tasks
 			case ApplePlatform.TVOS:
 				break;
 			default:
-				throw new InvalidOperationException (string.Format ("Invalid framework: {0}", Framework));
+				throw new InvalidOperationException (string.Format ("Invalid platform: {0}", Platform));
 			}
 
 			if (!string.IsNullOrEmpty (TargetArchitectures) && !Enum.TryParse (TargetArchitectures, out architectures)) {
@@ -99,10 +90,10 @@ namespace Xamarin.iOS.Tasks
 
 		bool Compile (PDictionary plist)
 		{
-			var currentSDK = IPhoneSdks.GetSdk (Framework);
+			var currentSDK = IPhoneSdks.GetSdk (Platform);
 
 			if (!currentSDK.SdkIsInstalled (sdkVersion, SdkIsSimulator)) {
-				Log.LogError (null, null, null, null, 0, 0, 0, 0, MSBStrings.E0013, Framework, sdkVersion);
+				Log.LogError (null, null, null, null, 0, 0, 0, 0, MSBStrings.E0013, Platform, sdkVersion);
 				return false;
 			}
 
@@ -192,7 +183,7 @@ namespace Xamarin.iOS.Tasks
 
 			if (UseFakeWatchOS4_3Sdk) {
 				// This is a workaround for https://github.com/xamarin/xamarin-macios/issues/4810
-				if (Framework == ApplePlatform.WatchOS) {
+				if (Platform == ApplePlatform.WatchOS) {
 					if (dtPlatformBuild != null)
 						dtPlatformBuild = "15T212";
 					if (dtPlatformVersion != null)
@@ -225,7 +216,7 @@ namespace Xamarin.iOS.Tasks
 
 			if (IsWatchExtension) {
 				// Note: Only watchOS1 Extensions target Xamarin.iOS
-				if (Framework == ApplePlatform.iOS) {
+				if (Platform == ApplePlatform.iOS) {
 					PObject value;
 
 					if (!plist.TryGetValue (ManifestKeys.UIRequiredDeviceCapabilities, out value)) {
@@ -353,7 +344,7 @@ namespace Xamarin.iOS.Tasks
 
 		void SetDeviceFamily (PDictionary plist)
 		{
-			switch (Framework) {
+			switch (Platform) {
 			case ApplePlatform.iOS:
 				SetIOSDeviceFamily (plist);
 				break;

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
@@ -13,11 +13,6 @@ namespace Xamarin.iOS.Tasks
 	{
 		public bool SdkIsSimulator { get; set; }
 		
-		public TargetFramework TargetFramework { get { return TargetFramework.Parse (TargetFrameworkMoniker); } }
-
-		[Required]
-		public string TargetFrameworkMoniker { get; set; }
-
 		static readonly HashSet<string> allowedProvisioningKeys = new HashSet<string> {
 			"application-identifier",
 			"aps-environment",

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileITunesMetadataTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileITunesMetadataTaskBase.cs
@@ -10,11 +10,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class CompileITunesMetadataTaskBase : Task
+	public abstract class CompileITunesMetadataTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string AppBundleDir { get; set; }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CreateAssetPackTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CreateAssetPackTaskBase.cs
@@ -7,11 +7,9 @@ using Xamarin.MacDev.Tasks;
 
 namespace Xamarin.iOS.Tasks
 {
-	public class CreateAssetPackTaskBase : ToolTask
+	public class CreateAssetPackTaskBase : XamarinToolTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public ITaskItem OutputFile { get; set; }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CreateDebugConfigurationTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CreateDebugConfigurationTaskBase.cs
@@ -10,11 +10,9 @@ using Xamarin.MacDev.Tasks;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class CreateDebugConfigurationTaskBase : Task
+	public abstract class CreateDebugConfigurationTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string AppBundleDir { get; set; }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CreateDebugSettingsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CreateDebugSettingsTaskBase.cs
@@ -11,11 +11,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class CreateDebugSettingsTaskBase : Task
+	public abstract class CreateDebugSettingsTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string AppBundleDir { get; set; }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectDebugNetworkConfigurationTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectDebugNetworkConfigurationTaskBase.cs
@@ -14,11 +14,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class DetectDebugNetworkConfigurationBase : Task
+	public abstract class DetectDebugNetworkConfigurationBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public bool DebugOverWiFi { get; set; }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
@@ -9,34 +9,12 @@ namespace Xamarin.iOS.Tasks
 {
 	public abstract class DetectSigningIdentityTaskBase : Xamarin.MacDev.Tasks.DetectSigningIdentityTaskBase
 	{
-		public TargetFramework TargetFramework { get { return TargetFramework.Parse (TargetFrameworkMoniker); } }
-
-		[Required]
-		public string TargetFrameworkMoniker { get; set; }
-
 		static readonly string[] directDistributionPrefixes = new string[0];
 
 		protected override string[] DevelopmentPrefixes { get { return IPhoneCertificate.DevelopmentPrefixes; } }
 		protected override string[] DirectDistributionPrefixes { get { return directDistributionPrefixes; } }
 		protected override string[] AppStoreDistributionPrefixes { get { return IPhoneCertificate.DistributionPrefixes; } }
 		protected override string DeveloperRoot { get { return IPhoneSdks.GetSdk (TargetFrameworkMoniker).DeveloperRoot; } }
-		protected override ApplePlatform Framework {
-			get { return PlatformFrameworkHelper.GetFramework (TargetFrameworkMoniker); }
-		}
-		protected override string PlatformName {
-			get {
-				switch (Framework) {
-				case ApplePlatform.iOS:
-					return "iOS";
-				case ApplePlatform.WatchOS:
-					return "watchOS";
-				case ApplePlatform.TVOS:
-					return "tvOS";
-				default:
-					throw new System.InvalidOperationException (string.Format ("Invalid framework: {0}", Framework));
-				}
-			}
-		}
 		protected override string ApplicationIdentifierKey { get { return "application-identifier"; } }
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/EmbedMobileProvisionTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/EmbedMobileProvisionTaskBase.cs
@@ -9,11 +9,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class EmbedMobileProvisionTaskBase : Task
+	public abstract class EmbedMobileProvisionTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string AppBundleDir { get; set; }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/FindWatchOS1AppExtensionBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/FindWatchOS1AppExtensionBundleTaskBase.cs
@@ -9,11 +9,9 @@ using Xamarin.MacDev;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class FindWatchOS1AppExtensionBundleTaskBase : Task
+	public abstract class FindWatchOS1AppExtensionBundleTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public ITaskItem[] AppExtensionReferences { get; set; }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/FindWatchOS2AppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/FindWatchOS2AppBundleTaskBase.cs
@@ -8,11 +8,9 @@ using Xamarin.MacDev;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class FindWatchOS2AppBundleTaskBase : Task
+	public abstract class FindWatchOS2AppBundleTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public ITaskItem[] WatchAppReferences { get; set; }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/GetDirectoriesTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/GetDirectoriesTaskBase.cs
@@ -10,10 +10,8 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class GetDirectoriesTaskBase : Task
+	public abstract class GetDirectoriesTaskBase : XamarinTask
 	{
-		public string SessionId { get; set; }
-
 		[Required]
 		public string Path { get; set; }
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/GetFilesTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/GetFilesTaskBase.cs
@@ -10,10 +10,8 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class GetFilesTaskBase : Task
+	public abstract class GetFilesTaskBase : XamarinTask
 	{
-		public string SessionId { get; set; }
-
 		[Required]
 		public string Path { get; set; }
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/GetFullPathTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/GetFullPathTaskBase.cs
@@ -7,10 +7,8 @@ using Xamarin.MacDev.Tasks;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class GetFullPathTaskBase : Task
+	public abstract class GetFullPathTaskBase : XamarinTask
 	{
-		public string SessionId { get; set; }
-
 		[Required]
 		public string RelativePath { get; set; }
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/GetPropertyValueTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/GetPropertyValueTaskBase.cs
@@ -9,14 +9,12 @@ using Xamarin.MacDev.Tasks;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class GetPropertyValueTaskBase : Task
+	public abstract class GetPropertyValueTaskBase : XamarinTask
 	{
 		public GetPropertyValueTaskBase ()
 		{
 			PropertyValue = string.Empty;
 		}
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public ITaskItem FileName { get; set; }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -327,7 +327,7 @@ namespace Xamarin.iOS.Tasks
 			}
 
 			if (EnableBitcode) {
-				switch (Framework) {
+				switch (Platform) {
 				case ApplePlatform.WatchOS:
 					args.AddLine ("--bitcode=full");
 					break;
@@ -335,7 +335,7 @@ namespace Xamarin.iOS.Tasks
 					args.AddLine ("--bitcode=asmonly");
 					break;
 				default:
-					throw new InvalidOperationException (string.Format ("Bitcode is currently not supported on {0}.", Framework));
+					throw new InvalidOperationException (string.Format ("Bitcode is currently not supported on {0}.", Platform));
 				}
 			}
 
@@ -515,7 +515,7 @@ namespace Xamarin.iOS.Tasks
 					return false;
 				}
 			} else {
-				switch (Framework) {
+				switch (Platform) {
 				case ApplePlatform.iOS:
 					IPhoneSdkVersion sdkVersion;
 					if (!IPhoneSdkVersion.TryParse (SdkVersion, out sdkVersion)) {
@@ -530,7 +530,7 @@ namespace Xamarin.iOS.Tasks
 					minimumOSVersion = IPhoneSdkVersion.UseDefault;
 					break;
 				default:
-					throw new InvalidOperationException (string.Format ("Invalid framework: {0}", Framework));
+					throw new InvalidOperationException (string.Format ("Invalid framework: {0}", Platform));
 				}
 			}
 
@@ -576,7 +576,7 @@ namespace Xamarin.iOS.Tasks
 			if (File.Exists (fullName))
 				return fullName;
 
-			var frameworkDir = TargetFrameworkIdentifier;
+			var frameworkDir = TargetFramework.Identifier;
 			var fileName = Path.GetFileName (fullName);
 
 			return ResolveFrameworkFileOrFacade (frameworkDir, fileName) ?? fullName;

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/OptimizeImageTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/OptimizeImageTaskBase.cs
@@ -8,14 +8,12 @@ using Xamarin.MacDev.Tasks;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class OptimizeImageTaskBase : ToolTask
+	public abstract class OptimizeImageTaskBase : XamarinToolTask
 	{
 		ITaskItem inputImage;
 		ITaskItem outputImage;
 
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public ITaskItem[] InputImages { get; set; }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ParseDeviceSpecificBuildInformationTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ParseDeviceSpecificBuildInformationTaskBase.cs
@@ -11,11 +11,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class ParseDeviceSpecificBuildInformationTaskBase : Task
+	public abstract class ParseDeviceSpecificBuildInformationTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string Architectures { get; set; }
@@ -25,11 +23,6 @@ namespace Xamarin.iOS.Tasks
 
 		[Required]
 		public string OutputPath { get; set; }
-
-		public TargetFramework TargetFramework { get { return TargetFramework.Parse (TargetFrameworkMoniker); } }
-
-		[Required]
-		public string TargetFrameworkMoniker { get; set; }
 
 		[Required]
 		public string TargetiOSDevice { get; set; }
@@ -62,7 +55,7 @@ namespace Xamarin.iOS.Tasks
 			PDictionary plist, device;
 			PString value, os;
 
-			switch (PlatformFrameworkHelper.GetFramework (TargetFrameworkMoniker)) {
+			switch (Platform) {
 			case ApplePlatform.WatchOS:
 				targetOperatingSystem = "watchOS";
 				break;

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ParseExtraMtouchArgsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ParseExtraMtouchArgsTaskBase.cs
@@ -8,10 +8,8 @@ using Xamarin.MacDev.Tasks;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class ParseExtraMtouchArgsTaskBase : Task
+	public abstract class ParseExtraMtouchArgsTaskBase : XamarinTask
 	{
-		public string SessionId { get; set; }
-
 		public string ExtraArgs { get; set; }
 
 		[Output]

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/PrepareResourceRulesTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/PrepareResourceRulesTaskBase.cs
@@ -9,11 +9,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class PrepareResourceRulesTaskBase : Task
+	public abstract class PrepareResourceRulesTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string AppBundleDir { get; set; }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ResolveNativeWatchAppTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ResolveNativeWatchAppTaskBase.cs
@@ -11,23 +11,15 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class ResolveNativeWatchAppTaskBase : Task
+	public abstract class ResolveNativeWatchAppTaskBase : XamarinTask
 	{
-
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public bool SdkIsSimulator { get; set; }
 
 		[Required]
 		public string SdkVersion { get; set; }
-
-		public TargetFramework TargetFramework { get { return TargetFramework.Parse (TargetFrameworkMoniker); } }
-
-		[Required]
-		public string TargetFrameworkMoniker { get; set; }
 
 		#endregion
 
@@ -40,7 +32,7 @@ namespace Xamarin.iOS.Tasks
 
 		bool IsWatchFramework {
 			get {
-				return PlatformFrameworkHelper.GetFramework (TargetFrameworkMoniker) == Utils.ApplePlatform.WatchOS;
+				return Platform == ApplePlatform.WatchOS;
 			}
 		}
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
@@ -12,11 +12,9 @@ using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class ValidateAppBundleTaskBase : Task
+	public abstract class ValidateAppBundleTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public string AppBundlePath { get; set; }
@@ -24,14 +22,7 @@ namespace Xamarin.iOS.Tasks
 		[Required]
 		public bool SdkIsSimulator { get; set; }
 
-		[Required]
-		public string TargetFrameworkMoniker { get; set; }
-
 		#endregion
-
-		public ApplePlatform Framework {
-			get { return PlatformFrameworkHelper.GetFramework (TargetFrameworkMoniker); }
-		}
 
 		void ValidateAppExtension (string path, string mainBundleIdentifier, string mainShortVersionString, string mainVersion)
 		{
@@ -403,7 +394,7 @@ namespace Xamarin.iOS.Tasks
 			var deviceFamilies = deviceTypes.ToDeviceFamily ();
 			AppleDeviceFamily[] validFamilies = null;
 
-			switch (Framework) {
+			switch (Platform) {
 			case ApplePlatform.iOS:
 				validFamilies = new AppleDeviceFamily[] {
 					AppleDeviceFamily.IPhone,
@@ -418,7 +409,7 @@ namespace Xamarin.iOS.Tasks
 				validFamilies = new AppleDeviceFamily[] { AppleDeviceFamily.TV };
 				break;
 			default:
-				Log.LogError ("Invalid framework: {0}", Framework);
+				Log.LogError ("Invalid platform: {0}", Platform);
 				break;
 			}
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/WriteAssetPackManifestTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/WriteAssetPackManifestTaskBase.cs
@@ -7,11 +7,9 @@ using Xamarin.MacDev.Tasks;
 
 namespace Xamarin.iOS.Tasks
 {
-	public class WriteAssetPackManifestTaskBase : Task
+	public class WriteAssetPackManifestTaskBase : XamarinTask
 	{
 		#region Inputs
-
-		public string SessionId { get; set; }
 
 		[Required]
 		public ITaskItem OutputFile { get; set; }


### PR DESCRIPTION
This makes it possible to remove a lot of duplicated code.