### PR TITLE
[msbuild] Add a GetMinimumOSVersion target that reads the app manifest and outputs the MinimumOSVersion.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -269,12 +269,6 @@ namespace Xamarin.Localization.MSBuild {
             }
         }
         
-        public static string E0056 {
-            get {
-                return ResourceManager.GetString("E0056", resourceCulture);
-            }
-        }
-        
         public static string E0057 {
             get {
                 return ResourceManager.GetString("E0057", resourceCulture);

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -221,11 +221,6 @@
         </value>
     </data>
     
-    <data name="E0056" xml:space="preserve">
-        <value>Could not parse SdkVersion '{0}'
-        </value>
-    </data>
-    
     <data name="E0057" xml:space="preserve">
         <value>Invalid architectures: '{0}'.
         </value>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
@@ -171,13 +171,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0056">
-        <source>Could not parse SdkVersion '{0}'
-        </source>
-        <target state="new">Could not parse SdkVersion '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0057">
         <source>Invalid architectures: '{0}'.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
@@ -171,13 +171,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0056">
-        <source>Could not parse SdkVersion '{0}'
-        </source>
-        <target state="new">Could not parse SdkVersion '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0057">
         <source>Invalid architectures: '{0}'.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
@@ -171,13 +171,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0056">
-        <source>Could not parse SdkVersion '{0}'
-        </source>
-        <target state="new">Could not parse SdkVersion '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0057">
         <source>Invalid architectures: '{0}'.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
@@ -171,13 +171,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0056">
-        <source>Could not parse SdkVersion '{0}'
-        </source>
-        <target state="new">Could not parse SdkVersion '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0057">
         <source>Invalid architectures: '{0}'.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
@@ -171,13 +171,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0056">
-        <source>Could not parse SdkVersion '{0}'
-        </source>
-        <target state="new">Could not parse SdkVersion '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0057">
         <source>Invalid architectures: '{0}'.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
@@ -171,13 +171,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0056">
-        <source>Could not parse SdkVersion '{0}'
-        </source>
-        <target state="new">Could not parse SdkVersion '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0057">
         <source>Invalid architectures: '{0}'.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
@@ -171,13 +171,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0056">
-        <source>Could not parse SdkVersion '{0}'
-        </source>
-        <target state="new">Could not parse SdkVersion '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0057">
         <source>Invalid architectures: '{0}'.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
@@ -171,13 +171,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0056">
-        <source>Could not parse SdkVersion '{0}'
-        </source>
-        <target state="new">Could not parse SdkVersion '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0057">
         <source>Invalid architectures: '{0}'.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
@@ -171,13 +171,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0056">
-        <source>Could not parse SdkVersion '{0}'
-        </source>
-        <target state="new">Could not parse SdkVersion '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0057">
         <source>Invalid architectures: '{0}'.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
@@ -171,13 +171,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0056">
-        <source>Could not parse SdkVersion '{0}'
-        </source>
-        <target state="new">Could not parse SdkVersion '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0057">
         <source>Invalid architectures: '{0}'.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
@@ -171,13 +171,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0056">
-        <source>Could not parse SdkVersion '{0}'
-        </source>
-        <target state="new">Could not parse SdkVersion '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0057">
         <source>Invalid architectures: '{0}'.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
@@ -171,13 +171,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0056">
-        <source>Could not parse SdkVersion '{0}'
-        </source>
-        <target state="new">Could not parse SdkVersion '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0057">
         <source>Invalid architectures: '{0}'.
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
@@ -171,13 +171,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0056">
-        <source>Could not parse SdkVersion '{0}'
-        </source>
-        <target state="new">Could not parse SdkVersion '{0}'
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0057">
         <source>Invalid architectures: '{0}'.
         </source>

--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -68,25 +68,6 @@ namespace Xamarin.Mac.Tasks
 			if (arch.HasFlag (XamMacArch.x86_64))
 				args.AddLine ("/arch:x86_64");
 
-			if (AppManifest != null) {
-				try {
-					var plist = PDictionary.FromFile (AppManifest.ItemSpec);
-
-					PString v;
-					string minimumDeploymentTarget;
-
-					if (!plist.TryGetValue (ManifestKeys.LSMinimumSystemVersion, out v) || string.IsNullOrEmpty (v.Value))
-						minimumDeploymentTarget = SdkVersion;
-					else
-						minimumDeploymentTarget = v.Value;
-
-					args.AddLine (string.Format("/targetver={0}", minimumDeploymentTarget));
-				}
-				catch (Exception ex) {
-					Log.LogWarning (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, MSBStrings.E0010, AppManifest.ItemSpec, ex.Message);
-				}
-			}
-
 			switch ((LinkMode ?? string.Empty).ToLower ()) {
 			case "full":
 				break;

--- a/msbuild/Xamarin.Mac.Tasks/Tasks/ACTool.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/ACTool.cs
@@ -4,8 +4,5 @@ using Xamarin.MacDev.Tasks;
 namespace Xamarin.Mac.Tasks {
 	public class ACTool : ACToolTaskBase
 	{
-		protected override string MinimumDeploymentTargetKey {
-			get { return ManifestKeys.LSMinimumSystemVersion; }
-		}
 	}
 }

--- a/msbuild/Xamarin.Mac.Tasks/Tasks/IBTool.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/IBTool.cs
@@ -7,9 +7,5 @@ namespace Xamarin.Mac.Tasks {
 		protected override bool AutoActivateCustomFonts {
 			get { return false; }
 		}
-
-		protected override string MinimumDeploymentTargetKey {
-			get { return ManifestKeys.LSMinimumSystemVersion; }
-		}
 	}
 }

--- a/msbuild/Xamarin.Mac.Tasks/Tasks/Metal.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/Metal.cs
@@ -6,12 +6,6 @@ namespace Xamarin.Mac.Tasks
 {
 	public class Metal : MetalTaskBase
 	{
-#if !MTOUCH_TESTS
-		protected override string MinimumDeploymentTargetKey {
-			get { return ManifestKeys.LSMinimumSystemVersion; }
-		}
-#endif
-
 		protected override string DevicePlatformBinDir {
 			get {
 				return AppleSdkSettings.XcodeVersion.Major >= 10

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -276,12 +276,12 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		</CollectBundleResources>
 	</Target>
 
-	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations;_ComputeTargetFrameworkMoniker">
+	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations;_ComputeTargetFrameworkMoniker;_GetMinimumOSVersion">
 		<Metal
 			Condition="'$(IsMacEnabled)' == 'true' and '%(Metal.Identity)' != ''"
 			SessionId="$(BuildSessionId)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
-			AppManifest="$(_AppManifest)"
+			MinimumOSVersion="$(_MinimumOSVersion)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			ResourcePrefix="$(_ResourcePrefix)"
@@ -402,7 +402,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CompileAppManifest"
-		DependsOnTargets="_DetectAppManifest;_GenerateBundleName;_DetectSigningIdentity"
+		DependsOnTargets="_GetMinimumOSVersion;_GenerateBundleName;_DetectSigningIdentity;_ComputeTargetFrameworkMoniker"
 		Inputs="$(_AppManifest);@(_PartialAppManifest)"
 		Outputs="$(_AppBundlePath)Contents\Info.plist" >
 		<CompileAppManifest
@@ -415,6 +415,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			BundleIdentifier="$(_BundleIdentifier)"
 			IsAppExtension="$(IsAppExtension)"
 			IsXPCService="$(IsXPCService)"
+			MinimumOSVersion="$(_MinimumOSVersion)"
 			PartialAppManifests="@(_PartialAppManifest)" />
 	</Target>
 	
@@ -450,6 +451,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			OutputPath="$(OutputPath)"
 			ApplicationName="$(_AppBundleName)"
 			MainAssembly="$(OutputPath)$(TargetName)$(TargetExt)"
+			MinimumOSVersion="$(_MinimumOSVersion)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			Architecture="$(TargetArchitectures)"
 			ArchiveSymbols="$(MonoSymbolArchive)"
@@ -464,7 +466,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			ResponseFilePath="$(IntermediateOutputPath)response-file.rsp"
 			SdkRoot="$(_SdkDevPath)"
 			IntermediateOutputPath="$(IntermediateOutputPath)mmp-cache"
-			AppManifest="$(_AppManifest)"
 			SdkVersion="$(_SdkVersion)"
 			IsAppExtension="$(IsAppExtension)"
 			IsXPCService="$(IsXPCService)"
@@ -544,7 +545,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Target Name="_CoreCompileImageAssets"
 		Inputs="@(ImageAsset);$(_AppManifest)"
 		Outputs="$(_ACTool_PartialAppManifestCache);$(_ACTool_BundleResourceCache)"
-		DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_BeforeCoreCompileImageAssets">
+		DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_BeforeCoreCompileImageAssets;_GetMinimumOSVersion">
 
 		<ACTool
 			SessionId="$(BuildSessionId)"
@@ -554,6 +555,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			AppManifest="$(_AppManifest)"
 			EnableOnDemandResources="false"
 			ImageAssets="@(ImageAsset)"
+			MinimumOSVersion="$(_MinimumOSVersion)"
 			OptimizePngs="false"
 			OutputPath="$(OutputPath)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
@@ -604,7 +606,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		</CompileSceneKitAssets>
 	</Target>
 
-	<Target Name="_CompileInterfaceDefinitions" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_CoreCompileInterfaceDefinitions" />
+	<Target Name="_CompileInterfaceDefinitions" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_GetMinimumOSVersion;_CoreCompileInterfaceDefinitions" />
 
 	<Target Name="_CoreCompileInterfaceDefinitions">
 		<IBTool
@@ -616,6 +618,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			EnableOnDemandResources="false"
 			InterfaceDefinitions="@(InterfaceDefinition)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
+			MinimumOSVersion="$(_MinimumOSVersion)"
 			SdkPlatform="MacOSX"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(_ResourcePrefix)"

--- a/msbuild/Xamarin.MacDev.Tasks.Core/PlatformFramework.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/PlatformFramework.cs
@@ -52,5 +52,19 @@ namespace Xamarin.MacDev.Tasks
 				throw new InvalidOperationException (string.Format ("Unknown target framework {0} for target framework moniker {1}.", framework, targetFrameworkMoniker));
 			}
 		}
+
+		public static string GetMinimumOSVersionKey (ApplePlatform platform)
+		{
+			switch (platform) {
+			case ApplePlatform.iOS:
+			case ApplePlatform.TVOS:
+			case ApplePlatform.WatchOS:
+				return ManifestKeys.MinimumOSVersion;
+			case ApplePlatform.MacOSX:
+				return ManifestKeys.LSMinimumSystemVersion;
+			default:
+				throw new InvalidOperationException ($"Invalid platform: {platform}");
+			}
+		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
@@ -86,15 +86,8 @@ namespace Xamarin.MacDev.Tasks
 
 		protected override void AppendCommandLineArguments (IDictionary<string, string> environment, CommandLineArgumentBuilder args, ITaskItem[] items)
 		{
-			string minimumDeploymentTarget;
-
 			if (plist != null) {
 				PString value;
-
-				if (!plist.TryGetValue (MinimumDeploymentTargetKey, out value) || string.IsNullOrEmpty (value.Value))
-					minimumDeploymentTarget = SdkVersion;
-				else
-					minimumDeploymentTarget = value.Value;
 
 				var assetDirs = new HashSet<string> (items.Select (x => BundleResource.GetVirtualProjectPath (ProjectDir, x, !string.IsNullOrEmpty (SessionId))));
 
@@ -149,8 +142,6 @@ namespace Xamarin.MacDev.Tasks
 
 				if (plist.TryGetValue (ManifestKeys.CLKComplicationGroup, out value) && !string.IsNullOrEmpty (value.Value))
 					args.Add ("--complication", value);
-			} else {
-				minimumDeploymentTarget = SdkVersion;
 			}
 
 			if (OptimizePNGs)
@@ -177,7 +168,7 @@ namespace Xamarin.MacDev.Tasks
 					args.Add ("--target-device", targetDevice);
 			}
 
-			args.Add ("--minimum-deployment-target", minimumDeploymentTarget);
+			args.Add ("--minimum-deployment-target", MinimumOSVersion);
 
 			var platform = PlatformUtils.GetTargetPlatform (SdkPlatform, IsWatchApp);
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BundlerToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BundlerToolTaskBase.cs
@@ -16,9 +16,6 @@ namespace Xamarin.MacDev.Tasks {
 		[Required]
 		public string AppBundleDir { get; set; }
 
-		[Required]
-		public ITaskItem AppManifest { get; set; }
-
 		public string ArchiveSymbols { get; set; }
 
 		[Required]
@@ -43,6 +40,9 @@ namespace Xamarin.MacDev.Tasks {
 
 		[Required]
 		public ITaskItem MainAssembly { get; set; }
+
+		[Required]
+		public string MinimumOSVersion { get; set; }
 
 		public ITaskItem [] NativeReferences { get; set; }
 
@@ -112,6 +112,8 @@ namespace Xamarin.MacDev.Tasks {
 				args.AddLine ("--profiling");
 
 			args.AddQuotedLine ($"--sdkroot={SdkRoot}");
+
+			args.AddQuotedLine ($"--targetver={MinimumOSVersion}");
 
 			var v = VerbosityUtils.Merge (ExtraArgs, (LoggerVerbosity) Verbosity);
 			foreach (var arg in v)

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -31,6 +31,9 @@ namespace Xamarin.MacDev.Tasks
 		[Required]
 		public string BundleIdentifier { get; set; }
 
+		[Required]
+		public string MinimumOSVersion { get; set; }
+
 		public ITaskItem[] PartialAppManifests { get; set; }
 
 		#endregion

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/GetMinimumOSVersionTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/GetMinimumOSVersionTaskBase.cs
@@ -1,0 +1,44 @@
+using System;
+
+using Microsoft.Build.Framework;
+
+using Xamarin.Localization.MSBuild;
+
+namespace Xamarin.MacDev.Tasks {
+	public abstract class GetMinimumOSVersionTaskBase : XamarinTask {
+		public string AppManifest { get; set; }
+
+		[Required]
+		public string SdkVersion { get; set; }
+
+		[Output]
+		public string MinimumOSVersion { get; set; }
+
+		public override bool Execute ()
+		{
+			PDictionary plist = null;
+
+			if (!string.IsNullOrEmpty (AppManifest)) {
+				try {
+					plist = PDictionary.FromFile (AppManifest);
+				} catch (Exception ex) {
+					Log.LogError (null, null, null, AppManifest, 0, 0, 0, 0, MSBStrings.E0010, AppManifest, ex.Message);
+					return false;
+				}
+			}
+
+			var minimumOSVersionInManifest = plist?.Get<PString> (PlatformFrameworkHelper.GetMinimumOSVersionKey (Platform))?.Value;
+			if (string.IsNullOrEmpty (minimumOSVersionInManifest)) {
+				MinimumOSVersion = SdkVersion;
+			} else if (!IAppleSdkVersion_Extensions.TryParse (minimumOSVersionInManifest, out var _)) {
+				Log.LogError (null, null, null, AppManifest, 0, 0, 0, 0, MSBStrings.E0011, minimumOSVersionInManifest);
+				return false;
+			} else {
+				MinimumOSVersion = minimumOSVersionInManifest;
+			}
+
+			return true;
+		}
+	}
+}
+

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
@@ -13,7 +13,6 @@ namespace Xamarin.MacDev.Tasks
 	public abstract class IBToolTaskBase : XcodeCompilerToolTask
 	{
 		static readonly string[] WatchAppExtensions = { "-glance.plist", "-notification.plist" };
-		string minimumDeploymentTarget;
 		PDictionary plist;
 
 		#region Inputs
@@ -52,10 +51,10 @@ namespace Xamarin.MacDev.Tasks
 
 		protected override void AppendCommandLineArguments (IDictionary<string, string> environment, CommandLineArgumentBuilder args, ITaskItem[] items)
 		{
-			environment.Add ("IBSC_MINIMUM_COMPATIBILITY_VERSION", minimumDeploymentTarget);
-			environment.Add ("IBC_MINIMUM_COMPATIBILITY_VERSION", minimumDeploymentTarget);
+			environment.Add ("IBSC_MINIMUM_COMPATIBILITY_VERSION", MinimumOSVersion);
+			environment.Add ("IBC_MINIMUM_COMPATIBILITY_VERSION", MinimumOSVersion);
 
-			args.Add ("--minimum-deployment-target", minimumDeploymentTarget);
+			args.Add ("--minimum-deployment-target", MinimumOSVersion);
 			
 			foreach (var targetDevice in GetTargetDevices (plist))
 				args.Add ("--target-device", targetDevice);
@@ -417,14 +416,6 @@ namespace Xamarin.MacDev.Tasks
 			if (InterfaceDefinitions.Length > 0) {
 				if (AppManifest != null) {
 					plist = PDictionary.FromFile (AppManifest.ItemSpec);
-					PString value;
-
-					if (!plist.TryGetValue (MinimumDeploymentTargetKey, out value) || string.IsNullOrEmpty (value.Value))
-						minimumDeploymentTarget = SdkVersion;
-					else
-						minimumDeploymentTarget = value.Value;
-				} else {
-					minimumDeploymentTarget = SdkVersion;
 				}
 
 				Directory.CreateDirectory (ibtoolManifestDir);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
@@ -16,10 +16,11 @@ namespace Xamarin.MacDev.Tasks
 	{
 		#region Inputs
 
-		public ITaskItem AppManifest { get; set; }
-
 		[Required]
 		public string IntermediateOutputPath { get; set; }
+
+		[Required]
+		public string MinimumOSVersion { get; set; }
 
 		[Required]
 		public string ProjectDir { get; set; }
@@ -46,10 +47,6 @@ namespace Xamarin.MacDev.Tasks
 
 		[Output]
 		public ITaskItem OutputFile { get; set; }
-
-		protected abstract string MinimumDeploymentTargetKey {
-			get;
-		}
 
 		protected virtual string OperatingSystem {
 			get {
@@ -102,22 +99,9 @@ namespace Xamarin.MacDev.Tasks
 			var path = Path.Combine (intermediate, logicalName);
 			var args = new CommandLineArgumentBuilder ();
 			var dir = Path.GetDirectoryName (path);
-			string minimumDeploymentTarget;
 
 			if (!Directory.Exists (dir))
 				Directory.CreateDirectory (dir);
-
-			if (AppManifest != null) {
-				var plist = PDictionary.FromFile (AppManifest.ItemSpec);
-				PString value;
-
-				if (!plist.TryGetValue (MinimumDeploymentTargetKey, out value) || string.IsNullOrEmpty (value.Value))
-					minimumDeploymentTarget = SdkVersion;
-				else
-					minimumDeploymentTarget = value.Value;
-			} else {
-				minimumDeploymentTarget = SdkVersion;
-			}
 
 			OutputFile = new TaskItem (Path.ChangeExtension (path, ".air"));
 			OutputFile.SetMetadata ("LogicalName", Path.ChangeExtension (logicalName, ".air"));
@@ -134,7 +118,7 @@ namespace Xamarin.MacDev.Tasks
 			args.Add ("-o");
 			args.AddQuoted (Path.ChangeExtension (path, ".air"));
 
-			args.Add (string.Format ("-m{0}-version-min={1}", OperatingSystem, minimumDeploymentTarget));
+			args.Add (string.Format ("-m{0}-version-min={1}", OperatingSystem, MinimumOSVersion));
 
 			args.AddQuoted (SourceFile.ItemSpec);
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
@@ -24,6 +24,9 @@ namespace Xamarin.MacDev.Tasks
 		public ITaskItem AppManifest { get; set; }
 
 		[Required]
+		public string MinimumOSVersion { get; set; }
+
+		[Required]
 		public string IntermediateOutputPath { get; set; }
 
 		[Required]
@@ -85,8 +88,6 @@ namespace Xamarin.MacDev.Tasks
 		}
 
 		protected abstract string ToolName { get; }
-
-		protected abstract string MinimumDeploymentTargetKey { get; }
 
 		protected virtual bool UseCompilationDirectory {
 			get { return false; }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMinimumOSVersion.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMinimumOSVersion.cs
@@ -1,0 +1,5 @@
+namespace Xamarin.MacDev.Tasks {
+	public class GetMinimumOSVersion : GetMinimumOSVersionTaskBase {
+	}
+}
+

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -17,6 +17,14 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 <!-- This is shared between Xamarin.iOS and Xamarin.Mac -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<PropertyGroup Condition="'$(_TaskAssemblyName)' == ''">
+		<_TaskAssemblyName Condition="'$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS'">Xamarin.iOS.Tasks.dll</_TaskAssemblyName>
+		<_TaskAssemblyName Condition="'$(_PlatformName)' == 'macOS'">Xamarin.Mac.Tasks.dll</_TaskAssemblyName>
+	</PropertyGroup>
+
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetMinimumOSVersion" AssemblyFile="$(_TaskAssemblyName)" />
+
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
 
@@ -148,6 +156,17 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<Output TaskParameter="Item" PropertyName="_AppManifest" />
 		</FindItemWithLogicalName>
 		<Error Condition="'$(_AppManifest)' == '' And '$(_CanOutputAppBundle)' == 'true'" Text="Info.plist not found."/>
+	</Target>
+
+	<Target Name="_GetMinimumOSVersion" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_ComputeTargetFrameworkMoniker">
+		<GetMinimumOSVersion
+			SessionId="$(BuildSessionId)"
+			AppManifest="$(_AppManifest)"
+			SdkVersion="$(_SdkVersion)"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+			>
+			<Output TaskParameter="MinimumOSVersion" PropertyName="_MinimumOSVersion" />
+		</GetMinimumOSVersion>
 	</Target>
 
 	<Target Name="_DetectSigningIdentity" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_ComputeTargetFrameworkMoniker">

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ACToolTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ACToolTaskBase.cs
@@ -5,10 +5,6 @@ using Xamarin.MacDev;
 namespace Xamarin.iOS.Tasks {
 	public abstract class ACToolTaskBase : Xamarin.MacDev.Tasks.ACToolTaskBase
 	{
-		protected override string MinimumDeploymentTargetKey {
-			get { return ManifestKeys.MinimumOSVersion; }
-		}
-
 		static bool IsWatchExtension (PDictionary plist)
 		{
 			PDictionary extension;

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -41,7 +41,6 @@ namespace Xamarin.iOS.Tasks
 
 		TargetArchitecture architectures;
 		IPhoneDeviceType supportedDevices;
-		IPhoneSdkVersion minimumOSVersion;
 		IPhoneSdkVersion sdkVersion;
 
 		bool IsIOS;
@@ -58,13 +57,6 @@ namespace Xamarin.iOS.Tasks
 			}
 
 			sdkVersion = IPhoneSdkVersion.Parse (DefaultSdkVersion);
-			var text = plist.GetMinimumOSVersion ();
-			if (string.IsNullOrEmpty (text)) {
-				minimumOSVersion = sdkVersion;
-			} else if (!IPhoneSdkVersion.TryParse (text, out minimumOSVersion)) {
-				LogAppManifestError (MSBStrings.E0011, text);
-				return false;
-			}
 
 			switch (Platform) {
 			case ApplePlatform.iOS:
@@ -187,7 +179,7 @@ namespace Xamarin.iOS.Tasks
 
 			SetDeviceFamily (plist);
 
-			plist.SetIfNotPresent (ManifestKeys.MinimumOSVersion, minimumOSVersion.ToString ());
+			plist.SetIfNotPresent (ManifestKeys.MinimumOSVersion, MinimumOSVersion);
 
 			if (IsWatchExtension) {
 				// Note: Only watchOS1 Extensions target Xamarin.iOS

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/IBToolTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/IBToolTaskBase.cs
@@ -10,10 +10,6 @@ namespace Xamarin.iOS.Tasks {
 			get { return true; }
 		}
 
-		protected override string MinimumDeploymentTargetKey {
-			get { return ManifestKeys.MinimumOSVersion; }
-		}
-
 		static bool IsWatchExtension (PDictionary plist)
 		{
 			PDictionary extension;

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -30,9 +30,6 @@ namespace Xamarin.iOS.Tasks
 			}
 		}
 
-		IPhoneSdkVersion minimumOSVersion;
-//		IPhoneDeviceType deviceType;
-
 		#region Inputs
 
 		public string Architectures { get; set; }
@@ -284,9 +281,6 @@ namespace Xamarin.iOS.Tasks
 
 			args.AddQuotedLine ($"--sdk={SdkVersion}");
 
-			if (!minimumOSVersion.IsUseDefault)
-				args.AddQuotedLine ($"--targetver={minimumOSVersion.ToString ()}");
-
 			if (UseFloat32 /* We want to compile 32-bit floating point code to use 32-bit floating point operations */)
 				args.AddLine ("--aot-options=-O=float32");
 			else
@@ -468,43 +462,6 @@ namespace Xamarin.iOS.Tasks
 
 		public override bool Execute ()
 		{
-			PDictionary plist;
-			PString value;
-
-			try {
-				plist = PDictionary.FromFile (AppManifest.ItemSpec);
-			} catch (Exception ex) {
-				Log.LogError (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, MSBStrings.E0055, ex.Message);
-				return false;
-			}
-
-//			deviceType = plist.GetUIDeviceFamily ();
-
-			if (plist.TryGetValue (ManifestKeys.MinimumOSVersion, out value)) {
-				if (!IPhoneSdkVersion.TryParse (value.Value, out minimumOSVersion)) {
-					Log.LogError (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, MSBStrings.E0011, value);
-					return false;
-				}
-			} else {
-				switch (Platform) {
-				case ApplePlatform.iOS:
-					IPhoneSdkVersion sdkVersion;
-					if (!IPhoneSdkVersion.TryParse (SdkVersion, out sdkVersion)) {
-						Log.LogError (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, MSBStrings.E0056, SdkVersion);
-						return false;
-					}
-
-					minimumOSVersion = sdkVersion;
-					break;
-				case ApplePlatform.WatchOS:
-				case ApplePlatform.TVOS:
-					minimumOSVersion = IPhoneSdkVersion.UseDefault;
-					break;
-				default:
-					throw new InvalidOperationException (string.Format ("Invalid framework: {0}", Platform));
-				}
-			}
-
 			Directory.CreateDirectory (AppBundleDir);
 
 			var executableLastWriteTime = default (DateTime);

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MetalTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MetalTaskBase.cs
@@ -6,10 +6,6 @@ namespace Xamarin.iOS.Tasks
 {
 	public abstract class MetalTaskBase : Xamarin.MacDev.Tasks.MetalTaskBase
 	{
-		protected override string MinimumDeploymentTargetKey {
-			get { return ManifestKeys.MinimumOSVersion; }
-		}
-
 		protected override string DevicePlatformBinDir {
 			get {
 				return AppleSdkSettings.XcodeVersion.Major >= 11

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -507,12 +507,12 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</CollectBundleResources>
 	</Target>
 
-	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations;_ComputeTargetFrameworkMoniker">
+	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations;_ComputeTargetFrameworkMoniker;_GetMinimumOSVersion">
 		<Metal
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' and '%(Metal.Identity)' != ''"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
-			AppManifest="$(_AppManifest)"
+			MinimumOSVersion="$(_MinimumOSVersion)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			ResourcePrefix="$(_ResourcePrefix)"
@@ -626,7 +626,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="GetAppBundleDir" DependsOnTargets="_GenerateBundleName" Returns="$(AppBundleDir)"/>
 
 	<Target Name="_CompileAppManifest"
-		DependsOnTargets="_DetectSdkLocations;_DetectAppManifest;_GenerateBundleName;_DetectSigningIdentity;_PrepareResourceRules;_ResolveWatchAppReferences;_DetectDebugNetworkConfiguration;_ComputeTargetFrameworkMoniker"
+		DependsOnTargets="_DetectSdkLocations;_GetMinimumOSVersion;_GenerateBundleName;_DetectSigningIdentity;_PrepareResourceRules;_ResolveWatchAppReferences;_DetectDebugNetworkConfiguration;_ComputeTargetFrameworkMoniker"
 		Inputs="$(_AppManifest);@(_PartialAppManifest)"
 		Outputs="$(_AppBundlePath)Info.plist" >
 		<CompileAppManifest
@@ -642,6 +642,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			IsAppExtension="$(IsAppExtension)"
 			IsWatchApp="$(IsWatchApp)"
 			IsWatchExtension="$(IsWatchExtension)"
+			MinimumOSVersion="$(_MinimumOSVersion)"
 			PartialAppManifests="@(_PartialAppManifest)"
 			ResourceRules="$(_PreparedResourceRules)"
 			TargetArchitectures="$(TargetArchitectures)"
@@ -745,7 +746,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			ToolExe="$(MtouchExe)"
 			ToolPath="$(MtouchPath)"
 			AppBundleDir="$(AppBundleDir)"
-			AppManifest="$(_AppBundlePath)Info.plist"
 			Architectures="$(TargetArchitectures)"
 			ExecutableName="$(_ExecutableName)"
 			CompiledEntitlements="$(_CompiledEntitlements)"
@@ -760,6 +760,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			LinkerDumpDependencies="$(MtouchLinkerDumpDependencies)"
 			LinkMode="$(_LinkMode)"
 			MainAssembly="$(TargetPath)"
+			MinimumOSVersion="$(_MinimumOSVersion)"
 			NativeReferences="@(NativeReference)"
 			OutputPath="$(DeviceSpecificOutputPath)"
 			Profiling="$(MtouchProfiling)"
@@ -1160,7 +1161,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CoreCompileImageAssets" 
 		Inputs="@(ImageAsset);$(_AppManifest)"
 		Outputs="$(_ACTool_PartialAppManifestCache);$(_ACTool_BundleResourceCache)"
-		DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_BeforeCoreCompileImageAssets">
+		DependsOnTargets="_GetMinimumOSVersion;_DetectSdkLocations;_BeforeCoreCompileImageAssets">
 
 		<ACTool
 			SessionId="$(BuildSessionId)"
@@ -1172,6 +1173,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			DeviceOSVersion="$(TargetDeviceOSVersion)"
 			EnableOnDemandResources="$(EnableOnDemandResources)"
 			ImageAssets="@(ImageAsset)"
+			MinimumOSVersion="$(_MinimumOSVersion)"
 			OptimizePNGs="$(OptimizePNGs)"
 			OutputPath="$(DeviceSpecificOutputPath)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
@@ -1277,7 +1279,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CoreCompileInterfaceDefinitions"
 		Inputs="@(InterfaceDefinition)"
 		Outputs="$(_IBToolCache)"
-		DependsOnTargets="_BeforeCoreCompileInterfaceDefinitions">
+		DependsOnTargets="_BeforeCoreCompileInterfaceDefinitions;_GetMinimumOSVersion">
 
 		<IBTool
 			SessionId="$(BuildSessionId)"
@@ -1288,6 +1290,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			EnableOnDemandResources="$(EnableOnDemandResources)"
 			InterfaceDefinitions="@(InterfaceDefinition)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
+			MinimumOSVersion="$(_MinimumOSVersion)"
 			IsWatchApp="$(IsWatchApp)"
 			IsWatch2App="$(IsWatch2App)"
 			ProjectDir="$(MSBuildProjectDirectory)"

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
@@ -37,6 +37,7 @@ namespace Xamarin.iOS.Tasks
 			Task.AssemblyName = assemblyName;
 			Task.AppManifest = CreateTempFile ("foo.plist");
 			Task.BundleIdentifier = bundleIdentifier;
+			Task.MinimumOSVersion = string.Empty;
 			Task.SdkPlatform = "iPhoneSimulator";
 
 			Plist = new PDictionary ();
@@ -59,7 +60,8 @@ namespace Xamarin.iOS.Tasks
 		{
 			base.Teardown ();
 
-			Directory.Delete ("AppBundlePath", true);
+			if (Directory.Exists ("AppBundlePath"))
+				Directory.Delete ("AppBundlePath", true);
 		}
 
 		#region General tests

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
@@ -51,6 +51,7 @@ namespace Xamarin.iOS.Tasks
 				InterfaceDefinitions = interfaceDefinitions.ToArray (),
 				IntermediateOutputPath = intermediateOutputPath,
 				BuildEngine = new TestEngine (),
+				MinimumOSVersion = PDictionary.FromFile (Path.Combine (projectDir, "Info.plist")).GetMinimumOSVersion (),
 				ResourcePrefix = "Resources",
 				ProjectDir = projectDir,
 				SdkPlatform = platform,

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/MTouchTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/MTouchTaskTests.cs
@@ -58,7 +58,7 @@ namespace Xamarin.iOS.Tasks
 			Task.ToolExe = "/path/to/mtouch";
 
 			Task.AppBundleDir = AppBundlePath;
-			Task.AppManifest = new TaskItem (Path.Combine (MonoTouchProjectPath, "Info.plist"));
+			Task.MinimumOSVersion = PDictionary.FromFile (Path.Combine (MonoTouchProjectPath, "Info.plist")).GetMinimumOSVersion ();
 			Task.CompiledEntitlements = Path.Combine (Path.GetDirectoryName (GetType ().Assembly.Location), "Resources", "Entitlements.plist");
 			Task.IntermediateOutputPath = Path.Combine ("obj", "mtouch-cache");
 			Task.MainAssembly = new TaskItem ("Main.exe");
@@ -110,12 +110,11 @@ namespace Xamarin.iOS.Tasks
 		}
 
 		[Test]
-		public void StandardCommandline_NoMinimumOsVersion ()
+		public void StandardCommandline_MinimumOsVersion ()
 		{
-			var modifiedPListPath = SetPListKey ("MinimumOSVersion", null);
-			Task.AppManifest = new TaskItem (modifiedPListPath); 
-			var args = Task.GenerateCommandLineCommands ();
-			Assert.IsFalse (Task.ResponseFile.Contains ("--targetver"), "#1");
+			Task.MinimumOSVersion = "10.0";
+			Task.GenerateCommandLineCommands ();
+			Assert.That (Task.ResponseFile, Does.Contain ("--targetver=10.0"), "#1");
 		}
 
 		[Test]

--- a/tests/common/mac/FSharpUnifiedLibrary.fsproj
+++ b/tests/common/mac/FSharpUnifiedLibrary.fsproj
@@ -40,9 +40,6 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Info.plist" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="Component1.fs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.FSharp.targets" />

--- a/tests/common/mac/FSharpXM45Library.fsproj
+++ b/tests/common/mac/FSharpXM45Library.fsproj
@@ -39,9 +39,6 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Info.plist" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="Component1.fs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.FSharp.targets" />


### PR DESCRIPTION
This makes it possible for several other tasks to take the MinimumOSVersion as
direct input, instead of the app manifest's path. Previously the app manifest
(Info.plist) was loaded and parsed in each task, slightly differently in each
place, and in addition there are differences between macOS and other
platforms, which made it even worse. This code refactoring also made it
possible to remove an error code which wasn't necessary anymore.

This task also computes the default MinimumOSVersion if none is specified in
the app manifest.

There is one breaking change: a library project could previously specify an
inexistent Info.plist, and it would build fine. This will now result in a
"Error loading 'Info.plist': File not found" error. This is trivial to fix:
just remove the Info.plist from the project file (or an alternative solution
could be to condition the inclusion of the Info.plist in the project file on
the existence of the Info.plist).

New commits in xamarin/Xamarin.MacDev:

* xamarin/Xamarin.MacDev@a1bc6f3 [Xamarin.MacDev] Split IAppleSdkVersion.TryParse in two methods. (#73)

Diff: https://github.com/xamarin/Xamarin.MacDev/compare/45c5a680e20a209ac846a32e0f2f0f83e843ab76..a1bc6f39b3efe5d817c60d78eaff3f4c2de720ea