### PR TITLE
[xharness] Fix showing unit test failure list and summary when there are many failing tests.

### DIFF
--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -1706,17 +1706,17 @@ namespace Xharness.Jenkins {
 														if (line.StartsWith ("Tests run:", StringComparison.Ordinal)) {
 															summary = line;
 														} else if (line.StartsWith ("[FAIL]", StringComparison.Ordinal)) {
-															fails.Add (line);
+															if (fails.Count < 100) {
+																fails.Add (line);
+															} else if (fails.Count == 100) {
+																fails.Add ("...");
+															}
 														}
 													}
 												} else {
 													var data_tuple = (Tuple<string, List<string>>) data.Item2;
 													summary = data_tuple.Item1;
 													fails = data_tuple.Item2;
-												}
-												if (fails.Count > 100) {
-													fails.Add ("...");
-													break;
 												}
 											}
 											if (fails.Count > 0) {


### PR DESCRIPTION
We'd check for more than 100 tests in the wrong location, and completely break
out of showing anything at all.