### PR TITLE
[Harness] Make sure that the error knowledge base is used in device runs.

### DIFF
--- a/tests/xharness/Jenkins/ErrorKnowledgeBase.cs
+++ b/tests/xharness/Jenkins/ErrorKnowledgeBase.cs
@@ -10,6 +10,7 @@ namespace Xharness.Jenkins {
 		static readonly Dictionary<string, (string HumanMessage, string IssueLink)> testErrorMaps = new Dictionary<string, (string HumanMessage, string IssueLink)> {
 			["error HE0038: Failed to launch the app"] = (HumanMessage: "HE0038", IssueLink: "https://github.com/xamarin/maccore/issues/581)"),
 			["Couldn't establish a TCP connection with any of the hostnames"] = (HumanMessage: "Tcp Connection Error: Tests are reported as crashes when they succeeded.", IssueLink: "https://github.com/xamarin/maccore/issues/1741"),
+			["BCLTests.TestRunner.Core.TcpTextWriter..ctor"] = (HumanMessage: "Tcp Connection Error: Tests are reported as crashes when they succeeded.", IssueLink: "https://github.com/xamarin/maccore/issues/1741"),
 		};
 		
 		static readonly Dictionary<string, (string HumanMessage, string IssueLink)> buildErrorMaps = new Dictionary<string, (string HumanMessage, string IssueLink)> {

--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -274,6 +274,7 @@ namespace Xharness.Jenkins {
 						buildTask: build64,
 						processManager: processManager,
 						tunnelBore: tunnelBore,
+						errorKnowledgeBase: ErrorKnowledgeBase,
 						useTcpTunnel: Harness.UseTcpTunnel,
 						candidates: devices.Connected64BitIOS.Where (d => project.IsSupported (d.DevicePlatform, d.ProductVersion))) { Ignored = !IncludeiOS64 });
 
@@ -290,6 +291,7 @@ namespace Xharness.Jenkins {
 						buildTask: build32,
 						processManager: processManager,
 						tunnelBore: tunnelBore,
+						errorKnowledgeBase: ErrorKnowledgeBase,
 						useTcpTunnel: Harness.UseTcpTunnel,
 						candidates: devices.Connected32BitIOS.Where (d => project.IsSupported (d.DevicePlatform, d.ProductVersion))) { Ignored = !IncludeiOS32 });
 
@@ -307,6 +309,7 @@ namespace Xharness.Jenkins {
 						buildTask: buildToday,
 						processManager: processManager,
 						tunnelBore: tunnelBore,
+						errorKnowledgeBase: ErrorKnowledgeBase,
 						useTcpTunnel: Harness.UseTcpTunnel,
 						candidates: devices.Connected64BitIOS.Where (d => project.IsSupported (d.DevicePlatform, d.ProductVersion))) { Ignored = !IncludeiOSExtensions, BuildOnly = ForceExtensionBuildOnly });
 				}
@@ -326,6 +329,7 @@ namespace Xharness.Jenkins {
 						buildTask: buildTV,
 						processManager: processManager,
 						tunnelBore: tunnelBore,
+						errorKnowledgeBase: ErrorKnowledgeBase,
 						useTcpTunnel: Harness.UseTcpTunnel,
 						candidates: devices.ConnectedTV.Where (d => project.IsSupported (d.DevicePlatform, d.ProductVersion))) { Ignored = !IncludetvOS });
 				}
@@ -346,6 +350,7 @@ namespace Xharness.Jenkins {
 							buildTask: buildWatch32,
 							processManager: processManager,
 							tunnelBore: tunnelBore,
+							errorKnowledgeBase: ErrorKnowledgeBase,
 							useTcpTunnel: Harness.UseTcpTunnel,
 							candidates: devices.ConnectedWatch) { Ignored = !IncludewatchOS });
 					}
@@ -364,6 +369,7 @@ namespace Xharness.Jenkins {
 							buildTask: buildWatch64_32,
 							processManager: processManager,
 							tunnelBore: tunnelBore,
+							errorKnowledgeBase: ErrorKnowledgeBase,
 							useTcpTunnel: Harness.UseTcpTunnel,
 							candidates: devices.ConnectedWatch32_64.Where (d => project.IsSupported (d.DevicePlatform, d.ProductVersion))) { Ignored = !IncludewatchOS });
 					}
@@ -383,6 +389,7 @@ namespace Xharness.Jenkins {
 					buildTask: buildTask,
 					processManager: processManager,
 					tunnelBore: tunnelBore,
+					errorKnowledgeBase: ErrorKnowledgeBase,
 					useTcpTunnel: Harness.UseTcpTunnel,
 					candidates: candidates?.Cast<IHardwareDevice> () ?? test.Candidates)));
 		}

--- a/tests/xharness/Jenkins/TestTasks/RunDeviceTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/RunDeviceTask.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Listeners;
@@ -37,7 +38,7 @@ namespace Xharness.Jenkins.TestTasks {
 			}
 		}
 
-		public RunDeviceTask (Jenkins jenkins, IHardwareDeviceLoader devices, MSBuildTask buildTask, IProcessManager processManager, ITunnelBore tunnelBore, bool useTcpTunnel, IEnumerable<IHardwareDevice> candidates)
+		public RunDeviceTask (Jenkins jenkins, IHardwareDeviceLoader devices, MSBuildTask buildTask, IProcessManager processManager, ITunnelBore tunnelBore, IErrorKnowledgeBase errorKnowledgeBase, bool useTcpTunnel, IEnumerable<IHardwareDevice> candidates)
 			: base (jenkins, buildTask, processManager, candidates.OrderBy ((v) => v.DebugSpeed))
 		{
 			TunnelBore = tunnelBore;
@@ -47,6 +48,7 @@ namespace Xharness.Jenkins.TestTasks {
 				resourceManager: ResourceManager,
 				mainLog: Jenkins.MainLog,
 				deviceLoadLog: Jenkins.DeviceLoadLog,
+				errorKnowledgeBase: errorKnowledgeBase,
 				defaultLogDirectory: Jenkins.Harness.LogDirectory,
 				uninstallTestApp: Jenkins.UninstallTestApp,
 				cleanSuccessfulTestRuns: Jenkins.CleanSuccessfulTestRuns,


### PR DESCRIPTION
The knowledgebase was just added in the simulator case, not in the
device. That meant that the tcp error was not reported.

Also added another possible case of tcp errors to be picked up and be
shown as a known error (device throws a diff error when on airplane
mode).

fixes: https://github.com/xamarin/xamarin-macios/issues/8659