### PR TITLE
[Bump] Bump maccore to use the new yaml pipelines.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 8b437d6ae31554a8bc5e8d0beaa42ffc757d0077
+NEEDED_MACCORE_VERSION := 8eee91b69c82f4a5549ed07bf0eb4a25c34909db
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
Commits:

* [DevOps] Update the pipeline ids to point to the new yaml based ones. (#2241)

Complete diff: https://github.com/xamarin/maccore/compare/8b437d6ae31554a8bc5e8d0beaa42ffc757d0077...8eee91b69c82f4a5549ed07bf0eb4a25c34909db