### PR TITLE
[Harness] Fix issues in the markdown when reporting failures.

### DIFF
--- a/tests/xharness/Jenkins/Reports/MarkdownReportWriter.cs
+++ b/tests/xharness/Jenkins/Reports/MarkdownReportWriter.cs
@@ -17,8 +17,7 @@ namespace Xharness.Jenkins.Reports {
 			writer.WriteLine ();
 
 			foreach (var group in failedTests.GroupBy ((v) => v.TestName)) {
-				var enumerableGroup = group as IEnumerable<ITestTask>;
-				if (enumerableGroup != null) {
+				if (group is IEnumerable<ITestTask> enumerableGroup) {
 					foreach (var test in enumerableGroup) {
 						writer.Write ($" * {group.Key}");
 						if (!string.IsNullOrEmpty (test.Mode))

--- a/tests/xharness/Jenkins/Reports/MarkdownReportWriter.cs
+++ b/tests/xharness/Jenkins/Reports/MarkdownReportWriter.cs
@@ -16,19 +16,26 @@ namespace Xharness.Jenkins.Reports {
 			writer.WriteLine ("## Failed tests");
 			writer.WriteLine ();
 
-			foreach (var test in failedTests) {
-				writer.Write ($" * {test.TestName}");
-				if (!string.IsNullOrEmpty (test.Mode))
-					writer.Write ($"/{test.Mode}");
-				if (!string.IsNullOrEmpty (test.Variation))
-					writer.Write ($"/{test.Variation}");
-				writer.Write ($": {test.ExecutionResult}");
-				if (!string.IsNullOrEmpty (test.FailureMessage))
-					writer.Write ($" ({test.FailureMessage})");
-				if (test.KnownFailure.HasValue)
-					writer.Write ($" Known issue: [{test.KnownFailure.Value.HumanMessage}]({test.KnownFailure.Value.IssueLink})");
-				writer.WriteLine ();
+			foreach (var group in failedTests.GroupBy ((v) => v.TestName)) {
+				var enumerableGroup = group as IEnumerable<ITestTask>;
+				if (enumerableGroup != null) {
+					foreach (var test in enumerableGroup) {
+						writer.Write ($" * {group.Key}");
+						if (!string.IsNullOrEmpty (test.Mode))
+							writer.Write ($"/{test.Mode}");
+						if (!string.IsNullOrEmpty (test.Variation))
+							writer.Write ($"/{test.Variation}");
+						writer.Write ($": {test.ExecutionResult}");
+						if (!string.IsNullOrEmpty (test.FailureMessage))
+							writer.Write ($" ({test.FailureMessage})");
+						if (test.KnownFailure.HasValue)
+							writer.Write ($" Known issue: [{test.KnownFailure.Value.HumanMessage}]({test.KnownFailure.Value.IssueLink})");
+						writer.WriteLine ();
+					}
+					continue;
+				}
 			}
+
 		}
 
 		public void Write (IList<ITestTask> allTasks, StreamWriter writer)


### PR DESCRIPTION
The failures are aggregated tasks, we need to get the grouped task, use the key as
the name of the test and use the rest of the data from the ITestTask.
The reason is that the ITestTask.Name was modified by Jenkins.cs to
group them.

fixes: https://github.com/xamarin/xamarin-macios/issues/8695