### PR TITLE
[d16-7] [jenkins] Timeout the tests on older macOS bots after 15 minutes.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -787,12 +787,14 @@ timestamps {
                                             }
                                             builders [nodeText] = {
                                                 try {
-                                                    if (excluded) {
-                                                        echo (nodeText)
-                                                    } else {
-                                                        node ("xamarin-macios && macos-10.${macOS}") {
-                                                            stage ("Running XM tests on '10.${macOS}'") {
-                                                                runXamarinMacTests (url, "macOS 10.${macOS}", maccore_hash, gitHash)
+                                                    timeout (time: 15, unit: 'MINUTES') {
+                                                        if (excluded) {
+                                                            echo (nodeText)
+                                                        } else {
+                                                            node ("xamarin-macios && macos-10.${macOS}") {
+                                                                stage ("Running XM tests on '10.${macOS}'") {
+                                                                    runXamarinMacTests (url, "macOS 10.${macOS}", maccore_hash, gitHash)
+                                                                }
                                                             }
                                                         }
                                                     }


### PR DESCRIPTION
Prevents deadlocks from holding up everything for hours:
https://jenkins.internalx.com/blue/organizations/jenkins/macios/detail/master/1583/pipeline/271/

Backport of #8637.

/cc @rolfbjarne 