### PR TITLE
[msbuild] Share the DeviceSpecificIntermediateOutputPath property.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.AppExtension.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.AppExtension.Common.targets
@@ -40,7 +40,7 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 
 	<Target Name="_GenerateBundleName" DependsOnTargets="_DetectSigningIdentity">
 		<PropertyGroup>
-			<AppBundleDir Condition="'$(AppBundleDir)' == ''">$(OutputPath)$(DeviceSpecificOutputPath)$(_AppBundleName)$(_AppBundleDirExt)</AppBundleDir>
+			<AppBundleDir Condition="'$(AppBundleDir)' == ''">$(DeviceSpecificOutputPath)$(_AppBundleName)$(_AppBundleDirExt)</AppBundleDir>
 			<_AppBundlePath>$(AppBundleDir)\</_AppBundlePath>
 
 			<_AppResourcesPath>$(_AppBundlePath)Contents\Resources\</_AppResourcesPath>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -104,6 +104,24 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<_BundlerDebug Condition="'$(_PlatformName)' != 'macOS'">$(MtouchDebug)</_BundlerDebug>
 		<!-- The default is false for all platforms -->
 		<_BundlerDebug Condition="'$(_BundlerDebug)' == ''">false</_BundlerDebug>
+
+		<!-- DeviceSpecificIntermediateOutputPath -->
+		<!--
+			We don't need this value for Xamarin.Mac, but many of the targets
+			that can be shared need to use this for Xamarin.iOS, so set this
+			value for Xamarin.Mac as well. It will always be the default
+			IntermediateOutputPath for Xamarin.Mac, while for Xamarin.iOS it
+			might be changed in _ComputeTargetArchitectures.
+		-->
+		<DeviceSpecificIntermediateOutputPath>$(IntermediateOutputPath)</DeviceSpecificIntermediateOutputPath>
+		<!-- Make sure DeviceSpecificOutputPath is a relative path, we depend
+		     on this elsewhere (we prepend the project's directory). When
+		     using dotnet IntermediateOutputPath (and thus
+		     DeviceSpecificIntermediateOutputPath) might be a full path, so
+		     handle this by calculating the corresponding relative path for
+		     DeviceSpecificOutputPath. -->
+		<DeviceSpecificOutputPath>$(OutputPath)</DeviceSpecificOutputPath>
+		<DeviceSpecificOutputPath Condition="$([System.IO.Path]::IsPathRooted ('$(DeviceSpecificOutputPath)')) == 'true'">$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)','$(OutputPath)'))</DeviceSpecificOutputPath>
 	</PropertyGroup>
 
 	<Target Name="_ComputeTargetFrameworkMoniker" Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -122,16 +122,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<_AppBundleName>$(AssemblyName)</_AppBundleName>
 
 		<AppBundleExtension Condition="'$(AppBundleExtension)' == ''">.app</AppBundleExtension>
-
-		<DeviceSpecificIntermediateOutputPath>$(IntermediateOutputPath)</DeviceSpecificIntermediateOutputPath>
-		<!-- Make sure DeviceSpecificOutputPath is a relative path, we depend
-		     on this elsewhere (we prepend the project's directory). When
-		     using dotnet IntermediateOutputPath (and thus
-		     DeviceSpecificIntermediateOutputPath) might be a full path, so
-		     handle this by calculating the corresponding relative path for
-		     DeviceSpecificOutputPath. -->
-		<DeviceSpecificOutputPath>$(OutputPath)</DeviceSpecificOutputPath>
-		<DeviceSpecificOutputPath Condition="$([System.IO.Path]::IsPathRooted ('$(DeviceSpecificOutputPath)')) == 'true'">$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)','$(OutputPath)'))</DeviceSpecificOutputPath>
 	</PropertyGroup>
 	
 	<PropertyGroup>


### PR DESCRIPTION
We don't technically need this value for Xamarin.Mac, but many of the targets
that can be shared need to use this for Xamarin.iOS, so set this value for
Xamarin.Mac as well. It will always be the default IntermediateOutputPath for
Xamarin.Mac, while for Xamarin.iOS it might be changed in
_ComputeTargetArchitectures.