### PR TITLE
[configure] Add an option to enable/disable install-source.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -186,6 +186,9 @@ INCLUDE_WATCH=1
 INCLUDE_TVOS=1
 INCLUDE_DEVICE=1
 
+# disable source code install by default (it's enabled for CI builds)
+ENABLE_INSTALL_SOURCE=
+
 -include $(TOP)/Make.config.local
 -include $(TOP)/configure.inc
 

--- a/configure
+++ b/configure
@@ -32,6 +32,12 @@ Usage: configure [options]
 
     --enable-dotnet         Enable building .NET 5 bits.
     --disable-dotnet        Disable building .NET 5 bits.
+
+    --enable-documentation  Enable building of API documentation
+    --disable-documentation Disable building of API documentation.
+
+    --enable-install-source  Enable building of API documentation
+    --disable-install-source Disable building of API documentation.
 EOL
 }
 
@@ -112,6 +118,14 @@ while test x$1 != x; do
         ;;
     --disable-dotnet)
         echo "ENABLE_DOTNET=" >> "$CONFIGURED_FILE"
+        shift
+        ;;
+    --enable-install-source)
+        echo "ENABLE_INSTALL_SOURCE=1" >> "$CONFIGURED_FILE"
+        shift
+        ;;
+    --disable-install-source)
+        echo "ENABLE_INSTALL_SOURCE=" >> "$CONFIGURED_FILE"
         shift
         ;;
 	--help|-h)

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -121,7 +121,7 @@ if test -z "$ENABLE_DEVICE_BUILD"; then
 fi
 
 # Enable dotnet bits on the bots
-CONFIGURE_FLAGS="$CONFIGURE_FLAGS --enable-dotnet"
+CONFIGURE_FLAGS="$CONFIGURE_FLAGS --enable-dotnet --enable-install-source"
 
 echo "Configuring the build with: $CONFIGURE_FLAGS"
 # shellcheck disable=SC2086

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,3 +1,8 @@
 TOP=..
-SUBDIRS=mmp mtouch install-source xibuild mlaunch siminstaller dotnet-linker
+SUBDIRS=mmp mtouch xibuild mlaunch siminstaller dotnet-linker
+
 include $(TOP)/Make.config
+
+ifdef ENABLE_INSTALL_SOURCE
+SUBDIRS += install-source
+endif


### PR DESCRIPTION
Disable by default, but automatically enable for CI builds.

This makes running 'make install' with a fully built tree take ~8s instead of
20+s.