### PR TITLE
[AVFoundation] Remove unnecessary Equals/GetHashCode that caused cras…

### DIFF
--- a/src/AVFoundation/AVAudioChannelLayout.cs
+++ b/src/AVFoundation/AVAudioChannelLayout.cs
@@ -36,16 +36,6 @@ namespace AVFoundation {
 			}
 		}
 		
-		public override bool Equals (object  obj)
-		{
-			if (this == null){
-				return (obj == null);
-			}
-			if (!(obj is NSObject))
-				return false;
-			return IsEqual ((NSObject)obj);
-		}
-
 		public static bool operator == (AVAudioChannelLayout a, AVAudioChannelLayout b)
 		{
 			return a.Equals (b);
@@ -55,11 +45,5 @@ namespace AVFoundation {
 		{
 			return !a.Equals (b);
 		}
-
-		public override int GetHashCode ()
-		{
-			return (int) ChannelCount;
-		}
-		
 	}
 }

--- a/src/AVFoundation/AVAudioFormat.cs
+++ b/src/AVFoundation/AVAudioFormat.cs
@@ -12,16 +12,6 @@ using System.Runtime.CompilerServices;
 
 namespace AVFoundation {
 	public partial class AVAudioFormat {
-		public override bool Equals (object  obj)
-		{
-			if (this == null){
-				return (obj == null);
-			}
-			if (!(obj is NSObject))
-				return false;
-			return IsEqual ((NSObject)obj);
-		}
-
 		public static bool operator == (AVAudioFormat a, AVAudioFormat b)
 		{
 			return a.Equals (b);
@@ -31,11 +21,5 @@ namespace AVFoundation {
 		{
 			return !a.Equals (b);
 		}
-
-		public override int GetHashCode ()
-		{
-			return (int) ChannelCount;
-		}
-		
 	}
 }


### PR DESCRIPTION
…h (#8907)

- Found in https://github.com/xamarin/xamarin-macios/issues/8882
- It turns out that https://github.com/xamarin/xamarin-macios/pull/8091 changed behavior so this:
	return (obj == null);
- Would call another equals which would call the original equals and it would repeat until stack overflow
- Missing manual tests tracked in https://github.com/xamarin/xamarin-macios/issues/8905