### PR TITLE
[d16-6] [sharpie] Bump version of sharpie and accommodate xtro to new output

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -87,9 +87,9 @@ MIN_CMAKE_URL=https://cmake.org/files/v3.6/cmake-3.6.2-Darwin-x86_64.dmg
 MIN_CMAKE_VERSION=2.8.8
 
 # ObjectiveSharpie min/max versions
-MIN_SHARPIE_VERSION=3.5.22
+MIN_SHARPIE_VERSION=3.5.37
 MAX_SHARPIE_VERSION=3.5.99
-MIN_SHARPIE_URL=https://download.visualstudio.microsoft.com/download/pr/693cb4a2-5455-4841-904f-a2936d2781f4/3890cb5f74ea75ff4474152f1f2b8008/objectivesharpie-3.5.22.pkg
+MIN_SHARPIE_URL=https://bosstoragemirror.blob.core.windows.net/objective-sharpie/builds/626091405aca6fdee94b2d2beb8a667d810994b6/440/696076/ObjectiveSharpie-3.5.37.pkg
 
 # Minimum OSX versions for building XI/XM
 MIN_OSX_BUILD_VERSION=10.15

--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -48,7 +48,7 @@ XMAC_ARCH = x86_64
 XMAC_PCH = macosx$(OSX_SDK_VERSION)-$(XMAC_ARCH).pch
 
 $(XMAC_PCH): .stamp-check-sharpie
-	sharpie sdk-db --xcode $(XCODE) -s macosx$(OSX_SDK_VERSION) -a $(XMAC_ARCH) -exclude DriverKit -exclude IOUSBHost -exclude NetworkingDriverKit -exclude USBDriverKit -exclude USBSerialDriverKit -exclude HIDDriverKit -exclude PCIDriverKit -exclude PDFKit
+	sharpie sdk-db --xcode $(XCODE) -s macosx$(OSX_SDK_VERSION) -a $(XMAC_ARCH)
 
 
 

--- a/tests/xtro-sharpie/SimdCheck.cs
+++ b/tests/xtro-sharpie/SimdCheck.cs
@@ -243,11 +243,17 @@ namespace Extrospection
 
 		string Undecorate (string native_name)
 		{
-			if (native_name.StartsWith ("const ", StringComparison.Ordinal))
-				return Undecorate (native_name.Substring ("const ".Length));
+			const string _const = "const ";
+			if (native_name.StartsWith (_const, StringComparison.Ordinal))
+				return Undecorate (native_name.Substring (_const.Length));
 
-			if (native_name.StartsWith ("struct ", StringComparison.Ordinal))
-				return Undecorate (native_name.Substring ("struct ".Length));
+			const string _struct = "struct ";
+			if (native_name.StartsWith (_struct, StringComparison.Ordinal))
+				return Undecorate (native_name.Substring (_struct.Length));
+
+			const string _nsrefinedforswift = "NS_REFINED_FOR_SWIFT ";
+			if (native_name.StartsWith (_nsrefinedforswift, StringComparison.Ordinal))
+				return Undecorate (native_name.Substring (_nsrefinedforswift.Length));
 
 			const string _Nonnull = " _Nonnull";
 			if (native_name.EndsWith (_Nonnull, StringComparison.Ordinal))

--- a/tests/xtro-sharpie/xtro-sharpie.csproj
+++ b/tests/xtro-sharpie/xtro-sharpie.csproj
@@ -48,7 +48,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'macOS' ">
     <StartAction>Project</StartAction>
-    <StartArguments>macosx10.14-x86_64.pch ../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/x86_64/mobile/Xamarin.Mac.dll</StartArguments>
+    <StartArguments>macosx10.15-x86_64.pch ../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/x86_64/mobile/Xamarin.Mac.dll</StartArguments>
     <StartWorkingDirectory>.</StartWorkingDirectory>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION

Backport of #8759.

This fixes the following random xtro errors:

    ?unknown-entry? !wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARFaceGeometry::GetRawTextureCoordinates(): simd type: simd_float2 in 'iOS-ARKit.ignore'
    ?unknown-entry? !wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARFaceGeometry::GetRawVertices(): simd type: simd_float3 in 'iOS-ARKit.ignore'
    ?unknown-entry? !wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARPlaneGeometry::GetRawBoundaryVertices(): simd type: simd_float3 in 'iOS-ARKit.ignore'
    ?unknown-entry? !wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARPlaneGeometry::GetRawTextureCoordinates(): simd type: simd_float2 in 'iOS-ARKit.ignore'
    ?unknown-entry? !wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARPlaneGeometry::GetRawVertices(): simd type: simd_float3 in 'iOS-ARKit.ignore'
    ?unknown-entry? !wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARPointCloud::GetRawPoints(): simd type: simd_float3 in 'iOS-ARKit.ignore'
    ?unknown-entry? !wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARSkeleton2D::get_RawJointLandmarks(): simd type: simd_float2 in 'iOS-ARKit.ignore'
    ?unknown-entry? !wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARSkeleton3D::get_RawJointLocalTransforms(): simd type: simd_float4x4 in 'iOS-ARKit.ignore'
    ?unknown-entry? !wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARSkeleton3D::get_RawJointModelTransforms(): simd type: simd_float4x4 in 'iOS-ARKit.ignore'
    Sanity check failed (9)

The reason they're random, is that they depend on the version of sharpie installed on the bot. The errors will show up when the new version is installed, and we don't have the changes in this PR.

/cc @rolfbjarne @dalexsoto