### PR TITLE
[msbuild] missing localization comments - part 3

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/README.md
+++ b/msbuild/Xamarin.Localization.MSBuild/README.md
@@ -11,7 +11,22 @@ If changes are made to `MBStrings.resx`, you will hit:
 
 To regenerate the `.xlf` files run:
 
-    $ msbuild Xamarin.Localization.MSBuild.csproj -restore -t:UpdateXlf
+    $ msbuild msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj -restore -t:UpdateXlf
+
+For `mtouch`, `Errors.resx` contains the localizable strings. Use
+these commands instead to update `.xlf` files:
+
+    $ nuget restore tools
+    $ msbuild tools/mtouch/mtouch.csproj -t:UpdateXlf
+
+For `generator`, `src/Resources.resx`, contains the localizable
+strings. To update the `.xlf` files:
+
+    $ nuget restore src
+    $ msbuild src/generator.csproj -t:UpdateXlf
+
+*NOTE: `nuget restore` can be used instead of the MSBuild `-restore`
+switch for projects using `packages.config`*
 
 See [dotnet/xliff-tasks][xliff-tasks] or [Xamarin.Android's
 documentation][xamarin-android] for details.

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -1526,31 +1526,30 @@ namespace Registrar {
 					if (attrib.Version <= sdk)
 						break;
 
-					string msg = Errors.MT4162;
+					string msg;
 					string zero = GetTypeFullName (type);
 					string one = string.Empty;
-					string two = string.Empty;
-					string three = PlatformName;
-					string four = sdk.ToString ();
-					string five = attrib.Version.ToString ();
-					string six = string.IsNullOrEmpty (attrib.Message) ? "." : ": '" + attrib.Message + "'.";
+					string two = PlatformName;
+					string three = sdk.ToString ();
+					string four = attrib.Version.ToString ();
+					string five = string.IsNullOrEmpty (attrib.Message) ? "." : ": '" + attrib.Message + "'.";
 					if (baseTypeOf != null) {
-						one = "a base type of";
-						two = GetTypeFullName (baseTypeOf);
+						msg = Errors.MT4162_BaseType;
+						one = GetTypeFullName (baseTypeOf);
 					} else if (parameterIn != null) {
-						one = "a parameter in";
-						two = parameterIn.DescriptiveMethodName;
+						msg = Errors.MT4162_Parameter;
+						one = parameterIn.DescriptiveMethodName;
 					} else if (returnTypeOf != null) {
-						one = "a return type in";
-						two = returnTypeOf.DescriptiveMethodName;
+						msg = Errors.MT4162_ReturnType;
+						one = returnTypeOf.DescriptiveMethodName;
 					} else if (propertyTypeOf != null) {
-						one = "the property type of";
-						two = propertyTypeOf.FullName;
+						msg = Errors.MT4162_PropertyType;
+						one = propertyTypeOf.FullName;
 					} else {
 						msg = Errors.MT4162_A;
 					}
 
-					msg = string.Format (msg, zero, one, two, three, four, five, six);
+					msg = string.Format (msg, zero, one, two, three, four, five);
 
 					Exception ex;
 

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -436,7 +436,10 @@
 	<data name="BI1033" xml:space="preserve">
 		<value>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
 		</value>
-		<comment>
+		<comment>Generating a strongly typed dictionary for type '{0}' is not supported.
+{0} - the property type.
+{1} - the dictionary type.
+{2} - the property name.
 		</comment>
 	</data>
 		
@@ -741,7 +744,8 @@
 	<data name="BI1077" xml:space="preserve">
 		<value>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
 		</value>
-		<comment>
+		<comment>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
+{0} - The method name.
 		</comment>
 	</data>
 	

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -359,7 +359,10 @@
 		</source>
         <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
 		</target>
-        <note>
+        <note>Generating a strongly typed dictionary for type '{0}' is not supported.
+{0} - the property type.
+{1} - the dictionary type.
+{2} - the property name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
@@ -708,7 +711,8 @@
 		</source>
         <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
 		</target>
-        <note>
+        <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
+{0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -359,7 +359,10 @@
 		</source>
         <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
 		</target>
-        <note>
+        <note>Generating a strongly typed dictionary for type '{0}' is not supported.
+{0} - the property type.
+{1} - the dictionary type.
+{2} - the property name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
@@ -708,7 +711,8 @@
 		</source>
         <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
 		</target>
-        <note>
+        <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
+{0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -359,7 +359,10 @@
 		</source>
         <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
 		</target>
-        <note>
+        <note>Generating a strongly typed dictionary for type '{0}' is not supported.
+{0} - the property type.
+{1} - the dictionary type.
+{2} - the property name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
@@ -708,7 +711,8 @@
 		</source>
         <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
 		</target>
-        <note>
+        <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
+{0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -359,7 +359,10 @@
 		</source>
         <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
 		</target>
-        <note>
+        <note>Generating a strongly typed dictionary for type '{0}' is not supported.
+{0} - the property type.
+{1} - the dictionary type.
+{2} - the property name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
@@ -708,7 +711,8 @@
 		</source>
         <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
 		</target>
-        <note>
+        <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
+{0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -359,7 +359,10 @@
 		</source>
         <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
 		</target>
-        <note>
+        <note>Generating a strongly typed dictionary for type '{0}' is not supported.
+{0} - the property type.
+{1} - the dictionary type.
+{2} - the property name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
@@ -708,7 +711,8 @@
 		</source>
         <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
 		</target>
-        <note>
+        <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
+{0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -359,7 +359,10 @@
 		</source>
         <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
 		</target>
-        <note>
+        <note>Generating a strongly typed dictionary for type '{0}' is not supported.
+{0} - the property type.
+{1} - the dictionary type.
+{2} - the property name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
@@ -708,7 +711,8 @@
 		</source>
         <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
 		</target>
-        <note>
+        <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
+{0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -359,7 +359,10 @@
 		</source>
         <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
 		</target>
-        <note>
+        <note>Generating a strongly typed dictionary for type '{0}' is not supported.
+{0} - the property type.
+{1} - the dictionary type.
+{2} - the property name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
@@ -708,7 +711,8 @@
 		</source>
         <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
 		</target>
-        <note>
+        <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
+{0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -359,7 +359,10 @@
 		</source>
         <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
 		</target>
-        <note>
+        <note>Generating a strongly typed dictionary for type '{0}' is not supported.
+{0} - the property type.
+{1} - the dictionary type.
+{2} - the property name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
@@ -708,7 +711,8 @@
 		</source>
         <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
 		</target>
-        <note>
+        <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
+{0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -359,7 +359,10 @@
 		</source>
         <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
 		</target>
-        <note>
+        <note>Generating a strongly typed dictionary for type '{0}' is not supported.
+{0} - the property type.
+{1} - the dictionary type.
+{2} - the property name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
@@ -708,7 +711,8 @@
 		</source>
         <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
 		</target>
-        <note>
+        <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
+{0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -359,7 +359,10 @@
 		</source>
         <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
 		</target>
-        <note>
+        <note>Generating a strongly typed dictionary for type '{0}' is not supported.
+{0} - the property type.
+{1} - the dictionary type.
+{2} - the property name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
@@ -708,7 +711,8 @@
 		</source>
         <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
 		</target>
-        <note>
+        <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
+{0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -359,7 +359,10 @@
 		</source>
         <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
 		</target>
-        <note>
+        <note>Generating a strongly typed dictionary for type '{0}' is not supported.
+{0} - the property type.
+{1} - the dictionary type.
+{2} - the property name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
@@ -708,7 +711,8 @@
 		</source>
         <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
 		</target>
-        <note>
+        <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
+{0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -359,7 +359,10 @@
 		</source>
         <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
 		</target>
-        <note>
+        <note>Generating a strongly typed dictionary for type '{0}' is not supported.
+{0} - the property type.
+{1} - the dictionary type.
+{2} - the property name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
@@ -708,7 +711,8 @@
 		</source>
         <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
 		</target>
-        <note>
+        <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
+{0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -359,7 +359,10 @@
 		</source>
         <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
 		</target>
-        <note>
+        <note>Generating a strongly typed dictionary for type '{0}' is not supported.
+{0} - the property type.
+{1} - the dictionary type.
+{2} - the property name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
@@ -708,7 +711,8 @@
 		</source>
         <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
 		</target>
-        <note>
+        <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
+{0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -1931,9 +1931,27 @@ namespace Xamarin.Bundler {
             }
         }
         
-        internal static string MT4162 {
+        internal static string MT4162_BaseType {
             get {
-                return ResourceManager.GetString("MT4162", resourceCulture);
+                return ResourceManager.GetString("MT4162_BaseType", resourceCulture);
+            }
+        }
+        
+        internal static string MT4162_Parameter {
+            get {
+                return ResourceManager.GetString("MT4162_Parameter", resourceCulture);
+            }
+        }
+        
+        internal static string MT4162_ReturnType {
+            get {
+                return ResourceManager.GetString("MT4162_ReturnType", resourceCulture);
+            }
+        }
+        
+        internal static string MT4162_PropertyType {
+            get {
+                return ResourceManager.GetString("MT4162_PropertyType", resourceCulture);
             }
         }
         

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -528,14 +528,24 @@
 	<data name="MT0073" xml:space="preserve">
 		<value>{4} {0} does not support a deployment target of {1} for {3} (the minimum is {2}). Please select a newer deployment target in your project's Info.plist.
 		</value>
-		<comment>
+		<comment>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The minimum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</comment>
 	</data>
 
 	<data name="MX0074" xml:space="preserve">
 		<value>{4} {0} does not support a deployment target of {1} for {3} (the maximum is {2}). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of {4}.
 		</value>
-		<comment>
+		<comment>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The maximum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</comment>
 	</data>
 
@@ -877,7 +887,8 @@
 	<data name="MT0112_c" xml:space="preserve">
 		<value>the container app has custom xml definitions for the managed linker ({0}).
 		</value>
-		<comment>
+		<comment>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</comment>
 	</data>
 
@@ -947,7 +958,8 @@
 	<data name="MT0113_i" xml:space="preserve">
 		<value>the extension has custom xml definitions for the managed linker ({0}).
 		</value>
-		<comment>
+		<comment>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</comment>
 	</data>
 	
@@ -1528,7 +1540,7 @@
 	<data name="MM2007" xml:space="preserve">
 		<value>Xamarin.Mac Unified API against a full .NET framework does not support linking SDK or All assemblies. Pass either the `-nolink` or `-linkplatform` flag.
 		</value>
-		<comment>
+		<comment>Using the linker is not supported in certain situations in Xamarin.Mac, see: https://docs.microsoft.com/xamarin/mac/deploy-test/linker. The following are literal names and should not be translated: Xamarin.Mac Unified API, .NET, SDK, All, `-nolink`, and `-linkplatform`.
 		</comment>
 	</data>
 
@@ -2112,7 +2124,8 @@
 	<data name="MT4145" xml:space="preserve">
 		<value>Invalid enum '{0}': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.
 		</value>
-		<comment>
+		<comment>The following are literal names and should not be translated: enum, [Native], long, ulong.
+{0} - The full name of the C# enum.
 		</comment>
 	</data>
 
@@ -2221,10 +2234,57 @@
 		</comment>
 	</data>
 	
-	<data name="MT4162" xml:space="preserve">
-		<value>The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
+	<!-- MT4162: split up into multiple messages -->
+	
+	<data name="MT4162_BaseType" xml:space="preserve">
+		<value>The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
 		</value>
-		<comment>
+		<comment>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the base type.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</comment>
+	</data>
+	
+	<data name="MT4162_Parameter" xml:space="preserve">
+		<value>The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</value>
+		<comment>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</comment>
+	</data>
+	
+	<data name="MT4162_ReturnType" xml:space="preserve">
+		<value>The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</value>
+		<comment>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</comment>
+	</data>
+	
+	<data name="MT4162_PropertyType" xml:space="preserve">
+		<value>The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</value>
+		<comment>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the property.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
 		</comment>
 	</data>
 	

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -167,7 +167,7 @@
 		</source>
         <target state="new">Xamarin.Mac Unified API against a full .NET framework does not support linking SDK or All assemblies. Pass either the `-nolink` or `-linkplatform` flag.
 		</target>
-        <note>
+        <note>Using the linker is not supported in certain situations in Xamarin.Mac, see: https://docs.microsoft.com/xamarin/mac/deploy-test/linker. The following are literal names and should not be translated: Xamarin.Mac Unified API, .NET, SDK, All, `-nolink`, and `-linkplatform`.
 		</note>
       </trans-unit>
       <trans-unit id="MM2009">
@@ -767,7 +767,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the minimum is {2}). Please select a newer deployment target in your project's Info.plist.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The minimum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MT0075">
@@ -1031,7 +1036,8 @@
 		</source>
         <target state="new">the container app has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113">
@@ -1111,7 +1117,8 @@
 		</source>
         <target state="new">the extension has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113_j">
@@ -2095,7 +2102,8 @@
 		</source>
         <target state="new">Invalid enum '{0}': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: enum, [Native], long, ulong.
+{0} - The full name of the C# enum.
 		</note>
       </trans-unit>
       <trans-unit id="MT4146">
@@ -2218,20 +2226,68 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT4162">
-        <source>The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</source>
-        <target state="new">The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT4162_A">
         <source>The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</source>
         <target state="new">The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</target>
         <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_BaseType">
+        <source>The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the base type.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_Parameter">
+        <source>The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_PropertyType">
+        <source>The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the property.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_ReturnType">
+        <source>The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
 		</note>
       </trans-unit>
       <trans-unit id="MT4163">
@@ -2775,7 +2831,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the maximum is {2}). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of {4}.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The maximum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MX0080">

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -167,7 +167,7 @@
 		</source>
         <target state="new">Xamarin.Mac Unified API against a full .NET framework does not support linking SDK or All assemblies. Pass either the `-nolink` or `-linkplatform` flag.
 		</target>
-        <note>
+        <note>Using the linker is not supported in certain situations in Xamarin.Mac, see: https://docs.microsoft.com/xamarin/mac/deploy-test/linker. The following are literal names and should not be translated: Xamarin.Mac Unified API, .NET, SDK, All, `-nolink`, and `-linkplatform`.
 		</note>
       </trans-unit>
       <trans-unit id="MM2009">
@@ -767,7 +767,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the minimum is {2}). Please select a newer deployment target in your project's Info.plist.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The minimum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MT0075">
@@ -1031,7 +1036,8 @@
 		</source>
         <target state="new">the container app has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113">
@@ -1111,7 +1117,8 @@
 		</source>
         <target state="new">the extension has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113_j">
@@ -2095,7 +2102,8 @@
 		</source>
         <target state="new">Invalid enum '{0}': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: enum, [Native], long, ulong.
+{0} - The full name of the C# enum.
 		</note>
       </trans-unit>
       <trans-unit id="MT4146">
@@ -2218,20 +2226,68 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT4162">
-        <source>The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</source>
-        <target state="new">The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT4162_A">
         <source>The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</source>
         <target state="new">The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</target>
         <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_BaseType">
+        <source>The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the base type.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_Parameter">
+        <source>The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_PropertyType">
+        <source>The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the property.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_ReturnType">
+        <source>The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
 		</note>
       </trans-unit>
       <trans-unit id="MT4163">
@@ -2775,7 +2831,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the maximum is {2}). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of {4}.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The maximum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MX0080">

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -167,7 +167,7 @@
 		</source>
         <target state="new">Xamarin.Mac Unified API against a full .NET framework does not support linking SDK or All assemblies. Pass either the `-nolink` or `-linkplatform` flag.
 		</target>
-        <note>
+        <note>Using the linker is not supported in certain situations in Xamarin.Mac, see: https://docs.microsoft.com/xamarin/mac/deploy-test/linker. The following are literal names and should not be translated: Xamarin.Mac Unified API, .NET, SDK, All, `-nolink`, and `-linkplatform`.
 		</note>
       </trans-unit>
       <trans-unit id="MM2009">
@@ -767,7 +767,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the minimum is {2}). Please select a newer deployment target in your project's Info.plist.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The minimum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MT0075">
@@ -1031,7 +1036,8 @@
 		</source>
         <target state="new">the container app has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113">
@@ -1111,7 +1117,8 @@
 		</source>
         <target state="new">the extension has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113_j">
@@ -2095,7 +2102,8 @@
 		</source>
         <target state="new">Invalid enum '{0}': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: enum, [Native], long, ulong.
+{0} - The full name of the C# enum.
 		</note>
       </trans-unit>
       <trans-unit id="MT4146">
@@ -2218,20 +2226,68 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT4162">
-        <source>The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</source>
-        <target state="new">The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT4162_A">
         <source>The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</source>
         <target state="new">The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</target>
         <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_BaseType">
+        <source>The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the base type.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_Parameter">
+        <source>The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_PropertyType">
+        <source>The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the property.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_ReturnType">
+        <source>The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
 		</note>
       </trans-unit>
       <trans-unit id="MT4163">
@@ -2775,7 +2831,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the maximum is {2}). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of {4}.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The maximum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MX0080">

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -167,7 +167,7 @@
 		</source>
         <target state="new">Xamarin.Mac Unified API against a full .NET framework does not support linking SDK or All assemblies. Pass either the `-nolink` or `-linkplatform` flag.
 		</target>
-        <note>
+        <note>Using the linker is not supported in certain situations in Xamarin.Mac, see: https://docs.microsoft.com/xamarin/mac/deploy-test/linker. The following are literal names and should not be translated: Xamarin.Mac Unified API, .NET, SDK, All, `-nolink`, and `-linkplatform`.
 		</note>
       </trans-unit>
       <trans-unit id="MM2009">
@@ -767,7 +767,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the minimum is {2}). Please select a newer deployment target in your project's Info.plist.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The minimum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MT0075">
@@ -1031,7 +1036,8 @@
 		</source>
         <target state="new">the container app has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113">
@@ -1111,7 +1117,8 @@
 		</source>
         <target state="new">the extension has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113_j">
@@ -2095,7 +2102,8 @@
 		</source>
         <target state="new">Invalid enum '{0}': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: enum, [Native], long, ulong.
+{0} - The full name of the C# enum.
 		</note>
       </trans-unit>
       <trans-unit id="MT4146">
@@ -2218,20 +2226,68 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT4162">
-        <source>The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</source>
-        <target state="new">The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT4162_A">
         <source>The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</source>
         <target state="new">The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</target>
         <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_BaseType">
+        <source>The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the base type.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_Parameter">
+        <source>The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_PropertyType">
+        <source>The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the property.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_ReturnType">
+        <source>The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
 		</note>
       </trans-unit>
       <trans-unit id="MT4163">
@@ -2775,7 +2831,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the maximum is {2}). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of {4}.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The maximum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MX0080">

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -167,7 +167,7 @@
 		</source>
         <target state="new">Xamarin.Mac Unified API against a full .NET framework does not support linking SDK or All assemblies. Pass either the `-nolink` or `-linkplatform` flag.
 		</target>
-        <note>
+        <note>Using the linker is not supported in certain situations in Xamarin.Mac, see: https://docs.microsoft.com/xamarin/mac/deploy-test/linker. The following are literal names and should not be translated: Xamarin.Mac Unified API, .NET, SDK, All, `-nolink`, and `-linkplatform`.
 		</note>
       </trans-unit>
       <trans-unit id="MM2009">
@@ -767,7 +767,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the minimum is {2}). Please select a newer deployment target in your project's Info.plist.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The minimum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MT0075">
@@ -1031,7 +1036,8 @@
 		</source>
         <target state="new">the container app has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113">
@@ -1111,7 +1117,8 @@
 		</source>
         <target state="new">the extension has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113_j">
@@ -2095,7 +2102,8 @@
 		</source>
         <target state="new">Invalid enum '{0}': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: enum, [Native], long, ulong.
+{0} - The full name of the C# enum.
 		</note>
       </trans-unit>
       <trans-unit id="MT4146">
@@ -2218,20 +2226,68 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT4162">
-        <source>The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</source>
-        <target state="new">The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT4162_A">
         <source>The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</source>
         <target state="new">The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</target>
         <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_BaseType">
+        <source>The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the base type.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_Parameter">
+        <source>The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_PropertyType">
+        <source>The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the property.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_ReturnType">
+        <source>The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
 		</note>
       </trans-unit>
       <trans-unit id="MT4163">
@@ -2775,7 +2831,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the maximum is {2}). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of {4}.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The maximum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MX0080">

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -167,7 +167,7 @@
 		</source>
         <target state="new">Xamarin.Mac Unified API against a full .NET framework does not support linking SDK or All assemblies. Pass either the `-nolink` or `-linkplatform` flag.
 		</target>
-        <note>
+        <note>Using the linker is not supported in certain situations in Xamarin.Mac, see: https://docs.microsoft.com/xamarin/mac/deploy-test/linker. The following are literal names and should not be translated: Xamarin.Mac Unified API, .NET, SDK, All, `-nolink`, and `-linkplatform`.
 		</note>
       </trans-unit>
       <trans-unit id="MM2009">
@@ -767,7 +767,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the minimum is {2}). Please select a newer deployment target in your project's Info.plist.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The minimum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MT0075">
@@ -1031,7 +1036,8 @@
 		</source>
         <target state="new">the container app has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113">
@@ -1111,7 +1117,8 @@
 		</source>
         <target state="new">the extension has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113_j">
@@ -2095,7 +2102,8 @@
 		</source>
         <target state="new">Invalid enum '{0}': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: enum, [Native], long, ulong.
+{0} - The full name of the C# enum.
 		</note>
       </trans-unit>
       <trans-unit id="MT4146">
@@ -2218,20 +2226,68 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT4162">
-        <source>The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</source>
-        <target state="new">The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT4162_A">
         <source>The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</source>
         <target state="new">The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</target>
         <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_BaseType">
+        <source>The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the base type.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_Parameter">
+        <source>The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_PropertyType">
+        <source>The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the property.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_ReturnType">
+        <source>The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
 		</note>
       </trans-unit>
       <trans-unit id="MT4163">
@@ -2775,7 +2831,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the maximum is {2}). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of {4}.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The maximum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MX0080">

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -167,7 +167,7 @@
 		</source>
         <target state="new">Xamarin.Mac Unified API against a full .NET framework does not support linking SDK or All assemblies. Pass either the `-nolink` or `-linkplatform` flag.
 		</target>
-        <note>
+        <note>Using the linker is not supported in certain situations in Xamarin.Mac, see: https://docs.microsoft.com/xamarin/mac/deploy-test/linker. The following are literal names and should not be translated: Xamarin.Mac Unified API, .NET, SDK, All, `-nolink`, and `-linkplatform`.
 		</note>
       </trans-unit>
       <trans-unit id="MM2009">
@@ -767,7 +767,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the minimum is {2}). Please select a newer deployment target in your project's Info.plist.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The minimum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MT0075">
@@ -1031,7 +1036,8 @@
 		</source>
         <target state="new">the container app has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113">
@@ -1111,7 +1117,8 @@
 		</source>
         <target state="new">the extension has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113_j">
@@ -2095,7 +2102,8 @@
 		</source>
         <target state="new">Invalid enum '{0}': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: enum, [Native], long, ulong.
+{0} - The full name of the C# enum.
 		</note>
       </trans-unit>
       <trans-unit id="MT4146">
@@ -2218,20 +2226,68 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT4162">
-        <source>The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</source>
-        <target state="new">The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT4162_A">
         <source>The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</source>
         <target state="new">The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</target>
         <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_BaseType">
+        <source>The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the base type.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_Parameter">
+        <source>The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_PropertyType">
+        <source>The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the property.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_ReturnType">
+        <source>The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
 		</note>
       </trans-unit>
       <trans-unit id="MT4163">
@@ -2775,7 +2831,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the maximum is {2}). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of {4}.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The maximum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MX0080">

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -167,7 +167,7 @@
 		</source>
         <target state="new">Xamarin.Mac Unified API against a full .NET framework does not support linking SDK or All assemblies. Pass either the `-nolink` or `-linkplatform` flag.
 		</target>
-        <note>
+        <note>Using the linker is not supported in certain situations in Xamarin.Mac, see: https://docs.microsoft.com/xamarin/mac/deploy-test/linker. The following are literal names and should not be translated: Xamarin.Mac Unified API, .NET, SDK, All, `-nolink`, and `-linkplatform`.
 		</note>
       </trans-unit>
       <trans-unit id="MM2009">
@@ -767,7 +767,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the minimum is {2}). Please select a newer deployment target in your project's Info.plist.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The minimum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MT0075">
@@ -1031,7 +1036,8 @@
 		</source>
         <target state="new">the container app has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113">
@@ -1111,7 +1117,8 @@
 		</source>
         <target state="new">the extension has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113_j">
@@ -2095,7 +2102,8 @@
 		</source>
         <target state="new">Invalid enum '{0}': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: enum, [Native], long, ulong.
+{0} - The full name of the C# enum.
 		</note>
       </trans-unit>
       <trans-unit id="MT4146">
@@ -2218,20 +2226,68 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT4162">
-        <source>The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</source>
-        <target state="new">The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT4162_A">
         <source>The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</source>
         <target state="new">The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</target>
         <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_BaseType">
+        <source>The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the base type.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_Parameter">
+        <source>The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_PropertyType">
+        <source>The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the property.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_ReturnType">
+        <source>The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
 		</note>
       </trans-unit>
       <trans-unit id="MT4163">
@@ -2775,7 +2831,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the maximum is {2}). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of {4}.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The maximum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MX0080">

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -167,7 +167,7 @@
 		</source>
         <target state="new">Xamarin.Mac Unified API against a full .NET framework does not support linking SDK or All assemblies. Pass either the `-nolink` or `-linkplatform` flag.
 		</target>
-        <note>
+        <note>Using the linker is not supported in certain situations in Xamarin.Mac, see: https://docs.microsoft.com/xamarin/mac/deploy-test/linker. The following are literal names and should not be translated: Xamarin.Mac Unified API, .NET, SDK, All, `-nolink`, and `-linkplatform`.
 		</note>
       </trans-unit>
       <trans-unit id="MM2009">
@@ -767,7 +767,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the minimum is {2}). Please select a newer deployment target in your project's Info.plist.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The minimum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MT0075">
@@ -1031,7 +1036,8 @@
 		</source>
         <target state="new">the container app has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113">
@@ -1111,7 +1117,8 @@
 		</source>
         <target state="new">the extension has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113_j">
@@ -2095,7 +2102,8 @@
 		</source>
         <target state="new">Invalid enum '{0}': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: enum, [Native], long, ulong.
+{0} - The full name of the C# enum.
 		</note>
       </trans-unit>
       <trans-unit id="MT4146">
@@ -2218,20 +2226,68 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT4162">
-        <source>The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</source>
-        <target state="new">The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT4162_A">
         <source>The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</source>
         <target state="new">The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</target>
         <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_BaseType">
+        <source>The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the base type.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_Parameter">
+        <source>The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_PropertyType">
+        <source>The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the property.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_ReturnType">
+        <source>The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
 		</note>
       </trans-unit>
       <trans-unit id="MT4163">
@@ -2775,7 +2831,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the maximum is {2}). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of {4}.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The maximum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MX0080">

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -167,7 +167,7 @@
 		</source>
         <target state="new">Xamarin.Mac Unified API against a full .NET framework does not support linking SDK or All assemblies. Pass either the `-nolink` or `-linkplatform` flag.
 		</target>
-        <note>
+        <note>Using the linker is not supported in certain situations in Xamarin.Mac, see: https://docs.microsoft.com/xamarin/mac/deploy-test/linker. The following are literal names and should not be translated: Xamarin.Mac Unified API, .NET, SDK, All, `-nolink`, and `-linkplatform`.
 		</note>
       </trans-unit>
       <trans-unit id="MM2009">
@@ -767,7 +767,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the minimum is {2}). Please select a newer deployment target in your project's Info.plist.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The minimum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MT0075">
@@ -1031,7 +1036,8 @@
 		</source>
         <target state="new">the container app has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113">
@@ -1111,7 +1117,8 @@
 		</source>
         <target state="new">the extension has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113_j">
@@ -2095,7 +2102,8 @@
 		</source>
         <target state="new">Invalid enum '{0}': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: enum, [Native], long, ulong.
+{0} - The full name of the C# enum.
 		</note>
       </trans-unit>
       <trans-unit id="MT4146">
@@ -2218,20 +2226,68 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT4162">
-        <source>The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</source>
-        <target state="new">The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT4162_A">
         <source>The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</source>
         <target state="new">The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</target>
         <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_BaseType">
+        <source>The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the base type.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_Parameter">
+        <source>The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_PropertyType">
+        <source>The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the property.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_ReturnType">
+        <source>The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
 		</note>
       </trans-unit>
       <trans-unit id="MT4163">
@@ -2775,7 +2831,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the maximum is {2}). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of {4}.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The maximum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MX0080">

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -167,7 +167,7 @@
 		</source>
         <target state="new">Xamarin.Mac Unified API against a full .NET framework does not support linking SDK or All assemblies. Pass either the `-nolink` or `-linkplatform` flag.
 		</target>
-        <note>
+        <note>Using the linker is not supported in certain situations in Xamarin.Mac, see: https://docs.microsoft.com/xamarin/mac/deploy-test/linker. The following are literal names and should not be translated: Xamarin.Mac Unified API, .NET, SDK, All, `-nolink`, and `-linkplatform`.
 		</note>
       </trans-unit>
       <trans-unit id="MM2009">
@@ -767,7 +767,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the minimum is {2}). Please select a newer deployment target in your project's Info.plist.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The minimum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MT0075">
@@ -1031,7 +1036,8 @@
 		</source>
         <target state="new">the container app has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113">
@@ -1111,7 +1117,8 @@
 		</source>
         <target state="new">the extension has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113_j">
@@ -2095,7 +2102,8 @@
 		</source>
         <target state="new">Invalid enum '{0}': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: enum, [Native], long, ulong.
+{0} - The full name of the C# enum.
 		</note>
       </trans-unit>
       <trans-unit id="MT4146">
@@ -2218,20 +2226,68 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT4162">
-        <source>The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</source>
-        <target state="new">The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT4162_A">
         <source>The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</source>
         <target state="new">The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</target>
         <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_BaseType">
+        <source>The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the base type.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_Parameter">
+        <source>The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_PropertyType">
+        <source>The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the property.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_ReturnType">
+        <source>The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
 		</note>
       </trans-unit>
       <trans-unit id="MT4163">
@@ -2775,7 +2831,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the maximum is {2}). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of {4}.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The maximum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MX0080">

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -167,7 +167,7 @@
 		</source>
         <target state="new">Xamarin.Mac Unified API against a full .NET framework does not support linking SDK or All assemblies. Pass either the `-nolink` or `-linkplatform` flag.
 		</target>
-        <note>
+        <note>Using the linker is not supported in certain situations in Xamarin.Mac, see: https://docs.microsoft.com/xamarin/mac/deploy-test/linker. The following are literal names and should not be translated: Xamarin.Mac Unified API, .NET, SDK, All, `-nolink`, and `-linkplatform`.
 		</note>
       </trans-unit>
       <trans-unit id="MM2009">
@@ -767,7 +767,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the minimum is {2}). Please select a newer deployment target in your project's Info.plist.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The minimum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MT0075">
@@ -1031,7 +1036,8 @@
 		</source>
         <target state="new">the container app has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113">
@@ -1111,7 +1117,8 @@
 		</source>
         <target state="new">the extension has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113_j">
@@ -2095,7 +2102,8 @@
 		</source>
         <target state="new">Invalid enum '{0}': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: enum, [Native], long, ulong.
+{0} - The full name of the C# enum.
 		</note>
       </trans-unit>
       <trans-unit id="MT4146">
@@ -2218,20 +2226,68 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT4162">
-        <source>The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</source>
-        <target state="new">The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT4162_A">
         <source>The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</source>
         <target state="new">The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</target>
         <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_BaseType">
+        <source>The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the base type.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_Parameter">
+        <source>The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_PropertyType">
+        <source>The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the property.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_ReturnType">
+        <source>The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
 		</note>
       </trans-unit>
       <trans-unit id="MT4163">
@@ -2775,7 +2831,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the maximum is {2}). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of {4}.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The maximum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MX0080">

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -167,7 +167,7 @@
 		</source>
         <target state="new">Xamarin.Mac Unified API against a full .NET framework does not support linking SDK or All assemblies. Pass either the `-nolink` or `-linkplatform` flag.
 		</target>
-        <note>
+        <note>Using the linker is not supported in certain situations in Xamarin.Mac, see: https://docs.microsoft.com/xamarin/mac/deploy-test/linker. The following are literal names and should not be translated: Xamarin.Mac Unified API, .NET, SDK, All, `-nolink`, and `-linkplatform`.
 		</note>
       </trans-unit>
       <trans-unit id="MM2009">
@@ -767,7 +767,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the minimum is {2}). Please select a newer deployment target in your project's Info.plist.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The minimum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MT0075">
@@ -1031,7 +1036,8 @@
 		</source>
         <target state="new">the container app has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113">
@@ -1111,7 +1117,8 @@
 		</source>
         <target state="new">the extension has custom xml definitions for the managed linker ({0}).
 		</target>
-        <note>
+        <note>A warning related to custom linker configuration, see: https://docs.microsoft.com/xamarin/cross-platform/deploy-test/linker. The following are literal names and should not be translated: xml, linker
+{0} - A list of xml file names.
 		</note>
       </trans-unit>
       <trans-unit id="MT0113_j">
@@ -2095,7 +2102,8 @@
 		</source>
         <target state="new">Invalid enum '{0}': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: enum, [Native], long, ulong.
+{0} - The full name of the C# enum.
 		</note>
       </trans-unit>
       <trans-unit id="MT4146">
@@ -2218,20 +2226,68 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT4162">
-        <source>The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</source>
-        <target state="new">The type '{0}' (used as {1} {2}) is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT4162_A">
         <source>The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</source>
         <target state="new">The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</target>
         <note>
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_BaseType">
+        <source>The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a base type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the base type.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_Parameter">
+        <source>The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a parameter in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_PropertyType">
+        <source>The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as the property type of {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the property.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
+		</note>
+      </trans-unit>
+      <trans-unit id="MT4162_ReturnType">
+        <source>The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</source>
+        <target state="new">The type '{0}' (used as a return type in {1}) is not available in {2} {3} (it was introduced in {2} {4}){5} Please build with a newer {2} SDK (usually done by using the most recent version of Xcode).
+		</target>
+        <note>This is a message for usage of a type that is not available targeting older platform versions. The following are literal names and should not be translated: SDK, Xcode
+{0} - The full C# type name.
+{1} - The name of the method.
+{2} - The platform name, such as 'iOS'.
+{3} - The current platform version number.
+{4} - The platform version where the type was introduced.
+{5} - An additional message about the platform version introducing the type.
 		</note>
       </trans-unit>
       <trans-unit id="MT4163">
@@ -2775,7 +2831,12 @@
 		</source>
         <target state="new">{4} {0} does not support a deployment target of {1} for {3} (the maximum is {2}). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of {4}.
 		</target>
-        <note>
+        <note>The following are literal names and should not be translated: SDK, Xcode
+{0} - The version number of the Xamarin product.
+{1} - The name of the deployment target such as a device, simulator, etc.
+{2} - The maximum version number.
+{3} - The platform name, such as 'iOS'.
+{4} - The produce name such as Xamarin.iOS or Xamarin.Mac.
 		</note>
       </trans-unit>
       <trans-unit id="MX0080">


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-macios/issues/8468

Added missing `<comment/>` fields for:

* BI1033
* BI1077
* MM2007
* MT0073
* MT0074
* MT0112_c
* MT0113_i
* MT4146
* MT4162

I had to split up the `MT4162` error message, introducing:

* `Errors.MT4162_BaseType` - a base type of
* `Errors.MT4162_Parameter` - a parameter in
* `Errors.MT4162_ReturnType` - a return type in
* `Errors.MT4162_PropertyType` - the property type of

This also removed an argument passed into `string.Format`.