### PR TITLE
[Harness] Move the logic to reload the simulators outside Jenkins.

### DIFF
--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -60,8 +60,8 @@ namespace Xharness.Jenkins {
 		public bool UninstallTestApp = true;
 
 		public ILog MainLog;
-		public ILog SimulatorLoadLog;
-		public ILog DeviceLoadLog;
+		public ILog SimulatorLoadLog => deviceLoader.SimulatorLoadLog;
+		public ILog DeviceLoadLog => deviceLoader.DeviceLoadLog;
 
 		string log_directory;
 		public string LogDirectory {

--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -24,7 +24,8 @@ namespace Xharness.Jenkins {
 		readonly ITunnelBore tunnelBore;
 		readonly TestSelector testSelector;
 		readonly TestVariationsFactory testVariationsFactory;
-		
+		readonly JenkinsDeviceLoader deviceLoader;
+
 		bool populating = true;
 
 		public Harness Harness { get; }
@@ -114,53 +115,7 @@ namespace Xharness.Jenkins {
 			devices = new HardwareDeviceLoader (processManager);
 			testSelector = new TestSelector (this, processManager, new GitHub (harness, processManager));
 			testVariationsFactory = new TestVariationsFactory (this, processManager);
-		}
-
-		Task LoadAsync (ref ILog log, IDeviceLoader deviceManager, string name)
-		{
-			if (log == null)
-				log = Logs.Create ($"{name}-list-{Helpers.Timestamp}.log", $"{name} Listing");
-
-			log.Description = $"{name} Listing (in progress)";
-
-			var capturedLog = log;
-			return deviceManager.LoadDevices (capturedLog, includeLocked: false, forceRefresh: true).ContinueWith ((v) => {
-				if (v.IsFaulted) {
-					capturedLog.WriteLine ("Failed to load:");
-					capturedLog.WriteLine (v.Exception.ToString ());
-					capturedLog.Description = $"{name} Listing {v.Exception.Message})";
-				} else if (v.IsCompleted) {
-					if (deviceManager is HardwareDeviceLoader devices) {
-						var devicesTypes = new StringBuilder ();
-						if (devices.Connected32BitIOS.Any ()) {
-							devicesTypes.Append ("iOS 32 bit");
-						}
-						if (devices.Connected64BitIOS.Any ()) {
-							devicesTypes.Append (devicesTypes.Length == 0 ? "iOS 64 bit" : ", iOS 64 bit");
-						}
-						if (devices.ConnectedTV.Any ()) {
-							devicesTypes.Append (devicesTypes.Length == 0 ? "tvOS" : ", tvOS");
-						}
-						if (devices.ConnectedWatch.Any ()) {
-							devicesTypes.Append (devicesTypes.Length == 0 ? "watchOS" : ", watchOS");
-						}
-						capturedLog.Description = (devicesTypes.Length == 0) ? $"{name} Listing (ok - no devices found)." : $"{name} Listing (ok). Devices types are: {devicesTypes.ToString ()}";
-					}
-					if (deviceManager is SimulatorLoader simulators) {
-						var simCount = simulators.AvailableDevices.Count ();
-						capturedLog.Description = ( simCount == 0) ? $"{name} Listing (ok - no simulators found)." : $"{name} Listing (ok - Found {simCount} simulators).";
-					}
-				}
-			});
-		}
-
-		// Loads both simulators and devices in parallel
-		Task LoadSimulatorsAndDevicesAsync ()
-		{
-			var devs = LoadAsync (ref DeviceLoadLog, devices, "Device");
-			var sims = LoadAsync (ref SimulatorLoadLog, Simulators, "Simulator");
-
-			return Task.WhenAll (devs, sims);
+			deviceLoader = new JenkinsDeviceLoader (Simulators, devices, Logs);
 		}
 
 		IEnumerable<RunSimulatorTask> CreateRunSimulatorTaskAsync (MSBuildTask buildTask)
@@ -455,7 +410,7 @@ namespace Xharness.Jenkins {
 
 			testSelector.SelectTests ();
 
-			LoadSimulatorsAndDevicesAsync ().DoNotAwait ();
+			deviceLoader.LoadAllAsync ().DoNotAwait ();
 
 			var loadsim = CreateRunSimulatorTasksAsync ()
 				.ContinueWith ((v) => { Console.WriteLine ("Simulator tasks created"); Tasks.AddRange (v.Result); });
@@ -866,10 +821,10 @@ namespace Xharness.Jenkins {
 							}
 							break;
 						case "/reload-devices":
-							LoadAsync (ref DeviceLoadLog, devices, "Device").DoNotAwait ();
+							deviceLoader.LoadDevicesAsync ().DoNotAwait ();
 							break;
 						case "/reload-simulators":
-							LoadAsync (ref SimulatorLoadLog, Simulators, "Simulator").DoNotAwait ();
+							deviceLoader.LoadSimulatorsAsync ().DoNotAwait ();
 							break;
 						case "/quit":
 							using (var writer = new StreamWriter (response.OutputStream)) {

--- a/tests/xharness/Jenkins/JenkinsDeviceLoader.cs
+++ b/tests/xharness/Jenkins/JenkinsDeviceLoader.cs
@@ -13,8 +13,8 @@ namespace Xharness.Jenkins {
 
 		readonly ISimulatorLoader simulators;
 		readonly IHardwareDeviceLoader devices;
-		readonly ILog simulatorsLog;
-		readonly ILog devicesLog;
+		public ILog SimulatorLoadLog { get; private set; }
+		public ILog DeviceLoadLog { get; private set; }
 
 		public JenkinsDeviceLoader (ISimulatorLoader simulators, IHardwareDeviceLoader devices, ILogs logs)
 		{
@@ -23,8 +23,8 @@ namespace Xharness.Jenkins {
 
 			this.simulators = simulators ?? throw new ArgumentNullException (nameof (simulators));
 			this.devices = devices ?? throw new ArgumentNullException (nameof (devices));
-			simulatorsLog = logs.Create ($"simulator-list-{Helpers.Timestamp}.log", $"Simulator Listing");
-			devicesLog = logs.Create ($"device-list-{Helpers.Timestamp}.log", $"Device Listing");
+			SimulatorLoadLog = logs.Create ($"simulator-list-{Helpers.Timestamp}.log", $"Simulator Listing");
+			DeviceLoadLog = logs.Create ($"device-list-{Helpers.Timestamp}.log", $"Device Listing");
 		}
 
 		static string BuildDevicesDescription (IHardwareDeviceLoader deviceLoader, string name)
@@ -73,10 +73,10 @@ namespace Xharness.Jenkins {
 		}
 
 		public Task LoadSimulatorsAsync ()
-			=> LoadAsync (simulatorsLog, simulators, simulatorsName);
+			=> LoadAsync (SimulatorLoadLog, simulators, simulatorsName);
 
 		public Task LoadDevicesAsync ()
-			=> LoadAsync (devicesLog, devices, devicesName);
+			=> LoadAsync (DeviceLoadLog, devices, devicesName);
 
 		public Task LoadAllAsync ()
 			=> Task.WhenAll (LoadDevicesAsync (), LoadSimulatorsAsync ());

--- a/tests/xharness/Jenkins/JenkinsDeviceLoader.cs
+++ b/tests/xharness/Jenkins/JenkinsDeviceLoader.cs
@@ -45,7 +45,7 @@ namespace Xharness.Jenkins {
 			return (devicesTypes.Length == 0) ? $"{name} Listing (ok - no devices found)." : $"{name} Listing (ok). Devices types are: {devicesTypes}";
 		}
 
-		static string BuildSimulatorsDescrition (ISimulatorLoader simulatorLoader, string name)
+		static string BuildSimulatorsDescription (ISimulatorLoader simulatorLoader, string name)
 		{
 			var simCount = simulatorLoader.AvailableDevices.Count ();
 			return ( simCount == 0) ? $"{name} Listing (ok - no simulators found)." : $"{name} Listing (ok - Found {simCount} simulators).";
@@ -65,7 +65,7 @@ namespace Xharness.Jenkins {
 					capturedLog.Description = deviceManager switch
 					{
 						IHardwareDeviceLoader d => BuildDevicesDescription (d, name),
-						ISimulatorLoader s => BuildSimulatorsDescrition (s, name),
+						ISimulatorLoader s => BuildSimulatorsDescription (s, name),
 						_ => throw new NotImplementedException (),
 					};
 				}

--- a/tests/xharness/Jenkins/JenkinsDeviceLoader.cs
+++ b/tests/xharness/Jenkins/JenkinsDeviceLoader.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
+using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
+
+namespace Xharness.Jenkins {
+	class JenkinsDeviceLoader {
+		static readonly string devicesName = "Device";
+		static readonly string simulatorsName = "Simulator";
+
+		readonly ISimulatorLoader simulators;
+		readonly IHardwareDeviceLoader devices;
+		readonly ILog simulatorsLog;
+		readonly ILog devicesLog;
+
+		public JenkinsDeviceLoader (ISimulatorLoader simulators, IHardwareDeviceLoader devices, ILogs logs)
+		{
+			if (logs == null)
+				throw new ArgumentNullException (nameof (logs));
+
+			this.simulators = simulators ?? throw new ArgumentNullException (nameof (simulators));
+			this.devices = devices ?? throw new ArgumentNullException (nameof (devices));
+			simulatorsLog = logs.Create ($"simulator-list-{Helpers.Timestamp}.log", $"Simulator Listing");
+			devicesLog = logs.Create ($"device-list-{Helpers.Timestamp}.log", $"Device Listing");
+		}
+
+		static string BuildDevicesDescription (IHardwareDeviceLoader deviceLoader, string name)
+		{ 
+			var devicesTypes = new StringBuilder ();
+			if (deviceLoader.Connected32BitIOS.Any ()) {
+				devicesTypes.Append ("iOS 32 bit");
+			}
+			if (deviceLoader.Connected64BitIOS.Any ()) {
+				devicesTypes.Append (devicesTypes.Length == 0 ? "iOS 64 bit" : ", iOS 64 bit");
+			}
+			if (deviceLoader.ConnectedTV.Any ()) {
+				devicesTypes.Append (devicesTypes.Length == 0 ? "tvOS" : ", tvOS");
+			}
+			if (deviceLoader.ConnectedWatch.Any ()) {
+				devicesTypes.Append (devicesTypes.Length == 0 ? "watchOS" : ", watchOS");
+			}
+			return (devicesTypes.Length == 0) ? $"{name} Listing (ok - no devices found)." : $"{name} Listing (ok). Devices types are: {devicesTypes}";
+		}
+
+		static string BuildSimulatorsDescrition (ISimulatorLoader simulatorLoader, string name)
+		{
+			var simCount = simulatorLoader.AvailableDevices.Count ();
+			return ( simCount == 0) ? $"{name} Listing (ok - no simulators found)." : $"{name} Listing (ok - Found {simCount} simulators).";
+		}
+
+		Task LoadAsync (ILog log, IDeviceLoader deviceManager, string name)
+		{
+			log.Description = $"{name} Listing (in progress)";
+
+			var capturedLog = log;
+			return deviceManager.LoadDevices (capturedLog, includeLocked: false, forceRefresh: true).ContinueWith ((v) => {
+				if (v.IsFaulted) {
+					capturedLog.WriteLine ("Failed to load:");
+					capturedLog.WriteLine (v.Exception.ToString ());
+					capturedLog.Description = $"{name} Listing {v.Exception.Message})";
+				} else if (v.IsCompleted) {
+					capturedLog.Description = deviceManager switch
+					{
+						IHardwareDeviceLoader d => BuildDevicesDescription (d, name),
+						ISimulatorLoader s => BuildSimulatorsDescrition (s, name),
+						_ => throw new NotImplementedException (),
+					};
+				}
+			});
+		}
+
+		public Task LoadSimulatorsAsync ()
+			=> LoadAsync (simulatorsLog, simulators, simulatorsName);
+
+		public Task LoadDevicesAsync ()
+			=> LoadAsync (devicesLog, devices, devicesName);
+
+		public Task LoadAllAsync ()
+			=> Task.WhenAll (LoadDevicesAsync (), LoadSimulatorsAsync ());
+	}
+}

--- a/tests/xharness/Xharness.Tests/Jenkins/JenkinsDeviceLoadterTests.cs
+++ b/tests/xharness/Xharness.Tests/Jenkins/JenkinsDeviceLoadterTests.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections;
+using System.Threading.Tasks;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
+using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
+using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Moq;
+using NUnit.Framework;
+using Xharness.Jenkins;
+
+namespace Xharness.Tests.Jenkins {
+
+	[TestFixture]
+	public class JenkinsDeviceLoadterTests {
+
+		public class TestCasesData {
+			public static IEnumerable GetDeviceTestCases {
+				get {
+					// set the mock expectations the expected results
+					var simulators = new Mock<ISimulatorLoader> ();
+					var aDevice = new Mock<IHardwareDevice> ();
+
+					// no devices found
+					var devices = new Mock<IHardwareDeviceLoader> ();
+					devices.Setup (d => d.Connected32BitIOS).Returns (Array.Empty<IHardwareDevice> ());
+					devices.Setup (d => d.Connected64BitIOS).Returns (Array.Empty<IHardwareDevice> ());
+					devices.Setup (d => d.ConnectedTV).Returns (Array.Empty<IHardwareDevice> ());
+					devices.Setup (d => d.ConnectedWatch).Returns (Array.Empty<IHardwareDevice> ());
+
+					yield return new TestCaseData (simulators.Object, devices.Object, $"Device Listing (ok - no devices found).");
+
+					// iOS 32b
+					devices = new Mock<IHardwareDeviceLoader> ();
+					devices.Setup (d => d.Connected32BitIOS).Returns (new IHardwareDevice [] { aDevice.Object });
+					devices.Setup (d => d.Connected64BitIOS).Returns (Array.Empty<IHardwareDevice> ());
+					devices.Setup (d => d.ConnectedTV).Returns (Array.Empty<IHardwareDevice> ());
+					devices.Setup (d => d.ConnectedWatch).Returns (Array.Empty<IHardwareDevice> ());
+
+					yield return new TestCaseData (simulators.Object, devices.Object, $"Device Listing (ok). Devices types are: iOS 32 bit");
+					
+					devices = new Mock<IHardwareDeviceLoader> ();
+					devices.Setup (d => d.Connected32BitIOS).Returns (new IHardwareDevice [] { aDevice.Object });
+					devices.Setup (d => d.Connected64BitIOS).Returns (new IHardwareDevice [] { aDevice.Object });
+					devices.Setup (d => d.ConnectedTV).Returns (Array.Empty<IHardwareDevice> ());
+					devices.Setup (d => d.ConnectedWatch).Returns (Array.Empty<IHardwareDevice> ());
+
+					yield return new TestCaseData (simulators.Object, devices.Object, $"Device Listing (ok). Devices types are: iOS 32 bit, iOS 64 bit");
+
+					devices = new Mock<IHardwareDeviceLoader> ();
+					devices.Setup (d => d.Connected32BitIOS).Returns (new IHardwareDevice [] { aDevice.Object });
+					devices.Setup (d => d.Connected64BitIOS).Returns (new IHardwareDevice [] { aDevice.Object });
+					devices.Setup (d => d.ConnectedTV).Returns (new IHardwareDevice [] { aDevice.Object });
+					devices.Setup (d => d.ConnectedWatch).Returns (Array.Empty<IHardwareDevice> ());
+					yield return new TestCaseData (simulators.Object, devices.Object, $"Device Listing (ok). Devices types are: iOS 32 bit, iOS 64 bit, tvOS");
+
+					devices = new Mock<IHardwareDeviceLoader> ();
+					devices.Setup (d => d.Connected32BitIOS).Returns (new IHardwareDevice [] { aDevice.Object });
+					devices.Setup (d => d.Connected64BitIOS).Returns (new IHardwareDevice [] { aDevice.Object });
+					devices.Setup (d => d.ConnectedTV).Returns (new IHardwareDevice [] { aDevice.Object });
+					devices.Setup (d => d.ConnectedWatch).Returns (new IHardwareDevice [] { aDevice.Object });
+					yield return new TestCaseData (simulators.Object, devices.Object, $"Device Listing (ok). Devices types are: iOS 32 bit, iOS 64 bit, tvOS, watchOS");
+				}
+			}
+
+			public static IEnumerable GetSimulatorTestCases {
+				get { 
+					var devices = new Mock<IHardwareDeviceLoader> ();
+					var simulators = new Mock<ISimulatorLoader> ();
+					var processManager = new Mock<IProcessManager> ();
+					var db = new Mock<ITCCDatabase> ();
+
+					simulators.Setup (s => s.AvailableDevices).Returns (Array.Empty<SimulatorDevice> ());
+					yield return new TestCaseData (simulators.Object, devices.Object, "Simulator Listing (ok - no simulators found).");
+
+					simulators = new Mock<ISimulatorLoader> ();
+					simulators.Setup (s => s.AvailableDevices).Returns (new SimulatorDevice [] { new SimulatorDevice (processManager.Object, db.Object)});
+					yield return new TestCaseData (simulators.Object, devices.Object, $"Simulator Listing (ok - Found 1 simulators).");
+				}
+			}
+		}
+
+		Mock<ILogs> logs;
+		Mock<ILog> log;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			logs = new Mock<ILogs> ();
+			log = new Mock<ILog> ();
+
+			logs.Setup (l => l.Create (
+				It.IsAny<string> (),
+				It.Is<string> (s => s.Equals ("Simulator Listing")),
+				null)).Returns (log.Object);
+
+			logs.Setup (l => l.Create (
+				It.IsAny<string> (),
+				It.Is<string> (s => s.Equals ("Device Listing")),
+				null)).Returns (log.Object);
+
+			log.SetupSet (l => l.Description = It.IsAny<string> ()).Verifiable ();
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			logs = null;
+			log = null;
+		}
+
+
+		[Test, TestCaseSource (typeof (TestCasesData), "GetDeviceTestCases")]
+		public async Task FoundDevicesTest (ISimulatorLoader simulators, IHardwareDeviceLoader devices, string expectedDescription)
+		{ 
+			var loader = new JenkinsDeviceLoader (simulators, devices, logs.Object);
+
+			await loader.LoadDevicesAsync ();
+			// validate that the log description will be set as expected
+			log.VerifySet (l => l.Description = It.Is<string> (s => s.Equals (expectedDescription)));
+		}
+
+		[Test, TestCaseSource (typeof (TestCasesData), "GetSimulatorTestCases")]
+		public async Task FoundSimulatorsTest (ISimulatorLoader simulators, IHardwareDeviceLoader devices, string expectedDescription)
+		{ 
+			var loader = new JenkinsDeviceLoader (simulators, devices, logs.Object);
+
+			await loader.LoadSimulatorsAsync ();
+			// validate that the log description will be set as expected
+			log.VerifySet (l => l.Description = It.Is<string> (s => s.Equals (expectedDescription)));
+		}
+
+	}
+}

--- a/tests/xharness/Xharness.Tests/Xharness.Tests.csproj
+++ b/tests/xharness/Xharness.Tests/Xharness.Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Tests\MacFlavorsExtensionsTests.cs" />
     <Compile Include="Jenkins\MakeTestTaskEnumerableTests.cs" />
     <Compile Include="Jenkins\NUnitTestTasksEnumerableTests.cs" />
+    <Compile Include="Jenkins\JenkinsDeviceLoadterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -136,6 +136,7 @@
     <Compile Include="MacFlavorsExtensions.cs" />
     <Compile Include="Jenkins\NUnitTestTasksEnumerable.cs" />
     <Compile Include="Jenkins\MakeTestTaskEnumerable.cs" />
+    <Compile Include="Jenkins\JenkinsDeviceLoader.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\tools\common\SdkVersions.cs">


### PR DESCRIPTION
Following other PRs, try to reduce the work of the Jenkins class to
ochestrate the different classes and move any other logic to classes
with a single concern. Add tests for the new class.