### PR TITLE
[foundation] Do not throw inside NSObject.SuperHandle property getter

### DIFF
--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -390,9 +390,6 @@ namespace Foundation {
 
 		public IntPtr SuperHandle {
 			get {
-				if (handle == IntPtr.Zero)
-					return IntPtr.Zero;
-
 				if (class_handle == IntPtr.Zero)
 					class_handle = ClassHandle;
 

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -391,7 +391,7 @@ namespace Foundation {
 		public IntPtr SuperHandle {
 			get {
 				if (handle == IntPtr.Zero)
-					throw new ObjectDisposedException (GetType ().Name);
+					return IntPtr.Zero;
 
 				if (class_handle == IntPtr.Zero)
 					class_handle = ClassHandle;

--- a/tests/monotouch-test/ObjCRuntime/Messaging.cs
+++ b/tests/monotouch-test/ObjCRuntime/Messaging.cs
@@ -29,6 +29,9 @@ namespace ObjCRuntime
 		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSendSuper")]
 		public extern static void void_objc_msgSendSuper (ref objc_super receiver, IntPtr selector);
 
+		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
+		public extern static void void_objc_msgSendSuper (IntPtr receiver, IntPtr selector);
+
 		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend")]
 		public extern static void void_objc_msgSend_IntPtr (IntPtr receiver, IntPtr selector, IntPtr value);
 

--- a/tests/monotouch-test/ObjCRuntime/MessagingTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/MessagingTest.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Foundation;
+using ObjCRuntime;
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.ObjCRuntime {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class MessagingTest {
+		[Test]
+		public void NullReceiver ()
+		{
+			// null receiver and valid selector
+			global::ObjCRuntime.Messaging.void_objc_msgSend (IntPtr.Zero, global::ObjCRuntime.Selector.GetHandle ("release"));
+
+			// null receiver and null selector - that null-selector only works because there's not receiver
+			global::ObjCRuntime.Messaging.void_objc_msgSend (IntPtr.Zero, IntPtr.Zero);
+
+#if false
+			// this disabled code would crash because selector is null (and there's a receiver)
+			var obj = new NSData ();
+			global::ObjCRuntime.Messaging.void_objc_msgSend (obj.Handle, IntPtr.Zero);
+#endif
+		}
+
+		[Test]
+		public void SuperNullReceiver ()
+		{
+			var obj = new NSData ();
+			// notes:
+			// * `IntPtr.Zero` would crash since it's used (without check) to get both `self` and `super`
+			// * unlike `objc_msgSend` a null selector would crash in this case
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper (obj.SuperHandle, global::ObjCRuntime.Selector.GetHandle ("retain"));
+
+			obj.Handle = IntPtr.Zero;
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper (obj.SuperHandle, global::ObjCRuntime.Selector.GetHandle ("release"));
+			// a null `Handle` just skip sending the message (as `objc_msgSend` does)
+
+#if false
+			// old bindings were using this structure (and tests still has a copy of it)
+			// this allows us to set `super` to `IntPtr.Zero` (defaut), which is not (easily) possible using our NSObject
+			var old = new Messaging.objc_super ();
+			// here both `self/Handle` and `super/SuperHandle` are `null` and this would crash, so `super` is super important
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper (ref old, global::ObjCRuntime.Selector.GetHandle ("retain"));
+#endif
+		}
+	}
+}


### PR DESCRIPTION
It's against the FXDG https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/property

> ❌ AVOID throwing exceptions from property getters.

and it makes things harder in some corner cases, like when Apple calls
a selector after an instance is disposed, e.g.

https://github.com/xamarin/xamarin-macios/issues/8606#issuecomment-637221248

It's not the only case where we throw in getters but this one is an
immediate and much more common case than others.