### PR TITLE
[src] Use `Runtime.NSLog` instead of `System.Console.WriteLine`

### DIFF
--- a/Xamarin.iOS.sln
+++ b/Xamarin.iOS.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator", "src\generator.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator-tests", "tests\generator\generator-tests.csproj", "{10790816-D00E-40A0-8653-2A8AB4DD33A9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cecil-tests", "tests\cecil-tests\cecil-tests.csproj", "{0C979851-15E9-4BB6-AD79-5F0C7DF69456}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -449,6 +451,42 @@ Global
 		{10790816-D00E-40A0-8653-2A8AB4DD33A9}.Debug|x86.Build.0 = Debug|Any CPU
 		{10790816-D00E-40A0-8653-2A8AB4DD33A9}.Release|x86.ActiveCfg = Release|Any CPU
 		{10790816-D00E-40A0-8653-2A8AB4DD33A9}.Release|x86.Build.0 = Release|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.net_2_0_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.net_2_0_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.net_2_0_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.net_2_0_Release|Any CPU.Build.0 = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.net_3_5_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.net_3_5_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.net_3_5_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.net_3_5_Release|Any CPU.Build.0 = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.net_4_0_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.net_4_0_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.net_4_0_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.net_4_0_Release|Any CPU.Build.0 = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.silverlight_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.silverlight_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.silverlight_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.silverlight_Release|Any CPU.Build.0 = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.winphone_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.winphone_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.winphone_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.winphone_Release|Any CPU.Build.0 = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Release|iPhone.Build.0 = Release|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Debug|x86.Build.0 = Debug|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Release|x86.ActiveCfg = Release|Any CPU
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{208744BD-504E-47D7-9A98-1CF02454A6DA} = {2BFA13F8-B568-48BF-9A70-9D43F718C523}
@@ -458,6 +496,7 @@ Global
 		{839212D5-C25B-4284-AA96-59C3872B8184} = {2BFA13F8-B568-48BF-9A70-9D43F718C523}
 		{9A1177F5-16E6-45DE-AA69-DC9924EC39B8} = {2BFA13F8-B568-48BF-9A70-9D43F718C523}
 		{10790816-D00E-40A0-8653-2A8AB4DD33A9} = {2BFA13F8-B568-48BF-9A70-9D43F718C523}
+		{0C979851-15E9-4BB6-AD79-5F0C7DF69456} = {2BFA13F8-B568-48BF-9A70-9D43F718C523}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -818,7 +818,7 @@ namespace Foundation {
 					obj = null;
 					cback = null;
 				} else {
-					Console.Error.WriteLine ("Warning: observer object was not disposed manually with Dispose()");
+					Runtime.NSLog ("Warning: observer object was not disposed manually with Dispose()");
 				}
 				base.Dispose (disposing);
 			}

--- a/src/ObjCRuntime/Dlfcn.cs
+++ b/src/ObjCRuntime/Dlfcn.cs
@@ -116,7 +116,7 @@ namespace ObjCRuntime {
 			// "no cache image with name (<top>)"
 			if (path.IndexOf ('/') == -1){
 				if (!warningShown){
-					Console.WriteLine ("You are using dlopen without a full path, retrying by prepending /usr/lib");
+					Runtime.NSLog ("You are using dlopen without a full path, retrying by prepending /usr/lib");
 					warningShown = true;
 				}
 				

--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -684,7 +684,7 @@ namespace Registrar {
 
 		protected override void ReportError (int code, string message, params object[] args)
 		{
-			Console.WriteLine (message, args);
+			Runtime.NSLog (String.Format (message, args));
 		}
 
 		Class.objc_attribute_prop [] GetPropertyAttributes (ObjCProperty property, out int count, bool isProtocol)

--- a/src/ObjCRuntime/ErrorHelper.runtime.cs
+++ b/src/ObjCRuntime/ErrorHelper.runtime.cs
@@ -19,7 +19,7 @@ namespace ObjCRuntime {
 				var pe = ex as ProductException;
 
 				// Show the exception
-				Console.Error.WriteLine (ex);
+				Runtime.NSLog (ex.ToString ());
 
 				// Add to list of errors if it's an error
 				if (pe?.Error == false) {

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -45,8 +45,14 @@ using R=ObjCRuntime.Runtime;
 using ProductException=ObjCRuntime.RuntimeException;
 #endif
 
+#if !MTOUCH && !MMP
+// static registrar needs them but they might not be marked (e.g. if System.Console is not used)
+[assembly: Preserve (typeof (System.Action))]
+[assembly: Preserve (typeof (System.Action<string>))]
+#endif
+
 //
-// This file cannot use any cecil code, since it's also compiled into monotouch.dll
+// This file cannot use any cecil code, since it's also compiled into Xamarin.[iOS|Mac].dll
 //
 
 #if MONOMAC
@@ -2455,8 +2461,8 @@ namespace Registrar {
 
 			if (exceptions.Count > 0) {
 				Exception ae = exceptions.Count == 1 ? exceptions [0] : new AggregateException (exceptions);
-#if !MTOUCH
-				Console.WriteLine (ae);
+#if !MTOUCH && !MMP
+				Runtime.NSLog (ae.ToString ());
 #endif
 				throw ae;
 			}

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -186,16 +186,16 @@ namespace ObjCRuntime {
 #endif
 			if (options->Size != Marshal.SizeOf (typeof (InitializationOptions))) {
 				string msg = "Version mismatch between the native " + ProductName + " runtime and " + AssemblyName + ". Please reinstall " + ProductName + ".";
-				Console.Error.WriteLine (msg);
+				NSLog (msg);
 #if MONOMAC
 				try {
 					// Print out where Xamarin.Mac.dll and the native runtime was loaded from.
-					Console.Error.WriteLine (AssemblyName + " was loaded from {0}", typeof (nint).Assembly.Location);
+					NSLog (AssemblyName + " was loaded from {0}", typeof (nint).Assembly.Location);
 
 					var sym2 = Dlfcn.dlsym (Dlfcn.RTLD.Default, "xamarin_initialize");
 					Dlfcn.Dl_info info2;
 					if (Dlfcn.dladdr (sym2, out info2) == 0) {
-						Console.Error.WriteLine ("The native runtime was loaded from {0}", Marshal.PtrToStringAuto (info2.dli_fname));
+						NSLog ("The native runtime was loaded from {0}", Marshal.PtrToStringAuto (info2.dli_fname));
 					} else if (Dlfcn.dlsym (Dlfcn.RTLD.MainOnly, "xamarin_initialize") != IntPtr.Zero) {
 						byte[] buf = new byte [128];
 						int length = buf.Length;
@@ -203,7 +203,7 @@ namespace ObjCRuntime {
 							Array.Resize (ref buf, length);
 							length = buf.Length;
 							if (_NSGetExecutablePath (buf, ref length) != 0) {
-								Console.Error.WriteLine ("Could not find out where the native runtime was loaded from.");
+								NSLog ("Could not find out where the native runtime was loaded from.");
 								buf = null;
 							}
 						}
@@ -211,10 +211,10 @@ namespace ObjCRuntime {
 							var strlength = 0;
 							for (int i = 0; i < buf.Length && buf [i] != 0; i++)
 								strlength++;
-							Console.Error.WriteLine ("The native runtime was loaded from {0}", System.Text.Encoding.UTF8.GetString (buf, 0, strlength));
+							NSLog ("The native runtime was loaded from {0}", System.Text.Encoding.UTF8.GetString (buf, 0, strlength));
 						}
 					} else {
-						Console.Error.WriteLine ("Could not find out where the native runtime was loaded from.");
+						NSLog ("Could not find out where the native runtime was loaded from.");
 					}
 				} catch {
 					// Just ignore any exceptions, the above code is just a debug help, and if it fails,
@@ -227,7 +227,7 @@ namespace ObjCRuntime {
 			if (IntPtr.Size != sizeof (nint)) {
 				string msg = string.Format ("Native type size mismatch between " + AssemblyName + " and the executing architecture. " + AssemblyName + " was built for {0}-bit, while the current process is {1}-bit.", 
 					IntPtr.Size == 4 ? "64" : "32", IntPtr.Size == 4 ? "32" : "64");
-				Console.Error.WriteLine (msg);
+				NSLog (msg);
 				throw ErrorHelper.CreateError (8010, msg);
 			}
 
@@ -505,7 +505,7 @@ namespace ObjCRuntime {
 				if (register_entry_assembly)
 					CollectReferencedAssemblies (assemblies, entry_assembly);
 			} else {
-				Console.WriteLine ("Could not find the entry assembly.");
+				NSLog ("Could not find the entry assembly.");
 			}
 
 #if MONOMAC

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1568,6 +1568,22 @@ namespace ObjCRuntime {
 		extern static void NSLog (IntPtr format, [MarshalAs (UnmanagedType.LPStr)] string s);
 #endif
 
+#if MONOMAC
+		[DllImport ("__Internal")]
+		extern static void xamarin_log (string s);
+		internal static void NSLog (string s)
+		{
+			if (PlatformHelper.CheckSystemVersion (10, 12)) {
+				Console.WriteLine (s);
+			} else {
+				xamarin_log (s);
+			}
+		}
+#else
+		[DllImport ("__Internal", EntryPoint="xamarin_log", CharSet=CharSet.Unicode)]
+		internal extern static void NSLog (string s);
+#endif
+
 #if !MONOMAC
 		[DllImport (Constants.FoundationLibrary, EntryPoint = "NSLog")]
 		extern static void NSLog_arm64 (IntPtr format, IntPtr p2, IntPtr p3, IntPtr p4, IntPtr p5, IntPtr p6, IntPtr p7, IntPtr p8, [MarshalAs (UnmanagedType.LPStr)] string s);

--- a/src/ObjCRuntime/RuntimeOptions.cs
+++ b/src/ObjCRuntime/RuntimeOptions.cs
@@ -157,7 +157,7 @@ namespace ObjCRuntime {
 			var handler_name = options?.http_message_handler;
 #if __WATCHOS__
 			if (handler_name != null && handler_name != NSUrlSessionHandlerValue)
-				Console.WriteLine ($"{handler_name} is not a valid HttpMessageHandler, defaulting to NSUrlSessionHandler");
+				Runtime.NSLog ($"{handler_name} is not a valid HttpMessageHandler, defaulting to NSUrlSessionHandler");
 			return new NSUrlSessionHandler ();
 #else
 			switch (handler_name) {
@@ -167,7 +167,7 @@ namespace ObjCRuntime {
 					return new NSUrlSessionHandler ();
 				default:
 					if (handler_name != null && handler_name != HttpClientHandlerValue)
-						Console.WriteLine ($"{handler_name} is not a valid HttpMessageHandler, defaulting to System.Net.Http.HttpClientHandler");
+						Runtime.NSLog ($"{handler_name} is not a valid HttpMessageHandler, defaulting to System.Net.Http.HttpClientHandler");
 					return new HttpClientHandler ();
 			}
 #endif

--- a/src/Security/SslContext.cs
+++ b/src/Security/SslContext.cs
@@ -543,7 +543,7 @@ namespace Security {
 		[Obsolete ("'SetSessionStrengthPolicy' is not available anymore.")]
 		public SslStatus SetSessionStrengthPolicy (SslSessionStrengthPolicy policyStrength)
 		{
-			Console.WriteLine ("SetSessionStrengthPolicy is not available anymore.");
+			Runtime.NSLog ("SetSessionStrengthPolicy is not available anymore.");
 			return SslStatus.Success;
 		}
 #endif

--- a/src/UIKit/UIButton.cs
+++ b/src/UIKit/UIButton.cs
@@ -28,7 +28,7 @@ namespace UIKit {
 			if (GetType () == typeof(UIButton))
 				return;
 
-			Console.WriteLine ("The UIButton subclass {0} called the (UIButtonType) constructor, but this is not allowed. Please use the default UIButton constructor from subclasses.\n{1}", GetType (), Environment.StackTrace);
+			Runtime.NSLog ("The UIButton subclass {0} called the (UIButtonType) constructor, but this is not allowed. Please use the default UIButton constructor from subclasses.\n{1}", GetType (), Environment.StackTrace);
 		}
 	}
 }

--- a/tests/cecil-tests/Test.cs
+++ b/tests/cecil-tests/Test.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 using NUnit.Framework;
 
@@ -85,6 +86,22 @@ namespace Cecil.Tests {
 				else
 					return; // single case, no point in iterating anymore
 			}
+		}
+
+		[TestCaseSource (typeof (Helper), "PlatformAssemblies")]
+		public void NoSystemConsoleReference (string assemblyPath)
+		{
+			if (Path.GetFileName (assemblyPath) == "Xamarin.Mac.dll")
+				Assert.Ignore ("Xamarin.Mac has a workaround for Sierra bug w/NSLog");
+
+			var assembly = Helper.GetAssembly (assemblyPath);
+			if (assembly == null) {
+				Assert.Ignore ("{assemblyPath} could not be found (might be disabled in build)");
+				return; // just to help nullability
+			}
+			// this has a quite noticable impact on (small) app size
+			if (assembly.MainModule.TryGetTypeReference ("System.Console", out var _))
+				Assert.Fail ($"{assemblyPath} has a reference to `System.Console`. Please use `Runtime.NSLog` inside the platform assemblies");
 		}
 	}
 }


### PR DESCRIPTION
inside the product assemblies [1]. The latter brings a lot [2] of the BCL
into the application for, eventually, ending up back to `NSLog` anyway

Also include a, cecil-based, test to ensure we don't regress.

[1] except for Xamarin.Mac.dll since there's a workaround for a
Sierra (only) bug

[2] https://gist.github.com/spouliot/c63343c1a76f4e49248be3a2c7aa25ed

* **A** `/Users/poupou/Desktop/linker.app/`
* **B** `/Users/poupou/Projects/linker/linker/bin/iPhone/Release/linker.app/`

| Directories / Files |  A  |  B  | diff |  %  |
| ------------------- | --: | --: | ---: | --: |
| ./_CodeSignature | | | | ||     CodeResources | 12,583 | 12,583 | 0 | 0.0% |
| ./ | | | | ||     AppIcon20x20@2x.png | 695 | 695 | 0 | 0.0% |
|     AppIcon20x20@2x~ipad.png | 695 | 695 | 0 | 0.0% |
|     AppIcon20x20@3x.png | 1,449 | 1,449 | 0 | 0.0% |
|     AppIcon20x20~ipad.png | 1,128 | 1,128 | 0 | 0.0% |
|     AppIcon29x29@2x.png | 1,069 | 1,069 | 0 | 0.0% |
|     AppIcon29x29@2x~ipad.png | 1,069 | 1,069 | 0 | 0.0% |
|     AppIcon29x29@3x.png | 1,945 | 1,945 | 0 | 0.0% |
|     AppIcon29x29~ipad.png | 492 | 492 | 0 | 0.0% |
|     AppIcon40x40@2x.png | 1,834 | 1,834 | 0 | 0.0% |
|     AppIcon40x40@2x~ipad.png | 1,834 | 1,834 | 0 | 0.0% |
|     AppIcon40x40@3x.png | 2,632 | 2,632 | 0 | 0.0% |
|     AppIcon40x40~ipad.png | 695 | 695 | 0 | 0.0% |
|     AppIcon60x60@2x.png | 2,632 | 2,632 | 0 | 0.0% |
|     AppIcon60x60@3x.png | 3,624 | 3,624 | 0 | 0.0% |
|     AppIcon76x76@2x~ipad.png | 3,125 | 3,125 | 0 | 0.0% |
|     AppIcon76x76~ipad.png | 1,699 | 1,699 | 0 | 0.0% |
|     AppIcon83.5x83.5@2x~ipad.png | 3,369 | 3,369 | 0 | 0.0% |
|     archived-expanded-entitlements.xcent | 181 | 181 | 0 | 0.0% |
|     Assets.car | 75,128 | 75,128 | 0 | 0.0% |
|     embedded.mobileprovision | 8,184 | 8,184 | 0 | 0.0% |
|     Info.plist | 1,785 | 1,785 | 0 | 0.0% |
|     linker | 4,018,784 | 3,747,984 | -270,800 | -6.7% |
|     linker.aotdata.arm64 | 1,240 | 1,240 | 0 | 0.0% |
|     linker.exe | 6,144 | 6,144 | 0 | 0.0% |
|     mscorlib.aotdata.arm64 | 376,648 | 296,544 | -80,104 | -21.3% |
|     mscorlib.dll | 478,720 | 406,528 | -72,192 | -15.1% |
|     NOTICE | 159 | 159 | 0 | 0.0% |
|     PkgInfo | 8 | 8 | 0 | 0.0% |
|     System.aotdata.arm64 | 752 | 752 | 0 | 0.0% |
|     System.dll | 4,608 | 4,608 | 0 | 0.0% |
|     Xamarin.iOS.aotdata.arm64 | 34,152 | 33,592 | -560 | -1.6% |
|     Xamarin.iOS.dll | 53,760 | 52,736 | -1,024 | -1.9% |
| ./LaunchScreen.storyboardc | | | | ||     01J-lp-oVM-view-Ze5-6b-2t3.nib | 1,832 | 1,833 | 1 | 0.1% |
|     Info.plist | 258 | 258 | 0 | 0.0% |
|     UIViewController-01J-lp-oVM.nib | 896 | 896 | 0 | 0.0% |
| ./Main.storyboardc | | | | ||     BYZ-38-t0r-view-8bC-Xf-vdC.nib | 1,833 | 1,832 | -1 | -0.1% |
|     Info.plist | 258 | 258 | 0 | 0.0% |
|     UIViewController-BYZ-38-t0r.nib | 916 | 916 | 0 | 0.0% |
| | | | | |
| **Statistics** | | | | |
| | | | | |
| Native subtotal | 4,018,784 | 3,747,984 | -270,800 | -6.7% |
|     Executable | 4,018,784 | 3,747,984 | -270,800 | -6.7% |
|     AOT data *.aotdata | 0 | 0 | 0 | -   |
| | | | | |
| Managed *.dll/exe | 543,232 | 470,016 | -73,216 | -13.5% |
| | | | | |
| **TOTAL** | 5,108,815 | 4,684,135 | -424,680 | -8.3% |