### PR TITLE
[mtouch] Remove empty comment tags from localization resx files.

### DIFF
--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -126,311 +126,223 @@
 	
 	<data name="BI0000" xml:space="preserve">
 		<value>Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</value>
-		<comment>
-		</comment>
 	</data>
 	
 
 	<data name="BI0001" xml:space="preserve">
 		<value>The .NET runtime could not load the {0} type. Message: {1}</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI0002" xml:space="preserve">
 		<value>Could not compile the API bindings.
 		{0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI0026" xml:space="preserve">
 		<value>Could not parse the command line argument '--warnaserror': {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI0068" xml:space="preserve">
 		<value>Invalid value for target framework: {0}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI0070" xml:space="preserve">
 		<value>Invalid target framework: {0}. Valid target frameworks are: {1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI0086" xml:space="preserve">
 		<value>A target framework (--target-framework) must be specified.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI0087" xml:space="preserve">
 		<value>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="BI0088" xml:space="preserve">
 		<value>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="BI0089" xml:space="preserve">
 		<value>Internal error: property {0} doesn't have neither a getter nor a setter.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="BI0099" xml:space="preserve">
 		<value>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1000" xml:space="preserve">
 		<value>Could not compile the generated API bindings.	
 		{0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1001" xml:space="preserve">
 		<value>Do not know how to make a trampoline for {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1002" xml:space="preserve">
 		<value>Unknown kind {0} in method '{1}.{2}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1003" xml:space="preserve">
 		<value>The delegate method {0}.{1} needs to take at least one parameter
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1004" xml:space="preserve">
 		<value>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1005" xml:space="preserve">
 		<value>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1006" xml:space="preserve">
 		<value>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1007" xml:space="preserve">
 		<value>Unknown attribute {0} on {1}.{2}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1008" xml:space="preserve">
 		<value>[IsThreadStatic] is only valid on properties that are also [Static]
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1009" xml:space="preserve">
 		<value>No selector specified for method `{0}.{1}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1010" xml:space="preserve">
 		<value>No Export attribute on {0}.{1} property
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1011" xml:space="preserve">
 		<value>Do not know how to extract type {0}/{1} from an NSDictionary
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1012" xml:space="preserve">
 		<value>No Export or Bind attribute defined on {0}.{1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1013" xml:space="preserve">
 		<value>Unsupported type for Fields (string), you probably meant NSString
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1014" xml:space="preserve">
 		<value>Unsupported type for Fields: {0} for '{1}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1015" xml:space="preserve">
 		<value>In class {0} You specified the Events property, but did not bind those to names with Delegates
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1016" xml:space="preserve">
 		<value>The delegate method {0}.{1} is missing the [DefaultValue] attribute
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1017" xml:space="preserve">
 		<value>Do not know how to make a signature for {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1018" xml:space="preserve">
 		<value>No [Export] attribute on property {0}.{1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1019" xml:space="preserve">
 		<value>Invalid [NoDefaultValue] attribute on method '{0}.{1}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1020" xml:space="preserve">
 		<value>Unsupported type {0} used on exported method {1}.{2} -> {3}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1021" xml:space="preserve">
 		<value>Unsupported type for read/write Fields: {0} for {1}.{2}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1022" xml:space="preserve">
 		<value>Model classes can not be categories
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1023" xml:space="preserve">
 		<value>The number of Events (Type) and Delegates (string) must match for `{0}`
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1024" xml:space="preserve">
 		<value>No selector specified for property '{0}.{1}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1025" xml:space="preserve">
 		<value>[Static] and [Protocol] are mutually exclusive ({0})
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1026" xml:space="preserve">
 		<value>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1027" xml:space="preserve">
 		<value>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1028" xml:space="preserve">
 		<value>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1029" xml:space="preserve">
 		<value>Internal error: invalid enum mode for type '{0}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1030" xml:space="preserve">
 		<value>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1031" xml:space="preserve">
 		<value>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="BI1032" xml:space="preserve">
 		<value>No support for setters in StrongDictionary classes for type {0} in {1}.{2}
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="BI1033" xml:space="preserve">
@@ -446,168 +358,120 @@
 	<data name="BI1034" xml:space="preserve">
 		<value>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1035" xml:space="preserve">
 		<value>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1036" xml:space="preserve">
 		<value>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1037" xml:space="preserve">
 		<value>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1038" xml:space="preserve">
 		<value>The selector {0} on type {1} is found multiple times with different return types.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1039" xml:space="preserve">
 		<value>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1040" xml:space="preserve">
 		<value>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1041" xml:space="preserve">
 		<value>The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1042" xml:space="preserve">
 		<value>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1043" xml:space="preserve">
 		<value>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1044" xml:space="preserve">
 		<value>Repeated name '{0}' provided in [DelegateApiNameAttribute].
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1045" xml:space="preserve">
 		<value>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1046" xml:space="preserve">
 		<value>The [Field] constant {0} cannot only be used once inside enum {1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1047" xml:space="preserve">
 		<value>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1048" xml:space="preserve">
 		<value>Unsupported type {0} decorated with [BindAs]
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1049" xml:space="preserve">
 		<value>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1050" xml:space="preserve">
 		<value>[BindAs] cannot be used inside Protocol or Model types. Type: {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1051" xml:space="preserve">
 		<value>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1052" xml:space="preserve">
 		<value>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1053" xml:space="preserve">
 		<value>Internal error: unknown target framework '{0}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1054" xml:space="preserve">
 		<value>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1055" xml:space="preserve">
 		<value>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1056" xml:space="preserve">
 		<value>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1057" xml:space="preserve">
 		<value>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1058" xml:space="preserve">
@@ -618,127 +482,91 @@
 	<data name="BI1059" xml:space="preserve">
 		<value>Found {0} {1} attributes on the member {2}. At most one was expected.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1060" xml:space="preserve">
 		<value>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1061" xml:space="preserve">
 		<value>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1062" xml:space="preserve">
 		<value>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1063" xml:space="preserve">
 		<value>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1064" xml:space="preserve">
 		<value>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1065" xml:space="preserve">
 		<value>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1066" xml:space="preserve">
 		<value>Unsupported return type '{0}' in {1}.{2}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1067" xml:space="preserve">
 		<value>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1068" xml:space="preserve">
 		<value>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1069" xml:space="preserve">
 		<value>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1070" xml:space="preserve">
 		<value>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1071" xml:space="preserve">
 		<value>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1072" xml:space="preserve">
 		<value>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="BI1073" xml:space="preserve">
 		<value>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="BI1074" xml:space="preserve">
 		<value> Missing [CoreImageFilterProperty] attribute on {0} property {1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="BI1075" xml:space="preserve">
 		<value>Unimplemented CoreImage property type {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="BI1076" xml:space="preserve">
 		<value>Unable to find selector for {0} on {1} on self or base class
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="BI1077" xml:space="preserve">
@@ -752,162 +580,116 @@
 	<data name="BI1078" xml:space="preserve">
 		<value>{0} in method `{1}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="BI1079" xml:space="preserve">
 		<value>{0} in parameter `{1}' from {2}.{3}
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="BI1080" xml:space="preserve">
 		<value>Unsupported type 'ref/out {0}' decorated with [BindAs]
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
     <data name="BI1081" xml:space="preserve">
         <value>Unable to find the assembly '{0}'. Add it as a reference using its full path.
         </value>
-        <comment>
-        </comment>
     </data>
 	
 	<data name="BI1101" xml:space="preserve">
 		<value>Trying to use a string as a [Target]
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1102" xml:space="preserve">
 		<value>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1103" xml:space="preserve">
 		<value>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1104" xml:space="preserve">
 		<value>Could not load the referenced library '{0}': {1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1105" xml:space="preserve">
 		<value>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1106" xml:space="preserve">
 		<value>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1107" xml:space="preserve">
 		<value>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1108" xml:space="preserve">
 		<value>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1109" xml:space="preserve">
 		<value>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1110" xml:space="preserve">
 		<value>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1111" xml:space="preserve">
 		<value>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1112" xml:space="preserve">
 		<value>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 
 	<data name="BI1113" xml:space="preserve">
 		<value>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1114" xml:space="preserve">
 		<value>Binding error: test unable to find property: {0} on {1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 		
 	<data name="BI1115" xml:space="preserve">
 		<value>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1116" xml:space="preserve">
 		<value>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1117" xml:space="preserve">
 		<value>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1118" xml:space="preserve">
 		<value>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="BI1119" xml:space="preserve">
 		<value>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
 		</value>
-		<comment>
-		</comment>
 	</data>
 </root>

--- a/src/bgen/bgen.csproj
+++ b/src/bgen/bgen.csproj
@@ -13,7 +13,6 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <!--<UpdateXlfOnBuild>true</UpdateXlfOnBuild>-->
     <RepositoryPath>$(MSBuildThisFileDirectory)/../..</RepositoryPath>
     <DotNetBuildDir>$(MSBuildThisFileDirectory)/../build/dotnet</DotNetBuildDir>
     <BuildsDir>$(RepositoryPath)/builds</BuildsDir>

--- a/src/generator.csproj
+++ b/src/generator.csproj
@@ -79,9 +79,6 @@
       <Variable name="XamarinMacFrameworkRoot" value="../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current" />
     </EnvironmentVariables>
   </PropertyGroup>
-  <PropertyGroup>
-       <UpdateXlfOnBuild>true</UpdateXlfOnBuild>
-  </PropertyGroup>
   <ItemGroup>
     <None Include="..\docs\website\generator-errors.md">
       <Link>generator-errors.md</Link>

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -33,9 +33,6 @@
     <Deterministic>True</Deterministic>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup>
-       <UpdateXlfOnBuild>true</UpdateXlfOnBuild>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -23,506 +23,362 @@
 	<data name="MT0000" xml:space="preserve">
 		<value>Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0001" xml:space="preserve">
 		<value>'-devname' was provided without any device-specific action
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM0001" xml:space="preserve">
 		<value>This version of Xamarin.Mac requires Mono {0} (the current Mono version is {1}). Please update the Mono.framework from http://mono-project.com/Downloads
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0002" xml:space="preserve">
 		<value>Could not parse the environment variable '{0}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0003" xml:space="preserve">
 		<value>Application name '{0}.exe' conflicts with an SDK or product assembly (.dll) name.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0004" xml:space="preserve">
 		<value>New refcounting logic requires SGen to be enabled too.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0005" xml:space="preserve">
 		<value>The output directory * does not exist.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0006" xml:space="preserve">
 		<value>There is no devel platform at {0}, use --platform=PLAT to specify the SDK.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0007" xml:space="preserve">
 		<value>The root assembly '{0}' does not exist
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM0008" xml:space="preserve">
 		<value>You should provide one root assembly only, found {0} assemblies: '{1}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MX0009" xml:space="preserve">
 		<value>Error while loading assemblies: {0}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0010" xml:space="preserve">
 		<value>Could not parse the command line arguments: {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0011" xml:space="preserve">
 		<value>{0} was built against a more recent runtime ({1}) than Xamarin.iOS supports.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0012" xml:space="preserve">
 		<value>Incomplete data is provided to complete *.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0013" xml:space="preserve">
 		<value>Profiling support requires sgen to be enabled too.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0014" xml:space="preserve">
 		<value>The iOS {0} SDK does not support building applications targeting {1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0015" xml:space="preserve">
 		<value>Invalid ABI: {0}. Supported ABIs are: i386, x86_64, armv7, armv7+llvm, armv7+llvm+thumb2, armv7s, armv7s+llvm, armv7s+llvm+thumb2, armv7k, armv7k+llvm, arm64, arm64+llvm, arm64_32 and arm64_32+llvm.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0016" xml:space="preserve">
 		<value>The option '{0}' has been deprecated.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0017" xml:space="preserve">
 		<value>You should provide a root assembly.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0018" xml:space="preserve">
 		<value>Unknown command line argument: '{0}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0019" xml:space="preserve">
 		<value>Only one --[log|install|kill|launch]dev or --[launch|debug]sim option can be used.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0020" xml:space="preserve">
 		<value>The valid options for '{0}' are '{1}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0021" xml:space="preserve">
 		<value>Cannot compile using gcc/g++ (--use-gcc) when using the static registrar (this is the default when compiling for device). Either remove the --use-gcc flag or use the dynamic registrar (--registrar:dynamic).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0022" xml:space="preserve">
 		<value>The options '--unsupported--enable-generics-in-registrar' and '--registrar' are not compatible.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0023" xml:space="preserve">
 		<value>The root assembly {0} conflicts with another assembly ({1}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM0023" xml:space="preserve">
 		<value>Application name '{0}.exe' conflicts with another user assembly.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0024" xml:space="preserve">
 		<value>Could not find required file '{0}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0025" xml:space="preserve">
 		<value>No SDK version was provided. Please add --sdk=X.Y to specify which {0} SDK should be used to build your application.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0026" xml:space="preserve">
 		<value>Could not parse the command line argument '-{0}': {1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0027" xml:space="preserve">
 		<value>The options '\*' and '\*' are not compatible.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0028" xml:space="preserve">
 		<value>Cannot enable PIE (-pie) when targeting iOS 4.1 or earlier. Please disable PIE (-pie:false) or set the deployment target to at least iOS 4.2
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0029" xml:space="preserve">
 		<value>REPL (--enable-repl) is only supported in the simulator (--sim).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0030" xml:space="preserve">
 		<value>The executable name ({0}) and the app name ({1}) are different, this may prevent crash logs from getting symbolicated properly.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0031" xml:space="preserve">
 		<value>The command line arguments '--enable-background-fetch' and '--launch-for-background-fetch' require '--launchsim' too.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0032" xml:space="preserve">
 		<value>The option '--debugtrack' is ignored unless '--debug' is also specified.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0033" xml:space="preserve">
 		<value>A Xamarin.iOS project must reference either monotouch.dll or Xamarin.iOS.dll
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0034" xml:space="preserve">
 		<value>Cannot reference '{0}.dll' in a {1} project - it is implicitly referenced by '{2}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0036" xml:space="preserve">
 		<value>Cannot launch a * simulator for a * app. Please enable the correct architecture(s) in your project's iOS Build options (Advanced page).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0037" xml:space="preserve">
 		<value>monotouch.dll is not 64-bit compatible. Either reference Xamarin.iOS.dll, or do not build for a 64-bit architecture (ARM64 and/or x86_64).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0038" xml:space="preserve">
 		<value>The old registrars (--registrar:oldstatic|olddynamic) are not supported when referencing Xamarin.iOS.dll.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0039" xml:space="preserve">
 		<value>Applications targeting ARMv6 cannot reference Xamarin.iOS.dll.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0040" xml:space="preserve">
 		<value>Could not find the assembly '\*', referenced by '\*'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0041" xml:space="preserve">
 		<value>Cannot reference '{0}' in a {1} app.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0042" xml:space="preserve">
 		<value>No reference to either monotouch.dll or Xamarin.iOS.dll was found. A reference to monotouch.dll will be added.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0043" xml:space="preserve">
 		<value>The Boehm garbage collector is not supported. The SGen garbage collector has been selected instead.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0044" xml:space="preserve">
 		<value>--listsim is only supported with Xcode 6.0 or later.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0045" xml:space="preserve">
 		<value>--extension is only supported when using the iOS 8.0 (or later) SDK.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0047" xml:space="preserve">
 		<value>The minimum deployment target for Unified applications is 5.1.1, the current deployment target is '*'. Please select a newer deployment target in your project's iOS Application options.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0049" xml:space="preserve">
 		<value>{0}.framework is supported only if deployment target is 8.0 or later. {0} features might not work correctly.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM0050" xml:space="preserve">
 		<value>You cannot provide a root assembly if --no-root-assembly is passed, found {0} assemblies: '{1}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0051" xml:space="preserve">
 		<value>{3} {0} requires Xcode {4} or later. The current Xcode version (found in {2}) is {1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM0051" xml:space="preserve">
 		<value>An output directory (--output) is required if --no-root-assembly is passed.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0052" xml:space="preserve">
 		<value>No command specified.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0054" xml:space="preserve">
 		<value>Unable to canonicalize the path '{0}': {1} ({2}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0055" xml:space="preserve">
 		<value>The Xcode path '{0}' does not exist.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0056" xml:space="preserve">
 		<value>Cannot find Xcode in the default location (/Applications/Xcode.app). Please install Xcode, or pass a custom path using --sdkroot &#60;path&#62;.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0057" xml:space="preserve">
 		<value>Cannot determine the path to Xcode.app from the sdk root '{0}'. Please specify the full path to the Xcode.app bundle.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0058" xml:space="preserve">
 		<value>The Xcode.app '{0}' is invalid (the file '{1}' does not exist).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0059" xml:space="preserve">
 		<value>Could not find the currently selected Xcode on the system: {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0060" xml:space="preserve">
 		<value>Could not find the currently selected Xcode on the system. 'xcode-select --print-path' returned '{0}', but that directory does not exist.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0061" xml:space="preserve">
 		<value>No Xcode.app specified (using --sdkroot), using the system Xcode as reported by 'xcode-select --print-path': {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0062" xml:space="preserve">
 		<value>No Xcode.app specified (using --sdkroot or 'xcode-select --print-path'), using the default Xcode instead: {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0063" xml:space="preserve">
 		<value>Cannot find the executable in the extension * (no CFBundleExecutable entry in its Info.plist)
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0064" xml:space="preserve">
 		<value>Xamarin.iOS only supports embedded frameworks with Unified projects.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0065" xml:space="preserve">
 		<value>Xamarin.iOS only supports embedded frameworks when deployment target is at least 8.0 (current deployment target: '{0}'; embedded frameworks: '{1}')
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0065_A" xml:space="preserve">
 		<value>Xamarin.iOS only supports embedded frameworks when deployment target is at least 2.0 (current deployment target: '{0}'; embedded frameworks: '{1}')
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0066" xml:space="preserve">
 		<value>Invalid build registrar assembly: *
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0067" xml:space="preserve">
 		<value>Invalid registrar: {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0068" xml:space="preserve">
 		<value>Invalid value for target framework: {0}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0070" xml:space="preserve">
 		<value>Invalid target framework: {0}. Valid target frameworks are: {1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 		
 	<data name="MX0071" xml:space="preserve">
 		<value>Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 
 	<data name="MT0072" xml:space="preserve">
 		<value>Extensions are not supported for the platform '{0}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0073" xml:space="preserve">
@@ -552,127 +408,91 @@
 	<data name="MT0075" xml:space="preserve">
 		<value>Invalid architecture '{0}' for {1} projects. Valid architectures are: {2}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0076" xml:space="preserve">
 		<value>No architecture specified (using the --abi argument). An architecture is required for {0} projects.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0077" xml:space="preserve">
 		<value>WatchOS projects must be extensions.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0078" xml:space="preserve">
 		<value>Incremental builds are enabled with a deployment target &#60; 8.0 (currently {0}). This is not supported (the resulting application will not launch on iOS 9), so the deployment target will be set to 8.0.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0079" xml:space="preserve">
 		<value>The recommended Xcode version for {4} {0} is Xcode {3} or later. The current Xcode version (found in {2}) is {1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM0079" xml:space="preserve">
 		<value>No executable was copied into the app bundle.  Please contact 'support@xamarin.com'
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0080" xml:space="preserve">
 		<value>Disabling the new refcount logic is deprecated.
 		</value>
-		<comment>
-		</comment>
 	</data>	
 
 	<data name="MT0081" xml:space="preserve">
 		<value>The command line argument --download-crash-report also requires --download-crash-report-to.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0082" xml:space="preserve">
 		<value>REPL (--enable-repl) is only supported when linking is not used (--nolink).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0083" xml:space="preserve">
 		<value>Asm-only bitcode is not supported on watchOS. Use either --bitcode:marker or --bitcode:full.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0084" xml:space="preserve">
 		<value>Bitcode is not supported in the simulator. Do not pass --bitcode when building for the simulator.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0085" xml:space="preserve">
 		<value>No reference to '{0}' was found. It will be added automatically.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0086" xml:space="preserve">
 		<value>A target framework (--target-framework) must be specified.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0087" xml:space="preserve">
 		<value>Incremental builds (--fastdev) is not supported with the Boehm GC. Incremental builds will be disabled.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0088" xml:space="preserve">
 		<value>The GC must be in cooperative mode for watchOS apps. Please remove the --coop:false argument to mtouch.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0089" xml:space="preserve">
 		<value>The option '{0}' cannot take the value '{1}' when cooperative mode is enabled for the GC.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0090" xml:space="preserve">
 		<value>The target framework '{0}' is deprecated. Use '{1}' instead.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0091" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<!-- MT0092 has been used in the past -->
@@ -680,8 +500,6 @@
 	<data name="MT0093" xml:space="preserve">
 		<value>Could not find 'mlaunch'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<!-- MT0094 has been used in the past -->
@@ -689,36 +507,26 @@
 	<data name="MT0095" xml:space="preserve">
 		<value>Aot files could not be copied to the destination directory {0}: {1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0095_A" xml:space="preserve">
 		<value>Aot files could not be copied to the destination directory {0}: Could not start process.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0095_B" xml:space="preserve">
 		<value>Aot files could not be copied to the destination directory {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0096" xml:space="preserve">
 		<value>No reference to Xamarin.iOS.dll was found.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM0097" xml:space="preserve">
 		<value>machine.config file '{0}' can not be found.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<!-- MM0098 has been used in the past -->
@@ -726,162 +534,116 @@
 	<data name="MX0099" xml:space="preserve">
 		<value>Internal error: {0}. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0129" xml:space="preserve">
 		<value>Debugging symbol file for '{0}' does not match the assembly and is ignored.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX0130" xml:space="preserve">
 		<value>No root assemblies found. You should provide at least one root assembly.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MX0131" xml:space="preserve">
 		<value>Product assembly '{0}' not found in assembly list: '{1}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MX0132" xml:space="preserve">
 		<value>Unknown optimization: '{0}'. Valid optimizations are: {1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MX0133" xml:space="preserve">
 		<value>Found more than 1 assembly matching '{0}' choosing first:{1}{2}
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MX0135" xml:space="preserve">
 		<value>Did not link system framework '{0}' (referenced by assembly '{1}') because it was introduced in {2} {3}, and we're using the {2} {4} SDK.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MX0148" xml:space="preserve">
 		<value>Unable to parse the linker flags '{0}' from the LinkWith attribute for the library '{1}' in {2} : {3}
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0150" xml:space="preserve">
 		<value>Internal error: The interpreter is currently only available for 64 bits.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0100" xml:space="preserve">
 		<value>Invalid assembly build target: '{0}'. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0101" xml:space="preserve">
 		<value>The assembly '{0}' is specified multiple times in --assembly-build-target arguments.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0102" xml:space="preserve">
 		<value>The assemblies '{0}' and '{1}' have the same target name ('{2}'), but different targets ('{3}' and '{4}').
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0103" xml:space="preserve">
 		<value>The static object '{0}' contains more than one assembly ('{1}'), but each static object must correspond with exactly one assembly.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0105" xml:space="preserve">
 		<value>No assembly build target was specified for '{0}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0106" xml:space="preserve">
 		<value>The assembly build target name '{0}' is invalid: the character '{1}' is not allowed.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0107" xml:space="preserve">
 		<value>The assemblies '{0}' have different custom LLVM optimizations ('{1}'), which is not allowed when they are all compiled to a single binary.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0108" xml:space="preserve">
 		<value>The assembly build target '{0}' did not match any assemblies.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0109" xml:space="preserve">
 		<value>The assembly '{0}' was loaded from a different path than the provided path (provided path: {1}, actual path: {2}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0110" xml:space="preserve">
 		<value>Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include third-party binding libraries and that compiles to bitcode.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0111" xml:space="preserve">
 		<value>Bitcode has been enabled because this version of Xamarin.iOS does not support building watchOS projects using LLVM without enabling bitcode.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0112" xml:space="preserve">
 		<value>Native code sharing has been disabled because {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0112_a" xml:space="preserve">
 		<value>the container app's deployment target is earlier than iOS 8.0 (it's {0}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0112_b" xml:space="preserve">
 		<value>the container app includes I18N assemblies ({0}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0112_c" xml:space="preserve">
@@ -895,64 +657,46 @@
 	<data name="MT0113" xml:space="preserve">
 		<value>Native code sharing has been disabled for the extension '{0}' because {1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0113_a" xml:space="preserve">
 		<value>the bitcode options differ between the container app ({0}) and the extension ({1}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0113_b" xml:space="preserve">
 		<value>the --assembly-build-target options are different between the container app ({0}) and the extension ({1}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0113_c" xml:space="preserve">
 		<value>the I18N assemblies are different between the container app ({0}) and the extension ({1}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0113_d" xml:space="preserve">
 		<value>the arguments to the AOT compiler are different between the container app ({0}) and the extension ({1}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0113_e" xml:space="preserve">
 		<value>the other arguments to the AOT compiler are different between the container app ({0}) and the extension ({1}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0113_f" xml:space="preserve">
 		<value>LLVM is not enabled or disabled in both the container app ({0}) and the extension ({1}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0113_g" xml:space="preserve">
 		<value>the managed linker settings are different between the container app ({0}) and the extension ({1}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0113_h" xml:space="preserve">
 		<value>the skipped assemblies for the managed linker are different between the container app ({0}) and the extension ({1}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0113_i" xml:space="preserve">
@@ -966,575 +710,411 @@
 	<data name="MT0113_j" xml:space="preserve">
 		<value>the interpreter settings are different between the container app ({0}) and the extension ({1}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0113_k" xml:space="preserve">
 		<value>the interpreted assemblies are different between the container app ({0}) and the extension ({1}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0113_l" xml:space="preserve">
 		<value>the container app does not build for the ABI {0} (while the extension is building for this ABI).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0113_m" xml:space="preserve">
 		<value>the container app is building for the ABI {0}, which is not compatible with the extension's ABI ({1}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0113_n" xml:space="preserve">
 		<value>the remove-dynamic-registrar optimization differ between the container app ({0}) and the extension ({1}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0113_o" xml:space="preserve">
 		<value>the container app is referencing the assembly '{0}' from '{1}', while the extension references a different version from '{2}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM0114" xml:space="preserve">
 		<value>Hybrid AOT compilation requires all assemblies to be AOT compiled
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0115" xml:space="preserve">
 		<value>It is recommended to reference dynamic symbols using code (--dynamic-symbol-mode=code) when bitcode is enabled.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0116" xml:space="preserve">
 		<value>Invalid architecture: {0}. 32-bit architectures are not supported when deployment target is 11 or later.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0117" xml:space="preserve">
 		<value>Can't launch a 32-bit app on a simulator that only supports 64-bit.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0118" xml:space="preserve">
 		<value>The directory {0} containing the mono symbols could not be found.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0123" xml:space="preserve">
 		<value>The executable assembly {0} does not reference {1}.dll.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0124" xml:space="preserve">
 		<value>Could not set the current language to '{0}' (according to LANG={1}): {2}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0125" xml:space="preserve">
 		<value>The --assembly-build-target command-line argument is ignored in the simulator.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0126" xml:space="preserve">
 		<value>Incremental builds have been disabled because incremental builds are not supported in the simulator.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0127" xml:space="preserve">
 		<value>Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include more than one third-party binding libraries.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0128" xml:space="preserve">
 		<value>Could not touch the file '{0}': {1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0136" xml:space="preserve">
 		<value>Cannot find the assembly '{0}' referenced from '{1}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0137" xml:space="preserve">
 		<value>Cannot find the assembly '{0}', referenced by a {2} attribute in '{1}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0140" xml:space="preserve">
 		<value>File '{0}' is not a valid framework.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0141" xml:space="preserve">
 		<value>The interpreter is not supported in the simulator. Switching to REPL which provide the same extra features on the simulator.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0142" xml:space="preserve">
 		<value>Cannot find the assembly '{0}', passed as an argument to --interpreter.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM0143" xml:space="preserve">
 		<value>Projects using the Classic API are not supported anymore. Please migrate the project to the Unified API.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM0144" xml:space="preserve">
 		<value>Building 32-bit apps is not supported anymore. Please change the architecture in the project's Mac Build options to 'x86_64'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0145" xml:space="preserve">
 		<value>Please use device specific builds on WatchOS when building for Debug.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0146" xml:space="preserve">
 		<value>ARM64_32 Debug mode requires --interpreter[=all], forcing it.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM0147" xml:space="preserve">
 		<value>Unable to parse the cflags '{0} from pkg-config: {1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0156" xml:space="preserve">
 		<value>Internal error: byref array is neither string, NSObject or INativeObject.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0157" xml:space="preserve">
 		<value>Internal error: can't convert from '{0}' to '{1}' in {2}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0158" xml:space="preserve">
 		<value>Internal error: the smart enum {0} doesn't seem to be a smart enum after all. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0159" xml:space="preserve">
 		<value>Internal error: unsupported tokentype ({0}) for {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0160" xml:space="preserve">
 		<value>Internal error: the static registrar should not execute unless the linker also executed (or was disabled). A potential workaround is to pass '-f' as an additional {0} argument to force a full build. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT0161" xml:space="preserve">
 		<value>Internal error: symbol without a name (type: {0}). Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0168" xml:space="preserve">
 		<value>Internal error: 'can't convert frameworks to frameworks: {0}'. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0174_a" xml:space="preserve">
 		<value>The assembly {0} was referenced by another assembly, but at the same time linked out by the linker.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0175_a" xml:space="preserve">
 		<value>The linker output contains more than one assemblies named '{0}':\n\t{1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0175_b" xml:space="preserve">
 		<value>Not all assemblies for {0} have link tasks
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT0175_c" xml:space="preserve">
 		<value>Link tasks for {0} aren't all the same
 		</value>
-		<comment>
-		</comment>
 	</data>
 
     <data name="MX0176" xml:space="preserve">
         <value>The assembly '{0}' was resolved from the system's GAC: {1}. This could potentially be a problem in the future; to avoid such problems, please make sure to not use assemblies only available in the system's GAC.
         </value>
-        <comment>
-        </comment>
     </data>
 
 	<data name="MX1009" xml:space="preserve">
 		<value>Could not copy the assembly '{0}' to '{1}': {2}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT1010" xml:space="preserve">
 		<value>Could not load the assembly '{0}': {1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT1013" xml:space="preserve">
 		<value>Dependency tracking error: no files to compare. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT1014" xml:space="preserve">
 		<value>Failed to re-use cached version of '{0}': {1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT1015" xml:space="preserve">
 		<value>Failed to create the executable '{0}': {1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT1016" xml:space="preserve">
 		<value>Failed to create the NOTICE file because a directory already exists with the same name.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT1017" xml:space="preserve">
 		<value>Failed to create the NOTICE file: {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT1022" xml:space="preserve">
 		<value>Could not copy the directory '{0}' to '{1}': {2}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM1034" xml:space="preserve">
 		<value>Could not create symlink '{0}' -> '{1}': error {2}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT1035" xml:space="preserve">
 		<value>Cannot include different versions of the framework '{0}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT1036" xml:space="preserve">
 		<value>Framework '{0}' included from: {1} (Related to previous error)
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT1300" xml:space="preserve">
 		<value>Unsupported bitcode platform: {0}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT1301" xml:space="preserve">
 		<value>Unsupported TvOS ABI: {0}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT1302" xml:space="preserve">
 		<value>Could not extract the native library '{0}' from '{1}'. Please ensure the native library was properly embedded in the managed assembly (if the assembly was built using a binding project, the native library must be included in the project, and its Build Action must be 'ObjcBindingNativeLibrary').
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT1302_A" xml:space="preserve">
 		<value>Invalid escape sequence when converting .s to .ll, \\ as the last characted in {0}:{1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT1302_B" xml:space="preserve">
 		<value>Invalid escape sequence when converting .s to .ll, bad octal escape in {0}:{1} due to {2}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT1303" xml:space="preserve">
 		<value>Could not decompress the native framework '{0}' from '{1}'. Please review the build log for more information from the native 'unzip' command.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT1305" xml:space="preserve">
 		<value>The binding library '{0}' contains a user framework ({0}), but embedded user frameworks require iOS 8.0 (the deployment target is {1}). Please set the deployment target in the Info.plist file to at least 8.0.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM1401" xml:space="preserve">
 		<value>The required 'Xamarin.Mac.dll' assembly is missing from the references
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM1402" xml:space="preserve">
 		<value>The assembly '{0}' is not compatible with this tool or profile
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MM1403" xml:space="preserve">
 		<value>{0} {1} could not be found. Target framework '{2}' is unusable to package the application.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MM1404" xml:space="preserve">
 		<value>Target framework '{0}' is invalid.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MM1405" xml:space="preserve">
 		<value>useFullXamMacFramework must always target framework .NET 4.5, not '{0}' which is invalid.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MM1407" xml:space="preserve">
 		<value>Mismatch between Xamarin.Mac reference '{0}' and target framework selected '{1}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MM1501" xml:space="preserve">
 		<value>Can not resolve reference: {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MX1502" xml:space="preserve">
 		<value>One or more reference(s) to type '{0}' already exists inside '{1}' before linking
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MX1503" xml:space="preserve">
 		<value>One or more reference(s) to type '{0}' still exists inside '{1}' after linking
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX1600" xml:space="preserve">
 		<value>Not a Mach-O dynamic library (unknown header '0x{0}'): {1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX1602" xml:space="preserve">
 		<value>Not a Mach-O dynamic library (unknown header '0x{0}'): {1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MX1603" xml:space="preserve">
 		<value>Unknown format for fat entry at position {0} in {1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX1604" xml:space="preserve">
 		<value>File of type {0} is not a MachO file ({1}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT1601" xml:space="preserve">
 		<value>Not a Mach-O static library (unknown header '{0}', expected '!&#60;arch&#62;').
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT1605" xml:space="preserve">
 		<value>Invalid entry '{0}' in the static library '{1}', entry header doesn't end with 0x60 0x0A (found '0x{2} 0x{3}')
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX2001" xml:space="preserve">
 		<value>Could not link assemblies. {0}
 		</value>
-		<comment>
-		</comment>
 	</data>	
 
 	<data name="MT2002" xml:space="preserve">
 		<value>Can not resolve reference: {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT2003" xml:space="preserve">
 		<value>Option '--optimize={0}{1}' will be ignored since the static registrar is not enabled
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT2003_A" xml:space="preserve">
 		<value>Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT2003_B" xml:space="preserve">
 		<value>Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX2004" xml:space="preserve">
 		<value>Extra linker definitions file '{0}' could not be located.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX2005" xml:space="preserve">
 		<value>Definitions from '{0}' could not be parsed.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT2006" xml:space="preserve">
 		<value>Can not load mscorlib.dll from: '{0}'. Please reinstall Xamarin.iOS.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM2006" xml:space="preserve">
 		<value>Native library '{0}' was referenced but could not be found.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT2007" xml:space="preserve">
 		<value>Failed to resolve "{0}" reference from "{1}"
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM2007" xml:space="preserve">
@@ -1547,64 +1127,46 @@
 	<data name="MM2009" xml:space="preserve">
 		<value>  Referenced by {0}.{1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT2010" xml:space="preserve">
 		<value>Unknown HttpMessageHandler `{0}`. Valid values are HttpClientHandler (default), CFNetworkHandler or NSUrlSessionHandler
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM2012" xml:space="preserve">
 		<value> Only first {0} of {1} \"Referenced by\" warnings shown.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM2013" xml:space="preserve">
 		<value>Failed to resolve the reference to \"{0}\", referenced in \"{1}\". The app will not include the referenced assembly, and may fail at runtime.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT2014" xml:space="preserve">
 		<value>Unable to link assembly '{0}' as it is mixed-mode.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT2015" xml:space="preserve">
 		<value>Invalid HttpMessageHandler `{0}` for watchOS. The only valid value is NSUrlSessionHandler.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX2017" xml:space="preserve">
 		<value>Could not process XML description: {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT2018" xml:space="preserve">
 		<value>The assembly '{0}' is referenced from two different locations: '{1}' and '{2}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT2019" xml:space="preserve">
 		<value>Can not load the root assembly '{0}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<!-- 2020 -> 2099 is used by the linker -->
@@ -1612,513 +1174,367 @@
 	<data name="MT2101" xml:space="preserve">
 		<value>Can't resolve the reference '{0}', referenced from the method '{1}' in '{2}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT2102" xml:space="preserve">
 		<value>Error processing the method '{0}' in the assembly '{1}': {2}
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT2102_A" xml:space="preserve">
 		<value>Error processing the method '{0}' in the assembly '{1}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MX2103" xml:space="preserve">
 		<value>Error processing assembly '{0}': {1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT2105_A" xml:space="preserve">
 		<value>The [BindingImpl] attribute on the member '{0}' is invalid: did not expect fields.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT2105_B" xml:space="preserve">
 		<value>The [BindingImpl] attribute on the member '{0}' is invalid: did not expect properties.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT2105_C" xml:space="preserve">
 		<value>The [BindingImpl] attribute on the member '{0}' is invalid: did not expect a constructor with a '{1}' parameter type (expected 'ObjCRuntime.BindingImplOptions).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT2105_D" xml:space="preserve">
 		<value>The [BindingImpl] attribute on the member '{0}' is invalid: did not expect a constructor with a {1} parameters (expected 1 parameters).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT2105_E" xml:space="preserve">
 		<value>The property {0}.{1} contains a '{2}' exception clause, which is currently not supported when compiling for bitcode. This property will throw an exception if called.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT2105_F" xml:space="preserve">
 		<value>The method {0}.{1} contains a '{2}' exception clause, which is currently not supported when compiling for bitcode. This method will throw an exception if called.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM2106" xml:space="preserve">
 		<value>Could not optimize the call to BlockLiteral.{2} in {0} at offset {1} because the previous instruction was unexpected ({3})
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MM2106_A" xml:space="preserve">
 		<value>Could not optimize the call to BlockLiteral.{2} in {0} at offset {1} because could not determine the type of the delegate type of the first argument (instruction: {3})
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MM2106_B" xml:space="preserve">
 		<value>Could not optimize the call to BlockLiteral.{2} in {0} because the type of the value passed as the first argument (the trampoline) is {1}, which makes it impossible to compute the block signature.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MM2106_C" xml:space="preserve">
 		<value>Could not optimize the call to BlockLiteral.SetupBlock in {0} at offset {1} because no [UserDelegateType] attribute could be found on {2}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MM2106_D" xml:space="preserve">
 		<value>Could not optimize the call to BlockLiteral.SetupBlock in {0} at offset {1}: {2}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MM2107" xml:space="preserve">
 		<value>It's not safe to remove the dynamic registrar, because {0} references '{1}.{2} ({3})'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MM2108" xml:space="preserve">
 		<value>{0} was stripped of architectures except {1} to comply with App Store restrictions. This could break existing codesigning signatures. Consider stripping the library with lipo or disabling with --optimize=-trim-architectures
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MM2110" xml:space="preserve">
 		<value>Xamarin.Mac 'Partial Static' registrar does not support linking. Disable linking or use another registrar mode.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX2111" xml:space="preserve">
 		<value>Can not find the corlib assembly '{0}' in the list of loaded assemblies.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX3001" xml:space="preserve">
 		<value>Could not {0} the assembly '{1}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT3003" xml:space="preserve">
 		<value>Debugging is not supported when building with LLVM. Debugging has been disabled.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT3004" xml:space="preserve">
 		<value>Could not AOT the assembly '{0}' because it doesn't exist.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT3005" xml:space="preserve">
 		<value>The dependency '{0}' of the assembly '{1}' was not found. Please review the project's references.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT3006" xml:space="preserve">
 		<value>Could not compute a complete dependency map for the project. This will result in slower build times because Xamarin.iOS can't properly detect what needs to be rebuilt (and what does not need to be rebuilt). Please review previous warnings for more details.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX3007" xml:space="preserve">
 		<value>Debug info files (*.mdb / *.pdb) will not be loaded when llvm is enabled.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT3008" xml:space="preserve">
 		<value>Bitcode support requires the use of LLVM (--abi=arm64+llvm etc.)
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM3009" xml:space="preserve">
 		<value>AOT of '{0}' was requested but was not found
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MM3010" xml:space="preserve">
 		<value>Exclusion of AOT of '{0}' was requested but was not found
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4001" xml:space="preserve">
 		<value>The main template could not be expanded to `{0}`.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4002" xml:space="preserve">
 		<value>Failed to compile the generated code for P/Invoke methods. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4101" xml:space="preserve">
 		<value>The registrar cannot build a signature for type `{0}`.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4102" xml:space="preserve">
 		<value>The registrar found an invalid type `{0}` in signature for method `{2}`. Use `{1}` instead.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4103" xml:space="preserve">
 		<value>The registrar found an invalid type `{0}` in signature for method `{1}`: The type implements INativeObject, but does not have a constructor that takes two (IntPtr, bool) arguments.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4104" xml:space="preserve">
 		<value>The registrar cannot marshal the return value for type `{0}` in signature for method `{1}`.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4104_A" xml:space="preserve">
 		<value>The registrar cannot marshal the return value of type `{0}` in the method `{1}.{2}`.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4105" xml:space="preserve">
 		<value>The registrar cannot marshal the parameter of type `{0}` in signature for method `{1}`.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4108" xml:space="preserve">
 		<value>The registrar cannot get the ObjectiveC type for managed type `{0}`.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4109" xml:space="preserve">
 		<value>Failed to compile the generated registrar code. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4110" xml:space="preserve">
 		<value>The registrar cannot marshal the out parameter of type `{0}` in signature for method `{1}`.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4111" xml:space="preserve">
 		<value>The registrar cannot build a signature for type `{0}' in method `{1}`.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4113" xml:space="preserve">
 		<value>The registrar found a generic method: '{0}'. Exporting generic methods is not supported, and will lead to random behavior and/or crashes
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4114" xml:space="preserve">
 		<value>Unexpected error in the registrar for the method '{0}.{1}' - Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4116" xml:space="preserve">
 		<value>Could not register the assembly '{0}': {1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4117" xml:space="preserve">
 		<value>The registrar found a signature mismatch in the method '{0}.{1}' - the selector '{4}' indicates the method takes {2} parameters, while the managed method has {3} parameters.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4118" xml:space="preserve">
 		<value>Cannot register two managed types ('{0}' and '{1}') with the same native name ('{2}').
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4119" xml:space="preserve">
 		<value>Could not register the selector '{0}' of the member '{1}.{2}' because the selector is already registered on the member '{3}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4120" xml:space="preserve">
 		<value>The registrar found an unknown field type '{0}' in field '{1}.{2}'. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4121" xml:space="preserve">
 		<value>Cannot use GCC/G++ to compile the generated code from the static registrar when using the Accounts framework (the header files provided by Apple used during the compilation require Clang). Either use Clang (--compiler:clang) or the dynamic registrar (--registrar:dynamic).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4123" xml:space="preserve">
 		<value>The type of the variadic parameter in the variadic function '{0}' must be System.IntPtr.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4124" xml:space="preserve">
 		<value>Invalid {0} found on '{1}'. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4124_A" xml:space="preserve">
 		<value>Invalid RegisterAttribute property {1} found on '{0}'. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4124_B" xml:space="preserve">
 		<value>Invalid AdoptsAttribute found on '{0}': expected 1 constructor arguments, got {1}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4124_C" xml:space="preserve">
 		<value>Invalid BindAsAttribute found on '{0}.{1}': unknown field {2}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4124_D" xml:space="preserve">
 		<value>Invalid {0} found on '{1}.{2}'. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4124_E" xml:space="preserve">
 		<value>Invalid BindAsAttribute found on '{0}': should have 1 constructor arguments, found {1}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>	
 	
 	<data name="MT4124_H" xml:space="preserve">
 		<value>Invalid BindAsAttribute found on '{0}': could not find the underlying enum type of {1}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>		
 	
 	<data name="MT4125" xml:space="preserve">
 		<value>The registrar found an invalid type '{0}' in signature for method '{1}': The interface must have a Protocol attribute specifying its wrapper type.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4126" xml:space="preserve">
 		<value>Cannot register two managed protocols ('{0}' and '{1}') with the same native name ('{2}').
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4127" xml:space="preserve">
 		<value>Cannot register more than one interface method for the method '{0}.{1}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4128" xml:space="preserve">
 		<value>The registrar found an invalid generic parameter type '{0}' in the parameter {2} of the method '{1}'. The generic parameter must have an 'NSObject' constraint.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4129" xml:space="preserve">
 		<value>The registrar found an invalid generic return type '{0}' in the method '{1}'. The generic return type must have an 'NSObject' constraint.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4130" xml:space="preserve">
 		<value>The registrar cannot export static methods in generic classes ('{0}').
 		</value>
-		<comment>
-		</comment>
 	</data>	
 	
 	<data name="MT4131" xml:space="preserve">
 		<value>The registrar cannot export static properties in generic classes ('{0}.{1}').
 		</value>
-		<comment>
-		</comment>
 	</data>	
 	
 	<data name="MT4132" xml:space="preserve">
 		<value>The registrar found an invalid generic return type '{0}' in the property '{1}.{2}'. The return type must have an 'NSObject' constraint.
 		</value>
-		<comment>
-		</comment>
 	</data>	
 	
 	<data name="MT4134" xml:space="preserve">
 		<value>Your application is using the '{0}' framework, which isn't included in the {3} SDK you're using to build your app (this framework was introduced in {3} {2}, while you're building with the {3} {1} SDK.) Please select a newer SDK in your app's {3} Build options.
 		</value>
-		<comment>
-		</comment>
 	</data>	
 	
 	<data name="MM4134" xml:space="preserve">
 		<value>Your application is using the '{0}' framework, which isn't included in the {3} SDK you're using to build your app (this framework was introduced in {3} {2}, while you're building with the {3} {1} SDK.) This configuration is not supported with the static registrar (pass --registrar:dynamic as an additional mmp argument in your project's Mac Build option to select). Alternatively select a newer SDK in your app's Mac Build options.	
 		</value>
-		<comment>
-		</comment>
 	</data>	
 
 	
 	<data name="MT4135" xml:space="preserve">
 		<value>The member '{0}' has an Export attribute without a selector. A selector is required.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4136" xml:space="preserve">
 		<value>The registrar cannot marshal the parameter type '{0}' of the parameter '{1}' in the method '{2}.{3}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4137" xml:space="preserve">
 		<value>The method '{0}.{1}' is implementing '{2}.{3}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4138" xml:space="preserve">
 		<value>The registrar cannot marshal the property type '{0}' of the property '{1}.{2}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4139" xml:space="preserve">
 		<value>The registrar cannot marshal the property type '{0}' of the property '{1}.{2}'. Properties with the [Connect] attribute must have a property type of NSObject (or a subclass of NSObject).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4140" xml:space="preserve">
 		<value>The registrar found a signature mismatch in the method '{0}.{1}' - the selector '{4}' indicates the variadic method takes {2} parameters, while the managed method has {3} parameters.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4141" xml:space="preserve">
 		<value>Cannot register the selector '{0}' on the member '{1}.{2}' because Xamarin.iOS implicitly registers this selector.
 		</value>
-		<comment>
-		</comment>
 	</data>
 		
 	<data name="MT4145" xml:space="preserve">
@@ -2132,106 +1548,76 @@
 	<data name="MT4146" xml:space="preserve">
 		<value>The Name parameter of the Registrar attribute on the class '{0}' ('{3}') contains an invalid character: '{1}' (0x{2}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4147" xml:space="preserve">
 		<value>Invalid {0} found on '{1}'. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4148" xml:space="preserve">
 		<value>The registrar found a generic protocol: '{0}'. Exporting generic protocols is not supported.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4149" xml:space="preserve">
 		<value>Cannot register the extension method '{0}.{1}' because the type of the first parameter ('{2}') does not match the category type ('{3}').
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4150" xml:space="preserve">
 		<value>Cannot register the type '{0}' because the category type '{1}' in its Category attribute does not inherit from NSObject.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4151" xml:space="preserve">
 		<value>Cannot register the type '{0}' because the Type property in its Category attribute isn't set.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4152" xml:space="preserve">
 		<value>Cannot register the type '{0}' as a category because it implements INativeObject or subclasses NSObject.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4153" xml:space="preserve">
 		<value>Cannot register the type '{0}' as a category because it's generic.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4154" xml:space="preserve">
 		<value>Cannot register the method '{0}.{1}' as a category method because it's generic.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4156" xml:space="preserve">
 		<value>Cannot register two categories ('{0}' and '{1}') with the same native name ('{2}')
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4157" xml:space="preserve">
 		<value>Cannot register the category method '{0}.{1}' because at least one parameter is required for extension methods (and its type must match the category type '{2}').
 		</value>
-		<comment>
-		</comment>
 	</data>	
 	
 	<data name="MT4158" xml:space="preserve">
 		<value>Cannot register the constructor {0}.{1} in the category {0} because constructors in categories are not supported.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4159" xml:space="preserve">
 		<value>Cannot register the method '{0}.{1}' as a category method because category methods must be static.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4160" xml:space="preserve">
 		<value>Invalid character '{0}' (0x{1}) found in selector '{2}' for '{3}.{4}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4161" xml:space="preserve">
 		<value>The registrar found an unsupported structure '{0}': All fields in a structure must also be structures (field '{1}' with type '{2}' is not a structure).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<!-- MT4162: split up into multiple messages -->
@@ -2291,476 +1677,340 @@
 	<data name="MT4162_A" xml:space="preserve">
 		<value>The type '{0}' is not available in {3} {4} (it was introduced in {3} {5}){6} Please build with a newer {3} SDK (usually done by using the most recent version of Xcode).
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4163" xml:space="preserve">
 		<value>Internal error in the registrar ({0} ctor with {1} arguments). Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4163_A" xml:space="preserve">
 		<value>Internal error in the registrar (Unknown availability kind: {0}). Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4163_B" xml:space="preserve">
 		<value>Internal error in the registrar (BindAs parameters can't be ref/out: {0}). Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4164" xml:space="preserve">
 		<value>Cannot export the property '{0}' because its selector '{1}' is an Objective-C keyword. Please use a different name.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4165" xml:space="preserve">
 		<value>The registrar couldn't find the type 'System.Void' in any of the referenced assemblies.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4166" xml:space="preserve">
 		<value>Cannot register the method '{0}' because the signature contains a type ({1}) that isn't a reference type.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4167" xml:space="preserve">
 		<value>Cannot register the method '{0}' because the signature contains a generic type ({1}) with a generic argument type that doesn't implement INativeObject ({2}).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4168" xml:space="preserve">
 		<value>Cannot register the type '{0}' because its Objective-C name '{1}' is an Objective-C keyword. Please use a different name.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4169" xml:space="preserve">
 		<value>Failed to generate a P/Invoke wrapper for {0}: {1}
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4170" xml:space="preserve">
 		<value>The registrar can't convert from '{0}' to '{1}' for the return value in the method {2}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4171" xml:space="preserve">
 		<value>The BindAs attribute on the return value of the method {0} is invalid: the BindAs type {1} is different from the return type {2}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4171_A" xml:space="preserve">
 		<value>The BindAs attribute on the parameter #{0} is invalid: the BindAs type {1} is different from the parameter type {2}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4171_B" xml:space="preserve">
 		<value>The BindAs attribute on the property {0}.{1} is invalid: the BindAs type {2} is different from the property type {1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4172" xml:space="preserve">
 		<value>The registrar can't convert from '{0}' to '{1}' for the parameter '{2}' in the method {3}.
 		</value>
-		<comment>
-		</comment>
 	</data>	
 	
 	<data name="MT4173" xml:space="preserve">
 		<value>The registrar can't compute the block signature for the delegate of type {0} in the method {1} because {0} doesn't have a specific signature.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4173_A" xml:space="preserve">
 		<value>The registrar can't compute the block signature for the delegate of type {0} in the method {1} because it couldn't find the Invoke method of the delegate type.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4174" xml:space="preserve">
 		<value>Unable to locate the block to delegate conversion method for the method {0}'s parameter #{1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4175" xml:space="preserve">
 		<value>Unable to locate the block to delegate conversion method for the method {0}'s parameter #{1}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 		
 	<data name="MT4176" xml:space="preserve">
 		<value>Unable to locate the delegate to block conversion type for the return value of the method {0}.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4177" xml:space="preserve">
 		<value>The 'ProtocolType' parameter of the 'Adopts' attribute used in class '{0}' contains an invalid character. Value used: '{1}' Invalid Char: '{2}'
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4178" xml:space="preserve">
 		<value>The class '{0}' will not be registered because the WatchKit framework has been removed from the iOS SDK.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT4179" xml:space="preserve">
 		<value>The registrar found the abstract type '{0}' in the signature for '{1}'. Abstract types should not be used in the signature for a member exported to Objective-C.
 		</value>
-		<comment>
-		</comment>
 	</data>
 		
 	<data name="MT4184" xml:space="preserve">
 		<value>Internal error in the registrar (BindAs parameters can't be ref/out: {0}). Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT4185" xml:space="preserve">
 		<value>The registrar can't compute the block signature for the delegate of type {0} in the method {1} because it couldn't find the Invoke method of the delegate type.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5101" xml:space="preserve">
 		<value>Missing '{0}' compiler. Please install Xcode 'Command-Line Tools' component
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5103" xml:space="preserve">
 		<value>Could not find neither the '{0}' nor the '{1}' compiler. Please install Xcode 'Command-Line Tools' component
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM5103" xml:space="preserve">
 		<value>Failed to compile. Error code - {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT5103_A" xml:space="preserve">
 		<value>Failed to compile the file(s) '{0}'. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5106" xml:space="preserve">
 		<value>Could not compile the file(s) '{0}'. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT5107" xml:space="preserve">
 		<value>The assembly '{0}' can't be AOT-compiled for 32-bit architectures because the native code is too big for the 32-bit ARM architecture.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MT5108" xml:space="preserve">
 		<value>The compiler output is too long, it's been limited to 1000 lines.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM5109" xml:space="preserve">
 		<value>Native linking failed with error code 1.  Check build log for details.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5201" xml:space="preserve">
 		<value>Native linking failed. Please review the build log and the user flags provided to gcc: {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5202" xml:space="preserve">
 		<value>Native linking failed. Please review the build log.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM5202" xml:space="preserve">
 		<value>Mono.framework MDK is missing. Please install the MDK for your Mono.framework version from https://www.mono-project.com/download/
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5203" xml:space="preserve">
 		<value>Native linking warning: {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM5203" xml:space="preserve">
 		<value>Can't find {0}, likely because of a corrupted Xamarin.Mac installation. Please reinstall Xamarin.Mac.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5204" xml:space="preserve">
 		<value>Native linking failed. Please review the build log.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM5205" xml:space="preserve">
 		<value>Invalid architecture '{0}'. The only valid architectures is x86_64.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5209" xml:space="preserve">
 		<value>Native linking error: {0}
 		</value>
-		<comment>
-		</comment>
 	</data>
 		
 	<data name="MT5210" xml:space="preserve">
 		<value>Native linking failed, undefined symbol: {0}. Please verify that all the necessary frameworks have been referenced and native libraries are properly linked in.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5211" xml:space="preserve">
 		<value>Native linking failed, undefined Objective-C class: {0}. The symbol '{1}' could not be found in any of the libraries or frameworks linked with your application.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5212" xml:space="preserve">
 		<value>Native linking failed, duplicate symbol: '{0}'.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5213" xml:space="preserve">
 		<value>Duplicate symbol in: {0} (Location related to previous error)
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5214" xml:space="preserve">
 		<value>Native linking failed, undefined symbol: {0}. This symbol was referenced by the managed member {1}.{2}. Please verify that all the necessary frameworks have been referenced and native libraries linked.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5215" xml:space="preserve">
 		<value>References to '{0}' might require additional -framework=XXX or -lXXX instructions to the native linker
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5216" xml:space="preserve">
 		<value>Native linking failed for '{0}'. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5217" xml:space="preserve">
 		<value>Native linking failed because the linker command line was too long ({0} characters).
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5218" xml:space="preserve">
 		<value>Can't ignore the dynamic symbol {0} (--ignore-dynamic-symbol={0}) because it was not detected as a dynamic symbol.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5219" xml:space="preserve">
 		<value>Not linking with WatchKit because it has been removed from iOS.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM5220" xml:space="preserve">
 		<value>Skipping framework '{0}'. It is prohibited (rejected) by the Mac App Store
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM5221" xml:space="preserve">
 		<value>Linking against framework '{0}'. It is prohibited (rejected) by the Mac App Store
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
     <data name="MX5222" xml:space="preserve">
         <value>The native linker failed to execute: {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
         </value>
-        <comment>
-        </comment>
     </data>
 
 	<data name="MT5301" xml:space="preserve">
 		<value>Missing 'strip' tool. Please install Xcode 'Command-Line Tools' component
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5302" xml:space="preserve">
 		<value>Missing 'dsymutil' tool. Please install Xcode 'Command-Line Tools' component
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5303" xml:space="preserve">
 		<value>Failed to generate the debug symbols (dSYM directory). Please review the build log.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5304" xml:space="preserve">
 		<value>Failed to strip the final binary. Please review the build log.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX5305" xml:space="preserve">
 		<value>Missing 'lipo' tool. Please install Xcode 'Command-Line Tools' component
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MT5306" xml:space="preserve">
 		<value>Failed to create the a fat library. Please review the build log.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX5307" xml:space="preserve">
 		<value>Missing '{0}' tool. Please install Xcode 'Command-Line Tools' component
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MM5308" xml:space="preserve">
 		<value>Xcode license agreement may not have been accepted.  Please launch Xcode.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX5309" xml:space="preserve">
 		<value>Failed to execute the tool '{0}', it failed with an error code '{1}'. Please check the build log for details.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	<data name="MM5310" xml:space="preserve">
 		<value>install_name_tool failed with an error code '{0}'. Check build log for details.
 		</value>
-		<comment>
-		</comment>
 	</data>
 	
 	<data name="MX5311" xml:space="preserve">
 		<value>lipo failed with an error code '{0}'. Check build log for details.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX5312" xml:space="preserve">
 		<value>pkg-config failed with an error code '{0}'. Check build log for details.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX5313" xml:space="preserve">
 		<value>Could not find {0}. Please install the Mono.framework from https://mono-project.com/Downloads
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX5314" xml:space="preserve">
 		<value>Failed to execute pkg-config: '{0}'. Check build log for details.
 		</value>
-		<comment>
-		</comment>
 	</data>
 
 	<data name="MX5315" xml:space="preserve">
@@ -2771,7 +2021,5 @@
 	<data name="MT8018" xml:space="preserve">
 		<value>Internal consistency error. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new.
 		</value>
-		<comment>
-		</comment>
 	</data>
 </root>

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -35,9 +35,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  <PropertyGroup>
-       <UpdateXlfOnBuild>true</UpdateXlfOnBuild>
-  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Compile Include="Application.mtouch.cs" />


### PR DESCRIPTION
Solves build errors like this:

     xamarin-macios/tools/dotnet-linker/packages/xlifftasks/1.0.0-beta.20154.1/build/XliffTasks.targets(91,5): error : 'Errors.cs.xlf' is out-of-date with 'Errors.resx'. Run `msbuild /t:UpdateXlf` to update .xlf files or set UpdateXlfOnBuild=true to update them on every build, but note that it is strongly discouraged to set UpdateXlfOnBuild=true in official/CI build environments as they should not modify source code during the build.

See also: https://github.com/xamarin/xamarin-macios/pull/8157