### PR TITLE
[xharness] Make ConsoleLog thread-safe. Fixes #8569.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ConsoleLog.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ConsoleLog.cs
@@ -9,7 +9,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging {
 
 		protected override void WriteImpl (string value)
 		{
-			captured.Append (value);
+			lock (captured)
+				captured.Append (value);
 			Console.Write (value);
 		}
 
@@ -17,8 +18,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging {
 
 		public override StreamReader GetReader ()
 		{
-			var str = new MemoryStream (Encoding.GetBytes (captured.ToString ()));
-			return new StreamReader (str, Encoding, false);
+			lock (captured) {
+				var str = new MemoryStream (Encoding.GetBytes (captured.ToString ()));
+				return new StreamReader (str, Encoding, false);
+			}
 		}
 
 		public override void Flush ()


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/8569.