### PR TITLE
[ObjCRuntime] Revert unintentional Unified API changes.

### DIFF
--- a/src/ObjCRuntime/Selector.mac.cs
+++ b/src/ObjCRuntime/Selector.mac.cs
@@ -29,8 +29,8 @@ using System.Runtime.InteropServices;
 
 namespace ObjCRuntime {
 	public partial class Selector {
-		public static readonly IntPtr Init = Selector.GetHandle ("init");
-		public static readonly IntPtr InitWithCoder = Selector.GetHandle ("initWithCoder:");
+		internal static readonly IntPtr Init = Selector.GetHandle ("init");
+		internal static readonly IntPtr InitWithCoder = Selector.GetHandle ("initWithCoder:");
 
 		internal static IntPtr AllocHandle = Selector.GetHandle (Alloc);
 		internal static IntPtr ReleaseHandle = Selector.GetHandle (Release);


### PR DESCRIPTION
This regressed here: https://github.com/xamarin/xamarin-macios/commit/73e6ef0eff61c9e2fa4b33761baa6622338200a7#diff-2a62fd8c864f19b9ce687f146b1ed682L35