### PR TITLE
[tests] Update the MT0051 tests to use newer test helper API.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -928,16 +928,14 @@ public class B : A {}
 		[Test]
 		public void MT0051 ()
 		{
-			if (Directory.Exists ("/Applications/Xcode44.app/Contents/Developer")) {
-				Asserts.ThrowsPattern<TestExecutionException> (() => {
-					ExecutionHelper.Execute (TestTarget.ToolPath, new [] { "-sdkroot", "/Applications/Xcode44.app/Contents/Developer", "-sim", "/tmp/foo" });
-				}, "error MT0051: Xamarin.iOS .* requires Xcode 6.0 or later. The current Xcode version [(]found in /Applications/Xcode44.app/Contents/Developer[)] is 4.*");
-			}
-
-			if (Directory.Exists ("/Applications/Xcode511.app/Contents/Developer")) {
-				Asserts.ThrowsPattern<TestExecutionException> (() => {
-					ExecutionHelper.Execute (TestTarget.ToolPath, new [] { "-sdkroot", "/Applications/Xcode511.app/Contents/Developer", "-sim", "/tmp/foo" });
-				}, "error MT0051: Xamarin.iOS .* requires Xcode 6.0 or later. The current Xcode version [(]found in /Applications/Xcode511.app/Contents/Developer[)] is 6.0");
+			var xcode_path = "/Applications/Xcode511.app/Contents/Developer";
+			if (Directory.Exists (xcode_path)) {
+				using (var mtouch = new MTouchTool ()) {
+					mtouch.CreateTemporaryApp ();
+					mtouch.SdkRoot = xcode_path;
+					mtouch.AssertExecuteFailure (xcode_path);
+					mtouch.AssertErrorPattern (51, $"Xamarin.iOS .* requires Xcode 6.0 or later. The current Xcode version [(]found in {xcode_path}[)] is 5.1.1");
+				}
 			}
 		}
 


### PR DESCRIPTION
And delete the test case about Xcode 4.4, that's a bit old by now.

However, keep the Xcode 5.1.1 test case (which I've confirmed to work by
installing Xcode 5.1.1), since we'll probably want to have the test around for
when we update our min Xcode requirement (which is currently 6.0).