### PR TITLE
[msbuild] Remove the support for faking the watchOS 4.3 SDK.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -35,8 +35,6 @@ namespace Xamarin.iOS.Tasks
 		[Required]
 		public bool Debug { get; set; }
 
-		public bool UseFakeWatchOS4_3Sdk { get; set; }
-
 		public string DebugIPAddresses { get; set; }
 
 		public string ResourceRules { get; set; }
@@ -179,26 +177,6 @@ namespace Xamarin.iOS.Tasks
 			if (!SdkIsSimulator) {
 				dtXcode = AppleSdkSettings.DTXcode;
 				dtXcodeBuild = dtSettings.DTXcodeBuild;
-			}
-
-			if (UseFakeWatchOS4_3Sdk) {
-				// This is a workaround for https://github.com/xamarin/xamarin-macios/issues/4810
-				if (Platform == ApplePlatform.WatchOS) {
-					if (dtPlatformBuild != null)
-						dtPlatformBuild = "15T212";
-					if (dtPlatformVersion != null)
-						dtPlatformVersion = "4.3";
-					if (dtSDKBuild != null)
-						dtSDKBuild = "15T212";
-					if (dtSDKName != null)
-						dtSDKName = "watchos4.3";
-					if (dtXcode != null)
-						dtXcode = "0940";
-					if (dtXcodeBuild != null)
-						dtXcodeBuild = "9F1027a";
-				} else {
-					Log.LogWarning (MSBStrings.W0016);
-				}
 			}
 
 			SetValueIfNotNull (plist, "DTCompiler", dtCompiler);

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.Common.targets
@@ -28,7 +28,6 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 
 		<!-- Enable nuget package conflict resolution -->
 		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
-		<UseFakeWatchOS4_3Sdk Condition="'$(UseFakeWatchOS4_3Sdk)' == ''">False</UseFakeWatchOS4_3Sdk>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)..\iOS\Xamarin.iOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -649,7 +649,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			SdkPlatform="$(_SdkPlatform)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			DebugIPAddresses="$(_DebugIPAddresses)"
-			UseFakeWatchOS4_3Sdk="$(UseFakeWatchOS4_3Sdk)"
 			>
 		</CompileAppManifest>
 


### PR DESCRIPTION
It's not needed, this was a workaround for an issue with the App Store to get
around an ARM64_32 requirement if building with the watchOS 4.3 SDK. The App
Store does not allow shipping apps built with the watchOS 4.3 SDK anymore, so
this workaround is not useful now.