### PR TITLE
[DevOps] Do not fail the tests is xamarin-storage cannot be reached.

### DIFF
--- a/tools/devops/device-tests/scripts/GitHub.psm1
+++ b/tools/devops/device-tests/scripts/GitHub.psm1
@@ -330,8 +330,19 @@ function New-GitHubSummaryComment {
     }
 
     $vstsTargetUrl = Get-TargetUrl
-    $xamarinStorageUrl = Get-XamarinStorageIndexUrl -Path $XamarinStoragePath
-    $headerLinks = "[Azure DevOps]($vstsTargetUrl) [Html Report]($xamarinStorageUrl)"
+    # build the links to provide extra info to the monitoring person, we need to make sure of a few things
+    # 1. We do have the xamarin-storage path
+    # 2. We did reach the xamarin-storage, stored in the env var XAMARIN_STORAGE_REACHED
+    $headerSb = [System.Text.StringBuilder]::new()
+    $headerSb.AppendLine(); # new line to start the list
+    $headerSb.AppendLine ("* [Azure DevOps]($vstsTargetUrl)"
+    if ($XamarinStoragePath -and $Env:XAMARIN_STORAGE_FAILED) { # if we do have the storage path but we failed. first part of the -and check string is not null or empty, second check presence of the env var
+        $headerSb.AppendLine ("* :warning: xamarin-storage could not be reached :warning:")
+    } else {
+        $xamarinStorageUrl = Get-XamarinStorageIndexUrl -Path $XamarinStoragePath
+        $headerSb.AppendLine ("* [Html Report]($xamarinStorageUrl)")
+    }
+    $headerLinks = $headerSb.ToString ()
     $request = $null
 
     if (-not (Test-Path $TestSummaryPath -PathType Leaf)) {

--- a/tools/devops/device-tests/scripts/GitHub.psm1
+++ b/tools/devops/device-tests/scripts/GitHub.psm1
@@ -335,14 +335,14 @@ function New-GitHubSummaryComment {
     # 2. We did reach the xamarin-storage, stored in the env var XAMARIN_STORAGE_REACHED
     $headerSb = [System.Text.StringBuilder]::new()
     $headerSb.AppendLine(); # new line to start the list
-    $headerSb.AppendLine ("* [Azure DevOps]($vstsTargetUrl)"
+    $headerSb.AppendLine("* [Azure DevOps]($vstsTargetUrl")
     if ($XamarinStoragePath -and $Env:XAMARIN_STORAGE_FAILED) { # if we do have the storage path but we failed. first part of the -and check string is not null or empty, second check presence of the env var
-        $headerSb.AppendLine ("* :warning: xamarin-storage could not be reached :warning:")
+        $headerSb.AppendLine("* :warning: xamarin-storage could not be reached :warning:")
     } else {
         $xamarinStorageUrl = Get-XamarinStorageIndexUrl -Path $XamarinStoragePath
-        $headerSb.AppendLine ("* [Html Report]($xamarinStorageUrl)")
+        $headerSb.AppendLine("* [Html Report]($xamarinStorageUrl)")
     }
-    $headerLinks = $headerSb.ToString ()
+    $headerLinks = $headerSb.ToString()
     $request = $null
 
     if (-not (Test-Path $TestSummaryPath -PathType Leaf)) {

--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -244,8 +244,13 @@ steps:
 
     cd $WORKING_DIR/xamarin-macios
     if [[ "$HTML_STORAGE" == "xamarin-storage" ]]; then
-      ssh builder@xamarin-storage "mkdir -p /volume1/storage/$XAMARIN_STORAGE_PATH"
-      export TESTS_PERIODIC_COMMAND="--periodic-interval 10 --periodic-command rsync --periodic-command-arguments '-avz -e \"ssh\" $PWD/jenkins-results builder@xamarin-storage:/volume1/storage/$XAMARIN_STORAGE_PATH'"
+      EC=0
+      ssh builder@xamarin-storage "mkdir -p /volume1/storage/$XAMARIN_STORAGE_PATH" || EC=$?
+      if [ $EC -eq 0 ]; then
+        export TESTS_PERIODIC_COMMAND="--periodic-interval 10 --periodic-command rsync --periodic-command-arguments '-avz -e \"ssh\" $PWD/jenkins-results builder@xamarin-storage:/volume1/storage/$XAMARIN_STORAGE_PATH'"
+      else
+        echo "##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED]true"
+      fi
     fi
 
     make -C builds download -j || true
@@ -280,6 +285,7 @@ steps:
     CONTEXT: ${{ parameters.statusContext }}
     GITHUB_TOKEN: $(GitHub.Token)
     XAMARIN_STORAGE_PATH: $(XAMARIN_STORAGE_PATH) # could be null if the step was not executed if we use vsdrops, the cmdlet will know how to handle that case
+    XAMARIN_STORAGE_REACHED: $(XAMARIN_STORAGE_FAILED) # could not reach xamarin-storage, either the bot is not in the vpn or it finally failed
   displayName: 'Add summaries'
   condition: and(always(), eq('${{ parameters.htmlReportStorage }}', 'xamarin-storage')) # execute always but when we are using vsdrops since we want to send the message and the url at the same time from the pusblish_hml job
   timeoutInMinutes: 1


### PR DESCRIPTION
Try to create the folder in xamarin-storage, if that fails, rather than
stop with an error, execute the tests and st an env var.

Once the tests are complete, when adding the summaries, check if we did
fail to reach xamarin-storage and notify it.

This will make sure that tests won't fail if:

* xamarin-storage dies.
* bots are not in the vpn and could not reach xamarin-storage.