### PR TITLE
[d16-7] [AppKit][Tests] Do not fail when we cannot create a NSPasteboard.

### DIFF
--- a/tests/apitest/src/AppKit/NSPasteboard.cs
+++ b/tests/apitest/src/AppKit/NSPasteboard.cs
@@ -14,8 +14,13 @@ namespace Xamarin.Mac.Tests
 		public void NSPasteboardTests_WriteObjectTests ()
 		{
 			NSPasteboard b = NSPasteboard.CreateWithUniqueName();
+			if (b == null)
+				Assert.Inconclusive ("NSPasteboard could not be provided by the OS.");
 			b.WriteObjects (new INSPasteboardWriting [] { (NSString)"asfd" });
 			b.WriteObjects (new NSPasteboardWriting [] { new MyPasteboard () });
+			// from the docs: the lifetime of a unique pasteboard is not related to the lifetime of the creating app,
+			// you must release a unique pasteboard by calling releaseGlobally to avoid possible leaks. 
+			b.ReleaseGlobally (); 
 		}
 		
 		class MyPasteboard2 : NSPasteboardReading


### PR DESCRIPTION
The test has started failign more commonly, but only in a number of old
OS versions and not all the time. The function should return a new
Pasteboard, but it is true that we are not releasing the old ones,
meaning that the pasteboard is left after the app is done as stated by
the apple documenation.

The test has been updated to:

1. Release the pasteboard.
2. Be inconclusive if the pasteboard service could not create a new one.

fixes: https://github.com/xamarin/xamarin-macios/issues/8787

Backport of #8788.

/cc @rolfbjarne @mandel-macaque