### PR TITLE
[DevOps] Update contexts to be more clear.

### DIFF
--- a/tools/devops/device-tests/cambridge-ios-32b-device-tests.yml
+++ b/tools/devops/device-tests/cambridge-ios-32b-device-tests.yml
@@ -27,5 +27,5 @@ stages:
     WindowsDevicePool: ${{ variables.WindowsDevicePool }}
     htmlReportStorage: ${{ variables.htmlReportStorage }}
     testsLabels: '--label=run-ios-32-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests'
-    statusContext: 'VSTS: device tests iOS 32b'
+    statusContext: 'VSTS: device tests iOS32b (Cambridge)'
     iOSDeviceDemand: 'xismoke-32' 

--- a/tools/devops/device-tests/cambridge-ios-beta-device-tests.yml
+++ b/tools/devops/device-tests/cambridge-ios-beta-device-tests.yml
@@ -27,5 +27,5 @@ stages:
     WindowsDevicePool: ${{ variables.WindowsDevicePool }}
     htmlReportStorage: ${{ variables.htmlReportStorage }}
     testsLabels: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests'
-    statusContext: 'VSTS: device tests iOS'
+    statusContext: 'VSTS: device tests iOS Beta (Cambridge)'
     iOSDeviceDemand: 'xismoke-beta'

--- a/tools/devops/device-tests/cambridge-ios-device-tests.yml
+++ b/tools/devops/device-tests/cambridge-ios-device-tests.yml
@@ -27,5 +27,5 @@ stages:
     WindowsDevicePool: ${{ variables.WindowsDevicePool }}
     htmlReportStorage: ${{ variables.htmlReportStorage }}
     testsLabels: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests'
-    statusContext: 'VSTS: device tests iOS'
+    statusContext: 'VSTS: device tests iOS (Cambridge)'
     iOSDeviceDemand: 'xismoke'

--- a/tools/devops/device-tests/cambridge-tvos-beta-device-tests.yml
+++ b/tools/devops/device-tests/cambridge-tvos-beta-device-tests.yml
@@ -27,5 +27,5 @@ stages:
     WindowsDevicePool: ${{ variables.WindowsDevicePool }}
     htmlReportStorage: ${{ variables.htmlReportStorage }}
     testsLabels: '--label=run-tvos-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests'
-    statusContext: 'VSTS: device tests iOS'
+    statusContext: 'VSTS: device tests tvOS Beta (Cambridge)'
     iOSDeviceDemand: 'xitvos-beta'

--- a/tools/devops/device-tests/cambridge-tvos-device-tests.yml
+++ b/tools/devops/device-tests/cambridge-tvos-device-tests.yml
@@ -27,5 +27,5 @@ stages:
     WindowsDevicePool: ${{ variables.WindowsDevicePool }}
     htmlReportStorage: ${{ variables.htmlReportStorage }}
     testsLabels: '--label=run-tvos-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests'
-    statusContext: 'VSTS: device tests iOS'
+    statusContext: 'VSTS: device tests tvOS (Cambridge)'
     iOSDeviceDemand: 'xitvos' 

--- a/tools/devops/device-tests/ddfun-ios-device-tests.yml
+++ b/tools/devops/device-tests/ddfun-ios-device-tests.yml
@@ -27,5 +27,5 @@ stages:
     WindowsDevicePool: ${{ variables.WindowsDevicePool }}
     htmlReportStorage: ${{ variables.htmlReportStorage }}
     testsLabels: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests'
-    statusContext: 'VSTS: device tests iOS'
+    statusContext: 'VSTS: device tests iOS (DDFun)'
     iOSDeviceDemand: 'ios'

--- a/tools/devops/device-tests/ddfun-tvos-device-tests.yml
+++ b/tools/devops/device-tests/ddfun-tvos-device-tests.yml
@@ -27,5 +27,5 @@ stages:
     WindowsDevicePool: ${{ variables.WindowsDevicePool }}
     htmlReportStorage: ${{ variables.htmlReportStorage }}
     testsLabels: '--label=run-tvos-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests'
-    statusContext: 'VSTS: device tests iOS'
+    statusContext: 'VSTS: device tests tvOS (DDFun)'
     iOSDeviceDemand: 'tvos' 


### PR DESCRIPTION
The contexts are the ones that link a status with a device run. Update
them so that we do know the labe used (and remove a typo where we used
TvOS).