### PR TITLE
[appkit] Allow ObjC calls into NSWindow.Close

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -20411,13 +20411,6 @@ namespace AppKit {
 		[Export ("keyDown:")]
 		void KeyDown (NSEvent  theEvent);
 	
-		/* NSWindow.Close by default calls [window release]
-		 * This will cause a double free in our code since we're not aware of this
-		 * and we end up GCing the proxy eventually and sending our own release
-		 */
-		[Internal, Export ("close")]
-		void _Close ();
-	
 		[Export ("releasedWhenClosed")]
 		bool ReleasedWhenClosed  { [Bind ("isReleasedWhenClosed")] get; set; }
 	


### PR DESCRIPTION
The public `Close` API has additional logic before calling the internal
`_Close` method. However it's the latter that is decorated with the
`[Export]` attributes so it's what's called from ObjC.

This means that closing an NSWindow from the UI chrome (red button)
would by-pass the extra logic in `Close`, which make it possible to
`Dispose` the instance.

reference: https://github.com/xamarin/xamarin-macios/issues/8606