### PR TITLE
[xharness] Add crash reports to a logs collection we care about.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -273,9 +273,7 @@ namespace Xharness {
 
 			// object that will take care of capturing and parsing the results
 			ILog runLog = MainLog;
-			var crashLogs = new Logs (Logs.Directory);
-
-			ICrashSnapshotReporter crashReporter = snapshotReporterFactory.Create (MainLog, crashLogs, isDevice: !isSimulator, deviceName);
+			ICrashSnapshotReporter crashReporter = snapshotReporterFactory.Create (MainLog, Logs, isDevice: !isSimulator, deviceName);
 
 			var testReporterTimeout = TimeSpan.FromMinutes (harness.Timeout * timeoutMultiplier);
 			var testReporter = testReporterFactory.Create (MainLog,


### PR DESCRIPTION
Add crash reports to a logs collection we care about, instead of to a logs
collection that's promptly forgotten.

This makes sure crash reports actually show up in the html report.