### PR TITLE
Fix old-style provisioning by using a non-composed variable for XCODE_URL.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -60,8 +60,7 @@ IOS_PACKAGE_UPDATE_ID=$(shell printf "2%02d%02d%02d%03d" $(IOS_PACKAGE_VERSION_M
 
 # Xcode version should have both a major and a minor version (even if the minor version is 0)
 XCODE_VERSION=11.5
-XCODE_XIP_NAME=Xcode_11.5.xip
-XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/$(XCODE_XIP_NAME)
+XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_11.5.xip
 XCODE_DEVELOPER_ROOT=/Applications/Xcode_11.5.0.app/Contents/Developer
 XCODE_PRODUCT_BUILD_VERSION:=$(shell /usr/libexec/PlistBuddy -c 'Print :ProductBuildVersion' $(XCODE_DEVELOPER_ROOT)/../version.plist)
 

--- a/tools/devops/Makefile
+++ b/tools/devops/Makefile
@@ -3,7 +3,7 @@ include $(TOP)/Make.config
 
 device-tests-provisioning.csx: device-tests-provisioning.csx.in Makefile $(TOP)/Make.config
 	$(Q_GEN) sed \
-		-e 's#@XCODE_XIP_NAME@#$(XCODE_XIP_NAME)#g' \
+		-e 's#@XCODE_XIP_NAME@#$(notdir $(XCODE_URL))#g' \
 		-e 's#@XI_PACKAGE@#$(XI_PACKAGE)#g' \
 		-e 's#@MONO_PACKAGE@#$(MIN_MONO_URL)#g' \
 		-e 's#@VS_PACKAGE@#$(MIN_VISUAL_STUDIO_URL)#g' \


### PR DESCRIPTION
Fixes this:

    Checking system...
        Found OSX 10.15.3 (at least 10.15 is required)
            Downloading Xcode 11.5 from http://xamarin-storage/bot-provisioning/xcodes/$(XCODE_XIP_NAME) to /tmp/x-provisioning...