### PR TITLE
[Devops] Move to use the devops xcode path to minimize issues in the pipelines.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -113,7 +113,7 @@ WATCHOS_NUGET_VERSION_FULL=$(WATCHOS_NUGET_VERSION_NO_METADATA)+$(NUGET_BUILD_ME
 # Xcode version should have both a major and a minor version (even if the minor version is 0)
 XCODE_VERSION=11.4
 XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_11.4.xip
-XCODE_DEVELOPER_ROOT=/Applications/Xcode114.app/Contents/Developer
+XCODE_DEVELOPER_ROOT=/Applications/Xcode_11.4.0.app/Contents/Developer
 XCODE_PRODUCT_BUILD_VERSION:=$(shell /usr/libexec/PlistBuddy -c 'Print :ProductBuildVersion' $(XCODE_DEVELOPER_ROOT)/../version.plist)
 
 # Mono version embedded in XI/XM (NEEDED_MONO_VERSION/BRANCH) are specified in mk/mono.mk

--- a/tools/devops/device-tests-provisioning.csx.in
+++ b/tools/devops/device-tests-provisioning.csx.in
@@ -5,8 +5,14 @@ using System.Linq;
 
 using static Xamarin.Provisioning.ProvisioningScript;
 
-var xcodePath = Path.GetDirectoryName (Path.GetDirectoryName ("@XCODE_DEVELOPER_ROOT@"));
-Xcode ("@XCODE_VERSION@").XcodeSelect (allowUntrusted: true, allowSymlink: true, symlinkTarget: xcodePath);
+var xcodeVersion = new Version ("@XCODE_VERSION@");
+
+if (xcodeVersion.Build == -1) { // we are dealing with a .0 release, Version ("11.4.3") returns 3, Version ("11.4.0") returns 0 and Version ("11.4") returns -1
+	// provisionator needs the extra .0 or it will place xcode in 11.4.app rather than in 11.4.0.app
+	Xcode ("@XCODE_VERSION@.0").XcodeSelect (allowUntrusted: true);
+} else {
+	Xcode (xcodeVersion.ToString ()).XcodeSelect (allowUntrusted: true);
+}
 
 // provisionator knows how to deal with this items
 Item ("@MONO_PACKAGE@");


### PR DESCRIPTION
Move to use the expected path in devops, but be careful when we have a
version without a build number.

Resulting script is:
```csharp
#r "_provisionator/provisionator.dll"

using System.IO;
using System.Linq;

using static Xamarin.Provisioning.ProvisioningScript;

var xcodeVersion = new Version ("11.4");

if (xcodeVersion.Build == -1) { // we are dealing with a .0 release, Version ("11.4.3") returns 3, Version ("11.4.0") returns 0 and Version ("11.4") returns -1
        // provisionator needs the extra .0 or it will place xcode in 11.4.app rather than in 11.4.0.app
        Xcode ("11.4.0").XcodeSelect (allowUntrusted: true);
} else {
        Xcode (xcodeVersion.ToString ()).XcodeSelect (allowUntrusted: true);
}

// provisionator knows how to deal with this items
Item ("https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2020-02/41/338349925cd380cad2d19c6c15184cf22cf14800/MonoFramework-MDK-6.12.0.39.macos10.xamarin.universal.pkg");
Item ("https://bosstoragemirror.blob.core.windows.net/vsmac/3425624/release-8.4/88f89d49594ac101891944e2a6b9a0b607a6fb52/VisualStudioForMac-8.4.4.8.dmg");
Item ("");

BrewPackage ("p7zip");

void BrewPackage (string name)
{
        // Assumes brew is already installed.
        // All Macs provisioned by Xamarin, VSEng, or DDFUN should have brew by default!
        Item (name).Action (i => Exec ("brew", "install", i.Name));
}
```

The third item is empty cause it was run in my personal machine without setting the XI_PACKAGE envvar.