### PR TITLE
[msbuild] missing localization comments - part 2

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -371,6 +371,10 @@
     <data name="E0085" xml:space="preserve">
         <value>Could not locate the {0} '{1}' SDK usr path at '{2}'
         </value>
+        <comment>The provided SDK path is missing a 'usr' directory. The following are literal names and should not be translated: SDK, usr
+{0} - The platform name, such as 'iOS'.
+{1} - The version number of the SDK.
+{2} - The file path of the SDK.</comment>
     </data>
         
     <data name="E0086" xml:space="preserve">

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
@@ -293,7 +293,10 @@
         </source>
         <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note />
+        <note>The provided SDK path is missing a 'usr' directory. The following are literal names and should not be translated: SDK, usr
+{0} - The platform name, such as 'iOS'.
+{1} - The version number of the SDK.
+{2} - The file path of the SDK.</note>
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
@@ -293,7 +293,10 @@
         </source>
         <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note />
+        <note>The provided SDK path is missing a 'usr' directory. The following are literal names and should not be translated: SDK, usr
+{0} - The platform name, such as 'iOS'.
+{1} - The version number of the SDK.
+{2} - The file path of the SDK.</note>
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
@@ -293,7 +293,10 @@
         </source>
         <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note />
+        <note>The provided SDK path is missing a 'usr' directory. The following are literal names and should not be translated: SDK, usr
+{0} - The platform name, such as 'iOS'.
+{1} - The version number of the SDK.
+{2} - The file path of the SDK.</note>
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
@@ -293,7 +293,10 @@
         </source>
         <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note />
+        <note>The provided SDK path is missing a 'usr' directory. The following are literal names and should not be translated: SDK, usr
+{0} - The platform name, such as 'iOS'.
+{1} - The version number of the SDK.
+{2} - The file path of the SDK.</note>
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
@@ -293,7 +293,10 @@
         </source>
         <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note />
+        <note>The provided SDK path is missing a 'usr' directory. The following are literal names and should not be translated: SDK, usr
+{0} - The platform name, such as 'iOS'.
+{1} - The version number of the SDK.
+{2} - The file path of the SDK.</note>
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
@@ -293,7 +293,10 @@
         </source>
         <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note />
+        <note>The provided SDK path is missing a 'usr' directory. The following are literal names and should not be translated: SDK, usr
+{0} - The platform name, such as 'iOS'.
+{1} - The version number of the SDK.
+{2} - The file path of the SDK.</note>
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
@@ -293,7 +293,10 @@
         </source>
         <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note />
+        <note>The provided SDK path is missing a 'usr' directory. The following are literal names and should not be translated: SDK, usr
+{0} - The platform name, such as 'iOS'.
+{1} - The version number of the SDK.
+{2} - The file path of the SDK.</note>
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
@@ -293,7 +293,10 @@
         </source>
         <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note />
+        <note>The provided SDK path is missing a 'usr' directory. The following are literal names and should not be translated: SDK, usr
+{0} - The platform name, such as 'iOS'.
+{1} - The version number of the SDK.
+{2} - The file path of the SDK.</note>
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
@@ -293,7 +293,10 @@
         </source>
         <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note />
+        <note>The provided SDK path is missing a 'usr' directory. The following are literal names and should not be translated: SDK, usr
+{0} - The platform name, such as 'iOS'.
+{1} - The version number of the SDK.
+{2} - The file path of the SDK.</note>
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
@@ -293,7 +293,10 @@
         </source>
         <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note />
+        <note>The provided SDK path is missing a 'usr' directory. The following are literal names and should not be translated: SDK, usr
+{0} - The platform name, such as 'iOS'.
+{1} - The version number of the SDK.
+{2} - The file path of the SDK.</note>
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
@@ -293,7 +293,10 @@
         </source>
         <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note />
+        <note>The provided SDK path is missing a 'usr' directory. The following are literal names and should not be translated: SDK, usr
+{0} - The platform name, such as 'iOS'.
+{1} - The version number of the SDK.
+{2} - The file path of the SDK.</note>
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
@@ -293,7 +293,10 @@
         </source>
         <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note />
+        <note>The provided SDK path is missing a 'usr' directory. The following are literal names and should not be translated: SDK, usr
+{0} - The platform name, such as 'iOS'.
+{1} - The version number of the SDK.
+{2} - The file path of the SDK.</note>
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
@@ -293,7 +293,10 @@
         </source>
         <target state="new">Could not locate the {0} '{1}' SDK usr path at '{2}'
         </target>
-        <note />
+        <note>The provided SDK path is missing a 'usr' directory. The following are literal names and should not be translated: SDK, usr
+{0} - The platform name, such as 'iOS'.
+{1} - The version number of the SDK.
+{2} - The file path of the SDK.</note>
       </trans-unit>
       <trans-unit id="E0086">
         <source>Could not find a valid Xcode developer path


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-macios/issues/8494

Added a missing `<comment/>` field for `E0085`.