### PR TITLE
[xharness] Always use nuget to restore nugets, and always use xibuild to run nuget.

### DIFF
--- a/tests/xharness/Jenkins/TestTasks/BuildProjectTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/BuildProjectTask.cs
@@ -25,10 +25,5 @@ namespace Xharness.Jenkins.TestTasks {
 
 		protected override void InitializeTool () 
 			=> buildToolTask = new BuildProject (Jenkins.Harness.XIBuildPath, ProcessManager, ResourceManager, this, this);
-
-		// This method must be called with the desktop resource acquired
-		// (which is why it takes an IAcquiredResources as a parameter without using it in the function itself).
-		protected async Task RestoreNugetsAsync (ILog log, IAcquiredResource resource, bool useXIBuild = false) => 	
-			ExecutionResult = await BuildProject.RestoreNugetsAsync (log, resource, useXIBuild);
 	}
 }

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Tasks/MSBuild.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Tasks/MSBuild.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tasks {
 		{
 			BuildLog = buildLog;
 			(TestExecutingResult ExecutionResult, (string HumanMessage, string IssueLink)? KnownFailure) result = (TestExecutingResult.NotStarted, ((string HumanMessage, string IssueLink)?) null);
-			await RestoreNugetsAsync (buildLog, resource, useXIBuild: true);
+			await RestoreNugetsAsync (buildLog, resource);
 
 			using (var xbuild = new Process ()) {
 				xbuild.StartInfo.FileName = msbuildPath;


### PR DESCRIPTION
This fixes an MSB4226 error code that shows up sometimes when restoring nugets:

<img width="2538" alt="Screenshot 2020-05-28 15 10 35" src="https://user-images.githubusercontent.com/249268/83145647-6dee8000-a0f5-11ea-8aad-65f627530e64.png">
