### PR TITLE
[.gitignore] Ignore the json that is created on a device crash on xharness.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ tests/bcl-test/SystemXunit.csproj
 global.json
 .idea
 device-tests-provisioning.csx
+mono_crash.*.json


### PR DESCRIPTION
Those files can be found when we test crashes locally and should not be
added to the project.