### PR TITLE
[xharness] Set the working directory to the project directory when building projects.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Tasks/MSBuild.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Tasks/MSBuild.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
@@ -59,6 +60,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tasks {
 			using (var xbuild = new Process ()) {
 				xbuild.StartInfo.FileName = msbuildPath;
 				xbuild.StartInfo.Arguments = StringUtils.FormatArguments (GetToolArguments (projectPlatform, projectConfiguration, projectFile, buildLog));
+				xbuild.StartInfo.WorkingDirectory = Path.GetDirectoryName (projectFile);
 				EnviromentManager.SetEnvironmentVariables (xbuild);
 				xbuild.StartInfo.EnvironmentVariables ["MSBuildExtensionsPath"] = null;
 				EventLogger.LogEvent (buildLog, "Building {0} ({1})", TestName, Mode);
@@ -96,6 +98,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tasks {
 				args.Add (project_file);
 				args.Add ("/t:Clean");
 				xbuild.StartInfo.Arguments = StringUtils.FormatArguments (args);
+				xbuild.StartInfo.WorkingDirectory = Path.GetDirectoryName (project_file);
 				EnviromentManager.SetEnvironmentVariables (xbuild);
 				EventLogger.LogEvent (log, "Cleaning {0} ({1}) - {2}", TestName, Mode, project_file);
 				var timeout = TimeSpan.FromMinutes (1);


### PR DESCRIPTION
This is particularly important when we have global.json and NuGet.config in
the project directory, because those are looked up starting with the current
directory, so those two need to match.