### PR TITLE
A few minor improvements to speed up rebuilds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ include $(TOP)/mk/versions.mk
 #
 
 all-local:: check-system
-install-local:: check-system
+install-local::
 
 .PHONY: world
 world: check-system

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -63,7 +63,8 @@ downloads/%: downloads/%.nupkg
 	$(Q) mv $@.tmp $@
 	$(Q) echo "Unzipped $*."
 
-.stamp-download-mono: download-mono $(TOP)/Make.config $(TOP)/mk/mono.mk
+.stamp-download-mono: $(TOP)/Make.config $(TOP)/mk/mono.mk
+	$(MAKE) download-mono
 	$(Q) touch $@
 
 DOTNET_DOWNLOADS = \


### PR DESCRIPTION
* There's no need to check the system when running 'make install', we already
  checked it during 'make all'.
* Remove the 'download-mono' dependency for the .stamp-download-mono target,
  since that makes the .stamp-download-mono target always out of date (since
  there will never be a 'download-mono' file). Instead execute the
  'download-mono' target manually. This fixes an issue where running 'make
  all' repeatedly would continue doing the same stuff over and over again.