### PR TITLE
[Harness] Add an extra index that will use full uris.

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -628,6 +628,13 @@ namespace Xharness {
 			}
 		}
 
+		public string VSDropsUri {
+			get {
+				var uri = Environment.GetEnvironmentVariable ("VSDROPS_URI");
+				return string.IsNullOrEmpty (uri) ? null : uri;
+			}
+		}
+
 		public int Execute ()
 		{
 			switch (Action) {

--- a/tests/xharness/IHarness.cs
+++ b/tests/xharness/IHarness.cs
@@ -57,6 +57,7 @@ namespace Xharness {
 		bool InCI { get; }
 		bool UseTcpTunnel { get; }
 		bool UseGroupedApps { get; }
+		string VSDropsUri { get; }
 		bool DisableWatchOSOnWrench { get; }
 
 		#endregion

--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -313,7 +313,7 @@ namespace Xharness.Jenkins {
 					var report = Path.Combine (LogDirectory, "index.html");
 					var vsdropsReport = Path.Combine (LogDirectory, "vsdrops_index.html");
 					var tmpreport = Path.Combine (LogDirectory, $"index-{Helpers.Timestamp}.tmp.html");
-					var tmpVsdropsReport= Path.Combine (LogDirectory, $"vsdrops_index-{Helpers.Timestamp}.tmp.html");
+					var tmpVsdropsReport = Path.Combine (LogDirectory, $"vsdrops_index-{Helpers.Timestamp}.tmp.html");
 					var tmpmarkdown = string.IsNullOrEmpty (Harness.MarkdownSummaryPath) ? string.Empty : (Harness.MarkdownSummaryPath + $".{Helpers.Timestamp}.tmp");
 
 					var allSimulatorTasks = new List<RunSimulatorTask> ();

--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -26,7 +26,8 @@ namespace Xharness.Jenkins {
 		readonly ResourceManager resourceManager;
 
 		// report writers, do need to be a class instance because the have state.
-		readonly HtmlReportWriter htmlReportWriter;
+		readonly HtmlReportWriter xamarinStorageHtmlReportWriter;
+		readonly HtmlReportWriter vsdropsHtmlReportWriter;
 		readonly MarkdownReportWriter markdownReportWriter;
 		
 		public bool Populating { get; private set; } = true;
@@ -103,7 +104,10 @@ namespace Xharness.Jenkins {
 			testVariationsFactory = new TestVariationsFactory (this, processManager);
 			DeviceLoader = new JenkinsDeviceLoader (Simulators, Devices, Logs);
 			resourceManager = new ResourceManager ();
-			htmlReportWriter = new HtmlReportWriter (jenkins: this, resourceManager: resourceManager, resultParser: resultParser);
+			xamarinStorageHtmlReportWriter = new HtmlReportWriter (jenkins: this, resourceManager: resourceManager, resultParser: resultParser);
+			// we only care about the vsdrops writer if we are in the CI, locally makes no sense
+			if (harness.InCI && !string.IsNullOrEmpty (Harness.VSDropsUri))
+				vsdropsHtmlReportWriter = new HtmlReportWriter (this, resourceManager, resultParser, linksPrefix: Harness.VSDropsUri, embeddedResources: true);
 			markdownReportWriter = new MarkdownReportWriter ();
 		}
 
@@ -233,7 +237,7 @@ namespace Xharness.Jenkins {
 				var tasks = new List<Task> ();
 				if (IsServerMode) {
 					var testServer = new TestServer ();
-					tasks.Add (testServer.RunAsync (this, htmlReportWriter));
+					tasks.Add (testServer.RunAsync (this, xamarinStorageHtmlReportWriter));
 				}
 
 				if (Harness.InCI) {
@@ -307,7 +311,9 @@ namespace Xharness.Jenkins {
 			try {
 				lock (report_lock) {
 					var report = Path.Combine (LogDirectory, "index.html");
+					var vsdropsReport = Path.Combine (LogDirectory, "vsdrops_index.html");
 					var tmpreport = Path.Combine (LogDirectory, $"index-{Helpers.Timestamp}.tmp.html");
+					var tmpVsdropsReport= Path.Combine (LogDirectory, $"vsdrops_index-{Helpers.Timestamp}.tmp.html");
 					var tmpmarkdown = string.IsNullOrEmpty (Harness.MarkdownSummaryPath) ? string.Empty : (Harness.MarkdownSummaryPath + $".{Helpers.Timestamp}.tmp");
 
 					var allSimulatorTasks = new List<RunSimulatorTask> ();
@@ -369,7 +375,15 @@ namespace Xharness.Jenkins {
 					// write the html
 					using (var stream = new FileStream (tmpreport, FileMode.Create, FileAccess.ReadWrite)) 
 					using (var writer = new StreamWriter (stream)) { 
-						htmlReportWriter.Write (allTasks, writer);
+						xamarinStorageHtmlReportWriter.Write (allTasks, writer);
+					}
+
+					// write the vsdrops report only if needed
+					if (vsdropsHtmlReportWriter != null) {
+						using (var stream = new FileStream (tmpVsdropsReport, FileMode.Create, FileAccess.ReadWrite)) 
+						using (var writer = new StreamWriter (stream)) { 
+							vsdropsHtmlReportWriter.Write (allTasks, writer);
+						}
 					}
 
 					// optionally, write the markdown
@@ -382,11 +396,19 @@ namespace Xharness.Jenkins {
 					if (File.Exists (report))
 						File.Delete (report);
 					File.Move (tmpreport, report);
+
+					if (vsdropsHtmlReportWriter != null) {
+						if (File.Exists (vsdropsReport))
+							File.Delete (vsdropsReport);
+						File.Move (tmpVsdropsReport, vsdropsReport);
+					}
+					
 					if (!string.IsNullOrEmpty (tmpmarkdown)) {
 						if (File.Exists (Harness.MarkdownSummaryPath))
 							File.Delete (Harness.MarkdownSummaryPath);
 						File.Move (tmpmarkdown, Harness.MarkdownSummaryPath);
 					}
+					
 					var dependentFileLocation = Path.GetDirectoryName (System.Reflection.Assembly.GetExecutingAssembly ().Location);
 					foreach (var file in new string [] { "xharness.js", "xharness.css" }) {
 						File.Copy (Path.Combine (dependentFileLocation, file), Path.Combine (LogDirectory, file), true);

--- a/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
+++ b/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
@@ -19,7 +19,7 @@ namespace Xharness.Jenkins.Reports {
 		readonly IResourceManager resourceManager;
 		readonly IResultParser resultParser;
 		readonly string? linksPrefix;
-		private readonly bool embededResources;
+		readonly bool embededResources;
 
 		Dictionary<ILog, Tuple<long, object>> log_data = new Dictionary<ILog, Tuple<long, object>> ();
 		string? previous_test_runs;

--- a/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
+++ b/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
@@ -62,7 +62,7 @@ namespace Xharness.Jenkins.Reports {
 			}
 		}
 
-		void IncludeCSS (StreamWriter writer)
+		void IncludeCss (StreamWriter writer)
 		{
 			if (embededResources) {
 				var cssPath = GetResourcePath ("xharness.css");
@@ -96,7 +96,7 @@ namespace Xharness.Jenkins.Reports {
 			if (jenkins.IsServerMode && jenkins.Populating)
 				writer.WriteLine ("<meta http-equiv=\"refresh\" content=\"1\">");
 			writer.WriteLine ("<head>");
-			IncludeCSS (writer);
+			IncludeCss (writer);
 			writer.WriteLine ("<title>Test results</title>");
 			IncludeJavascript (writer);
 			if (jenkins.IsServerMode) {

--- a/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
+++ b/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
@@ -18,7 +18,7 @@ namespace Xharness.Jenkins.Reports {
 		readonly Jenkins jenkins;
 		readonly IResourceManager resourceManager;
 		readonly IResultParser resultParser;
-		private readonly string? linksPrefix;
+		readonly string? linksPrefix;
 		private readonly bool embededResources;
 
 		Dictionary<ILog, Tuple<long, object>> log_data = new Dictionary<ILog, Tuple<long, object>> ();
@@ -41,7 +41,7 @@ namespace Xharness.Jenkins.Reports {
 
 		string GetResourcePath (string resource)
 		{
-			var executingDir= Path.GetDirectoryName (Assembly.GetExecutingAssembly ().Location);
+			var executingDir = Path.GetDirectoryName (Assembly.GetExecutingAssembly ().Location);
 			return Path.Combine (executingDir, resource); 
 		}
 		

--- a/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
+++ b/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
@@ -17,20 +18,66 @@ namespace Xharness.Jenkins.Reports {
 		readonly Jenkins jenkins;
 		readonly IResourceManager resourceManager;
 		readonly IResultParser resultParser;
+		private readonly string? linksPrefix;
+		private readonly bool embededResources;
 
 		Dictionary<ILog, Tuple<long, object>> log_data = new Dictionary<ILog, Tuple<long, object>> ();
 		string? previous_test_runs;
 
-		// convinient
+		// convenient
 		IHarness Harness => jenkins.Harness;
 
-		public HtmlReportWriter (Jenkins jenkins, IResourceManager resourceManager, IResultParser resultParser)
+		public HtmlReportWriter (Jenkins jenkins, IResourceManager resourceManager, IResultParser resultParser, string? linksPrefix = null, bool embeddedResources = false)
 		{
 			this.jenkins = jenkins ?? throw new ArgumentNullException (nameof (jenkins));
 			this.resourceManager = resourceManager ?? throw new ArgumentNullException (nameof (resourceManager));
 			this.resultParser = resultParser ?? throw new ArgumentNullException (nameof (resultParser));
+			this.linksPrefix = linksPrefix;
+			this.embededResources = embeddedResources;
 		}
 
+		string GetLinkPath (string path)
+			=> linksPrefix != null ? Path.Combine (linksPrefix, path) : path;
+
+		string GetResourcePath (string resource)
+		{
+			var executingDir= Path.GetDirectoryName (Assembly.GetExecutingAssembly ().Location);
+			return Path.Combine (executingDir, resource); 
+		}
+		
+		void IncludeJavascript (StreamWriter writer)
+		{
+			if (embededResources) {
+				var jsPath = GetResourcePath("xharness.js"); 
+				writer.WriteLine ("<script type='text/javascript'>");
+				using (var reader = new StreamReader (jsPath)) {
+					string? line = null;
+					while ((line = reader.ReadLine ()) != null) {
+						writer.WriteLine (line);
+					}
+				}
+				writer.WriteLine("</script>");
+			} else {
+				writer.WriteLine (@"<script type='text/javascript' src='xharness.js'></script>");
+			}
+		}
+
+		void IncludeCSS (StreamWriter writer)
+		{
+			if (embededResources) {
+				var cssPath = GetResourcePath ("xharness.css");
+				writer.WriteLine("<style>");
+				using (var reader = new StreamReader (cssPath)) {
+					string? line = null;
+					while ((line = reader.ReadLine ()) != null) {
+						writer.WriteLine (line);
+					}
+				}
+				writer.WriteLine("</style>");
+			} else {
+				writer.WriteLine ("<link rel='stylesheet' href='xharness.css'>");
+			}
+		}
 		public void Write (IList<ITestTask> allTasks, StreamWriter writer)
 		{
 			var id_counter = 0;
@@ -49,9 +96,9 @@ namespace Xharness.Jenkins.Reports {
 			if (jenkins.IsServerMode && jenkins.Populating)
 				writer.WriteLine ("<meta http-equiv=\"refresh\" content=\"1\">");
 			writer.WriteLine ("<head>");
-			writer.WriteLine ("<link rel='stylesheet' href='xharness.css'>");
+			IncludeCSS (writer);
 			writer.WriteLine ("<title>Test results</title>");
-			writer.WriteLine (@"<script type='text/javascript' src='xharness.js'></script>");
+			IncludeJavascript (writer);
 			if (jenkins.IsServerMode) {
 				writer.WriteLine ("<script type='text/javascript'>");
 				writer.WriteLine ("setTimeout (autorefresh, 1000);");
@@ -69,7 +116,7 @@ namespace Xharness.Jenkins.Reports {
 
 			writer.WriteLine ($"<span id='x{id_counter++}' class='autorefreshable'>");
 			foreach (var log in jenkins.Logs)
-				writer.WriteLine ("<a href='{0}' type='text/plain;charset=UTF-8'>{1}</a><br />", log.FullPath.Substring (jenkins.LogDirectory.Length + 1), log.Description);
+				writer.WriteLine ("<a href='{0}' type='text/plain;charset=UTF-8'>{1}</a><br />", GetLinkPath (log.FullPath.Substring (jenkins.LogDirectory.Length + 1)), log.Description);
 			writer.WriteLine ("</span>");
 
 			var headerColor = "black";
@@ -395,18 +442,18 @@ namespace Xharness.Jenkins.Reports {
 									break;
 								}
 								if (!exists) {
-									writer.WriteLine ("<a href='{0}' type='{2}' target='{3}'>{1}</a> (does not exist)<br />", LinkEncode (log.FullPath.Substring (jenkins.LogDirectory.Length + 1)), log.Description, log_type, log_target);
+									writer.WriteLine ("<a href='{0}' type='{2}' target='{3}'>{1}</a> (does not exist)<br />", LinkEncode (GetLinkPath (log.FullPath.Substring (jenkins.LogDirectory.Length + 1))), log.Description, log_type, log_target);
 								} else if (log.Description == LogType.BuildLog.ToString ()) {
 									var binlog = log.FullPath.Replace (".txt", ".binlog");
 									if (File.Exists (binlog)) {
-										var textLink = string.Format ("<a href='{0}' type='{2}' target='{3}'>{1}</a>", LinkEncode (log.FullPath.Substring (jenkins.LogDirectory.Length + 1)), log.Description, log_type, log_target);
-										var binLink = string.Format ("<a href='{0}' type='{2}' target='{3}' style='display:{4}'>{1}</a><br />", LinkEncode (binlog.Substring (jenkins.LogDirectory.Length + 1)), "Binlog download", log_type, log_target, test.Building ? "none" : "inline");
+										var textLink = string.Format ("<a href='{0}' type='{2}' target='{3}'>{1}</a>", LinkEncode (GetLinkPath (log.FullPath.Substring (jenkins.LogDirectory.Length + 1))), log.Description, log_type, log_target);
+										var binLink = string.Format ("<a href='{0}' type='{2}' target='{3}' style='display:{4}'>{1}</a><br />", LinkEncode (GetLinkPath (binlog.Substring (jenkins.LogDirectory.Length + 1))), "Binlog download", log_type, log_target, test.Building ? "none" : "inline");
 										writer.Write ("{0} {1}", textLink, binLink);
 									} else {
-										writer.WriteLine ("<a href='{0}' type='{2}' target='{3}'>{1}</a><br />", LinkEncode (log.FullPath.Substring (jenkins.LogDirectory.Length + 1)), log.Description, log_type, log_target);
+										writer.WriteLine ("<a href='{0}' type='{2}' target='{3}'>{1}</a><br />", LinkEncode (GetLinkPath (log.FullPath.Substring (jenkins.LogDirectory.Length + 1))), log.Description, log_type, log_target);
 									}
 								} else {
-									writer.WriteLine ("<a href='{0}' type='{2}' target='{3}'>{1}</a><br />", LinkEncode (log.FullPath.Substring (jenkins.LogDirectory.Length + 1)), log.Description, log_type, log_target);
+									writer.WriteLine ("<a href='{0}' type='{2}' target='{3}'>{1}</a><br />", LinkEncode (GetLinkPath (log.FullPath.Substring (jenkins.LogDirectory.Length + 1))), log.Description, log_type, log_target);
 								}
 								if (!exists) {
 									// Don't try to parse files that don't exist


### PR DESCRIPTION
Vsdrops does not support serving a static html. Therefore we need to use
full uris that will be used to download the logs. To make things less
dangerous, we leave the xamarin-storage report as it was and create a
new one for vsdrops.

This means that:

1. xamarin-storage index.html is left as is.
2. vsdrops_index.html contains full uris to download (the env var will
   have to be set in the step) and js and css are in the header.
3. because we use and env var, jenkins won't generate the
   vsdrops_index.html only device pipelines will.

For this to take effect needs updates in the device pipelines. The
solution is not yet optimal since we need to add some workaround to
rather than make the monitoring person open a text file, we should
display it in the browser.