### PR TITLE
[d16-7] [src] Remove Classic code from the FinderSync, FileProvider[UI], ExternalAccessory, EventKit[UI], DeviceCheck, CoreWlan and CoreVideo frameworks.

### DIFF
--- a/src/CoreVideo/CVBuffer.cs
+++ b/src/CoreVideo/CVBuffer.cs
@@ -41,30 +41,6 @@ namespace CoreVideo {
 #endif
 		{
 #if !COREBUILD
-#if !XAMCORE_2_0
-		public static readonly NSString MovieTimeKey;
-		public static readonly NSString TimeValueKey;
-		public static readonly NSString TimeScaleKey;
-		public static readonly NSString PropagatedAttachmentsKey;
-		public static readonly NSString NonPropagatedAttachmentsKey;
-
-		static CVBuffer ()
-		{
-			var hlib = Dlfcn.dlopen (Constants.CoreVideoLibrary, 0);
-			if (hlib == IntPtr.Zero)
-				return;
-			try {
-				MovieTimeKey = Dlfcn.GetStringConstant (hlib, "kCVBufferMovieTimeKey");
-				TimeValueKey = Dlfcn.GetStringConstant (hlib, "kCVBufferTimeValueKey");
-				TimeScaleKey = Dlfcn.GetStringConstant (hlib, "kCVBufferTimeScaleKey");
-				PropagatedAttachmentsKey = Dlfcn.GetStringConstant (hlib, "kCVBufferPropagatedAttachmentsKey");
-				NonPropagatedAttachmentsKey = Dlfcn.GetStringConstant (hlib, "kCVBufferNonPropagatedAttachmentsKey");
-			}
-			finally {
-				Dlfcn.dlclose (hlib);
-			}
-		}
-#endif
 		internal IntPtr handle;
 
 		internal CVBuffer ()
@@ -141,7 +117,7 @@ namespace CoreVideo {
 		extern static /* CFTypeRef */ IntPtr CVBufferGetAttachment (/* CVBufferRef */ IntPtr buffer, /* CFStringRef */ IntPtr key, out CVAttachmentMode attachmentMode);
 
 // FIXME: we need to bring the new API to xamcore
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 		// any CF object can be attached
 		public T GetAttachment<T> (NSString key, out CVAttachmentMode attachmentMode) where T : class, INativeObject
 		{
@@ -166,7 +142,6 @@ namespace CoreVideo {
 			return (NSDictionary) Runtime.GetNSObject (CVBufferGetAttachments (handle, attachmentMode));
 		}
 
-#if XAMCORE_2_0
 		// There is some API that needs a more strongly typed version of a NSDictionary
 		// and there is no easy way to downcast from NSDictionary to NSDictionary<TKey, TValue>
 		public NSDictionary<TKey, TValue> GetAttachments<TKey, TValue> (CVAttachmentMode attachmentMode)
@@ -175,7 +150,6 @@ namespace CoreVideo {
 		{
 			return Runtime.GetNSObject<NSDictionary<TKey, TValue>> (CVBufferGetAttachments (handle, attachmentMode));
 		}
-#endif
 
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static void CVBufferPropagateAttachments (/* CVBufferRef */ IntPtr sourceBuffer, /* CVBufferRef */ IntPtr destinationBuffer);
@@ -191,7 +165,6 @@ namespace CoreVideo {
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static void CVBufferSetAttachment (/* CVBufferRef */ IntPtr buffer, /* CFStringRef */ IntPtr key, /* CFTypeRef */ IntPtr @value, CVAttachmentMode attachmentMode);
 
-#if XAMCORE_2_0
 		public void SetAttachment (NSString key, INativeObject @value, CVAttachmentMode attachmentMode)
 		{
 			if (key == null)
@@ -200,16 +173,6 @@ namespace CoreVideo {
 				throw new ArgumentNullException ("value");
 			CVBufferSetAttachment (handle, key.Handle, @value.Handle, attachmentMode);
 		}
-#else
-		public void SetAttachment (NSString key, NSObject @value, CVAttachmentMode attachmentMode)
-		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
-			if (@value == null)
-				throw new ArgumentNullException ("value");
-			CVBufferSetAttachment (handle, key.Handle, @value.Handle, attachmentMode);
-		}
-#endif
 
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static void CVBufferSetAttachments (/* CVBufferRef */ IntPtr buffer, /* CFDictionaryRef */ IntPtr theAttachments, CVAttachmentMode attachmentMode);

--- a/src/CoreVideo/CVImageBuffer.cs
+++ b/src/CoreVideo/CVImageBuffer.cs
@@ -38,110 +38,6 @@ namespace CoreVideo {
 	[Watch (4,0)]
 	public partial class CVImageBuffer : CVBuffer {
 #if !COREBUILD
-#if !XAMCORE_2_0
-		public static readonly NSString CGColorSpaceKey;
-		public static readonly NSString GammaLevelKey;
-		public static readonly NSString CleanApertureKey;
-		public static readonly NSString PreferredCleanApertureKey;
-		public static readonly NSString CleanApertureWidthKey;
-		public static readonly NSString CleanApertureHeightKey;
-		public static readonly NSString CleanApertureHorizontalOffsetKey;
-		public static readonly NSString CleanApertureVerticalOffsetKey;
-		public static readonly NSString FieldCountKey;
-		public static readonly NSString FieldDetailKey;
-		public static readonly NSString FieldDetailTemporalTopFirst;
-		public static readonly NSString FieldDetailTemporalBottomFirst;
-		public static readonly NSString FieldDetailSpatialFirstLineEarly;
-		public static readonly NSString FieldDetailSpatialFirstLineLate;
-		public static readonly NSString PixelAspectRatioKey;
-		public static readonly NSString PixelAspectRatioHorizontalSpacingKey;
-		public static readonly NSString PixelAspectRatioVerticalSpacingKey;
-		public static readonly NSString DisplayDimensionsKey;
-		public static readonly NSString DisplayWidthKey;
-		public static readonly NSString DisplayHeightKey;
-		public static readonly NSString YCbCrMatrixKey;
-		public static readonly NSString YCbCrMatrix_ITU_R_709_2;
-		public static readonly NSString YCbCrMatrix_ITU_R_601_4;
-		public static readonly NSString YCbCrMatrix_SMPTE_240M_1995;
-
-		public static readonly NSString ChromaSubsamplingKey;
-		public static readonly NSString ChromaSubsampling_420;
-		public static readonly NSString ChromaSubsampling_422;
-		public static readonly NSString ChromaSubsampling_411;
-
-		public static readonly NSString TransferFunctionKey;
-		public static readonly NSString TransferFunction_ITU_R_709_2;
-		public static readonly NSString TransferFunction_SMPTE_240M_1995;
-		public static readonly NSString TransferFunction_UseGamma;
-
-		public static readonly NSString ChromaLocationTopFieldKey;
-		public static readonly NSString ChromaLocationBottomFieldKey;
-		public static readonly NSString ChromaLocation_Left;
-		public static readonly NSString ChromaLocation_Center;
-		public static readonly NSString ChromaLocation_TopLeft;
-		public static readonly NSString ChromaLocation_Top;
-		public static readonly NSString ChromaLocation_BottomLeft;
-		public static readonly NSString ChromaLocation_Bottom;
-		public static readonly NSString ChromaLocation_DV420;
-		public static readonly NSString AlphaChannelIsOpaque;
-
-		static CVImageBuffer ()
-		{
-			var handle = Dlfcn.dlopen (Constants.CoreVideoLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				CGColorSpaceKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferCGColorSpaceKey");
-				GammaLevelKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferGammaLevelKey");
-				CleanApertureKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferCleanApertureKey");
-				PreferredCleanApertureKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferPreferredCleanApertureKey");
-				CleanApertureWidthKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferCleanApertureWidthKey");
-				CleanApertureHeightKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferCleanApertureHeightKey");
-				CleanApertureHorizontalOffsetKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferCleanApertureHorizontalOffsetKey");
-				CleanApertureVerticalOffsetKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferCleanApertureVerticalOffsetKey");
-				FieldCountKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferFieldCountKey");
-				FieldDetailKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferFieldDetailKey");
-				FieldDetailTemporalTopFirst = Dlfcn.GetStringConstant (handle, "kCVImageBufferFieldDetailTemporalTopFirst");
-				FieldDetailTemporalBottomFirst = Dlfcn.GetStringConstant (handle, "kCVImageBufferFieldDetailTemporalBottomFirst");
-				FieldDetailSpatialFirstLineEarly = Dlfcn.GetStringConstant (handle, "kCVImageBufferFieldDetailSpatialFirstLineEarly");
-				FieldDetailSpatialFirstLineLate = Dlfcn.GetStringConstant (handle, "kCVImageBufferFieldDetailSpatialFirstLineLate");
-				PixelAspectRatioKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferPixelAspectRatioKey");
-				PixelAspectRatioHorizontalSpacingKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferPixelAspectRatioHorizontalSpacingKey");
-				PixelAspectRatioVerticalSpacingKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferPixelAspectRatioVerticalSpacingKey");
-				DisplayDimensionsKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferDisplayDimensionsKey");
-				DisplayWidthKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferDisplayWidthKey");
-				DisplayHeightKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferDisplayHeightKey");
-				YCbCrMatrixKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferYCbCrMatrixKey");
-				YCbCrMatrix_ITU_R_709_2 = Dlfcn.GetStringConstant (handle, "kCVImageBufferYCbCrMatrix_ITU_R_709_2");
-				YCbCrMatrix_ITU_R_601_4 = Dlfcn.GetStringConstant (handle, "kCVImageBufferYCbCrMatrix_ITU_R_601_4");
-				YCbCrMatrix_SMPTE_240M_1995 = Dlfcn.GetStringConstant (handle, "kCVImageBufferYCbCrMatrix_SMPTE_240M_1995");
-
-				ChromaSubsamplingKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferChromaSubsamplingKey");
-				ChromaSubsampling_420 = Dlfcn.GetStringConstant (handle, "kCVImageBufferChromaSubsampling_420");
-				ChromaSubsampling_422 = Dlfcn.GetStringConstant (handle, "kCVImageBufferChromaSubsampling_422");
-				ChromaSubsampling_411 = Dlfcn.GetStringConstant (handle, "kCVImageBufferChromaSubsampling_411");
-
-				TransferFunctionKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferTransferFunctionKey");
-				TransferFunction_ITU_R_709_2 = Dlfcn.GetStringConstant (handle, "kCVImageBufferTransferFunction_ITU_R_709_2");
-				TransferFunction_SMPTE_240M_1995 = Dlfcn.GetStringConstant (handle, "kCVImageBufferTransferFunction_SMPTE_240M_1995");
-				TransferFunction_UseGamma = Dlfcn.GetStringConstant (handle, "kCVImageBufferTransferFunction_UseGamma");
-
-				ChromaLocationTopFieldKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferChromaLocationTopFieldKey");
-				ChromaLocationBottomFieldKey = Dlfcn.GetStringConstant (handle, "kCVImageBufferChromaLocationBottomFieldKey");
-				ChromaLocation_Left = Dlfcn.GetStringConstant (handle, "kCVImageBufferChromaLocation_Left");
-				ChromaLocation_Center = Dlfcn.GetStringConstant (handle, "kCVImageBufferChromaLocation_Center");
-				ChromaLocation_TopLeft = Dlfcn.GetStringConstant (handle, "kCVImageBufferChromaLocation_TopLeft");
-				ChromaLocation_Top = Dlfcn.GetStringConstant (handle, "kCVImageBufferChromaLocation_Top");
-				ChromaLocation_BottomLeft = Dlfcn.GetStringConstant (handle, "kCVImageBufferChromaLocation_BottomLeft");
-				ChromaLocation_Bottom = Dlfcn.GetStringConstant (handle, "kCVImageBufferChromaLocation_Bottom");
-				ChromaLocation_DV420 = Dlfcn.GetStringConstant (handle, "kCVImageBufferChromaLocation_DV420");
-				AlphaChannelIsOpaque = Dlfcn.GetStringConstant (handle, "kCVImageBufferAlphaChannelIsOpaque");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
-		}
-#endif
 		internal CVImageBuffer (IntPtr handle) : base (handle)
 		{
 		}
@@ -225,8 +121,6 @@ namespace CoreVideo {
 		}
 #endif
 
-#if XAMCORE_2_0
-
 		[DllImport (Constants.CoreVideoLibrary)]
 		[iOS (11, 0), Mac (10, 13), TV (11, 0), Watch (4, 0)]
 		extern static int CVYCbCrMatrixGetIntegerCodePointForString (IntPtr yCbCrMatrixString);
@@ -289,8 +183,6 @@ namespace CoreVideo {
 			var ret = Runtime.GetNSObject<NSString> (CVTransferFunctionGetStringForIntegerCodePoint (transferFunctionCodePoint));
 			return CVImageBufferTransferFunctionExtensions.GetValue (ret);
 		}
-
-#endif // XAMCORE_2_0
 
 #endif // !COREBUILD
 	}

--- a/src/CoreVideo/CVMetalTextureAttributes.cs
+++ b/src/CoreVideo/CVMetalTextureAttributes.cs
@@ -6,7 +6,7 @@
 // Copyright 2017 Xamarin Inc.
 //
 
-#if XAMCORE_2_0 && !WATCH
+#if !WATCH
 using System;
 using Foundation;
 using Metal;

--- a/src/CoreVideo/CVMetalTextureCache.cs
+++ b/src/CoreVideo/CVMetalTextureCache.cs
@@ -88,7 +88,6 @@ namespace CoreVideo {
 			return null;
 		}
 
-#if XAMCORE_2_0
 		public CVMetalTextureCache (IMTLDevice metalDevice, CVMetalTextureAttributes textureAttributes)
 		{
 			if (metalDevice == null)
@@ -125,7 +124,6 @@ namespace CoreVideo {
 			CVReturn creationErr;
 			return FromDevice (metalDevice, textureAttributes, out creationErr);
 		}
-#endif
 
 		public CVMetalTexture TextureFromImage (CVImageBuffer imageBuffer, MTLPixelFormat format, nint width, nint height, nint planeIndex, out CVReturn errorCode)
 		{

--- a/src/CoreVideo/CVOpenGLESTexture.cs
+++ b/src/CoreVideo/CVOpenGLESTexture.cs
@@ -17,21 +17,12 @@ using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Graphics.ES20;
 
-#if XAMCORE_2_0
 using ObjCRuntime;
 using CoreFoundation;
 using Foundation;
 using OpenGLES;
 
 namespace CoreVideo {
-#else
-using MonoTouch.ObjCRuntime;
-using MonoTouch.CoreFoundation;
-using MonoTouch.Foundation;
-using MonoTouch.OpenGLES;
-
-namespace MonoTouch.CoreVideo {
-#endif
 
 	// CVOpenGLESTexture.h
 	[Deprecated (PlatformName.iOS, 12,0, message: "Use 'CVMetalTexture' instead.")]
@@ -58,12 +49,7 @@ namespace MonoTouch.CoreVideo {
 			GC.SuppressFinalize (this);
 		}
 
-#if XAMCORE_2_0 
-		protected
-#else
-		public
-#endif
-		virtual void Dispose (bool disposing)
+		protected virtual void Dispose (bool disposing)
 		{
 			if (handle != IntPtr.Zero){
 				CFRelease (handle);
@@ -113,14 +99,6 @@ namespace MonoTouch.CoreVideo {
 				return CVOpenGLESTextureIsFlipped (handle);
 			}
 		}
-
-#if !XAMCORE_2_0
-		[Obsolete ("Use GetCleanTexCoords instead")]
-		public void GetCleanTextCoords (out float [] lowerLeft, out float [] lowerRight, out float [] upperRight, out float [] upperLeft)
-		{
-			GetCleanTexCoords (out lowerLeft, out lowerRight, out upperRight, out upperLeft);
-		}
-#endif
 
 		public void GetCleanTexCoords (out float [] lowerLeft, out float [] lowerRight, out float [] upperRight, out float [] upperLeft)
 		{

--- a/src/CoreVideo/CVOpenGLESTextureCache.cs
+++ b/src/CoreVideo/CVOpenGLESTextureCache.cs
@@ -16,21 +16,12 @@ using System.Runtime.InteropServices;
 using OpenTK;
 using OpenTK.Graphics;
 
-#if XAMCORE_2_0
 using ObjCRuntime;
 using CoreFoundation;
 using Foundation;
 using OpenGLES;
 
 namespace CoreVideo {
-#else
-using MonoTouch.ObjCRuntime;
-using MonoTouch.CoreFoundation;
-using MonoTouch.Foundation;
-using MonoTouch.OpenGLES;
-
-namespace MonoTouch.CoreVideo {
-#endif
 
 	// CVOpenGLESTextureCache.h
 	[Deprecated (PlatformName.iOS, 12,0, message: "Use 'CVMetalTextureCache' instead.")]
@@ -53,12 +44,7 @@ namespace MonoTouch.CoreVideo {
 			GC.SuppressFinalize (this);
 		}
 
-#if XAMCORE_2_0
-		protected
-#else
-		public
-#endif
-		virtual void Dispose (bool disposing)
+		protected virtual void Dispose (bool disposing)
 		{
 			if (handle != IntPtr.Zero){
 				CVOpenGLESTexture.CFRelease (handle);

--- a/src/CoreVideo/CVPixelBuffer.cs
+++ b/src/CoreVideo/CVPixelBuffer.cs
@@ -20,60 +20,6 @@ namespace CoreVideo {
 		[DllImport (Constants.CoreVideoLibrary, EntryPoint = "CVPixelBufferGetTypeID")]
 		public extern static /* CFTypeID */ nint GetTypeID ();
 
-#if !XAMCORE_2_0
-		public static readonly NSString PixelFormatTypeKey;
-		public static readonly NSString MemoryAllocatorKey;
-		public static readonly NSString WidthKey;
-		public static readonly NSString HeightKey;
-		public static readonly NSString ExtendedPixelsLeftKey;
-		public static readonly NSString ExtendedPixelsTopKey;
-		public static readonly NSString ExtendedPixelsRightKey;
-		public static readonly NSString ExtendedPixelsBottomKey;
-		public static readonly NSString BytesPerRowAlignmentKey;
-		public static readonly NSString CGBitmapContextCompatibilityKey;
-		public static readonly NSString CGImageCompatibilityKey;
-		public static readonly NSString OpenGLCompatibilityKey;
-		public static readonly NSString IOSurfacePropertiesKey;
-		public static readonly NSString PlaneAlignmentKey;
-#if !MONOMAC || !XAMCORE_2_0
-		public static readonly NSString MetalCompatibilityKey;
-		public static readonly NSString OpenGLESCompatibilityKey;
-#endif
-
-		public static readonly nint CVImageBufferType;
-
-		static CVPixelBuffer ()
-		{
-			var handle = Dlfcn.dlopen (Constants.CoreVideoLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				PixelFormatTypeKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferPixelFormatTypeKey");
-				MemoryAllocatorKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferMemoryAllocatorKey");
-				WidthKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferWidthKey");
-				HeightKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferHeightKey");
-				ExtendedPixelsLeftKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferExtendedPixelsLeftKey");
-				ExtendedPixelsTopKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferExtendedPixelsTopKey");
-				ExtendedPixelsRightKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferExtendedPixelsRightKey");
-				ExtendedPixelsBottomKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferExtendedPixelsBottomKey");
-				BytesPerRowAlignmentKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferBytesPerRowAlignmentKey");
-				CGBitmapContextCompatibilityKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferCGBitmapContextCompatibilityKey");
-				CGImageCompatibilityKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferCGImageCompatibilityKey");
-				OpenGLCompatibilityKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferOpenGLCompatibilityKey");
-				IOSurfacePropertiesKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferIOSurfacePropertiesKey");
-				PlaneAlignmentKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferPlaneAlignmentKey");
-				CVImageBufferType = GetTypeID ();
-				MetalCompatibilityKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferMetalCompatibilityKey");
-#if !MONOMAC
-				OpenGLESCompatibilityKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferOpenGLESCompatibilityKey");
-#endif
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
-		}
-#endif
-
 		internal CVPixelBuffer (IntPtr handle) : base (handle)
 		{
 		}
@@ -101,22 +47,7 @@ namespace CoreVideo {
 		{
 		}
 
-#if !XAMCORE_2_0
-		public CVPixelBuffer (System.Drawing.Size size, CVPixelFormatType pixelFormat)
-			: this (size.Width, size.Height, pixelFormat, (NSDictionary) null)
-		{
-		}
-
-		public CVPixelBuffer (System.Drawing.Size size, CVPixelFormatType pixelFormatType, CVPixelBufferAttributes attributes)
-			: this (size.Width, size.Height, pixelFormatType, attributes == null ? null : attributes.Dictionary)
-		{
-		}
-#endif
-
 		[Advice ("Use constructor with CVPixelBufferAttributes")]
-#if !XAMCORE_2_0
-		public
-#endif
 		CVPixelBuffer (nint width, nint height, CVPixelFormatType pixelFormatType, NSDictionary pixelBufferAttributes)
 		{
 			if (width <= 0)

--- a/src/CoreVideo/CVPixelBufferAttributes.cs
+++ b/src/CoreVideo/CVPixelBufferAttributes.cs
@@ -54,13 +54,6 @@ namespace CoreVideo {
 			Height = height;
 		}
 
-#if !XAMCORE_2_0
-		public CVPixelBufferAttributes (CVPixelFormatType pixelFormatType, System.Drawing.Size size)
-			: this (pixelFormatType, size.Width, size.Height)
-		{
-		}
-#endif
-
 		public CVPixelFormatType? PixelFormatType {
 			set {
 				SetNumberValue (CVPixelBuffer.PixelFormatTypeKey, (uint?)value);
@@ -179,7 +172,7 @@ namespace CoreVideo {
 		}
 
 		// TODO: kCVPixelBufferIOSurfacePropertiesKey
-#if !MONOMAC || !XAMCORE_2_0
+#if !MONOMAC
 		// The presence of the IOSurfacePropertiesKey mandates the allocation via IOSurfaceProperty
 		public bool? AllocateWithIOSurface {
 			set {

--- a/src/CoreVideo/CVPixelBufferIOSurface.cs
+++ b/src/CoreVideo/CVPixelBufferIOSurface.cs
@@ -6,7 +6,7 @@
 // Copyright 2017 Xamarin Inc.
 //
 
-#if XAMCORE_2_0 && !WATCH
+#if !WATCH
 using System;
 using System.Runtime.InteropServices;
 using CoreFoundation;

--- a/src/CoreVideo/CVPixelBufferPool.cs
+++ b/src/CoreVideo/CVPixelBufferPool.cs
@@ -23,25 +23,6 @@ namespace CoreVideo {
 #endif
 		{
 #if !COREBUILD
-#if !XAMCORE_2_0
-		public static readonly NSString MinimumBufferCountKey;
-		public static readonly NSString MaximumBufferAgeKey;
-
-		static CVPixelBufferPool ()
-		{
-			var handle = Dlfcn.dlopen (Constants.CoreVideoLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				MinimumBufferCountKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferPoolMinimumBufferCountKey");
-				MaximumBufferAgeKey = Dlfcn.GetStringConstant (handle, "kCVPixelBufferPoolMaximumBufferAgeKey");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
-		}
-#endif
-
 		IntPtr handle;
 
 		internal CVPixelBufferPool (IntPtr handle)

--- a/src/CoreVideo/CVTime.cs
+++ b/src/CoreVideo/CVTime.cs
@@ -74,21 +74,13 @@ namespace CoreVideo {
 		// CVHostTime.h
 
 		[DllImport (Constants.CoreVideoLibrary, EntryPoint = "CVGetCurrentHostTime")]
-#if XAMCORE_2_0
 		public static extern /* uint64_t */ ulong GetCurrentHostTime ();
-#else
-		public static extern /* uint64_t */ long GetCurrentHostTime ();
-#endif
 
 
 		[DllImport (Constants.CoreVideoLibrary, EntryPoint = "CVGetHostClockFrequency")]
 		public static extern /* double */ double GetHostClockFrequency ();
 
 		[DllImport (Constants.CoreVideoLibrary, EntryPoint = "CVGetHostClockMinimumTimeDelta")]
-#if XAMCORE_2_0
 		public static extern /* uint32_t */ uint GetHostClockMinimumTimeDelta ();
-#else
-		public static extern /* uint32_t */ int GetHostClockMinimumTimeDelta ();
-#endif
 	}
 }

--- a/src/CoreVideo/CoreVideo.cs
+++ b/src/CoreVideo/CoreVideo.cs
@@ -146,11 +146,7 @@ namespace CoreVideo {
 
 	[Flags]
 	[Watch (4,0)]
-#if XAMCORE_2_0
 	public enum CVTimeStampFlags : ulong {
-#else
-	public enum CVTimeStampFlags {
-#endif
 		VideoTimeValid              = (1 << 0),
 		HostTimeValid               = (1 << 1),
 		SMPTETimeValid              = (1 << 2),

--- a/src/CoreWlan/Enums.cs
+++ b/src/CoreWlan/Enums.cs
@@ -138,10 +138,6 @@ namespace CoreWlan {
 		ScanCacheUpdated = 8,
 		VirtualInterfaceStateChanged = 9,
 		RangingReportEvent = 10,
-#if XAMCORE_2_0
 		Unknown = long.MaxValue
-#else
-		Unknown = int.MaxValue
-#endif
 	}
 }

--- a/src/EventKit/EKEnums.cs
+++ b/src/EventKit/EKEnums.cs
@@ -119,19 +119,6 @@ namespace EventKit {
 		ThisEvent, FutureEvents
 	}
 
-	// note: old binding mistakes - they should have been in EventKitUI (not EventKit)
-#if !XAMCORE_2_0
-	// untyped enum -> EKEventViewController.h
-	public enum EKEventViewAction {
-		Done, Responded, Deleted
-	}
-
-	// untyped enum -> EKEventEditViewController.h
-	public enum EKEventEditViewAction {
-		Canceled, Saved, Deleted
-	}
-#endif
-
 	// NSUInteger -> EKTypes.h
 	[Native]
 	[Flags]

--- a/src/EventKit/EventKit.cs
+++ b/src/EventKit/EventKit.cs
@@ -7,8 +7,6 @@
 // Copyright 2012-2014, Xamarin Inc.
 //
 
-#if XAMCORE_2_0 || !MONOMAC
-
 using ObjCRuntime;
 using Foundation;
 using System;
@@ -17,16 +15,13 @@ namespace EventKit {
 
 #if !XAMCORE_4_0
 
-#if XAMCORE_2_0
 	partial class EKRecurrenceRule {
 		public EKDay FirstDayOfTheWeek {
 			get { return (EKDay) (int) _FirstDayOfTheWeek; }
 		}
 	}
-#endif
 
 	partial class EKRecurrenceDayOfWeek {
-#if XAMCORE_2_0
 		public static EKRecurrenceDayOfWeek FromDay (EKDay dayOfTheWeek)
 		{
 			return _FromDay ((int) dayOfTheWeek);
@@ -36,7 +31,7 @@ namespace EventKit {
 		{
 			return _FromDay ((int) dayOfTheWeek, weekNumber);
 		}
-#endif
+
 		public static EKRecurrenceDayOfWeek FromWeekDay (nint dayOfWeek, nint weekNumber)
 		{
 			return FromDay ((EKDay) (int) dayOfWeek, weekNumber);
@@ -44,36 +39,6 @@ namespace EventKit {
 	}
 
 #endif // !XAMCORE_4_0
-
-	partial class EKEventStore {
-#if !MONOMAC && !XAMCORE_2_0
-		[Obsolete ("Replaced by RemoveCalendar")]
-		public bool RemoveCalendarc (EKCalendar calendar, bool commit, out NSError error)
-		{
-			return RemoveCalendar (calendar, commit, out error);
-		}
-#endif
-	}
-
-	partial class EKEvent {
-#if !MONOMAC && !XAMCORE_2_0
-		[Obsolete ("Use BirthdayPersonID")]
-		nint birthdayPersonID {
-			get {
-				return BirthdayPersonID;
-			}
-		}
-#endif
-#if !XAMCORE_2_0
-		// Apple will reject application using the 'recurrenceRule' selector - 
-		// so we can't ship it anymore (e.g. for people not enabling linking)
-		[Obsolete ("Removed in iOS 6.0", true)]
-		public virtual EKRecurrenceRule RecurrenceRule {
-			get { throw new NotSupportedException (); }
-			set { throw new NotSupportedException (); }
-		}
-#endif
-	}
 
 	partial class EKAlarm {
 #if !XAMCORE_4_0
@@ -90,4 +55,3 @@ namespace EventKit {
 #endif
 	}
 }
-#endif // XAMCORE_2_0 || !MONOMAC

--- a/src/EventKitUI/Defs.cs
+++ b/src/EventKitUI/Defs.cs
@@ -25,8 +25,6 @@ namespace EventKitUI {
 		AllCalendars, WritableCalendarsOnly
 	}
 
-	// note: old binding mistake - this should have been in EventKitUI (not EventKit)
-#if XAMCORE_2_0
 	// untyped enum -> EKEventViewController.h
 	// iOS 9 promoted this to an NSInteger - which breaks compatibility
 	[Native]
@@ -40,5 +38,4 @@ namespace EventKitUI {
 	public enum EKEventEditViewAction : long {
 		Canceled, Saved, Deleted
 	}
-#endif
 }

--- a/src/EventKitUI/EKUIBundle.cs
+++ b/src/EventKitUI/EKUIBundle.cs
@@ -7,7 +7,6 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0
 using System;
 using System.Runtime.InteropServices;
 using Foundation;
@@ -27,4 +26,3 @@ namespace EventKitUI {
 		}
 	}
 }
-#endif

--- a/src/corevideo.cs
+++ b/src/corevideo.cs
@@ -7,7 +7,7 @@
 using System;
 using Foundation;
 using ObjCRuntime;
-#if XAMCORE_2_0 && !WATCH
+#if !WATCH
 using Metal;
 #endif
 
@@ -20,7 +20,6 @@ namespace CoreVideo {
 		NSString ThresholdKey { get; }
 	}
 
-#if XAMCORE_2_0
 	[Partial]
 	interface CVBuffer {
 
@@ -407,7 +406,7 @@ namespace CoreVideo {
 		[Field ("kCVPixelBufferPlaneAlignmentKey")]
 		NSString PlaneAlignmentKey { get; }
 
-#if !MONOMAC || !XAMCORE_2_0
+#if !MONOMAC
 		[NoWatch]
 		[Field ("kCVPixelBufferOpenGLESCompatibilityKey")]
 		NSString OpenGLESCompatibilityKey { get; }
@@ -476,5 +475,4 @@ namespace CoreVideo {
 	interface CVMetalTextureAttributes {
 		// Create stub DictionaryContainer class
 	}
-#endif
 }

--- a/src/devicecheck.cs
+++ b/src/devicecheck.cs
@@ -8,7 +8,6 @@
 // Copyright 2019 Microsoft Corporation.
 //
 
-#if XAMCORE_2_0
 using System;
 using ObjCRuntime;
 using Foundation;
@@ -46,4 +45,3 @@ namespace DeviceCheck {
 		void GenerateToken (DCDeviceGenerateTokenCompletionHandler completion);
 	}
 }
-#endif

--- a/src/eventkit.cs
+++ b/src/eventkit.cs
@@ -16,9 +16,7 @@ using ObjCRuntime;
 using Foundation;
 using CoreGraphics;
 using CoreLocation;
-#if XAMCORE_2_0
 using MapKit;
-#endif
 using System;
 #if MONOMAC
 using AppKit;
@@ -29,9 +27,7 @@ using UIKit;
 namespace EventKit {
 
 	[BaseType (typeof (NSObject))]
-#if XAMCORE_2_0 || MONOMAC
 	[Abstract]
-#endif
 	interface EKObject {
 		[Export ("hasChanges")]
 		bool HasChanges { get; }
@@ -172,12 +168,10 @@ namespace EventKit {
 		[Export ("locationWithTitle:"), Static]
 		EKStructuredLocation FromTitle (string title);
 
-#if XAMCORE_2_0
 		[iOS (9,0), Mac(10,11)]
 		[Static]
 		[Export ("locationWithMapItem:")]
 		EKStructuredLocation FromMapItem (MKMapItem mapItem);
-#endif
 	}
 
 	[BaseType (typeof (EKObject))]
@@ -411,22 +405,18 @@ namespace EventKit {
 		[Export ("dayOfWeek:")]
 #if XAMCORE_4_0
 		EKRecurrenceDayOfWeek FromDay (EKWeekday dayOfTheWeek);
-#elif XAMCORE_2_0
+#else
 		[Internal]
 		EKRecurrenceDayOfWeek _FromDay (nint dayOfTheWeek);
-#else
-		EKRecurrenceDayOfWeek FromDay (EKDay dayOfTheWeek);
 #endif
 
 		[Static]
 		[Export ("dayOfWeek:weekNumber:")]
 #if XAMCORE_4_0
 		EKRecurrenceDayOfWeek FromDay (EKWeekday dayOfTheWeek, nint weekNumber);
-#elif XAMCORE_2_0
+#else
 		[Internal]
 		EKRecurrenceDayOfWeek _FromDay (nint dayOfTheWeek, nint weekNumber);
-#else
-		EKRecurrenceDayOfWeek FromDay (EKDay dayOfTheWeek, nint weekNumber);
 #endif
 
 		[Export ("initWithDayOfTheWeek:weekNumber:")]
@@ -455,11 +445,9 @@ namespace EventKit {
 		[Export ("firstDayOfTheWeek")]
 #if XAMCORE_4_0
 		EKWeekday FirstDayOfTheWeek { get; }
-#elif XAMCORE_2_0
+#else
 		[Internal]
 		nint _FirstDayOfTheWeek { get; }
-#else
-		EKDay FirstDayOfTheWeek { get;  }
 #endif
 
 		[NullAllowed]

--- a/src/externalaccessory.cs
+++ b/src/externalaccessory.cs
@@ -225,27 +225,19 @@ namespace ExternalAccessory {
 	[BaseType (typeof (NSObject))]
 	interface EAWiFiUnconfiguredAccessoryBrowserDelegate {
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("accessoryBrowser:didUpdateState:"), EventArgs ("EAWiFiUnconfiguredAccessory")]
 		void DidUpdateState(EAWiFiUnconfiguredAccessoryBrowser browser, EAWiFiUnconfiguredAccessoryBrowserState state);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("accessoryBrowser:didFindUnconfiguredAccessories:"), EventArgs ("EAWiFiUnconfiguredAccessoryBrowser")]
 		void DidFindUnconfiguredAccessories (EAWiFiUnconfiguredAccessoryBrowser browser, NSSet accessories);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("accessoryBrowser:didRemoveUnconfiguredAccessories:"), EventArgs ("EAWiFiUnconfiguredAccessoryBrowser")]
 		void DidRemoveUnconfiguredAccessories (EAWiFiUnconfiguredAccessoryBrowser browser, NSSet accessories);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("accessoryBrowser:didFinishConfiguringAccessory:withStatus:"), EventArgs ("EAWiFiUnconfiguredAccessoryDidFinish")]
 		void DidFinishConfiguringAccessory (EAWiFiUnconfiguredAccessoryBrowser browser, EAWiFiUnconfiguredAccessory accessory, EAWiFiUnconfiguredAccessoryConfigurationStatus status);
 	}

--- a/src/fileprovider.cs
+++ b/src/fileprovider.cs
@@ -9,8 +9,6 @@
 // Copyright 2019 Microsoft Corporation
 //
 
-#if XAMCORE_2_0
-
 using System;
 using ObjCRuntime;
 using CoreGraphics;
@@ -820,4 +818,3 @@ namespace FileProvider {
 		bool PathExtensionHidden { [Bind ("isPathExtensionHidden")] get; }
 	}
 }
-#endif

--- a/src/fileproviderui.cs
+++ b/src/fileproviderui.cs
@@ -7,8 +7,6 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0
-
 using System;
 using ObjCRuntime;
 using Foundation;
@@ -69,4 +67,3 @@ namespace FileProviderUI {
 		void Prepare (string actionIdentifier, NSString [] itemIdentifiers);
 	}
 }
-#endif

--- a/src/findersync.cs
+++ b/src/findersync.cs
@@ -3,7 +3,6 @@ using Foundation;
 using ObjCRuntime;
 using AppKit;
 
-#if XAMCORE_2_0
 namespace FinderSync {
 	delegate void GetValuesCompletionHandler (NSDictionary<NSString, NSObject> values, NSError error);
 
@@ -107,4 +106,3 @@ namespace FinderSync {
 	{
 	}
 }
-#endif


### PR DESCRIPTION


Backport of #8793.

/cc @rolfbjarne 