### PR TITLE
[corefoundation] Safer NativeObject

### DIFF
--- a/src/CoreFoundation/NativeObject.cs
+++ b/src/CoreFoundation/NativeObject.cs
@@ -85,7 +85,7 @@ namespace CoreFoundation {
 		public IntPtr GetCheckedHandle ()
 		{
 			if (handle == IntPtr.Zero)
-				ObjCRuntime.ThrowHelper.ThrowObjectDisposedException (GetType ());
+				ObjCRuntime.ThrowHelper.ThrowObjectDisposedException (this);
 			return handle;
 		}
 	}

--- a/src/CoreFoundation/NativeObject.cs
+++ b/src/CoreFoundation/NativeObject.cs
@@ -6,13 +6,12 @@
 //   Alex Soto
 //   Miguel de Icaza
 //
-// Copyrigh 2018 Microsoft Inc
+// Copyright 2018, 2020 Microsoft Corp
 //
 using System;
 using System.Runtime.InteropServices;
 using ObjCRuntime;
 using Foundation;
-using CoreFoundation;
 
 namespace CoreFoundation {
 	//
@@ -64,8 +63,13 @@ namespace CoreFoundation {
 			}
 		}
 
-		protected virtual void Retain () => CFObject.CFRetain (Handle);
-		protected virtual void Release () => CFObject.CFRelease (Handle);
+		// <quote>If cf is NULL, this will cause a runtime error and your application will crash.</quote>
+		// https://developer.apple.com/documentation/corefoundation/1521269-cfretain?language=occ
+		protected virtual void Retain () => CFObject.CFRetain (GetCheckedHandle ());
+
+		// <quote>If cf is NULL, this will cause a runtime error and your application will crash.</quote>
+		// https://developer.apple.com/documentation/corefoundation/1521153-cfrelease
+		protected virtual void Release () => CFObject.CFRelease (GetCheckedHandle ());
 
 		protected virtual void InitializeHandle (IntPtr handle)
 		{
@@ -78,12 +82,10 @@ namespace CoreFoundation {
 			this.handle = handle;
 		}
 
-		void Throw () => throw new ObjectDisposedException (GetType ().ToString ());
-
-		internal IntPtr GetCheckedHandle ()
+		public IntPtr GetCheckedHandle ()
 		{
 			if (handle == IntPtr.Zero)
-				Throw ();
+				ObjCRuntime.ThrowHelper.ThrowObjectDisposedException (GetType ());
 			return handle;
 		}
 	}

--- a/src/ObjCRuntime/ThrowHelper.cs
+++ b/src/ObjCRuntime/ThrowHelper.cs
@@ -1,0 +1,17 @@
+using System;
+// the linker will remove the attributes
+using System.Diagnostics.CodeAnalysis;
+
+#nullable enable
+
+namespace ObjCRuntime {
+
+	static class ThrowHelper {
+
+		[DoesNotReturn]
+		static internal void ThrowObjectDisposedException (Type? t)
+		{
+			throw new ObjectDisposedException (t?.ToString ());
+		}
+	}
+}

--- a/src/ObjCRuntime/ThrowHelper.cs
+++ b/src/ObjCRuntime/ThrowHelper.cs
@@ -9,9 +9,9 @@ namespace ObjCRuntime {
 	static class ThrowHelper {
 
 		[DoesNotReturn]
-		static internal void ThrowObjectDisposedException (Type? t)
+		static internal void ThrowObjectDisposedException (object o)
 		{
-			throw new ObjectDisposedException (t?.ToString ());
+			throw new ObjectDisposedException (o.GetType ().ToString ());
 		}
 	}
 }

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1747,6 +1747,7 @@ SHARED_CORE_SOURCES = \
 	ObjCRuntime/Registrar.core.cs \
 	ObjCRuntime/RequiresSuperAttribute.cs \
 	ObjCRuntime/Selector.cs \
+	ObjCRuntime/ThrowHelper.cs \
 	Simd/MatrixDouble4x4.cs \
 	Simd/MatrixFloat2x2.cs \
 	Simd/MatrixFloat3x3.cs \

--- a/tests/monotouch-test/CoreFoundation/NativeObjectTest.cs
+++ b/tests/monotouch-test/CoreFoundation/NativeObjectTest.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using CoreFoundation;
+using Foundation;
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.CoreFoundation {
+
+	class FakeNativeObject : NativeObject {
+
+		int rc;
+
+		public FakeNativeObject (IntPtr handle, bool own) : base (handle, own)
+		{
+		}
+
+		protected override void Retain ()
+		{
+			rc++;
+		}
+
+		protected override void Release ()
+		{
+			rc--;
+		}
+
+		public int RetainCount => rc;
+	}
+
+	class NativeObjectPoker : NativeObject {
+
+		// `true` since it's a fake handle - and we don't want to call native API with it
+		public NativeObjectPoker (IntPtr handle) : base (handle, true)
+		{
+		}
+
+		public bool CallNative { get; set; }
+
+		protected override void Retain ()
+		{
+			if (CallNative)
+				base.Retain ();
+		}
+
+		protected override void Release ()
+		{
+			if (CallNative)
+				base.Release ();
+		}
+
+		public void _Retain () => Retain ();
+		public void _Release () => Release ();
+	}
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class NativeObjectTest {
+
+		[Test]
+		public void Create ()
+		{
+			using (var x = new FakeNativeObject ((IntPtr) 1, false)) {
+				Assert.That (x.RetainCount, Is.EqualTo (1), "x.RetainCount");
+			}
+			using (var y = new FakeNativeObject ((IntPtr) 2, true)) {
+				Assert.That (y.RetainCount, Is.EqualTo (0), "y.RetainCount");
+			}
+		}
+
+		[Test]
+		public void Dispose ()
+		{
+			var x = new FakeNativeObject ((IntPtr) 1, false);
+			Assert.That (x.RetainCount, Is.EqualTo (1), "1");
+			x.Dispose ();
+			Assert.That (x.RetainCount, Is.EqualTo (0), "0");
+			Assert.Throws<ObjectDisposedException> (() => x.GetCheckedHandle (), "Dispose");
+			// Dispose should be safe to call multiple times
+			x.Dispose ();
+		}
+
+		[Test]
+		public void CreateInvalidHandle ()
+		{
+			Assert.Throws<Exception> (() => new NativeObjectPoker (IntPtr.Zero));
+		}
+
+		[Test]
+		public void RetainAfterDispose ()
+		{
+			var x = new NativeObjectPoker ((IntPtr) 1);
+			x.CallNative = false; // handle does not exists natively
+			x.Dispose ();
+			x.CallNative = true; // handle is null
+			Assert.Throws<ObjectDisposedException> (() => x._Retain ());
+		}
+
+		[Test]
+		public void ReleaseAfterDispose ()
+		{
+			var x = new NativeObjectPoker ((IntPtr) 1);
+			x.CallNative = false; // handle does not exists natively
+			x.Dispose ();
+			x.CallNative = true; // handle is null
+			Assert.Throws<ObjectDisposedException> (() => x._Release ());
+		}
+	}
+}


### PR DESCRIPTION
Do not allow calling `CFRetain` or `CFRelease` on a null handle as this
will crash the process, instead use `GetCheckedHandle` so a managed (and
catchable) `ObjectDisposedException` can be thrown.

Make `GetCheckedHandle` public so subclasses (outside the platform
assembly) can use it - it's already recommended in some `[Obsolete]`
attributes (but was not made available).

Move the `ObjectDisposedException` thrower into a new `ThrowHelper`
class. This will allow sharing it (to be re-used in future PR).

Add unit tests for `NativeObject`.