### PR TITLE
[runtime] Fix warning in launcher.m

### DIFF
--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -133,7 +133,6 @@ get_mono_env_options (int *count)
 	unsigned char *start, *inptr;
 	char *value, **argv;
 	int i, n = 0;
-	size_t size;
 
 	if (env == NULL) {
 		*count = 0;


### PR DESCRIPTION
```
launcher.m:136:9: warning: unused variable 'size' [-Wunused-variable]
        size_t size;
               ^
1 warning generated.
```

missed in https://github.com/xamarin/xamarin-macios/pull/8853