### PR TITLE
[DevOps] Move away from a testing branch and use main.

### DIFF
--- a/tools/devops/device-tests.yml
+++ b/tools/devops/device-tests.yml
@@ -15,7 +15,7 @@ resources:
   - repository: maccore
     type: github
     name: xamarin/maccore
-    ref: refs/heads/device-tests-yaml # should this be on a branch and not on main???
+    ref: refs/heads/main
     endpoint: xamarin
 
 variables:


### PR DESCRIPTION
This is mainly for completeness. If we revert the coming yaml, we should use main.