### PR TITLE
[dotnet] Improve incremental builds in make.

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -5,27 +5,23 @@ include $(TOP)/mk/rules.mk
 
 PLATFORMS=iOS tvOS watchOS macOS
 
-IOS_RIDS=$(subst ios-,,$(DOTNET_IOS_RUNTIME_IDENTIFIERS))
-TVOS_RIDS=$(subst tvos-,,$(DOTNET_TVOS_RUNTIME_IDENTIFIERS))
-WATCHOS_RIDS=$(subst watchos-,,$(DOTNET_WATCHOS_RUNTIME_IDENTIFIERS))
-MACOS_RIDS=$(subst osx-,,$(DOTNET_MACOS_RUNTIME_IDENTIFIERS))
-
-NUGET_TARGETS += \
-	$(foreach platform,$(PLATFORMS), \
-		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/Sdk/Sdk.targets \
-		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/Sdk/Sdk.props \
-		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Microsoft.$(platform).Sdk.DefaultItems.props \
-		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Microsoft.$(platform).Sdk.props \
-		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Microsoft.$(platform).Sdk.targets \
-		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Microsoft.$(platform).TargetFrameworkInference.targets \
-		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Xamarin.Shared.Sdk.DefaultItems.props \
-		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Xamarin.Shared.Sdk.DefaultItems.targets \
-		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Xamarin.Shared.Sdk.props \
-		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Xamarin.Shared.Sdk.TargetFrameworkInference.targets \
-		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Xamarin.Shared.Sdk.targets \
-		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Xamarin.Shared.Sdk.Versions.props \
-		$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets/Xamarin.Shared.Sdk.Versions.template.props \
-	)
+define DefineTargets
+$(1)_NUGET_TARGETS = \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/Sdk/Sdk.targets \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/Sdk/Sdk.props \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.DefaultItems.props \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.props \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.targets \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Microsoft.$(1).TargetFrameworkInference.targets \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Xamarin.Shared.Sdk.DefaultItems.props \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Xamarin.Shared.Sdk.DefaultItems.targets \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Xamarin.Shared.Sdk.props \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Xamarin.Shared.Sdk.TargetFrameworkInference.targets \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Xamarin.Shared.Sdk.targets \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Xamarin.Shared.Sdk.Versions.props \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Xamarin.Shared.Sdk.Versions.template.props
+endef
+$(foreach platform,$(PLATFORMS),$(eval $(call DefineTargets,$(platform))))
 
 DIRECTORIES += \
 	$(DOTNET_NUPKG_DIR) \
@@ -81,22 +77,36 @@ nupkgs/$(WATCHOS_NUGET).%.nupkg: CURRENT_VERSION_FULL=$(WATCHOS_NUGET_VERSION_FU
 nupkgs/$(MACOS_NUGET).%.nupkg: CURRENT_VERSION_FULL=$(MACOS_NUGET_VERSION_FULL)
 
 # Create the nuget in a temporary directory (nupkgs/)
-nupkgs/%.nupkg: $(TEMPLATED_FILES) $(NUGET_TARGETS)
-	$(Q) rm -f $@
-	$(Q_PACK) $(DOTNET5) pack package/$(shell echo $(notdir $@) | sed 's/[.]$(CURRENT_VERSION_FULL).*//')/package.csproj --output "$(dir $@)" $(DOTNET_PACK_VERBOSITY)
+define CreateNuGetTemplate
+nupkgs/$(1).$(2)+$(NUGET_BUILD_METADATA).nupkg: $(TEMPLATED_FILES) $(3) package/$(1)/package.csproj $(wildcard $(DOTNET_DESTDIR)/$(1)/* $(DOTNET_DESTDIR)/$(1)/*/* $(DOTNET_DESTDIR)/$(1)/*/*/* $(DOTNET_DESTDIR)/$(1)/*/*/*/*)
+	@# Delete any versions of the nuget we're building
+	$$(Q) rm -f nupkgs/$(1).*.nupkg
+	$$(Q_PACK) $(DOTNET5) pack package/$(1)/package.csproj --output "$$(dir $$@)" $(DOTNET_PACK_VERBOSITY)
 	@# Nuget pack doesn't add the metadata to the filename, but we want that, so rename nuget to contain the full name
-	$(Q) mv "nupkgs/$(shell echo $(notdir $@) | sed -e 's/[+]$(NUGET_BUILD_METADATA)//')" "$@"
+	$$(Q) mv "nupkgs/$(1).$(2).nupkg" "$$@"
+	@# Clean the local feed
+	$$(Q_NUGET_DEL) if test -d $(DOTNET_FEED_DIR)/$(shell echo $(1) | tr A-Z a-z)/$(2); then nuget delete $(1) $(2) -source $(abspath $(DOTNET_FEED_DIR)) -NonInteractive $(NUGET_VERBOSITY); fi
 	@# Add the nupkg to our local feed
-	$(Q_NUGET_ADD) nuget add "$@" -source $(DOTNET_FEED_DIR) $(NUGET_VERBOSITY)
+	$$(Q_NUGET_ADD) nuget add "$$@" -source $(DOTNET_FEED_DIR) -NonInteractive $(NUGET_VERBOSITY)
+endef
+
+# Create variables prefixed with the correctly cased platform name from the upper-cased platform name. This makes the next section somewhat simpler.
+$(foreach platform,$(PLATFORMS),$(eval $(platform)_NUGET_VERSION_NO_METADATA:=$($(shell echo $(platform) | tr a-z A-Z)_NUGET_VERSION_NO_METADATA)))
+$(foreach platform,$(PLATFORMS),$(eval DOTNET_$(platform)_RUNTIME_IDENTIFIERS:=$(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS)))
+
+# Create the NuGet packaging targets. It's amazing what make allows you to do...
+$(foreach platform,$(PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Sdk,$($(platform)_NUGET_VERSION_NO_METADATA),$($(platform)_NUGET_TARGETS))))
+$(foreach platform,$(PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Ref,$($(platform)_NUGET_VERSION_NO_METADATA))))
+$(foreach platform,$(PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Runtime.$(rid),$($(platform)_NUGET_VERSION_NO_METADATA)))))
 
 # Copy the nuget from the temporary directory into the final directory
 $(DOTNET_NUPKG_DIR)/%.nupkg: nupkgs/%.nupkg | $(DOTNET_NUPKG_DIR)
-	$(Q) cp $< $@
+	$(Q) $(CP) $< $@
 
-RUNTIME_PACKS_IOS = $(foreach rid,$(IOS_RIDS),$(DOTNET_NUPKG_DIR)/$(IOS_NUGET).Runtime.ios-$(rid).$(IOS_NUGET_VERSION_FULL).nupkg)
-RUNTIME_PACKS_TVOS = $(foreach rid,$(TVOS_RIDS),$(DOTNET_NUPKG_DIR)/$(TVOS_NUGET).Runtime.tvos-$(rid).$(TVOS_NUGET_VERSION_FULL).nupkg)
-RUNTIME_PACKS_WATCHOS = $(foreach rid,$(WATCHOS_RIDS),$(DOTNET_NUPKG_DIR)/$(WATCHOS_NUGET).Runtime.watchos-$(rid).$(WATCHOS_NUGET_VERSION_FULL).nupkg)
-RUNTIME_PACKS_MACOS = $(foreach rid,$(MACOS_RIDS),$(DOTNET_NUPKG_DIR)/$(MACOS_NUGET).Runtime.osx-$(rid).$(MACOS_NUGET_VERSION_FULL).nupkg)
+RUNTIME_PACKS_IOS = $(foreach rid,$(DOTNET_IOS_RUNTIME_IDENTIFIERS),$(DOTNET_NUPKG_DIR)/$(IOS_NUGET).Runtime.$(rid).$(IOS_NUGET_VERSION_FULL).nupkg)
+RUNTIME_PACKS_TVOS = $(foreach rid,$(DOTNET_TVOS_RUNTIME_IDENTIFIERS),$(DOTNET_NUPKG_DIR)/$(TVOS_NUGET).Runtime.$(rid).$(TVOS_NUGET_VERSION_FULL).nupkg)
+RUNTIME_PACKS_WATCHOS = $(foreach rid,$(DOTNET_WATCHOS_RUNTIME_IDENTIFIERS),$(DOTNET_NUPKG_DIR)/$(WATCHOS_NUGET).Runtime.$(rid).$(WATCHOS_NUGET_VERSION_FULL).nupkg)
+RUNTIME_PACKS_MACOS = $(foreach rid,$(DOTNET_MACOS_RUNTIME_IDENTIFIERS),$(DOTNET_NUPKG_DIR)/$(MACOS_NUGET).Runtime.$(rid).$(MACOS_NUGET_VERSION_FULL).nupkg)
 RUNTIME_PACKS = $(RUNTIME_PACKS_IOS) $(RUNTIME_PACKS_TVOS) $(RUNTIME_PACKS_WATCHOS) $(RUNTIME_PACKS_MACOS)
 
 REF_PACK_IOS = $(DOTNET_NUPKG_DIR)/$(IOS_NUGET).Ref.$(IOS_NUGET_VERSION_FULL).nupkg

--- a/mk/quiet.mk
+++ b/mk/quiet.mk
@@ -27,6 +27,7 @@ Q_MDB=  $(if $(V),,@echo "MDB      $(@F)";)
 Q_NUNIT= $(if $(V),,@echo "NUNIT     $(@F)";)
 Q_PACK     =$(if $(V),,@echo "PACK      $(@F)";)
 Q_NUGET_ADD=$(if $(V),,@echo "NUGET ADD $(@F)";)
+Q_NUGET_DEL=$(if $(V),,@echo "NUGET DEL $(@F)";)
 
 Q_SN=   $(if $(V),,@echo "SN       $(@F)";)
 Q_XBUILD=$(if $(V),,@echo "XBUILD  $(@F)";)


### PR DESCRIPTION
* Be more exact when specifying dependencies for nuget packages: instead of
  making every package depend on every file within this directory, only make
  the specific package the files go into depend on those files. This means
  that if any of these files change, only the package that contains that file
  will be rebuilt.
* Have each package depend on all the files that are to be included in that
  package. This means that if any other directory adds or updates a file for a
  nuget, we'll rebuild that nuget here.
* Removes packages from the local feed before trying to (re-)add them. This
  makes them actually install locally, instead of nuget just skipping them,
  when the version hasn't changed.

This was easier to express with make templates than pattern rules, so some of
the logic was re-implemented as make templates.