### PR TITLE
[Harness] Fix markdown take two.

### DIFF
--- a/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
+++ b/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
@@ -31,65 +31,9 @@ namespace Xharness.Jenkins.Reports {
 			this.resultParser = resultParser ?? throw new ArgumentNullException (nameof (resultParser));
 		}
 
-		public void Write (IList<ITestTask> tasks, StreamWriter writer)
+		public void Write (IList<ITestTask> allTasks, StreamWriter writer)
 		{
 			var id_counter = 0;
-
-			var allSimulatorTasks = new List<RunSimulatorTask> ();
-			var allExecuteTasks = new List<MacExecuteTask> ();
-			var allNUnitTasks = new List<NUnitExecuteTask> ();
-			var allMakeTasks = new List<MakeTask> ();
-			var allDeviceTasks = new List<RunDeviceTask> ();
-			var allDotNetTestTasks = new List<DotNetTestTask> ();
-
-			foreach (var task in tasks) {
-				var aggregated = task as AggregatedRunSimulatorTask;
-				if (aggregated != null) {
-					allSimulatorTasks.AddRange (aggregated.Tasks);
-					continue;
-				}
-
-				var execute = task as MacExecuteTask;
-				if (execute != null) {
-					allExecuteTasks.Add (execute);
-					continue;
-				}
-
-				var nunit = task as NUnitExecuteTask;
-				if (nunit != null) {
-					allNUnitTasks.Add (nunit);
-					continue;
-				}
-
-				var make = task as MakeTask;
-				if (make != null) {
-					allMakeTasks.Add (make);
-					continue;
-				}
-
-				var run_device = task as RunDeviceTask;
-				if (run_device != null) {
-					allDeviceTasks.Add (run_device);
-					continue;
-				}
-
-				if (task is DotNetTestTask dotnet) {
-					allDotNetTestTasks.Add (dotnet);
-					continue;
-				}
-
-				throw new NotImplementedException ();
-			}
-
-			var allTasks = new List<ITestTask> ();
-			if (!jenkins.Populating) {
-				allTasks.AddRange (allExecuteTasks);
-				allTasks.AddRange (allSimulatorTasks);
-				allTasks.AddRange (allNUnitTasks);
-				allTasks.AddRange (allMakeTasks);
-				allTasks.AddRange (allDeviceTasks);
-				allTasks.AddRange (allDotNetTestTasks);
-			}
 
 			var failedTests = allTasks.Where ((v) => v.Failed);
 			var deviceNotFound = allTasks.Where ((v) => v.DeviceNotFound);

--- a/tests/xharness/Jenkins/Reports/MarkdownReportWriter.cs
+++ b/tests/xharness/Jenkins/Reports/MarkdownReportWriter.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.DotNet.XHarness.iOS.Shared.Tasks;


### PR DESCRIPTION
The grouping of the tasks was moved to the html report. This meant that
the markdown was not getting all the correct tasks. Move the grouping of
the tasks out of the hml report and use it with the markdown so that
both reports have the same data.

Also fixes an issue when tests failed and did not appear correctly in
the comment such as in comment: https://github.com/xamarin/xamarin-macios/pull/8698#issuecomment-635006243