### PR TITLE
[jenkins] Hide the list of packages by default.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -720,7 +720,7 @@ timestamps {
                             }
 
                             if (packagesMessage != "")
-                                appendFileComment ("✅ Packages built successfully\n<details><summary>View packages</summary>\n${packagesMessage}\n</details>\n\n")
+                                appendFileComment ("✅ Packages built successfully\n<details><summary>View packages</summary>\n\n${packagesMessage}\n</details>\n\n")
                         }
 
                         stage ('Publish Nugets') {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -720,7 +720,7 @@ timestamps {
                             }
 
                             if (packagesMessage != "")
-                                appendFileComment ("✅ Packages: \n${packagesMessage}\n")
+                                appendFileComment ("✅ Packages built successfully\n<details><summary>View packages</summary>\n${packagesMessage}\n</details>\n\n")
                         }
 
                         stage ('Publish Nugets') {


### PR DESCRIPTION
The list of packages got big with the NuGet packages, and we usually don't
want to see the whole thing, so hide it by default.

This is how it looks like:

<img width="269" alt="Screenshot 2020-05-14 09 32 53" src="https://user-images.githubusercontent.com/249268/81906066-f6cdcd80-95c5-11ea-92fc-38c1c5382382.png">
