### PR TITLE
[dotnet] Add a KnownFrameworkReference node to the targets to tell the .NETCore build system about us.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -1,3 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Declare the XI/XM framework bundled with this version of the SDK. See Microsoft.NETCoreSdk.BundledVersions.props -->
+  <PropertyGroup>
+    <!-- Runtime pack identifiers -->
+    <_RuntimePackRuntimeIdentifiers Condition=" '$(_PlatformName)' == 'iOS' ">ios-x64;ios-arm64;ios-arm;ios-x86</_RuntimePackRuntimeIdentifiers>
+    <_RuntimePackRuntimeIdentifiers Condition=" '$(_PlatformName)' == 'tvOS' ">tvos-x64;tvos-arm64</_RuntimePackRuntimeIdentifiers>
+    <_RuntimePackRuntimeIdentifiers Condition=" '$(_PlatformName)' == 'watchOS' ">watchos-x86;watchos-arm</_RuntimePackRuntimeIdentifiers>
+    <_RuntimePackRuntimeIdentifiers Condition=" '$(_PlatformName)' == 'macOS' ">osx-x64</_RuntimePackRuntimeIdentifiers>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <KnownFrameworkReference Include="Microsoft.$(_PlatformName)"
+                            TargetFramework="net5.0"
+                            RuntimeFrameworkName="Microsoft.$(_PlatformName)"
+                            DefaultRuntimeFrameworkVersion="$(_ShortPackageVersion)"
+                            LatestRuntimeFrameworkVersion="$(_ShortPackageVersion)"
+                            TargetingPackName="Microsoft.$(_PlatformName).Ref"
+                            TargetingPackVersion="$(_ShortPackageVersion)"
+                            RuntimePackNamePatterns="Microsoft.$(_PlatformName).Runtime.**RID**"
+                            RuntimePackRuntimeIdentifiers="$(_RuntimePackRuntimeIdentifiers)"
+                            Profile="$(_PlatformName)"
+                            />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true'">
+    <FrameworkReference Include="Microsoft.$(_PlatformName)" IsImplicitlyDefined="true" Pack="false" PrivateAssets="All" />
+  </ItemGroup>
+
 </Project>

--- a/tests/dotnet/Makefile
+++ b/tests/dotnet/Makefile
@@ -7,6 +7,7 @@ include $(TOP)/Make.config
 NuGet.config: $(TOP)/NuGet.config Makefile
 	$(Q) $(CP) $< $@.tmp
 	$(Q) nuget sources add -Name local-dotnet-feed -Source $(abspath $(DOTNET_FEED_DIR)) -ConfigFile $@.tmp
+	$(Q) nuget sources add -Name dotnet5 -Source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" -ConfigFile $@.tmp
 	$(Q) nuget config -Set globalPackagesFolder=packages -Config $@.tmp
 	$(Q) mv $@.tmp $@
 


### PR DESCRIPTION
Also add another nuget source to get Mono's net5 runtime packs.

This makes the tests/dotnet/MySingleView test app:

* Compile managed code successfully, referencing Xamarin.iOS.dll.
* Resolve the correct targeting and runtime packs (aka Mono).

The compiled result is not put into an .app bundle as iOS expects, so the
result isn't actually executable.