### PR TITLE
[jenkins] Timeout the tests on older macOS bots after 15 minutes.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -881,12 +881,14 @@ timestamps {
                                             }
                                             builders [nodeText] = {
                                                 try {
-                                                    if (excluded) {
-                                                        echo (nodeText)
-                                                    } else {
-                                                        node ("xamarin-macios && macos-10.${macOS}") {
-                                                            stage ("Running XM tests on '10.${macOS}'") {
-                                                                runXamarinMacTests (url, "macOS 10.${macOS}", maccore_hash, gitHash)
+                                                    timeout (time: 15, unit: 'MINUTES') {
+                                                        if (excluded) {
+                                                            echo (nodeText)
+                                                        } else {
+                                                            node ("xamarin-macios && macos-10.${macOS}") {
+                                                                stage ("Running XM tests on '10.${macOS}'") {
+                                                                    runXamarinMacTests (url, "macOS 10.${macOS}", maccore_hash, gitHash)
+                                                                }
                                                             }
                                                         }
                                                     }


### PR DESCRIPTION
Prevents deadlocks from holding up everything for hours:
https://jenkins.internalx.com/blue/organizations/jenkins/macios/detail/master/1583/pipeline/271/