### PR TITLE
[Harness] Move GetColor method out of Jenkins.

### DIFF
--- a/tests/xharness/Jenkins/ITestTaskExtensions.cs
+++ b/tests/xharness/Jenkins/ITestTaskExtensions.cs
@@ -1,0 +1,78 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.DotNet.XHarness.iOS.Shared.Tasks;
+using Xharness.Jenkins.TestTasks;
+
+namespace Xharness.Jenkins {
+	public static class ITestTaskExtensions {
+
+		public static string GetTestColor (this IEnumerable<ITestTask> tests)
+		{
+			if (!tests.Any ())
+				return "black";
+
+			var first = tests.First ();
+			if (tests.All ((v) => v.ExecutionResult == first.ExecutionResult))
+				return GetTestColor (first);
+			if (tests.Any ((v) => v.Crashed))
+				return "maroon";
+			else if (tests.Any ((v) => v.TimedOut))
+				return "purple";
+			else if (tests.Any ((v) => v.BuildFailure))
+				return "darkred";
+			else if (tests.Any ((v) => v.Failed))
+				return "red";
+			else if (tests.Any ((v) => v.NotStarted))
+				return "black";
+			else if (tests.Any ((v) => v.Ignored))
+				return "gray";
+			else if (tests.Any ((v) => v.DeviceNotFound))
+				return "orangered";
+			else if (tests.All ((v) => v.BuildSucceeded))
+				return "lightgreen";
+			else if (tests.All ((v) => v.Succeeded))
+				return "green";
+			else
+				return "black";
+		}
+
+		public static string GetTestColor (this ITestTask test)
+		{
+			if (test.NotStarted) {
+				return "black";
+			} else if (test.InProgress) {
+				if (test.Building) {
+					return "darkblue";
+				} else if (test.Running) {
+					return "lightblue";
+				} else {
+					return "blue";
+				}
+			} else {
+				if (test.Crashed) {
+					return "maroon";
+				} else if (test.HarnessException) {
+					return "orange";
+				} else if (test.TimedOut) {
+					return "purple";
+				} else if (test.BuildFailure) {
+					return "darkred";
+				} else if (test.Failed) {
+					return "red";
+				} else if (test.BuildSucceeded) {
+					return "lightgreen";
+				} else if (test.Succeeded) {
+					return "green";
+				} else if (test.Ignored) {
+					return "gray";
+				} else if (test.Waiting) {
+					return "darkgray";
+				} else if (test.DeviceNotFound) {
+					return "orangered";
+				} else {
+					return "pink";
+				}
+			}
+		}
+	}
+}

--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -1449,75 +1449,6 @@ namespace Xharness.Jenkins {
 			return tcs.Task;
 		}
 
-		string GetTestColor (IEnumerable<AppleTestTask> tests)
-		{
-			if (!tests.Any ())
-				return "black";
-
-			var first = tests.First ();
-			if (tests.All ((v) => v.ExecutionResult == first.ExecutionResult))
-				return GetTestColor (first);
-			if (tests.Any ((v) => v.Crashed))
-				return "maroon";
-			else if (tests.Any ((v) => v.TimedOut))
-				return "purple";
-			else if (tests.Any ((v) => v.BuildFailure))
-				return "darkred";
-			else if (tests.Any ((v) => v.Failed))
-				return "red";
-			else if (tests.Any ((v) => v.NotStarted))
-				return "black";
-			else if (tests.Any ((v) => v.Ignored))
-				return "gray";
-			else if (tests.Any ((v) => v.DeviceNotFound))
-				return "orangered";
-			else if (tests.All ((v) => v.BuildSucceeded))
-				return "lightgreen";
-			else if (tests.All ((v) => v.Succeeded))
-				return "green";
-			else
-				return "black";
-		}
-
-		string GetTestColor (AppleTestTask test)
-		{
-			if (test.NotStarted) {
-				return "black";
-			} else if (test.InProgress) {
-				if (test.Building) {
-					return "darkblue";
-				} else if (test.Running) {
-					return "lightblue";
-				} else {
-					return "blue";
-				}
-			} else {
-				if (test.Crashed) {
-					return "maroon";
-				} else if (test.HarnessException) {
-					return "orange";
-				} else if (test.TimedOut) {
-					return "purple";
-				} else if (test.BuildFailure) {
-					return "darkred";
-				} else if (test.Failed) {
-					return "red";
-				} else if (test.BuildSucceeded) {
-					return "lightgreen";
-				} else if (test.Succeeded) {
-					return "green";
-				} else if (test.Ignored) {
-					return "gray";
-				} else if (test.Waiting) {
-					return "darkgray";
-				} else if (test.DeviceNotFound) {
-					return "orangered";
-				} else {
-					return "pink";
-				}
-			}
-		}
-
 		object report_lock = new object ();
 		public void GenerateReport ()
 		{
@@ -1779,7 +1710,7 @@ namespace Xharness.Jenkins {
 					var list = new List<string> ();
 					var grouped = allTasks.GroupBy ((v) => v.ExecutionResult).OrderBy ((v) => (int) v.Key);
 					foreach (var @group in grouped)
-						list.Add ($"<span style='color: {GetTestColor (@group)}'>{@group.Key.ToString ()}: {@group.Count ()}</span>");
+						list.Add ($"<span style='color: {@group.GetTestColor ()}'>{@group.Key.ToString ()}: {@group.Count ()}</span>");
 					writer.Write (string.Join (", ", list));
 					writer.Write (")");
 				} else if (failedTests.Any ()) {
@@ -1997,7 +1928,7 @@ namespace Xharness.Jenkins {
 							var knownFailure = string.Empty;
 							if (!string.IsNullOrEmpty (test.KnownFailure))
 								knownFailure = $" {test.KnownFailure}";
-							writer.Write ($"<span id='x{id_counter++}' class='p3 autorefreshable' onclick='javascript: toggleLogVisibility (\"{log_id}\");'>{title} (<span style='color: {GetTestColor (test)}'>{state}{knownFailure}</span>{buildOnly}) </span>");
+							writer.Write ($"<span id='x{id_counter++}' class='p3 autorefreshable' onclick='javascript: toggleLogVisibility (\"{log_id}\");'>{title} (<span style='color: {test.GetTestColor ()}'>{state}{knownFailure}</span>{buildOnly}) </span>");
 							if (IsServerMode) {
 								writer.Write ($" <span id='x{id_counter++}' class='autorefreshable'>");
 								if (test.Waiting) {
@@ -2199,7 +2130,7 @@ namespace Xharness.Jenkins {
 						foreach (var group in failedTests.GroupBy ((v) => v.TestName)) {
 							var enumerableGroup = group as IEnumerable<AppleTestTask>;
 							if (enumerableGroup != null) {
-								writer.WriteLine ("<a href='#test_{2}'>{0}</a> ({1})<br />", group.Key, string.Join (", ", enumerableGroup.Select ((v) => string.Format ("<span style='color: {0}'>{1}</span>", GetTestColor (v), string.IsNullOrEmpty (v.Mode) ? v.ExecutionResult.ToString () : v.Mode)).ToArray ()), group.Key.Replace (' ', '-'));
+								writer.WriteLine ("<a href='#test_{2}'>{0}</a> ({1})<br />", group.Key, string.Join (", ", enumerableGroup.Select ((v) => string.Format ("<span style='color: {0}'>{1}</span>", v.GetTestColor (), string.IsNullOrEmpty (v.Mode) ? v.ExecutionResult.ToString () : v.Mode)).ToArray ()), group.Key.Replace (' ', '-'));
 								continue;
 							}
 
@@ -2277,7 +2208,7 @@ namespace Xharness.Jenkins {
 				.GroupBy ((v) => v.ExecutionResult)
 				.Select ((v) => v.First ()) // GroupBy + Select = Distinct (lambda)
 				.OrderBy ((v) => v.ID)
-				.Select ((v) => $"<span style='color: {GetTestColor (v)}'>{v.ExecutionResult.ToString ()}</span>")
+				.Select ((v) => $"<span style='color: {v.GetTestColor ()}'>{v.ExecutionResult.ToString ()}</span>")
 				.ToArray ();
 			return " (" + string.Join ("; ", results) + ")";
 		}

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Tasks/ITestTask.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Tasks/ITestTask.cs
@@ -6,14 +6,30 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Tasks {
 	public interface ITestTask {
-		bool HasCustomTestName { get; }
+
+		#region Status properties
+
+		bool NotStarted { get; }
+		bool Building { get; }
 		bool BuildSucceeded { get; }
+		bool BuildFailure { get; }
+		bool Waiting { get; }
+		bool InProgress { get; }
+		bool Running { get; }
+		bool Finished { get; }
+		bool HarnessException { get; }
+
 		bool Succeeded { get; }
 		bool Failed { get; }
-		bool Ignored { get; set; }
 		bool TimedOut { get; }
-		bool Finished { get; }
+		bool Crashed { get; }
+		bool DeviceNotFound { get; }
+
+		#endregion
+
+		bool HasCustomTestName { get; }
 		bool BuildOnly { get; set; }
+		bool Ignored { get; set; }
 
 		string KnownFailure { get; set; }
 		string ProjectConfiguration { get; set; }

--- a/tests/xharness/Xharness.Tests/Jenkins/ITestTaskExtensionsTests.cs
+++ b/tests/xharness/Xharness.Tests/Jenkins/ITestTaskExtensionsTests.cs
@@ -1,0 +1,181 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Microsoft.DotNet.XHarness.iOS.Shared;
+using Microsoft.DotNet.XHarness.iOS.Shared.Tasks;
+
+using Moq;
+using NUnit.Framework;
+
+using Xharness.Jenkins;
+
+namespace Xharness.Tests.Jenkins {
+
+	[TestFixture]
+	public class ITestTaskExtensionsTests {
+
+		public class TestCasesData {
+			public static IEnumerable GetColorTestCases {
+				get {
+					var task = new Mock<ITestTask> ();
+					task.Setup (t => t.NotStarted).Returns (true);
+					yield return new TestCaseData (task.Object).Returns ("black");
+
+					task = new Mock<ITestTask> ();
+					task.Setup (t => t.InProgress).Returns (true);
+					task.Setup (t => t.Building).Returns (true);
+					yield return new TestCaseData (task.Object).Returns ("darkblue");
+
+					task = new Mock<ITestTask> ();
+					task.Setup (t => t.InProgress).Returns (true);
+					task.Setup (t => t.Building).Returns (false);
+					task.Setup (t => t.Running).Returns (true);
+					yield return new TestCaseData (task.Object).Returns ("lightblue");
+
+					task = new Mock<ITestTask> ();
+					task.Setup (t => t.InProgress).Returns (true);
+					task.Setup (t => t.Building).Returns (false);
+					task.Setup (t => t.Running).Returns (false);
+					yield return new TestCaseData (task.Object).Returns ("blue");
+
+					task = new Mock<ITestTask> ();
+					task.Setup (t => t.InProgress).Returns (false);
+					task.Setup (t => t.Crashed).Returns (true);
+					yield return new TestCaseData (task.Object).Returns ("maroon");
+
+					task = new Mock<ITestTask> ();
+					task.Setup (t => t.InProgress).Returns (false);
+					task.Setup (t => t.HarnessException).Returns (true);
+					yield return new TestCaseData (task.Object).Returns ("orange");
+
+					task = new Mock<ITestTask> ();
+					task.Setup (t => t.InProgress).Returns (false);
+					task.Setup (t => t.TimedOut).Returns (true);
+					yield return new TestCaseData (task.Object).Returns ("purple");
+
+					task = new Mock<ITestTask> ();
+					task.Setup (t => t.InProgress).Returns (false);
+					task.Setup (t => t.BuildFailure).Returns (true);
+					yield return new TestCaseData (task.Object).Returns ("darkred");
+
+					task = new Mock<ITestTask> ();
+					task.Setup (t => t.InProgress).Returns (false);
+					task.Setup (t => t.Failed).Returns (true);
+					yield return new TestCaseData (task.Object).Returns ("red");
+
+					task = new Mock<ITestTask> ();
+					task.Setup (t => t.InProgress).Returns (false);
+					task.Setup (t => t.BuildSucceeded).Returns (true);
+					yield return new TestCaseData (task.Object).Returns ("lightgreen");
+
+					task = new Mock<ITestTask> ();
+					task.Setup (t => t.InProgress).Returns (false);
+					task.Setup (t => t.Succeeded).Returns (true);
+					yield return new TestCaseData (task.Object).Returns ("green");
+
+					task = new Mock<ITestTask> ();
+					task.Setup (t => t.InProgress).Returns (false);
+					task.Setup (t => t.Ignored).Returns (true);
+					yield return new TestCaseData (task.Object).Returns ("gray");
+
+					task = new Mock<ITestTask> ();
+					task.Setup (t => t.InProgress).Returns (false);
+					task.Setup (t => t.Waiting).Returns (true);
+					yield return new TestCaseData (task.Object).Returns ("darkgray");
+
+					task = new Mock<ITestTask> ();
+					task.Setup (t => t.InProgress).Returns (false);
+					task.Setup (t => t.DeviceNotFound).Returns (true);
+					yield return new TestCaseData (task.Object).Returns ("orangered");
+
+					task = new Mock<ITestTask> ();
+					task.Setup (t => t.InProgress).Returns (false);
+					yield return new TestCaseData (task.Object).Returns ("pink");
+				}
+			}
+
+			public static IEnumerable GetColorCollectionTestCases {
+				get {
+
+					Mock<ITestTask> firstTask = new Mock<ITestTask> ();
+					firstTask.Setup (t => t.Succeeded).Returns (true);
+					firstTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.Succeeded);
+					Mock<ITestTask> secondTask = new Mock<ITestTask> ();
+					secondTask.Setup (t => t.Crashed).Returns (true);
+					secondTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.Crashed);
+					yield return new TestCaseData (new List<ITestTask> { firstTask.Object, secondTask.Object}).Returns ("maroon");
+
+					firstTask = new Mock<ITestTask> ();
+					firstTask.Setup (t => t.Succeeded).Returns (true);
+					firstTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.Succeeded);
+					secondTask = new Mock<ITestTask> ();
+					secondTask.Setup (t => t.TimedOut).Returns (true);
+					secondTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.TimedOut);
+					yield return new TestCaseData (new List<ITestTask> { firstTask.Object, secondTask.Object}).Returns ("purple");
+
+					firstTask = new Mock<ITestTask> ();
+					firstTask.Setup (t => t.Succeeded).Returns (true);
+					firstTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.Succeeded);
+					secondTask = new Mock<ITestTask> ();
+					secondTask.Setup (t => t.BuildFailure).Returns (true);
+					secondTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.BuildFailure);
+					yield return new TestCaseData (new List<ITestTask> { firstTask.Object, secondTask.Object}).Returns ("darkred");
+
+					firstTask = new Mock<ITestTask> ();
+					firstTask.Setup (t => t.Succeeded).Returns (true);
+					firstTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.Succeeded);
+					secondTask = new Mock<ITestTask> ();
+					secondTask.Setup (t => t.Failed).Returns (true);
+					secondTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.Failed);
+					yield return new TestCaseData (new List<ITestTask> { firstTask.Object, secondTask.Object}).Returns ("red");
+
+					firstTask = new Mock<ITestTask> ();
+					firstTask.Setup (t => t.Succeeded).Returns (true);
+					firstTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.Succeeded);
+					secondTask = new Mock<ITestTask> ();
+					secondTask.Setup (t => t.NotStarted).Returns (true);
+					secondTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.NotStarted);
+					yield return new TestCaseData (new List<ITestTask> { firstTask.Object, secondTask.Object}).Returns ("black");
+
+					firstTask = new Mock<ITestTask> ();
+					firstTask.Setup (t => t.Succeeded).Returns (true);
+					firstTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.Succeeded);
+					secondTask = new Mock<ITestTask> ();
+					secondTask.Setup (t => t.Ignored).Returns (true);
+					secondTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.Ignored);
+					yield return new TestCaseData (new List<ITestTask> { firstTask.Object, secondTask.Object}).Returns ("gray");
+
+					firstTask = new Mock<ITestTask> ();
+					firstTask.Setup (t => t.Succeeded).Returns (true);
+					firstTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.Succeeded);
+					secondTask = new Mock<ITestTask> ();
+					secondTask.Setup (t => t.DeviceNotFound).Returns (true);
+					secondTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.DeviceNotFound);
+					yield return new TestCaseData (new List<ITestTask> { firstTask.Object, secondTask.Object}).Returns ("orangered");
+
+					firstTask = new Mock<ITestTask> ();
+					firstTask.Setup (t => t.BuildSucceeded).Returns (true);
+					firstTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.BuildSucceeded);
+					secondTask = new Mock<ITestTask> ();
+					secondTask.Setup (t => t.BuildSucceeded).Returns (true);
+					secondTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.BuildSucceeded);
+					yield return new TestCaseData (new List<ITestTask> { firstTask.Object, secondTask.Object }).Returns ("lightgreen");
+
+					firstTask = new Mock<ITestTask> ();
+					firstTask.Setup (t => t.Succeeded).Returns (true);
+					firstTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.Succeeded);
+					secondTask = new Mock<ITestTask> ();
+					secondTask.Setup (t => t.Succeeded).Returns (true);
+					firstTask.Setup (t => t.ExecutionResult).Returns (TestExecutingResult.Succeeded);
+					yield return new TestCaseData (new List<ITestTask> { firstTask.Object, secondTask.Object }).Returns ("green");
+
+				}
+			}
+		}
+
+		[Test, TestCaseSource (typeof (TestCasesData), "GetColorTestCases")]
+		public string GetTestColorTest (ITestTask task) => task.GetTestColor ();
+
+		[Test, TestCaseSource (typeof (TestCasesData), "GetColorCollectionTestCases")]
+		public string GetTestColorCollectionTest (IEnumerable<ITestTask> tasks) => tasks.GetTestColor ();
+	}
+}

--- a/tests/xharness/Xharness.Tests/Xharness.Tests.csproj
+++ b/tests/xharness/Xharness.Tests/Xharness.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="TestImporter\Xamarin\Tests\ProjectFilterTest.cs" />
     <Compile Include="TestImporter\Xamarin\Tests\AssemblyLocatorTest.cs" />
     <Compile Include="TestImporter\Xamarin\Tests\XamariniOSTemplateTest.cs" />
+    <Compile Include="Jenkins\ITestTaskExtensionsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -125,6 +125,7 @@
     <Compile Include="TestTasks\IRunSimulatorTask.cs" />
     <Compile Include="TestTasks\RunDevice.cs" />
     <Compile Include="TestProjectExtensions.cs" />
+    <Compile Include="Jenkins\ITestTaskExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\tools\common\SdkVersions.cs">


### PR DESCRIPTION
Reduce the logic that is not related to the execution of tests out of
jenkins. Add tests.