### PR TITLE
[msbuild] Share the _DetectSigningIdentity target.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/DetectSigningIdentityTaskCore.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/DetectSigningIdentityTaskCore.cs
@@ -1,0 +1,16 @@
+using Xamarin.MacDev.Tasks;
+
+namespace Xamarin.Mac.Tasks {
+	public abstract class DetectSigningIdentityTaskCore : DetectSigningIdentityTaskBase {
+		static readonly string [] appStoreDistributionPrefixes = { "3rd Party Mac Developer Application", "Apple Distribution" };
+		static readonly string [] directDistributionPrefixes = { "Developer ID Application" };
+		static readonly string [] developmentPrefixes = { "Mac Developer", "Apple Development" };
+
+		protected override string [] DevelopmentPrefixes { get { return developmentPrefixes; } }
+		protected override string [] DirectDistributionPrefixes { get { return directDistributionPrefixes; } }
+		protected override string [] AppStoreDistributionPrefixes { get { return appStoreDistributionPrefixes; } }
+		protected override string DeveloperRoot { get { return MacOSXSdks.Native.DeveloperRoot; } }
+		protected override string ApplicationIdentifierKey { get { return "com.apple.application-identifier"; } }
+	}
+}
+

--- a/msbuild/Xamarin.Mac.Tasks/Tasks/DetectSigningIdentity.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/DetectSigningIdentity.cs
@@ -6,21 +6,9 @@
 //
 // Copyright 2014 Xamarin Inc.
 
-using Xamarin.MacDev.Tasks;
-using Xamarin.Utils;
-
 namespace Xamarin.Mac.Tasks
 {
-	public class DetectSigningIdentity : DetectSigningIdentityTaskBase
+	public class DetectSigningIdentity : DetectSigningIdentityTaskCore
 	{
-		static readonly string[] appStoreDistributionPrefixes = { "3rd Party Mac Developer Application", "Apple Distribution" };
-		static readonly string[] directDistributionPrefixes = { "Developer ID Application" };
-		static readonly string[] developmentPrefixes = { "Mac Developer", "Apple Development" };
-
-		protected override string[] DevelopmentPrefixes { get { return developmentPrefixes; } }
-		protected override string[] DirectDistributionPrefixes { get { return directDistributionPrefixes; } }
-		protected override string[] AppStoreDistributionPrefixes { get { return appStoreDistributionPrefixes; } }
-		protected override string DeveloperRoot { get { return MacOSXSdks.Native.DeveloperRoot; } }
-		protected override string ApplicationIdentifierKey { get { return "com.apple.application-identifier"; } }
 	}
 }

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -393,29 +393,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		</UnpackLibraryResources>
 	</Target>
 
-	<Target Name="_DetectSigningIdentity" DependsOnTargets="_DetectAppManifest;_ComputeTargetFrameworkMoniker">
-		<DetectSigningIdentity
-			Condition="'$(IsMacEnabled)' == 'true'"
-			SessionId="$(BuildSessionId)"
-			AppBundleName="$(_AppBundleName)"
-			AppManifest="$(_AppManifest)"
-			Keychain="$(CodesignKeychain)"
-			RequireCodeSigning="$(_RequireCodeSigning)"
-			RequireProvisioningProfile="$(_RequireProvisioningProfile)"
-			SdkPlatform="MacOSX"
-			ProvisioningProfile="$(CodeSignProvision)"
-			SigningKey="$(_SpecifiedCodesignKey)"
-			DetectedCodeSigningKey="$(_CodeSigningKey)"
-			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
-			>
-			<Output TaskParameter="DetectedAppId" PropertyName="_AppIdentifier" />
-			<Output TaskParameter="DetectedBundleId" PropertyName="_BundleIdentifier" />
-			<Output TaskParameter="DetectedCodeSigningKey" PropertyName="_CodeSigningKey" />
-			<Output TaskParameter="DetectedCodesignAllocate" PropertyName="_CodesignAllocate" />
-			<Output TaskParameter="DetectedProvisioningProfile" PropertyName="_ProvisioningProfile" />
-		</DetectSigningIdentity>
-	</Target>
-
 	<Target Name="_GenerateBundleName">
 		<PropertyGroup>
 			<AppBundleDir>$(OutputPath)$(_AppBundleName)$(AppBundleExtension)</AppBundleDir>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 
 using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 
 using Xamarin.Utils;
 using Xamarin.Localization.MSBuild;

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -155,6 +155,33 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<Error Condition="'$(_AppManifest)' == '' And '$(_CanOutputAppBundle)' == 'true'" Text="Info.plist not found."/>
 	</Target>
 
+	<Target Name="_DetectSigningIdentity" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_ComputeTargetFrameworkMoniker">
+		<DetectSigningIdentity
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			AppBundleName="$(_AppBundleName)"
+			AppManifest="$(_AppManifest)"
+			Keychain="$(CodesignKeychain)"
+			RequireCodeSigning="$(_RequireCodeSigning)"
+			RequireProvisioningProfile="$(_RequireProvisioningProfile)"
+			SdkIsSimulator="$(_SdkIsSimulator)"
+			SdkPlatform="$(_SdkPlatform)"
+			ProvisioningProfile="$(CodesignProvision)"
+			SigningKey="$(_SpecifiedCodesignKey)"
+			DetectedCodeSigningKey="$(_CodeSigningKey)"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+			>
+
+			<Output TaskParameter="DetectedAppId" PropertyName="_AppIdentifier" />
+			<Output TaskParameter="DetectedBundleId" PropertyName="_BundleIdentifier" />
+			<Output TaskParameter="DetectedBundleVersion" PropertyName="_BundleVersion" />
+			<Output TaskParameter="DetectedCodeSigningKey" PropertyName="_CodeSigningKey" />
+			<Output TaskParameter="DetectedCodesignAllocate" PropertyName="_CodesignAllocate" />
+			<Output TaskParameter="DetectedDistributionType" PropertyName="_DistributionType" />
+			<Output TaskParameter="DetectedProvisioningProfile" PropertyName="_ProvisioningProfile" />
+		</DetectSigningIdentity>
+	</Target>
+
 	<Target Name="_DetectSdkLocations" DependsOnTargets="_ComputeTargetArchitectures;_ComputeTargetFrameworkMoniker">
 		<DetectSdkLocations
 			SessionId="$(BuildSessionId)"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSigningIdentityTaskCore.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSigningIdentityTaskCore.cs
@@ -1,13 +1,9 @@
-﻿using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
-
 using Xamarin.MacDev;
 using Xamarin.MacDev.Tasks;
-using Xamarin.Utils;
 
 namespace Xamarin.iOS.Tasks
 {
-	public abstract class DetectSigningIdentityTaskBase : Xamarin.MacDev.Tasks.DetectSigningIdentityTaskBase
+	public abstract class DetectSigningIdentityTaskCore : DetectSigningIdentityTaskBase
 	{
 		static readonly string[] directDistributionPrefixes = new string[0];
 
@@ -18,3 +14,4 @@ namespace Xamarin.iOS.Tasks
 		protected override string ApplicationIdentifierKey { get { return "application-identifier"; } }
 	}
 }
+

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -582,32 +582,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</UnpackLibraryResources>
 	</Target>
 
-	<Target Name="_DetectSigningIdentity" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_ComputeTargetFrameworkMoniker">
-		<DetectSigningIdentity
-			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true'"
-			AppBundleName="$(_AppBundleName)"
-			AppManifest="$(_AppManifest)"
-			Keychain="$(CodesignKeychain)"
-			RequireCodeSigning="$(_RequireCodeSigning)"
-			RequireProvisioningProfile="$(_RequireProvisioningProfile)"
-			SdkIsSimulator="$(_SdkIsSimulator)"
-			SdkPlatform="$(_SdkPlatform)"
-			ProvisioningProfile="$(CodesignProvision)"
-			SigningKey="$(_SpecifiedCodesignKey)"
-			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
-			>
-
-			<Output TaskParameter="DetectedAppId" PropertyName="_AppIdentifier" />
-			<Output TaskParameter="DetectedBundleId" PropertyName="_BundleIdentifier" />
-			<Output TaskParameter="DetectedBundleVersion" PropertyName="_BundleVersion" />
-			<Output TaskParameter="DetectedCodeSigningKey" PropertyName="_CodeSigningKey" />
-			<Output TaskParameter="DetectedCodesignAllocate" PropertyName="_CodesignAllocate" />
-			<Output TaskParameter="DetectedDistributionType" PropertyName="_DistributionType" />
-			<Output TaskParameter="DetectedProvisioningProfile" PropertyName="_ProvisioningProfile" />
-		</DetectSigningIdentity>
-	</Target>
-	
 	<Target Name="_GenerateBundleName" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_ComputeTargetArchitectures;_GenerateAppBundleName;_GenerateAppExBundleName" />
 
 	<Target Name="_GenerateAppBundleName" Condition="'$(_CanOutputAppBundle)' == 'true' And '$(IsAppExtension)' != 'true'" DependsOnTargets="_ComputeTargetArchitectures">

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/DetectSigningIdentity.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/DetectSigningIdentity.cs
@@ -1,6 +1,6 @@
 namespace Xamarin.iOS.Tasks
 {
-	public class DetectSigningIdentity : DetectSigningIdentityTaskBase
+	public class DetectSigningIdentity : DetectSigningIdentityTaskCore
 	{
 	}
 }


### PR DESCRIPTION
Also rework the class hierarchy a little bit, so that Xamarin.iOS and
Xamarin.Mac are identical:

	DetectSigningIdentityTaskBase
	└─── iOS/DetectSigningIdentityTaskCore
	│    └─── iOS/DetectSigningIdentity
	└─── Mac/DetectSigningIdentityTaskCore
	│    └─── Mac/DetectSigningIdentity