### PR TITLE
[Devops] Add scripts folder and examples on how to write tests.

### DIFF
--- a/tools/devops/scripts/Example.Tests.ps1
+++ b/tools/devops/scripts/Example.Tests.ps1
@@ -1,0 +1,22 @@
+<#
+Example of a pester test.
+#>
+Import-Module ./Example
+
+Describe TestExample {
+    Context 'The weather outside is frightful' {
+        $testdata = 'But the fire is so delightful'
+
+        It 'Should be delightful' {
+            LetItSnow -Delightful | Should -Be $testdata
+        }
+    }
+
+    Context "Seems there's no place to go" {
+        $testdata = 'Let it snow, let it snow, let it snow'
+
+        It 'Should snow' {
+            LetItSnow | Should -Be $testdata
+        }
+    }
+}

--- a/tools/devops/scripts/Example.psm1
+++ b/tools/devops/scripts/Example.psm1
@@ -1,0 +1,10 @@
+function LetItSnow {
+    param ([switch]$Delightful)
+    
+    if ($Delightful) {
+        'But the fire is so delightful'
+    } else {
+        'Let it snow, let it snow, let it snow'
+    }
+}
+Export-ModuleMember -Function LetItSnow 

--- a/tools/devops/scripts/Makefile
+++ b/tools/devops/scripts/Makefile
@@ -1,0 +1,5 @@
+TOP=../../..
+include $(TOP)/Make.config
+
+run-tests:
+	$(Q_GEN) pwsh -Command Invoke-Pester

--- a/tools/devops/scripts/Makefile
+++ b/tools/devops/scripts/Makefile
@@ -2,4 +2,4 @@ TOP=../../..
 include $(TOP)/Make.config
 
 run-tests:
-	$(Q_GEN) pwsh -Command Invoke-Pester
+	$(Q_GEN) pwsh -Command "Install-Module Pester;Invoke-Pester"

--- a/tools/devops/scripts/Makefile
+++ b/tools/devops/scripts/Makefile
@@ -2,4 +2,4 @@ TOP=../../..
 include $(TOP)/Make.config
 
 run-tests:
-	$(Q_GEN) pwsh -Command "Install-Module Pester;Invoke-Pester"
+	$(Q_GEN) pwsh -Command "Install-Module -AcceptLicense -Force -AllowClobber Pester;Invoke-Pester"


### PR DESCRIPTION
CI is not very tested and fragile, but pwsh scripts can be unit tested.

Added a scripts folder where all the scripts will be placed and an
example showing a test.

In order to run the test we simply have to execute

```bash
make -C tools/devops/scripts run-tests
```

This will find all the test modules present in the scripts folder and
will execute all of them. An example output is:

```
Executing script /Users/mandel/Xamarin/xamarin-macios/master/xamarin-macios/tools/devops/scripts/Example.Tests.ps1

  Describing TestExample

    Context The weather outside is frightful
      [+] Should be delightful 76ms

    Context Seems there's no place to go
      [+] Should snow 5ms
Tests completed in 372ms
Tests Passed: 2, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0
```

This can be later added in the CI to make sure that changes in the
scripts dont break the CI.