### PR TITLE
[tests] Use Cache.CreateTemporaryDirectory to create temporary directories for the msbuild-mac tests.

### DIFF
--- a/tests/msbuild-mac/msbuild-mac.csproj
+++ b/tests/msbuild-mac/msbuild-mac.csproj
@@ -64,6 +64,9 @@
     <Compile Include="..\common\Profile.cs">
       <Link>Profile.cs</Link>
     </Compile>
+    <Compile Include="..\mtouch\Cache.cs">
+      <Link>Cache.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tests/msbuild-mac/src/MSBuild-Smoke.cs
+++ b/tests/msbuild-mac/src/MSBuild-Smoke.cs
@@ -7,21 +7,16 @@ using System.Reflection;
 using System.Text;
 using NUnit.Framework;
 
+using Xamarin;
+
 namespace Xamarin.MMP.Tests
 {
 	[TestFixture]
 	public partial class MMPTests
 	{
-		void RunMSBuildTest (Action <string> test)
+		void RunMSBuildTest (Action <string> test, string directory_name = null)
 		{
-			string tmpDir = Path.Combine (Path.GetTempPath (), "msbuild-tests");
-			try {
-				Directory.CreateDirectory (tmpDir);
-				test (tmpDir);
-			}
-			finally {
-				Directory.Delete (tmpDir, true);
-			}
+			test (Cache.CreateTemporaryDirectory (directory_name ?? "msbuild-tests"));
 		}
 
 		[Test]


### PR DESCRIPTION
This makes it easier to diagnose failures, because the temporary directory stay on disk after
the test has finished executing (until the next time the test is run).