### PR TITLE
[dotnet] Inject logic into the Build target to put resolved assemblies and dylibs into the .app.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -6,6 +6,41 @@
 	<Import Project="Xamarin.Shared.Sdk.DefaultItems.targets" />
 	<Import Project="Xamarin.Shared.Sdk.TargetFrameworkInference.targets" />
 
+	<!-- Inject our custom logic into *DependsOn variables -->
+	<PropertyGroup>
+		<BuildDependsOn>
+			$(BuildDependsOn);
+			_CreateAppBundle;
+		</BuildDependsOn>
+
+		<!-- We re-use ComputeFilesToPublish & CopyFilesToPublishDirectory to copy files to the .app -->
+		<CreateAppBundleDependsOn>
+			ComputeFilesToPublish;
+			_ComputePublishLocation;
+			CopyFilesToPublishDirectory;
+		</CreateAppBundleDependsOn>
+	</PropertyGroup>
+
+	<Target Name="_ComputePublishLocation" DependsOnTargets="_GenerateBundleName">
+		<!-- Put .dll, .pdb, .exe and .dylib in the .app -->
+		<PropertyGroup>
+			<_AssemblyPublishDir Condition="'$(_PlatformName)' != 'macOS'">$(MSBuildProjectDirectory)$(_AppBundlePath)\</_AssemblyPublishDir>
+			<_AssemblyPublishDir Condition="'$(_PlatformName)' == 'macOS'">$(MSBuildProjectDirectory)$(_AppBundlePath)\Contents\MonoBundle\</_AssemblyPublishDir>
+			<_DylibPublishDir Condition="'$(_PlatformName)' != 'macOS'">$(MSBuildProjectDirectory)$(_AppBundlePath)\</_DylibPublishDir>
+			<_DylibPublishDir Condition="'$(_PlatformName)' == 'macOS'">$(MSBuildProjectDirectory)$(_AppBundlePath)\Contents\MonoBundle\</_DylibPublishDir>
+		</PropertyGroup>
+		<ItemGroup>
+			<ResolvedFileToPublish
+				Update="@(ResolvedFileToPublish)"
+				RelativePath="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_AssemblyPublishDir)))%(Filename)%(Extension)"
+				Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.pdb' Or '$(Extension)' == '.exe'" />
+			<ResolvedFileToPublish
+				Update="@(ResolvedFileToPublish)"
+				RelativePath="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_DylibPublishDir)))%(Filename)%(Extension)"
+				Condition="'%(Extension)' == '.dylib'" />
+		</ItemGroup>
+	</Target>
+
 	<!-- Project types and how do we distinguish between them
 
 									  OutputType   Custom variable

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -121,7 +121,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Target Name="_CompileColladaAssets" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="$(CompileColladaAssetsDependsOn)" />
 
 	<PropertyGroup>
-		<CreateAppBundleDependsOn>
+		<CreateAppBundleDependsOn Condition="'$(_UsingXamarinSdk)' != 'true'">
 			_DetectSigningIdentity;
 			_CopyContentToBundle;
 			_SmeltMetal;


### PR DESCRIPTION
Inject logic into the Build target to start creating the app bundle:

* Make sure the pre-existing list of targets (CreateAppBundleDependsOn) to
  create an app bundle is not evaluated.
* Create a new CreateAppBundleDependsOn variable that contains the new targets
  we want to run to create the app bundle for net5.
* Call the built-in publishing targets to copy files to the publish directory
  (ComputeFilesToPublish / CopyFilesToPublishDirectory).
* Add a target that rewrites the publish directory for assemblies and dylibs
  to put them in the app bundle instead.