### PR TITLE
[msbuild] Rename a few CodeSign* variables to Codesign* variables to make Xamarin.iOS and Xamarin.Mac code identical.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.AppExtension.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.AppExtension.Common.targets
@@ -34,7 +34,7 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 
 	<Target Name="_EnabledLocalSigning" DependsOnTargets="_DetectSigningIdentity">
 		<PropertyGroup>
-			<CodeSignEntitlements Condition="'$(CodeSignEntitlements)' == ''">Entitlements.plist</CodeSignEntitlements>
+			<CodesignEntitlements Condition="'$(CodesignEntitlements)' == ''">Entitlements.plist</CodesignEntitlements>
 		</PropertyGroup>
 	</Target>
 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -60,10 +60,10 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<CodeSignProvision Condition="'$(CodeSignProvision)' == ''"></CodeSignProvision>
-		<CodeSignEntitlements Condition="'$(CodeSignEntitlements)' == ''"></CodeSignEntitlements>
-		<CodeSignResourceRules Condition="'$(CodeSignResourceRules)' == ''"></CodeSignResourceRules>
-		<CodeSignExtraArgs Condition="'$(CodeSignExtraArgs)' == ''"></CodeSignExtraArgs>
+		<CodesignProvision Condition="'$(CodesignProvision)' == ''"></CodesignProvision>
+		<CodesignEntitlements Condition="'$(CodesignEntitlements)' == ''"></CodesignEntitlements>
+		<CodesignResourceRules Condition="'$(CodesignResourceRules)' == ''"></CodesignResourceRules>
+		<CodesignExtraArgs Condition="'$(CodesignExtraArgs)' == ''"></CodesignExtraArgs>
 		<CreatePackage Condition="'$(CreatePackage)' == ''">false</CreatePackage>
 		<HttpClientHandler Condition="'$(HttpClientHandler)' == ''">HttpClientHandler</HttpClientHandler>
 		<EnablePackageSigning Condition="'$(EnablePackageSigning)' == ''">false</EnablePackageSigning>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -76,7 +76,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<_CanArchive Condition="'$(OutputType)' == 'Exe'">true</_CanArchive>
 
 		<_RequireProvisioningProfile>False</_RequireProvisioningProfile>
-		<_RequireProvisioningProfile Condition="'$(CodeSignProvision)' != ''">True</_RequireProvisioningProfile>
+		<_RequireProvisioningProfile Condition="'$(CodesignProvision)' != ''">True</_RequireProvisioningProfile>
 
 		<_PreparedResourceRules></_PreparedResourceRules>
 		<_AppBundleName>$(AssemblyName)</_AppBundleName>
@@ -211,7 +211,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			AppBundleDir="$(AppBundleDir)"
 			AppIdentifier="$(_AppIdentifier)"
 			BundleIdentifier="$(_BundleIdentifier)"
-			Entitlements="$(CodeSignEntitlements)"
+			Entitlements="$(CodesignEntitlements)"
 			CompiledEntitlements="$(IntermediateOutputPath)Entitlements.xcent"
 			IsAppExtension="$(IsAppExtension)"
 			ProvisioningProfile="$(_ProvisioningProfile)"


### PR DESCRIPTION
This is just a case difference in the variable name, and MSBuild properties
are case-insensitive, so this has no functional effect.