### PR TITLE
[mtouch/mmp] Add CFNetwork to our list of frameworks for iOS and macOS.

### DIFF
--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -124,6 +124,7 @@ public class Frameworks : Dictionary <string, Framework>
 
 					{ "Accounts", 10, 8 },
 					{ "AudioVideoBridging", 10, 8 },
+					{ "CFNetwork", 10, 8 },
 					{ "EventKit", 10, 8 },
 					{ "GameKit", 10, 8 },
 					{ "GLKit", 10, 8 },
@@ -211,6 +212,7 @@ public class Frameworks : Dictionary <string, Framework>
 				{ "AddressBookUI", "AddressBookUI", 3 },
 				{ "AudioToolbox", "AudioToolbox", 3 },
 				{ "AVFoundation", "AVFoundation", 3 },
+				{ "CFNetwork", "CFNetwork", 3 },
 				{ "CoreAnimation", "QuartzCore", 3 },
 				{ "CoreData", "CoreData", 3 },
 				{ "CoreGraphics", "CoreGraphics", 3 },


### PR DESCRIPTION
It's already in the list for tvOS and watchOS.