### PR TITLE
[msbuild] Remove version comparisons that will always be true by now.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -131,12 +131,6 @@ namespace Xamarin.Localization.MSBuild {
             }
         }
         
-        public static string E0015 {
-            get {
-                return ResourceManager.GetString("E0015", resourceCulture);
-            }
-        }
-        
         public static string W0016 {
             get {
                 return ResourceManager.GetString("W0016", resourceCulture);

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -83,11 +83,6 @@
         </value>
     </data>
     
-    <data name="E0015" xml:space="preserve">
-        <value>Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </value>
-    </data>
-    
      <data name="W0016" xml:space="preserve">
         <value>Can only fake the watchOS 4.3 SDK when building for watchOS.
         </value>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
@@ -86,13 +86,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0015">
-        <source>Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </source>
-        <target state="new">Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0023">
         <source>Cannot have more than 1 iTunesMetadata.plist.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
@@ -86,13 +86,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0015">
-        <source>Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </source>
-        <target state="new">Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0023">
         <source>Cannot have more than 1 iTunesMetadata.plist.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
@@ -86,13 +86,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0015">
-        <source>Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </source>
-        <target state="new">Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0023">
         <source>Cannot have more than 1 iTunesMetadata.plist.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
@@ -86,13 +86,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0015">
-        <source>Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </source>
-        <target state="new">Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0023">
         <source>Cannot have more than 1 iTunesMetadata.plist.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
@@ -86,13 +86,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0015">
-        <source>Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </source>
-        <target state="new">Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0023">
         <source>Cannot have more than 1 iTunesMetadata.plist.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
@@ -86,13 +86,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0015">
-        <source>Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </source>
-        <target state="new">Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0023">
         <source>Cannot have more than 1 iTunesMetadata.plist.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
@@ -86,13 +86,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0015">
-        <source>Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </source>
-        <target state="new">Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0023">
         <source>Cannot have more than 1 iTunesMetadata.plist.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
@@ -86,13 +86,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0015">
-        <source>Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </source>
-        <target state="new">Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0023">
         <source>Cannot have more than 1 iTunesMetadata.plist.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
@@ -86,13 +86,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0015">
-        <source>Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </source>
-        <target state="new">Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0023">
         <source>Cannot have more than 1 iTunesMetadata.plist.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
@@ -86,13 +86,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0015">
-        <source>Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </source>
-        <target state="new">Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0023">
         <source>Cannot have more than 1 iTunesMetadata.plist.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
@@ -86,13 +86,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0015">
-        <source>Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </source>
-        <target state="new">Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0023">
         <source>Cannot have more than 1 iTunesMetadata.plist.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
@@ -86,13 +86,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0015">
-        <source>Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </source>
-        <target state="new">Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0023">
         <source>Cannot have more than 1 iTunesMetadata.plist.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
@@ -86,13 +86,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0015">
-        <source>Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </source>
-        <target state="new">Applications using a storyboard as the Main Interface must have a deployment target greater than 5.0
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0023">
         <source>Cannot have more than 1 iTunesMetadata.plist.
         </source>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
@@ -186,14 +186,6 @@ namespace Xamarin.MacDev.Tasks
 			var buf = doc.ToByteArray (false);
 
 			using (var stream = new MemoryStream ()) {
-				if (AppleSdkSettings.XcodeVersion < new Version (4, 4, 1)) {
-					// write the xcent file with the magic header, length, and the plist
-					var length = Mono.DataConverter.BigEndian.GetBytes ((uint) buf.Length + 8); // 8 = magic.length + magicLen.Length
-
-					stream.Write (XcentMagic, 0, XcentMagic.Length);
-					stream.Write (length, 0, length.Length);
-				}
-
 				stream.Write (buf, 0, buf.Length);
 
 				var src = stream.ToArray ();

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
@@ -55,8 +55,7 @@ namespace Xamarin.MacDev.Tasks
 			environment.Add ("IBSC_MINIMUM_COMPATIBILITY_VERSION", minimumDeploymentTarget);
 			environment.Add ("IBC_MINIMUM_COMPATIBILITY_VERSION", minimumDeploymentTarget);
 
-			if (AppleSdkSettings.XcodeVersion.Major >= 5)
-				args.Add ("--minimum-deployment-target", minimumDeploymentTarget);
+			args.Add ("--minimum-deployment-target", minimumDeploymentTarget);
 			
 			foreach (var targetDevice in GetTargetDevices (plist))
 				args.Add ("--target-device", targetDevice);

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -129,9 +129,6 @@ namespace Xamarin.iOS.Tasks
 			}
 
 			if (IsIOS) {
-				if (minimumOSVersion < IPhoneSdkVersion.V5_0 && plist.GetUIMainStoryboardFile (true) != null)
-					LogAppManifestError (MSBStrings.E0015);
-
 				if (!plist.ContainsKey (ManifestKeys.CFBundleName))
 					plist [ManifestKeys.CFBundleName] = plist.ContainsKey (ManifestKeys.CFBundleDisplayName) ? plist.GetString (ManifestKeys.CFBundleDisplayName).Clone () : new PString (AppBundleName);
 			} else {
@@ -347,7 +344,7 @@ namespace Xamarin.iOS.Tasks
 				if (!IsAppExtension)
 					plist.SetIfNotPresent (ManifestKeys.LSRequiresIPhoneOS, true);
 
-				if (minimumOSVersion >= IPhoneSdkVersion.V3_2 && supportedDevices == IPhoneDeviceType.NotSet)
+				if (supportedDevices == IPhoneDeviceType.NotSet)
 					plist.SetUIDeviceFamily (IPhoneDeviceType.IPhone);
 			}
 		}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -261,9 +261,6 @@ namespace Xamarin.iOS.Tasks
 			
 			args.AddQuotedLine ((SdkIsSimulator ? "--sim=" : "--dev=") + Path.GetFullPath (AppBundleDir));
 
-			if (AppleSdkSettings.XcodeVersion.Major >= 5 && IPhoneSdks.MonoTouch.Version.CompareTo (new IPhoneSdkVersion (6, 3, 7)) < 0)
-				args.AddLine ("--compiler=clang");
-
 			args.AddQuotedLine ($"--executable={ExecutableName}");
 
 			if (IsAppExtension)


### PR DESCRIPTION
This also allowed us to remove an error (and the corresponding message).