### PR TITLE
[dotnet] Add the Sdk build files to the Sdk NuGet.

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -5,19 +5,53 @@ include $(TOP)/mk/rules.mk
 
 PLATFORMS=iOS tvOS watchOS macOS
 
-IOS_RIDS=arm64 arm x86 x64
-TVOS_RIDS=arm64 x64
-WATCHOS_RIDS=arm x86
-MACOS_RIDS=x64
+IOS_RIDS=$(subst ios-,,$(DOTNET_IOS_RUNTIME_IDENTIFIERS))
+TVOS_RIDS=$(subst tvos-,,$(DOTNET_TVOS_RUNTIME_IDENTIFIERS))
+WATCHOS_RIDS=$(subst watchos-,,$(DOTNET_WATCHOS_RUNTIME_IDENTIFIERS))
+MACOS_RIDS=$(subst osx-,,$(DOTNET_MACOS_RUNTIME_IDENTIFIERS))
+
+NUGET_TARGETS += \
+	$(foreach platform,$(PLATFORMS), \
+		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/Sdk/Sdk.targets \
+		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/Sdk/Sdk.props \
+		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Microsoft.$(platform).Sdk.DefaultItems.props \
+		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Microsoft.$(platform).Sdk.props \
+		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Microsoft.$(platform).Sdk.targets \
+		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Microsoft.$(platform).TargetFrameworkInference.targets \
+		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Xamarin.Shared.Sdk.DefaultItems.props \
+		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Xamarin.Shared.Sdk.DefaultItems.targets \
+		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Xamarin.Shared.Sdk.props \
+		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Xamarin.Shared.Sdk.TargetFrameworkInference.targets \
+		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Xamarin.Shared.Sdk.targets \
+		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Xamarin.Shared.Sdk.Versions.props \
+		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Xamarin.Shared.Sdk.Versions.template.props \
+	)
 
 DIRECTORIES += \
 	$(DOTNET_NUPKG_DIR) \
 	$(DOTNET_FEED_DIR) \
+	$(foreach platform,$(PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/Sdk) \
+	$(foreach platform,$(PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets) \
 
 $(DIRECTORIES):
 	$(Q) mkdir -p $@
 
 CURRENT_HASH_LONG:=$(shell git log -1 --pretty=%H)
+
+$(DOTNET_DESTDIR)/Microsoft.%: Microsoft.% | $(foreach platform,$(PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/Sdk $(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets)
+	$(Q) $(CP) $< $@
+
+$(DOTNET_DESTDIR)/Microsoft.iOS.Sdk/targets/%: targets/% | $(DOTNET_DESTDIR)/Microsoft.iOS.Sdk/targets
+	$(Q) $(CP) $< $@
+
+$(DOTNET_DESTDIR)/Microsoft.tvOS.Sdk/targets/%: targets/% | $(DOTNET_DESTDIR)/Microsoft.tvOS.Sdk/targets
+	$(Q) $(CP) $< $@
+
+$(DOTNET_DESTDIR)/Microsoft.watchOS.Sdk/targets/%: targets/% | $(DOTNET_DESTDIR)/Microsoft.watchOS.Sdk/targets
+	$(Q) $(CP) $< $@
+
+$(DOTNET_DESTDIR)/Microsoft.macOS.Sdk/targets/%: targets/% | $(DOTNET_DESTDIR)/Microsoft.macOS.Sdk/targets
+	$(Q) $(CP) $< $@
 
 targets/%.props: targets/%.template.props Makefile $(TOP)/Make.config.inc
 	$(Q_GEN) sed \
@@ -47,7 +81,7 @@ nupkgs/$(WATCHOS_NUGET).%.nupkg: CURRENT_VERSION_FULL=$(WATCHOS_NUGET_VERSION_FU
 nupkgs/$(MACOS_NUGET).%.nupkg: CURRENT_VERSION_FULL=$(MACOS_NUGET_VERSION_FULL)
 
 # Create the nuget in a temporary directory (nupkgs/)
-nupkgs/%.nupkg: $(TEMPLATED_FILES)
+nupkgs/%.nupkg: $(TEMPLATED_FILES) $(NUGET_TARGETS)
 	$(Q) rm -f $@
 	$(Q_PACK) $(DOTNET5) pack package/$(shell echo $(notdir $@) | sed 's/[.]$(CURRENT_VERSION_FULL).*//')/package.csproj --output "$(dir $@)" $(DOTNET_PACK_VERBOSITY)
 	@# Nuget pack doesn't add the metadata to the filename, but we want that, so rename nuget to contain the full name

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 TOP = ..
-SUBDIRS=test-libraries
+SUBDIRS=test-libraries dotnet
 
 # disabled for now: mac-test
 

--- a/tests/dotnet/.gitignore
+++ b/tests/dotnet/.gitignore
@@ -1,0 +1,3 @@
+global.json
+NuGet.config
+

--- a/tests/dotnet/Makefile
+++ b/tests/dotnet/Makefile
@@ -1,0 +1,29 @@
+TOP=../..
+
+include $(TOP)/Make.config
+
+# This tells NuGet to use the nupkgs we're building locally,
+# and to put any extracted packages in the 'packages' directory (to not clutter up ~/.nuget/packages)
+NuGet.config: $(TOP)/NuGet.config Makefile
+	$(Q) $(CP) $< $@.tmp
+	$(Q) nuget sources add -Name local-dotnet-feed -Source $(abspath $(DOTNET_FEED_DIR)) -ConfigFile $@.tmp
+	$(Q) nuget config -Set globalPackagesFolder=packages -Config $@.tmp
+	$(Q) mv $@.tmp $@
+
+# This tells NuGet to use the version we're building locally.
+global.json: $(TOP)/Make.config.inc Makefile
+	$(Q_GEN) \
+		printf "{\n" > $@; \
+		printf "\t\"sdk\": { \"version\": \"5.*\" },\n" >> $@; \
+		printf "\t\"msbuild-sdks\": {\n" >> $@; \
+		printf "\t\t\"Microsoft.iOS.Sdk\": \"$(IOS_NUGET_VERSION_NO_METADATA)\",\n" >> $@; \
+		printf "\t\t\"Microsoft.tvOS.Sdk\": \"$(TVOS_NUGET_VERSION_NO_METADATA)\",\n" >> $@; \
+		printf "\t\t\"Microsoft.watchOS.Sdk\": \"$(WATCHOS_NUGET_VERSION_NO_METADATA)\",\n" >> $@; \
+		printf "\t\t\"Microsoft.macOS.Sdk\": \"$(MACOS_NUGET_VERSION_NO_METADATA)\"\n" >> $@; \
+		printf "\t}\n}\n" >> $@
+
+TARGETS += \
+	NuGet.config \
+	global.json \
+
+all-local:: $(TARGETS)

--- a/tests/dotnet/MySingleView/AppDelegate.cs
+++ b/tests/dotnet/MySingleView/AppDelegate.cs
@@ -1,0 +1,15 @@
+using System;
+
+using Foundation;
+using UIKit;
+
+namespace MySingleView
+{
+	public partial class AppDelegate : UIApplicationDelegate
+	{
+		public override UIWindow Window {
+			get;
+			set;
+		}
+	}
+}

--- a/tests/dotnet/MySingleView/Entitlements.plist
+++ b/tests/dotnet/MySingleView/Entitlements.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/tests/dotnet/MySingleView/Info.plist
+++ b/tests/dotnet/MySingleView/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIMainStoryboardFile</key>
+	<string>MainStoryboard</string>
+	<key>MinimumOSVersion</key>
+	<string>7.0</string>
+	<key>CFBundleDisplayName</key>
+	<string>ApplicationName</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.your-company.mysingleview</string>
+	<key>XSAppIconAssets</key>
+	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
+	<key>XSLaunchImageAssets</key>
+	<string>Resources/Images.xcassets/LaunchImage.launchimage</string>
+</dict>
+</plist>

--- a/tests/dotnet/MySingleView/Main.cs
+++ b/tests/dotnet/MySingleView/Main.cs
@@ -1,0 +1,15 @@
+using System;
+
+using Foundation;
+using UIKit;
+
+namespace MySingleView
+{
+	public class Application
+	{
+		static void Main (string[] args)
+		{
+			UIApplication.Main (args, null, typeof (AppDelegate));
+		}
+	}
+}

--- a/tests/dotnet/MySingleView/MainStoryboard.storyboard
+++ b/tests/dotnet/MySingleView/MainStoryboard.storyboard
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="1.0" toolsVersion="1938" systemVersion="11C74" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="1">
+    <dependencies>
+        <development defaultVersion="4200" identifier="xcode"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="933"/>
+    </dependencies>
+    <scenes>
+        <scene sceneID="0">
+            <objects>
+                <viewController id="1" sceneMemberID="viewController" customClass="MySingleViewViewController">
+                    <view key="view" contentMode="scaleToFill" id="2">
+                        <rect key="frame" x="0.0" y="20" width="320" height="460"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="5">
+                                <rect key="frame" x="124" y="81" width="72" height="37"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                <state key="normal" title="Button">
+                                    <color key="titleColor" red="0.196078" green="0.3098" blue="0.52157" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <state key="highlighted">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                            </button>
+                        </subviews>
+                    </view>
+                    <connections>
+                        <outlet property="MyButton" destination="5" id="name-outlet-5"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="3" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-313" y="-220"/>
+        </scene>
+    </scenes>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar" statusBarStyle="blackTranslucent"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination"/>
+    </simulatedMetricsContainer>
+    <resources/>
+</document>

--- a/tests/dotnet/MySingleView/MySingleView.csproj
+++ b/tests/dotnet/MySingleView/MySingleView.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.iOS.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet/MySingleView/MySingleViewViewController.cs
+++ b/tests/dotnet/MySingleView/MySingleViewViewController.cs
@@ -1,0 +1,28 @@
+using System;
+using CoreGraphics;
+using Foundation;
+using UIKit;
+
+namespace MySingleView
+{
+	public partial class MySingleViewViewController : UIViewController
+	{
+		public MySingleViewViewController (IntPtr handle) : base (handle)
+		{
+		}
+
+		public override void ViewDidLoad ()
+		{
+			base.ViewDidLoad ();
+			
+			MyButton.SetTitle ("net5!", UIControlState.Normal);
+		}
+
+		public override bool ShouldAutorotateToInterfaceOrientation (UIInterfaceOrientation toInterfaceOrientation)
+		{
+			// Return true for supported orientations
+			return (toInterfaceOrientation != UIInterfaceOrientation.PortraitUpsideDown);
+		}
+	}
+}
+

--- a/tests/dotnet/MySingleView/MySingleViewViewController.designer.cs
+++ b/tests/dotnet/MySingleView/MySingleViewViewController.designer.cs
@@ -1,0 +1,26 @@
+//
+// This file has been generated automatically by MonoDevelop to store outlets and
+// actions made in the Xcode designer. If it is removed, they will be lost.
+// Manual changes to this file may not be handled correctly.
+//
+using Foundation;
+using System.CodeDom.Compiler;
+
+namespace MySingleView
+{
+	[Register ("MySingleViewViewController")]
+	partial class MySingleViewViewController
+	{
+		[Outlet]
+		[GeneratedCode ("iOS Designer", "1.0")]
+		UIKit.UIButton MyButton { get; set; }
+
+		void ReleaseDesignerOutlets ()
+		{
+			if (MyButton != null) {
+				MyButton.Dispose ();
+				MyButton = null;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Also add a very simple net5 test app (which doesn't build yet).

Current (expected) build result:

    > xamarin-macios/tests/dotnet/MySingleView $ dotnet build
    Microsoft (R) Build Engine version 16.7.0-preview-20258-02+26f6d1d87 for .NET
    Copyright (C) Microsoft Corporation. All rights reserved.

      Determining projects to restore...
    xamarin-macios/tests/dotnet/MySingleView/MySingleView.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Runtime.ios-x64 with version (= 5.0.0-preview.6.20264.1)
    xamarin-macios/tests/dotnet/MySingleView/MySingleView.csproj : error NU1102:   - Found 1 version(s) in nuget.org [ Nearest version: 5.0.0-preview.4.20251.6 ]
    xamarin-macios/tests/dotnet/MySingleView/MySingleView.csproj : error NU1102:   - Found 1 version(s) in Nuget Official [ Nearest version: 5.0.0-preview.4.20251.6 ]
    xamarin-macios/tests/dotnet/MySingleView/MySingleView.csproj : error NU1102:   - Found 0 version(s) in local-dotnet-feed
    xamarin-macios/tests/dotnet/MySingleView/MySingleView.csproj : error NU1102:   - Found 0 version(s) in Dotnet arcade
      Failed to restore xamarin-macios/tests/dotnet/MySingleView/MySingleView.csproj (in 951 ms).

This fails because the .NET build logic isn't being told that it should look
for the mono runtime packs instead of the .NET Core runtime packs.