### PR TITLE
[tests] Don't add the build output to the assert message our mmp tests, it makes html reports hard to read.

### DIFF
--- a/tests/mmptest/src/CodeStrippingTests.cs
+++ b/tests/mmptest/src/CodeStrippingTests.cs
@@ -115,14 +115,14 @@ namespace Xamarin.MMP.Tests
 
 		void AssertNoLipoOrWarning (string buildOutput, string context)
 		{
-			Assert.False (DidAnyLipoStrip (buildOutput), "lipo incorrectly run in context: " + context + "\n" + buildOutput);
-			Assert.False (buildOutput.Contains ("MM2108"), "MM2108 incorrectly given in in context: " + context + "\n" + buildOutput);
+			Assert.False (DidAnyLipoStrip (buildOutput), "lipo incorrectly run in context: " + context);
+			Assert.False (buildOutput.Contains ("MM2108"), "MM2108 incorrectly given in in context: " + context);
 		}
 
 		void AssertLipoOnlyMonoPosixAndMonoNative (string buildOutput, string context)
 		{
-			Assert.False (DidAnyLipoStripSkipPosixAndMonoNative (buildOutput), "lipo incorrectly run in context outside of libMonoPosixHelper/libmono-native: " + context + "\n" + buildOutput);
-			Assert.False (buildOutput.Contains ("MM2108"), "MM2108 incorrectly given in in context: " + context + "\n" + buildOutput);
+			Assert.False (DidAnyLipoStripSkipPosixAndMonoNative (buildOutput), "lipo incorrectly run in context outside of libMonoPosixHelper/libmono-native: " + context);
+			Assert.False (buildOutput.Contains ("MM2108"), "MM2108 incorrectly given in in context: " + context);
 		}
 
 		[TestCase (false)]
@@ -142,8 +142,8 @@ namespace Xamarin.MMP.Tests
 				// Should always lipo/warn in Release
 				test.Release = true;
 				buildOutput = TI.TestUnifiedExecutable (test).BuildOutput;
-				Assert.True (DidAnyLipoStrip (buildOutput), $"lipo did not run in release\n{buildOutput}");
-				Assert.True (buildOutput.Contains ("MM2108"), $"MM2108 not given in release\n{buildOutput}");
+				Assert.True (DidAnyLipoStrip (buildOutput), $"lipo did not run in release");
+				Assert.True (buildOutput.Contains ("MM2108"), $"MM2108 not given in release");
 
 			});
 		}

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -398,7 +398,7 @@ namespace Xamarin.MMP.Tests
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { XM45 = xm45 };
 				test.Release = true;
 				string buildResults = TI.TestUnifiedExecutable (test).BuildOutput;
-				Assert.IsFalse (buildResults.Contains ("Xamarin.Mac.registrar"), "Release build should not use partial static registrar\n" + buildResults);
+				Assert.IsFalse (buildResults.Contains ("Xamarin.Mac.registrar"), "Release build should not use partial static registrar");
 			});
 		}
 
@@ -411,7 +411,7 @@ namespace Xamarin.MMP.Tests
 				test.Release = false;
 				test.CSProjConfig = "<DebugSymbols>true</DebugSymbols>";
 				var buildResults = TI.TestUnifiedExecutable (test).BuildOutput;
-				Assert.IsTrue (buildResults.Contains ("Xamarin.Mac.registrar"), "Debug build should use partial static registrar\n" + buildResults);
+				Assert.IsTrue (buildResults.Contains ("Xamarin.Mac.registrar"), "Debug build should use partial static registrar");
 			});
 		}
 
@@ -424,7 +424,7 @@ namespace Xamarin.MMP.Tests
 				test.Release = false;
 				test.CSProjConfig = "<DebugSymbols>true</DebugSymbols><MonoBundlingExtraArgs>--registrar=dynamic</MonoBundlingExtraArgs><XamMacArch>x86_64</XamMacArch>";
 				var buildResults = TI.TestUnifiedExecutable (test).BuildOutput;
-				Assert.IsFalse (buildResults.Contains ("Xamarin.Mac.registrar"), "registrar=dynamic build should not use partial static registrar\n" + buildResults);
+				Assert.IsFalse (buildResults.Contains ("Xamarin.Mac.registrar"), "registrar=dynamic build should not use partial static registrar");
 			});
 		}
 
@@ -437,7 +437,7 @@ namespace Xamarin.MMP.Tests
 				test.Release = false;
 				test.CSProjConfig = "<DebugSymbols>true</DebugSymbols><MonoBundlingExtraArgs>--registrar=partial</MonoBundlingExtraArgs><XamMacArch>x86_64</XamMacArch>";
 				var buildResults = TI.TestUnifiedExecutable (test).BuildOutput;
-				Assert.IsTrue (buildResults.Contains ("Xamarin.Mac.registrar"), "registrar=partial build should use partial static registrar\n" + buildResults);
+				Assert.IsTrue (buildResults.Contains ("Xamarin.Mac.registrar"), "registrar=partial build should use partial static registrar");
 			});
 		}
 		//https://testrail.xamarin.com/index.php?/cases/view/234141&group_by=cases:section_id&group_order=asc&group_id=51097


### PR DESCRIPTION
The build output is very verbose, which means the html reports are just
impossible to navigate due to the amount of text. The build output will be
printed to the terminal anyway, so it'll still be available.