### PR TITLE
[d16-7] [src] Remove Classic code from the GameController, GameKit, GameplayKit, GLKit, HealthKit, iAd, IdentityLookup[UI], ImageIO, ImageKit, Intents[UI] and IOSurface frameworks.

### DIFF
--- a/src/GLKit/Defs.cs
+++ b/src/GLKit/Defs.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using System.Runtime.InteropServices;
 using Foundation;
@@ -146,5 +146,3 @@ namespace GLKit {
 #endif
 	}
 }
-#endif
-

--- a/src/GLKit/GLKMesh.cs
+++ b/src/GLKit/GLKMesh.cs
@@ -1,7 +1,5 @@
 // Copyright 2015 Xamarin Inc.
 
-#if XAMCORE_2_0 || !MONOMAC
-
 using Foundation;
 using ModelIO;
 
@@ -18,5 +16,3 @@ namespace GLKit {
 		}
 	}
 }
-
-#endif

--- a/src/GLKit/GLTextureLoader.cs
+++ b/src/GLKit/GLTextureLoader.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using System.Runtime.InteropServices;
 using Foundation;
@@ -203,4 +203,3 @@ namespace GLKit {
 		}
 	}
 }
-#endif

--- a/src/GameKit/GKScore.cs
+++ b/src/GameKit/GKScore.cs
@@ -63,11 +63,6 @@ namespace GameKit {
 				Handle = InitWithCategory (categoryOrIdentifier);
 #endif
 		}
-
-#if !XAMCORE_2_0
-		[Obsolete ("Use Date property")]
-		NSDate date { get { return Date; }}
-#endif
 	}
 }
 

--- a/src/GameKit/GameKit2.cs
+++ b/src/GameKit/GameKit2.cs
@@ -27,73 +27,8 @@ namespace GameKit {
 		public GKSession Session { get; private set; }
 	}
 
-#if !XAMCORE_2_0
-	public partial class GKVoiceChatService {
-		public bool StartVoiceChat (string participantID, out NSError error)
-		{
-			unsafe {
-				IntPtr errhandle;
-				IntPtr ptrtohandle = (IntPtr) (&errhandle);
-
-				var ret = StartVoiceChat (participantID, ptrtohandle);
-				if (errhandle != IntPtr.Zero)
-					error = (NSError) Runtime.GetNSObject (errhandle);
-				else
-					error = null;
-				return ret;
-			}
-		}
-
-		public bool AcceptCall (int callId, out NSError error)
-		{
-			unsafe {
-				IntPtr errhandle;
-				IntPtr ptrtohandle = (IntPtr) (&errhandle);
-
-				var ret = AcceptCall (callId, ptrtohandle);
-				if (errhandle != IntPtr.Zero)
-					error = (NSError) Runtime.GetNSObject (errhandle);
-				else
-					error = null;
-				return ret;
-			}
-		}
-	}
-#endif
-
 #if !TVOS && !WATCH
 	public partial class GKSession {
-#if !XAMCORE_2_0
-		public bool SendData (NSData data, string [] peers, GKSendDataMode mode, out NSError error)
-		{
-			unsafe {
-				IntPtr errhandle;
-				IntPtr ptrtohandle = (IntPtr) (&errhandle);
-
-				var ret = SendData (data, peers, mode, ptrtohandle);
-				if (errhandle != IntPtr.Zero)
-					error = (NSError) Runtime.GetNSObject (errhandle);
-				else
-					error = null;
-				return ret;
-			}
-		}
-
-		public bool SendDataToAllPeers (NSData data, GKSendDataMode mode, out NSError error)
-		{
-			unsafe {
-				IntPtr errhandle;
-				IntPtr ptrtohandle = (IntPtr) (&errhandle);
-
-				var ret = SendDataToAllPeers (data, mode, ptrtohandle);
-				if (errhandle != IntPtr.Zero)
-					error = (NSError) Runtime.GetNSObject (errhandle);
-				else
-					error = null;
-				return ret;
-			}
-		}
-#endif
 		[Register ("MonoTouch_GKSession_ReceivedObject")]
 		internal class ReceiverObject : NSObject {
 			internal EventHandler<GKDataReceivedEventArgs> receiver;
@@ -257,27 +192,8 @@ namespace GameKit {
 		public NSError Error { get; private set; }
 	}
 #endif
-	
-#if !XAMCORE_2_0
-	public partial class GKPlayer {
-		// mistake, non-static
-		public NSString DidChangeNotificationName {
-			get {
-				return DidChangeNotificationNameNotification;
-			}
-		}
-	}
-#endif
 
 	public partial class GKVoiceChat {
-
-#if !XAMCORE_2_0
-		[Obsolete ("Use 'PlayerStateUpdateHandler' property.")]
-		public virtual void SetPlayerStateUpdateHandler (GKPlayerStateUpdateHandler handler)
-		{
-			PlayerStateUpdateHandler = handler;
-		}
-#endif
 
 #if !XAMCORE_3_0
 		[Obsolete ("Use 'SetMute (bool, string)' method.")]
@@ -304,20 +220,6 @@ namespace GameKit {
 		}
 	}
 
-#if !XAMCORE_2_0
-	public partial class GKLeaderboardViewController {
-
-		[Obsolete ("Apple never shipped the `initWithTimeScope:playerScope:` selector. Use the default constructor.")]
-		public GKLeaderboardViewController (GKLeaderboardTimeScope timeScope, GKLeaderboardPlayerScope playerScope) : 
-			base (NSObjectFlag.Empty)
-		{
-			// we can't set `playerScope` with the existing API and
-			// setting `timeScope` does not work at this stage either so...
-			throw new NotSupportedException ();
-		}
-	}
-#endif
-
 	public partial class GKChallenge {
 
 		public override string ToString ()
@@ -334,35 +236,5 @@ namespace GameKit {
 			return SendData (data, players, mode, out error);
 		}
 #endif
-
-#if !XAMCORE_2_0
-		[Obsolete ("Use 'SendDataToAllPlayers'.")]
-		public virtual bool SendDataToAllPlayer (NSData data, GKMatchSendDataMode mode, out NSError error)
-		{
-			return SendDataToAllPlayers (data, mode, out error);
-		}
-
-#if MONOMAC
-		// never been released with XI
-		[Obsolete ("Use 'SendDataToAllPlayers' that takes out NSError.")]
-		public bool SendDataToAllPlayers (NSData data, GKMatchSendDataMode mode, IntPtr ptrToNSErrorHandle)
-		{
-			NSError error = new NSError (ptrToNSErrorHandle);
-			return SendDataToAllPlayers (data, mode, out error);
-		}
-#endif
-#endif
-
 	}
-
-#if !XAMCORE_2_0
-	public partial class GKScore {
-		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'LeaderboardIdentifier' instead.")]
-		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'LeaderboardIdentifier' instead.")]
-		public string Category {
-			get { return category; }
-			set { category = value; }
-		}
-	}
-#endif
 }

--- a/src/GameplayKit/GKBehavior.cs
+++ b/src/GameplayKit/GKBehavior.cs
@@ -6,7 +6,7 @@
 //
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using Foundation;
 
@@ -23,4 +23,3 @@ namespace GameplayKit {
 		}
 	}
 }
-#endif

--- a/src/GameplayKit/GKComponentSystem.cs
+++ b/src/GameplayKit/GKComponentSystem.cs
@@ -6,7 +6,7 @@
 //
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
-#if XAMCORE_2_0 // GKComponentSystem is a generic type, which we only support in Unified (for now at least)
+
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -28,4 +28,3 @@ namespace GameplayKit {
 		}
 	}
 }
-#endif

--- a/src/GameplayKit/GKCompositeBehavior.cs
+++ b/src/GameplayKit/GKCompositeBehavior.cs
@@ -7,7 +7,6 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 using Foundation;
 
@@ -24,4 +23,3 @@ namespace GameplayKit {
 		}
 	}
 }
-#endif

--- a/src/GameplayKit/GKEntity.cs
+++ b/src/GameplayKit/GKEntity.cs
@@ -6,7 +6,7 @@
 //
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -25,4 +25,3 @@ namespace GameplayKit {
 		}
 	}
 }
-#endif

--- a/src/GameplayKit/GKGridGraph.cs
+++ b/src/GameplayKit/GKGridGraph.cs
@@ -7,7 +7,6 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 using ObjCRuntime;
 using Vector2i = global::OpenTK.Vector2i;
@@ -27,4 +26,3 @@ namespace GameplayKit {
 		}
 	}
 }
-#endif

--- a/src/GameplayKit/GKObstacleGraph.cs
+++ b/src/GameplayKit/GKObstacleGraph.cs
@@ -7,8 +7,6 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 || !MONOMAC
-
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -26,7 +24,6 @@ namespace GameplayKit {
 		}
 	}
 
-#if XAMCORE_2_0
 	[iOS (10,0), TV (10,0), Mac (10,12)]
 	[Register ("GKObstacleGraph", SkipRegistration = true)]
 	public partial class GKObstacleGraph<NodeType> : GKObstacleGraph where NodeType : GKGraphNode2D {
@@ -54,6 +51,4 @@ namespace GameplayKit {
 			return NSArray.ArrayFromHandle<NodeType> (_GetNodes (obstacle));
 		}
 	}
-#endif
 }
-#endif

--- a/src/GameplayKit/GKPath.cs
+++ b/src/GameplayKit/GKPath.cs
@@ -6,7 +6,7 @@
 //
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -99,4 +99,3 @@ namespace GameplayKit {
 		}
 	}
 }
-#endif

--- a/src/GameplayKit/GKPolygonObstacle.cs
+++ b/src/GameplayKit/GKPolygonObstacle.cs
@@ -6,7 +6,7 @@
 //
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -71,4 +71,3 @@ namespace GameplayKit {
 		}
 	}
 }
-#endif

--- a/src/GameplayKit/GKPrimitives.cs
+++ b/src/GameplayKit/GKPrimitives.cs
@@ -7,8 +7,6 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 || !MONOMAC
-
 using System;
 using System.Runtime.InteropServices;
 using ObjCRuntime;
@@ -51,4 +49,3 @@ namespace GameplayKit {
 		}
 	}
 }
-#endif

--- a/src/GameplayKit/GKState.cs
+++ b/src/GameplayKit/GKState.cs
@@ -6,7 +6,7 @@
 //
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -52,4 +52,3 @@ namespace GameplayKit {
 		}
 	}
 }
-#endif

--- a/src/GameplayKit/GKStateMachine.cs
+++ b/src/GameplayKit/GKStateMachine.cs
@@ -6,7 +6,7 @@
 //
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -45,4 +45,3 @@ namespace GameplayKit {
 		}
 	}
 }
-#endif

--- a/src/GameplayKit/NSArray_GameplayKit.cs
+++ b/src/GameplayKit/NSArray_GameplayKit.cs
@@ -7,7 +7,6 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -31,4 +30,3 @@ namespace GameplayKit {
 		}
 	}
 }
-#endif

--- a/src/IOSurface/IOSurface.cs
+++ b/src/IOSurface/IOSurface.cs
@@ -22,7 +22,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-#if XAMCORE_2_0
+
 using System;
 using System.Runtime.InteropServices;
 using CoreFoundation;
@@ -101,4 +101,3 @@ namespace IOSurface {
 #endif
 	}
 }
-#endif

--- a/src/ImageIO/CGImageDestination.cs
+++ b/src/ImageIO/CGImageDestination.cs
@@ -35,93 +35,6 @@ using CoreGraphics;
 
 namespace ImageIO {
 
-#if !XAMCORE_2_0
-	public partial class CGImageDestinationOptions {
-
-		public float? LossyCompressionQuality { get; set; }
-		public CGColor DestinationBackgroundColor { get; set; }
-
-		// new in iOS 7 and 10.8
-		[iOS (7,0)]
-		public CGImageMetadata Metadata { get; set; }
-
-		[iOS (7,0)]
-		public bool MergeMetadata { get; set; }
-
-		[iOS (7,0)]
-		public bool ShouldExcludeXMP { get; set; }
-
-		[iOS (7,0)]
-		public int? Orientation { get; set; }
-
-		[iOS (7,0)]
-		public DateTime? DateTime { get; set; }
-
-		[Mac (10, 10)]
-		[iOS (8, 0)]
-		public int? ImageMaxPixelSize { get; set; }
-
-		[Mac (10, 10)]
-		[iOS (8, 0)]
-		public bool EmbedThumbnail { get; set; }
-
-		[Mac (10, 10)]
-		[iOS (8, 0)]
-		public bool ShouldExcludeGPS { get; set; }
-
-		[iOS (9,3)][Mac (10,12)]
-		public bool OptimizeColorForSharing { get; set; }
-
-		internal NSMutableDictionary ToDictionary ()
-		{
-			var dict = new NSMutableDictionary ();
-
-			if (LossyCompressionQuality.HasValue)
-				dict.LowlevelSetObject (new NSNumber (LossyCompressionQuality.Value), kLossyCompressionQuality);
-			if (DestinationBackgroundColor != null)
-				dict.LowlevelSetObject (DestinationBackgroundColor.Handle, kBackgroundColor);
-
-			// new in iOS 7 and 10.8
-			if (Metadata != null) {
-				dict.LowlevelSetObject (Metadata.Handle, kMetadata);
-				// default are false
-				if (MergeMetadata)
-					dict.LowlevelSetObject (CFBoolean.TrueHandle, kMergeMetadata);
-				if (ShouldExcludeXMP)
-					dict.LowlevelSetObject (CFBoolean.TrueHandle, kShouldExcludeXMP);
-			} else {
-				// DateTime is exclusive of metadata (which includes its own)
-				if (DateTime.HasValue)
-					dict.LowlevelSetObject ((NSDate) DateTime, kDateTime);
-			}
-
-			if (Orientation.HasValue) {
-				using (var n = new NSNumber (Orientation.Value))
-					dict.LowlevelSetObject (n.Handle, kOrientation);
-			}
-
-			// new in iOS 8 and 10.10 
-			if (ImageMaxPixelSize.HasValue && (kImageMaxPixelSize != IntPtr.Zero)) {
-				using (var n = new NSNumber (ImageMaxPixelSize.Value))
-					dict.LowlevelSetObject (n.Handle, kOrientation);
-			}
-
-			// new in iOS 8 and 10.10 - default is false
-			if (EmbedThumbnail && (kEmbedThumbnail != IntPtr.Zero))
-				dict.LowlevelSetObject (CFBoolean.TrueHandle, kEmbedThumbnail);
-
-			// new in iOS 8 and 10.10 - default is false
-			if (ShouldExcludeGPS && (kShouldExcludeGPS != IntPtr.Zero))
-				dict.LowlevelSetObject (CFBoolean.TrueHandle, kShouldExcludeGPS);
-
-			if (OptimizeColorForSharing && (kOptimizeColorForSharing != IntPtr.Zero))
-				dict.LowlevelSetObject (CFBoolean.TrueHandle, kOptimizeColorForSharing);
-
-			return dict;
-		}
-	}
-
-#else
 	public partial class CGImageDestinationOptions
 	{
 		CGColor destinationBackgroundColor;
@@ -190,7 +103,6 @@ namespace ImageIO {
 			return dict;
 		}
 	}
-#endif
 
 	public partial class CGImageAuxiliaryDataInfo {
 
@@ -286,18 +198,7 @@ namespace ImageIO {
 			/* CFMutableDataRef __nonnull */ IntPtr data, /* CFStringRef __nonnull */ IntPtr stringType, 
 			/* size_t */ nint count, /* CFDictionaryRef __nullable */ IntPtr options);
 
-		// binding mistake -> NSMutableData, not NSData
-		// naming mistake -> it's not From since it will write into (not read from) 'data'
-#if XAMCORE_2_0
 		public static CGImageDestination Create (NSMutableData data, string typeIdentifier, int imageCount, CGImageDestinationOptions options = null)
-#else
-		public static CGImageDestination FromData (NSData data, string typeIdentifier, int imageCount)
-		{
-			return FromData (data, typeIdentifier, imageCount, null);
-		}
-
-		public static CGImageDestination FromData (NSData data, string typeIdentifier, int imageCount, CGImageDestinationOptions options)
-#endif
 		{
 			if (data == null)
 				throw new ArgumentNullException ("data");
@@ -319,22 +220,7 @@ namespace ImageIO {
 			/* CFURLRef __nonnull */ IntPtr url, /* CFStringRef __nonnull */ IntPtr stringType,
 			/* size_t */ nint count, /* CFDictionaryRef __nullable */ IntPtr options);
 
-		// naming mistake -> it's not From since it will write into (not read from) 'url'
-#if XAMCORE_2_0
-		//
-		// Dropped the CGImageDestinationOption parameter, as it turns out that for *creation* operations
-		// it was never supported to begin with (it is expected to be null).   The CGImageDestinationOption
-		// is actually just used for AddImage methods
-		//
 		public static CGImageDestination Create (NSUrl url, string typeIdentifier, int imageCount)
-#else
-		public static CGImageDestination FromUrl (NSUrl url, string typeIdentifier, int imageCount)
-		{
-			return FromUrl (url, typeIdentifier, imageCount, null);
-		}
-		
-		public static CGImageDestination FromUrl (NSUrl url, string typeIdentifier, int imageCount, CGImageDestinationOptions options)
-#endif
 		{
 			if (url == null)
 				throw new ArgumentNullException ("url");
@@ -469,11 +355,7 @@ namespace ImageIO {
 		}
 
 		[iOS (7,0)]
-#if XAMCORE_2_0
 		public bool CopyImageSource (CGImageSource image, CGCopyImageSourceOptions options, out NSError error)
-#else
-		public bool CopyImageSource (CGImageSource image, CGImageDestinationOptions options, out NSError error)
-#endif
 		{
 			NSDictionary o = null;
 			if (options != null)

--- a/src/ImageIO/CGImageSource.cs
+++ b/src/ImageIO/CGImageSource.cs
@@ -348,13 +348,6 @@ namespace ImageIO {
 			/* CGDataProviderRef __nonnull */ IntPtr dataProvider,
 			[MarshalAs (UnmanagedType.I1)] bool final);
 
-#if !XAMCORE_2_0
-		[Obsolete ("Use 'UpdateDataProvider(CGDataProvider,bool)'.")]
-		public void UpdateDataProvider (CGDataProvider provider)
-		{
-			UpdateDataProvider (provider, true);
-		}
-#endif
 		public void UpdateDataProvider (CGDataProvider provider, bool final)
 		{
 			if (provider == null)

--- a/src/Intents/INBillTypeResolutionResult.cs
+++ b/src/Intents/INBillTypeResolutionResult.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/Intents/INCallRecord.cs
+++ b/src/Intents/INCallRecord.cs
@@ -7,7 +7,6 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -24,4 +23,3 @@ namespace Intents {
 		}
 	}
 }
-#endif

--- a/src/Intents/INCallRecordTypeResolutionResult.cs
+++ b/src/Intents/INCallRecordTypeResolutionResult.cs
@@ -7,7 +7,6 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -44,4 +43,3 @@ namespace Intents {
 		}
 	}
 }
-#endif

--- a/src/Intents/INCarAirCirculationModeResolutionResult.cs
+++ b/src/Intents/INCarAirCirculationModeResolutionResult.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/Intents/INCarAudioSourceResolutionResult.cs
+++ b/src/Intents/INCarAudioSourceResolutionResult.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/Intents/INCarDefrosterResolutionResult.cs
+++ b/src/Intents/INCarDefrosterResolutionResult.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/Intents/INCarSeatResolutionResult.cs
+++ b/src/Intents/INCarSeatResolutionResult.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/Intents/INCarSignalOptionsResolutionResult.cs
+++ b/src/Intents/INCarSignalOptionsResolutionResult.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/Intents/INCompat.cs
+++ b/src/Intents/INCompat.cs
@@ -1,6 +1,6 @@
 // Compatibility stubs
 
-#if XAMCORE_2_0 && IOS
+#if IOS
 
 using System;
 using Foundation;

--- a/src/Intents/INGetCarLockStatusIntentResponse.cs
+++ b/src/Intents/INGetCarLockStatusIntentResponse.cs
@@ -6,7 +6,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && (IOS || TVOS)
+#if IOS || TVOS
 
 using Foundation;
 using Intents;

--- a/src/Intents/INGetCarPowerLevelStatusIntentResponse.cs
+++ b/src/Intents/INGetCarPowerLevelStatusIntentResponse.cs
@@ -6,7 +6,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && (IOS || TVOS)
+#if IOS || TVOS
 
 using Foundation;
 using Intents;

--- a/src/Intents/INIntentResolutionResult.cs
+++ b/src/Intents/INIntentResolutionResult.cs
@@ -7,7 +7,6 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -54,4 +53,3 @@ namespace Intents {
 #endif
 	}
 }
-#endif // XAMCORE_2_0

--- a/src/Intents/INInteraction.cs
+++ b/src/Intents/INInteraction.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/Intents/INMessageAttributeOptionsResolutionResult.cs
+++ b/src/Intents/INMessageAttributeOptionsResolutionResult.cs
@@ -7,7 +7,6 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -44,4 +43,3 @@ namespace Intents {
 		}
 	}
 }
-#endif

--- a/src/Intents/INMessageAttributeResolutionResult.cs
+++ b/src/Intents/INMessageAttributeResolutionResult.cs
@@ -7,7 +7,6 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -44,4 +43,3 @@ namespace Intents {
 		}
 	}
 }
-#endif

--- a/src/Intents/INPaymentStatusResolutionResult.cs
+++ b/src/Intents/INPaymentStatusResolutionResult.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/Intents/INPlayMediaIntentResponse.cs
+++ b/src/Intents/INPlayMediaIntentResponse.cs
@@ -7,7 +7,7 @@
 // Copyright 2018 Microsoft Corporation.
 //
 
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/Intents/INPriceRange.cs
+++ b/src/Intents/INPriceRange.cs
@@ -7,7 +7,7 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && IOS
+#if IOS
 using System;
 using Foundation;
 
@@ -28,4 +28,4 @@ namespace Intents {
 		}
 	}
 }
-#endif // XAMCORE_2_0 && IOS
+#endif // IOS

--- a/src/Intents/INRadioTypeResolutionResult.cs
+++ b/src/Intents/INRadioTypeResolutionResult.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/Intents/INRelativeReferenceResolutionResult.cs
+++ b/src/Intents/INRelativeReferenceResolutionResult.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/Intents/INRelativeSettingResolutionResult.cs
+++ b/src/Intents/INRelativeSettingResolutionResult.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/Intents/INRideOption.cs
+++ b/src/Intents/INRideOption.cs
@@ -1,4 +1,4 @@
-#if XAMCORE_2_0 && (IOS || TVOS)
+#if IOS || TVOS
 
 using Foundation;
 using Intents;

--- a/src/Intents/INSaveProfileInCarIntent.cs
+++ b/src/Intents/INSaveProfileInCarIntent.cs
@@ -7,7 +7,7 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && IOS
+#if IOS
 
 using Foundation;
 using Intents;

--- a/src/Intents/INSearchCallHistoryIntent.cs
+++ b/src/Intents/INSearchCallHistoryIntent.cs
@@ -7,7 +7,6 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -20,4 +19,3 @@ namespace Intents {
 		}
 	}
 }
-#endif

--- a/src/Intents/INSetCarLockStatusIntent.cs
+++ b/src/Intents/INSetCarLockStatusIntent.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && (IOS || TVOS)
+#if IOS || TVOS
 
 using Foundation;
 using Intents;

--- a/src/Intents/INSetClimateSettingsInCarIntent.cs
+++ b/src/Intents/INSetClimateSettingsInCarIntent.cs
@@ -1,4 +1,4 @@
-#if XAMCORE_2_0 && IOS
+#if IOS
 
 using Foundation;
 using Intents;

--- a/src/Intents/INSetDefrosterSettingsInCarIntent.cs
+++ b/src/Intents/INSetDefrosterSettingsInCarIntent.cs
@@ -1,4 +1,4 @@
-#if XAMCORE_2_0 && IOS
+#if IOS
 
 using Foundation;
 using Intents;

--- a/src/Intents/INSetProfileInCarIntent.cs
+++ b/src/Intents/INSetProfileInCarIntent.cs
@@ -1,4 +1,4 @@
-#if XAMCORE_2_0 && IOS
+#if IOS
 
 using Foundation;
 using Intents;

--- a/src/Intents/INSetSeatSettingsInCarIntent.cs
+++ b/src/Intents/INSetSeatSettingsInCarIntent.cs
@@ -1,4 +1,4 @@
-#if XAMCORE_2_0 && IOS
+#if IOS
 
 using Foundation;
 using Intents;

--- a/src/Intents/INSpeakableString.cs
+++ b/src/Intents/INSpeakableString.cs
@@ -7,7 +7,6 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -30,4 +29,3 @@ namespace Intents {
 		}
 	}
 }
-#endif

--- a/src/Intents/INStartWorkoutIntent.cs
+++ b/src/Intents/INStartWorkoutIntent.cs
@@ -1,4 +1,4 @@
-#if XAMCORE_2_0 && IOS
+#if IOS
 
 using Foundation;
 using Intents;

--- a/src/Intents/INWorkoutGoalUnitTypeResolutionResult.cs
+++ b/src/Intents/INWorkoutGoalUnitTypeResolutionResult.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/Intents/INWorkoutLocationTypeResolutionResult.cs
+++ b/src/Intents/INWorkoutLocationTypeResolutionResult.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/gamecontroller.cs
+++ b/src/gamecontroller.cs
@@ -299,10 +299,6 @@ namespace GameController {
 		GCExtendedGamepadSnapshotDataVersion DataVersion { get; }
 	}
 
-#if !XAMCORE_2_0
-	delegate void GCControllerPausedHandler (GCController controller);
-#endif
-
 	[iOS (7,0), Mac (10,9)]
 	[BaseType (typeof (NSObject))]
 	partial interface GCController {
@@ -313,11 +309,7 @@ namespace GameController {
 
 		[NullAllowed]
 		[Export ("controllerPausedHandler", ArgumentSemantic.Copy)]
-#if XAMCORE_2_0
 		Action<GCController> ControllerPausedHandler { get; set; }
-#else
-		GCControllerPausedHandler ControllerPausedHandler { get; set; }
-#endif
 
 		[NullAllowed]
 		[Export ("vendorName", ArgumentSemantic.Copy)]

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -25,9 +25,6 @@ using NSViewController = Foundation.NSObject;
 
 namespace GameKit {
 
-#if !XAMCORE_2_0
-	delegate void GKNotificationHandler ([NullAllowed] NSError error);
-#endif
 	delegate void GKFriendsHandler      (string [] friends, NSError error);
 	delegate void GKPlayersHandler      (GKPlayer [] players, NSError error);
 	delegate void GKLeaderboardsHandler (GKLeaderboard [] leaderboards, NSError error);
@@ -150,21 +147,13 @@ namespace GameKit {
 		GKVoiceChatClient Client { get; set; }
 
 		[Export ("startVoiceChatWithParticipantID:error:")]
-#if XAMCORE_2_0
 		bool StartVoiceChat (string participantID, out NSError error);
-#else
-		bool StartVoiceChat (string participantID, IntPtr ns_error_out);
-#endif
 		
 		[Export ("stopVoiceChatWithParticipantID:")]
 		void StopVoiceChat (string participantID);
 
 		[Export ("acceptCallID:error:")]
-#if XAMCORE_2_0
 		bool AcceptCall (nint callID, out NSError error);
-#else
-		bool AcceptCall (nint callID, IntPtr ns_error_out);
-#endif
 
 		[Export ("denyCallID:")]
 		void DenyCall (nint callId);
@@ -243,20 +232,12 @@ namespace GameKit {
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Export ("sendData:toPeers:withDataMode:error:")]
-#if XAMCORE_2_0
 		bool SendData (NSData data, string [] peers, GKSendDataMode mode, out NSError error);
-#else
-		bool SendData (NSData data, string [] peers, GKSendDataMode mode, IntPtr ns_error_out);
-#endif
 
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Export ("sendDataToAllPeers:withDataMode:error:")]
-#if XAMCORE_2_0
 		bool SendDataToAllPeers (NSData data, GKSendDataMode mode, out NSError error);
-#else
-		bool SendDataToAllPeers (NSData data, GKSendDataMode mode, IntPtr ns_error_out);
-#endif
 
 		// // SEL = -receiveData:fromPeer:inSession:context:
 		[Export ("setDataReceiveHandler:withContext:")][Internal]
@@ -269,11 +250,7 @@ namespace GameKit {
 		void CancelConnect (string peerID);
 
 		[Export ("acceptConnectionFromPeer:error:")]
-#if XAMCORE_2_0
 		bool AcceptConnection (string peerID, out NSError error);
-#else
-		bool AcceptConnection (string peerID, IntPtr error_out);
-#endif
 		
 		[Export ("denyConnectionFromPeer:")]
 		void DenyConnection (string peerID);
@@ -348,11 +325,7 @@ namespace GameKit {
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'SetDefaultLeaderboard' on 'GKLocalPlayer' instead.")]
 		[Export ("setDefaultLeaderboard:withCompletionHandler:")]
 		[Async]
-#if XAMCORE_2_0
 		void SetDefaultLeaderboard ([NullAllowed] string leaderboardIdentifier, [NullAllowed] Action<NSError> notificationHandler);
-#else
-		void SetDefaultLeaderboard ([NullAllowed] string leaderboardIdentifier, [NullAllowed] GKNotificationHandler notificationHandler);
-#endif
 
 		[Export ("groupIdentifier", ArgumentSemantic.Retain)]
 		string GroupIdentifier { get; [NotImplemented] set; }
@@ -535,23 +508,10 @@ namespace GameKit {
 		[Export ("initWithLeaderboardIdentifier:")]
 		IntPtr InitWithLeaderboardIdentifier (string identifier);
 
-#if !XAMCORE_2_0
-		[NoWatch]
-		// [Deprecated (PlatformName.iOS, 8, 0, message : "Use 'Player' instead.")] - Unlike rest of deprecations we are just ripping out due to poor naming
-		// [Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'Player' instead.")] - Unlike rest of deprecations we are just ripping out due to poor naming
-		[Export ("playerID", ArgumentSemantic.Retain)]
-		string Player { get;  }
-
-		[NullAllowed]
-		[iOS (8,0)][Mac (10,10)]
-		[Export ("player", ArgumentSemantic.Retain)]
-		GKPlayer GamePlayer { get; }
-#else
 		[NullAllowed]
 		[iOS (8,0)][Mac (10,10)]
 		[Export ("player", ArgumentSemantic.Retain)]
 		GKPlayer Player { get; }
-#endif
 
 		[Export ("rank", ArgumentSemantic.Assign)]
 		nint Rank { get;  }
@@ -571,12 +531,7 @@ namespace GameKit {
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'LeaderboardIdentifier' instead.")]
 		[NullAllowed] // by default this property is null
 		[Export ("category", ArgumentSemantic.Copy)]
-#if XAMCORE_2_0
 		string Category { get; set;  }
-#else
-		[Obsolete ("Use the 'Category' property instead.")]
-		string category { get; set;  }
-#endif
 
 		[NoWatch]
 		[NoTV]
@@ -584,11 +539,7 @@ namespace GameKit {
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'ReportScores' instead.")]
 		[Export ("reportScoreWithCompletionHandler:")]
 		[Async]
-#if XAMCORE_2_0
 		void ReportScore ([NullAllowed] Action<NSError> errorHandler);
-#else
-		void ReportScore ([NullAllowed] GKNotificationHandler errorHandler);
-#endif
 
 		[Export ("context", ArgumentSemantic.Assign)]
 		ulong Context { get; set; }
@@ -649,9 +600,7 @@ namespace GameKit {
 	[Protocol]
 	[NoTV]
 	interface GKLeaderboardViewControllerDelegate {
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("leaderboardViewControllerDidFinish:")]
 		void DidFinish (GKLeaderboardViewController viewController);
 	}
@@ -721,11 +670,7 @@ namespace GameKit {
 		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Set the 'AuthenticationHandler' instead.")]
 		[Export ("authenticateWithCompletionHandler:")]
 		[Async]
-#if XAMCORE_2_0
 		void Authenticate ([NullAllowed] Action<NSError> handler);
-#else
-		void Authenticate ([NullAllowed] GKNotificationHandler handler);
-#endif
 
 		[iOS (10,0)][Mac (10,12)]
 		[Async]
@@ -982,15 +927,6 @@ namespace GameKit {
 		[Export ("xamarin:selector:removed:"), EventArgs ("GKPlayerError")]
 		void ConnectionFailed (GKMatch match, string playerId, NSError error);
 #endif
-#elif !XAMCORE_2_0
-		// but Apple now reject applications using this selector
-		// it's not easy to remove from the bindings because it's a delegate, with events and *EventArgs
-		// so we fake a selector (that Apple won't check) and let the generator do it's job
-		// note: not worth throwing an exception using a [PreSnippet] since the code already throws a 
-		//       You_Should_Not_Call_base_In_This_Method (so it would not be generated)
-		[Obsolete ("It will never be called.")]
-		[Export ("xamarin:selector:removed:"), EventArgs ("GKPlayerError")]
-		void ConnectionFailed (GKMatch match, string playerId, NSError error);
 #endif
 
 		[Export ("match:didFailWithError:"), EventArgs ("GKError")]
@@ -1185,11 +1121,7 @@ namespace GameKit {
 
 		[Export ("addPlayersToMatch:matchRequest:completionHandler:")]
 		[Async]
-#if XAMCORE_2_0
 		void AddPlayers (GKMatch toMatch, GKMatchRequest matchRequest, [NullAllowed] Action<NSError> completionHandler);
-#else
-		void AddPlayers (GKMatch toMatch, GKMatchRequest matchRequest, [NullAllowed] GKNotificationHandler completionHandler);
-#endif
 
 		[Export ("cancel")]
 		void Cancel ();
@@ -1387,11 +1319,7 @@ namespace GameKit {
 		[Static]
 		[Export ("resetAchievementsWithCompletionHandler:")]
 		[Async]
-#if XAMCORE_2_0
 		void ResetAchivements ([NullAllowed] Action<NSError> completionHandler);
-#else
-		void ResetAchivements ([NullAllowed] GKNotificationHandler completionHandler);
-#endif
 
 		[Wrap ("this ((string) null!)")]
 		IntPtr Constructor ();
@@ -1408,17 +1336,11 @@ namespace GameKit {
 
 		[Export ("reportAchievementWithCompletionHandler:")]
 		[Async]
-#if XAMCORE_2_0
 		[NoWatch]
 		[NoTV]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use ReportAchievements '(GKAchievement[] achievements, Action<NSError> completionHandler)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use ReportAchievements '(GKAchievement[] achievements, Action<NSError> completionHandler)' instead.")]
 		void ReportAchievement ([NullAllowed] Action<NSError> completionHandler);
-#else
-		[Deprecated (PlatformName.iOS, 7, 0, message : "Use ReportAchievements '(GKAchievement[] achievements, GKNotificationHandler completionHandler)' instead.")]
-		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use ReportAchievements '(GKAchievement[] achievements, GKNotificationHandler completionHandler)' instead.")]
-		void ReportAchievement ([NullAllowed] GKNotificationHandler completionHandler);
-#endif
 
 		[Export ("showsCompletionBanner", ArgumentSemantic.Assign)]
 		bool ShowsCompletionBanner { get; set;  }
@@ -1426,11 +1348,7 @@ namespace GameKit {
 		[Static]
 		[Export ("reportAchievements:withCompletionHandler:")]
 		[Async]
-#if XAMCORE_2_0
 		void ReportAchievements (GKAchievement[] achievements, [NullAllowed] Action<NSError> completionHandler);
-#else
-		void ReportAchievements (GKAchievement[] achievements, [NullAllowed] GKNotificationHandler completionHandler);
-#endif
 
 		[NoTV]
 		[NoWatch]
@@ -1454,11 +1372,6 @@ namespace GameKit {
 		[Export ("playerID", ArgumentSemantic.Copy)]
 		string PlayerID { 
 			get;
-#if !XAMCORE_2_0
-			// binding bug - it should not have been exposed (and Apple now rejects it, desk #63237)
-			// using [NotImplemented] makes generator emit a throw *and* does not use the selector!
-			[NotImplemented] set;
-#endif
 		}
 #endif
 
@@ -1582,9 +1495,7 @@ namespace GameKit {
 	[Protocol]
 	[NoTV]
 	interface GKAchievementViewControllerDelegate {
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("achievementViewControllerDidFinish:")]
 		void DidFinish (GKAchievementViewController viewController);
 	}
@@ -1668,13 +1579,8 @@ namespace GameKit {
 		[Export ("addRecipientsWithPlayerIDs:")]
 		void AddRecipientsFromPlayerIDs (string [] playerIDs);
 
-#if XAMCORE_2_0
 		[Export ("setMessage:")]
 		void SetMessage ([NullAllowed] string message);
-#else
-		[Export ("message")]
-		string Message { set; }
-#endif
 	}
 
 	[NoWatch]
@@ -1736,15 +1642,7 @@ namespace GameKit {
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKLocalPlayer.RegisterListener' with an object that implements 'IGKTurnBasedEventListener'.")]
 	[Watch (3,0)]
 	interface GKTurnBasedEventHandlerDelegate {
-#if !XAMCORE_2_0
-		[Export ("handleInviteFromGameCenterDoNotUse:")]
-		[Obsolete ("Use HandleInviteFromGameCenter(NSString[]).")]
-		void HandleInviteFromGameCenter (GKPlayer [] playersToInvite);
-#endif
-
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("handleInviteFromGameCenter:")]
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
@@ -1760,7 +1658,7 @@ namespace GameKit {
 		[Export ("handleMatchEnded:")]
 		void HandleMatchEnded (GKTurnBasedMatch match);
 
-#if (XAMCORE_2_0 && !MONOMAC) || XAMCORE_4_0
+#if !MONOMAC || XAMCORE_4_0
 		[Abstract]
 #endif
 		[Export ("handleTurnEventForMatch:didBecomeActive:")]
@@ -1830,11 +1728,7 @@ namespace GameKit {
 
 		[Export ("removeWithCompletionHandler:")]
 		[Async]
-#if XAMCORE_2_0
 		void Remove (Action<NSError> onCompletion);
-#else
-		void Remove (GKNotificationHandler onCompletion);
-#endif
 
 		[Export ("loadMatchDataWithCompletionHandler:")]
 		[Async]
@@ -1845,38 +1739,22 @@ namespace GameKit {
 		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'EndTurn' instead.")]
 		[Export ("endTurnWithNextParticipant:matchData:completionHandler:")]
 		[Async]
-#if XAMCORE_2_0
 		void EndTurnWithNextParticipant (GKTurnBasedParticipant nextParticipant, NSData matchData, [NullAllowed] Action<NSError> noCompletion);
-#else
-		void EndTurnWithNextParticipant (GKTurnBasedParticipant nextParticipant, NSData matchData, [NullAllowed] GKNotificationHandler noCompletion);
-#endif
 
 		[NoTV]
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'ParticipantQuitInTurn (GKTurnBasedMatchOutcome, GKTurnBasedParticipant[], double, NSData, Action<NSError>)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'ParticipantQuitInTurn (GKTurnBasedMatchOutcome, GKTurnBasedParticipant[], double, NSData, Action<NSError>)' instead.")]
 		[Export ("participantQuitInTurnWithOutcome:nextParticipant:matchData:completionHandler:")]
 		[Async]
-#if XAMCORE_2_0
 		void ParticipantQuitInTurn (GKTurnBasedMatchOutcome matchOutcome, GKTurnBasedParticipant nextParticipant, NSData matchData, [NullAllowed] Action<NSError> onCompletion);
-#else
-		void ParticipantQuitInTurn (GKTurnBasedMatchOutcome matchOutcome, GKTurnBasedParticipant nextParticipant, NSData matchData, [NullAllowed] GKNotificationHandler onCompletion);
-#endif
 
 		[Export ("participantQuitOutOfTurnWithOutcome:withCompletionHandler:")]
 		[Async]
-#if XAMCORE_2_0
 		void ParticipantQuitOutOfTurn (GKTurnBasedMatchOutcome matchOutcome, [NullAllowed] Action<NSError> onCompletion);
-#else
-		void ParticipantQuitOutOfTurn (GKTurnBasedMatchOutcome matchOutcome, [NullAllowed] GKNotificationHandler onCompletion);
-#endif
 
 		[Export ("endMatchInTurnWithMatchData:completionHandler:")]
 		[Async]
-#if XAMCORE_2_0
 		void EndMatchInTurn (NSData matchData, [NullAllowed] Action<NSError> onCompletion);
-#else
-		void EndMatchInTurn (NSData matchData, [NullAllowed] GKNotificationHandler onCompletion);
-#endif
 
 		[Static]
 		[Export ("loadMatchWithID:withCompletionHandler:")]
@@ -2146,9 +2024,7 @@ namespace GameKit {
 	[Protocol]
 	interface GKGameCenterControllerDelegate
 	{
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("gameCenterViewControllerDidFinish:")]
 		void Finished (GKGameCenterViewController controller);
 	}

--- a/src/gameplaykit.cs
+++ b/src/gameplaykit.cs
@@ -6,7 +6,7 @@
 //
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using System.ComponentModel;
 using ObjCRuntime;
@@ -235,7 +235,6 @@ namespace GameplayKit {
 		void WillRemoveFromEntity ();
 	}
 
-#if XAMCORE_2_0 // GKComponentSystem is a generic type, which we only support in Unified (for now at least)
 	[iOS (9,0), Mac (10,11)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // We have a manual default ctor.
@@ -283,7 +282,6 @@ namespace GameplayKit {
 		[Wrap ("Class.Lookup (GetClassForGenericArgument (index))")]
 		Type GetTypeForGenericArgument (nuint index);
 	}
-#endif // XAMCORE_2_0
 
 	[iOS (10,0), TV (10,0), Mac (10,12)]
 	[BaseType (typeof (GKBehavior))]
@@ -355,11 +353,8 @@ namespace GameplayKit {
 		IntPtr Constructor (NSObject attribute);
 
 		[Export ("initWithExamples:actions:attributes:")]
-#if XAMCORE_2_0
 		IntPtr Constructor (NSArray<NSObject> [] examples, NSObject [] actions, NSObject [] attributes);
-#else
-		IntPtr Constructor (NSArray [] examples, NSObject [] actions, NSObject [] attributes);
-#endif
+
 		[Export ("findActionForAnswers:")]
 		[return: NullAllowed]
 		NSObject FindAction (NSDictionary<NSObject, NSObject> answers);
@@ -708,7 +703,6 @@ namespace GameplayKit {
 		Type GetTypeForGenericArgument (nuint index);
 	}
 
-#if XAMCORE_2_0
 	[iOS (10,0), TV (10,0), Mac (10,12)]
 	[BaseType (typeof (GKGraph))]
 	interface GKMeshGraph<NodeType> where NodeType : GKGraphNode2D {
@@ -773,7 +767,6 @@ namespace GameplayKit {
 		[Wrap ("Class.Lookup (GetClassForGenericArgument (index))")]
 		Type GetTypeForGenericArgument (nuint index);
 	}
-#endif
 
 	[iOS (9,0), Mac (10,11)]
 	[BaseType (typeof (NSObject))]
@@ -856,10 +849,6 @@ namespace GameplayKit {
 		Vector2i GridPosition { 
 			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 			get;
-#if !XAMCORE_2_0
-			// classic expose the xamarin_simd__void_objc_msgSend[Super]_Vector2i so it's a breaking change not to include the attribute
-			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-#endif
 #if !XAMCORE_4_0
 			[NotImplemented]
 			set; 
@@ -1727,7 +1716,6 @@ namespace GameplayKit {
 		}
 	}
 
-#if XAMCORE_2_0
 	[iOS (10,0), TV (10,0), Mac (10,12)]
 	[BaseType (typeof (NSObject))]
 	interface GKOctree <ElementType> where ElementType : NSObject {
@@ -1792,7 +1780,6 @@ namespace GameplayKit {
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		ElementType [] GetElements (Vector2 rectMin, Vector2 rectMax);
 	}
-#endif
 
 	[iOS (10,0), TV (10,0), Mac (10,12)]
 	[BaseType (typeof (GKComponent))]
@@ -1996,4 +1983,3 @@ namespace GameplayKit {
 #endif
 	}
 }
-#endif

--- a/src/glkit.cs
+++ b/src/glkit.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -691,4 +691,3 @@ namespace GLKit {
 	}
 #endif
 }
-#endif

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -73,12 +73,9 @@ namespace HealthKit {
 	}
 
 	delegate void HKAnchoredObjectResultHandler2 (HKAnchoredObjectQuery query, HKSample[] results, nuint newAnchor, NSError error);
-#if XAMCORE_2_0
+
 	[Obsolete ("Use HKAnchoredObjectResultHandler2 instead")]
 	delegate void HKAnchoredObjectResultHandler (HKAnchoredObjectQuery query, HKSampleType[] results, nuint newAnchor, NSError error);
-#else
-	delegate void HKAnchoredObjectResultHandler (HKAnchoredObjectQuery query, NSObject[] results, nuint newAnchor, NSError error);
-#endif
 
 	delegate void HKAnchoredObjectUpdateHandler (HKAnchoredObjectQuery query, HKSample[] addedObjects, HKDeletedObject[] deletedObjects, HKQueryAnchor newAnchor, NSError error);
 
@@ -91,9 +88,7 @@ namespace HealthKit {
 	interface HKAnchoredObjectQuery {
 
 		[NoWatch]
-#if XAMCORE_2_0
 		[Obsolete ("Use the overload that takes HKAnchoredObjectResultHandler2 instead")]
-#endif
 		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0)]
 		[Export ("initWithType:predicate:anchor:limit:completionHandler:")]
 		IntPtr Constructor (HKSampleType type, [NullAllowed] NSPredicate predicate, nuint anchor, nuint limit, HKAnchoredObjectResultHandler completion);
@@ -1040,9 +1035,7 @@ namespace HealthKit {
 	[iOS (8,0)]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKSampleType
 	[BaseType (typeof (HKObjectType))]
-#if XAMCORE_2_0
 	[Abstract] // The HKSampleType class is an abstract subclass of the HKObjectType class, used to represent data samples. Never instantiate an HKSampleType object directly. Instead, you should always work with one of its concrete subclasses [...]
-#endif
 	interface HKSampleType {
 		[iOS (13,0), Watch (6,0)]
 		[Export ("isMaximumDurationRestricted")]
@@ -1097,12 +1090,7 @@ namespace HealthKit {
 		bool IsCompatible (HKUnit unit);
 	}
 
-#if XAMCORE_2_0
 	delegate void HKObserverQueryUpdateHandler (HKObserverQuery query, [BlockCallback] Action completion, NSError error);
-#else
-	delegate void HKObserverQueryCompletionHandler ();
-	delegate void HKObserverQueryUpdateHandler (HKObserverQuery query, [BlockCallback] HKObserverQueryCompletionHandler completion, NSError error);
-#endif
 
 	[Watch (2,0)]
 	[iOS (8,0)]

--- a/src/iad.cs
+++ b/src/iad.cs
@@ -172,39 +172,23 @@ namespace iAd {
 	[Obsoleted (PlatformName.iOS, 12,0)] // header removed in xcode10 beta5
 	partial interface IAdPreroll {
 
-#if XAMCORE_2_0
 		[Internal]
-#else
-		[EditorBrowsable (EditorBrowsableState.Advanced)] // this is not the one we want to be seen (compat only)
-#endif
 		[iOS (7,0), Static, Export ("preparePrerollAds")]
 		void PreparePrerollAds ();
 
 		[iOS (7,0), Export ("playPrerollAdWithCompletionHandler:")]
-#if XAMCORE_2_0
 		void PlayPrerollAd (Action<NSError> completionHandler);
-#else
-		void PlayPrerollAd (PlayPrerollAdCompletionHandler completionHandler);
-#endif
 
 		[iOS (8,0), Export ("cancelPreroll")]
 		void CancelPreroll ();
 	}
-
-#if !XAMCORE_2_0
-	delegate void PlayPrerollAdCompletionHandler (NSError error);
-#endif
 
 	[Deprecated (PlatformName.iOS, 10, 0)]
 	[Category (allowStaticMembers: true)] // Classic isn't internal so we need this
 	[BaseType (typeof (UIViewController))]
 	partial interface IAdAdditions {
 
-#if XAMCORE_2_0
 		[Internal]
-#else
-		[EditorBrowsable (EditorBrowsableState.Advanced)] // this is not the one we want to be seen (compat only)
-#endif
 		[iOS (7,0), Static, Export ("prepareInterstitialAds")]
 		void PrepareInterstitialAds ();
 
@@ -280,11 +264,7 @@ namespace iAd {
 	interface iAdPreroll_AVPlayerViewController {
 		[iOS (8,0)]
 		[Static, Export ("preparePrerollAds")]
-#if XAMCORE_2_0
 		[Internal]
-#else
-		[EditorBrowsable (EditorBrowsableState.Advanced)] // this is not the one we want to be seen (compat only)
-#endif
 		void PreparePrerollAds ();
 
 		[iOS (8,0)]

--- a/src/identitylookup.cs
+++ b/src/identitylookup.cs
@@ -8,7 +8,6 @@
 // Copyright 2019 Microsoft Corporation.
 //
 
-#if XAMCORE_2_0
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -219,4 +218,3 @@ namespace IdentityLookup {
 		bool IsEqualTo (ILMessageCommunication communication);
 	}
 }
-#endif

--- a/src/identitylookupui.cs
+++ b/src/identitylookupui.cs
@@ -7,7 +7,6 @@
 // Copyright 2018-2019 Microsoft Corporation.
 //
 
-#if XAMCORE_2_0
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -40,4 +39,3 @@ namespace IdentityLookupUI {
 		ILClassificationResponse GetClassificationResponse (ILClassificationRequest request);
 	}
 }
-#endif

--- a/src/imageio.cs
+++ b/src/imageio.cs
@@ -2090,55 +2090,6 @@ namespace ImageIO {
 		IntPtr kCGImageMetadataEnumerateRecursively { get; }
 	}
 
-#if !XAMCORE_2_0
-	[Partial]
-	interface CGImageDestinationOptions {
-		[Internal][Field ("kCGImageDestinationLossyCompressionQuality")]
-		IntPtr kLossyCompressionQuality { get; }
-
-		[Internal][Field ("kCGImageDestinationBackgroundColor")]
-		IntPtr kBackgroundColor { get; }
-
-		[iOS (7,0)]
-		[Internal][Field ("kCGImageDestinationDateTime")]
-		IntPtr kDateTime { get; }
-
-		[iOS (7,0)]
-		[Internal][Field ("kCGImageDestinationMergeMetadata")]
-		IntPtr kMergeMetadata { get; }
-
-		[iOS (7,0)]
-		[Internal][Field ("kCGImageDestinationMetadata")]
-		IntPtr kMetadata { get; }
-
-		[iOS (7,0)]
-		[Internal][Field ("kCGImageDestinationOrientation")]
-		IntPtr kOrientation { get; }
-
-		[iOS (7,0)]
-		[Internal][Field ("kCGImageMetadataShouldExcludeXMP")]
-		IntPtr kShouldExcludeXMP { get; }
-
-		[iOS (8,0)][Mac (10,10)]
-		[Internal][Field ("kCGImageDestinationImageMaxPixelSize")]
-		IntPtr kImageMaxPixelSize { get; }
-
-		[iOS (8,0)][Mac (10,10)]
-		[Internal][Field ("kCGImageDestinationEmbedThumbnail")]
-		IntPtr kEmbedThumbnail { get; }
-
-		[iOS (8,0)][Mac (10,10)]
-		[Internal][Field ("kCGImageMetadataShouldExcludeGPS")]
-		IntPtr kShouldExcludeGPS { get; }
-
-		[iOS (9,3)][Mac (10,12)]
-		[TV (9,2)]
-		[Watch (2,3)]
-		[Internal][Field ("kCGImageDestinationOptimizeColorForSharing")]
-		IntPtr kOptimizeColorForSharing { get; }
-	}
-#else
-
 	// Defined in CGImageProperties.cs in CoreGraphics
 	interface CGImagePropertiesTiff { }
 	interface CGImagePropertiesExif { }
@@ -2308,7 +2259,6 @@ namespace ImageIO {
 		[Internal][Field ("kCGImageDestinationOrientation")]
 		IntPtr kOrientation { get; }
 	}
-#endif
 
 	[Mac (10, 13), iOS (11,0), TV (11,0), Watch (4,0)]
 	enum CGImageAuxiliaryDataType {

--- a/src/imagekit.cs
+++ b/src/imagekit.cs
@@ -292,11 +292,7 @@ namespace ImageKit {
 		// just turns ugly). So rename this for new-style assemblies to ProvideFilterUIView.
 		[Abstract]
 		[Export ("provideViewForUIConfiguration:excludedKeys:")]
-#if XAMCORE_2_0
 		IKFilterUIView ProvideFilterUIView (NSDictionary configurationOptions, [NullAllowed] NSArray excludedKeys);
-#else
-		IKFilterUIView GetFilterUIView (NSDictionary configurationOptions, [NullAllowed] NSArray excludedKeys);
-#endif
 
 		//UIConfiguration keys for NSDictionary
 		[Field ("IKUISizeFlavor")]
@@ -560,11 +556,7 @@ namespace ImageKit {
 
 		[Abstract]
 		[Export ("imageBrowser:itemAtIndex:")]
-#if XAMCORE_2_0
 		IIKImageBrowserItem GetItem (IKImageBrowserView aBrowser, nint index);
-#else
-		IKImageBrowserItem GetItem (IKImageBrowserView aBrowser, nint index);
-#endif
 
 		[Export ("imageBrowser:removeItemsAtIndexes:")]
 		void RemoveItems (IKImageBrowserView aBrowser, NSIndexSet indexes);

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -7,8 +7,6 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 // The Intents framework uses generics which is only supported in Unified
-
 using System;
 using System.ComponentModel;
 using CoreGraphics;
@@ -12828,4 +12826,3 @@ namespace Intents {
 		INIntent GetIntent ();
 	}
 }
-#endif // XAMCORE_2_0

--- a/src/intentsui.cs
+++ b/src/intentsui.cs
@@ -7,8 +7,6 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 // The IntentsUI framework relies on Intents which is only available in Unified
-
 using System;
 using CoreGraphics;
 using Foundation;
@@ -216,5 +214,3 @@ namespace IntentsUI {
 		void PresentEditVoiceShortcut (INUIEditVoiceShortcutViewController editVoiceShortcutViewController, INUIAddVoiceShortcutButton addVoiceShortcutButton);
 	}
 }
-
-#endif


### PR DESCRIPTION


Backport of #8795.

/cc @rolfbjarne 