### PR TITLE
[generator] Move optimization that skips required (warning) checks

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4165,9 +4165,13 @@ public partial class Generator : IMemberGatherer {
 
 		foreach (var pi in mi.GetParameters ()) {
 			if (!BindThirdPartyLibrary) {
-				if (!mi.IsSpecialName && IsModel (pi.ParameterType) && !Protocolize (pi))
-					ErrorHelper.Warning (1106,
-						mi.DeclaringType, mi.Name, pi.Name, pi.ParameterType, pi.ParameterType.Namespace, pi.ParameterType.Name);
+				if (!mi.IsSpecialName && IsModel (pi.ParameterType) && !Protocolize (pi)) {
+					// don't warn on obsoleted API, there's likely a new version that fix this
+					// any no good reason for using the obsolete API anyway
+					if (!AttributeManager.HasAttribute <ObsoleteAttribute> (mi) && !AttributeManager.HasAttribute<ObsoleteAttribute> (mi.DeclaringType))
+						ErrorHelper.Warning (1106,
+							mi.DeclaringType, mi.Name, pi.Name, pi.ParameterType, pi.ParameterType.Namespace, pi.ParameterType.Name);
+				}
 			}
 
 			if (null_allowed_override)

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4160,22 +4160,22 @@ public partial class Generator : IMemberGatherer {
 
 	void GenerateArgumentChecks (MethodInfo mi, bool null_allowed_override, PropertyInfo propInfo = null)
 	{
-		if (null_allowed_override)
-			return;
-
 		if (AttributeManager.HasAttribute<NullAllowedAttribute> (mi))
 			ErrorHelper.Show (new BindingException (1118, false, mi));
 
 		foreach (var pi in mi.GetParameters ()) {
-			var needs_null_check = ParameterNeedsNullCheck (pi, mi, propInfo);
-			if (!needs_null_check)
-				continue;
-
 			if (!BindThirdPartyLibrary) {
 				if (!mi.IsSpecialName && IsModel (pi.ParameterType) && !Protocolize (pi))
 					ErrorHelper.Warning (1106,
 						mi.DeclaringType, mi.Name, pi.Name, pi.ParameterType, pi.ParameterType.Namespace, pi.ParameterType.Name);
 			}
+
+			if (null_allowed_override)
+				continue;
+
+			var needs_null_check = ParameterNeedsNullCheck (pi, mi, propInfo);
+			if (!needs_null_check)
+				continue;
 
 			var safe_name = pi.Name.GetSafeParamName ();
 


### PR DESCRIPTION
We're getting out of `GenerateArgumentChecks` too fast when
`null_allowed_override` is `true` so we miss the warning check for
exposing a `[Model]` type instead of the protocol/interface.

Sadly this uncovered a few mistakes in our existing bindings...

```
warning BI1106: bgen: The parameter sampleBufferDelegate in the method AVFoundation.AVCaptureAudioDataOutput.SetSampleBufferDelegateQueue exposes a model (AVFoundation.AVCaptureAudioDataOutputSampleBufferDelegate). Please expose the corresponding protocol type instead (AVFoundation.IAVCaptureAudioDataOutputSampleBufferDelegate).

warning BI1106: bgen: The parameter sampleBufferDelegate in the method AVFoundation.AVCaptureAudioDataOutput.SetSampleBufferDelegateQueue exposes a model (AVFoundation.AVCaptureAudioDataOutputSampleBufferDelegate). Please expose the corresponding protocol type instead (AVFoundation.IAVCaptureAudioDataOutputSampleBufferDelegate).

warning BI1106: bgen: The parameter sampleBufferDelegate in the method AVFoundation.AVCaptureVideoDataOutput.SetSampleBufferDelegate exposes a model (AVFoundation.AVCaptureVideoDataOutputSampleBufferDelegate). Please expose the corresponding protocol type instead (AVFoundation.IAVCaptureVideoDataOutputSampleBufferDelegate).

warning BI1106: bgen: The parameter sampleBufferDelegate in the method AVFoundation.AVCaptureVideoDataOutput.SetSampleBufferDelegate exposes a model (AVFoundation.AVCaptureVideoDataOutputSampleBufferDelegate). Please expose the corresponding protocol type instead (AVFoundation.IAVCaptureVideoDataOutputSampleBufferDelegate).

warning BI1106: bgen: The parameter sampleBufferDelegate in the method AVFoundation.AVCaptureAudioDataOutput.SetSampleBufferDelegateQueue exposes a model (AVFoundation.AVCaptureAudioDataOutputSampleBufferDelegate). Please expose the corresponding protocol type instead (AVFoundation.IAVCaptureAudioDataOutputSampleBufferDelegate).

warning BI1106: bgen: The parameter sampleBufferDelegate in the method AVFoundation.AVCaptureVideoDataOutput.SetSampleBufferDelegate exposes a model (AVFoundation.AVCaptureVideoDataOutputSampleBufferDelegate). Please expose the corresponding protocol type instead (AVFoundation.IAVCaptureVideoDataOutputSampleBufferDelegate).

warning BI1106: bgen: The parameter receiver in the method SceneKit.SCNAnimationDidStartHandler.Invoke exposes a model (SceneKit.SCNAnimatable). Please expose the corresponding protocol type instead (SceneKit.ISCNAnimatable).

warning BI1106: bgen: The parameter receiver in the method SceneKit.SCNAnimationDidStopHandler.Invoke exposes a model (SceneKit.SCNAnimatable). Please expose the corresponding protocol type instead (SceneKit.ISCNAnimatable).

CSC      [watch] Xamarin.WatchOS.dll
warning BI1106: bgen: The parameter receiver in the method SceneKit.SCNAnimationDidStartHandler.Invoke exposes a model (SceneKit.SCNAnimatable). Please expose the corresponding protocol type instead (SceneKit.ISCNAnimatable).

warning BI1106: bgen: The parameter receiver in the method SceneKit.SCNAnimationDidStopHandler.Invoke exposes a model (SceneKit.SCNAnimatable). Please expose the corresponding protocol type instead (SceneKit.ISCNAnimatable).

warning BI1106: bgen: The parameter shadable in the method SceneKit.SCNBufferBindingHandler.Invoke exposes a model (SceneKit.SCNShadable). Please expose the corresponding protocol type instead (SceneKit.ISCNShadable).

CSC      [tvos] Xamarin.TVOS.dll
STRIP    Xamarin.WatchOS.dll
CSC      [watch] MonoTouch.NUnitLite.pdb
warning BI1106: bgen: The parameter receiver in the method SceneKit.SCNAnimationDidStartHandler.Invoke exposes a model (SceneKit.SCNAnimatable). Please expose the corresponding protocol type instead (SceneKit.ISCNAnimatable).

warning BI1106: bgen: The parameter receiver in the method SceneKit.SCNAnimationDidStopHandler.Invoke exposes a model (SceneKit.SCNAnimatable). Please expose the corresponding protocol type instead (SceneKit.ISCNAnimatable).

warning BI1106: bgen: The parameter shadable in the method SceneKit.SCNBufferBindingHandler.Invoke exposes a model (SceneKit.SCNShadable). Please expose the corresponding protocol type instead (SceneKit.ISCNShadable).

warning BI1106: bgen: The parameter receiver in the method SceneKit.SCNAnimationDidStartHandler.Invoke exposes a model (SceneKit.SCNAnimatable). Please expose the corresponding protocol type instead (SceneKit.ISCNAnimatable).

warning BI1106: bgen: The parameter receiver in the method SceneKit.SCNAnimationDidStopHandler.Invoke exposes a model (SceneKit.SCNAnimatable). Please expose the corresponding protocol type instead (SceneKit.ISCNAnimatable).

warning BI1106: bgen: The parameter shadable in the method SceneKit.SCNBufferBindingHandler.Invoke exposes a model (SceneKit.SCNShadable). Please expose the corresponding protocol type instead (SceneKit.ISCNShadable).

CSC      [mac/mobile-64] Xamarin.Mac.dll
CSC      [mac/full-64] Xamarin.Mac.dll
warning BI1106: bgen: The parameter receiver in the method SceneKit.SCNAnimationDidStartHandler.Invoke exposes a model (SceneKit.SCNAnimatable). Please expose the corresponding protocol type instead (SceneKit.ISCNAnimatable).

warning BI1106: bgen: The parameter receiver in the method SceneKit.SCNAnimationDidStopHandler.Invoke exposes a model (SceneKit.SCNAnimatable). Please expose the corresponding protocol type instead (SceneKit.ISCNAnimatable).

warning BI1106: bgen: The parameter shadable in the method SceneKit.SCNBufferBindingHandler.Invoke exposes a model (SceneKit.SCNShadable). Please expose the corresponding protocol type instead (SceneKit.ISCNShadable).
```