### PR TITLE
[AppKit] NSTextView allows passing nil to PasteAsPlainText and PasteAsRichText.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -18928,10 +18928,10 @@ namespace AppKit {
 		NSObject ValidRequestorForSendType (string sendType, string returnType);
 
 		[Export ("pasteAsPlainText:")]
-		void PasteAsPlainText (NSObject sender);
+		void PasteAsPlainText ([NullAllowed] NSObject sender);
 
 		[Export ("pasteAsRichText:")]
-		void PasteAsRichText (NSObject sender);
+		void PasteAsRichText ([NullAllowed] NSObject sender);
 
 		//
 		// Dragging support

--- a/tests/xtro-sharpie/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/macOS-AppKit.ignore
@@ -2155,8 +2155,6 @@
 !missing-null-allowed! 'System.Void AppKit.NSTextView::OrderFrontSubstitutionsPanel(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSTextView::OrderFrontTablePanel(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSTextView::Outline(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void AppKit.NSTextView::PasteAsPlainText(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void AppKit.NSTextView::PasteAsRichText(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSTextView::PerformFindPanelAction(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSTextView::RaiseBaseline(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSTextView::set_AllowedInputSourceLocales(System.String[])' is missing an [NullAllowed] on parameter #0


### PR DESCRIPTION
This is documented in Apple's documentation, their headers, and even proved
experimentally.