### PR TITLE
[tests] Port cecil-tests to new-style csproj.

### DIFF
--- a/tests/cecil-tests/Makefile
+++ b/tests/cecil-tests/Makefile
@@ -5,11 +5,10 @@ include $(TOP)/Make.config
 all-local::
 
 build:
-	nuget restore
-	$(SYSTEM_MSBUILD)
+	$(SYSTEM_MSBUILD) /r
 
 run-tests: build
-	$(SYSTEM_MONO) --debug $(TOP)/packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe $(abspath $(TOP)/tests/cecil-tests/bin/Debug/cecil-tests.dll)
+	$(TOP)/tools/nunit3-console-3.11.1 $(abspath $(TOP)/tests/cecil-tests/bin/Debug/net472/cecil-tests.dll)
 
 clean:
 	rm -rf bin/ obj/ TestResult.xml

--- a/tests/cecil-tests/cecil-tests.csproj
+++ b/tests/cecil-tests/cecil-tests.csproj
@@ -1,55 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.12.0\build\NUnit.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{0C979851-15E9-4BB6-AD79-5F0C7DF69456}</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
     <RootNamespace>ceciltests</RootNamespace>
     <AssemblyName>cecil-tests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
+  <ItemGroup>    
+    <PackageReference Include="Mono.Cecil" Version="0.11.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
+  </ItemGroup>
   <ItemGroup>
-    <Compile Include="Test.cs" />
-    <Compile Include="Helper.cs" />
     <Compile Include="..\common\Configuration.cs">
       <Link>Configuration.cs</Link>
     </Compile>
@@ -66,9 +32,4 @@
       <Link>StringUtils.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-    <None Include="README.md" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tests/cecil-tests/packages.config
+++ b/tests/cecil-tests/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Mono.Cecil" version="0.11.1" targetFramework="net472" />
-  <package id="NUnit" version="3.12.0" targetFramework="net472" />
-</packages>

--- a/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
+++ b/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
@@ -98,17 +98,17 @@ namespace Xharness.Jenkins {
 			};
 			yield return runGenerator;
 
-			var buildCecilTests = new MakeTask (jenkins: jenkins, processManager: processManager) {
+			var buildCecilTestsProject = new TestProject (Path.GetFullPath (Path.Combine (Harness.RootDirectory, "cecil-tests", "cecil-tests.csproj")));
+			buildCecilTestsProject.RestoreNugetsInProject = true;
+			var buildCecilTests = new MSBuildTask (jenkins: jenkins, testProject: buildCecilTestsProject, processManager: processManager) {
+				SpecifyPlatform = false,
 				Platform = TestPlatform.All,
-				TestName = "Cecil",
-				Target = "build",
-				WorkingDirectory = Path.Combine (Harness.RootDirectory, "cecil-tests"),
+				ProjectConfiguration = "Debug",
 				Ignored = !jenkins.IncludeCecil,
-				Timeout = TimeSpan.FromMinutes (5),
 			};
 			var runCecilTests = new NUnitExecuteTask (jenkins, buildCecilTests, processManager) {
-				TestLibrary = Path.Combine (buildCecilTests.WorkingDirectory, "bin", "Debug", "cecil-tests.dll"),
-				TestProject = new TestProject (Path.Combine (buildCecilTests.WorkingDirectory, "cecil-tests.csproj")),
+				TestLibrary = Path.Combine (Path.GetDirectoryName (buildCecilTestsProject.Path), "bin", "Debug", "net472", "cecil-tests.dll"),
+				TestProject = buildCecilTestsProject,
 				Platform = TestPlatform.iOS,
 				TestName = "Cecil-based tests",
 				Timeout = TimeSpan.FromMinutes (5),


### PR DESCRIPTION
Also switch xharness to build the csproj instead of running the makefile to
build the tests, because that way xharness is able to automatically use the
correct NUnit runner depending on the NUnit version the tests are using.