### PR TITLE
Revert "[runtime] set mono_set_crash_chaining (#2184)"

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -554,10 +554,6 @@
 			"mono_bool", "chain_signals"
 		),
 
-		new Export ("void", "mono_set_crash_chaining",
-			"mono_bool", "chain_signals"
-		),
-
 		new Export ("void", "mono_jit_set_trace_options",
 			"const char *", "option"
 		),

--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -542,7 +542,6 @@ app_initialize (xamarin_initialize_data *data)
 	xamarin_initialize_cocoa_threads (NULL);
 	init_logdir ();
 	mono_set_signal_chaining (TRUE);
-	mono_set_crash_chaining (TRUE);
 }
 
 #define __XAMARIN_MAC_RELAUNCH_APP__ "__XAMARIN_MAC_RELAUNCH_APP__"

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -416,7 +416,6 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 #endif
 
 	mono_set_signal_chaining (TRUE);
-	mono_set_crash_chaining (TRUE);
 	mono_install_unhandled_exception_hook (xamarin_unhandled_exception_handler, NULL);
 	mono_install_ftnptr_eh_callback (xamarin_ftnptr_exception_handler);
 


### PR DESCRIPTION
This reverts commit 15c9275b43f40f504b6f115aa951d0b50e1e5425.

Fixes https://github.com/mono/mono/issues/19860

cc @rolfbjarne