### PR TITLE
[dotnet] Ship libxamarin.dylib and friends.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -453,10 +453,15 @@ else
 DOTNET5=$(abspath $(TOP)/builds/downloads/dotnet/$(DOTNET5_VERSION))/dotnet
 endif
 
+DOTNET_PLATFORMS=iOS tvOS watchOS macOS
+
 DOTNET_IOS_RUNTIME_IDENTIFIERS=ios-arm ios-arm64 ios-x86 ios-x64
 DOTNET_TVOS_RUNTIME_IDENTIFIERS=tvos-arm64 tvos-x64
 DOTNET_WATCHOS_RUNTIME_IDENTIFIERS=watchos-arm watchos-x86
 DOTNET_MACOS_RUNTIME_IDENTIFIERS=osx-x64
+
+# Create variables prefixed with the correctly cased platform name from the upper-cased platform name. This simplifies code in a few areas (whenever we foreach over DOTNET_PLATFORMS).
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval DOTNET_$(platform)_RUNTIME_IDENTIFIERS:=$(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS)))
 
 DOTNET_IOS_RUNTIME_IDENTIFIERS_32=ios-arm ios-x86
 DOTNET_IOS_RUNTIME_IDENTIFIERS_64=ios-arm64 ios-x64

--- a/Make.config
+++ b/Make.config
@@ -453,19 +453,45 @@ else
 DOTNET5=$(abspath $(TOP)/builds/downloads/dotnet/$(DOTNET5_VERSION))/dotnet
 endif
 
-DOTNET_PLATFORMS=iOS tvOS watchOS macOS
-
+DOTNET_PLATFORMS=
+ifdef INCLUDE_IOS
+DOTNET_PLATFORMS+=iOS
+ifdef INCLUDE_DEVICE
 DOTNET_IOS_RUNTIME_IDENTIFIERS=ios-arm ios-arm64 ios-x86 ios-x64
+DOTNET_IOS_RUNTIME_IDENTIFIERS_32=ios-arm ios-x86
+DOTNET_IOS_RUNTIME_IDENTIFIERS_64=ios-arm64 ios-x64
+else
+DOTNET_IOS_RUNTIME_IDENTIFIERS=ios-x86 ios-x64
+DOTNET_IOS_RUNTIME_IDENTIFIERS_32=ios-x86
+DOTNET_IOS_RUNTIME_IDENTIFIERS_64=ios-x64
+endif
+endif
+
+ifdef INCLUDE_TVOS
+DOTNET_PLATFORMS+=tvOS
+ifdef INCLUDE_DEVICE
 DOTNET_TVOS_RUNTIME_IDENTIFIERS=tvos-arm64 tvos-x64
+else
+DOTNET_TVOS_RUNTIME_IDENTIFIERS=tvos-x64
+endif
+endif
+
+ifdef INCLUDE_WATCH
+DOTNET_PLATFORMS+=watchOS
+ifdef INCLUDE_DEVICE
 DOTNET_WATCHOS_RUNTIME_IDENTIFIERS=watchos-arm watchos-x86
+DOTNET_WATCHOS_RUNTIME_IDENTIFIERS_32=watchos-arm watchos-x86
+else
+DOTNET_WATCHOS_RUNTIME_IDENTIFIERS=watchos-x86
+DOTNET_WATCHOS_RUNTIME_IDENTIFIERS_32=watchos-x86
+endif
+endif
+
+DOTNET_PLATFORMS+=macOS
 DOTNET_MACOS_RUNTIME_IDENTIFIERS=osx-x64
 
 # Create variables prefixed with the correctly cased platform name from the upper-cased platform name. This simplifies code in a few areas (whenever we foreach over DOTNET_PLATFORMS).
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval DOTNET_$(platform)_RUNTIME_IDENTIFIERS:=$(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS)))
-
-DOTNET_IOS_RUNTIME_IDENTIFIERS_32=ios-arm ios-x86
-DOTNET_IOS_RUNTIME_IDENTIFIERS_64=ios-arm64 ios-x64
-DOTNET_WATCHOS_RUNTIME_IDENTIFIERS_32=watchos-arm watchos-x86
 
 # If we should inject an x86_64 slice into every binary that doesn't have one.
 # This is sometimes necessary to work around an Apple bug wrt notarization where Apple flags all binaries that don't have a x86_64 slice, even if they're correctly signed.

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -3,8 +3,6 @@ TOP = ..
 include $(TOP)/Make.config
 include $(TOP)/mk/rules.mk
 
-PLATFORMS=iOS tvOS watchOS macOS
-
 define DefineTargets
 $(1)_NUGET_TARGETS = \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/Sdk/Sdk.targets \
@@ -21,20 +19,20 @@ $(1)_NUGET_TARGETS = \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Xamarin.Shared.Sdk.Versions.props \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Xamarin.Shared.Sdk.Versions.template.props
 endef
-$(foreach platform,$(PLATFORMS),$(eval $(call DefineTargets,$(platform))))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call DefineTargets,$(platform))))
 
 DIRECTORIES += \
 	$(DOTNET_NUPKG_DIR) \
 	$(DOTNET_FEED_DIR) \
-	$(foreach platform,$(PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/Sdk) \
-	$(foreach platform,$(PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets) \
+	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/Sdk) \
+	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets) \
 
 $(DIRECTORIES):
 	$(Q) mkdir -p $@
 
 CURRENT_HASH_LONG:=$(shell git log -1 --pretty=%H)
 
-$(DOTNET_DESTDIR)/Microsoft.%: Microsoft.% | $(foreach platform,$(PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/Sdk $(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets)
+$(DOTNET_DESTDIR)/Microsoft.%: Microsoft.% | $(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/Sdk $(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets)
 	$(Q) $(CP) $< $@
 
 $(DOTNET_DESTDIR)/Microsoft.iOS.Sdk/targets/%: targets/% | $(DOTNET_DESTDIR)/Microsoft.iOS.Sdk/targets
@@ -91,13 +89,12 @@ nupkgs/$(1).$(2)+$(NUGET_BUILD_METADATA).nupkg: $(TEMPLATED_FILES) $(3) package/
 endef
 
 # Create variables prefixed with the correctly cased platform name from the upper-cased platform name. This makes the next section somewhat simpler.
-$(foreach platform,$(PLATFORMS),$(eval $(platform)_NUGET_VERSION_NO_METADATA:=$($(shell echo $(platform) | tr a-z A-Z)_NUGET_VERSION_NO_METADATA)))
-$(foreach platform,$(PLATFORMS),$(eval DOTNET_$(platform)_RUNTIME_IDENTIFIERS:=$(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS)))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_NUGET_VERSION_NO_METADATA:=$($(shell echo $(platform) | tr a-z A-Z)_NUGET_VERSION_NO_METADATA)))
 
 # Create the NuGet packaging targets. It's amazing what make allows you to do...
-$(foreach platform,$(PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Sdk,$($(platform)_NUGET_VERSION_NO_METADATA),$($(platform)_NUGET_TARGETS))))
-$(foreach platform,$(PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Ref,$($(platform)_NUGET_VERSION_NO_METADATA))))
-$(foreach platform,$(PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Runtime.$(rid),$($(platform)_NUGET_VERSION_NO_METADATA)))))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Sdk,$($(platform)_NUGET_VERSION_NO_METADATA),$($(platform)_NUGET_TARGETS))))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Ref,$($(platform)_NUGET_VERSION_NO_METADATA))))
+$(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Runtime.$(rid),$($(platform)_NUGET_VERSION_NO_METADATA)))))
 
 # Copy the nuget from the temporary directory into the final directory
 $(DOTNET_NUPKG_DIR)/%.nupkg: nupkgs/%.nupkg | $(DOTNET_NUPKG_DIR)

--- a/dotnet/package/common.csproj
+++ b/dotnet/package/common.csproj
@@ -55,6 +55,8 @@
     </PropertyGroup>
     <ItemGroup>
       <_PackageFiles Include="$(_packagePath)$(_PackTargetPath)/Xamarin.$(_AssemblyInfix).dll" PackagePath="$(_PackTargetPath)" TargetPath="$(_PackTargetPath)" />
+      <_PackageFiles Include="$(_packagePath)$(_PackNativePath)/*.a" PackagePath="$(_PackNativePath)" TargetPath="$(_PackNativePath)" IsNative="true" />
+      <_PackageFiles Include="$(_packagePath)$(_PackNativePath)/*.dylib" PackagePath="$(_PackNativePath)" TargetPath="$(_PackNativePath)" IsNative="true" />
       <_FrameworkListFileClass Include="@(_PackageFiles->'%(Filename)%(Extension)')" Profile="$(_PlatformName)" />
     </ItemGroup>
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -514,6 +514,115 @@ all-local:: $(RUNTIME_MAC_TARGETS)
 install-local:: $(RUNTIME_MAC_TARGETS)
 
 #
+# .NET
+#
+
+iOS_LIBRARIES = libapp.a libextension.a
+tvOS_LIBRARIES = libtvextension.a
+watchOS_LIBRARIES = libextension.a libwatchextension.a
+macOS_LIBRARIES = libextension.a
+macOS_SHIPPED_HEADERS = $(MAC_SHIPPED_HEADERS)
+
+define DotNetLibTemplate
+DOTNET_TARGETS += \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/libxamarin.dylib \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/libxamarin-debug.dylib \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/libxamarin.a \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/libxamarin-debug.a \
+	$$(foreach lib,$$($(2)_LIBRARIES),$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/$$(lib)) \
+	$$(foreach header,$$(SHIPPED_HEADERS),$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/$$(header)) \
+	$$(foreach header,$$($(2)_SHIPPED_HEADERS),$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/$(header)) \
+
+DOTNET_TARGET_DIRS += \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/xamarin \
+
+$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/xamarin/%.h: xamarin/%.h | $(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/xamarin
+	$$(Q) $$(CP) $$< $$@
+endef
+
+define DotNetLipoLibTemplate
+$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/%: .libs/$(3)/% | $(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native
+	$$(call Q_2,LIPO,  [$1]) $(DEVICE_BIN_PATH)/lipo $$< $$(foreach arch,$(4),-extract_family $$(arch)) -output $$@
+endef
+
+define DotNetCopyLibTemplate
+$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/%: .libs/$(3)/% | $(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native
+	$$(Q) $$(CP) $$< $$@
+endef
+
+# Copy libxammac* to libxamarin* for macOS for now. Eventually we might rename libxammac to libxamarin, which would make it possible to remove this hack.
+.libs/mac/libxamarin%: .libs/mac/libxammac%
+	$(Q)$(CP) $< $@
+
+
+$(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call DotNetLibTemplate,$(platform),$(rid)))))
+
+# If the RID represents fewer architectures than the library in .libs, then use the LipoTemplate, otherwise the CopyTemplate
+$(eval $(call DotNetLipoLibTemplate,iOS,ios-x64,iphonesimulator,x86_64))
+$(eval $(call DotNetLipoLibTemplate,iOS,ios-x86,iphonesimulator,i386))
+$(eval $(call DotNetLipoLibTemplate,iOS,ios-arm64,iphoneos,arm64))
+$(eval $(call DotNetLipoLibTemplate,iOS,ios-arm,iphoneos,armv7 armv7s))
+$(eval $(call DotNetCopyLibTemplate,tvOS,tvos-x64,tvsimulator,x86_64))
+$(eval $(call DotNetCopyLibTemplate,tvOS,tvos-arm64,tvos,arm64))
+$(eval $(call DotNetCopyLibTemplate,watchOS,watchos-x86,watchsimulator,i386))
+$(eval $(call DotNetLipoLibTemplate,watchOS,watchos-arm,watchos,armv7k arm64_32))
+$(eval $(call DotNetCopyLibTemplate,macOS,osx-x64,mac,x86_64))
+
+define DotNetFrameworkTemplate
+DOTNET_TARGETS += \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/Xamarin.framework/Xamarin \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/Xamarin.framework/Info.plist \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/Xamarin-debug.framework/Xamarin-debug \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/Xamarin-debug.framework/Info.plist \
+
+DOTNET_TARGET_DIRS += \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/Xamarin.framework \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/Xamarin-debug.framework
+
+$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/%: $(5)/% | $(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/Xamarin.framework $(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/Xamarin-debug.framework
+	$$(Q) $$(CP) $$< $$@
+endef
+
+# Frameworks have two files: Info.plist and the executable. Here we copy the Info.plist and lipo the executable.
+define DotNetLipoFrameworkTemplate
+$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/%.plist: $(5)/%.plist | $(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/Xamarin.framework $(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/Xamarin-debug.framework
+	$$(Q) $$(CP) $$< $$@
+
+$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/%: $(5)/% | $(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/Xamarin.framework $(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/Xamarin-debug.framework
+	$$(call Q_2,LIPO,  [$1]) $(DEVICE_BIN_PATH)/lipo $$< $$(foreach arch,$(4),-extract_family $$(arch)) -output $$@
+endef
+
+# Just copy both the Info.plist and the executable.
+define DotNetCopyFrameworkTemplate
+$(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/%: $(5)/% | $(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/Xamarin.framework $(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/Frameworks/Xamarin-debug.framework
+	$$(Q) $$(CP) $$< $$@
+endef
+
+# macOS does not have the Xamarin[-debug].framework frameworks
+$(foreach platform,$(filter-out macOS,$(DOTNET_PLATFORMS)),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call DotNetFrameworkTemplate,$(platform),$(rid)))))
+
+# If the RID represents fewer architectures than the library in .libs, then use the LipoTemplate, otherwise the CopyTemplate
+$(eval $(call DotNetLipoFrameworkTemplate,iOS,ios-x64,iphonesimulator,x86_64,$(IOS_DESTDIR)$(XAMARIN_IOSSIMULATOR_SDK)/Frameworks))
+$(eval $(call DotNetLipoFrameworkTemplate,iOS,ios-x86,iphonesimulator,i386,$(IOS_DESTDIR)$(XAMARIN_IOSSIMULATOR_SDK)/Frameworks))
+$(eval $(call DotNetLipoFrameworkTemplate,iOS,ios-arm64,iphoneos,arm64,$(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/Frameworks))
+$(eval $(call DotNetLipoFrameworkTemplate,iOS,ios-arm,iphoneos,armv7 armv7s,$(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/Frameworks))
+$(eval $(call DotNetCopyFrameworkTemplate,tvOS,tvos-x64,tvsimulator,x86_64,$(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/Frameworks))
+$(eval $(call DotNetCopyFrameworkTemplate,tvOS,tvos-arm64,tvos,arm64,$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks))
+$(eval $(call DotNetCopyFrameworkTemplate,watchOS,watchos-x86,watchsimulator,i386,$(IOS_DESTDIR)$(XAMARIN_WATCHSIMULATOR_SDK)/Frameworks))
+$(eval $(call DotNetLipoFrameworkTemplate,watchOS,watchos-arm,watchos,armv7k arm64_32,$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks))
+
+dotnet: $(DOTNET_TARGETS)
+
+$(DOTNET_TARGET_DIRS):
+	$(Q) mkdir -p $@
+
+ifdef ENABLE_DOTNET
+all-local:: $(DOTNET_TARGETS)
+install-local:: $(DOTNET_TARGETS)
+endif
+
+#
 # Common
 #
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -559,14 +559,26 @@ endef
 $(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call DotNetLibTemplate,$(platform),$(rid)))))
 
 # If the RID represents fewer architectures than the library in .libs, then use the LipoTemplate, otherwise the CopyTemplate
+ifdef INCLUDE_IOS
 $(eval $(call DotNetLipoLibTemplate,iOS,ios-x64,iphonesimulator,x86_64))
 $(eval $(call DotNetLipoLibTemplate,iOS,ios-x86,iphonesimulator,i386))
+ifdef INCLUDE_DEVICE
 $(eval $(call DotNetLipoLibTemplate,iOS,ios-arm64,iphoneos,arm64))
 $(eval $(call DotNetLipoLibTemplate,iOS,ios-arm,iphoneos,armv7 armv7s))
+endif
+endif
+ifdef INCLUDE_TVOS
 $(eval $(call DotNetCopyLibTemplate,tvOS,tvos-x64,tvsimulator,x86_64))
+ifdef INCLUDE_DEVICE
 $(eval $(call DotNetCopyLibTemplate,tvOS,tvos-arm64,tvos,arm64))
+endif
+endif
+ifdef INCLUDE_WATCH
 $(eval $(call DotNetCopyLibTemplate,watchOS,watchos-x86,watchsimulator,i386))
+ifdef INCLUDE_DEVICE
 $(eval $(call DotNetLipoLibTemplate,watchOS,watchos-arm,watchos,armv7k arm64_32))
+endif
+endif
 $(eval $(call DotNetCopyLibTemplate,macOS,osx-x64,mac,x86_64))
 
 define DotNetFrameworkTemplate
@@ -603,14 +615,26 @@ endef
 $(foreach platform,$(filter-out macOS,$(DOTNET_PLATFORMS)),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call DotNetFrameworkTemplate,$(platform),$(rid)))))
 
 # If the RID represents fewer architectures than the library in .libs, then use the LipoTemplate, otherwise the CopyTemplate
+ifdef INCLUDE_IOS
 $(eval $(call DotNetLipoFrameworkTemplate,iOS,ios-x64,iphonesimulator,x86_64,$(IOS_DESTDIR)$(XAMARIN_IOSSIMULATOR_SDK)/Frameworks))
 $(eval $(call DotNetLipoFrameworkTemplate,iOS,ios-x86,iphonesimulator,i386,$(IOS_DESTDIR)$(XAMARIN_IOSSIMULATOR_SDK)/Frameworks))
+ifdef INCLUDE_DEVICE
 $(eval $(call DotNetLipoFrameworkTemplate,iOS,ios-arm64,iphoneos,arm64,$(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/Frameworks))
 $(eval $(call DotNetLipoFrameworkTemplate,iOS,ios-arm,iphoneos,armv7 armv7s,$(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/Frameworks))
+endif
+endif
+ifdef INCLUDE_TVOS
 $(eval $(call DotNetCopyFrameworkTemplate,tvOS,tvos-x64,tvsimulator,x86_64,$(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/Frameworks))
+ifdef INCLUDE_DEVICE
 $(eval $(call DotNetCopyFrameworkTemplate,tvOS,tvos-arm64,tvos,arm64,$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks))
+endif
+endif
+ifdef INCLUDE_WATCH
 $(eval $(call DotNetCopyFrameworkTemplate,watchOS,watchos-x86,watchsimulator,i386,$(IOS_DESTDIR)$(XAMARIN_WATCHSIMULATOR_SDK)/Frameworks))
+ifdef INCLUDE_DEVICE
 $(eval $(call DotNetLipoFrameworkTemplate,watchOS,watchos-arm,watchos,armv7k arm64_32,$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks))
+endif
+endif
 
 dotnet: $(DOTNET_TARGETS)
 

--- a/tools/dotnet-linker/Makefile
+++ b/tools/dotnet-linker/Makefile
@@ -3,17 +3,15 @@ TOP=../..
 include $(TOP)/Make.config
 include $(TOP)/mk/rules.mk
 
-PLATFORMS=iOS tvOS watchOS macOS
-
 BUILD_DIR=bin/Debug/net5.0
 
 DOTNET_TARGETS += \
 	$(BUILD_DIR)/dotnet-linker.dll \
-	$(foreach platform,$(PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/tools/dotnet-linker/dotnet-linker.dll) \
-	$(foreach platform,$(PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/tools/dotnet-linker/dotnet-linker.pdb) \
+	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/tools/dotnet-linker/dotnet-linker.dll) \
+	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/tools/dotnet-linker/dotnet-linker.pdb) \
 
 DOTNET_DIRECTORIES += \
-	$(foreach platform,$(PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/tools/dotnet-linker) \
+	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/tools/dotnet-linker) \
 
 # dotnet-linker.csproj.inc contains the dotnet_linker_dependencies variable used to determine if mtouch needs to be rebuilt or not.
 dotnet-linker.csproj.inc: export BUILD_EXECUTABLE=$(DOTNET5) build


### PR DESCRIPTION
Add libxamarin[-debug].[a|dylib] to the NuGets.

Also create a DOTNET_PLATFORMS variable in Make.config and use it everywhere
instead of the PLATFORMS variable we were defining in multiple Makefiles.