### PR TITLE
[msbuild/tests] Set MSBUILD_EXE_PATH when running unit tests from within VS. Fixes #5042.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -544,7 +544,7 @@ namespace Xamarin.iOS.Tasks
 		{
 			// It may have been resolved to an existing local full path
 			// already, such as when building from XS on the Mac.
-			if (File.Exists (fullName))
+			if (Path.IsPathRooted (fullName) && File.Exists (fullName))
 				return fullName;
 
 			var frameworkDir = TargetFramework.Identifier;

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/AssemblySetup.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/AssemblySetup.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using NUnit.Framework;
+
+using Xamarin.Tests;
+
+[SetUpFixture]
+public class AssemblySetup {
+	[OneTimeSetUp]
+	public void AssemblyInitialization ()
+	{
+		// Seems like the ServiceHubUniqueLogDir environment variable is set when executing unit tests from within VS
+		var is_in_vsmac = !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("ServiceHubUniqueLogDir"));
+		const string msbuild_exe_path = "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/MSBuild.dll";
+		if (is_in_vsmac) {
+			var env = new Dictionary<string, string> {
+				{ "MD_APPLE_SDK_ROOT", Path.GetDirectoryName (Path.GetDirectoryName (Configuration.xcode_root)) },
+				{ "TargetFrameworkFallbackSearchPaths", Path.Combine (Configuration.TargetDirectoryXI, "Library", "Frameworks", "Mono.framework", "External", "xbuild-frameworks") },
+				{ "MSBuildExtensionsPathFallbackPathsOverride", Path.Combine (Configuration.TargetDirectoryXI, "Library", "Frameworks", "Mono.framework", "External", "xbuild") },
+				{ "MD_MTOUCH_SDK_ROOT", Path.Combine (Configuration.TargetDirectoryXI, "Library", "Frameworks", "Xamarin.iOS.framework", "Versions", "Current") },
+				{ "MSBUILD_EXE_PATH", msbuild_exe_path },
+			};
+
+			foreach (var kvp in env)
+				Environment.SetEnvironmentVariable (kvp.Key, kvp.Value);
+
+			Console.WriteLine ($"Detected that we're running inside Visual Studio, and the environment has been configured.");
+		} else {
+			Console.WriteLine ("Detected that we're not running inside Visual Studio, and thus will not set MSBUILD_EXE_PATH.");
+		}
+	}
+}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/FrameworkListTest.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/FrameworkListTest.cs
@@ -70,7 +70,7 @@ namespace Xamarin.iOS.Tasks
 		List<AssemblyInfo> ScanFrameworkListXml (string frameworkListFile, bool isMac)
 		{
 			var assemblies = new List<AssemblyInfo> ();
-			var path = Path.GetFullPath (Path.Combine ("..", "..", isMac ? "Xamarin.Mac.Tasks" : "Xamarin.iOS.Tasks.Core", frameworkListFile));
+			var path = Path.GetFullPath (Path.Combine (Configuration.SourceRoot, "msbuild", isMac ? "Xamarin.Mac.Tasks" : "Xamarin.iOS.Tasks.Core", frameworkListFile));
 			using (var reader = XmlReader.Create (path)) {
 				while (reader.Read ()) {
 					if (reader.IsStartElement ()) {

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectReference.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectReference.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 
@@ -18,32 +19,16 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void BasicTest ()
 		{
-			// We set MSBuildExtensionsPath when building with xbuild to redirect to our locally build XI/XM, but that confuses MSBuild, which uses MSBuildExtensionsPathFallbackPathsOverride instead.
-			// So if MSBuildExtensionsPath is set, move the value temporarily to MSBuildExtensionsPathFallbackPathsOverride instead, since we're using MSBuild here.
-			// This will become unnecessary when PR #4111 is merged.
-			var msbuildExtensions = Environment.GetEnvironmentVariable ("MSBuildExtensionsPath");
-			if (!string.IsNullOrEmpty (msbuildExtensions)) {
-				Environment.SetEnvironmentVariable ("MSBuildExtensionsPath", null);
-				Environment.SetEnvironmentVariable ("MSBuildExtensionsPathFallbackPathsOverride", msbuildExtensions);
-			}
-			try {
-				NugetRestore ("../MyAppWithPackageReference/MyAppWithPackageReference.csproj");
-				NugetRestore ("../MyExtensionWithPackageReference/MyExtensionWithPackageReference.csproj");
+			NugetRestore (Path.Combine (Configuration.SourceRoot, "msbuild", "tests", "MyAppWithPackageReference", "MyAppWithPackageReference.csproj"));
+			NugetRestore (Path.Combine (Configuration.SourceRoot, "msbuild", "tests", "MyExtensionWithPackageReference", "MyExtensionWithPackageReference.csproj"));
 
-				// Can't use the in-process MSBuild engine, because it complains that the project file is invalid (the attribute 'Version' in the element '<PackageReference>' is unrecognized)
-				var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, new [] { "--", "../MyAppWithPackageReference/MyAppWithPackageReference.csproj", $"/p:Platform={Platform}", "/p:Configuration=Debug" }, out var output);
-				if (rv != 0) {
-					Console.WriteLine ("Build failed:");
-					Console.WriteLine (output);
-					Assert.Fail ("Build failed");
-				}
-			} finally {
-				if (!string.IsNullOrEmpty (msbuildExtensions)) {
-					Environment.SetEnvironmentVariable ("MSBuildExtensionsPath", msbuildExtensions);
-					Environment.SetEnvironmentVariable ("MSBuildExtensionsPathFallbackPathsOverride", null);
-				}
+			// Can't use the in-process MSBuild engine, because it complains that the project file is invalid (the attribute 'Version' in the element '<PackageReference>' is unrecognized)
+			var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, new [] { "--", Path.Combine (Configuration.SourceRoot, "msbuild", "tests", "MyAppWithPackageReference", "MyAppWithPackageReference.csproj"), $"/p:Platform={Platform}", "/p:Configuration=Debug" }, out var output);
+			if (rv != 0) {
+				Console.WriteLine ("Build failed:");
+				Console.WriteLine (output);
+				Assert.AreEqual (0, rv, "Build failed");
 			}
 		}
 	}
 }
-

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/EnsureEmptyTasks.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/EnsureEmptyTasks.cs
@@ -6,6 +6,8 @@ using System.Text;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
 
+using Xamarin.Tests;
+
 namespace Xamarin.iOS.Tasks
 {
 	[TestFixture (Description = @"Ensures that all non-abstract task classes have empty bodies, 
@@ -16,15 +18,7 @@ since all code must exist in the base classes instead, so it can be reused from 
 		static readonly Regex ClassNameExpr = new Regex (@"public class (?<name>[^\s]+)", RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.ExplicitCapture);
 		static readonly Regex AbstractClassExpr = new Regex (@"abstract class ", RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.ExplicitCapture);
 
-		static readonly string TasksPath;
-
-		static EnsureEmptyTasks()
-		{
-			if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-				TasksPath = @"..\..\Xamarin.iOS.Tasks\Tasks";
-			else
-				TasksPath = @"../../Xamarin.iOS.Tasks/Tasks";
-		}
+		static readonly string TasksPath = Path.Combine (Configuration.SourceRoot, "msbuild", "Xamarin.iOS.Tasks", "Tasks");
 
 		[TestCaseSource ("TaskFiles")]
 		[Test]

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 
 using Xamarin.MacDev;
 using Xamarin.MacDev.Tasks;
+using Xamarin.Tests;
 using Xamarin.Utils;
 
 namespace Xamarin.iOS.Tasks
@@ -68,7 +69,8 @@ namespace Xamarin.iOS.Tasks
 			Directory.CreateDirectory (tmp);
 
 			try {
-				var ibtool = CreateIBToolTask (ApplePlatform.iOS, "../MyIBToolLinkTest", tmp);
+				var srcdir = Path.Combine (Configuration.SourceRoot, "msbuild", "tests", "MyIBToolLinkTest");
+				var ibtool = CreateIBToolTask (ApplePlatform.iOS, srcdir, tmp);
 				var bundleResources = new HashSet<string> ();
 
 				Assert.IsTrue (ibtool.Execute (), "Execution of IBTool task failed.");
@@ -119,7 +121,8 @@ namespace Xamarin.iOS.Tasks
 			Directory.CreateDirectory (tmp);
 
 			try {
-				ibtool = CreateIBToolTask (ApplePlatform.iOS, "../IBToolTaskTests/LinkedAndTranslated", tmp);
+				var srcdir = Path.Combine (Configuration.SourceRoot, "msbuild", "tests", "IBToolTaskTests", "LinkedAndTranslated");
+				ibtool = CreateIBToolTask (ApplePlatform.iOS, srcdir, tmp);
 				var bundleResources = new HashSet<string> ();
 
 				// Add some ResourceTags...
@@ -199,7 +202,8 @@ namespace Xamarin.iOS.Tasks
 			Directory.CreateDirectory (tmp);
 
 			try {
-				ibtool = CreateIBToolTask (ApplePlatform.iOS, "../IBToolTaskTests/GenericAndDeviceSpecific", tmp, fileNames);
+				var srcdir = Path.Combine (Configuration.SourceRoot, "msbuild", "tests", "IBToolTaskTests", "GenericAndDeviceSpecific");
+				ibtool = CreateIBToolTask (ApplePlatform.iOS, srcdir, tmp, fileNames);
 				var bundleResources = new HashSet<string> ();
 
 				// Add some ResourceTags...

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -51,6 +51,9 @@
     <Compile Include="..\..\..\tests\common\ExecutionHelper.cs">
       <Link>ExecutionHelper.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tests\mtouch\Cache.cs">
+      <Link>Cache.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Entitlements.plist">

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -306,7 +306,7 @@ namespace Xamarin.Tests
 			
 		static string TestAssemblyDirectory {
 			get {
-				return TestContext.CurrentContext.TestDirectory;
+				return TestContext.CurrentContext.WorkDirectory;
 			}
 		}
 


### PR DESCRIPTION
Also fix several tests to work when executed from within VS due to some difference

There's also a change to the MtouchTask: lookup of framework assemblies won't
succeed anymore if the path to the assembly is just an unrooted filename
(which may happen to be a file in the current directory (as a test proved
accidentally) - in which case it will never be a framework assembly).

Unfortunately this won't make all tests pass, around 20 tests will still fail
(when run from within VS) with:

     #RunTarget-ErrorCount
    	The "GetReferenceNearestTargetFrameworkTask" task could not be instantiated from the assembly "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/NuGet.Build.Tasks.dll". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. Specified cast is not valid.
    	The "GetReferenceNearestTargetFrameworkTask" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.
      Expected: 0
      But was:  2

but I couldn't figure out how to fix these errors.

Fixes https://github.com/xamarin/xamarin-macios/issues/5042.