### PR TITLE
Remove notice from generated iOS Apps

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -1100,9 +1100,13 @@ This indicates a bug in Xamarin.iOS. Please file a new issue on [github](https:/
 
 Remove the directory `NOTICE` from the project.
 
+Earlier versions of our tools generated a NOTICE file.
+
 <a name="MT1017" />
 
 ### MT1017: Failed to create the NOTICE file: *.
+
+Earlier versions of our tools generated a NOTICE file.
 
 <a name="MT1018" />
 

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -190,7 +190,6 @@ public class B : A {}
 
 				var expectedFiles = new string []
 				{
-					"NOTICE",
 					"testApp",
 					"testApp.aotdata.armv7",
 					"testApp.aotdata.arm64",
@@ -319,7 +318,6 @@ public class B : A {}
 				mtouch.GccFlags = "-v";
 				mtouch.AssertExecute (MTouchAction.BuildDev, "fourth build");
 				Console.WriteLine ("fourth build done");
-				mtouch.AssertAllModified (dt, name + " - fourth build", "NOTICE");
 			}
 		}
 

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2860,47 +2860,6 @@ public class TestApp {
 		}
 
 		[Test]
-		public void MT1016 ()
-		{
-			AssertDeviceAvailable ();
-
-			// #20607
-
-			using (var tool = new MTouchTool ()) {
-				tool.CreateTemporaryCacheDirectory ();
-				tool.CreateTemporaryApp ();
-
-				// Create a NOTICE directory
-				var notice = Path.Combine (tool.AppPath, "NOTICE");
-				Directory.CreateDirectory (notice);
-
-				tool.AssertExecuteFailure (MTouchAction.BuildDev);
-				tool.AssertError (1016, "Failed to create the NOTICE file because a directory already exists with the same name.");
-			}
-		}
-
-		[Test]
-		public void MT1017 ()
-		{
-			AssertDeviceAvailable ();
-
-			// #20607
-
-			using (var tool = new MTouchTool ()) {
-				tool.CreateTemporaryCacheDirectory ();
-				tool.CreateTemporaryApp ();
-
-				// Create a readonly NOTICE file
-				var notice = Path.Combine (tool.AppPath, "NOTICE");
-				File.WriteAllText (notice, "contents");
-				new FileInfo (notice).IsReadOnly = true;
-
-				tool.AssertExecute (MTouchAction.BuildDev);
-				Assert.AreNotEqual ("contents", File.ReadAllText (notice), "NOTICE file written successfully");
-			}
-		}
-
-		[Test]
 		public void MT1202 ()
 		{
 			using (var mtouch = new MTouchTool ()) {

--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -662,7 +662,6 @@ namespace Xamarin.Bundler {
 			StripNativeCode ();
 			BundleAssemblies ();
 
-			WriteNotice ();
 			GenerateRuntimeOptions ();
 
 			if (Cache.IsCacheTemporary) {
@@ -1280,35 +1279,6 @@ namespace Xamarin.Bundler {
 					final_build_task.AddDependency (link_tasks);
 					build_tasks.Add (final_build_task);
 				}
-			}
-		}
-
-		void WriteNotice ()
-		{
-			if (!IsDeviceBuild || IsExtension)
-				return;
-
-			if (Embeddinator)
-				return;
-
-			WriteNotice (AppDirectory);
-		}
-
-		void WriteNotice (string directory)
-		{
-			var path = Path.Combine (directory, "NOTICE");
-			if (Directory.Exists (path))
-				throw new ProductException (1016, true, Errors.MT1016);
-
-			try {
-				// write license information inside the .app
-				StringBuilder sb = new StringBuilder ();
-				sb.Append ("Xamarin built applications contain open source software.  ");
-				sb.Append ("For detailed attribution and licensing notices, please visit...");
-				sb.AppendLine ().AppendLine ().Append ("http://xamarin.com/mobile-licensing").AppendLine ();
-				Driver.WriteIfDifferent (path, sb.ToString ());
-			} catch (Exception ex) {
-				throw new ProductException (1017, true, ex, Errors.MT1017, ex.Message);
 			}
 		}
 
@@ -2024,8 +1994,6 @@ namespace Xamarin.Bundler {
 		{
 			if (!Embeddinator)
 				return;
-
-			WriteNotice (output_path);
 		}
 
 		public void CreateFrameworkInfoPList (string output_path, string framework_name, string bundle_identifier, string bundle_name)

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -927,16 +927,6 @@
 		</value>
 	</data>
 
-	<data name="MT1016" xml:space="preserve">
-		<value>Failed to create the NOTICE file because a directory already exists with the same name.
-		</value>
-	</data>
-	
-	<data name="MT1017" xml:space="preserve">
-		<value>Failed to create the NOTICE file: {0}
-		</value>
-	</data>
-
 	<data name="MT1022" xml:space="preserve">
 		<value>Could not copy the directory '{0}' to '{1}': {2}
 		</value>

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -1433,22 +1433,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT1016">
-        <source>Failed to create the NOTICE file because a directory already exists with the same name.
-		</source>
-        <target state="new">Failed to create the NOTICE file because a directory already exists with the same name.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT1017">
-        <source>Failed to create the NOTICE file: {0}
-		</source>
-        <target state="new">Failed to create the NOTICE file: {0}
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT1022">
         <source>Could not copy the directory '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -1433,22 +1433,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT1016">
-        <source>Failed to create the NOTICE file because a directory already exists with the same name.
-		</source>
-        <target state="new">Failed to create the NOTICE file because a directory already exists with the same name.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT1017">
-        <source>Failed to create the NOTICE file: {0}
-		</source>
-        <target state="new">Failed to create the NOTICE file: {0}
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT1022">
         <source>Could not copy the directory '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -1433,22 +1433,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT1016">
-        <source>Failed to create the NOTICE file because a directory already exists with the same name.
-		</source>
-        <target state="new">Failed to create the NOTICE file because a directory already exists with the same name.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT1017">
-        <source>Failed to create the NOTICE file: {0}
-		</source>
-        <target state="new">Failed to create the NOTICE file: {0}
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT1022">
         <source>Could not copy the directory '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -1433,22 +1433,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT1016">
-        <source>Failed to create the NOTICE file because a directory already exists with the same name.
-		</source>
-        <target state="new">Failed to create the NOTICE file because a directory already exists with the same name.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT1017">
-        <source>Failed to create the NOTICE file: {0}
-		</source>
-        <target state="new">Failed to create the NOTICE file: {0}
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT1022">
         <source>Could not copy the directory '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -1433,22 +1433,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT1016">
-        <source>Failed to create the NOTICE file because a directory already exists with the same name.
-		</source>
-        <target state="new">Failed to create the NOTICE file because a directory already exists with the same name.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT1017">
-        <source>Failed to create the NOTICE file: {0}
-		</source>
-        <target state="new">Failed to create the NOTICE file: {0}
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT1022">
         <source>Could not copy the directory '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -1433,22 +1433,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT1016">
-        <source>Failed to create the NOTICE file because a directory already exists with the same name.
-		</source>
-        <target state="new">Failed to create the NOTICE file because a directory already exists with the same name.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT1017">
-        <source>Failed to create the NOTICE file: {0}
-		</source>
-        <target state="new">Failed to create the NOTICE file: {0}
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT1022">
         <source>Could not copy the directory '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -1433,22 +1433,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT1016">
-        <source>Failed to create the NOTICE file because a directory already exists with the same name.
-		</source>
-        <target state="new">Failed to create the NOTICE file because a directory already exists with the same name.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT1017">
-        <source>Failed to create the NOTICE file: {0}
-		</source>
-        <target state="new">Failed to create the NOTICE file: {0}
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT1022">
         <source>Could not copy the directory '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -1433,22 +1433,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT1016">
-        <source>Failed to create the NOTICE file because a directory already exists with the same name.
-		</source>
-        <target state="new">Failed to create the NOTICE file because a directory already exists with the same name.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT1017">
-        <source>Failed to create the NOTICE file: {0}
-		</source>
-        <target state="new">Failed to create the NOTICE file: {0}
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT1022">
         <source>Could not copy the directory '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -1433,22 +1433,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT1016">
-        <source>Failed to create the NOTICE file because a directory already exists with the same name.
-		</source>
-        <target state="new">Failed to create the NOTICE file because a directory already exists with the same name.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT1017">
-        <source>Failed to create the NOTICE file: {0}
-		</source>
-        <target state="new">Failed to create the NOTICE file: {0}
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT1022">
         <source>Could not copy the directory '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -1433,22 +1433,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT1016">
-        <source>Failed to create the NOTICE file because a directory already exists with the same name.
-		</source>
-        <target state="new">Failed to create the NOTICE file because a directory already exists with the same name.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT1017">
-        <source>Failed to create the NOTICE file: {0}
-		</source>
-        <target state="new">Failed to create the NOTICE file: {0}
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT1022">
         <source>Could not copy the directory '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -1433,22 +1433,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT1016">
-        <source>Failed to create the NOTICE file because a directory already exists with the same name.
-		</source>
-        <target state="new">Failed to create the NOTICE file because a directory already exists with the same name.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT1017">
-        <source>Failed to create the NOTICE file: {0}
-		</source>
-        <target state="new">Failed to create the NOTICE file: {0}
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT1022">
         <source>Could not copy the directory '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -1433,22 +1433,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT1016">
-        <source>Failed to create the NOTICE file because a directory already exists with the same name.
-		</source>
-        <target state="new">Failed to create the NOTICE file because a directory already exists with the same name.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT1017">
-        <source>Failed to create the NOTICE file: {0}
-		</source>
-        <target state="new">Failed to create the NOTICE file: {0}
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT1022">
         <source>Could not copy the directory '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -1433,22 +1433,6 @@
         <note>
 		</note>
       </trans-unit>
-      <trans-unit id="MT1016">
-        <source>Failed to create the NOTICE file because a directory already exists with the same name.
-		</source>
-        <target state="new">Failed to create the NOTICE file because a directory already exists with the same name.
-		</target>
-        <note>
-		</note>
-      </trans-unit>
-      <trans-unit id="MT1017">
-        <source>Failed to create the NOTICE file: {0}
-		</source>
-        <target state="new">Failed to create the NOTICE file: {0}
-		</target>
-        <note>
-		</note>
-      </trans-unit>
       <trans-unit id="MT1022">
         <source>Could not copy the directory '{0}' to '{1}': {2}
 		</source>


### PR DESCRIPTION
- The notice referenced a web site that no longer exists.
- The new location for the notice is [here](https://github.com/xamarin/xamarin-macios/blob/main/NOTICE.txt) and is linked in https://github.com/xamarin/xamarin-macios/issues/8849