### PR TITLE
[d16-7] [src] Remove Classic code from the CoreData, CoreFoundation, CoreGraphics, CoreImage and CoreLocation frameworks.

### DIFF
--- a/src/CoreData/Enums.cs
+++ b/src/CoreData/Enums.cs
@@ -69,17 +69,6 @@ namespace CoreData {
 		NSCountResultType = 0x04
 	}
 
-#if !XAMCORE_2_0
-	// NUInteger -> NSKeyValueObserving.h in Foundation.framework (and it already exists there)
-	[Native]
-	public enum NSKeyValueSetMutationKind : ulong {
-		Union = 1,
-		Minus = 2,
-		Intersect = 3,
-		NSKeyValueSet = 4 // misnamed
-	}
-#endif
-
 	// NUInteger -> NSRelationshipDescription.h
 	[Native]
 	public enum NSDeleteRule : ulong {

--- a/src/CoreData/Obsolete.cs
+++ b/src/CoreData/Obsolete.cs
@@ -3,17 +3,6 @@
 using System;
 
 namespace CoreData {
-
-#if !XAMCORE_2_0
-	public partial class NSPersistentStoreCoordinator {
-
-		[Obsolete ("Use .ctor(NSManagedObjectModel)")]
-		public NSPersistentStoreCoordinator ()
-		{
-		}
-	}
-#endif
-	
 #if !XAMCORE_3_0
 	public partial class NSMergeConflict {
 

--- a/src/CoreFoundation/CFAllocator.cs
+++ b/src/CoreFoundation/CFAllocator.cs
@@ -115,17 +115,10 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		static extern /* void* */ IntPtr CFAllocatorAllocate (/* CFAllocatorRef*/ IntPtr allocator, /*CFIndex*/ nint size, /* CFOptionFlags */ nuint hint);
 
-#if XAMCORE_2_0
 		public IntPtr Allocate (long size)
 		{
 			return CFAllocatorAllocate (handle, (nint)size, 0);
 		}
-#else
-		public IntPtr Allocate (long size, CFAllocatorFlags hint = 0)
-		{
-			return CFAllocatorAllocate (handle, (nint)size, (nuint) hint);
-		}
-#endif
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		static extern void CFAllocatorDeallocate (/* CFAllocatorRef */ IntPtr allocator, /* void* */ IntPtr ptr);
@@ -138,17 +131,4 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary, EntryPoint="CFAllocatorGetTypeID")]
 		public extern static /* CFTypeID */ nint GetTypeID ();
 	}
-
-#if !XAMCORE_2_0
-	// XAMCORE 2.0: removing this enum, I can't find any documentation anywhere about it,
-	//              and in any case it seems to refer to the deprecated/deleted ObjC GC.
-	// Seems to be some sort of secret values
-	[Flags]
-	[Native]
-	public enum CFAllocatorFlags : ulong
-	{
-		GCScannedMemory	= 0x200,
-		GCObjectMemory	= 0x400,
-	}
-#endif
 }

--- a/src/CoreFoundation/CFBoolean.cs
+++ b/src/CoreFoundation/CFBoolean.cs
@@ -66,11 +66,7 @@ namespace CoreFoundation {
 			GC.SuppressFinalize (this);
 		}
 
-#if XAMCORE_2_0
 		protected virtual void Dispose (bool disposing)
-#else
-		public virtual void Dispose (bool disposing)
-#endif
 		{
 			if (handle != IntPtr.Zero){
 				CFObject.CFRelease (handle);

--- a/src/CoreFoundation/CFDictionary.cs
+++ b/src/CoreFoundation/CFDictionary.cs
@@ -67,11 +67,7 @@ namespace CoreFoundation {
 			GC.SuppressFinalize (this);
 		}
 
-#if XAMCORE_2_0
 		protected virtual void Dispose (bool disposing)
-#else
-		public virtual void Dispose (bool disposing)
-#endif
 		{
 			if (Handle != IntPtr.Zero){
 				CFObject.CFRelease (Handle);

--- a/src/CoreFoundation/CFReadStream.cs
+++ b/src/CoreFoundation/CFReadStream.cs
@@ -37,9 +37,7 @@ using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
-#if XAMCORE_2_0
 using CFIndex = System.nint;
-#endif
 
 namespace CoreFoundation {
 

--- a/src/CoreFoundation/CFRunLoop.cs
+++ b/src/CoreFoundation/CFRunLoop.cs
@@ -34,9 +34,7 @@ using System.Runtime.InteropServices;
 using ObjCRuntime;
 using Foundation;
 
-#if XAMCORE_2_0
 using CFIndex = System.nint;
-#endif
 
 namespace CoreFoundation {
 
@@ -130,11 +128,7 @@ namespace CoreFoundation {
 			GC.SuppressFinalize (this);
 		}
 
-#if XAMCORE_2_0
 		protected virtual void Dispose (bool disposing)
-#else
-		public virtual void Dispose (bool disposing)
-#endif
 		{
 			if (handle != IntPtr.Zero) {
 				CFObject.CFRelease (handle);
@@ -185,19 +179,11 @@ namespace CoreFoundation {
 
 			using (var loop = new CFRunLoop (runLoop))
 			using (var mstring = new NSString (mode)) {
-#if XAMCORE_2_0
 				source.OnSchedule (loop, mstring);
-#else
-				source.OnSchedule (loop, (string)mstring);
-#endif
 			}
 		}
 
-#if XAMCORE_2_0
 		protected abstract void OnSchedule (CFRunLoop loop, NSString mode);
-#else
-		protected abstract void OnSchedule (CFRunLoop loop, string mode);
-#endif
 
 		delegate void CancelCallback (IntPtr info, IntPtr runLoop, IntPtr mode);
 
@@ -208,19 +194,11 @@ namespace CoreFoundation {
 
 			using (var loop = new CFRunLoop (runLoop))
 			using (var mstring = new NSString (mode)) {
-#if XAMCORE_2_0
 				source.OnCancel (loop, mstring);
-#else
-				source.OnCancel (loop, (string)mstring);
-#endif
 			}
 		}
 
-#if XAMCORE_2_0
 		protected abstract void OnCancel (CFRunLoop loop, NSString mode);
-#else
-		protected abstract void OnCancel (CFRunLoop loop, string mode);
-#endif
 
 		delegate void PerformCallback (IntPtr info);
 
@@ -233,11 +211,7 @@ namespace CoreFoundation {
 
 		protected abstract void OnPerform ();
 
-#if XAMCORE_2_0
 		protected override void Dispose (bool disposing)
-#else
-		public override void Dispose (bool disposing)
-#endif
 		{
 			if (disposing) {
 				if (gch.IsAllocated)
@@ -256,16 +230,6 @@ namespace CoreFoundation {
 #if !COREBUILD
 		internal IntPtr handle;
 
-#if !XAMCORE_2_0
-		public static NSString CFDefaultRunLoopMode {
-			get { return ModeDefault; }
-		}
-
-		public static NSString CFRunLoopCommonModes {
-			get { return ModeCommon; }
-		}
-#endif
-		
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFRunLoopRef */ IntPtr CFRunLoopGetCurrent ();
 
@@ -331,17 +295,6 @@ namespace CoreFoundation {
 			return (CFRunLoopExitReason) CFRunLoopRunInMode (mode.Handle, seconds, returnAfterSourceHandled);
 		}
 
-#if !XAMCORE_2_0
-		[Obsolete ("Use the NSString version of CFRunLoop.RunInMode() instead.")]
-		public CFRunLoopExitReason RunInMode (string mode, double seconds, bool returnAfterSourceHandled)
-		{
-			// .ctor will check for ANE
-			using (CFString s = new CFString (mode)) {
-				return (CFRunLoopExitReason) CFRunLoopRunInMode (s.Handle, seconds, returnAfterSourceHandled);
-			}
-		}
-#endif
-
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static void CFRunLoopAddSource (/* CFRunLoopRef */ IntPtr rl, /* CFRunLoopSourceRef */ IntPtr source, /* CFStringRef */ IntPtr mode);
 
@@ -372,11 +325,7 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static void CFRunLoopRemoveSource (/* CFRunLoopRef */ IntPtr rl, /* CFRunLoopSourceRef */ IntPtr source, /* CFStringRef */ IntPtr mode);
 
-#if XAMCORE_2_0
 		public void RemoveSource (CFRunLoopSource source, NSString mode)
-#else
-		public bool RemoveSource (CFRunLoopSource source, NSString mode)
-#endif
 		{
 			if (source == null)
 				throw new ArgumentNullException ("source");
@@ -384,9 +333,6 @@ namespace CoreFoundation {
 				throw new ArgumentNullException ("mode");
 
 			CFRunLoopRemoveSource (handle, source.Handle, mode.Handle);
-#if !XAMCORE_2_0
-			return true;
-#endif
 		}
 
 		internal CFRunLoop (IntPtr handle)
@@ -419,11 +365,7 @@ namespace CoreFoundation {
 			GC.SuppressFinalize (this);
 		}
 
-#if XAMCORE_2_0
 		protected virtual void Dispose (bool disposing)
-#else
-		public virtual void Dispose (bool disposing)
-#endif
 		{
 			if (handle != IntPtr.Zero){
 				CFObject.CFRelease (handle);

--- a/src/CoreFoundation/CFStream.cs
+++ b/src/CoreFoundation/CFStream.cs
@@ -42,9 +42,7 @@ using CoreServices;
 using ObjCRuntime;
 using Foundation;
 
-#if XAMCORE_2_0
 using CFIndex = System.nint;
-#endif
 
 namespace CoreFoundation {
 

--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -72,13 +72,11 @@ namespace CoreFoundation {
 			this.len = (nint) len;
 		}
 
-#if XAMCORE_2_0
 		public CFRange (nint l, nint len)
 		{
 			this.loc = l;
 			this.len = len;
 		}
-#endif
 
 		public override string ToString ()
 		{

--- a/src/CoreFoundation/CFWriteStream.cs
+++ b/src/CoreFoundation/CFWriteStream.cs
@@ -33,9 +33,7 @@ using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
-#if XAMCORE_2_0
 using CFIndex = System.nint;
-#endif
 
 namespace CoreFoundation {
 

--- a/src/CoreGraphics/CGBitmapContext.cs
+++ b/src/CoreGraphics/CGBitmapContext.cs
@@ -155,15 +155,9 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGBitmapInfo */ uint CGBitmapContextGetBitmapInfo (/* CGContextRef */ IntPtr context);
 
-#if XAMCORE_2_0
 		public CGBitmapFlags BitmapInfo {
 			get {return (CGBitmapFlags) CGBitmapContextGetBitmapInfo (Handle);}
 		}
-#else
-		public uint BitmapInfo {
-			get {return CGBitmapContextGetBitmapInfo (Handle);}
-		}
-#endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGImageRef */ IntPtr CGBitmapContextCreateImage (/* CGContextRef */ IntPtr context);

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -68,10 +68,7 @@ namespace CoreGraphics {
 
 #if !XAMCORE_3_0
 		[Obsolete ("Use a real 'null' value instead of this managed wrapper over a null native instance.")]
-#if XAMCORE_2_0
-		readonly
-#endif
-		public static CGColorSpace Null = new CGColorSpace (IntPtr.Zero);
+		public readonly static CGColorSpace Null = new CGColorSpace (IntPtr.Zero);
 #endif
 
 		// Invoked by the marshallers, we need to take a ref

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -633,14 +633,6 @@ namespace CoreGraphics {
 			CGContextSetFillColorWithColor (handle, color == null ? IntPtr.Zero : color.handle);
 		}
 
-#if !XAMCORE_2_0
-		[Advice ("Use SetFillColor() instead.")]
-		public void SetFillColorWithColor (CGColor color)
-		{
-			SetFillColor (color);
-		}
-#endif
-		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetStrokeColorWithColor (/* CGContextRef */ IntPtr c,
 			/* CGColorRef __nullable */ IntPtr color);
@@ -649,14 +641,6 @@ namespace CoreGraphics {
 		{
 			CGContextSetStrokeColorWithColor (handle, color == null ? IntPtr.Zero : color.handle);
 		}
-		
-#if !XAMCORE_2_0
-		[Advice ("Use SetStrokeColor() instead.")]
-		public void SetStrokeColorWithColor (CGColor color)
-		{
-			SetStrokeColor (color);
-		}
-#endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetFillColorSpace (/* CGContextRef */ IntPtr context,
@@ -728,14 +712,6 @@ namespace CoreGraphics {
 			CGContextSetGrayFillColor (handle, gray, alpha);
 		}
 
-#if !XAMCORE_2_0
-		[Advice ("Use SetFillColor() instead.")]
-		public void SetGrayFillColor (nfloat gray, nfloat alpha)
-		{
-			CGContextSetGrayFillColor (handle, gray, alpha);
-		}
-#endif
-		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetGrayStrokeColor (/* CGContextRef */ IntPtr context, /* CGFloat */ nfloat gray, /* CGFloat */ nfloat alpha);
 
@@ -744,14 +720,6 @@ namespace CoreGraphics {
 			CGContextSetGrayStrokeColor (handle, gray, alpha);
 		}
 		
-#if !XAMCORE_2_0
-		[Advice ("Use SetStrokeColor() instead.")]
-		public void SetGrayStrokeColor (nfloat gray, nfloat alpha)
-		{
-			CGContextSetGrayStrokeColor (handle, gray, alpha);
-		}
-#endif
-		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetRGBFillColor (/* CGContextRef */ IntPtr context, /* CGFloat */ nfloat red, /* CGFloat */ nfloat green, /* CGFloat */ nfloat blue, /* CGFloat */ nfloat alpha);
 
@@ -759,14 +727,6 @@ namespace CoreGraphics {
 		{
 			CGContextSetRGBFillColor (handle, red, green, blue, alpha);
 		}
-		
-#if !XAMCORE_2_0
-		[Advice ("Use SetFillColor() instead.")]
-		public void SetRGBFillColor (nfloat red, nfloat green, nfloat blue, nfloat alpha)
-		{
-			CGContextSetRGBFillColor (handle, red, green, blue, alpha);
-		}
-#endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetRGBStrokeColor (/* CGContextRef */ IntPtr context, /* CGFloat */ nfloat red, /* CGFloat */ nfloat green, /* CGFloat */ nfloat blue, /* CGFloat */ nfloat alpha);
@@ -775,14 +735,6 @@ namespace CoreGraphics {
 		{
 			CGContextSetRGBStrokeColor (handle, red, green, blue, alpha);
 		}
-		
-#if !XAMCORE_2_0
-		[Advice ("Use SetStrokeColor() instead.")]
-		public void SetRGBStrokeColor (nfloat red, nfloat green, nfloat blue, nfloat alpha)
-		{
-			CGContextSetRGBStrokeColor (handle, red, green, blue, alpha);
-		}
-#endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetCMYKFillColor (/* CGContextRef */ IntPtr context, /* CGFloat */ nfloat cyan, /* CGFloat */ nfloat magenta, /* CGFloat */ nfloat yellow, /* CGFloat */ nfloat black, /* CGFloat */ nfloat alpha);
@@ -791,14 +743,6 @@ namespace CoreGraphics {
 		{
 			CGContextSetCMYKFillColor (handle, cyan, magenta, yellow, black, alpha);
 		}
-		
-#if !XAMCORE_2_0
-		[Advice ("Use SetFillColor() instead.")]
-		public void SetCMYKFillColor (nfloat cyan, nfloat magenta, nfloat yellow, nfloat black, nfloat alpha)
-		{
-			CGContextSetCMYKFillColor (handle, cyan, magenta, yellow, black, alpha);
-		}
-#endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetCMYKStrokeColor (/* CGContextRef */ IntPtr context, /* CGFloat */ nfloat cyan, /* CGFloat */ nfloat magenta, /* CGFloat */ nfloat yellow, /* CGFloat */ nfloat black, /* CGFloat */ nfloat alpha);
@@ -807,14 +751,6 @@ namespace CoreGraphics {
 		{
 			CGContextSetCMYKStrokeColor (handle, cyan, magenta, yellow, black, alpha);
 		}
-		
-#if !XAMCORE_2_0
-		[Advice ("Use SetStrokeColor() instead.")]
-		public void SetCMYKStrokeColor (nfloat cyan, nfloat magenta, nfloat yellow, nfloat black, nfloat alpha)
-		{
-			CGContextSetCMYKStrokeColor (handle, cyan, magenta, yellow, black, alpha);
-		}
-#endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetRenderingIntent (/* CGContextRef */ IntPtr context, CGColorRenderingIntent intent);
@@ -865,7 +801,6 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetShadow (IntPtr context, CGSize offset, nfloat blur);
 
-#if XAMCORE_2_0
 		public void SetShadow (CGSize offset, nfloat blur, CGColor color = null)
 		{
 			if (color == null)
@@ -873,17 +808,6 @@ namespace CoreGraphics {
 			else
 				CGContextSetShadowWithColor (handle, offset, blur, color.handle);
 		}
-#else
-		public void SetShadowWithColor (CGSize offset, nfloat blur, CGColor color)
-		{
-			CGContextSetShadowWithColor (handle, offset, blur, color == null ? IntPtr.Zero : color.handle);
-		}
-		
-		public void SetShadow (CGSize offset, nfloat blur)
-		{
-			CGContextSetShadow (handle, offset, blur);
-		}
-#endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextDrawLinearGradient (/* CGContextRef __nullable */ IntPtr context,
@@ -993,7 +917,6 @@ namespace CoreGraphics {
 			/* const CGGlyph * __nullable */ ushort [] glyphs,
 			/* const CGPoint * __nullable */ CGPoint [] positions, /* size_t */ nint count);
 
-#if XAMCORE_2_0
 		public void ShowGlyphsAtPositions (ushort [] glyphs, CGPoint [] positions, int count = -1)
 		{
 			if (glyphs == null)
@@ -1002,14 +925,6 @@ namespace CoreGraphics {
 				count = glyphs.Length;
 			CGContextShowGlyphsAtPositions (handle, glyphs, positions, count);
 		}
-#else
-		public void ShowGlyphsAtPositions (ushort [] glyphs, CGPoint [] positions, int size_t_count)
-		{
-			if (size_t_count < 0 || size_t_count > glyphs.Length)
-				throw new ArgumentException ("size_t_count");
-			CGContextShowGlyphsAtPositions (handle, glyphs, positions, size_t_count);
-		}
-#endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowText (/* CGContextRef */ IntPtr c, /* const char* __nullable */ string s, /* size_t */ nint length);
@@ -1343,13 +1258,6 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextBeginTransparencyLayer (/* CGContextRef */ IntPtr context, /* CFDictionaryRef __nullable */ IntPtr auxiliaryInfo);
 
-#if !XAMCORE_2_0
-		public void BeginTransparencyLayer ()
-		{
-			CGContextBeginTransparencyLayer (handle, IntPtr.Zero);
-		}
-#endif
-		
 		public void BeginTransparencyLayer (NSDictionary auxiliaryInfo = null)
 		{
 			CGContextBeginTransparencyLayer (handle, auxiliaryInfo == null ? IntPtr.Zero : auxiliaryInfo.Handle);
@@ -1362,13 +1270,6 @@ namespace CoreGraphics {
 		{
 			CGContextBeginTransparencyLayerWithRect (handle, rectangle, auxiliaryInfo == null ? IntPtr.Zero : auxiliaryInfo.Handle);
 		}
-
-#if !XAMCORE_2_0
-		public void BeginTransparencyLayer (CGRect rectangle)
-		{
-			CGContextBeginTransparencyLayerWithRect (handle, rectangle, IntPtr.Zero);
-		}
-#endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextEndTransparencyLayer (/* CGContextRef */ IntPtr context);

--- a/src/CoreGraphics/CGEvent.cs
+++ b/src/CoreGraphics/CGEvent.cs
@@ -24,9 +24,6 @@ namespace CoreGraphics {
 		public delegate IntPtr CGEventTapCallback (IntPtr tapProxyEvent, CGEventType eventType, IntPtr eventRef, IntPtr userInfo);
 
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary)]
-#if !XAMCORE_2_0 // Accidently exposed this to public, can't break API
-		public
-#endif
 		extern static IntPtr CGEventTapCreate (CGEventTapLocation location, CGEventTapPlacement place, CGEventTapOptions options, CGEventMask mask, CGEventTapCallback cback, IntPtr data);
 
 		public static CFMachPort CreateTap (CGEventTapLocation location, CGEventTapPlacement place, CGEventTapOptions options, CGEventMask mask, CGEventTapCallback cback, IntPtr data)

--- a/src/CoreGraphics/CGFont.cs
+++ b/src/CoreGraphics/CGFont.cs
@@ -283,15 +283,6 @@ namespace CoreGraphics {
 			return new CTFont (CTFontCreateWithGraphicsFont (handle, size, null, IntPtr.Zero), true);
 		}
 
-#if !XAMCORE_2_0
-		[Obsolete ("Use ToCTFont(GCFloat,CGAffineTransform)")]
-		public unsafe CTFont ToCTFont (nfloat size, ref CGAffineTransform matrix)
-		{
-			CGAffineTransform m = matrix;
-			return new CTFont (CTFontCreateWithGraphicsFont (handle, size, &m, IntPtr.Zero), true);
-		}
-#endif // !XAMCORE_2_0
-
 		public unsafe CTFont ToCTFont (nfloat size, CGAffineTransform matrix)
 		{
 			return new CTFont (CTFontCreateWithGraphicsFont (handle, size, &matrix, IntPtr.Zero), true);

--- a/src/CoreGraphics/CGGeometry.cs
+++ b/src/CoreGraphics/CGGeometry.cs
@@ -42,39 +42,6 @@ namespace CoreGraphics {
 		MaxYEdge,
 	}
 
-#if !COREBUILD && !XAMCORE_2_0
-	public static class PointFExtensions {
-
-		// CGGeometry.h
-		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CFDictionaryRef */ IntPtr CGPointCreateDictionaryRepresentation (CGPoint point);
-
-		// This exact method is defined on CGPoint in the Unified API, so there's no need for the extension method.
-		public static NSDictionary ToDictionary (this CGPoint self)
-		{
-			return new NSDictionary (CGPointCreateDictionaryRepresentation (self));
-		}
-	}
-
-	public static class NSDictionaryExtensions {
-
-		// CGGeometry.h
-		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static bool CGPointMakeWithDictionaryRepresentation (/* CFDictionaryRef */ IntPtr dict, out CGPoint ret);
-
-		// Use CGPoint.TryParse (NSDictionary, out CGPoint) instead in the Unified API.
-		// Not sure how to best advice Classic API users here, since the method does 
-		// not exist in the Classic API (so an Obsolete method can't point anywhere).
-		public static bool ToPoint (this NSDictionary dictionary, out CGPoint point)
-		{
-			if (dictionary == null)
-				throw new ArgumentNullException ("dictionary");
-			
-			return CGPointMakeWithDictionaryRepresentation (dictionary.Handle, out point);
-		}
-	}
-#endif
-	
 	public static class RectangleFExtensions {
 
 		[DllImport (Constants.CoreGraphicsLibrary)]

--- a/src/CoreGraphics/CGImageProperties.cs
+++ b/src/CoreGraphics/CGImageProperties.cs
@@ -114,27 +114,7 @@ namespace CoreGraphics {
 				SetNumberValue (Keys.Depth, value);
 			}
 		}
-#if !XAMCORE_2_0
-		[Obsolete ("Use the DPIHeightF property")]
-		public int? DPIHeight {
-			get {
-				return GetInt32Value (Keys.DPIHeight);
-			}
-			set {
-				SetNumberValue (Keys.DPIHeight, value);
-			}
-		}
 
-		[Obsolete ("Use the DPIWidthF property")]
-		public int? DPIWidth {
-			get {
-				return GetInt32Value (Keys.DPIWidth);
-			}
-			set {
-				SetNumberValue (Keys.DPIWidth, value);
-			}
-		}
-#endif
 		public float? DPIHeightF {
 			get {
 				return GetFloatValue (Keys.DPIHeight);

--- a/src/CoreGraphics/CGPDFDocument.cs
+++ b/src/CoreGraphics/CGPDFDocument.cs
@@ -161,17 +161,10 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static bool CGPDFDocumentUnlockWithPassword (/* CGPDFDocumentRef */ IntPtr document, /* const char* */ string password);
 
-#if XAMCORE_2_0
 		public bool Unlock (string password)
 		{
 			return CGPDFDocumentUnlockWithPassword (handle, password);
 		}
-#else
-		public bool UnlockWithPassword (string pass)
-		{
-			return CGPDFDocumentUnlockWithPassword (handle, pass);
-		}
-#endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static bool CGPDFDocumentIsUnlocked (/* CGPDFDocumentRef */ IntPtr document);
@@ -200,50 +193,6 @@ namespace CoreGraphics {
 			}
 		}
 
-#if !XAMCORE_2_0
-		// deprecated in OSX 10.5 in favor of CGPDFPage API and never part of iOS
-
-		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static CGRect CGPDFDocumentGetMediaBox (/* CGPDFDocumentRef */ IntPtr document, /* int */ int page);
-
-		public CGRect GetMediaBox (int page)
-		{
-			return CGPDFDocumentGetMediaBox (handle, page);
-		}
-
-		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static CGRect CGPDFDocumentGetCropBox (/* CGPDFDocumentRef */ IntPtr document, /* int */ int page);
-
-		public CGRect GetCropBox (int page)
-		{
-			return CGPDFDocumentGetCropBox (handle, page);
-		}
-		
-		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static CGRect CGPDFDocumentGetBleedBox (/* CGPDFDocumentRef */ IntPtr document, /* int */ int page);
-
-		public CGRect GetBleedBox (int page)
-		{
-			return CGPDFDocumentGetBleedBox (handle, page);
-		}
-		
-		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static CGRect CGPDFDocumentGetTrimBox (/* CGPDFDocumentRef */ IntPtr document, /* int */ int page);
-
-		public CGRect GetTrimBox (int page)
-		{
-			return CGPDFDocumentGetTrimBox (handle, page);
-		}
-		
-		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static CGRect CGPDFDocumentGetArtBox (/* CGPDFDocumentRef */ IntPtr document, /* int */ int page);
-
-		public CGRect GetArtBox (int page)
-		{
-			return CGPDFDocumentGetArtBox (handle, page);
-		}
-#endif
-		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGPDFDictionaryRef */ IntPtr CGPDFDocumentGetCatalog (/* CGPDFDocumentRef */ IntPtr document);
 		public CGPDFDictionary GetCatalog ()

--- a/src/CoreGraphics/CGPDFStream.cs
+++ b/src/CoreGraphics/CGPDFStream.cs
@@ -65,16 +65,6 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CFDataRef */ IntPtr CGPDFStreamCopyData (/* CGPDFStreamRef */ IntPtr stream, /* CGPDFDataFormat* */ out CGPDFDataFormat format);
 
-#if !XAMCORE_2_0
-		[Obsolete ("Use 'GetData(out CGPDFDataFormat)' instead.")]
-		public NSData Data {
-			get {
-				CGPDFDataFormat format;
-				return GetData (out format);
-			}
-		}
-#endif
-
 		public NSData GetData (out CGPDFDataFormat format)
 		{
 			IntPtr obj = CGPDFStreamCopyData (handle, out format);

--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -191,14 +191,6 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		unsafe extern static void CGPathAddLineToPoint (/* CGMutablePathRef */ IntPtr path, CGAffineTransform *m, /* CGFloat */ nfloat x, /* CGFloat */ nfloat y);
 
-#if !XAMCORE_2_0
-		[Advice ("Use 'AddLineToPoint' instead.")] // Bad name
-		public void CGPathAddLineToPoint (nfloat x, nfloat y)
-		{
-			AddLineToPoint (x, y);
-		}
-#endif
-
 		public unsafe void AddLineToPoint (nfloat x, nfloat y)
 		{
 			CGPathAddLineToPoint (handle, null, x, y);
@@ -208,14 +200,6 @@ namespace CoreGraphics {
 		{
 			CGPathAddLineToPoint (handle, null, point.X, point.Y);
 		}
-		
-#if !XAMCORE_2_0
-		[Advice ("Use 'AddLineToPoint' instead.")] // Bad name
-		public void CGPathAddLineToPoint (CGAffineTransform transform, nfloat x, nfloat y)
-		{
-			AddLineToPoint (transform, x, y);
-		}
-#endif
 
 		public unsafe void AddLineToPoint (CGAffineTransform transform, nfloat x, nfloat y)
 		{
@@ -329,12 +313,7 @@ namespace CoreGraphics {
 			CGPathAddLines (handle, &m, points, points.Length);
 		}
 
-#if !XAMCORE_2_0
-		[Advice ("Misnamed method, it's 'AddLines'.")]
-		public unsafe void AddRects (CGAffineTransform m, CGPoint [] points, int count)
-#else
 		public unsafe void AddLines (CGAffineTransform m, CGPoint [] points, int count)
-#endif
 		{
 			if (points == null)
 				throw new ArgumentNullException ("points");
@@ -350,12 +329,7 @@ namespace CoreGraphics {
 			CGPathAddLines (handle, null, points, points.Length);
 		}
 
-#if !XAMCORE_2_0
-		[Advice ("Misnamed method, it's 'AddLines'.")]
-		public unsafe void AddRects (CGPoint [] points, int count)
-#else
 		public unsafe void AddLines (CGPoint [] points, int count)
-#endif
 		{
 			if (points == null)
 				throw new ArgumentNullException ("points");
@@ -371,25 +345,11 @@ namespace CoreGraphics {
 		{
 			CGPathAddEllipseInRect (handle, &m, rect);
 		}
-#if !XAMCORE_2_0
-		[Obsolete ("Use 'AddEllipseInRect' instead.")]
-		public unsafe void AddElipseInRect (CGAffineTransform m, CGRect rect)
-		{
-			CGPathAddEllipseInRect (handle, &m, rect);
-		}
-#endif
 		
 		public unsafe void AddEllipseInRect (CGRect rect)
 		{
 			CGPathAddEllipseInRect (handle, null, rect);
 		}
-#if !XAMCORE_2_0
-		[Obsolete ("Use 'AddEllipseInRect' instead.")]
-		public unsafe void AddElipseInRect (CGRect rect)
-		{
-			CGPathAddEllipseInRect (handle, null, rect);
-		}
-#endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		unsafe extern static void CGPathAddArc (/* CGMutablePathRef */ IntPtr path, CGAffineTransform *m, /* CGFloat */ nfloat x, /* CGFloat */ nfloat y, /* CGFloat */ nfloat radius, /* CGFloat */ nfloat startAngle, /* CGFloat */ nfloat endAngle, bool clockwise);

--- a/src/CoreImage/CIImage.cs
+++ b/src/CoreImage/CIImage.cs
@@ -100,26 +100,6 @@ namespace CoreImage {
 
 	public partial class CIImage {
 
-#if !MONOMAC && !XAMCORE_2_0
-		[Obsolete ("A CIImage cannot be created from a CGLayer on iOS (only OSX)")]
-		public CIImage (CGLayer layer)
-		{
-			throw new NotSupportedException ();
-		}
-
-		[Obsolete ("A CIImage cannot be created from a CGLayer on iOS (only OSX)")]
-		public CIImage (CGLayer layer, NSDictionary d)
-		{
-			throw new NotSupportedException ();
-		}
-
-		[Obsolete ("A CIImage cannot be created from a CGLayer on iOS (only OSX)")]
-		public CIImage (CGLayer layer, CIImageInitializationOptions options)
-		{
-			throw new NotSupportedException ();
-		}
-#endif
-
 		static CIFilter [] WrapFilters (NSArray filters)
 		{
 			if (filters == null)

--- a/src/CoreLocation/CLCompat.cs
+++ b/src/CoreLocation/CLCompat.cs
@@ -5,16 +5,6 @@ using ObjCRuntime;
 
 namespace CoreLocation {
 
-#if !XAMCORE_2_0
-	public partial class CLBeaconRegion {
-
-		[Obsolete ("Does not return a valid instance on iOS 8.")]
-		public CLBeaconRegion ()
-		{
-		}
-	}
-#endif
-
 #if !XAMCORE_4_0 && !WATCH
 
 #if !TVOS

--- a/src/CoreLocation/CLLocationManager.cs
+++ b/src/CoreLocation/CLLocationManager.cs
@@ -48,15 +48,4 @@ namespace CoreLocation {
 		}
 #endif
 	}
-
-#if !XAMCORE_2_0
-	[Obsolete ("Use 'CLAuthorizationChangedEventArgs'.")]
-	public class CLAuthroziationChangedEventArgs : CLAuthorizationChangedEventArgs
-	{
-		public CLAuthroziationChangedEventArgs (CLAuthorizationStatus status)
-			: base (status)
-		{
-		}
-	}
-#endif
 }

--- a/src/CoreLocation/CoreLocation.cs
+++ b/src/CoreLocation/CoreLocation.cs
@@ -33,7 +33,7 @@ using System;
 using System.Runtime.InteropServices;
 
 using ObjCRuntime;
-#if IOS && !COREBUILD && XAMCORE_2_0
+#if IOS && !COREBUILD
 using Contacts;
 using Intents;
 #endif
@@ -67,40 +67,8 @@ namespace CoreLocation {
 			return $"(Latitude={Latitude}, Longitude={Longitude}";
 		}
 	}
-	
-#if !MONOMAC && !COREBUILD && !XAMCORE_2_0
-	public partial class CLHeading {
 
-		[Obsolete ("This type is not meant to be created by application code")]
-		public CLHeading () : base (IntPtr.Zero)
-		{
-			// calling ToString, 'description' selector, would crash the application
-			IsDirectBinding = GetType () == typeof (CLHeading);
-		}
-	}
-
-	public partial class CLRegion {
-
-		[Obsolete ("This type is not meant to be created by application code")]
-		public CLRegion () : base (IntPtr.Zero)
-		{
-			// calling ToString, 'description' selector, would crash the application
-			IsDirectBinding = GetType () == typeof (CLRegion);
-		}
-	}
-
-	public partial class CLPlacemark {
-
-		[Obsolete ("This type is not meant to be created by application code")]
-		public CLPlacemark () : base (IntPtr.Zero)
-		{
-			// calling ToString, 'description' selector, or disposing the instance would crash the application
-			IsDirectBinding = GetType () == typeof (CLPlacemark);
-		}
-	}
-#endif
-
-#if IOS && !COREBUILD && XAMCORE_2_0 // This code comes from Intents.CLPlacemark_INIntentsAdditions Category
+#if IOS && !COREBUILD // This code comes from Intents.CLPlacemark_INIntentsAdditions Category
 	public partial class CLPlacemark {
 		[iOS (10, 0)]
 		static public CLPlacemark GetPlacemark (CLLocation location, string name, CNPostalAddress postalAddress)

--- a/src/coregraphics.cs
+++ b/src/coregraphics.cs
@@ -249,21 +249,17 @@ namespace CoreGraphics {
 		[Field ("kCGColorConversionBlackPointCompensation")]
 		NSString BlackPointCompensationKey { get; }
 
-#if XAMCORE_2_0
 		[Internal]
 		[Field ("kCGColorConversionTRCSize")]
 		[iOS (11,0), Mac(10,13), TV(11,0), Watch(4,0)]
 		NSString TrcSizeKey { get; }
-#endif
 	}
 
 	[iOS (10,0)][TV (10,0)][Watch (3,0)][Mac (10,12)]
 	[StrongDictionary ("CGColorConversionInfo")]
 	interface CGColorConversionOptions {
 		bool BlackPointCompensation { get; set; }
-#if XAMCORE_2_0
 		CGSize TrcSize { get; set; }
-#endif
 	}
 
 	[iOS(11,0), Mac(10,13)]
@@ -299,9 +295,7 @@ namespace CoreGraphics {
 		string OutlineTitle { get; set; }
 		NSDictionary [] OutlineChildren { get; set; }
 		NSObject OutlineDestination { get; set; }
-#if XAMCORE_2_0
 		CGRect DestinationRect { get; set; }
-#endif
 	}
 
 	[Mac (10,15)]

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -36,9 +36,7 @@ using CoreML;
 using CoreVideo;
 using ImageIO;
 using IOSurface;
-#if !MONOMAC || XAMCORE_2_0
 using Metal;
-#endif
 #if !MONOMAC
 using OpenGLES;
 using UIKit;
@@ -209,25 +207,21 @@ namespace CoreImage {
 		[Export ("init")]
 		IntPtr Constructor ();
 
-#if !MONOMAC || XAMCORE_2_0
 		[iOS (9,0)][Mac (10,11)]
 		[Static]
 		[Export ("contextWithMTLDevice:")]
 		CIContext FromMetalDevice (IMTLDevice device);
 
-#if XAMCORE_2_0
 		[iOS (9,0)][Mac (10,11)]
 		[Internal] // This overload is needed for our strong dictionary support (but only for Unified, since for Classic the generic version is transformed to this signature)
 		[Static]
 		[Export ("contextWithMTLDevice:options:")]
 		CIContext FromMetalDevice (IMTLDevice device, [NullAllowed] NSDictionary options);
-#endif
 
 		[iOS (9,0)][Mac (10,11)]
 		[Static]
 		[Export ("contextWithMTLDevice:options:")]
 		CIContext FromMetalDevice (IMTLDevice device, [NullAllowed] NSDictionary<NSString, NSObject> options);
-#endif
 
 		[iOS (9,0)]
 		[Internal, Static]
@@ -282,11 +276,9 @@ namespace CoreImage {
 		CGSize OutputImageMaximumSize { get; }
 #endif
 
-#if !MONOMAC || XAMCORE_2_0
 		[iOS (9,0)][Mac (10,11)]
 		[Export ("render:toMTLTexture:commandBuffer:bounds:colorSpace:")]
 		void Render (CIImage image, IMTLTexture texture, [NullAllowed] IMTLCommandBuffer commandBuffer, CGRect bounds, [NullAllowed] CGColorSpace colorSpace);
-#endif
 
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'DrawImage (image, CGRect, CGRect)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'DrawImage (image, CGRect, CGRect)' instead.")]
@@ -1416,11 +1408,7 @@ namespace CoreImage {
 
 		[Static]
 		[Export ("imageWithBitmapData:bytesPerRow:size:format:colorSpace:")]
-#if XAMCORE_2_0
 		[Internal] // there's a CIFormat enum that maps to the kCIFormatARGB8, kCIFormatRGBA16, kCIFormatRGBAf, kCIFormatRGBAh constants
-#else
-		[Obsolete ("Use the overload acceping a 'CIFormat' enum instead of an 'int'.")]
-#endif
 		CIImage FromData (NSData bitmapData, nint bytesPerRow, CGSize size, int /* CIFormat = int */ pixelFormat, [NullAllowed] CGColorSpace colorSpace);
 
 		[Deprecated (PlatformName.iOS, 12, 0)]
@@ -1466,14 +1454,13 @@ namespace CoreImage {
 		[Export ("imageWithCVImageBuffer:options:")]
 		CIImage FromImageBuffer (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary dict);
 #else
-#if XAMCORE_2_0
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Static]
 		[iOS(9,0)]
 		[Internal] // This overload is needed for our strong dictionary support (but only for Unified, since for Classic the generic version is transformed to this signature)
 		[Export ("imageWithCVImageBuffer:options:")]
 		CIImage FromImageBuffer (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary dict);
-#endif
+
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Static]
 		[iOS(9,0)]
@@ -1618,13 +1605,11 @@ namespace CoreImage {
 		[Export ("initWithCVImageBuffer:options:")]
 		IntPtr Constructor (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary<NSString, NSObject> dict);
 
-#if XAMCORE_2_0
 		[iOS(9,0)]
 		[Internal] // This overload is needed for our strong dictionary support (but only for Unified, since for Classic the generic version is transformed to this signature)
 		[Sealed]
 		[Export ("initWithCVImageBuffer:options:")]
 		IntPtr Constructor (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary dict);
-#endif
 #endif
 
 		[iOS(9,0)]
@@ -1646,11 +1631,9 @@ namespace CoreImage {
 		[Export ("initWithColor:")]
 		IntPtr Constructor (CIColor color);
 
-#if !MONOMAC || XAMCORE_2_0
 		[iOS (9,0)][Mac (10,11)]
 		[Export ("initWithMTLTexture:options:")]
 		IntPtr Constructor (IMTLTexture texture, [NullAllowed] NSDictionary options);
-#endif
 
 #if MONOMAC
 		[Export ("initWithBitmapImageRep:")]
@@ -1885,12 +1868,10 @@ namespace CoreImage {
 		[Export ("initWithImageProvider:size::format:colorSpace:options:")]
 		IntPtr Constructor (ICIImageProvider provider, nuint width, nuint height, int f, [NullAllowed] CGColorSpace colorSpace, [NullAllowed] NSDictionary options);
 
-#if !MONOMAC || XAMCORE_2_0
 		[iOS (9,0)][Mac (10,11)]
 		[Static]
 		[Export ("imageWithMTLTexture:options:")]
 		CIImage FromMetalTexture (IMTLTexture texture, [NullAllowed] NSDictionary<NSString, NSObject> options);
-#endif
 
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10,0)]
@@ -2122,11 +2103,9 @@ namespace CoreImage {
 		[NullAllowed, Export ("pixelBuffer")]
 		CVPixelBuffer PixelBuffer { get; }
 
-#if !MONOMAC || XAMCORE_2_0
 		[Abstract]
 		[NullAllowed, Export ("metalTexture")]
 		IMTLTexture MetalTexture { get; }
-#endif
 
 #if XAMCORE_4_0
 		[Abstract] // @required but it was added in Xcode9
@@ -2163,7 +2142,6 @@ namespace CoreImage {
 		[NullAllowed, Export ("pixelBuffer")]
 		CVPixelBuffer PixelBuffer { get; }
 
-#if !MONOMAC || XAMCORE_2_0
 		[Abstract]
 		[NullAllowed, Export ("metalTexture")]
 		IMTLTexture MetalTexture { get; }
@@ -2171,7 +2149,6 @@ namespace CoreImage {
 		[Abstract]
 		[NullAllowed, Export ("metalCommandBuffer")]
 		IMTLCommandBuffer MetalCommandBuffer { get; }
-#endif
 
 #if XAMCORE_4_0
 		[Abstract] // @required but it was added in Xcode9
@@ -2217,15 +2194,6 @@ namespace CoreImage {
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // avoid crashes
 	interface CIKernel {
-#if !XAMCORE_2_0
-		[Obsolete ("Use 'FromProgramSingle'.")] // better API
-		[Static, Export ("kernelWithString:")]
-		CIKernel FromProgram (string coreImageShaderProgram);
-
-		[Obsolete ("Use 'FromProgramMultiple'.")] // better API
-		[Static, Export ("kernelsWithString:")]
-		CIKernel [] FromPrograms (string coreImageShaderProgram);
-#endif
 		[Deprecated (PlatformName.iOS, 12, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Static, Export ("kernelsWithString:")]
@@ -5153,13 +5121,11 @@ namespace CoreImage {
 		[Export ("initWithIOSurface:")]
 		IntPtr Constructor (IOSurface.IOSurface surface);
 
-#if XAMCORE_2_0
 		[Export ("initWithMTLTexture:commandBuffer:")]
 		IntPtr Constructor (IMTLTexture texture, [NullAllowed] IMTLCommandBuffer commandBuffer);
 
 		[Export ("initWithWidth:height:pixelFormat:commandBuffer:mtlTextureProvider:")]
 		IntPtr Constructor (nuint width, nuint height, MTLPixelFormat pixelFormat, [NullAllowed] IMTLCommandBuffer commandBuffer, Func<IMTLTexture> block);
-#endif
 
 		[Export ("initWithGLTexture:target:width:height:")]
 		IntPtr Constructor (uint texture, uint target, nuint width, nuint height);

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -17,7 +17,7 @@ using CoreLocation;
 #if !MONOMAC
 using UIKit;
 #endif
-#if XAMCORE_2_0 && !TVOS
+#if !TVOS
 using Contacts;
 #endif
 using System;
@@ -131,7 +131,6 @@ namespace CoreLocation {
 		[Field ("kCLErrorUserInfoAlternateRegionKey")]
 		NSString ErrorUserInfoAlternateRegionKey { get; }
 
-#if XAMCORE_2_0
 		[Field ("kCLLocationAccuracyBestForNavigation")]
 		double AccurracyBestForNavigation { get; }
 
@@ -149,7 +148,6 @@ namespace CoreLocation {
 
 		[Field ("kCLLocationAccuracyThreeKilometers")]
 		double AccuracyThreeKilometers { get; }
-#endif
 
 		[Mac (10,15)]
 		[iOS (8,0)]
@@ -622,7 +620,7 @@ namespace CoreLocation {
 		[NullAllowed, Export ("timeZone")]
 		[iOS (9,0), Mac(10,11)]
 		NSTimeZone TimeZone { get; }
-#if XAMCORE_2_0 && !TVOS
+#if !TVOS
 		// From CLPlacemark (ContactsAdditions) category.
 		[Watch (4,0), NoTV, Mac (10,13), iOS (11,0)]
 		[NullAllowed, Export ("postalAddress")]
@@ -785,7 +783,7 @@ namespace CoreLocation {
 		[Export ("cancelGeocode")]
 		void CancelGeocode ();
 
-#if XAMCORE_2_0 && !TVOS
+#if !TVOS
 		[Watch (4,0), NoTV, Mac (10,13), iOS (11,0)]
 		[Export ("geocodePostalAddress:completionHandler:")]
 		[Async]


### PR DESCRIPTION


Backport of #8779.

/cc @rolfbjarne 