### PR TITLE
[d16-7] [tools] Remove MD5 from tooling

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Helpers.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Helpers.cs
@@ -18,9 +18,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 			var bytes = new byte [16];
 			if (seed == null) guid_generator.NextBytes (bytes);
 			else {
-				using (var provider = MD5.Create ()) {
+				using (var provider = SHA256.Create ()) {
 					var inputBytes = Encoding.UTF8.GetBytes (seed);
-					bytes = provider.ComputeHash (inputBytes);
+					var output = provider.ComputeHash (inputBytes);
+					Array.Copy (output, bytes, 16);
 				}
 			}
 			return new Guid (bytes);

--- a/tools/apidiff/merger.cs
+++ b/tools/apidiff/merger.cs
@@ -54,10 +54,10 @@ class Merger {
 		// https://github.com/MicrosoftDocs/xamarin-docs/blob/live/contributing-guidelines/template.md#file-name
 		var filename = $"{os}-{from}-{to}".Replace ('.', '-').ToLowerInvariant () + ".md";
 		byte[] digest = null;
-		using (var md = MD5.Create ())
+		using (var md = SHA256.Create ())
 			digest = md.ComputeHash (Encoding.UTF8.GetBytes (filename));
 		// (not cryptographically) unique (but good enough) for each filename - so document remains with the same id when it's updated/regenerated
-		var guid = new Guid (digest);
+		var guid = new Guid (digest[0..15]);
 
 		var headers = new StringWriter ();
 		var title = $"{platform} SDK API diff: {from} vs {to}";


### PR DESCRIPTION
Note: affected tools are not included in the code shipping inside the SDK

Usage of deprecated cryptographic algorithms is not approved anymore,
even if not used for cryptographic purpose.

MD5 was used to create immutable GUID since it's output is 128bits which
is just what a GUID wants as it's input (16 bytes). The same can be
achieved (even if a bit slower) with a newer/longer hash function

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1128148

Backport of #8769.

/cc @spouliot 