### PR TITLE
[dotnet] Improve the 'clean' target.

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -123,7 +123,7 @@ all-local:: $(TARGETS) targets/Xamarin.Shared.Sdk.Versions.props
 endif
 
 clean-local::
-	$(Q) rm -Rf $(DOTNET_DESTDIR) $(DOTNET_NUPKG_DIR) $(DOTNET_FEED_DIR)
+	$(Q) rm -Rf $(DOTNET_NUPKG_DIR) $(DOTNET_FEED_DIR)
 	$(Q) git clean -xfdq
 
 .SECONDARY:


### PR DESCRIPTION
Don't nuke the entire DOTNET_DESTDIR, because that means it will be necessary
to run 'make' in the top-level directory again. Instead only clean files that
the dotnet/ directory will re-build.