### PR TITLE
[tools] Fix printing failed command to print the actual arguments instead of the list itself.

### DIFF
--- a/tests/common/mac/ProjectTestHelpers.cs
+++ b/tests/common/mac/ProjectTestHelpers.cs
@@ -699,7 +699,7 @@ namespace Xamarin.Bundler {
 					// note: this repeat the failing command line. However we can't avoid this since we're often
 					// running commands in parallel (so the last one printed might not be the one failing)
 					if (!suppressPrintOnErrors)
-						Console.Error.WriteLine ("Process exited with code {0}, command:\n{1} {2}{3}", p.ExitCode, path, args, output.Length > 0 ? "\n" + output.ToString () : string.Empty);
+						Console.Error.WriteLine ("Process exited with code {0}, command:\n{1} {2}{3}", p.ExitCode, path, StringUtils.FormatArguments (args), output.Length > 0 ? "\n" + output.ToString () : string.Empty);
 					return p.ExitCode;
 				} else if (verbose > 0 && output.Length > 0 && !suppressPrintOnErrors) {
 					Console.WriteLine (output.ToString ());

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -631,7 +631,7 @@ namespace Xamarin.Bundler {
 						// also write to the Console, confusing the output.
 						if (output == null)
 							output = new StringBuilder ();
-						output.Insert (0, $"Process exited with code {p.ExitCode}, command:\n{path} {args}\n");
+						output.Insert (0, $"Process exited with code {p.ExitCode}, command:\n{path} {StringUtils.FormatArguments (args)}\n");
 						Console.Error.WriteLine (output);
 					}
 					return p.ExitCode;


### PR DESCRIPTION
Fixes this:

    Process exited with code 1, command:
    /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tools/xibuild/xibuild System.Collections.Generic.List`1[System.String]