### PR TITLE
[Harness] Remove logic that builds sim tasks.

### DIFF
--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -22,7 +22,7 @@ namespace Xharness.Jenkins {
 		readonly IHardwareDeviceLoader devices;
 		readonly IProcessManager processManager;
 		readonly IResultParser resultParser;
-		readonly ITunnelBore tunnelBore;
+		public ITunnelBore TunnelBore { get; private set; }
 		readonly TestSelector testSelector;
 		readonly TestVariationsFactory testVariationsFactory;
 		readonly JenkinsDeviceLoader deviceLoader;
@@ -98,7 +98,7 @@ namespace Xharness.Jenkins {
 		{
 			this.processManager = processManager ?? throw new ArgumentNullException (nameof (processManager));
 			this.resultParser = resultParser ?? throw new ArgumentNullException (nameof (resultParser));
-			this.tunnelBore = tunnelBore ?? throw new ArgumentNullException (nameof (tunnelBore));
+			this.TunnelBore = tunnelBore ?? throw new ArgumentNullException (nameof (tunnelBore));
 			Harness = harness ?? throw new ArgumentNullException (nameof (harness));
 			Simulators = new SimulatorLoader (processManager);
 			devices = new HardwareDeviceLoader (processManager);
@@ -108,53 +108,6 @@ namespace Xharness.Jenkins {
 			resourceManager = new ResourceManager ();
 			htmlReportWriter = new HtmlReportWriter (jenkins: this, resourceManager: resourceManager, resultParser: resultParser);
 			markdownReportWriter = new MarkdownReportWriter ();
-		}
-
-		IEnumerable<RunSimulatorTask> CreateRunSimulatorTaskAsync (MSBuildTask buildTask)
-		{
-			var runtasks = new List<RunSimulatorTask> ();
-
-			TestTarget [] targets = buildTask.Platform.GetAppRunnerTargets ();
-			TestPlatform [] platforms;
-			bool [] ignored;
-
-			switch (buildTask.Platform) {
-			case TestPlatform.tvOS:
-				platforms = new TestPlatform [] { TestPlatform.tvOS };
-				ignored = new [] { false };
-				break;
-			case TestPlatform.watchOS:
-				platforms = new TestPlatform [] { TestPlatform.watchOS_32 };
-				ignored = new [] { false };
-				break;
-			case TestPlatform.iOS_Unified:
-				platforms = new TestPlatform [] { TestPlatform.iOS_Unified32, TestPlatform.iOS_Unified64 };
-				ignored = new [] { !IncludeiOS32, false};
-				break;
-			case TestPlatform.iOS_TodayExtension64:
-				targets = new TestTarget[] { TestTarget.Simulator_iOS64 };
-				platforms = new TestPlatform[] { TestPlatform.iOS_TodayExtension64 };
-				ignored = new [] { false };
-				break;
-			default:
-				throw new NotImplementedException ();
-			}
-
-			for (int i = 0; i < targets.Length; i++) {
-				var sims = Simulators.SelectDevices (targets [i], SimulatorLoadLog, false);
-				runtasks.Add (new RunSimulatorTask (
-					jenkins: this,
-					simulators: Simulators,
-					buildTask: buildTask,
-					processManager: processManager,
-					tunnelBore: tunnelBore,
-					candidates: sims) {
-					Platform = platforms [i],
-					Ignored = ignored[i] || buildTask.Ignored
-				});
-			}
-
-			return runtasks;
 		}
 
 		public bool IsIncluded (TestProject project)
@@ -180,76 +133,6 @@ namespace Xharness.Jenkins {
 				return false;
 
 			return true;
-		}
-
-		async Task<IEnumerable<AppleTestTask>> CreateRunSimulatorTasksAsync ()
-		{
-			var runSimulatorTasks = new List<RunSimulatorTask> ();
-
-			foreach (var project in Harness.IOSTestProjects) {
-				if (!project.IsExecutableProject)
-					continue;
-
-				bool ignored = !IncludeSimulator;
-				if (!IsIncluded (project))
-					ignored = true;
-
-				var ps = new List<Tuple<TestProject, TestPlatform, bool>> ();
-				if (!project.SkipiOSVariation)
-					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project, TestPlatform.iOS_Unified, ignored || !IncludeiOS64));
-				if (project.MonoNativeInfo != null)
-					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project, TestPlatform.iOS_TodayExtension64, ignored || !IncludeiOS64));
-				if (!project.SkiptvOSVariation)
-					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project.AsTvOSProject (), TestPlatform.tvOS, ignored || !IncludetvOS));
-				if (!project.SkipwatchOSVariation)
-					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project.AsWatchOSProject (), TestPlatform.watchOS, ignored || !IncludewatchOS));
-				
-				var configurations = project.Configurations;
-				if (configurations == null)
-					configurations = new string [] { "Debug" };
-				foreach (var config in configurations) {
-					foreach (var pair in ps) {
-						var derived = new MSBuildTask (jenkins: this, testProject: project, processManager: processManager) {
-							ProjectConfiguration = config,
-							ProjectPlatform = "iPhoneSimulator",
-							Platform = pair.Item2,
-							Ignored = pair.Item3,
-							TestName = project.Name,
-							Dependency = project.Dependency,
-						};
-						derived.CloneTestProject (MainLog, processManager, pair.Item1);
-						var simTasks = CreateRunSimulatorTaskAsync (derived);
-						runSimulatorTasks.AddRange (simTasks);
-						foreach (var task in simTasks) {
-							if (configurations.Length > 1)
-								task.Variation = config;
-							task.TimeoutMultiplier = project.TimeoutMultiplier;
-						}
-					}
-				}
-			}
-
-			var testVariations = testVariationsFactory.CreateTestVariations (runSimulatorTasks, (buildTask, test, candidates) =>
-				new RunSimulatorTask (
-					jenkins: this,
-					simulators: Simulators,
-					buildTask: buildTask,
-					processManager: processManager,
-					tunnelBore: tunnelBore,
-					candidates: candidates?.Cast<SimulatorDevice> () ?? test.Candidates)).ToList ();
-
-			foreach (var tv in testVariations) {
-				if (!tv.Ignored)
-					await tv.FindSimulatorAsync ();
-			}
-
-			var rv = new List<AggregatedRunSimulatorTask> ();
-			foreach (var taskGroup in testVariations.GroupBy ((RunSimulatorTask task) => task.Device?.UDID ?? task.Candidates.ToString ())) {
-				rv.Add (new AggregatedRunSimulatorTask (jenkins: this, tasks: taskGroup) {
-					TestName = $"Tests for {taskGroup.Key}",
-				});
-			}
-			return rv;
 		}
 
 		Task<IEnumerable<AppleTestTask>> CreateRunDeviceTasksAsync ()
@@ -279,7 +162,7 @@ namespace Xharness.Jenkins {
 						devices: devices,
 						buildTask: build64,
 						processManager: processManager,
-						tunnelBore: tunnelBore,
+						tunnelBore: TunnelBore,
 						errorKnowledgeBase: ErrorKnowledgeBase,
 						useTcpTunnel: Harness.UseTcpTunnel,
 						candidates: devices.Connected64BitIOS.Where (d => project.IsSupported (d.DevicePlatform, d.ProductVersion))) { Ignored = !IncludeiOS64 });
@@ -296,7 +179,7 @@ namespace Xharness.Jenkins {
 						devices: devices,
 						buildTask: build32,
 						processManager: processManager,
-						tunnelBore: tunnelBore,
+						tunnelBore: TunnelBore,
 						errorKnowledgeBase: ErrorKnowledgeBase,
 						useTcpTunnel: Harness.UseTcpTunnel,
 						candidates: devices.Connected32BitIOS.Where (d => project.IsSupported (d.DevicePlatform, d.ProductVersion))) { Ignored = !IncludeiOS32 });
@@ -314,7 +197,7 @@ namespace Xharness.Jenkins {
 						devices: devices,
 						buildTask: buildToday,
 						processManager: processManager,
-						tunnelBore: tunnelBore,
+						tunnelBore: TunnelBore,
 						errorKnowledgeBase: ErrorKnowledgeBase,
 						useTcpTunnel: Harness.UseTcpTunnel,
 						candidates: devices.Connected64BitIOS.Where (d => project.IsSupported (d.DevicePlatform, d.ProductVersion))) { Ignored = !IncludeiOSExtensions, BuildOnly = ForceExtensionBuildOnly });
@@ -334,7 +217,7 @@ namespace Xharness.Jenkins {
 						devices: devices,
 						buildTask: buildTV,
 						processManager: processManager,
-						tunnelBore: tunnelBore,
+						tunnelBore: TunnelBore,
 						errorKnowledgeBase: ErrorKnowledgeBase,
 						useTcpTunnel: Harness.UseTcpTunnel,
 						candidates: devices.ConnectedTV.Where (d => project.IsSupported (d.DevicePlatform, d.ProductVersion))) { Ignored = !IncludetvOS });
@@ -355,7 +238,7 @@ namespace Xharness.Jenkins {
 							devices: devices,
 							buildTask: buildWatch32,
 							processManager: processManager,
-							tunnelBore: tunnelBore,
+							tunnelBore: TunnelBore,
 							errorKnowledgeBase: ErrorKnowledgeBase,
 							useTcpTunnel: Harness.UseTcpTunnel,
 							candidates: devices.ConnectedWatch) { Ignored = !IncludewatchOS });
@@ -374,7 +257,7 @@ namespace Xharness.Jenkins {
 							devices: devices,
 							buildTask: buildWatch64_32,
 							processManager: processManager,
-							tunnelBore: tunnelBore,
+							tunnelBore: TunnelBore,
 							errorKnowledgeBase: ErrorKnowledgeBase,
 							useTcpTunnel: Harness.UseTcpTunnel,
 							candidates: devices.ConnectedWatch32_64.Where (d => project.IsSupported (d.DevicePlatform, d.ProductVersion))) { Ignored = !IncludewatchOS });
@@ -394,7 +277,7 @@ namespace Xharness.Jenkins {
 					devices: devices,
 					buildTask: buildTask,
 					processManager: processManager,
-					tunnelBore: tunnelBore,
+					tunnelBore: TunnelBore,
 					errorKnowledgeBase: ErrorKnowledgeBase,
 					useTcpTunnel: Harness.UseTcpTunnel,
 					candidates: candidates?.Cast<IHardwareDevice> () ?? test.Candidates)));
@@ -411,7 +294,7 @@ namespace Xharness.Jenkins {
 
 			deviceLoader.LoadAllAsync ().DoNotAwait ();
 
-			var loadsim = CreateRunSimulatorTasksAsync ()
+			var loadsim = RunSimulatorTasksFactory.Create (this, processManager, testVariationsFactory)
 				.ContinueWith ((v) => { Console.WriteLine ("Simulator tasks created"); Tasks.AddRange (v.Result); });
 			
 			//Tasks.AddRange (await CreateRunSimulatorTasksAsync ());

--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -294,7 +294,8 @@ namespace Xharness.Jenkins {
 
 			deviceLoader.LoadAllAsync ().DoNotAwait ();
 
-			var loadsim = RunSimulatorTasksFactory.Create (this, processManager, testVariationsFactory)
+			var simTasksFactory = new RunSimulatorTasksFactory ();
+			var loadsim = simTasksFactory.Create (this, processManager, testVariationsFactory)
 				.ContinueWith ((v) => { Console.WriteLine ("Simulator tasks created"); Tasks.AddRange (v.Result); });
 			
 			//Tasks.AddRange (await CreateRunSimulatorTasksAsync ());

--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -21,12 +21,7 @@ namespace Xharness.Jenkins {
 		public readonly ISimulatorLoader Simulators;
 		readonly IHardwareDeviceLoader devices;
 		readonly IProcessManager processManager;
-<<<<<<< HEAD
-		readonly IResultParser resultParser;
 		public ITunnelBore TunnelBore { get; private set; }
-=======
-		readonly ITunnelBore tunnelBore;
->>>>>>> master
 		readonly TestSelector testSelector;
 		readonly TestVariationsFactory testVariationsFactory;
 		readonly JenkinsDeviceLoader deviceLoader;

--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -295,7 +295,7 @@ namespace Xharness.Jenkins {
 			deviceLoader.LoadAllAsync ().DoNotAwait ();
 
 			var simTasksFactory = new RunSimulatorTasksFactory ();
-			var loadsim = simTasksFactory.Create (this, processManager, testVariationsFactory)
+			var loadsim = simTasksFactory.CreateAsync (this, processManager, testVariationsFactory)
 				.ContinueWith ((v) => { Console.WriteLine ("Simulator tasks created"); Tasks.AddRange (v.Result); });
 			
 			//Tasks.AddRange (await CreateRunSimulatorTasksAsync ());

--- a/tests/xharness/Jenkins/RunSimulatorTasksFactory.cs
+++ b/tests/xharness/Jenkins/RunSimulatorTasksFactory.cs
@@ -5,13 +5,14 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
+using Microsoft.DotNet.XHarness.iOS.Shared.Tasks;
 using Xharness.Jenkins.TestTasks;
 
 namespace Xharness.Jenkins {
 	// lets try and keep this class stateless, will make our lifes better
 	class RunSimulatorTasksFactory {
 
-		public async Task<IEnumerable<AppleTestTask>> Create (Jenkins jenkins, IProcessManager processManager, TestVariationsFactory testVariationsFactory)
+		public async Task<IEnumerable<ITestTask>> CreateAsync (Jenkins jenkins, IProcessManager processManager, TestVariationsFactory testVariationsFactory)
 		{
 			var runSimulatorTasks = new List<RunSimulatorTask> ();
 
@@ -47,7 +48,7 @@ namespace Xharness.Jenkins {
 							Dependency = project.Dependency,
 						};
 						derived.CloneTestProject (jenkins.MainLog, processManager, pair.Item1);
-						var simTasks = Create (jenkins, processManager, derived);
+						var simTasks = CreateAsync (jenkins, processManager, derived);
 						runSimulatorTasks.AddRange (simTasks);
 						foreach (var task in simTasks) {
 							if (configurations.Length > 1)
@@ -81,7 +82,7 @@ namespace Xharness.Jenkins {
 			return rv;
 		}
 
-		IEnumerable<RunSimulatorTask> Create (Jenkins jenkins, IProcessManager processManager, MSBuildTask buildTask)
+		IEnumerable<RunSimulatorTask> CreateAsync (Jenkins jenkins, IProcessManager processManager, MSBuildTask buildTask)
 		{
 			var runtasks = new List<RunSimulatorTask> ();
 

--- a/tests/xharness/Jenkins/RunSimulatorTasksFactory.cs
+++ b/tests/xharness/Jenkins/RunSimulatorTasksFactory.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.XHarness.iOS.Shared;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
+using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
+using Xharness.Jenkins.TestTasks;
+
+namespace Xharness.Jenkins {
+	// lets try and keep this class stateless, will make our lifes better
+	static class RunSimulatorTasksFactory {
+
+		public static async Task<IEnumerable<AppleTestTask>> Create (Jenkins jenkins, IProcessManager processManager, TestVariationsFactory testVariationsFactory)
+		{
+			var runSimulatorTasks = new List<RunSimulatorTask> ();
+
+			foreach (var project in jenkins.Harness.IOSTestProjects) {
+				if (!project.IsExecutableProject)
+					continue;
+
+				bool ignored = !jenkins.IncludeSimulator;
+				if (!jenkins.IsIncluded (project))
+					ignored = true;
+
+				var ps = new List<Tuple<TestProject, TestPlatform, bool>> ();
+				if (!project.SkipiOSVariation)
+					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project, TestPlatform.iOS_Unified, ignored || !jenkins.IncludeiOS64));
+				if (project.MonoNativeInfo != null)
+					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project, TestPlatform.iOS_TodayExtension64, ignored || !jenkins.IncludeiOS64));
+				if (!project.SkiptvOSVariation)
+					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project.AsTvOSProject (), TestPlatform.tvOS, ignored || !jenkins.IncludetvOS));
+				if (!project.SkipwatchOSVariation)
+					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project.AsWatchOSProject (), TestPlatform.watchOS, ignored || !jenkins.IncludewatchOS));
+
+				var configurations = project.Configurations;
+				if (configurations == null)
+					configurations = new string [] { "Debug" };
+				foreach (var config in configurations) {
+					foreach (var pair in ps) {
+						var derived = new MSBuildTask (jenkins: jenkins, testProject: project, processManager: processManager) {
+							ProjectConfiguration = config,
+							ProjectPlatform = "iPhoneSimulator",
+							Platform = pair.Item2,
+							Ignored = pair.Item3,
+							TestName = project.Name,
+							Dependency = project.Dependency,
+						};
+						derived.CloneTestProject (jenkins.MainLog, processManager, pair.Item1);
+						var simTasks = Create (jenkins, processManager, derived);
+						runSimulatorTasks.AddRange (simTasks);
+						foreach (var task in simTasks) {
+							if (configurations.Length > 1)
+								task.Variation = config;
+							task.TimeoutMultiplier = project.TimeoutMultiplier;
+						}
+					}
+				}
+			}
+
+			var testVariations = testVariationsFactory.CreateTestVariations (runSimulatorTasks, (buildTask, test, candidates) =>
+				new RunSimulatorTask (
+					jenkins: jenkins, 
+					simulators: jenkins.Simulators,
+					buildTask: buildTask,
+					processManager: processManager,
+					tunnelBore: jenkins.TunnelBore,
+					candidates: candidates?.Cast<SimulatorDevice> () ?? test.Candidates)).ToList ();
+
+			foreach (var tv in testVariations) {
+				if (!tv.Ignored)
+					await tv.FindSimulatorAsync ();
+			}
+
+			var rv = new List<AggregatedRunSimulatorTask> ();
+			foreach (var taskGroup in testVariations.GroupBy ((RunSimulatorTask task) => task.Device?.UDID ?? task.Candidates.ToString ())) {
+				rv.Add (new AggregatedRunSimulatorTask (jenkins: jenkins, tasks: taskGroup) {
+					TestName = $"Tests for {taskGroup.Key}",
+				});
+			}
+			return rv;
+		}
+
+		static IEnumerable<RunSimulatorTask> Create (Jenkins jenkins, IProcessManager processManager, MSBuildTask buildTask)
+		{
+			var runtasks = new List<RunSimulatorTask> ();
+
+			TestTarget [] targets = buildTask.Platform.GetAppRunnerTargets ();
+			TestPlatform [] platforms;
+			bool [] ignored;
+
+			switch (buildTask.Platform) {
+			case TestPlatform.tvOS:
+				platforms = new TestPlatform [] { TestPlatform.tvOS };
+				ignored = new [] { false };
+				break;
+			case TestPlatform.watchOS:
+				platforms = new TestPlatform [] { TestPlatform.watchOS_32 };
+				ignored = new [] { false };
+				break;
+			case TestPlatform.iOS_Unified:
+				platforms = new TestPlatform [] { TestPlatform.iOS_Unified32, TestPlatform.iOS_Unified64 };
+				ignored = new [] { !jenkins.IncludeiOS32, false };
+				break;
+			case TestPlatform.iOS_TodayExtension64:
+				targets = new TestTarget [] { TestTarget.Simulator_iOS64 };
+				platforms = new TestPlatform [] { TestPlatform.iOS_TodayExtension64 };
+				ignored = new [] { false };
+				break;
+			default:
+				throw new NotImplementedException ();
+			}
+
+			for (int i = 0; i < targets.Length; i++) {
+				var sims = jenkins.Simulators.SelectDevices (targets [i], jenkins.SimulatorLoadLog, false);
+				runtasks.Add (new RunSimulatorTask (
+					jenkins: jenkins,
+					simulators: jenkins.Simulators,
+					buildTask: buildTask,
+					processManager: processManager,
+					tunnelBore: jenkins.TunnelBore,
+					candidates: sims) {
+					Platform = platforms [i],
+					Ignored = ignored [i] || buildTask.Ignored
+				});
+			}
+
+			return runtasks;
+		}
+	}
+}

--- a/tests/xharness/Jenkins/RunSimulatorTasksFactory.cs
+++ b/tests/xharness/Jenkins/RunSimulatorTasksFactory.cs
@@ -9,9 +9,9 @@ using Xharness.Jenkins.TestTasks;
 
 namespace Xharness.Jenkins {
 	// lets try and keep this class stateless, will make our lifes better
-	static class RunSimulatorTasksFactory {
+	class RunSimulatorTasksFactory {
 
-		public static async Task<IEnumerable<AppleTestTask>> Create (Jenkins jenkins, IProcessManager processManager, TestVariationsFactory testVariationsFactory)
+		public async Task<IEnumerable<AppleTestTask>> Create (Jenkins jenkins, IProcessManager processManager, TestVariationsFactory testVariationsFactory)
 		{
 			var runSimulatorTasks = new List<RunSimulatorTask> ();
 
@@ -81,7 +81,7 @@ namespace Xharness.Jenkins {
 			return rv;
 		}
 
-		static IEnumerable<RunSimulatorTask> Create (Jenkins jenkins, IProcessManager processManager, MSBuildTask buildTask)
+		IEnumerable<RunSimulatorTask> Create (Jenkins jenkins, IProcessManager processManager, MSBuildTask buildTask)
 		{
 			var runtasks = new List<RunSimulatorTask> ();
 

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Jenkins\Reports\IReportWriter.cs" />
     <Compile Include="Jenkins\Reports\MarkdownReportWriter.cs" />
     <Compile Include="Jenkins\Reports\HtmlReportWriter.cs" />
+    <Compile Include="Jenkins\RunSimulatorTasksFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\tools\common\SdkVersions.cs">


### PR DESCRIPTION
One step closer to make the Jenkins class just know how to spin the
tasks and what tests are selected. This new class, once we can have a
clean Jenkins class will be testeable.

There are no logic changes.