### PR TITLE
[dotnet-linker] Add support for passing configuration from the MSBuild targets to our linker steps.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -55,6 +55,12 @@
 
 		<!-- App extensions are self-contained, even though their OutputType=Library -->
 		<SelfContained Condition="'$(SelfContained)' == '' And $(_ProjectType.EndsWith ('AppExtensionProject'))">true</SelfContained>
+
+		<!-- Add a property that specifies the name of the platform assembly for each platform -->
+		<_PlatformAssemblyName Condition=" '$(_PlatformName)' == 'iOS' ">Xamarin.iOS</_PlatformAssemblyName>
+		<_PlatformAssemblyName Condition=" '$(_PlatformName)' == 'tvOS' ">Xamarin.TVOS</_PlatformAssemblyName>
+		<_PlatformAssemblyName Condition=" '$(_PlatformName)' == 'watchOS' ">Xamarin.WatchOS</_PlatformAssemblyName>
+		<_PlatformAssemblyName Condition=" '$(_PlatformName)' == 'macOS' ">Xamarin.Mac</_PlatformAssemblyName>
 	</PropertyGroup>
 
 	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
@@ -86,6 +92,18 @@
 		<_AdditionalTaskAssembly>$(_AdditionalTaskAssemblyDirectory)dotnet-linker.dll</_AdditionalTaskAssembly>
 	</PropertyGroup>
 	<Target Name="_ComputeLinkerArguments">
+		<PropertyGroup>
+			<!-- Pass the custom options to our custom steps -->
+			<_CustomLinkerOptionsFile>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)custom-linker-options.txt'))</_CustomLinkerOptionsFile>
+			<_CustomLinkerOptions>
+				Platform=$(_PlatformName)
+				PlatformAssembly=$(_PlatformAssemblyName).dll
+			</_CustomLinkerOptions>
+			<_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --custom-data "LinkerOptionsFile=$(_CustomLinkerOptionsFile)"</_ExtraTrimmerArgs>
+
+			<!-- Verbose output, so that we get something to stdout when something goes wrong -->
+			<_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --verbose</_ExtraTrimmerArgs>
+		</PropertyGroup>
 		<ItemGroup>
 			<!-- add our custom steps -->
 			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)">
@@ -93,6 +111,9 @@
 				<Type>Xamarin.SetupStep</Type>
 			</_TrimmerCustomSteps>
 		</ItemGroup>
+
+		<!-- Create the file with our custom linker options -->
+		<WriteLinesToFile File="$(_CustomLinkerOptionsFile)" Lines="$(_CustomLinkerOptions)" Overwrite="true" />
 	</Target>
 
 	<Target Name="_ComputePublishLocation" DependsOnTargets="_GenerateBundleName">

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+using Mono.Linker;
+
+using Xamarin.Utils;
+
+namespace Xamarin.Linker {
+	public class LinkerConfiguration {
+		public ApplePlatform Platform { get; private set; }
+		public string PlatformAssembly { get; private set; }
+
+		static ConditionalWeakTable<LinkContext, LinkerConfiguration> configurations = new ConditionalWeakTable<LinkContext, LinkerConfiguration> ();
+
+		public static LinkerConfiguration GetInstance (LinkContext context)
+		{
+			if (!configurations.TryGetValue (context, out var instance)) {
+				if (!context.TryGetCustomData ("LinkerOptionsFile", out var linker_options_file))
+					throw new Exception ($"No custom linker options file was passed to the linker (using --custom-data LinkerOptionsFile=...");
+				instance = new LinkerConfiguration (linker_options_file);
+				configurations.Add (context, instance);
+			}
+
+			return instance;
+		}
+
+		LinkerConfiguration (string linker_file)
+		{
+			if (!File.Exists (linker_file))
+				throw new FileNotFoundException ($"The custom linker file {linker_file} does not exist.");
+
+			var lines = File.ReadAllLines (linker_file);
+			for (var i = 0; i < lines.Length; i++) {
+				var line = lines [i].TrimStart ();
+				if (line.Length == 0 || line [0] == '#')
+					continue; // Allow comments
+
+				var eq = line.IndexOf ('=');
+				if (eq == -1)
+					throw new InvalidOperationException ($"Invalid syntax for line {i + 1} in {linker_file}: No equals sign.");
+
+				var key = line [..eq];
+				var value = line [(eq + 1)..];
+				switch (key) {
+				case "Platform":
+					switch (value) {
+					case "iOS":
+						Platform = ApplePlatform.iOS;
+						break;
+					case "tvOS":
+						Platform = ApplePlatform.TVOS;
+						break;
+					case "watchOS":
+						Platform = ApplePlatform.WatchOS;
+						break;
+					case "macOS":
+						Platform = ApplePlatform.MacOSX;
+						break;
+					default:
+						throw new InvalidOperationException ($"Unknown platform: {value} for the entry {line} in {linker_file}");
+					}
+					break;
+				case "PlatformAssembly":
+					PlatformAssembly = Path.GetFileNameWithoutExtension (value);
+					break;
+				default:
+					throw new InvalidOperationException ($"Unknown key '{key}' in {linker_file}");
+				}
+			}
+		}
+
+		public void Write ()
+		{
+			Console.WriteLine ($"LinkerConfiguration:");
+			Console.WriteLine ($"    Platform: {Platform}");
+			Console.WriteLine ($"    PlatformAssembly: {PlatformAssembly}.dll");
+		}
+	}
+}

--- a/tools/dotnet-linker/SetupStep.cs
+++ b/tools/dotnet-linker/SetupStep.cs
@@ -2,14 +2,17 @@ using System;
 
 using Mono.Linker.Steps;
 
+using Xamarin.Linker;
+
 namespace Xamarin {
 
-	public class SetupStep : BaseStep {
+	public class SetupStep : ConfigurationAwareStep {
 
 		protected override void Process ()
 		{
 			// This will be replaced with something more useful later.
 			Console.WriteLine ("Hello SetupStep");
+			Configuration.Write ();
 		}
 	}
 }

--- a/tools/dotnet-linker/Steps/ConfigurationAwareStep.cs
+++ b/tools/dotnet-linker/Steps/ConfigurationAwareStep.cs
@@ -1,0 +1,9 @@
+using Mono.Linker.Steps;
+
+namespace Xamarin.Linker {
+	public abstract class ConfigurationAwareStep : BaseStep {
+		public LinkerConfiguration Configuration {
+			get { return LinkerConfiguration.GetInstance (Context); }
+		}
+	}
+}

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -6,4 +6,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.ILLink" Version="5.0.0-preview.3.20302.1" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\common\ApplePlatform.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
+</ItemGroup>
 </Project>


### PR DESCRIPTION
Add support for passing configuration from the MSBuild targets to our linker
steps using the linker's --custom-data option.

There are just two values being passed now, but this will grow significantly
over time as linker steps are implemented.