### PR TITLE
[d16-7] [src] Remove Classic code from the CoreMedia, CoreMidi, CoreML, CoreMotion, CoreNFC, CoreTelephony and CoreText frameworks.

### DIFF
--- a/src/CoreML/MLDictionaryFeatureProvider.cs
+++ b/src/CoreML/MLDictionaryFeatureProvider.cs
@@ -7,8 +7,6 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0
-
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -22,4 +20,3 @@ namespace CoreML {
 		}
 	}
 }
-#endif

--- a/src/CoreML/MLMultiArray.cs
+++ b/src/CoreML/MLMultiArray.cs
@@ -7,8 +7,6 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0
-
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -88,4 +86,3 @@ namespace CoreML {
 		}
 	}
 }
-#endif

--- a/src/CoreML/MLMultiArrayConstraint.cs
+++ b/src/CoreML/MLMultiArrayConstraint.cs
@@ -7,8 +7,6 @@
 // Copyright 2017 Microsoft Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0
-
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -22,4 +20,3 @@ namespace CoreML {
 		}
 	}
 }
-#endif

--- a/src/CoreMedia/CMAttachmentBearer.cs
+++ b/src/CoreMedia/CMAttachmentBearer.cs
@@ -30,7 +30,6 @@ namespace CoreMedia {
 			return Runtime.GetNSObject<NSDictionary> (attachments, true);
 		}
 
-#if XAMCORE_2_0
 		// There is some API that needs a more strongly typed version of a NSDictionary
 		// and there is no easy way to downcast from NSDictionary to NSDictionary<TKey, TValue>
 		public static NSDictionary<TKey, TValue> GetAttachments<TKey, TValue> (this ICMAttachmentBearer target, CMAttachmentMode attachmentMode)
@@ -45,7 +44,6 @@ namespace CoreMedia {
 
 			return Runtime.GetNSObject<NSDictionary<TKey, TValue>> (attachments, true);
 		}
-#endif
 
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CFTypeRef */ IntPtr CMGetAttachment (/* CMAttachmentBearerRef */ IntPtr target, /* CFStringRef */ IntPtr key,

--- a/src/CoreMedia/CMFormatDescription.cs
+++ b/src/CoreMedia/CMFormatDescription.cs
@@ -21,11 +21,6 @@ using ObjCRuntime;
 using CoreVideo;
 using AudioToolbox;
 
-#if !XAMCORE_2_0
-using System.Drawing;
-using CMVideoDimensions = System.Drawing.Size;
-#endif
-
 namespace CoreMedia {
 
 	// untyped enum (uses as OSStatus) -> CMFormatDescription.h
@@ -324,41 +319,6 @@ namespace CoreMedia {
 		[DllImport (Constants.CoreMediaLibrary)]
 		internal extern static /* Boolean */ bool CMVideoFormatDescriptionMatchesImageBuffer (/* CMVideoFormatDescriptionRef */ IntPtr videoDesc, /* CVImageBufferRef */ IntPtr imageBuffer);
 
-#if !XAMCORE_2_0
-		[Advice ("Use 'CMVideoFormatDescription'.")]
-		public Size  VideoDimensions {
-			get {
-				return CMVideoFormatDescriptionGetDimensions (handle);
-			}
-		}
-
-		[Advice ("Use 'CMVideoFormatDescription'.")]
-		public CGRect GetVideoCleanAperture (bool originIsAtTopLeft)
-		{
-			return CMVideoFormatDescriptionGetCleanAperture (handle, originIsAtTopLeft);
-		}
-
-		// Belongs to CMVideoFormatDescription
-		public static NSObject [] GetExtensionKeysCommonWithImageBuffers ()
-		{
-			var arr = CMVideoFormatDescriptionGetExtensionKeysCommonWithImageBuffers ();
-			return NSArray.ArrayFromHandle<NSString> (arr);
-		}
-
-		[Advice ("Use 'CMVideoFormatDescription'.")]
-		public CGSize GetVideoPresentationDimensions (bool usePixelAspectRatio, bool useCleanAperture)
-		{
-			return CMVideoFormatDescriptionGetPresentationDimensions (handle, usePixelAspectRatio, useCleanAperture);
-		}
-
-		// Belongs to CMVideoFormatDescription
-		public bool VideoMatchesImageBuffer (CVImageBuffer imageBuffer)
-		{
-			if (imageBuffer == null)
-				throw new ArgumentNullException ("imageBuffer");
-			return CMVideoFormatDescriptionMatchesImageBuffer (handle, imageBuffer.Handle);
-		}
-#endif
 #endif
 	}
 
@@ -525,7 +485,6 @@ namespace CoreMedia {
 			return CMVideoFormatDescriptionGetPresentationDimensions (handle, usePixelAspectRatio, useCleanAperture);
 		}
 
-#if XAMCORE_2_0
 		public static NSObject [] GetExtensionKeysCommonWithImageBuffers ()
 		{
 			var arr = CMVideoFormatDescriptionGetExtensionKeysCommonWithImageBuffers ();
@@ -538,7 +497,6 @@ namespace CoreMedia {
 				throw new ArgumentNullException ("imageBuffer");
 			return CMVideoFormatDescriptionMatchesImageBuffer (handle, imageBuffer.Handle);
 		}
-#endif
 
 		[iOS (11,0), Mac (10,13), TV (11,0)]
 		[DllImport (Constants.CoreMediaLibrary)]

--- a/src/CoreMedia/CMSampleBuffer.cs
+++ b/src/CoreMedia/CMSampleBuffer.cs
@@ -346,20 +346,6 @@ namespace CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMFormatDescriptionRef */ IntPtr CMSampleBufferGetFormatDescription (/* CMSampleBufferRef */ IntPtr sbuf);
 
-#if !XAMCORE_2_0
-		[Advice ("Use 'GetAudioFormatDescription' or 'GetVideoFormatDescription'.")]
-		public CMFormatDescription GetFormatDescription ()
-		{
-			var desc = default(CMFormatDescription);
-			var descHandle = CMSampleBufferGetFormatDescription (handle);
-			if (descHandle != IntPtr.Zero)
-			{
-				desc = new CMFormatDescription (descHandle, false);
-			}
-			return desc;					
-		}
-#endif
-
 		public CMAudioFormatDescription GetAudioFormatDescription ()
 		{
 			var descHandle = CMSampleBufferGetFormatDescription (handle);
@@ -440,13 +426,6 @@ namespace CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* OSStatus */ CMSampleBufferError CMSampleBufferSetOutputPresentationTimeStamp (/* CMSampleBufferRef */ IntPtr sbuf, CMTime outputPresentationTimeStamp);
 
-#if !XAMCORE_2_0
-		public int SetOutputPresentationTimeStamp (CMTime outputPresentationTimeStamp)
-		{
-			return (int)CMSampleBufferSetOutputPresentationTimeStamp (handle, outputPresentationTimeStamp);
-		}
-#endif
-
 		/*[DllImport(Constants.CoreMediaLibrary)]
 		int CMSampleBufferGetOutputSampleTimingInfoArray (
 		   CMSampleBufferRef sbuf,
@@ -462,13 +441,11 @@ namespace CoreMedia {
 			get {
 				return CMSampleBufferGetPresentationTimeStamp (handle);
 			}
-#if XAMCORE_2_0
 			set {
 				var result = CMSampleBufferSetOutputPresentationTimeStamp (handle, value);
 				if (result != 0)
 					throw new ArgumentException (result.ToString ());
 			}
-#endif
 		}
 
 		[DllImport(Constants.CoreMediaLibrary)]
@@ -575,17 +552,10 @@ namespace CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* OSStatus */ CMSampleBufferError CMSampleBufferInvalidate (/* CMSampleBufferRef */ IntPtr sbuf);
 
-#if XAMCORE_2_0
 		public CMSampleBufferError Invalidate ()
 		{
 			return CMSampleBufferInvalidate (handle);
 		}
-#else
-		public int Invalidate()
-		{
-			return (int)CMSampleBufferInvalidate (handle);
-		}
-#endif
 		
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* Boolean */ bool CMSampleBufferIsValid (/* CMSampleBufferRef */ IntPtr sbuf);
@@ -601,38 +571,19 @@ namespace CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* OSStatus */ CMSampleBufferError CMSampleBufferMakeDataReady (IntPtr handle);
 
-#if XAMCORE_2_0
 		public CMSampleBufferError MakeDataReady ()
 		{
 			return CMSampleBufferMakeDataReady (handle);
 		}
-#else
-		public int MakeDataReady ()
-		{
-			return (int)CMSampleBufferMakeDataReady (handle);
-		}
-#endif
 		
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* OSStatus */ CMSampleBufferError CMSampleBufferSetDataBuffer (IntPtr handle, IntPtr dataBufferHandle);
 		
-#if XAMCORE_2_0
 		public CMSampleBufferError SetDataBuffer (CMBlockBuffer dataBuffer)
 		{
 			var dataBufferHandle = dataBuffer == null ? IntPtr.Zero : dataBuffer.handle;
 			return CMSampleBufferSetDataBuffer (handle, dataBufferHandle);
 		}
-#else
-		public int /*CMSampleBufferError*/ SetDataBuffer (CMBlockBuffer dataBuffer)
-		{
-			var dataBufferHandle = IntPtr.Zero;
-			if (dataBuffer != null)
-			{
-				dataBufferHandle = dataBuffer.handle;
-			}
-			return (int)CMSampleBufferSetDataBuffer (handle, dataBufferHandle);
-		}
-#endif
 		
 		/*[DllImport(Constants.CoreMediaLibrary)]
 		int CMSampleBufferSetDataBufferFromAudioBufferList (
@@ -646,17 +597,10 @@ namespace CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* OSStatus */ CMSampleBufferError CMSampleBufferSetDataReady (/* CMSampleBufferRef */ IntPtr sbuf);
 
-#if XAMCORE_2_0
 		public CMSampleBufferError SetDataReady ()
 		{
 			return CMSampleBufferSetDataReady (handle);
 		}
-#else
-		public int/*CMSampleBufferError*/ SetDataReady ()
-		{
-			return (int)CMSampleBufferSetDataReady (handle);
-		}
-#endif
 		
 #if false
 		// new in iOS 8 beta 5 - but the signature is not easy to bind with the AOT limitation, i.e. MonoPInvokeCallback
@@ -709,22 +653,11 @@ namespace CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* OSStatus */ CMSampleBufferError CMSampleBufferTrackDataReadiness (/* CMSampleBufferRef */ IntPtr sbuf, /* CMSampleBufferRef */ IntPtr sbufToTrack);
 
-#if XAMCORE_2_0
 		public CMSampleBufferError TrackDataReadiness (CMSampleBuffer bufferToTrack)
 		{
 			var handleToTrack = bufferToTrack == null ? IntPtr.Zero : bufferToTrack.handle;
 			return CMSampleBufferTrackDataReadiness (handle, handleToTrack);
 		}
-#else
-		public int/*CMSampleBufferError*/ TrackDataReadiness (CMSampleBuffer bufferToTrack)
-		{
-			var handleToTrack = IntPtr.Zero;
-			if (bufferToTrack != null) {
-				handleToTrack = bufferToTrack.handle;
-			}
-			return (int)CMSampleBufferTrackDataReadiness (handle, handleToTrack);
-		}
-#endif
 
 		[iOS (7,0)][Mac (10,9)]
 		[DllImport(Constants.CoreMediaLibrary)]

--- a/src/CoreMedia/CMSync.cs
+++ b/src/CoreMedia/CMSync.cs
@@ -57,14 +57,7 @@ namespace CoreMedia {
 			}
 		}
 
-#if MONOMAC && !XAMCORE_2_0
-		// avoid breaking change on MonoMac.dll
-		[Obsolete ("The 'CMAudioClockCreate' API is only available on iOS.")]
-		public static CMClock CreateAudioClock (out CMClockError clockError)
-		{
-			throw new NotSupportedException ();
-		}
-#elif !MONOMAC
+#if !MONOMAC
 		// CMAudioClock.h
 		[Mac (10,10)]
 		[DllImport(Constants.CoreMediaLibrary)]

--- a/src/CoreMedia/CMTime.cs
+++ b/src/CoreMedia/CMTime.cs
@@ -28,33 +28,18 @@ namespace CoreMedia {
 		}
 #if !COREBUILD
 
-#if XAMCORE_2_0
-		readonly
-#endif
-		public static CMTime Invalid = new CMTime (0);
+		public readonly static CMTime Invalid = new CMTime (0);
 
 		const Flags kIndefinite = Flags.Valid | Flags.Indefinite;
-#if XAMCORE_2_0
-		readonly
-#endif
-		public static CMTime Indefinite = new CMTime (kIndefinite);
+		public readonly static CMTime Indefinite = new CMTime (kIndefinite);
 
 		const Flags kPositive = Flags.Valid | Flags.PositiveInfinity;
-#if XAMCORE_2_0
-		readonly
-#endif
-		public static CMTime PositiveInfinity = new CMTime (kPositive);
+		public readonly static CMTime PositiveInfinity = new CMTime (kPositive);
 
 		const Flags kNegative = Flags.Valid | Flags.NegativeInfinity;
-#if XAMCORE_2_0
-		readonly
-#endif
-		public static CMTime NegativeInfinity = new CMTime (kNegative);
+		public readonly static CMTime NegativeInfinity = new CMTime (kNegative);
 
-#if XAMCORE_2_0
-		readonly
-#endif
-		public static CMTime Zero = new CMTime (Flags.Valid, 1);
+		public readonly static CMTime Zero = new CMTime (Flags.Valid, 1);
 		
 		public const int MaxTimeScale = 0x7fffffff;
 
@@ -341,15 +326,6 @@ namespace CoreMedia {
 		{
 			return new NSDictionary (CMTimeCopyAsDictionary (this, IntPtr.Zero), true);
 		}
-			
-#if !XAMCORE_2_0
-		[Obsolete ("Use 'ToDictionary' instead.")]
-		public IntPtr AsDictionary {
-			get {
-				return CMTimeCopyAsDictionary (this, IntPtr.Zero);
-			}
-		}
-#endif
 		
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CFStringRef */ IntPtr CMTimeCopyDescription (/* CFAllocatorRef */ IntPtr allocator, CMTime time);
@@ -374,16 +350,6 @@ namespace CoreMedia {
 				throw new ArgumentNullException ("dict");
 			return CMTimeMakeFromDictionary (dict.Handle);
 		}
-
-#if !XAMCORE_2_0
-#if !WATCH
-		[Obsolete ("Use 'FromDictionary (NSDictionary)' instead.")]
-		public static CMTime FromDictionary (IntPtr dict)
-		{
-			return CMTimeMakeFromDictionary (dict);
-		}
-#endif // !WATCH
-#endif	// !XAMCORE_2_0
 #endif // !COREBUILD
 	}
 }

--- a/src/CoreMedia/CoreMedia.cs
+++ b/src/CoreMedia/CoreMedia.cs
@@ -25,13 +25,6 @@ namespace CoreMedia {
 		ClosedCaption = 1668047728, // 'clcp'
 		Subtitle      = 1935832172, // 'sbtl'
 		TimeCode      = 1953325924, // 'tmcd'
-#if !XAMCORE_2_0
-#if !WATCH
-		// not part of the header file anymore
-		[Obsolete ("Use 'Metadata' instead.")]
-		TimedMetadata = 1953326452, // 'tmet'
-#endif // !WATCH
-#endif // !XAMCORE_2_0
 		// note: the 4CC was obsoleted, i.e. Metadata is a new 4CC
 		Metadata      = 0x6D657461, // 'meta'
 	}
@@ -270,7 +263,6 @@ namespace CoreMedia {
 		Hevc             = 0x68766331
 	}
 
-#if XAMCORE_2_0
 	// CMVideoDimensions => int32_t width + int32_t height
 	[Watch (6,0)]
 	public struct CMVideoDimensions {
@@ -283,7 +275,6 @@ namespace CoreMedia {
 			Height = height;
 		}
 	}
-#endif
 
 	// UInt32 enum => CMFormatDescription.h
 	[Watch (6,0)]

--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -161,17 +161,9 @@ namespace CoreMidi {
 	}
 	
 	public class MidiObject
-#if !XAMCORE_2_0
-  #if !COREBUILD
-	: IDisposable, INativeObject
-  #else
-	: INativeObject
-  #endif
-#else
-  #if !COREBUILD
+ #if !COREBUILD
 	: IDisposable
   #endif
-#endif
 	{
 #if !COREBUILD
 		internal const MidiObjectRef InvalidRef = 0;
@@ -280,15 +272,9 @@ namespace CoreMidi {
 			kMIDIPropertyNameConfigurationDictionary = Dlfcn.GetIntPtr (midiLibrary, "kMIDIPropertyNameConfigurationDictionary");
 		}
 	
-#if XAMCORE_2_0
 		public MidiObjectRef Handle {
 			get { return handle; }
 		}
-#else
-		public IntPtr Handle {
-			get { return (IntPtr) handle; }
-		}
-#endif
 
 		internal MidiObjectRef MidiHandle {
 			get { return handle; }
@@ -422,14 +408,6 @@ namespace CoreMidi {
 			return value;
 		}
 
-#if !XAMCORE_2_0
-		[Obsolete ("Use the (int) overload instead.")]
-		public MidiObject (IntPtr handle)
-			: this ((int) handle, true)
-		{
-		}
-#endif
-			
 		public MidiObject (MidiObjectRef handle)
 		: this (handle, true)
 		{
@@ -461,11 +439,7 @@ namespace CoreMidi {
 			GC.SuppressFinalize (this);
 		}
 		
-#if XAMCORE_2_0
 		protected virtual void Dispose (bool disposing)
-#else
-		public virtual void Dispose (bool disposing)
-#endif
 		{
 			DisposeHandle ();
 		}
@@ -568,24 +542,6 @@ namespace CoreMidi {
 		{
 			return Name;
 		}
-
-#if !XAMCORE_2_0
-		[Obsolete ("It is better to use 'CreateVirtualSource (string name, out MidiError statusCode)' to flag errors.")]
-		public MidiEndpoint CreateVirtualSource (string name)
-		{
-			using (var nsstr = new NSString (name)){
-				MidiObjectRef ret;
-				var code = MIDISourceCreate (handle, nsstr.Handle, out ret);
-				if (code != 0){
-					if (code == (int)MidiError.NotPermitted){
-						Console.WriteLine ("Does your Info.plist contain a UIBackgroundModes to contain the key 'audio'?");
-					}
-					return null;
-				}
-				return new MidiEndpoint (ret, true);
-			}			
-		}
-#endif
 
 		public MidiEndpoint CreateVirtualSource (string name, out MidiError statusCode)
 		{
@@ -691,11 +647,7 @@ namespace CoreMidi {
 			}
 		}
 
-#if XAMCORE_2_0
 		protected override void Dispose (bool disposing)
-#else
-		public override void Dispose (bool disposing)
-#endif
 		{
 			SetupChanged = null;
 			ObjectAdded = null;
@@ -965,11 +917,7 @@ namespace CoreMidi {
 				gch.Free ();
 		}
 
-#if XAMCORE_2_0
 		protected override void Dispose (bool disposing)
-#else
-		public override void Dispose (bool disposing)
-#endif
 		{
 			MessageReceived = null;
 			base.Dispose (disposing);
@@ -1169,7 +1117,6 @@ namespace CoreMidi {
 			}
 		}
 
-#if XAMCORE_2_0
 		public bool IsBroadcast {
 			get {
 				return GetInt (kMIDIPropertyIsBroadcast) != 0;
@@ -1178,16 +1125,6 @@ namespace CoreMidi {
 				SetInt (kMIDIPropertyIsBroadcast, value ? 1 : 0);
 			}
 		}
-#else
-		public int IsBroadcast {
-			get {
-				return GetInt (kMIDIPropertyIsBroadcast);
-			}
-			set {
-				SetInt (kMIDIPropertyIsBroadcast, value);
-			}
-		}
-#endif
 
 		public bool IsDrumMachine {
 			get {
@@ -2032,11 +1969,7 @@ namespace CoreMidi {
 			}
 		}
 
-#if XAMCORE_2_0
 		protected override void Dispose (bool disposing)
-#else
-		public override void Dispose (bool disposing)
-#endif
 		{
 			MessageReceived = null;
 			base.Dispose (disposing);
@@ -2152,7 +2085,6 @@ namespace CoreMidi {
 			}
 		}
 
-#if XAMCORE_2_0
 		public bool IsBroadcast {
 			get {
 				return GetInt (kMIDIPropertyIsBroadcast) != 0;
@@ -2161,16 +2093,6 @@ namespace CoreMidi {
 				SetInt (kMIDIPropertyIsBroadcast, value ? 1 : 0);
 			}
 		}
-#else
-		public int IsBroadcast {
-			get {
-				return GetInt (kMIDIPropertyIsBroadcast);
-			}
-			set {
-				SetInt (kMIDIPropertyIsBroadcast, value);
-			}
-		}
-#endif
 
 		public string Manufacturer {
 			get {

--- a/src/CoreMotion/Extras.cs
+++ b/src/CoreMotion/Extras.cs
@@ -6,65 +6,7 @@ using System;
 
 namespace CoreMotion {
 
-#if !XAMCORE_2_0 && !MONOMAC
-	public partial class CMAttitude {
-
-		[Obsolete ("This type is not meant to be created by application code")]
-		public CMAttitude () : base (IntPtr.Zero)
-		{
-			// calling ToString, 'description' selector, would crash the application
-		}
-	}
-
-	public partial class CMDeviceMotion {
-
-		[Obsolete ("This type is not meant to be created by application code")]
-		public CMDeviceMotion () : base (IntPtr.Zero)
-		{
-			// calling ToString, 'description' selector, would crash the application
-		}
-	}
-
-	public partial class CMGyroData {
-
-		[Obsolete ("This type is not meant to be created by application code")]
-		public CMGyroData () : base (IntPtr.Zero)
-		{
-			// calling ToString, 'description' selector, would crash the application
-		}
-	}
-
-	public partial class CMMagnetometerData {
-
-		[Obsolete ("This type is not meant to be created by application code")]
-		public CMMagnetometerData () : base (IntPtr.Zero)
-		{
-			// calling ToString, 'description' selector, would crash the application
-		}
-	}
-
-	public partial class CMLogItem {
-
-		[Obsolete ("This type is not meant to be created by application code")]
-		public CMLogItem () : base (IntPtr.Zero)
-		{
-			// calling ObjC init would crash when calling it's Timestamp property
-		}
-	}
-#endif
-
 	public partial class CMAccelerometerData {
-
-#if !XAMCORE_2_0
-		[Obsolete ("This type is not meant to be created by application code")]
-		public CMAccelerometerData ()
-		{
-			// calling ObjC init would crash when calling it's (base) Timestamp property
-			// or Acceleration property - which is exactly what ToString does (and what
-			// the debugger does since it calls ToString).
-		}
-#endif
-
 		public override string ToString ()
 		{
 			return String.Format ("t={0} {1}", Acceleration.ToString (), Timestamp);

--- a/src/CoreText/Adapter.cs
+++ b/src/CoreText/Adapter.cs
@@ -66,7 +66,6 @@ namespace CoreText {
 			return ((NSNumber) value).Int32Value;
 		}
 
-#if XAMCORE_2_0
 		public static nuint? GetUnsignedIntegerValue (IDictionary<NSObject, NSObject> dictionary, NSObject key)
 		{
 			var value = dictionary [key];
@@ -74,7 +73,6 @@ namespace CoreText {
 				return null;
 			return ((NSNumber) value).NUIntValue;
 		}
-#endif
 
 		public static T[] GetNativeArray<T> (NSDictionary dictionary, NSObject key, Converter<IntPtr, T> converter)
 		{
@@ -156,7 +154,6 @@ namespace CoreText {
 				dictionary.Remove (key);
 		}
 
-#if XAMCORE_2_0
 		public static void SetValue (IDictionary<NSObject, NSObject> dictionary, NSObject key, nuint? value)
 		{
 			if (value.HasValue)
@@ -164,7 +161,6 @@ namespace CoreText {
 			else
 				dictionary.Remove (key);
 		}
-#endif
 
 		public static void SetValue (IDictionary<NSObject, NSObject> dictionary, NSObject key, IEnumerable<string> value)
 		{

--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -227,14 +227,6 @@ namespace CoreText {
 
 		public NSDictionary Dictionary {get; private set;}
 
-#if !XAMCORE_2_0
-		[Advice ("Use 'FeatureGroup' property instead.")]
-		public NSNumber Identifier {
-			get {return (NSNumber) Dictionary [CTFontFeatureKey.Identifier];}
-			set {Adapter.SetValue (Dictionary, CTFontFeatureKey.Identifier, value);}
-		}
-#endif
-
 		public string Name {
 			get {return Adapter.GetStringValue (Dictionary, CTFontFeatureKey.Name);}
 			set {Adapter.SetValue (Dictionary, CTFontFeatureKey.Name, value);}
@@ -376,14 +368,6 @@ namespace CoreText {
 		}
 
 		public NSDictionary Dictionary {get; private set;}
-
-#if !XAMCORE_2_0
-		[Advice ("Use one of descendant classes")]
-		public NSNumber Identifier {
-			get {return (NSNumber) Dictionary [CTFontFeatureSelectorKey.Identifier];}
-			set {Adapter.SetValue (Dictionary, CTFontFeatureSelectorKey.Identifier, value);}
-		}
-#endif
 
 		protected int FeatureWeak {
 			get {
@@ -1367,13 +1351,7 @@ namespace CoreText {
 
 	public class CTFontFeatureSettings {
 
-#if XAMCORE_2_0
-		internal
-#else
-		// It should be internal
-		public
-#endif
-		CTFontFeatureSettings (NSDictionary dictionary)
+		internal CTFontFeatureSettings (NSDictionary dictionary)
 		{
 			if (dictionary == null)
 				throw new ArgumentNullException ("dictionary");
@@ -1382,27 +1360,11 @@ namespace CoreText {
 
 		public NSDictionary Dictionary {get; private set;}
 
-#if !XAMCORE_2_0
-		[Advice ("Use 'FeatureGroup' property instead.")]
-		public NSNumber TypeIdentifier {
-			get {return (NSNumber) Dictionary [CTFontFeatureKey.Identifier];}
-			set {Adapter.SetValue (Dictionary, CTFontFeatureKey.Identifier, value);}
-		}
-#endif
-
 		public FontFeatureGroup FeatureGroup {
 			get {
 				return (FontFeatureGroup) (int) (NSNumber) Dictionary [CTFontFeatureKey.Identifier];
 			}
 		}
-
-#if !XAMCORE_2_0
-		[Advice ("Use 'FeatureWeak' or 'FeatureGroup' instead.")]
-		public NSNumber SelectorIdentifier {
-			get {return (NSNumber) Dictionary [CTFontFeatureSelectorKey.Identifier];}
-			set {Adapter.SetValue (Dictionary, CTFontFeatureSelectorKey.Identifier, value);}
-		}
-#endif
 
 		public int FeatureWeak {
 			get {

--- a/src/CoreText/CTFontDescriptor.cs
+++ b/src/CoreText/CTFontDescriptor.cs
@@ -312,7 +312,6 @@ namespace CoreText {
 			}
 		}
 
-#if XAMCORE_2_0
 		public CTFontManagerScope? RegistrationScope {
 			get {
 				var value = Adapter.GetUnsignedIntegerValue (Dictionary, CTFontDescriptorAttributeKey.RegistrationScope);
@@ -323,13 +322,6 @@ namespace CoreText {
 				value.HasValue ? (nuint?) (ulong) value.Value : null);
 			}
 		}
-#else
-		// TODO: docs mention CTFontManagerScope values, but I don't see any such enumeration.
-		public NSNumber RegistrationScope {
-			get {return (NSNumber) Dictionary [CTFontDescriptorAttributeKey.RegistrationScope];}
-			set {Adapter.SetValue (Dictionary, CTFontDescriptorAttributeKey.RegistrationScope, value);}
-		}
-#endif
 
 		public CTFontPriority? Priority {
 			get {
@@ -457,18 +449,6 @@ namespace CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontDescriptorCreateCopyWithFeature (IntPtr original, IntPtr featureTypeIdentifier, IntPtr featureSelectorIdentifier);
 
-#if !XAMCORE_2_0
-		[Advice ("Use 'WithFeature' with specific selector.")]
-		public CTFontDescriptor WithFeature (NSNumber featureTypeIdentifier, NSNumber featureSelectorIdentifier)
-		{
-			if (featureTypeIdentifier == null)
-				throw new ArgumentNullException ("featureTypeIdentifier");
-			if (featureSelectorIdentifier == null)
-				throw new ArgumentNullException ("featureSelectorIdentifier");
-			return CreateDescriptor (CTFontDescriptorCreateCopyWithFeature (handle, featureTypeIdentifier.Handle, featureSelectorIdentifier.Handle));
-		}
-#endif
-
 		public CTFontDescriptor WithFeature (CTFontFeatureAllTypographicFeatures.Selector featureSelector)
 		{
 			return WithFeature (FontFeatureGroup.AllTypographicFeatures, (int) featureSelector);
@@ -483,14 +463,6 @@ namespace CoreText {
 		{
 			return WithFeature (FontFeatureGroup.CursiveConnection, (int) featureSelector);
 		}
-
-#if !XAMCORE_2_0
-		[Obsolete]
-		public CTFontDescriptor WithFeature (CTFontFeatureLetterCase.Selector featureSelector)
-		{
-			return WithFeature (FontFeatureGroup.LetterCase, (int) featureSelector);
-		}
-#endif
 
 		public CTFontDescriptor WithFeature (CTFontFeatureVerticalSubstitutionConnection.Selector featureSelector)
 		{

--- a/src/CoreText/CTRunDelegate.cs
+++ b/src/CoreText/CTRunDelegate.cs
@@ -57,7 +57,6 @@ namespace CoreText {
 			handle = GCHandle.Alloc (this);
 		}
 
-#if XAMCORE_2_0
 		~CTRunDelegateOperations ()
 		{
 			Dispose (false);
@@ -72,11 +71,6 @@ namespace CoreText {
 		protected virtual void Dispose (bool disposing)
 		{
 		}
-#else
-		public virtual void Dispose ()
-		{
-		}
-#endif
 
 #if XAMCORE_4_0
 		public virtual nfloat GetAscent ()

--- a/src/coreml.cs
+++ b/src/coreml.cs
@@ -7,8 +7,6 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0
-
 using System;
 using ObjCRuntime;
 using CoreFoundation;
@@ -985,4 +983,3 @@ namespace CoreML {
 		bool Write (NSUrl url, [NullAllowed] out NSError error);
 	}
 }
-#endif // XAMCORE_2_0

--- a/src/corenfc.cs
+++ b/src/corenfc.cs
@@ -7,8 +7,6 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0
-
 using System;
 using ObjCRuntime;
 using CoreFoundation;
@@ -937,4 +935,3 @@ namespace CoreNFC {
 		IntPtr Constructor (NFCVasCommandConfiguration[] commandConfigurations, INFCVasReaderSessionDelegate @delegate, [NullAllowed] DispatchQueue queue);
 	}
 }
-#endif

--- a/src/coretelephony.cs
+++ b/src/coretelephony.cs
@@ -26,10 +26,6 @@ namespace CoreTelephony {
 	}
 	
 
-#if !XAMCORE_2_0
-	delegate void CTCarrierEventHandler (CTCarrier call);
-#endif
-
 	[Static]
 	[iOS (7,0)]
 	interface CTRadioAccessTechnology {
@@ -88,11 +84,7 @@ namespace CoreTelephony {
 		[Deprecated (PlatformName.iOS, 12,0, message: "Use 'ServiceSubscriberCellularProvidersDidUpdateNotifier' instead.")]
 		[NullAllowed] // by default this property is null
 		[Export ("subscriberCellularProviderDidUpdateNotifier")]
-#if XAMCORE_2_0
 		Action<CTCarrier> CellularProviderUpdatedEventHandler { get; set; }
-#else
-		CTCarrierEventHandler CellularProviderUpdatedEventHandler { get; set; }
-#endif
 
 		[Deprecated (PlatformName.iOS, 12,0, message: "Use 'ServiceCurrentRadioAccessTechnology' instead.")]
 		[iOS (7,0), Export ("currentRadioAccessTechnology")]
@@ -133,21 +125,13 @@ namespace CoreTelephony {
 		NSObject WeakDelegate { get; set; }
 	}
 
-#if !XAMCORE_2_0
-	delegate void CTCallEventHandler (CTCall call);
-#endif
-
 	[Deprecated (PlatformName.iOS, 10, 0, message: "Replaced by 'CXCallObserver' from 'CallKit'.")]
 	[BaseType (typeof (NSObject))]
 	interface CTCallCenter {
 		[Availability (Deprecated = Platform.iOS_10_0, Message = "Use 'CallKit' instead.")]
 		[NullAllowed] // by default this property is null
 		[Export ("callEventHandler")]
-#if XAMCORE_2_0
 		Action<CTCall> CallEventHandler { get; set; }
-#else
-		CTCallEventHandler CallEventHandler { get; set; }
-#endif
 
 		[Availability (Deprecated = Platform.iOS_10_0, Message = "Use 'CallKit' instead.")]
 		[Export ("currentCalls")]
@@ -209,10 +193,6 @@ namespace CoreTelephony {
 		[NullAllowed]
 		ICTSubscriberDelegate Delegate { get; set; }
 	}
-
-#if !XAMCORE_2_0
-	delegate void SimAuthenticationCallback (NSDictionary dictionary);
-#endif
 
 	[BaseType (typeof (NSObject))]
 	partial interface CTSubscriberInfo {

--- a/src/coretext.cs
+++ b/src/coretext.cs
@@ -13,11 +13,7 @@ using ObjCRuntime;
 
 namespace CoreText {
 
-#if XAMCORE_2_0
 	[Static]
-#else
-	[Partial]
-#endif
 	interface CTFontFeatureKey {
 		[Field ("kCTFontFeatureTypeIdentifierKey")]
 		NSString Identifier { get; }
@@ -32,11 +28,7 @@ namespace CoreText {
 		NSString Selectors { get; }
 	}
 
-#if XAMCORE_2_0
 	[Static]
-#else
-	[Partial]
-#endif
 	interface CTFontFeatureSelectorKey {
 		[Field ("kCTFontFeatureSelectorIdentifierKey")]
 		NSString Identifier { get; }


### PR DESCRIPTION


Backport of #8786.

/cc @rolfbjarne 