### PR TITLE
[dotnet] Switch to net5.0 instead of netcoreapp5.0.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -443,9 +443,9 @@ DOTNET_FEED_DIR ?= $(DOTNET_DESTDIR)/nuget-feed
 # We're using preview versions, and there will probably be many of them, so install locally (into builds/downloads) if there's no system version to
 # avoid consuming a lot of disk space (since they're never automatically deleted). The system-dependencies.sh script will install locally as long
 # as there's a TARBALL url.
-DOTNET5_VERSION=5.0.100-preview.5.20256.10
-DOTNET5_URL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-preview.5.20256.10/dotnet-sdk-5.0.100-preview.5.20256.10-osx-x64.pkg
-DOTNET5_TARBALL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-preview.5.20256.10/dotnet-sdk-5.0.100-preview.5.20256.10-osx-x64.tar.gz
+DOTNET5_VERSION=5.0.100-preview.6.20265.2
+DOTNET5_URL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-preview.6.20265.2/dotnet-sdk-5.0.100-preview.6.20265.2-osx-x64.pkg
+DOTNET5_TARBALL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-preview.6.20265.2/dotnet-sdk-5.0.100-preview.6.20265.2-osx-x64.tar.gz
 # Use the system dotnet executable if the dotnet version we need is installed, otherwise use the local version.
 ifneq ($(wildcard /usr/local/share/dotnet/sdk/$(DOTNET5_VERSION)),)
 DOTNET5=$(DOTNET)

--- a/dotnet/package/common.csproj
+++ b/dotnet/package/common.csproj
@@ -2,7 +2,7 @@
   <Import Project="../targets/Xamarin.Shared.Sdk.Versions.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <PackageVersion>$(_PackageVersion)</PackageVersion>
     <RepositoryUrl>https://github.com/xamarin/xamarin-macios</RepositoryUrl>
@@ -40,12 +40,12 @@
     <!-- https://github.com/dotnet/runtime/blob/0647ec314948904319da5eb15e9931f7c85ed1e2/src/installer/pkg/projects/Directory.Build.targets#L281 -->
     <PropertyGroup Condition="'$(_CreateFrameworkList)' == 'true'">
       <_FrameworkListFile>$(IntermediateOutputPath)FrameworkList.xml</_FrameworkListFile>
-      <_PackTargetPath>ref/netcoreapp5.0</_PackTargetPath>
+      <_PackTargetPath>ref/net5.0</_PackTargetPath>
       <_PackNativePath>runtimes/$(_RuntimeIdentifier)/native</_PackNativePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(_CreateRuntimeList)' == 'true'">
       <_FrameworkListFile>$(IntermediateOutputPath)RuntimeList.xml</_FrameworkListFile>
-      <_PackTargetPath>runtimes/$(_RuntimeIdentifier)/lib/netcoreapp5.0</_PackTargetPath>
+      <_PackTargetPath>runtimes/$(_RuntimeIdentifier)/lib/net5.0</_PackTargetPath>
       <_PackNativePath>runtimes/$(_RuntimeIdentifier)/native</_PackNativePath>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
This also requires bumping .NET to a version that supports 'net5.0'.

The actual TFM is still '.NETCoreApp,Version=5.0', it's just the short name
that has changed.