### PR TITLE
Ignore *.binlog files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ global.json
 .idea
 device-tests-provisioning.csx
 mono_crash.*.json
+*.binlog


### PR DESCRIPTION
They're binary msbuild logs produced by 'msbuild /bl:msbuild.binlog'.