### PR TITLE
[src] Only run make from csproj if the csproj isn't built from make.

### DIFF
--- a/src/generator.csproj
+++ b/src/generator.csproj
@@ -401,7 +401,8 @@
     </EmbeddedResource>
   </ItemGroup>
   <Target Name="AfterBuild">
-    <Exec Command="make bgen" />
+    <!-- Only run 'make bgen' if we're not executed as part of 'make' (i.e. MAKEFLAGS is empty) -->
+    <Exec Command="make bgen" Condition="'$(MAKEFLAGS)' == ''"/>
   </Target>
   <Import Project="..\packages\XliffTasks.1.0.0-beta.19607.1\build\XliffTasks.targets" Condition="Exists('..\packages\XliffTasks.1.0.0-beta.19607.1\build\XliffTasks.targets')" />
 </Project>


### PR DESCRIPTION
Fixes warnings like these:

           "/Users/builder/jenkins/workspace/xamarin-macios-pr-builder/src/generator.csproj" (default target) (1) ->
           (AfterBuild target) ->
             make[2] : warning : jobserver unavailable: using -j1.  Add `+' to parent make rule. [/Users/builder/jenkins/workspace/xamarin-macios-pr-builder/src/generator.csproj]
             make[2] : warning : jobserver unavailable: using -j1.  Add `+' to parent make rule. [/Users/builder/jenkins/workspace/xamarin-macios-pr-builder/src/generator.csproj]

        2 Warning(s)
        0 Error(s)

    Time Elapsed 00:00:10.61