### PR TITLE
[xharness] Always capture stdout/stderr from the simulator to actual files.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -323,16 +323,10 @@ namespace Xharness {
 					return 1;
 
 				if (runMode != RunMode.WatchOS) {
-					var stderr_tty = harness.GetStandardErrorTty ();
-					if (!string.IsNullOrEmpty (stderr_tty)) {
-						args.Add (new SetStdoutArgument (stderr_tty));
-						args.Add (new SetStderrArgument (stderr_tty));
-					} else {
-						var stdout_log = Logs.CreateFile ($"stdout-{Helpers.Timestamp}.log", "Standard output");
-						var stderr_log = Logs.CreateFile ($"stderr-{Helpers.Timestamp}.log", "Standard error");
-						args.Add (new SetStdoutArgument (stdout_log));
-						args.Add (new SetStderrArgument (stderr_log));
-					}
+					var stdout_log = Logs.CreateFile ($"stdout-{Helpers.Timestamp}.log", "Standard output");
+					var stderr_log = Logs.CreateFile ($"stderr-{Helpers.Timestamp}.log", "Standard error");
+					args.Add (new SetStdoutArgument (stdout_log));
+					args.Add (new SetStderrArgument (stderr_log));
 				}
 
 				var systemLogs = new List<ICaptureLog> ();

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -58,7 +58,6 @@ namespace Xharness {
 		XmlResultJargon XmlJargon { get; }
 
 		bool GetIncludeSystemPermissionTests (TestPlatform platform, bool device);
-		string GetStandardErrorTty ();
 		void Log (int min_level, string message, params object [] args);
 	}
 
@@ -160,8 +159,6 @@ namespace Xharness {
 		public TimeSpan PeriodicCommandInterval { get; }
 		// whether tests that require access to system resources (system contacts, photo library, etc) should be executed or not
 		public bool? IncludeSystemPermissionTests { get; set; }
-
-		public string GetStandardErrorTty () => Helpers.GetTerminalName (2);
 
 		public Harness (IResultParser resultParser, HarnessAction action, HarnessConfiguration configuration)
 		{

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Helpers.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Helpers.cs
@@ -27,13 +27,5 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 		}
 
 		public static string Timestamp => $"{DateTime.Now:yyyyMMdd_HHmmss}";
-
-		[DllImport ("/usr/lib/libc.dylib")]
-		extern static IntPtr ttyname (int filedes);
-
-		public static string GetTerminalName (int filedescriptor)
-		{
-			return Marshal.PtrToStringAuto (ttyname (filedescriptor));
-		}
 	}
 }

--- a/tests/xharness/Xharness.Tests/Tests/AppRunnerTests.cs
+++ b/tests/xharness/Xharness.Tests/Tests/AppRunnerTests.cs
@@ -783,8 +783,7 @@ namespace Xharness.Tests {
 					{ "env1", "value1" },
 					{ "env2", "value2" },
 				}
-				&& x.Timeout == 1d
-				&& x.GetStandardErrorTty () == "tty1");
+				&& x.Timeout == 1d);
 		}
 	}
 }


### PR DESCRIPTION
This avoids confusion when tests are run locally using 'make runner' (and
would print the simulator's stdout/stderr to the terminal) versus when run on
bots (and would write the simulator's stdout/stderr to separate files that
would show up in the html report).