### PR TITLE
[d16-7] [apidiff] Fix range expression.

### DIFF
--- a/tools/apidiff/merger.cs
+++ b/tools/apidiff/merger.cs
@@ -57,7 +57,7 @@ class Merger {
 		using (var md = SHA256.Create ())
 			digest = md.ComputeHash (Encoding.UTF8.GetBytes (filename));
 		// (not cryptographically) unique (but good enough) for each filename - so document remains with the same id when it's updated/regenerated
-		var guid = new Guid (digest[0..15]);
+		var guid = new Guid (digest[0..16]);
 
 		var headers = new StringWriter ();
 		var title = $"{platform} SDK API diff: {from} vs {to}";


### PR DESCRIPTION
The C# range expression is somewhat confusing: the lower bound is inclusive,
but the upper bound is exclusive. This means that [0..15] is 15 characters,
not the 16 characters we want here.

Fixes this during API comparison:

    System.ArgumentException: Byte array for GUID must be exactly 16 bytes long.
    Parameter name: b
      at System.Guid..ctor (System.ReadOnlySpan`1[T] b) [0x00111] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/external/corefx/src/Common/src/CoreLib/System/Guid.cs:66
      at System.Guid..ctor (System.Byte[] b) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/external/corefx/src/Common/src/CoreLib/System/Guid.cs:45
      at Merger.Process (System.String platform, System.String path, System.String os) [0x001d1] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tools/apidiff/merger.cs:60
      at Merger.Main (System.String[] args) [0x00002] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tools/apidiff/merger.cs:94
    make[2]: *** [tvos-markdown] Error 1

Backport of #8827.

/cc @rolfbjarne 