### PR TITLE
page through github statuses for manifest URL

### DIFF
--- a/tools/devops/utils.csx
+++ b/tools/devops/utils.csx
@@ -36,14 +36,12 @@ string GetManifestUrl (string hash)
 {
 	var page = 1;
 	var hasContent = true;
-	while (manifest_url == null && hasContent)
-	{
+	while (manifest_url == null && hasContent) {
 		var url = $"https://api.github.com/repos/xamarin/xamarin-macios/statuses/{hash}?page={page}";
 		var json = JToken.Parse (DownloadWithGithubAuth (url));
 		var statuses = (JValue) ((JArray) json);
 		hasContent &= statuses.HasValues;
-		if (hasContent)
-		{
+		if (hasContent) {
 			var value = statuses.Where ((v) => v ["context"].ToString () == "manifest").Select ((v) => v ["target_url"]).FirstOrDefault ();
 			manifest_url = (string) value?.Value;
 		}

--- a/tools/devops/utils.csx
+++ b/tools/devops/utils.csx
@@ -34,14 +34,25 @@ string DownloadWithGithubAuth (string uri)
 string manifest_url = null;
 string GetManifestUrl (string hash)
 {
-	if (manifest_url == null) {
-		var url = $"https://api.github.com/repos/xamarin/xamarin-macios/statuses/{hash}";
-		var json = JToken.Parse (DownloadWithGithubAuth (url));
-		var value = (JValue) ((JArray) json).Where ((v) => v ["context"].ToString () == "manifest").Select ((v) => v ["target_url"]).FirstOrDefault ();
-		manifest_url = (string) value?.Value;
-		if (manifest_url == null)
-			throw new Exception ($"Could not find the manifest for {hash}. Is the commit already built by CI?");
+	var page = 1;
+	var hasContent = true;
+	while (manifest_url == null && hasContent)
+	{
+		var url = $"https://api.github.com/repos/xamarin/xamarin-macios/statuses/{hash}?page={page}";
+		var content = DownloadWithGithubAuth (url);
+		hasContent &= !String.IsNullOrEmpty(content);
+		if (hasContent)
+		{
+			var json = JToken.Parse (content);
+			var value = (JValue) ((JArray) json).Where ((v) => v ["context"].ToString () == "manifest").Select ((v) => v ["target_url"]).FirstOrDefault ();
+			manifest_url = (string) value?.Value;
+		}
+		page++;
 	}
+
+	if (manifest_url == null)
+		throw new Exception ($"Could not find the manifest for {hash}. Is the commit already built by CI?");
+
 	return manifest_url;
 }
 

--- a/tools/devops/utils.csx
+++ b/tools/devops/utils.csx
@@ -39,12 +39,12 @@ string GetManifestUrl (string hash)
 	while (manifest_url == null && hasContent)
 	{
 		var url = $"https://api.github.com/repos/xamarin/xamarin-macios/statuses/{hash}?page={page}";
-		var content = DownloadWithGithubAuth (url);
-		hasContent &= !String.IsNullOrEmpty(content);
+		var json = JToken.Parse (DownloadWithGithubAuth (url));
+		var statuses = (JValue) ((JArray) json);
+		hasContent &= statuses.HasValues;
 		if (hasContent)
 		{
-			var json = JToken.Parse (content);
-			var value = (JValue) ((JArray) json).Where ((v) => v ["context"].ToString () == "manifest").Select ((v) => v ["target_url"]).FirstOrDefault ();
+			var value = statuses.Where ((v) => v ["context"].ToString () == "manifest").Select ((v) => v ["target_url"]).FirstOrDefault ();
 			manifest_url = (string) value?.Value;
 		}
 		page++;


### PR DESCRIPTION
Fixes (as seen by [CI](https://dev.azure.com/xamarin/internal/_build/results?buildId=18702&view=logs&j=307a3e1d-f0f2-5a3d-98c5-8c16e3f24b09&t=1ea22bc9-7602-5454-032c-4e9789b26d98)):
```
Unhandled exception. System.Exception: Could not find the manifest for 89d621e37355592d071ce92b9f58e7bcbdf322f0. Is the commit already built by CI?
```

There are so many statuses on the commit that the `manifest` status gets pushed back to a different page.