### PR TITLE
[d16-7] [src] Remove Classic code from the JavaScriptCore, MapKit, MediaLibrary, MediaToolbox, Metal, MetalKit, MetalPerformanceShaders, MobileCoreServices, ModelIO, MultipeerConnectivity, NetworkExtension and NotificationCenter frameworks.

### DIFF
--- a/src/JavaScriptCore/Enums.cs
+++ b/src/JavaScriptCore/Enums.cs
@@ -9,7 +9,6 @@
 using System;
 
 namespace JavaScriptCore {
-#if !MONOMAC || XAMCORE_2_0
 	// untyped enum -> JSValueRef.h
 	public enum JSType {
 		Undefined,
@@ -37,5 +36,4 @@ namespace JavaScriptCore {
 		None = 0,
 		NoAutomaticPrototype = 1 << 1
 	}
-#endif
 }

--- a/src/JavaScriptCore/Extensions.cs
+++ b/src/JavaScriptCore/Extensions.cs
@@ -11,7 +11,6 @@ using Foundation;
 
 namespace JavaScriptCore {
 
-#if !MONOMAC || XAMCORE_2_0
 	public partial class JSContext {
 		
 		public JSValue this[NSObject key] {
@@ -44,5 +43,4 @@ namespace JavaScriptCore {
 			set { _SetObject (value, key); }
 		}
 	}
-#endif
 }

--- a/src/MapKit/MKEnums.cs
+++ b/src/MapKit/MKEnums.cs
@@ -7,7 +7,7 @@
 // Copyright 2009 Novell, Inc.
 // Copyright 2014-2016 Xamarin Inc.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using System.Runtime.InteropServices;
 using CoreGraphics;
@@ -290,5 +290,3 @@ namespace MapKit {
 
 #endif
 }
-
-#endif

--- a/src/MapKit/MKFeatureDisplayPriority.cs
+++ b/src/MapKit/MKFeatureDisplayPriority.cs
@@ -1,4 +1,3 @@
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 using ObjCRuntime;
 
@@ -12,5 +11,3 @@ namespace MapKit {
 		public const float DefaultLow = 250f;
 	}
 }
-
-#endif

--- a/src/MapKit/MKGeodesicPolyline.cs
+++ b/src/MapKit/MKGeodesicPolyline.cs
@@ -25,7 +25,6 @@
 //
 
 #if !WATCH
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 using System.Threading.Tasks;
 using System.Threading;
@@ -61,5 +60,4 @@ namespace MapKit {
 		}
 	}
 }
-#endif
 #endif // !WATCH

--- a/src/MapKit/MKLocalSearch.cs
+++ b/src/MapKit/MKLocalSearch.cs
@@ -26,7 +26,6 @@
 #pragma warning disable 414
 
 #if !WATCH // doesn't show up in watch headers
-#if XAMCORE_2_0 || !MONOMAC
 
 using System;
 using System.Threading.Tasks;
@@ -61,5 +60,4 @@ namespace MapKit {
 		}
 	}
 }
-#endif
 #endif // !WATCH

--- a/src/MapKit/MKMapItem.cs
+++ b/src/MapKit/MKMapItem.cs
@@ -5,7 +5,7 @@
 // Copyright 2011-2014 Xamarin Inc.
 //
 
-#if !TVOS && (XAMCORE_2_0 || !MONOMAC)
+#if !TVOS
 
 using Foundation;
 using CoreLocation;

--- a/src/MapKit/MKMultiPoint.cs
+++ b/src/MapKit/MKMultiPoint.cs
@@ -1,5 +1,4 @@
 #if !WATCH
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 using System.Runtime.InteropServices;
 using Foundation;
@@ -32,5 +31,4 @@ namespace MapKit {
 		}
 	}
 }
-#endif
 #endif // !WATCH

--- a/src/MapKit/MKPolygon.cs
+++ b/src/MapKit/MKPolygon.cs
@@ -1,5 +1,4 @@
 #if !WATCH
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 using System.Runtime.InteropServices;
 using Foundation;
@@ -60,5 +59,4 @@ namespace MapKit {
 
 	}
 }
-#endif
 #endif // !WATCH

--- a/src/MapKit/MKPolyline.cs
+++ b/src/MapKit/MKPolyline.cs
@@ -1,5 +1,4 @@
 #if !WATCH
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 using System.Runtime.InteropServices;
 using Foundation;
@@ -35,5 +34,4 @@ namespace MapKit {
 		}
 	}
 }
-#endif
 #endif // !WATCH

--- a/src/MapKit/MapKit.cs
+++ b/src/MapKit/MapKit.cs
@@ -7,7 +7,7 @@
 // Copyright 2009 Novell, Inc.
 // Copyright 2014-2015 Xamarin Inc.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using System.Runtime.InteropServices;
 using CoreGraphics;
@@ -394,22 +394,5 @@ namespace MapKit {
 #if COREBUILD
 	public partial class MKMapLaunchOptions :NSObject {
 	}
-#elif !XAMCORE_2_0
-	public partial class MKLocalSearch {
-
-		[Obsolete ("This will not work on iOS8+")]
-		public MKLocalSearch ()
-		{
-		}
-	}
-
-	public partial class MKTileOverlayRenderer {
-
-		[Obsolete ("This will not work on iOS8+")]
-		public MKTileOverlayRenderer ()
-		{
-		}
-	}
 #endif
 }
-#endif

--- a/src/MediaLibrary/Enums.cs
+++ b/src/MediaLibrary/Enums.cs
@@ -23,7 +23,6 @@
 using System;
 using ObjCRuntime;
 
-#if XAMCORE_2_0
 namespace MediaLibrary {
 	[Native]
 	public enum MLMediaSourceType : ulong
@@ -41,4 +40,3 @@ namespace MediaLibrary {
 		Movie = 1 << 2
 	}
 }
-#endif

--- a/src/MediaPlayer/MPMediaItem.cs
+++ b/src/MediaPlayer/MPMediaItem.cs
@@ -19,23 +19,6 @@ using CoreGraphics;
 
 namespace MediaPlayer {
 	public partial class MPMediaItem {
-
-#if !XAMCORE_2_0
-		[Obsolete ("Use 'CanFilterByProperty (NSString)' instead.")]
-		public static bool CanFilterByProperty (string property)
-		{
-			using (NSString ns = new NSString (property))
-				return CanFilterByProperty (ns);
-		}
-
-		[Obsolete ("Use 'ValueForProperty (NSString)' instead.")]
-		public virtual NSObject ValueForProperty (string property)
-		{
-			using (NSString ns = new NSString (property))
-				return ValueForProperty (ns);
-		}
-#endif
-
 		ulong UInt64ForProperty (NSString property)
 		{
 			var prop = ValueForProperty (property) as NSNumber;

--- a/src/MediaPlayer/MPMediaQuery.cs
+++ b/src/MediaPlayer/MPMediaQuery.cs
@@ -15,29 +15,23 @@ using System;
 using Foundation; 
 using ObjCRuntime;
 
-#if XAMCORE_2_0
-using xint = System.nuint;
-#else
-using xint = System.Int32;
-#endif
-
 namespace MediaPlayer {
 
 	public partial class MPMediaQuery
 	{
-		public MPMediaItem GetItem (xint index)
+		public MPMediaItem GetItem (nuint index)
 		{
 			using (var array = new NSArray (Messaging.IntPtr_objc_msgSend (Handle, Selector.GetHandle ("items"))))
 				return array.GetItem<MPMediaItem> (index);
 		}
 
-		public MPMediaQuerySection GetSection (xint index)
+		public MPMediaQuerySection GetSection (nuint index)
 		{
 			using (var array = new NSArray (Messaging.IntPtr_objc_msgSend (Handle, Selector.GetHandle ("itemSections"))))
 				return array.GetItem<MPMediaQuerySection> (index);
 		}
 
-		public MPMediaItemCollection GetCollection (xint index)
+		public MPMediaItemCollection GetCollection (nuint index)
 		{
 			using (var array = new NSArray (Messaging.IntPtr_objc_msgSend (Handle, Selector.GetHandle ("collections"))))
 				return array.GetItem<MPMediaItemCollection> (index);

--- a/src/MediaPlayer/MPNowPlayingInfoCenter.cs
+++ b/src/MediaPlayer/MPNowPlayingInfoCenter.cs
@@ -7,8 +7,6 @@
 // Copyright 2011, Xamarin Inc
 //
 
-#if XAMCORE_2_0 || !MONOMAC
-
 using Foundation;
 using ObjCRuntime;
 
@@ -229,5 +227,3 @@ namespace MediaPlayer {
 		}
 	}
 }
-
-#endif

--- a/src/MediaPlayer/MPSkipIntervalCommand.cs
+++ b/src/MediaPlayer/MPSkipIntervalCommand.cs
@@ -12,7 +12,6 @@ using Foundation;
 using ObjCRuntime;
 
 namespace MediaPlayer {
-#if XAMCORE_2_0
 	public partial class MPSkipIntervalCommand {
 		public double[] PreferredIntervals {
 			get {
@@ -36,5 +35,4 @@ namespace MediaPlayer {
 			}
 		}
 	}
-#endif
 }

--- a/src/MediaPlayer/MediaPlayer.cs
+++ b/src/MediaPlayer/MediaPlayer.cs
@@ -13,7 +13,6 @@ using Foundation;
 using ObjCRuntime;
 
 namespace MediaPlayer {
-#if XAMCORE_2_0 || !MONOMAC
 	// NSInteger -> MPMoviePlayerController.h
 	[Native]
 	[NoMac]
@@ -111,16 +110,6 @@ namespace MediaPlayer {
 	[NoWatch]
 	[Flags]
 	public enum MPMediaType : ulong {
-#if !XAMCORE_2_0
-		[Obsolete ("Use Shorter name Music")]
-		MPMediaTypeMusic        = 1 << 0,
-		[Obsolete ("Use Shorter name Podcast")]
-		MPMediaTypePodcast      = 1 << 1,
-		[Obsolete ("Use Shorter name AudioBook")]
-		MPMediaTypeAudioBook    = 1 << 2,
-		[Obsolete ("Use Shorter name AnyAudio")]
-		MPMediaTypeAnyAudio     = 0x00ff,
-#endif	
 		Music        = 1 << 0,
 		Podcast      = 1 << 1,
 		AudioBook    = 1 << 2,
@@ -142,11 +131,7 @@ namespace MediaPlayer {
 		HomeVideo = 1 << 13,
 		[Mac (10,12,2)]
 		TypeAnyVideo = 0xff00,
-#if XAMCORE_2_0
 		Any          = 0xFFFFFFFFFFFFFFFF
-#else
-		Any          = ~0
-#endif
 	}
 
 	// NSInteger -> MPMediaPlaylist.h
@@ -369,5 +354,4 @@ namespace MediaPlayer {
 		Stopped,
 		Interrupted,
 	}
-#endif
 }

--- a/src/MediaToolbox/MTAudioProcessingTap.cs
+++ b/src/MediaToolbox/MTAudioProcessingTap.cs
@@ -1,5 +1,4 @@
 #if IOS || TVOS || MONOMAC
-#if XAMCORE_2_0
 //
 // MTAudioProcessingTap.cs: Type wrapper for MTAudioProcessingTap
 //
@@ -299,5 +298,4 @@ namespace MediaToolbox
 	public class AudioBufferList {}
 #endif
 }
-#endif // XAMCORE_2_0
 #endif // IOS || TVOS

--- a/src/Metal/Defs.cs
+++ b/src/Metal/Defs.cs
@@ -1,4 +1,3 @@
-#if XAMCORE_2_0 || !MONOMAC
 //
 // API for the Metal framework
 //
@@ -388,4 +387,3 @@ namespace Metal {
 #endif
 
 }
-#endif

--- a/src/Metal/MTLArgumentEncoder.cs
+++ b/src/Metal/MTLArgumentEncoder.cs
@@ -1,4 +1,3 @@
-#if XAMCORE_2_0
 using System;
 
 namespace Metal {
@@ -10,4 +9,3 @@ namespace Metal {
 		}
 	}
 }
-#endif

--- a/src/Metal/MTLArrays.cs
+++ b/src/Metal/MTLArrays.cs
@@ -6,7 +6,6 @@
 //
 // Copyrigh 2014, Xamarin Inc.
 //
-#if XAMCORE_2_0 || !MONOMAC
 
 using System;
 using System.ComponentModel;
@@ -106,4 +105,3 @@ namespace Metal {
 	}
 #endif
 }
-#endif

--- a/src/Metal/MTLDevice.cs
+++ b/src/Metal/MTLDevice.cs
@@ -6,7 +6,6 @@
 //
 // Copyrigh 2014-2015, Xamarin Inc.
 //
-#if XAMCORE_2_0 || !MONOMAC
 
 using System;
 using System.ComponentModel;
@@ -214,4 +213,3 @@ namespace Metal {
 #endif
 	}
 }
-#endif

--- a/src/Metal/MTLEnums.cs
+++ b/src/Metal/MTLEnums.cs
@@ -1,4 +1,3 @@
-#if XAMCORE_2_0 || !MONOMAC
 //
 // API for the Metal framework
 //
@@ -1144,4 +1143,3 @@ namespace Metal {
 
 #endif
 }
-#endif

--- a/src/Metal/MTLRenderCommandEncoder.cs
+++ b/src/Metal/MTLRenderCommandEncoder.cs
@@ -1,4 +1,4 @@
-﻿#if XAMCORE_2_0 && MONOMAC
+#if MONOMAC
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
@@ -43,3 +43,4 @@ namespace Metal {
 	}
 }
 #endif
+

--- a/src/Metal/MTLRenderPassDescriptor.cs
+++ b/src/Metal/MTLRenderPassDescriptor.cs
@@ -1,4 +1,4 @@
-#if XAMCORE_2_0 && !COREBUILD
+#if !COREBUILD
 using System;
 
 namespace Metal {

--- a/src/Metal/MTLVertexDescriptor.cs
+++ b/src/Metal/MTLVertexDescriptor.cs
@@ -1,4 +1,3 @@
-﻿#if XAMCORE_2_0 || !MONOMAC
 using System;
 using System.Runtime.InteropServices;
 
@@ -40,4 +39,4 @@ namespace Metal {
 		}
 	}
 }
-#endif
+

--- a/src/MetalKit/MTKMesh.cs
+++ b/src/MetalKit/MTKMesh.cs
@@ -1,7 +1,7 @@
 //
 // MTKMesh.cs: just so we can implement IMDLMeshBufferAllocator
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using ModelIO;
 using Metal;
 using Foundation;
@@ -18,4 +18,3 @@ namespace MetalKit {
 		}
 	}
 }
-#endif

--- a/src/MetalKit/MTKMeshBufferAllocator.cs
+++ b/src/MetalKit/MTKMeshBufferAllocator.cs
@@ -1,11 +1,10 @@
 //
 // MTKMeshBufferAllocator.cs: just so we can implement IMDLMeshBufferAllocator
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using ModelIO;
 namespace MetalKit {
 
 	public partial class MTKMeshBufferAllocator : IMDLMeshBufferAllocator {
 	}
 }
-#endif

--- a/src/MetalKit/MTKTextureLoaderOptions.cs
+++ b/src/MetalKit/MTKTextureLoaderOptions.cs
@@ -6,7 +6,7 @@
 //
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using Foundation;
 using Metal;
@@ -97,4 +97,3 @@ namespace MetalKit {
 	}
 #endif
 }
-#endif

--- a/src/MetalPerformanceShaders/MPSCnnConvolutionDescriptor.cs
+++ b/src/MetalPerformanceShaders/MPSCnnConvolutionDescriptor.cs
@@ -1,4 +1,3 @@
-﻿#if XAMCORE_2_0 || !MONOMAC
 using System;
 using ObjCRuntime;
 
@@ -18,4 +17,4 @@ namespace MetalPerformanceShaders {
 
 	}
 }
-#endif
+

--- a/src/MetalPerformanceShaders/MPSCnnKernel.cs
+++ b/src/MetalPerformanceShaders/MPSCnnKernel.cs
@@ -1,4 +1,3 @@
-﻿#if XAMCORE_2_0 || !MONOMAC
 using System;
 using Metal;
 using Foundation;
@@ -28,4 +27,4 @@ namespace MetalPerformanceShaders {
 		}
 	}
 }
-#endif
+

--- a/src/MetalPerformanceShaders/MPSCnnNeuron.cs
+++ b/src/MetalPerformanceShaders/MPSCnnNeuron.cs
@@ -1,4 +1,3 @@
-﻿#if XAMCORE_2_0 || !MONOMAC
 using System;
 using Metal;
 using Foundation;
@@ -16,4 +15,4 @@ namespace MetalPerformanceShaders {
 		}
 	}
 }
-#endif
+

--- a/src/MetalPerformanceShaders/MPSDefs.cs
+++ b/src/MetalPerformanceShaders/MPSDefs.cs
@@ -1,4 +1,3 @@
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 using System.Runtime.InteropServices;
 
@@ -518,4 +517,3 @@ namespace MetalPerformanceShaders {
 		//Count, // must always be last, and because of this it will cause breaking changes.
 	}
 }
-#endif

--- a/src/MetalPerformanceShaders/MPSImageBatch.cs
+++ b/src/MetalPerformanceShaders/MPSImageBatch.cs
@@ -6,7 +6,7 @@
 //
 // Copyright 2019 Microsoft Corporation.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using System.Runtime.InteropServices;
 using ObjCRuntime;
@@ -109,4 +109,3 @@ namespace MetalPerformanceShaders {
 		//}
 	}
 }
-#endif

--- a/src/MetalPerformanceShaders/MPSImageHistogram.cs
+++ b/src/MetalPerformanceShaders/MPSImageHistogram.cs
@@ -1,4 +1,4 @@
-﻿#if (XAMCORE_2_0 && !MONOMAC) && !XAMCORE_4_0
+#if !MONOMAC && !XAMCORE_4_0
 using System;
 using Metal;
 using Foundation;
@@ -13,3 +13,4 @@ namespace MetalPerformanceShaders {
 	}
 }
 #endif
+

--- a/src/MetalPerformanceShaders/MPSImageScale.cs
+++ b/src/MetalPerformanceShaders/MPSImageScale.cs
@@ -1,4 +1,3 @@
-#if XAMCORE_2_0 || !MONOMAC
 // Copyright 2015 Xamarin Inc. All rights reserved.
 
 using System;
@@ -36,4 +35,3 @@ namespace MetalPerformanceShaders {
 		}
 	}
 }
-#endif

--- a/src/MetalPerformanceShaders/MPSKernel.cs
+++ b/src/MetalPerformanceShaders/MPSKernel.cs
@@ -1,4 +1,3 @@
-#if XAMCORE_2_0 || !MONOMAC
 // Copyright 2015-2016 Xamarin Inc. All rights reserved.
 
 using System;
@@ -367,4 +366,3 @@ namespace MetalPerformanceShaders {
 	}
 #endif
 }
-#endif

--- a/src/MetalPerformanceShaders/MPSMatrixDescriptor.cs
+++ b/src/MetalPerformanceShaders/MPSMatrixDescriptor.cs
@@ -1,4 +1,4 @@
-﻿#if (XAMCORE_2_0 && !MONOMAC) && !XAMCORE_4_0
+#if !MONOMAC && !XAMCORE_4_0
 using System;
 using Metal;
 using Foundation;
@@ -14,3 +14,4 @@ namespace MetalPerformanceShaders {
 	}
 }
 #endif
+

--- a/src/MetalPerformanceShaders/MPSStateBatch.cs
+++ b/src/MetalPerformanceShaders/MPSStateBatch.cs
@@ -6,7 +6,7 @@
 //
 // Copyright 2019 Microsoft Corporation.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using System.Runtime.InteropServices;
 using ObjCRuntime;
@@ -58,4 +58,3 @@ namespace MetalPerformanceShaders {
 		}
 	}
 }
-#endif

--- a/src/MetalPerformanceShaders/MPSStateResourceList.cs
+++ b/src/MetalPerformanceShaders/MPSStateResourceList.cs
@@ -7,7 +7,6 @@
 // Copyright 2019 Microsoft Corporation.
 //
 
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 using System.Runtime.InteropServices;
 using Foundation;
@@ -75,4 +74,3 @@ namespace MetalPerformanceShaders {
 		static extern IntPtr IntPtr_objc_msgSend_IntPtrx13 (IntPtr receiver, IntPtr selector, IntPtr arg0, IntPtr arg1, IntPtr arg2, IntPtr arg3, IntPtr arg4, IntPtr arg5, IntPtr arg6, IntPtr arg7, IntPtr arg8, IntPtr arg9, IntPtr arg10);
 	}
 }
-#endif

--- a/src/MobileCoreServices/UTType.cs
+++ b/src/MobileCoreServices/UTType.cs
@@ -33,10 +33,7 @@ using Foundation;
 
 namespace MobileCoreServices {
 
-#if XAMCORE_2_0
-	static
-#endif
-	public partial class UTType {
+	public static partial class UTType {
 
 		[iOS (8,0)][Mac (10,10)]
 		[DllImport (Constants.CoreServicesLibrary)]
@@ -84,10 +81,7 @@ namespace MobileCoreServices {
 		[DllImport (Constants.CoreServicesLibrary)]
 		extern static IntPtr /* NSString Array */ UTTypeCreateAllIdentifiersForTag (IntPtr /* CFStringRef */ tagClassStr, IntPtr /* CFStringRef */ tagStr, IntPtr /* CFStringRef */ conformingToUtiStr);
 
-#if XAMCORE_2_0
-		static
-#endif
-		public string [] CreateAllIdentifiers (string tagClass, string tag, string conformingToUti)
+		public static string [] CreateAllIdentifiers (string tagClass, string tag, string conformingToUti)
 		{
 			if (tagClass == null)
 				throw new ArgumentNullException ("tagClass");
@@ -109,10 +103,7 @@ namespace MobileCoreServices {
 		extern static IntPtr /* NSString Array */ UTTypeCopyAllTagsWithClass (IntPtr /* CFStringRef */ utiStr, IntPtr /* CFStringRef */ tagClassStr);
 		
 		[iOS (8,0)][Mac (10,10)]
-#if XAMCORE_2_0
-		static
-#endif
-		public string [] CopyAllTags (string uti, string tagClass)
+		public static string [] CopyAllTags (string uti, string tagClass)
 		{
 			if (uti == null)
 				throw new ArgumentNullException ("uti");
@@ -130,10 +121,7 @@ namespace MobileCoreServices {
 		[DllImport (Constants.CoreServicesLibrary)]
 		extern static int /* Boolean */ UTTypeConformsTo (IntPtr /* CFStringRef */ utiStr, IntPtr /* CFStringRef */ conformsToUtiStr);
 
-#if XAMCORE_2_0
-		static
-#endif
-		public bool ConformsTo (string uti, string conformsToUti)
+		public static bool ConformsTo (string uti, string conformsToUti)
 		{
 			if (uti == null)
 				throw new ArgumentNullException ("uti");
@@ -151,10 +139,7 @@ namespace MobileCoreServices {
 		[DllImport (Constants.CoreServicesLibrary)]
 		extern static IntPtr /* NSString */ UTTypeCopyDescription (IntPtr /* CFStringRef */ utiStr);
 
-#if XAMCORE_2_0
-		static
-#endif
-		public string GetDescription (string uti)
+		public static string GetDescription (string uti)
 		{
 			if (uti == null)
 				throw new ArgumentNullException ("uti");

--- a/src/ModelIO/MDLAnimatedValueTypes.cs
+++ b/src/ModelIO/MDLAnimatedValueTypes.cs
@@ -7,7 +7,6 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 using System.Runtime.InteropServices;
 using Foundation;
@@ -873,4 +872,3 @@ namespace ModelIO {
 		}
 	}
 }
-#endif

--- a/src/ModelIO/MDLAsset.cs
+++ b/src/ModelIO/MDLAsset.cs
@@ -1,4 +1,3 @@
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 namespace ModelIO {
 	public partial class MDLAsset {
@@ -17,4 +16,3 @@ namespace ModelIO {
 #endif
 	}
 }
-#endif

--- a/src/ModelIO/MDLMaterial.cs
+++ b/src/ModelIO/MDLMaterial.cs
@@ -1,4 +1,3 @@
-#if XAMCORE_2_0 || !MONOMAC
 namespace ModelIO {
 	public partial class MDLAsset {
 		public MDLMaterialProperty this [nuint index] {
@@ -14,4 +13,3 @@ namespace ModelIO {
 		}
 	}
 }
-#endif

--- a/src/ModelIO/MDLMesh.cs
+++ b/src/ModelIO/MDLMesh.cs
@@ -1,4 +1,3 @@
-#if XAMCORE_2_0 || !MONOMAC
 //
 // ModelIO/MIEnums.cs: enumerations and definitions
 //
@@ -235,4 +234,3 @@ namespace ModelIO {
 		}
 	}
 }
-#endif

--- a/src/ModelIO/MDLNoiseTexture.cs
+++ b/src/ModelIO/MDLNoiseTexture.cs
@@ -1,4 +1,3 @@
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 using ObjCRuntime;
 using Vector2i = global::OpenTK.Vector2i;
@@ -34,4 +33,3 @@ namespace ModelIO {
 		}
 	}
 }
-#endif

--- a/src/ModelIO/MDLTransform.cs
+++ b/src/ModelIO/MDLTransform.cs
@@ -1,4 +1,3 @@
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 using MatrixFloat4x4 = global::OpenTK.NMatrix4;
 
@@ -13,4 +12,3 @@ namespace ModelIO {
 #endif
 	}
 }
-#endif

--- a/src/ModelIO/MDLTransformComponent.cs
+++ b/src/ModelIO/MDLTransformComponent.cs
@@ -1,4 +1,4 @@
-#if XAMCORE_2_0 && !XAMCORE_4_0
+#if !XAMCORE_4_0
 using OpenTK;
 using MatrixFloat4x4 = global::OpenTK.NMatrix4;
 

--- a/src/ModelIO/MDLVertexDescriptor.cs
+++ b/src/ModelIO/MDLVertexDescriptor.cs
@@ -1,5 +1,4 @@
-﻿#if XAMCORE_2_0 || !MONOMAC
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 
 using Foundation;
@@ -37,4 +36,3 @@ namespace ModelIO {
 		}
 	}
 }
-#endif

--- a/src/ModelIO/MIEnums.cs
+++ b/src/ModelIO/MIEnums.cs
@@ -1,4 +1,3 @@
-#if XAMCORE_2_0 || !MONOMAC
 //
 // ModelIO/MIEnums.cs: enumerations and definitions
 //
@@ -308,4 +307,3 @@ namespace ModelIO {
 		IrradianceDistribution,
 	}
 }
-#endif

--- a/src/MultipeerConnectivity/Compat.cs
+++ b/src/MultipeerConnectivity/Compat.cs
@@ -6,7 +6,7 @@
 //
 // Copyright 2015 Xamarin Inc.
 //
-#if XAMCORE_2_0 || !MONOMAC // MultipeerConnectivity is 64-bit only on OS X
+
 using System;
 
 namespace MultipeerConnectivity {
@@ -29,4 +29,3 @@ namespace MultipeerConnectivity {
 	}
 #endif
 }
-#endif

--- a/src/MultipeerConnectivity/Enums.cs
+++ b/src/MultipeerConnectivity/Enums.cs
@@ -7,7 +7,6 @@
 //
 // Copyright 2013-2014, 2016 Xamarin, Inc.
 
-#if XAMCORE_2_0 || !MONOMAC // MultipeerConnectivity is 64-bit only on OS X
 using ObjCRuntime;
 
 namespace MultipeerConnectivity {
@@ -56,4 +55,3 @@ namespace MultipeerConnectivity {
 		Unavailable
 	}
 }
-#endif

--- a/src/MultipeerConnectivity/MCSession.cs
+++ b/src/MultipeerConnectivity/MCSession.cs
@@ -6,7 +6,6 @@
 //
 // Copyright 2013-2014 Xamarin Inc.
 //
-#if XAMCORE_2_0 || !MONOMAC // MultipeerConnectivity is 64-bit only on OS X
 
 using System;
 using System.Collections.Generic;
@@ -44,4 +43,3 @@ namespace MultipeerConnectivity {
 		}
 	}
 }
-#endif

--- a/src/NetworkExtension/NECompat.cs
+++ b/src/NetworkExtension/NECompat.cs
@@ -1,5 +1,3 @@
-#if XAMCORE_2_0 || !MONOMAC
-
 using System;
 using System.Threading.Tasks;
 using Foundation;
@@ -50,5 +48,3 @@ namespace NetworkExtension {
 	}
 #endif
 }
-
-#endif

--- a/src/NetworkExtension/NEHotspotEapSettings.cs
+++ b/src/NetworkExtension/NEHotspotEapSettings.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && !MONOMAC
+#if !MONOMAC
 using System;
 using Foundation;
 

--- a/src/NetworkExtension/NEVpnConnectionStartOptions.cs
+++ b/src/NetworkExtension/NEVpnConnectionStartOptions.cs
@@ -1,5 +1,3 @@
-#if XAMCORE_2_0 || !MONOMAC
-
 using Foundation;
 
 namespace NetworkExtension {
@@ -30,5 +28,3 @@ namespace NetworkExtension {
 #endif
 	}
 }
-
-#endif

--- a/src/NetworkExtension/NEVpnManager.cs
+++ b/src/NetworkExtension/NEVpnManager.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && MONOMAC
+#if MONOMAC
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -10,7 +10,7 @@
 // Copyright 2011-2013 Xamarin Inc.
 // Copyright 2019 Microsoft Corp.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
@@ -22,7 +22,7 @@ using UITraitCollection = System.Int32;
 #else
 using UIKit;
 #endif
-#if !TVOS && XAMCORE_2_0
+#if !TVOS
 using Contacts;
 #endif
 using System;
@@ -53,11 +53,7 @@ namespace MapKit {
 	[Mac (10,9)]
 	interface MKAnnotation {
 		[Export ("coordinate")][Abstract]
-		CLLocationCoordinate2D Coordinate { get;
-#if !MONOMAC && !XAMCORE_2_0
-			set;
-#endif
-		}
+		CLLocationCoordinate2D Coordinate { get; }
 
 		[Export ("title", ArgumentSemantic.Copy)]
 		string Title { get; }
@@ -65,11 +61,9 @@ namespace MapKit {
 		[Export ("subtitle", ArgumentSemantic.Copy)]
 		string Subtitle { get; } 
 
-#if MONOMAC || XAMCORE_2_0
 		[Export ("setCoordinate:")]
 		[Mac (10,9)]
 		void SetCoordinate (CLLocationCoordinate2D value);
-#endif
 	}
 
 	interface IMKAnnotation {}
@@ -80,22 +74,18 @@ namespace MapKit {
 	[Protocol]
 	[Mac (10,9)]
 	interface MKOverlay {
-#if MONOMAC || XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("boundingMapRect")]
 		MKMapRect BoundingMapRect { get; }
 
 		[Export ("intersectsMapRect:")]
 		bool Intersects (MKMapRect rect);
 
-#if MONOMAC || XAMCORE_2_0
 		// optional, not implemented by MKPolygon, MKPolyline and MKCircle
 		// implemented by MKTileOverlay (and defined there)
 		[OptionalImplementation]
 		[iOS (7,0), Export ("canReplaceMapContent")]
 		bool CanReplaceMapContent { get; }
-#endif
 	}
 
 	interface IMKOverlay {}
@@ -108,11 +98,7 @@ namespace MapKit {
 		[DesignatedInitializer]
 		[Export ("initWithAnnotation:reuseIdentifier:")]
 		[PostGet ("Annotation")]
-#if XAMCORE_2_0
 		IntPtr Constructor ([NullAllowed] IMKAnnotation annotation, [NullAllowed] string reuseIdentifier);
-#else
-		IntPtr Constructor ([NullAllowed] NSObject annotation, [NullAllowed] string reuseIdentifier);
-#endif
 	
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
@@ -126,11 +112,7 @@ namespace MapKit {
 		[Export ("annotation", ArgumentSemantic.Retain)]
 		[ThreadSafe] // Sometimes iOS will request the annotation from a non-UI thread (see https://bugzilla.xamarin.com/show_bug.cgi?27609)
 		[NullAllowed]
-#if XAMCORE_2_0
 		IMKAnnotation Annotation { get; set; }
-#else
-		NSObject Annotation { get; set; }
-#endif
 	
 		[Export ("image", ArgumentSemantic.Retain)]
 		[NullAllowed]
@@ -463,49 +445,25 @@ namespace MapKit {
 	
 		[Export ("addAnnotation:")]
 		[PostGet ("Annotations")]
-#if XAMCORE_2_0
 		void AddAnnotation (IMKAnnotation annotation);
-#else
-		void AddAnnotationObject (NSObject annotation);
-#endif
 	
 		[Export ("addAnnotations:")]
 		[PostGet ("Annotations")]
-#if XAMCORE_2_0
 		void AddAnnotations ([Params] IMKAnnotation [] annotations);
-#else
-		void AddAnnotationObjects ([Params] NSObject [] annotations);
-#endif
 	
 		[Export ("removeAnnotation:")]
 		[PostGet ("Annotations")]
-#if XAMCORE_2_0
 		void RemoveAnnotation (IMKAnnotation annotation);
-#else
-		void RemoveAnnotation (NSObject annotation);
-#endif
 	
 		[Export ("removeAnnotations:")]
 		[PostGet ("Annotations")]
-#if XAMCORE_2_0
 		void RemoveAnnotations ([Params] IMKAnnotation [] annotations);
-#else
-		void RemoveAnnotations ([Params] NSObject [] annotations);
-#endif
 	
 		[Export ("annotations")]
-#if XAMCORE_2_0
 		IMKAnnotation [] Annotations { get; }
-#else
-		NSObject [] Annotations { get; }
-#endif
 	
 		[Export ("viewForAnnotation:")]
-#if XAMCORE_2_0
 		MKAnnotationView ViewForAnnotation (IMKAnnotation annotation);
-#else
-		MKAnnotationView ViewForAnnotation (NSObject annotation);
-#endif
 	
 		[Export ("dequeueReusableAnnotationViewWithIdentifier:")]
 		[return: NullAllowed]
@@ -525,86 +483,42 @@ namespace MapKit {
 
 		[Export ("selectAnnotation:animated:")]
 		[PostGet ("SelectedAnnotations")]
-#if XAMCORE_2_0
 		void SelectAnnotation (IMKAnnotation annotation, bool animated);
-#else
-		void SelectAnnotation (NSObject annotation, bool animated);
-#endif
 	
 		[Export ("deselectAnnotation:animated:")]
 		[PostGet ("SelectedAnnotations")]
-#if XAMCORE_2_0
 		void DeselectAnnotation (IMKAnnotation annotation, bool animated);
-#else
-		void DeselectAnnotation (NSObject annotation, bool animated);
-#endif
 	
 		[NullAllowed] // by default this property is null
 		[Export ("selectedAnnotations", ArgumentSemantic.Copy)]
-#if XAMCORE_2_0
 		IMKAnnotation [] SelectedAnnotations { get; set;	}
-#else
-		NSObject [] SelectedAnnotations { get; set;	}
-#endif
 	
 		[Export ("annotationVisibleRect")]
 		CGRect AnnotationVisibleRect { get; }
 
 		[Export ("addOverlay:")][PostGet ("Overlays")]
-#if XAMCORE_2_0
 		void AddOverlay (IMKOverlay overlay);
-#else
-		void AddOverlay (NSObject overlay);
-#endif
 
 		[Export ("addOverlays:")][PostGet ("Overlays")]
-#if XAMCORE_2_0
 		void AddOverlays (IMKOverlay [] overlays);
-#else
-		void AddOverlays (NSObject [] overlays);
-#endif
 
 		[Export ("removeOverlay:")][PostGet ("Overlays")]
-#if XAMCORE_2_0
 		void RemoveOverlay (IMKOverlay overlay);
-#else
-		void RemoveOverlay (NSObject overlay);
-#endif
 
 		[Export ("removeOverlays:")][PostGet ("Overlays")]
-#if XAMCORE_2_0
 		void RemoveOverlays ([Params] IMKOverlay [] overlays);
-#else
-		void RemoveOverlays ([Params] NSObject [] overlays);
-#endif
 
 		[Export ("overlays")]
-#if XAMCORE_2_0
 		IMKOverlay [] Overlays { get;  }
-#else
-		NSObject [] Overlays { get;  }
-#endif
 
 		[Export ("insertOverlay:atIndex:")][PostGet ("Overlays")]
-#if XAMCORE_2_0
 		void InsertOverlay (IMKOverlay overlay, nint index);
-#else
-		void InsertOverlay (NSObject overlay, nint index);
-#endif
 
 		[Export ("insertOverlay:aboveOverlay:")][PostGet ("Overlays")]
-#if XAMCORE_2_0
 		void InsertOverlayAbove (IMKOverlay overlay, IMKOverlay sibling);
-#else
-		void InsertOverlayAbove (NSObject overlay, NSObject sibling);
-#endif
 
 		[Export ("insertOverlay:belowOverlay:")][PostGet ("Overlays")]
-#if XAMCORE_2_0
 		void InsertOverlayBelow (IMKOverlay overlay, IMKOverlay sibling);
-#else
-		void InsertOverlayBelow (NSObject overlay, NSObject sibling);
-#endif
 
 		[Export ("exchangeOverlayAtIndex:withOverlayAtIndex:")]
 		void ExchangeOverlays (nint index1, nint index2);
@@ -624,11 +538,7 @@ namespace MapKit {
 #if !MONOMAC && !TVOS
 		[Export ("viewForOverlay:")]
 		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'MKOverlayRenderer.RendererForOverlay' instead.")]
-#if XAMCORE_2_0
 		MKOverlayView ViewForOverlay (IMKOverlay overlay);
-#else
-		MKOverlayView ViewForOverlay (NSObject overlay);
-#endif
 #endif // !MONOMAC && !TVOS
 
 		[Export ("visibleMapRect")]
@@ -771,11 +681,7 @@ namespace MapKit {
 		void LoadingMapFailed (MKMapView mapView, NSError error);
 	
 		[Export ("mapView:viewForAnnotation:"), DelegateName ("MKMapViewAnnotation"), DefaultValue (null)]
-#if XAMCORE_2_0
 		MKAnnotationView GetViewForAnnotation (MKMapView mapView, IMKAnnotation annotation);
-#else
-		MKAnnotationView GetViewForAnnotation (MKMapView mapView, NSObject annotation);
-#endif // !XAMCORE_2_0
 	
 		[Export ("mapView:didAddAnnotationViews:"), EventArgs ("MKMapViewAnnotation")]
 		void DidAddAnnotationViews (MKMapView mapView, MKAnnotationView [] views);
@@ -793,11 +699,7 @@ namespace MapKit {
 #if !MONOMAC && !TVOS
 		[Export ("mapView:viewForOverlay:"), DelegateName ("MKMapViewOverlay"), DefaultValue (null)]
 		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'MKOverlayRenderer.RendererForOverlay' instead.")]
-#if XAMCORE_2_0
 		MKOverlayView GetViewForOverlay (MKMapView mapView, IMKOverlay overlay);
-#else
-		MKOverlayView GetViewForOverlay (MKMapView mapView, NSObject overlay);
-#endif // XAMCORE_2_0
 
 		[Export ("mapView:didAddOverlayViews:"), EventArgs ("MKOverlayViews")]
 		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'DidAddOverlayRenderers' instead.")]
@@ -824,11 +726,7 @@ namespace MapKit {
 
 #if !MONOMAC
 		[Export ("mapView:didChangeUserTrackingMode:animated:"), EventArgs ("MMapViewUserTracking")]
-#if XAMCORE_2_0
 		void DidChangeUserTrackingMode (MKMapView mapView, MKUserTrackingMode mode, bool animated);
-#else
-		void DidChageUserTrackingMode (MKMapView mapView, MKUserTrackingMode mode, bool animated);
-#endif // XAMCORE_2_0
 #endif // !MONOMAC
 
 		[iOS (7,0), Export ("mapView:rendererForOverlay:"), DelegateName ("MKRendererForOverlayDelegate"), DefaultValue (null)]
@@ -862,11 +760,7 @@ namespace MapKit {
 		IntPtr Constructor (CGRect frame);
 
 		[Export ("initWithAnnotation:reuseIdentifier:")]
-#if XAMCORE_2_0
 		IntPtr Constructor ([NullAllowed] IMKAnnotation annotation, [NullAllowed] string reuseIdentifier);
-#else
-		IntPtr Constructor ([NullAllowed] NSObject annotation, [NullAllowed] string reuseIdentifier);
-#endif
 
 		[NoTV]
 		[Export ("pinColor")]
@@ -936,7 +830,7 @@ namespace MapKit {
 		[Export ("initWithCoordinate:")]
 		IntPtr Constructor (CLLocationCoordinate2D coordinate);
 
-#if !TVOS && XAMCORE_2_0
+#if !TVOS
 		[Watch (3,0)][iOS (10,0)]
 		[Mac (10,12)]
 		[NoTV]
@@ -999,22 +893,14 @@ namespace MapKit {
 	[BaseType (typeof (UIView))]
 	interface MKOverlayView {
 		[Export ("overlay")]
-#if XAMCORE_2_0
 		IMKOverlay Overlay { get; }
-#else
-		NSObject Overlay { get; }
-#endif
 
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
 		[DesignatedInitializer]
 		[Export ("initWithOverlay:")]
-#if XAMCORE_2_0
 		IntPtr Constructor (IMKOverlay overlay);
-#else
-		IntPtr Constructor (NSObject overlay);
-#endif
 
 		[Export ("pointForMapPoint:")]
 		[ThreadSafe]
@@ -1050,11 +936,7 @@ namespace MapKit {
 	[BaseType (typeof (MKOverlayView))]
 	interface MKOverlayPathView {
 		[Export ("initWithOverlay:")]
-#if XAMCORE_2_0
 		IntPtr Constructor (IMKOverlay overlay);
-#else
-		IntPtr Constructor (NSObject overlay);
-#endif
 
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
@@ -1113,27 +995,16 @@ namespace MapKit {
 #if !WATCH
 	[TV (9,2)]
 	[Mac (10,9)]
-#if XAMCORE_2_0 || MONOMAC
 	[BaseType (typeof (NSObject))]
 	[Abstract]
 	interface MKShape : MKAnnotation {
-#else
-	[BaseType (typeof (MKAnnotation))]
-	interface MKShape {
-#endif
 		[NullAllowed] // by default this property is null
 		[Export ("title", ArgumentSemantic.Copy)]
-#if XAMCORE_2_0 || MONOMAC
-		new
-#endif
-		string Title { get; set; }
+		new string Title { get; set; }
 	
 		[NullAllowed] // by default this property is null
 		[Export ("subtitle", ArgumentSemantic.Copy)]
-#if XAMCORE_2_0 || MONOMAC
-		new
-#endif
-		string Subtitle { get; set; } 
+		new string Subtitle { get; set; } 
 	}
 
 	[TV (9,2)]
@@ -1183,9 +1054,7 @@ namespace MapKit {
 		MKPolygon _FromPoints (IntPtr points, nint count);
 
 		[Static]
-#if XAMCORE_2_0
 		[Internal]
-#endif
 		[Export ("polygonWithPoints:count:interiorPolygons:")]
 		MKPolygon _FromPoints (IntPtr points, nint count, MKPolygon [] interiorPolygons);
 
@@ -1304,9 +1173,6 @@ namespace MapKit {
 	[Mac (10,9)]
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
-#if !XAMCORE_2_0 && !MONOMAC
-	[Protocol] // This isn't right
-#endif
 	[DisableDefaultCtor] // crash on iOS8 beta
 	interface MKLocalSearch {
 
@@ -1330,9 +1196,6 @@ namespace MapKit {
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
 	[DesignatedDefaultCtor]
-#if !XAMCORE_2_0 && !MONOMAC
-	[Protocol] // This isn't right
-#endif
 	interface MKLocalSearchRequest : NSCopying {
 
 		[DesignatedInitializer]
@@ -1370,9 +1233,6 @@ namespace MapKit {
 	[ThreadSafe]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** setObjectForKey: object cannot be nil (key: mapItems)
 	[DisableDefaultCtor]
-#if !XAMCORE_2_0 && !MONOMAC
-	[Protocol] // This isn't right
-#endif
 	interface MKLocalSearchResponse {
 
 		[Export ("boundingRegion")]
@@ -1832,13 +1692,8 @@ namespace MapKit {
 	[ThreadSafe]
 	[TV (9,2)]
 	[Mac (10,9)]
-#if XAMCORE_2_0 || MONOMAC
 	[iOS (7,0), BaseType (typeof (NSObject))]
 	partial interface MKTileOverlay : MKOverlay {
-#else
-	[iOS (7,0), BaseType (typeof (MKOverlay))]
-	partial interface MKTileOverlay {
-#endif
 		[DesignatedInitializer]
 		[Export ("initWithURLTemplate:")]
 		IntPtr Constructor (string URLTemplate);
@@ -1859,10 +1714,7 @@ namespace MapKit {
 		string URLTemplate { get; }
 
 		[Export ("canReplaceMapContent")]
-#if XAMCORE_2_0 || MONOMAC
-		new
-#endif
-		bool CanReplaceMapContent { get; set; }
+		new bool CanReplaceMapContent { get; set; }
 
 		[Export ("URLForTilePath:")]
 		NSUrl URLForTilePath (MKTileOverlayPath path);
@@ -1870,10 +1722,8 @@ namespace MapKit {
 		[Export ("loadTileAtPath:result:")]
 		void LoadTileAtPath (MKTileOverlayPath path, MKTileOverlayLoadTileCompletionHandler result);
 
-#if MONOMAC || XAMCORE_2_0
 		[Export ("coordinate")]
 		CLLocationCoordinate2D Coordinate { get; }
-#endif
 	}
 
 	delegate void MKTileOverlayLoadTileCompletionHandler (NSData tileData, NSError error);
@@ -2240,4 +2090,3 @@ namespace MapKit {
 		MKMultiPolyline MultiPolyline { get; }
 	}
 }
-#endif // XAMCORE_2_0 || !MONOMAC

--- a/src/medialibrary.cs
+++ b/src/medialibrary.cs
@@ -19,8 +19,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#if XAMCORE_2_0
-
 using System;
 
 using AppKit;
@@ -652,4 +650,3 @@ namespace MediaLibrary {
 		NSString MediaObjectProtectedKey { get; }
 	}
 }
-#endif

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -22,7 +22,6 @@ using UIKit;
 using System;
 
 namespace MediaPlayer {
-#if XAMCORE_2_0 || !MONOMAC
 	[Mac (10,12,2)] // type exists only to expose fields
 	[BaseType (typeof (NSObject))]
 #if IOS || WATCH
@@ -279,13 +278,13 @@ namespace MediaPlayer {
 	[NoWatch]
 	// Objective-C exception thrown.  Name: MPMediaItemCollectionInitException Reason: -init is not supported, use -initWithItems:
 	[DisableDefaultCtor]
-#if XAMCORE_2_0 && IOS
+#if IOS
 	// introduced in 4.2 - but the type was never added to classic
 	[BaseType (typeof (MPMediaEntity))]
 #else
 	[BaseType (typeof (NSObject))]
 #endif
-#if XAMCORE_3_0 || !XAMCORE_2_0 || !IOS
+#if XAMCORE_3_0 || !IOS
 	interface MPMediaItemCollection : NSSecureCoding {
 #else
 	// part of the bug is that we inlined MPMediaEntity needlessly
@@ -347,8 +346,7 @@ namespace MediaPlayer {
 		[iOS (9,3)]
 		[Export ("addItemWithProductID:completionHandler:")]
 		[Async]
-#if XAMCORE_2_0 && IOS
-		// MPMediaEntity was not part of classic
+#if IOS
 		void AddItem (string productID, [NullAllowed] Action<MPMediaEntity[], NSError> completionHandler);
 #else
 		void AddItem (string productID, [NullAllowed] Action<MPMediaItem[], NSError> completionHandler);
@@ -510,7 +508,7 @@ namespace MediaPlayer {
 
 		[Export ("groupingType")]
 		MPMediaGrouping GroupingType { get; set; }
-#if XAMCORE_2_0
+
 		[Export ("albumsQuery")][Static]
 		MPMediaQuery AlbumsQuery { get; }
 
@@ -537,34 +535,7 @@ namespace MediaPlayer {
 
 		[Export ("genresQuery")][Static]
 		MPMediaQuery GenresQuery { get; }
-#else
-		[Export ("albumsQuery")][Static]
-		MPMediaQuery albumsQuery { get; }
-		
-		[Export ("artistsQuery")][Static]
-		MPMediaQuery artistsQuery { get; }
-		
-		[Export ("songsQuery")][Static]
-		MPMediaQuery songsQuery { get; }
-		
-		[Export ("playlistsQuery")][Static]
-		MPMediaQuery playlistsQuery { get; }
-		
-		[Export ("podcastsQuery")][Static]
-		MPMediaQuery podcastsQuery { get; }
-		
-		[Export ("audiobooksQuery")][Static]
-		MPMediaQuery audiobooksQuery { get; }
-		
-		[Export ("compilationsQuery")][Static]
-		MPMediaQuery compilationsQuery { get; }
-		
-		[Export ("composersQuery")][Static]
-		MPMediaQuery composersQuery { get; }
-		
-		[Export ("genresQuery")][Static]
-		MPMediaQuery genresQuery { get; }
-#endif
+
 		[Export ("collectionSections")]
 		MPMediaQuerySection [] CollectionSections { get; }
 
@@ -1518,9 +1489,7 @@ namespace MediaPlayer {
 	[Protocol]
 	interface MPPlayableContentDataSource {
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("contentItemAtIndexPath:")]
 #if XAMCORE_4_0
 		MPContentItem GetContentItem (NSIndexPath indexPath);
@@ -1534,9 +1503,7 @@ namespace MediaPlayer {
 		[Export ("childItemsDisplayPlaybackProgressAtIndexPath:")]
 		bool ChildItemsDisplayPlaybackProgress (NSIndexPath indexPath);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("numberOfChildItemsAtIndexPath:")]
 		nint NumberOfChildItems (NSIndexPath indexPath);
 
@@ -1733,9 +1700,7 @@ namespace MediaPlayer {
 	[DisableDefaultCtor] // NSGenericException Reason: MPSkipIntervalCommands cannot be initialized externally.
 	interface MPSkipIntervalCommand {
 
-#if XAMCORE_2_0
 		[Internal] // -> we can't do double[] for an NSArray of NSTimeInterval
-#endif
 		[Export ("preferredIntervals")]
 		NSArray _PreferredIntervals { get; set; }
 	}
@@ -2213,7 +2178,7 @@ namespace MediaPlayer {
 		[Export ("setExternalMediaContentIdentifier:")]
 		void SetExternalMediaContentIdentifier ([NullAllowed] NSString identifier);
 	}
-#endif
+
 	[iOS (9,0)][TV (9,0)]
 	[Mac (10,12,1)]
 	[Watch (6,0)]

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -11,7 +11,7 @@
 //    * MTLRenderPipelineReflection: the two arrays are NSObject
 //    * Make the *array classes implement all the ICollection methods.
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using System.ComponentModel;
 
@@ -299,22 +299,16 @@ namespace Metal {
 		[Field ("MTLCommandBufferErrorDomain")]
 		NSString ErrorDomain { get; }
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("parallelRenderCommandEncoderWithDescriptor:")]
 		[return: NullAllowed]
 		IMTLParallelRenderCommandEncoder CreateParallelRenderCommandEncoder (MTLRenderPassDescriptor renderPassDescriptor);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("presentDrawable:")]
 		void PresentDrawable (IMTLDrawable drawable);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("presentDrawable:atTime:")]
 		void PresentDrawable (IMTLDrawable drawable, double presentationTime);
 
@@ -326,9 +320,7 @@ namespace Metal {
 		[Export ("presentDrawable:afterMinimumDuration:")]
 		void PresentDrawableAfter (IMTLDrawable drawable, double duration);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("renderCommandEncoderWithDescriptor:")]
 		IMTLRenderCommandEncoder CreateRenderCommandEncoder (MTLRenderPassDescriptor renderPassDescriptor);
 
@@ -443,11 +435,7 @@ namespace Metal {
 		void SetThreadgroupMemoryLength (nuint length, nuint index);
 
 		[Abstract, Export ("dispatchThreadgroups:threadsPerThreadgroup:")]
-#if XAMCORE_2_0
 		void DispatchThreadgroups (MTLSize threadgroupsPerGrid, MTLSize threadsPerThreadgroup);
-#else
-		void SispatchThreadgroups (MTLSize threadgroupsPerGrid, MTLSize threadsPerThreadgroup);
-#endif
 
 #if XAMCORE_4_0
 		[Abstract]
@@ -456,27 +444,19 @@ namespace Metal {
 		[Export ("dispatchThreadgroupsWithIndirectBuffer:indirectBufferOffset:threadsPerThreadgroup:")]
 		void DispatchThreadgroups (IMTLBuffer indirectBuffer, nuint indirectBufferOffset, MTLSize threadsPerThreadgroup);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("setBuffers:offsets:withRange:")]
 		void SetBuffers (IMTLBuffer [] buffers, IntPtr offsets, NSRange range);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("setSamplerStates:lodMinClamps:lodMaxClamps:withRange:")]
 		void SetSamplerStates (IMTLSamplerState [] samplers, IntPtr floatArrayPtrLodMinClamps, IntPtr floatArrayPtrLodMaxClamps, NSRange range);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("setSamplerStates:withRange:")]
 		void SetSamplerStates (IMTLSamplerState [] samplers, NSRange range);
 		
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("setTextures:withRange:")]
 		void SetTextures (IMTLTexture [] textures, NSRange range);
 
@@ -1013,29 +993,21 @@ namespace Metal {
 		[Abstract, Export ("newRenderPipelineStateWithDescriptor:completionHandler:")]
 		void CreateRenderPipelineState (MTLRenderPipelineDescriptor descriptor, Action<IMTLRenderPipelineState, NSError> completionHandler);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("newRenderPipelineStateWithDescriptor:options:reflection:error:")]
 		[return: Release]
 		IMTLRenderPipelineState CreateRenderPipelineState (MTLRenderPipelineDescriptor descriptor, MTLPipelineOption options, out MTLRenderPipelineReflection reflection, out NSError error);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("newRenderPipelineStateWithDescriptor:options:completionHandler:")]
 		void CreateRenderPipelineState (MTLRenderPipelineDescriptor descriptor, MTLPipelineOption options, Action<IMTLRenderPipelineState, MTLRenderPipelineReflection, NSError> completionHandler);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("newComputePipelineStateWithFunction:options:reflection:error:")]
 		[return: Release]
 		IMTLComputePipelineState CreateComputePipelineState (IMTLFunction computeFunction, MTLPipelineOption options, out MTLComputePipelineReflection reflection, out NSError error);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("newComputePipelineStateWithFunction:completionHandler:")]
 		void CreateComputePipelineState (IMTLFunction computeFunction, Action<IMTLComputePipelineState, NSError> completionHandler);
 
@@ -1570,27 +1542,19 @@ namespace Metal {
 		[return: Release]
 		IMTLTexture CreateTextureView (MTLPixelFormat pixelFormat, MTLTextureType textureType, NSRange levelRange, NSRange sliceRange);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("getBytes:bytesPerRow:bytesPerImage:fromRegion:mipmapLevel:slice:")]
 		void GetBytes (IntPtr pixelBytes, nuint bytesPerRow, nuint bytesPerImage, MTLRegion region, nuint level, nuint slice);		
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("getBytes:bytesPerRow:fromRegion:mipmapLevel:")]
 		void GetBytes (IntPtr pixelBytes, nuint bytesPerRow,  MTLRegion region, nuint level);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("replaceRegion:mipmapLevel:slice:withBytes:bytesPerRow:bytesPerImage:")]
 		void ReplaceRegion (MTLRegion region, nuint level, nuint slice, IntPtr pixelBytes, nuint bytesPerRow, nuint bytesPerImage);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("replaceRegion:mipmapLevel:withBytes:bytesPerRow:")]
 		void ReplaceRegion (MTLRegion region, nuint level, IntPtr pixelBytes, nuint bytesPerRow);
 
@@ -2359,15 +2323,11 @@ namespace Metal {
 	[iOS (8,0)][Mac (10,11)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
 	partial interface MTLDepthStencilState  {
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("label")]
 		string Label { get; }
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("device")]
 		IMTLDevice Device { get; }
 	}
@@ -2630,9 +2590,7 @@ namespace Metal {
 		[Abstract, Export ("setVertexSamplerStates:withRange:")]
 		void SetVertexSamplerStates (IMTLSamplerState [] samplers, NSRange range);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("setVertexTextures:withRange:")]
 		void SetVertexTextures (IMTLTexture [] textures, NSRange range);
 
@@ -4227,4 +4185,3 @@ namespace Metal {
 		nuint SampleCount { get; set; }
 	}
 }
-#endif

--- a/src/metalkit.cs
+++ b/src/metalkit.cs
@@ -1,5 +1,4 @@
-#if XAMCORE_2_0 || !MONOMAC
-﻿using System;
+using System;
 using CoreAnimation;
 using CoreGraphics;
 using Foundation;
@@ -471,4 +470,3 @@ namespace MetalKit {
 		string Name { get; set; }
 	}
 }
-#endif

--- a/src/metalperformanceshaders.cs
+++ b/src/metalperformanceshaders.cs
@@ -1,4 +1,3 @@
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 using CoreGraphics;
 using Foundation;
@@ -8259,4 +8258,3 @@ namespace MetalPerformanceShaders {
 		MPSRnnMatrixTrainingLayer Copy ([NullAllowed] NSZone zone, [NullAllowed] IMTLDevice device);
 	}
 }
-#endif

--- a/src/mobilecoreservices.cs
+++ b/src/mobilecoreservices.cs
@@ -486,8 +486,6 @@ namespace MobileCoreServices {
 		[Field ("kUTTypeSwiftSource", "+CoreServices")]
 		NSString SwiftSource { get; }
 
-// exclude from MonoMac classic
-#if (XAMCORE_2_0 || !MONOMAC)
 		[NoWatch]
 		[iOS (9,0)][Mac(10,11)]
 		[Field ("kUTTypeAlembic", "ModelIO")]
@@ -519,6 +517,5 @@ namespace MobileCoreServices {
 		[NoMac]
 		[Field ("kUTTypeLivePhoto", "+CoreServices")]
 		NSString LivePhoto { get; }
-#endif
 	}
 }

--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -5,7 +5,7 @@
 // Copyright 2015 Xamarin, Inc.
 //
 //
-#if XAMCORE_2_0 || !MONOMAC
+
 using System;
 using System.ComponentModel;
 
@@ -3084,4 +3084,3 @@ namespace ModelIO {
 	}
 
 }
-#endif

--- a/src/multipeerconnectivity.cs
+++ b/src/multipeerconnectivity.cs
@@ -5,7 +5,7 @@
 //   Aaron Bockover (abock@xamarin.com)
 //
 // Copyright 2013 Xamarin, Inc.
-#if XAMCORE_2_0 || !MONOMAC // MultipeerConnectivity is 64-bit only on OS X
+
 using System;
 
 using Foundation;
@@ -180,9 +180,7 @@ namespace MultipeerConnectivity {
 	[Protocol]
 	partial interface MCNearbyServiceAdvertiserDelegate {
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("advertiser:didReceiveInvitationFromPeer:withContext:invitationHandler:")]
 		void DidReceiveInvitationFromPeer (MCNearbyServiceAdvertiser advertiser, MCPeerID peerID, [NullAllowed] NSData context, MCNearbyServiceAdvertiserInvitationHandler invitationHandler);
 
@@ -230,16 +228,12 @@ namespace MultipeerConnectivity {
 	[Protocol]
 	partial interface MCNearbyServiceBrowserDelegate {
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Mac (10,9)]
 		[Export ("browser:foundPeer:withDiscoveryInfo:")]
 		void FoundPeer (MCNearbyServiceBrowser browser, MCPeerID peerID, [NullAllowed] NSDictionary info);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Mac (10,9)]
 		[Export ("browser:lostPeer:")]
 		void LostPeer (MCNearbyServiceBrowser browser, MCPeerID peerID);
@@ -302,15 +296,11 @@ namespace MultipeerConnectivity {
 	[Protocol]
 	partial interface MCBrowserViewControllerDelegate {
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("browserViewControllerWasCancelled:")]
 		void WasCancelled (MCBrowserViewController browserViewController);
 
-#if XAMCORE_2_0
 		[Abstract]
-#endif
 		[Export ("browserViewControllerDidFinish:")]
 		void DidFinish (MCBrowserViewController browserViewController);
 
@@ -368,4 +358,3 @@ namespace MultipeerConnectivity {
 		void WillPresentInvitation (MCAdvertiserAssistant advertiserAssistant);
 	}
 }
-#endif

--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -1,7 +1,6 @@
 // Copyright 2014-2015 Xamarin Inc. All rights reserved.
 // Copyright 2019 Microsoft Corporation
 
-#if XAMCORE_2_0 || !MONOMAC
 using System;
 using CoreFoundation;
 using Foundation;
@@ -2100,4 +2099,3 @@ namespace NetworkExtension {
 		NENetworkRule[] ExcludedNetworkRules { get; set; }
 	}
 }
-#endif

--- a/src/notificationcenter.cs
+++ b/src/notificationcenter.cs
@@ -11,7 +11,6 @@ using AppKit;
 #endif
 
 namespace NotificationCenter {
-#if XAMCORE_2_0 || !MONOMAC
 	[iOS (8,0)][Mac (10,10)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // not meant to be user created
@@ -68,11 +67,7 @@ namespace NotificationCenter {
 	[BaseType (typeof (UIVibrancyEffect))]
 	[Category (allowStaticMembers: true)] // Classic isn't internal so we need this
 	interface UIVibrancyEffect_NotificationCenter {
-#if XAMCORE_2_0
 		[Internal]
-#else
-		[EditorBrowsable (EditorBrowsableState.Advanced)] // this is not the one we want to be seen (compat only)
-#endif
 		[Deprecated (PlatformName.iOS, 10,0, message: "Use 'UIVibrancyEffect.GetWidgetEffect' instead.")]
 		[Static, Export ("notificationCenterVibrancyEffect")]
 		UIVibrancyEffect NotificationCenterVibrancyEffect ();
@@ -233,6 +228,5 @@ namespace NotificationCenter {
 		[Export ("widgetSearch:resultSelected:"), EventArgs ("NSWidgetSearchResultSelected"), DefaultValue (false)]
 		void ResultSelected (NCWidgetSearchViewController controller, NSObject obj);
 	}
-#endif
 #endif
 }


### PR DESCRIPTION


Backport of #8796.

/cc @rolfbjarne 