### PR TITLE
[tools] Ignore generator.csproj when comparing generated code.

### DIFF
--- a/tools/compare-commits.sh
+++ b/tools/compare-commits.sh
@@ -241,7 +241,7 @@ find build build-new '(' \
 	-name '*.rsp' -or \
 	-name 'AssemblyInfo.cs' -or \
 	-name 'Constants.cs' -or \
-	-name 'generator.csproj.*' -or \
+	-name 'generator.csproj*' -or \
 	-name 'bgen.csproj.*' -or \
 	-name '*.cache' \
 	')' -delete


### PR DESCRIPTION
Fixes an issue where generator.csproj would show up as a new file when
comparing generated output.

This probably regressed in 4b917ad2de20c790ec548299f316067202f11a6d.