### PR TITLE
[dotnet] Detect, compile and publish Info.plist into the app.

### DIFF
--- a/dotnet/DefaultCompilationIncludes.md
+++ b/dotnet/DefaultCompilationIncludes.md
@@ -1,0 +1,24 @@
+# Default complication includes in iOS, tvOS, watchOS and macOS projects
+
+Default compilation includes for .NET Core projects is explained here:
+[Default compilation includes in .NET Core projects][1]
+
+This document explains how default compilation includes is implemented for
+iOS, tvOS, watchOS and macOS projects.
+
+Default inclusion can be completely disabled by setting
+`EnableDefaultItems=false`. Each file type also have its own specific flag.
+
+Specific files can also be excluded by adding them to `DefaultItemExcludes`,
+or the specific variable for each file type.
+
+## Property lists
+
+All \*.plist files in the root directory are included by default (as `None`
+items).
+
+To completely disable: `EnableDefaultXamarinPlistItems=false`. To exclude
+specific files from being included, add them to
+`DefaultXamarinPlistItemExcludes`.
+
+[1]: https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#default-compilation-includes-in-net-core-projects

--- a/dotnet/DefaultCompilationIncludes.md
+++ b/dotnet/DefaultCompilationIncludes.md
@@ -7,18 +7,14 @@ This document explains how default compilation includes is implemented for
 iOS, tvOS, watchOS and macOS projects.
 
 Default inclusion can be completely disabled by setting
-`EnableDefaultItems=false`. Each file type also have its own specific flag.
-
-Specific files can also be excluded by adding them to `DefaultItemExcludes`,
-or the specific variable for each file type.
+`EnableDefaultItems=false`. It can also be disabled per-platform by setting
+the platform-specific variables `EnableDefaultiOSItems=false`,
+`EnableDefaulttvOSItems=false`, `EnableDefaultwatchOSItems=false`, or
+`EnableDefaultmacOSItems=false`.
 
 ## Property lists
 
 All \*.plist files in the root directory are included by default (as `None`
 items).
-
-To completely disable: `EnableDefaultXamarinPlistItems=false`. To exclude
-specific files from being included, add them to
-`DefaultXamarinPlistItemExcludes`.
 
 [1]: https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#default-compilation-includes-in-net-core-projects

--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--  Default inclusion -->
+  <PropertyGroup>
+    <!-- Enable default inclusion behavior unless told otherwise, but default to the value for EnableDefaultItems -->
+    <EnableDefaultXamarinPlistItems Condition=" '$(EnableDefaultXamarinPlistItems)' == '' ">$(EnableDefaultItems)</EnableDefaultXamarinPlistItems>
+  </PropertyGroup>
+
+  <!-- Default plist file inclusion -->
+  <ItemGroup Condition="'$(EnableDefaultXamarinPlistItems)' == 'true' ">
+    <None Include="*.plist" Exclude="$(DefaultItemExcludes);$(DefaultXamarinPlistItemExcludes)">
+      <Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
+    </None>
+  </ItemGroup>
+
   <!-- Declare the XI/XM framework bundled with this version of the SDK. See Microsoft.NETCoreSdk.BundledVersions.props -->
   <PropertyGroup>
     <!-- Runtime pack identifiers -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--  Default inclusion -->
-  <PropertyGroup>
-    <!-- Enable default inclusion behavior unless told otherwise, but default to the value for EnableDefaultItems -->
-    <EnableDefaultXamarinPlistItems Condition=" '$(EnableDefaultXamarinPlistItems)' == '' ">$(EnableDefaultItems)</EnableDefaultXamarinPlistItems>
-  </PropertyGroup>
 
   <!-- Default plist file inclusion -->
-  <ItemGroup Condition="'$(EnableDefaultXamarinPlistItems)' == 'true' ">
-    <None Include="*.plist" Exclude="$(DefaultItemExcludes);$(DefaultXamarinPlistItemExcludes)">
+  <ItemGroup Condition="'$(_EnableDefaultXamarinItems)' == 'true' ">
+    <None Include="*.plist">
       <Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
     </None>
   </ItemGroup>

--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -13,7 +13,6 @@
     <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'tvOS' ">$(EnableDefaulttvOSItems)</_EnableDefaultXamarinItems>
     <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'watchOS' ">$(EnableDefaultwatchOSItems)</_EnableDefaultXamarinItems>
     <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'macOS' ">$(EnableDefaultmacOSItems)</_EnableDefaultXamarinItems>
-    <FooFoo>HelloWorld</FooFoo>
   </PropertyGroup>
 
   <!-- Default plist file inclusion -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -2,6 +2,20 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--  Default inclusion -->
 
+  <PropertyGroup>
+    <!-- Enable default inclusion behavior unless told otherwise, but default to the value for EnableDefaultItems -->
+    <!-- We have a public property for each platform, and unify them into a single private property for our own build logic -->
+    <EnableDefaultiOSItems Condition=" '$(_PlatformName)' == 'iOS' And '$(EnableDefaultiOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaultiOSItems>
+    <EnableDefaulttvOSItems Condition=" '$(_PlatformName)' == 'tvOS' And '$(EnableDefaulttvOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaulttvOSItems>
+    <EnableDefaultwatchOSItems Condition=" '$(_PlatformName)' == 'watchOS' And '$(EnableDefaultwatchOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaultwatchOSItems>
+    <EnableDefaultmacOSItems Condition=" '$(_PlatformName)' == 'macOS' And '$(EnableDefaultmacOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaultmacOSItems>
+    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'iOS' ">$(EnableDefaultiOSItems)</_EnableDefaultXamarinItems>
+    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'tvOS' ">$(EnableDefaulttvOSItems)</_EnableDefaultXamarinItems>
+    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'watchOS' ">$(EnableDefaultwatchOSItems)</_EnableDefaultXamarinItems>
+    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'macOS' ">$(EnableDefaultmacOSItems)</_EnableDefaultXamarinItems>
+    <FooFoo>HelloWorld</FooFoo>
+  </PropertyGroup>
+
   <!-- Default plist file inclusion -->
   <ItemGroup Condition="'$(_EnableDefaultXamarinItems)' == 'true' ">
     <None Include="*.plist">

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -8,18 +8,6 @@
     <_UsingXamarinSdk>true</_UsingXamarinSdk>
     <!-- This is the location of the Microsoft.<platform>.Sdk NuGet (/usr/local/share/dotnet/sdk/<version>/Sdks/Microsoft.[iOS/tvOS/watchOS/macOS].Sdk) -->
     <_XamarinSdkRootDirectory>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..'))\</_XamarinSdkRootDirectory>
-
-    <!-- Enable default inclusion behavior unless told otherwise, but default to the value for EnableDefaultItems -->
-    <!-- We have a public property for each platform, and unify them into a single private property for our own build logic -->
-    <EnableDefaultiOSItems Condition=" '$(_PlatformName)' == 'iOS' And '$(EnableDefaultiOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaultiOSItems>
-    <EnableDefaulttvOSItems Condition=" '$(_PlatformName)' == 'tvOS' And '$(EnableDefaulttvOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaulttvOSItems>
-    <EnableDefaultwatchOSItems Condition=" '$(_PlatformName)' == 'watchOS' And '$(EnableDefaultwatchOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaultwatchOSItems>
-    <EnableDefaultmacOSItems Condition=" '$(_PlatformName)' == 'macOS' And '$(EnableDefaultmacOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaultmacOSItems>
-    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'iOS' ">$(EnableDefaultiOSItems)</_EnableDefaultXamarinItems>
-    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'tvOS' ">$(EnableDefaulttvOSItems)</_EnableDefaultXamarinItems>
-    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'watchOS' ">$(EnableDefaultwatchOSItems)</_EnableDefaultXamarinItems>
-    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'macOS' ">$(EnableDefaultmacOSItems)</_EnableDefaultXamarinItems>
-
   </PropertyGroup>
 
   <!-- Default item includes (globs and implicit references) -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -8,6 +8,18 @@
     <_UsingXamarinSdk>true</_UsingXamarinSdk>
     <!-- This is the location of the Microsoft.<platform>.Sdk NuGet (/usr/local/share/dotnet/sdk/<version>/Sdks/Microsoft.[iOS/tvOS/watchOS/macOS].Sdk) -->
     <_XamarinSdkRootDirectory>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..'))\</_XamarinSdkRootDirectory>
+
+    <!-- Enable default inclusion behavior unless told otherwise, but default to the value for EnableDefaultItems -->
+    <!-- We have a public property for each platform, and unify them into a single private property for our own build logic -->
+    <EnableDefaultiOSItems Condition=" '$(_PlatformName)' == 'iOS' And '$(EnableDefaultiOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaultiOSItems>
+    <EnableDefaulttvOSItems Condition=" '$(_PlatformName)' == 'tvOS' And '$(EnableDefaulttvOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaulttvOSItems>
+    <EnableDefaultwatchOSItems Condition=" '$(_PlatformName)' == 'watchOS' And '$(EnableDefaultwatchOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaultwatchOSItems>
+    <EnableDefaultmacOSItems Condition=" '$(_PlatformName)' == 'macOS' And '$(EnableDefaultmacOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaultmacOSItems>
+    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'iOS' ">$(EnableDefaultiOSItems)</_EnableDefaultXamarinItems>
+    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'tvOS' ">$(EnableDefaulttvOSItems)</_EnableDefaultXamarinItems>
+    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'watchOS' ">$(EnableDefaultwatchOSItems)</_EnableDefaultXamarinItems>
+    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'macOS' ">$(EnableDefaultmacOSItems)</_EnableDefaultXamarinItems>
+
   </PropertyGroup>
 
   <!-- Default item includes (globs and implicit references) -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -73,6 +73,8 @@
 		<!-- We re-use ComputeFilesToPublish & CopyFilesToPublishDirectory to copy files to the .app -->
 		<!-- ComputeFilesToPublish will run ILLink -->
 		<CreateAppBundleDependsOn>
+			_DetectAppManifest;
+			_CompileAppManifest;
 			_ComputeLinkerArguments;
 			ComputeFilesToPublish;
 			_ComputePublishLocation;

--- a/tests/dotnet/UnitTests/DotNetUnitTests.csproj
+++ b/tests/dotnet/UnitTests/DotNetUnitTests.csproj
@@ -26,6 +26,9 @@
     <Compile Include="..\..\..\tools\common\StringUtils.cs">
       <Link>external\StringUtils.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tools\common\ApplePlatform.cs">
+      <Link>external\ApplePlatform.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="external\" />

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1,6 +1,9 @@
+using System;
 using System.IO;
 
 using NUnit.Framework;
+
+using Xamarin.Utils;
 
 namespace Xamarin.Tests {
 	[TestFixture]
@@ -35,28 +38,34 @@ namespace Xamarin.Tests {
 		[Test]
 		public void BuildMySingleView ()
 		{
+			var platform = ApplePlatform.iOS;
 			var project_path = GetProjectPath ("MySingleView");
 			Clean (project_path);
 			var result = DotNet.AssertBuild (project_path);
 			AssertThatLinkerExecuted (result);
+			AssertAppContents (platform, Path.Combine (Path.GetDirectoryName (project_path), "bin", "Debug", "net5.0", "ios-x64", "MySingleView.app"));
 		}
 
 		[Test]
 		public void BuildMyCocoaApp ()
 		{
+			var platform = ApplePlatform.MacOSX;
 			var project_path = GetProjectPath ("MyCocoaApp");
 			Clean (project_path);
 			var result = DotNet.AssertBuild (project_path);
 			AssertThatLinkerExecuted (result);
+			AssertAppContents (platform, Path.Combine (Path.GetDirectoryName (project_path), "bin", "Debug", "net5.0", "osx-x64", "MyCocoaApp.app"));
 		}
 
 		[Test]
 		public void BuildMyTVApp ()
 		{
+			var platform = ApplePlatform.TVOS;
 			var project_path = GetProjectPath ("MyTVApp");
 			Clean (project_path);
 			var result = DotNet.AssertBuild (project_path);
 			AssertThatLinkerExecuted (result);
+			AssertAppContents (platform, Path.Combine (Path.GetDirectoryName (project_path), "bin", "Debug", "net5.0", "tvos-x64", "MyTVApp.app"));
 		}
 
 		[Test]
@@ -85,6 +94,24 @@ namespace Xamarin.Tests {
 			var output = result.StandardOutput.ToString ();
 			Assert.That (output, Does.Contain ("Building target \"_RunILLink\" completely."), "Linker did not executed as expected.");
 			Assert.That (output, Does.Contain ("Hello SetupStep"), "Custom steps did not run as expected.");
+		}
+
+		void AssertAppContents (ApplePlatform platform, string app_directory)
+		{
+			string info_plist_path;
+			switch (platform) {
+			case ApplePlatform.iOS:
+			case ApplePlatform.TVOS:
+			case ApplePlatform.WatchOS:
+				info_plist_path = Path.Combine (app_directory, "Info.plist");
+				break;
+			case ApplePlatform.MacOSX:
+				info_plist_path = Path.Combine (app_directory, "Contents", "Info.plist");
+				break;
+			default:
+				throw new NotImplementedException ($"Unknown platform: {platform}");
+			}
+			Assert.That (info_plist_path, Does.Exist, "Info.plist");
 		}
 	}
 }


### PR DESCRIPTION
* Automatically detect any property lists in the root project directory, and
  include them into the build.
* Introduce the existing build targets to detect and compile Info.plist into
  the .NET build.
* Add documentation for default inclusion. This document will grow over time
  as more file types are automatically included.
* Add some tests.