### PR TITLE
[runtime] Use `strnlen` instead of `strlen`

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2467,7 +2467,7 @@ xamarin_vprintf (const char *format, va_list args)
 	
 #if TARGET_OS_WATCH && defined (__arm__) // maybe make this configurable somehow?
 	const char *msg = [message UTF8String];
-	size_t len = strlen (msg);
+	NSUInteger len = [message lengthOfBytesUsingEncoding:NSUTF8StringEncoding] + 1; // does not include NULL
 	fwrite (msg, 1, len, stdout);
 	if (len == 0 || msg [len - 1] != '\n')
 		fwrite ("\n", 1, 1, stdout);
@@ -2499,7 +2499,9 @@ xamarin_vprintf (const char *format, va_list args)
 void
 xamarin_get_assembly_name_without_extension (const char *aname, char *name, size_t namelen)
 {
-	size_t len = strlen (aname);
+	size_t len = strnlen (aname, namelen);
+	if (len == namelen)
+		return;
 	strlcpy (name, aname, namelen);
 	if (namelen <= 4 || len <= 4)
 		return;

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -208,10 +208,10 @@ namespace ObjCRuntime {
 							}
 						}
 						if (buf != null) {
-							var strlength = 0;
+							var str_length = 0;
 							for (int i = 0; i < buf.Length && buf [i] != 0; i++)
-								strlength++;
-							NSLog ("The native runtime was loaded from {0}", System.Text.Encoding.UTF8.GetString (buf, 0, strlength));
+								str_length++;
+							NSLog ("The native runtime was loaded from {0}", System.Text.Encoding.UTF8.GetString (buf, 0, str_length));
 						}
 					} else {
 						NSLog ("Could not find out where the native runtime was loaded from.");


### PR DESCRIPTION
`strlen` is part of the list of C API banned by Microsoft.

Also rename a local variable in `Runtime.cs` so grepping the source
files won't show `strlen` outside the `tests` subdirectories.