### PR TITLE
[monotouch-test] Check for Metal compatibility for all platforms before creating indirect command buffers. Fixes #xamarin/maccore@2235.

### DIFF
--- a/tests/monotouch-test/Metal/MTLDeviceTests.cs
+++ b/tests/monotouch-test/Metal/MTLDeviceTests.cs
@@ -272,9 +272,7 @@ namespace MonoTouchFixtures.Metal {
 			}
 
 			if (TestRuntime.CheckXcodeVersion (10, 0)) {
-#if __MACOS__
-				if (device.SupportsFeatureSet (MTLFeatureSet.macOS_GPUFamily2_v1))
-#endif
+				if (device.SupportsFamily (MTLGpuFamily.Common2))
 				using (var descriptor = new MTLIndirectCommandBufferDescriptor ()) {
 					using (var library = device.CreateIndirectCommandBuffer (descriptor, 1, MTLResourceOptions.CpuCacheModeDefault)) {
 						Assert.IsNotNull (library, "CreateIndirectCommandBuffer: NonNull");

--- a/tests/monotouch-test/Metal/MTLDeviceTests.cs
+++ b/tests/monotouch-test/Metal/MTLDeviceTests.cs
@@ -271,8 +271,7 @@ namespace MonoTouchFixtures.Metal {
 				Assert.IsNotNull (library, "CreateArgumentEncoder (MTLArgumentDescriptor[]): NonNull");
 			}
 
-			if (TestRuntime.CheckXcodeVersion (10, 0)) {
-				if (device.SupportsFamily (MTLGpuFamily.Common2))
+			if (TestRuntime.CheckXcodeVersion (11, 0) && device.SupportsFamily (MTLGpuFamily.Common2)) {
 				using (var descriptor = new MTLIndirectCommandBufferDescriptor ()) {
 					using (var library = device.CreateIndirectCommandBuffer (descriptor, 1, MTLResourceOptions.CpuCacheModeDefault)) {
 						Assert.IsNotNull (library, "CreateIndirectCommandBuffer: NonNull");


### PR DESCRIPTION
This fixes an iOS assertion (crash) when running on iPhone 6 with iOS 12+:

    2020-06-15 13:52:35.138 monotouchtest[6887:5713672] failed assertion 0 at line 54 in NopIndirectCommandBuffer

    =================================================================
    	Native Crash Reporting
    =================================================================
    Got a abrt while executing native code. This usually indicates
    a fatal error in the mono runtime or one of the native libraries
    used by your application.
    =================================================================

    =================================================================
    	Native stacktrace:
    =================================================================
    	0x1060b23fc - /private/var/containers/Bundle/Application/B3C2F137-4C0F-48EF-A50A-8972FF268069/monotouchtest.app/libmonosgen-2.0.dylib : mono_dump_native_crash_info
    	0x1060a8674 - /private/var/containers/Bundle/Application/B3C2F137-4C0F-48EF-A50A-8972FF268069/monotouchtest.app/libmonosgen-2.0.dylib : mono_handle_native_crash
    	0x1060b1948 - /private/var/containers/Bundle/Application/B3C2F137-4C0F-48EF-A50A-8972FF268069/monotouchtest.app/libmonosgen-2.0.dylib : sigabrt_signal_handler
    	0x20049e9fc - /usr/lib/system/libsystem_platform.dylib : <redacted>
    	0x2004a4094 - /usr/lib/system/libsystem_pthread.dylib : <redacted>
    	0x200383ea8 - /usr/lib/system/libsystem_c.dylib : abort
    	0x2029c5dac - /System/Library/Frameworks/Metal.framework/Metal : MTLGetWarningMode
    	0x2210cff78 - /System/Library/Extensions/AGXMetalA8.bundle/AGXMetalA8 :
    	0x20299fb80 - /System/Library/Frameworks/Metal.framework/Metal : <redacted>
    	0x103143c58 - /private/var/containers/Bundle/Application/B3C2F137-4C0F-48EF-A50A-8972FF268069/monotouchtest.app/libXamarin.iOS.dll.dylib : wrapper_managed_to_native_ObjCRuntime_Messaging_IntPtr_objc_msgSend_IntPtr_nuint_UInt64_intptr_intptr_intptr_System_nuint_ulong
    	0x102f4cbdc - /private/var/containers/Bundle/Application/B3C2F137-4C0F-48EF-A50A-8972FF268069/monotouchtest.app/libXamarin.iOS.dll.dylib : Metal_MTLDevice_Extensions_CreateIndirectCommandBuffer_Metal_IMTLDevice_Metal_MTLIndirectCommandBufferDescriptor_System_nuint_Metal_MTLResourceOptions
    	0x101a8bd58 - /private/var/containers/Bundle/Application/B3C2F137-4C0F-48EF-A50A-8972FF268069/monotouchtest.app/libmonotouchtest.exe.dylib : MonoTouchFixtures_Metal_MTLDeviceTests_ReturnReleaseTest
    	[...]

Fixes https://github.com/xamarin/maccore/issues/2235.