### PR TITLE
[jenkins] Fix assumption in build-nugets.sh.

### DIFF
--- a/jenkins/Makefile
+++ b/jenkins/Makefile
@@ -5,4 +5,4 @@ all check:
 	shellcheck *.sh
 
 print-abspath-variable:
-	@echo $(abspath $($(VARIABLE)))
+	@echo $(VARIABLE)=$(abspath $($(VARIABLE)))

--- a/jenkins/build-nugets.sh
+++ b/jenkins/build-nugets.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -ex
 
-DOTNET_NUPKG_DIR=$(make print-abspath-variable VARIABLE=DOTNET_NUPKG_DIR)
-
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+DOTNET_NUPKG_DIR=$(make -C jenkins print-abspath-variable VARIABLE=DOTNET_NUPKG_DIR | grep "^DOTNET_NUPKG_DIR=" | sed -e 's/^DOTNET_NUPKG_DIR=//')
 
 mkdir -p ../package/
 rm -f ../package/*.nupkg


### PR DESCRIPTION
* The current directory doesn't have to be the script directory, so only
  execute 'make' after we've changed the current directory to a known
  directory.
* 'make ...' can output extra lines, depending on other circumstances, so
  change logic to filter to just the line we're interested in:

    DOTNET_NUPKG_DIR='Found ccache on the system, enabling it
    Detected the maccore repository, automatically enabled the Xamarin build
    Downloading mono archives
    /Users/rolf/work/maccore/msbuild/xamarin-macios/_build/nupkgs'