### PR TITLE
[runtime] Remove internal memcpy p/invoke

### DIFF
--- a/src/AudioToolbox/AudioConverter.cs
+++ b/src/AudioToolbox/AudioConverter.cs
@@ -586,8 +586,8 @@ namespace AudioToolbox
 							inst.packetDescriptions = Marshal.AllocHGlobal (data.Length * size);
 						}
 						unsafe { 
-							fixed (AudioStreamPacketDescription* inptr = data) {
-								Runtime.memcpy ((byte *) inst.packetDescriptions, (byte *) inptr, data.Length * size);
+							fixed (void* source = data) {
+								Buffer.MemoryCopy (source, (void*) inst.packetDescriptions, inst.packetDescriptionSize * size, data.Length * size);
 							}
 						}
 						Marshal.WriteIntPtr (outDataPacketDescription, inst.packetDescriptions);

--- a/src/AudioToolbox/AudioQueue.cs
+++ b/src/AudioToolbox/AudioQueue.cs
@@ -253,9 +253,7 @@ namespace AudioToolbox {
 
 		public unsafe void CopyToAudioData (IntPtr source, int size)
 		{
-			byte *t = (byte *) AudioData;
-			byte *s = (byte *) source;
-			Runtime.memcpy (t, s, size);
+			Buffer.MemoryCopy ((void*) source, (void*) AudioData, AudioDataByteSize, size);
 		}
 	}
 
@@ -481,9 +479,7 @@ namespace AudioToolbox {
 		{
 			IntPtr target = Marshal.ReadIntPtr (audioQueueBuffer, IntPtr.Size);
 			unsafe {
-				byte *targetp = (byte *) target;
-				byte *sourcep = (byte *) source;
-				Runtime.memcpy (targetp + offset, sourcep + sourceOffset, size);
+				Buffer.MemoryCopy ((void*) (source + sourceOffset), (void*) (target + offset), size, size);
 			}
 		}
 		

--- a/src/AudioToolbox/MusicTrack.cs
+++ b/src/AudioToolbox/MusicTrack.cs
@@ -121,7 +121,7 @@ namespace AudioToolbox {
 				if (data != null)
 					Marshal.Copy (data, start, (IntPtr) rdata, len);
 				else
-					Runtime.memcpy (rdata, (byte *) buffer, len);
+					Buffer.MemoryCopy ((void*) buffer, (void*) rdata, len, len);
 				return (IntPtr) target;
 			}
 		}
@@ -166,7 +166,7 @@ namespace AudioToolbox {
 				if (data != null)
 					Marshal.Copy (data, start, (IntPtr) rdata, len);
 				else
-					Runtime.memcpy (rdata, (byte *) buffer, len);
+					Buffer.MemoryCopy ((void*) buffer, (void*) rdata, len, len);
 				return (IntPtr) target;
 			}
 		}

--- a/src/CoreMidi/MidiThruConnectionParams.cs
+++ b/src/CoreMidi/MidiThruConnectionParams.cs
@@ -329,7 +329,7 @@ namespace CoreMidi {
 				if (connectionParams.NumControlTransforms > 0) {
 					unsafe {
 						fixed (void* arrAddr = &Controls[0])
-							Buffer.MemoryCopy ((void*) bufferEnd, arrAddr, controlsSize * connectionParams.NumControlTransforms, controlsSize * connectionParams.NumControlTransforms);
+							Buffer.MemoryCopy (arrAddr, (void*) bufferEnd, controlsSize * connectionParams.NumControlTransforms, controlsSize * connectionParams.NumControlTransforms);
 					}
 				}
 
@@ -339,7 +339,7 @@ namespace CoreMidi {
 					unsafe {
 						for (int i = 0; i < connectionParams.NumMaps; i++) {
 							fixed (void* arrAddr = &Maps[i].Value [0])
-								Buffer.MemoryCopy ((void*) bufferEnd, arrAddr, 128, 128);
+								Buffer.MemoryCopy (arrAddr, (void*) bufferEnd, 128, 128);
 							bufferEnd += 128;
 						}
 					}

--- a/src/CoreMidi/MidiThruConnectionParams.cs
+++ b/src/CoreMidi/MidiThruConnectionParams.cs
@@ -270,9 +270,9 @@ namespace CoreMidi {
 				Controls = null;
 			else {
 				Controls = new MidiControlTransform[connectionParams.NumControlTransforms];
-				unsafe { // Lets use memcpy to avoid a for loop
-					fixed (MidiControlTransform* arrAddr = &Controls[0])
-						Runtime.memcpy ((IntPtr) arrAddr, bufferEnd, controlsSize * connectionParams.NumControlTransforms);
+				unsafe {
+					fixed (void* arrAddr = &Controls[0])
+						Buffer.MemoryCopy ((void*) bufferEnd, arrAddr, controlsSize * connectionParams.NumControlTransforms, controlsSize * connectionParams.NumControlTransforms);
 				}
 			}
 
@@ -281,11 +281,11 @@ namespace CoreMidi {
 			else {
 				Maps = new MidiValueMap [connectionParams.NumMaps];
 				bufferEnd = IntPtr.Add (bufferEnd, controlsSize * connectionParams.NumControlTransforms);
-				unsafe { // Lets use memcpy to avoid a for loop
+				unsafe {
 					for (int i = 0; i < connectionParams.NumMaps; i++) {
 						Maps [i].Value = new byte [128];
-						fixed (byte* arrAddr = &Maps[i].Value [0])
-							Runtime.memcpy ((IntPtr) arrAddr, bufferEnd, 128);
+						fixed (void* arrAddr = &Maps[i].Value [0])
+							Buffer.MemoryCopy ((void*) bufferEnd, arrAddr, 128, 128);
 					}
 				}
 			}
@@ -327,19 +327,19 @@ namespace CoreMidi {
 				Marshal.StructureToPtr (connectionParams, buffer, false);
 
 				if (connectionParams.NumControlTransforms > 0) {
-					unsafe { // Lets use memcpy to avoid a for loop
-						fixed (MidiControlTransform* arrAddr = &Controls[0])
-							Runtime.memcpy (bufferEnd, (IntPtr) arrAddr, controlsSize * connectionParams.NumControlTransforms);
+					unsafe {
+						fixed (void* arrAddr = &Controls[0])
+							Buffer.MemoryCopy ((void*) bufferEnd, arrAddr, controlsSize * connectionParams.NumControlTransforms, controlsSize * connectionParams.NumControlTransforms);
 					}
 				}
 
 				if (connectionParams.NumMaps > 0) {
 					// Set the destination buffer after controls arr if any
 					bufferEnd = IntPtr.Add (bufferEnd, controlsSize * connectionParams.NumControlTransforms);
-					unsafe { // Lets use memcpy to avoid a for loop
+					unsafe {
 						for (int i = 0; i < connectionParams.NumMaps; i++) {
-							fixed (byte* arrAddr = &Maps[i].Value [0])
-								Runtime.memcpy (bufferEnd, (IntPtr) arrAddr, 128);
+							fixed (void* arrAddr = &Maps[i].Value [0])
+								Buffer.MemoryCopy ((void*) bufferEnd, arrAddr, 128, 128);
 							bufferEnd += 128;
 						}
 					}

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1651,12 +1651,6 @@ namespace ObjCRuntime {
 			return rv;
 		}
 
-		[DllImport (Constants.libSystemLibrary)]
-		extern internal static void memcpy (IntPtr target, IntPtr source, nint n);
-
-		[DllImport (Constants.libSystemLibrary)]
-		unsafe extern internal static void memcpy (byte * target, byte * source, nint n);
-
 		// This function will try to compare a native UTF8 string to a managed string without creating a temporary managed string for the native UTF8 string.
 		// Currently this only works if the UTF8 string only contains single-byte characters.
 		// If any multi-byte characters are found, the native utf8 string is converted to a managed string, and then normal managed comparison is done.

--- a/tests/xtro-sharpie/common-ObjCRuntime.ignore
+++ b/tests/xtro-sharpie/common-ObjCRuntime.ignore
@@ -12,7 +12,6 @@
 !unknown-pinvoke! dlerror bound
 !unknown-pinvoke! dlopen bound
 !unknown-pinvoke! dlsym bound
-!unknown-pinvoke! memcpy bound
 !unknown-pinvoke! NXGetLocalArchInfo bound
 !unknown-pinvoke! objc_allocateClassPair bound
 !unknown-pinvoke! objc_allocateProtocol bound


### PR DESCRIPTION
* Replace `memcpy` with `Buffer.MemoryCopy`
* Add cecil-based test to make sure we're not p/invoke into it again (nor any other MS banned API)
* Remove `memcpy` from xtro ignore file