### PR TITLE
[d16-7] [src] Remove Classic code from the AudioUnit, AudioToolbox and AssetsLibrary frameworks.

### DIFF
--- a/src/AssetsLibrary/ALAsset.cs
+++ b/src/AssetsLibrary/ALAsset.cs
@@ -53,11 +53,7 @@ namespace AssetsLibrary {
 		public ALAssetOrientation Orientation {
 			get {
 				NSNumber n = (NSNumber) ValueForProperty (_PropertyOrientation);
-#if XAMCORE_2_0
 				return (ALAssetOrientation) (int)n.NIntValue;
-#else
-				return (ALAssetOrientation) (int)n.IntValue;
-#endif
 			}
 		}
 

--- a/src/AssetsLibrary/ALAssetsGroup.cs
+++ b/src/AssetsLibrary/ALAssetsGroup.cs
@@ -26,11 +26,7 @@ namespace AssetsLibrary {
 		
 		public ALAssetsGroupType Type {
 			get {
-#if XAMCORE_2_0
 				return (ALAssetsGroupType) (int) ((NSNumber) ValueForProperty (_Type)).NIntValue;
-#else
-				return (ALAssetsGroupType) (int) ((NSNumber) ValueForProperty (_Type)).IntValue;
-#endif
 			}
 		}
 

--- a/src/AudioToolbox/AudioFile.cs
+++ b/src/AudioToolbox/AudioFile.cs
@@ -513,9 +513,6 @@ namespace AudioToolbox {
 
 	public class AudioFile : IDisposable, INativeObject {
 
-#if !XAMCORE_2_0
-		protected
-#endif
 		internal IntPtr handle;
 		
 		protected internal AudioFile (bool x)
@@ -793,22 +790,6 @@ namespace AudioToolbox {
 		{
 			return ReadPacketData (useCache, inStartingPacket, ref nPackets, buffer, offset, ref count, out error);
 		}
-
-#if !XAMCORE_2_0
-		[DllImport (Constants.AudioToolboxLibrary)]
-		extern static AudioFileError AudioFileReadPackets (IntPtr inAudioFile, bool inUseCache, out int numBytes,
-			[MarshalAs (UnmanagedType.LPArray)] AudioStreamPacketDescription[] packetDescriptions, long startingPacket, ref int numPackets, IntPtr buffer);
-
-		[Obsolete ("Use 'ReadPacketData' instead.")]
-		public AudioFileError ReadPackets (bool useCache, out int numBytes,
-			AudioStreamPacketDescription[] packetDescriptions, long startingPacket, ref int numPackets, IntPtr buffer)
-		{
-			if (buffer == IntPtr.Zero)
-				throw new ArgumentException ("buffer");
-
-			return AudioFileReadPackets (handle, useCache, out numBytes, packetDescriptions, startingPacket, ref numPackets, buffer);
-		}
-#endif
 
 		static internal AudioStreamPacketDescription [] PacketDescriptionFrom (int nPackets, IntPtr b)
 		{

--- a/src/AudioToolbox/AudioQueue.cs
+++ b/src/AudioToolbox/AudioQueue.cs
@@ -303,7 +303,6 @@ namespace AudioToolbox {
 						      AudioTimeStamp *startTime, int descriptors, IntPtr AudioStreamPacketDescription_inPacketDesc);
 	delegate void AudioQueuePropertyListener (IntPtr userData, IntPtr AQ,  AudioQueueProperty id);
 
-#if XAMCORE_2_0
 	public class BufferCompletedEventArgs : EventArgs {
 		public BufferCompletedEventArgs (IntPtr audioQueueBuffer)
 		{
@@ -314,18 +313,6 @@ namespace AudioToolbox {
 		{
 			IntPtrBuffer = (IntPtr) audioQueueBuffer;
 		}
-#else
-	public class OutputCompletedEventArgs : EventArgs {
-		public OutputCompletedEventArgs (IntPtr audioQueueBuffer)
-		{
-			IntPtrBuffer = audioQueueBuffer;
-		}
-
-		public unsafe OutputCompletedEventArgs (AudioQueueBuffer *audioQueueBuffer)
-		{
-			IntPtrBuffer = (IntPtr) audioQueueBuffer;
-		}
-#endif
 
 		public IntPtr IntPtrBuffer { get; private set; }
 		public unsafe AudioQueueBuffer *UnsafeBuffer {
@@ -383,16 +370,12 @@ namespace AudioToolbox {
 		[DllImport (Constants.AudioToolboxLibrary)]
 		extern static OSStatus AudioQueueDispose (IntPtr AQ, bool immediate);
 
-#if XAMCORE_2_0
 		protected virtual void Dispose (bool disposing)
 		{
 			Dispose (disposing, true);
 		}
 
 		void Dispose (bool disposing, bool immediate)
-#else
-		public virtual void Dispose (bool disposing, bool immediate)
-#endif
 		{
 			if (handle != IntPtr.Zero){
 				if (disposing){
@@ -1160,15 +1143,6 @@ namespace AudioToolbox {
 			IntPtr inClientData, AudioQueueProcessingTapFlags inFlags, out uint outMaxFrames,
 			out AudioStreamBasicDescription outProcessingFormat, out IntPtr outAQTap);
 
-#if !XAMCORE_2_0
-		[Obsolete ("Use 'CreateProcessingTap (AudioQueueProcessingTapDelegate, AudioQueueProcessingTapFlags, out AudioQueueStatus)' instead.", true)]
-		public AudioQueueProcessingTap CreateProcessingTap (AudioQueueProcessingTapCallback processingCallback, AudioQueueProcessingTapFlags flags,
-		                                                    out AudioQueueStatus status)
-		{
-			throw new NotSupportedException ();
-		}
-#endif
-
 		public AudioQueueProcessingTap CreateProcessingTap (AudioQueueProcessingTapDelegate processingCallback, AudioQueueProcessingTapFlags flags,
 		                                                    out AudioQueueStatus status)
 		{		
@@ -1195,13 +1169,6 @@ namespace AudioToolbox {
 	delegate void AudioQueueProcessingTapCallbackShared (IntPtr clientData, IntPtr tap, uint numberOfFrames,
 	                                                     ref AudioTimeStamp timeStamp, ref AudioQueueProcessingTapFlags flags,
 	                                                     out uint outNumberFrames, IntPtr data);
-
-#if !XAMCORE_2_0
-	[Obsolete ("Use 'AudioQueueProcessingTapDelegate'.")]
-	public delegate uint AudioQueueProcessingTapCallback (AudioQueueProcessingTap audioQueueTap, uint numberOfFrames,
-	                                                      ref AudioTimeStamp timeStamp, ref AudioQueueProcessingTapFlags flags,
-	                                                      AudioBufferList data);
-#endif
 
 	public delegate uint AudioQueueProcessingTapDelegate (AudioQueueProcessingTap audioQueueTap, uint numberOfFrames,
 	                                                      ref AudioTimeStamp timeStamp, ref AudioQueueProcessingTapFlags flags,
@@ -1256,25 +1223,6 @@ namespace AudioToolbox {
 		[DllImport (Constants.AudioToolboxLibrary)]
 		extern static OSStatus AudioQueueProcessingTapDispose (IntPtr inAQTap);
 
-#if !XAMCORE_2_0
-		[Obsolete]
-		[DllImport (Constants.AudioToolboxLibrary)]
-		extern static AudioQueueStatus AudioQueueProcessingTapGetSourceAudio (IntPtr inAQTap, uint inNumberFrames, ref AudioTimeStamp ioTimeStamp,
-		                                                               out AudioQueueProcessingTapFlags outFlags, out uint outNumberFrames,
-		                                                               AudioBufferList ioData);
-
-		[Obsolete ("Use overload with 'AudioBuffers'.")]
-		public AudioQueueStatus GetSourceAudio (uint numberOfFrames, ref AudioTimeStamp timeStamp,
-		                                        out AudioQueueProcessingTapFlags flags, out uint parentNumberOfFrames, AudioBufferList data)
-		{
-			if (data == null)
-				throw new ArgumentNullException ("data");
-
-			return AudioQueueProcessingTapGetSourceAudio (TapHandle, numberOfFrames, ref timeStamp,
-		                                                  out flags, out parentNumberOfFrames, data);
-		}
-#endif
-
 		[DllImport (Constants.AudioToolboxLibrary)]
 		extern static AudioQueueStatus AudioQueueProcessingTapGetSourceAudio (IntPtr inAQTap, uint inNumberFrames, ref AudioTimeStamp ioTimeStamp,
 		                                                               out AudioQueueProcessingTapFlags outFlags, out uint outNumberFrames,
@@ -1324,14 +1272,9 @@ namespace AudioToolbox {
 		{
 			GCHandle gch = GCHandle.FromIntPtr (userData);
 			var aq = gch.Target as OutputAudioQueue;
-#if XAMCORE_2_0
 			aq.OnBufferCompleted (audioQueueBuffer);
-#else
-			aq.OnOutputCompleted (audioQueueBuffer);
-#endif
 		}
 
-#if XAMCORE_2_0
 		public event EventHandler<BufferCompletedEventArgs> BufferCompleted;
 
 		protected virtual void OnBufferCompleted (IntPtr audioQueueBuffer)
@@ -1340,16 +1283,6 @@ namespace AudioToolbox {
 			if (h != null)
 				h (this, new BufferCompletedEventArgs (audioQueueBuffer));
 		}
-#else
-		public event EventHandler<OutputCompletedEventArgs> OutputCompleted;
-		
-		protected virtual void OnOutputCompleted (IntPtr audioQueueBuffer)
-		{
-			var h = OutputCompleted;
-			if (h != null)
-				h (this, new OutputCompletedEventArgs (audioQueueBuffer));
-		}
-#endif
 
 		public OutputAudioQueue (AudioStreamBasicDescription desc) : this (desc, null, (CFString) null)
 		{
@@ -1496,11 +1429,7 @@ namespace AudioToolbox {
 			Dispose (true);
 		}
 	
-#if XAMCORE_2_0
 		protected virtual void Dispose (bool disposing)
-#else
-		public virtual void Dispose (bool disposing)
-#endif
 		{
 			if (timelineHandle != IntPtr.Zero){
 				AudioQueueDisposeTimeline (queueHandle, timelineHandle);

--- a/src/AudioToolbox/AudioSession.cs
+++ b/src/AudioToolbox/AudioSession.cs
@@ -45,7 +45,7 @@ namespace AudioToolbox {
 // also AudioSession has been removed from TVOS already and AVAudioSession has been around since iOS 3.0
 #if !XAMCORE_3_0
 #if !TVOS
-#if !MONOMAC || !XAMCORE_2_0 // AudioSession isn't an OS X API, but can't remove from compat
+#if !MONOMAC // AudioSession isn't an OS X API, but can't remove from compat
 	public class AudioSessionException : Exception {
 		static string Lookup (int k)
 		{
@@ -894,7 +894,7 @@ namespace AudioToolbox {
 			}
 		}
 	}
-#endif // !MONOMAC || !XAMCORE_2_0
+#endif // !MONOMAC
 #endif // !TVOS
 #endif // !XAMCORE_3_0
 }

--- a/src/AudioToolbox/AudioToolbox.cs
+++ b/src/AudioToolbox/AudioToolbox.cs
@@ -48,10 +48,7 @@ namespace AudioToolbox {
 		public NSDictionary Dictionary { get; private set; }
 	}
 
-#if XAMCORE_2_0
-	static
-#endif
-	public class SoundBank {
+	public static class SoundBank {
 
 		[iOS (7,0)] // 10.5
 		[DllImport (Constants.AudioToolboxLibrary)]

--- a/src/AudioToolbox/AudioType.cs
+++ b/src/AudioToolbox/AudioType.cs
@@ -1214,7 +1214,6 @@ namespace AudioToolbox {
 		}
 	}
 
-#if XAMCORE_2_0
 	// CoreAudioClock.h (inside AudioToolbox)
 	// It was a confusion between CA (CoreAudio) and CA (CoreAnimation)
 	[StructLayout (LayoutKind.Sequential)]
@@ -1225,5 +1224,4 @@ namespace AudioToolbox {
 		public /* UInt16 */ ushort SubbeatDivisor;
 		public /* UInt16 */ ushort Reserved;
 	}
-#endif
 }

--- a/src/AudioToolbox/MusicSequence.cs
+++ b/src/AudioToolbox/MusicSequence.cs
@@ -220,20 +220,6 @@ namespace AudioToolbox {
 		[DllImport (Constants.AudioToolboxLibrary)]
 		extern static /* OSStatus */ MusicPlayerStatus MusicSequenceGetTrackIndex (/* MusicSequence */ IntPtr inSequence, /* MusicTrack */ IntPtr inTrack, /* UInt32* */ out int outTrackIndex);
 
-#if !XAMCORE_2_0
-		[Obsolete ("Use GetTrackIndex(MusicTrack, out int) to distinguish between the track or an error code")]
-		public int GetTrackIndex (MusicTrack track)
-		{
-			int idx;
-			if (track == null)
-				throw new ArgumentNullException ("track");
-			var status = MusicSequenceGetTrackIndex (handle, track.Handle, out idx);
-			if (status == MusicPlayerStatus.Success)
-				return idx;
-			// that's never clear if the return value is the track or an error code
-			return (int) status;
-		}
-#endif
 		public MusicPlayerStatus GetTrackIndex (MusicTrack track, out int index)
 		{
 			if (track == null)
@@ -328,14 +314,6 @@ namespace AudioToolbox {
 		
 		[DllImport (Constants.AudioToolboxLibrary)]
 		extern static /* OSStatus */ MusicPlayerStatus MusicSequenceBarBeatTimeToBeats (/* MusicSequence */ IntPtr inSequence, CABarBeatTime inBarBeatTime, /* MusicTimeStamp*/ out double outBeats);
-#if !XAMCORE_2_0
-		[Obsolete ("Use overload with an out 'double beats'")]
-		public MusicPlayerStatus BarBeatTimeToBeats (CABarBeatTime barBeatTime)
-		{
-			double d;
-			return MusicSequenceBarBeatTimeToBeats (handle, barBeatTime, out d);
-		}
-#endif
 		public MusicPlayerStatus BarBeatTimeToBeats (CABarBeatTime barBeatTime, out double beats)
 		{
 			return MusicSequenceBarBeatTimeToBeats (handle, barBeatTime, out beats);

--- a/src/AudioUnit/AUParameter.cs
+++ b/src/AudioUnit/AUParameter.cs
@@ -4,7 +4,6 @@ using ObjCRuntime;
 
 namespace AudioUnit
 {
-#if XAMCORE_2_0 || !MONOMAC
 	[iOS (9,0), Mac(10,11)]
 	public partial class AUParameter
 	{
@@ -31,5 +30,4 @@ namespace AudioUnit
 			SetValue (value, originator.ObserverToken, hostTime);
 		}
 	}
-#endif
 }

--- a/src/AudioUnit/AUParameterNode.cs
+++ b/src/AudioUnit/AUParameterNode.cs
@@ -1,5 +1,3 @@
-﻿#if XAMCORE_2_0 || !MONOMAC
-
 using System;
 
 namespace AudioUnit
@@ -37,4 +35,3 @@ namespace AudioUnit
 	}
 }
 
-#endif

--- a/src/AudioUnit/AudioComponent.cs
+++ b/src/AudioUnit/AudioComponent.cs
@@ -225,35 +225,13 @@ namespace AudioUnit
 			return new AudioUnit (this);
 		}
 
-#if !XAMCORE_2_0
-		[Obsolete ("Use the overload that accept a ref to the 'AudioComponentDescription' parameter.")]
-		public static AudioComponent FindNextComponent (AudioComponent cmp, AudioComponentDescription cd)
-		{
-			return FindNextComponent (cmp, ref cd);
-		}
-
-		[Obsolete ("Use the overload that accept a ref to the 'AudioComponentDescription' parameter.")]
-		public static AudioComponent FindComponent (AudioComponentDescription cd)
-		{
-			return FindNextComponent (null, ref cd);
-		}
-
-		public static AudioComponent FindNextComponent (AudioComponent cmp, ref AudioComponentDescription cd)
-		{
-			var handle = cmp == null ? IntPtr.Zero : cmp.Handle;
-			var cdn = new AudioComponentDescriptionNative (cd);
-			handle = AudioComponentFindNext (handle, ref cdn);
-			cdn.CopyTo (cd);
-			return  (handle != IntPtr.Zero) ? new AudioComponent (handle) : null;
-		}
-#else
 		public static AudioComponent FindNextComponent (AudioComponent cmp, ref AudioComponentDescription cd)
 		{
 			var handle = cmp == null ? IntPtr.Zero : cmp.Handle;
 			handle = AudioComponentFindNext (handle, ref cd);
 			return  (handle != IntPtr.Zero) ? new AudioComponent (handle) : null;
 		}
-#endif
+
 		public static AudioComponent FindComponent (ref AudioComponentDescription cd)
 		{
 			return FindNextComponent (null, ref cd);
@@ -302,11 +280,7 @@ namespace AudioUnit
 		}
 
 		[DllImport(Constants.AudioUnitLibrary)]
-#if XAMCORE_2_0
 		static extern IntPtr AudioComponentFindNext (IntPtr inComponent, ref AudioComponentDescription inDesc);
-#else
-		static extern IntPtr AudioComponentFindNext (IntPtr inComponent, ref AudioComponentDescriptionNative inDesc);
-#endif
 		
 		[DllImport(Constants.AudioUnitLibrary, EntryPoint = "AudioComponentCopyName")]
 		static extern int /* OSStatus */ AudioComponentCopyName (IntPtr component, out IntPtr cfstr);
@@ -320,7 +294,6 @@ namespace AudioUnit
 			}
 		}
 	
-#if XAMCORE_2_0
 		[DllImport (Constants.AudioUnitLibrary)]
 		static extern int /* OSStatus */ AudioComponentGetDescription (IntPtr component, out AudioComponentDescription desc);
 
@@ -334,20 +307,6 @@ namespace AudioUnit
 				return null;
 			}
 		}
-#else
-		[DllImport (Constants.AudioUnitLibrary)]
-		static extern int /* OSStatus */ AudioComponentGetDescription (IntPtr component, out AudioComponentDescriptionNative desc);
-		public AudioComponentDescription Description {
-			get {
-				AudioComponentDescriptionNative desc;
-
-				if (AudioComponentGetDescription (handle, out desc) == 0)
-					return new AudioComponentDescription (desc);
-
-				return null;
-			}
-		}
-#endif
 
 		[DllImport(Constants.AudioUnitLibrary)]
 		static extern int /* OSStatus */ AudioComponentGetVersion (IntPtr component, out int /* UInt32* */ version);

--- a/src/AudioUnit/AudioComponentDescription.cs
+++ b/src/AudioUnit/AudioComponentDescription.cs
@@ -77,10 +77,6 @@ namespace AudioUnit
 	}
 
 	public enum AudioTypeMusicDevice { // OSType in AudioComponentDescription
-#if !XAMCORE_2_0
-		[Obsolete]
-		None,
-#endif
 #if MONOMAC
 		DlsSynth	= 0x646c7320, // 'dls '
 #endif
@@ -194,43 +190,8 @@ namespace AudioUnit
 		CanLoadInProcess			= 0x10
 	}
 
-
-#if !XAMCORE_2_0
-	[StructLayout(LayoutKind.Sequential, Pack=4)]
-	public struct AudioComponentDescriptionNative // AudioComponentDescription in AudioComponent.h
-	{
-		public AudioComponentType ComponentType;
-		public int ComponentSubType;
-		public AudioComponentManufacturerType ComponentManufacturer;
-		public AudioComponentFlag ComponentFlags;
-		public int ComponentFlagsMask;
-
-		public AudioComponentDescriptionNative (AudioComponentDescription other)
-		{
-			this.ComponentType = other.ComponentType;
-			this.ComponentSubType = other.ComponentSubType;
-			this.ComponentManufacturer = other.ComponentManufacturer;
-			this.ComponentFlags = other.ComponentFlags;
-			this.ComponentFlagsMask = other.ComponentFlagsMask;
-		}
-
-		public void CopyTo (AudioComponentDescription cd)
-		{
-			cd.ComponentType = ComponentType;
-			cd.ComponentSubType = ComponentSubType;
-			cd.ComponentManufacturer = ComponentManufacturer;
-			cd.ComponentFlags = ComponentFlags;
-			cd.ComponentFlagsMask = ComponentFlagsMask;
-		}
-	}
-#endif
-
 	[StructLayout(LayoutKind.Sequential)]
-#if XAMCORE_2_0
 	public struct AudioComponentDescription
-#else
-	public class AudioComponentDescription
-#endif
 	{
 		[MarshalAs(UnmanagedType.U4)] 
 		public AudioComponentType ComponentType;
@@ -244,10 +205,6 @@ namespace AudioUnit
 		public AudioComponentFlag ComponentFlags;
 		public int ComponentFlagsMask;
 
-#if !XAMCORE_2_0
-		public AudioComponentDescription () {}
-#endif
-
 		internal AudioComponentDescription (AudioComponentType type, int subType)
 		{
 			ComponentType = type;
@@ -256,18 +213,6 @@ namespace AudioUnit
 			ComponentFlags = (AudioComponentFlag) 0;
 			ComponentFlagsMask = 0;
 		}
-
-#if !XAMCORE_2_0
-		// Because someone made AudioComponentDescription a class
-		internal AudioComponentDescription (AudioComponentDescriptionNative native)
-		{
-			this.ComponentType = native.ComponentType;
-			this.ComponentSubType = native.ComponentSubType;
-			this.ComponentManufacturer = native.ComponentManufacturer;
-			this.ComponentFlags = native.ComponentFlags;
-			this.ComponentFlagsMask = native.ComponentFlagsMask;
-		}
-#endif
 
 		public static AudioComponentDescription CreateGeneric (AudioComponentType type, int subType)
 		{

--- a/src/AudioUnit/AudioUnitUtils.cs
+++ b/src/AudioUnit/AudioUnitUtils.cs
@@ -40,51 +40,5 @@ namespace AudioUnit
     public static class AudioUnitUtils
     {
         public const int SampleFractionBits = 24;
-
-#if !XAMCORE_2_0
-        [Advice ("Use 'AudioStreamBasicDescription::CreateLinearPCM' instead.")]
-        public static AudioStreamBasicDescription AUCanonicalASBD(double sampleRate, int channel)
-        {
-            // setting AudioStreamBasicDescription
-            int AudioUnitSampleTypeSize = 		
-#if !MONOMAC
-            (ObjCRuntime.Runtime.Arch == ObjCRuntime.Arch.SIMULATOR) ? sizeof(float) : sizeof(int);
-#else
-		sizeof (float);
-#endif
-            AudioStreamBasicDescription audioFormat = new AudioStreamBasicDescription()
-            {
-                SampleRate = sampleRate,
-                Format = AudioFormatType.LinearPCM,
-                //kAudioFormatFlagsAudioUnitCanonical = kAudioFormatFlagIsSignedInteger | kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsPacked | kAudioFormatFlagIsNonInterleaved | (SampleFractionBits << kLinearPCMFormatFlagsSampleFractionShift),
-                FormatFlags      = (AudioFormatFlags)((int)AudioFormatFlags.IsSignedInteger | (int)AudioFormatFlags.IsPacked | (int)AudioFormatFlags.IsNonInterleaved | (int)(SampleFractionBits << (int)AudioFormatFlags.LinearPCMSampleFractionShift)),
-                ChannelsPerFrame = channel,
-                BytesPerPacket   = AudioUnitSampleTypeSize,
-                BytesPerFrame    = AudioUnitSampleTypeSize,
-                FramesPerPacket  = 1,
-                BitsPerChannel   = 8 * AudioUnitSampleTypeSize,
-                Reserved = 0
-            };
-            return audioFormat;
-        }
-
-        [Advice ("Use 'AudioSession::OverrideCategoryDefaultToSpeaker' instead.")]
-        public static void SetOverrideCategoryDefaultToSpeaker(bool isSpeaker)
-        {
-		int val = isSpeaker ? 1 : 0;
-		int err = AudioSessionSetProperty(
-			0x6373706b, //'cspk'
-			(UInt32)sizeof(UInt32),
-			ref val);
-		if (err != 0)
-			throw new ArgumentException();            
-        }
-
-	    [DllImport(Constants.AudioToolboxLibrary, EntryPoint = "AudioSessionSetProperty")]
-	    static extern int AudioSessionSetProperty(
-		    UInt32 inID,
-		    UInt32 inDataSize,
-		    ref int inData);
-#endif
     }
 }

--- a/src/AudioUnit/ExtAudioFile.cs
+++ b/src/AudioUnit/ExtAudioFile.cs
@@ -316,23 +316,6 @@ namespace AudioUnit
             return frame;
         }
 
-#if !XAMCORE_2_0
-        [Obsolete ("Use overload with 'AudioBuffers'.")]
-        public int Read(int numberFrames, AudioBufferList data)
-        {
-            if (data == null)
-                throw new ArgumentNullException ("data");
-
-            int err = ExtAudioFileRead(_extAudioFile, ref numberFrames, data);
-            if (err != 0)
-            {
-                throw new ArgumentException(String.Format("Error code:{0}", err));
-            }
-
-            return numberFrames;
-        }
-#endif
-
         public uint Read (uint numberFrames, AudioBuffers audioBufferList, out ExtAudioFileError status)
         {
             if (audioBufferList == null)
@@ -341,18 +324,6 @@ namespace AudioUnit
             status = ExtAudioFileRead (_extAudioFile, ref numberFrames, (IntPtr) audioBufferList);
             return numberFrames;
         }
-
-#if !XAMCORE_2_0
-        [Obsolete ("Use overload with 'AudioBuffers'.")]
-        public void WriteAsync(int numberFrames, AudioBufferList data)
-        {
-            int err = ExtAudioFileWriteAsync(_extAudioFile, numberFrames, data);
-            
-            if (err != 0) {
-                throw new ArgumentException(String.Format("Error code:{0}", err));
-            }        
-        }
-#endif
 
         public ExtAudioFileError WriteAsync (uint numberFrames, AudioBuffers audioBufferList)
         {
@@ -398,23 +369,11 @@ namespace AudioUnit
         [DllImport (Constants.AudioToolboxLibrary)]
         static extern ExtAudioFileError ExtAudioFileWrapAudioFileID (IntPtr inFileID, bool inForWriting, IntPtr outExtAudioFile);    
 
-#if !XAMCORE_2_0
-        [Obsolete]
-        [DllImport(Constants.AudioToolboxLibrary, EntryPoint = "ExtAudioFileRead")]
-        static extern int ExtAudioFileRead(IntPtr inExtAudioFile, ref int /* UInt32* */ ioNumberFrames, AudioBufferList ioData);
-#endif
-
         [DllImport(Constants.AudioToolboxLibrary)]
 		static extern ExtAudioFileError ExtAudioFileRead (IntPtr inExtAudioFile, ref uint /* UInt32* */ ioNumberFrames, IntPtr ioData);
 
         [DllImport(Constants.AudioToolboxLibrary)]
 		static extern ExtAudioFileError ExtAudioFileWrite (IntPtr inExtAudioFile, uint /* UInt32 */ inNumberFrames, IntPtr ioData);                 
-
-#if !XAMCORE_2_0
-        [Obsolete]
-        [DllImport(Constants.AudioToolboxLibrary, EntryPoint = "ExtAudioFileWriteAsync")]
-		static extern int /* OSStatus */ ExtAudioFileWriteAsync(IntPtr inExtAudioFile, int /* UInt32 */ inNumberFrames, AudioBufferList ioData);
-#endif
 
         [DllImport(Constants.AudioToolboxLibrary)]
 		static extern ExtAudioFileError ExtAudioFileWriteAsync(IntPtr inExtAudioFile, uint /* UInt32 */ inNumberFrames, IntPtr ioData);

--- a/src/assetslibrary.cs
+++ b/src/assetslibrary.cs
@@ -37,53 +37,29 @@ namespace AssetsLibrary {
 	[BaseType (typeof (NSObject))]
 	interface ALAssetsLibrary {
 		[Export ("assetForURL:resultBlock:failureBlock:")]
-#if XAMCORE_2_0
 		void AssetForUrl (NSUrl assetURL, Action<ALAsset> resultBlock, Action<NSError> failureBlock);
-#else
-		void AssetForUrl (NSUrl assetURL, ALAssetsLibraryAssetForURLResultDelegate resultBlock, ALAssetsLibraryAccessFailureDelegate failureBlock);
-#endif
 
 		[Export ("enumerateGroupsWithTypes:usingBlock:failureBlock:")]
-#if XAMCORE_2_0
 		void Enumerate (ALAssetsGroupType types, ALAssetsLibraryGroupsEnumerationResultsDelegate enumerationBlock, Action<NSError> failureBlock);
-#else
-		void Enumerate (ALAssetsGroupType types, ALAssetsLibraryGroupsEnumerationResultsDelegate enumerationBlock, ALAssetsLibraryAccessFailureDelegate failureBlock);
-#endif
 
 		[Export ("videoAtPathIsCompatibleWithSavedPhotosAlbum:")]
 		bool VideoAtPathIsIsCompatibleWithSavedPhotosAlbum (NSUrl videoPathURL);
 
 		[Export ("writeImageDataToSavedPhotosAlbum:metadata:completionBlock:")]
 		[Async]
-#if XAMCORE_2_0
 		void WriteImageToSavedPhotosAlbum (NSData imageData, NSDictionary metadata, [NullAllowed] Action<NSUrl,NSError> completionBlock);
-#else
-		void WriteImageToSavedPhotosAlbum (NSData imageData, NSDictionary metadata, [NullAllowed] ALAssetsLibraryWriteCompletionDelegate completionBlock);
-#endif
 
 		[Export ("writeImageToSavedPhotosAlbum:metadata:completionBlock:")]
 		[Async]
-#if XAMCORE_2_0
 		void WriteImageToSavedPhotosAlbum (CGImage imageData, NSDictionary metadata, [NullAllowed] Action<NSUrl,NSError> completionBlock);
-#else
-		void WriteImageToSavedPhotosAlbum (CGImage imageData, NSDictionary metadata, [NullAllowed] ALAssetsLibraryWriteCompletionDelegate completionBlock);
-#endif
 
 		[Export ("writeImageToSavedPhotosAlbum:orientation:completionBlock:")]
 		[Async]
-#if XAMCORE_2_0
 		void WriteImageToSavedPhotosAlbum (CGImage imageData, ALAssetOrientation orientation, [NullAllowed] Action<NSUrl,NSError> completionBlock);
-#else
-		void WriteImageToSavedPhotosAlbum (CGImage imageData, ALAssetOrientation orientation,  [NullAllowed] ALAssetsLibraryWriteCompletionDelegate completionBlock);
-#endif
 
 		[Export ("writeVideoAtPathToSavedPhotosAlbum:completionBlock:")]
 		[Async]
-#if XAMCORE_2_0
 		void WriteVideoToSavedPhotosAlbum (NSUrl videoPathURL, [NullAllowed] Action<NSUrl,NSError> completionBlock);
-#else
-		void WriteVideoToSavedPhotosAlbum (NSUrl videoPathURL,  [NullAllowed] ALAssetsLibraryWriteCompletionDelegate completionBlock);
-#endif
 
 		[Field ("ALAssetsLibraryChangedNotification")]
 		[Notification]
@@ -91,18 +67,10 @@ namespace AssetsLibrary {
 		NSString ChangedNotification { get; }
 
 		[Export ("groupForURL:resultBlock:failureBlock:")]
-#if XAMCORE_2_0
 		void GroupForUrl (NSUrl groupURL, Action<ALAssetsGroup> resultBlock, Action<NSError> failureBlock);
-#else
-		void GroupForUrl (NSUrl groupURL, ALAssetsLibraryGroupResult resultBlock, ALAssetsLibraryAccessFailure failureBlock);
-#endif
 
 		[Export ("addAssetsGroupAlbumWithName:resultBlock:failureBlock:")]
-#if XAMCORE_2_0
 		void AddAssetsGroupAlbum (string name, Action<ALAssetsGroup> resultBlock, Action<NSError> failureBlock);
-#else
-		void AddAssetsGroupAlbum (string name, ALAssetsLibraryGroupResult resultBlock, ALAssetsLibraryAccessFailure failureBlock);
-#endif
 
 		[Static]
 		[Export ("authorizationStatus")]
@@ -125,14 +93,6 @@ namespace AssetsLibrary {
 		NSString DeletedAssetGroupsKey { get; }
 	}
 
-#if !XAMCORE_2_0
-	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use the 'Photos' API instead.")]
-	delegate void ALAssetsLibraryAssetForURLResultDelegate (ALAsset asset);
-	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use the 'Photos' API instead.")]
-	delegate void ALAssetsLibraryAccessFailureDelegate (NSError error);
-	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use the 'Photos' API instead.")]
-	delegate void ALAssetsLibraryWriteCompletionDelegate (NSUrl assetURL, NSError error);
-#endif
 	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use the 'Photos' API instead.")]
 	delegate void ALAssetsLibraryGroupsEnumerationResultsDelegate (ALAssetsGroup group, ref bool stop);
 
@@ -195,35 +155,19 @@ namespace AssetsLibrary {
 
 		[Export ("writeModifiedImageDataToSavedPhotosAlbum:metadata:completionBlock:")]
 		[Async]
-#if XAMCORE_2_0
 		void WriteModifiedImageToSavedToPhotosAlbum (NSData imageData, NSDictionary metadata, [NullAllowed] Action<NSUrl,NSError> completionBlock);
-#else
-		void WriteModifiedImageToSavedToPhotosAlbum (NSData imageData, NSDictionary metadata,  [NullAllowed] ALAssetsLibraryWriteCompletionDelegate completionBlock);
-#endif
 
 		[Export ("writeModifiedVideoAtPathToSavedPhotosAlbum:completionBlock:")]
 		[Async]
-#if XAMCORE_2_0
 		void WriteModifiedVideoToSavedPhotosAlbum (NSUrl videoPathURL, [NullAllowed] Action<NSUrl,NSError> completionBlock);
-#else
-		void WriteModifiedVideoToSavedPhotosAlbum (NSUrl videoPathURL,  [NullAllowed] ALAssetsLibraryWriteCompletionDelegate completionBlock);
-#endif
 
 		[Export ("setImageData:metadata:completionBlock:")]
 		[Async]
-#if XAMCORE_2_0
 		void SetImageData (NSData imageData, NSDictionary metadata, [NullAllowed] Action<NSUrl,NSError> completionBlock);
-#else
-		void SetImageData (NSData imageData, NSDictionary metadata,  [NullAllowed] ALAssetsLibraryWriteCompletionDelegate completionBlock);
-#endif
 
 		[Export ("setVideoAtPath:completionBlock:")]
 		[Async]
-#if XAMCORE_2_0
 		void SetVideoAtPath (NSUrl videoPathURL, [NullAllowed] Action<NSUrl,NSError> completionBlock);
-#else
-		void SetVideoAtPath (NSUrl videoPathURL,  [NullAllowed] ALAssetsLibraryWriteCompletionDelegate completionBlock);
-#endif
 	}
 
 	[BaseType (typeof (NSObject))]
@@ -284,14 +228,6 @@ namespace AssetsLibrary {
 
 	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use the 'Photos' API instead.")]
 	delegate void ALAssetsEnumerator (ALAsset result, nint index, ref bool stop);
-
-#if !XAMCORE_2_0
-	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use the 'Photos' API instead.")]
-	delegate void ALAssetsLibraryGroupResult (ALAssetsGroup group);
-
-	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use the 'Photos' API instead.")]
-	delegate void ALAssetsLibraryAccessFailure (NSError error);
-#endif
 
 	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use the 'Photos' API instead.")]
 	[BaseType (typeof (NSObject))]

--- a/src/audiounit.cs
+++ b/src/audiounit.cs
@@ -33,7 +33,6 @@ using AUViewControllerBase = UIKit.UIViewController;
 #endif
 
 namespace AudioUnit {
-#if XAMCORE_2_0 || !MONOMAC
 	delegate AudioUnitStatus AUInternalRenderBlock (ref AudioUnitRenderActionFlags actionFlags, ref AudioTimeStamp timestamp, uint frameCount, nint outputBusNumber, AudioBuffers outputData, AURenderEventEnumerator realtimeEventListHead, [BlockCallback][NullAllowed]AURenderPullInputBlock pullInputBlock);
 	delegate AudioUnitStatus AURenderBlock (ref AudioUnitRenderActionFlags actionFlags, ref AudioTimeStamp timestamp, uint frameCount, nint outputBusNumber, AudioBuffers outputData, [BlockCallback][NullAllowed] AURenderPullInputBlock pullInputBlock);
 
@@ -74,7 +73,6 @@ namespace AudioUnit {
 	[DisableDefaultCtor]
 	interface AUAudioUnit
 	{
-#if XAMCORE_2_0 // AudioComponentDescription went under large changes between Classic and Unified. Since this is a new API, no reason to pollute it with the Classic hacks
 		[Static]
 		[Export ("registerSubclass:asComponentDescription:name:version:")] // AUAudioUnitImplementation
 		void RegisterSubclass (Class cls, AudioComponentDescription componentDescription, string name, uint version);
@@ -93,7 +91,6 @@ namespace AudioUnit {
 
 		[Export ("componentDescription")]
 		AudioComponentDescription ComponentDescription { get; }
-#endif
 
 		[Export ("renderBlock")]
 		AURenderBlock RenderBlock { get; }
@@ -671,7 +668,6 @@ namespace AudioUnit {
 		AUParameterTree CreateTree (AUParameterNode[] children);
 	}
 
-#if XAMCORE_2_0
 	[Protocol]
 	interface AUAudioUnitFactory : NSExtensionRequestHandling
 	{
@@ -680,6 +676,4 @@ namespace AudioUnit {
 		[return: NullAllowed]
 		AUAudioUnit CreateAudioUnit (AudioComponentDescription desc, [NullAllowed] out NSError error);
 	}
-#endif
-#endif
 }


### PR DESCRIPTION


Backport of #8762.

/cc @rolfbjarne 