### PR TITLE
[xcode12] Backport CODEOWNERS and .gitignore changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ global.json
 device-tests-provisioning.csx
 mono_crash.*.json
 *.binlog
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ global.json
 .idea
 device-tests-provisioning.csx
 mono_crash.*.json
+*.binlog

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ tests/bcl-test/SystemXunit.csproj
 global.json
 .idea
 device-tests-provisioning.csx
+mono_crash.*.json

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,8 +37,8 @@
 /src/callkit.cs @dalexsoto
 /src/CarPlay @dalexsoto
 /src/carplay.cs @dalexsoto
-/src/CFNetwork @spouliot
-/src/cfnetwork.cs @spouliot
+/src/CFNetwork @spouliot @mandel-macaque
+/src/cfnetwork.cs @spouliot @mandel-macaque
 /src/CloudKit @mandel-macaque
 /src/cloudkit.cs @mandel-macaque
 /src/Compression @mandel-macaque
@@ -79,6 +79,7 @@
 /src/ExternalAccessory @dalexsoto @spouliot
 /src/externalaccessory.cs @dalexsoto @spouliot
 /src/Foundation @spouliot @rolfbjarne @chamons
+/src/Foundation/NSUrl* @mandel-macaque
 /src/foundation.cs @spouliot @rolfbjarne @chamons
 /src/GameController @spouliot
 /src/gamecontroller.cs @spouliot
@@ -113,8 +114,8 @@
 /src/localauthentication.cs @spouliot
 /src/MapKit @spouliot
 /src/mapkit.cs @spouliot
-/src/MediaPlayer
-/src/mediaplayer.cs
+/src/MediaPlayer @mandel-macaque
+/src/mediaplayer.cs @mandel-macaque
 /src/Messages
 /src/messages.cs
 /src/MessageUI
@@ -133,7 +134,7 @@
 /src/multipeerconnectivity.cs @spouliot
 /src/naturallanguage.cs @mandel-macaque
 /src/NaturalLanguage @mandel-macaque
-/src/Network @migueldeicaza
+/src/Network @mandel-macaque
 /src/NetworkExtension @spouliot
 /src/networkextension.cs @spouliot
 /src/NotificationCenter @spouliot
@@ -166,6 +167,7 @@
 /src/spritekit.cs
 /src/SystemConfiguration @spouliot
 /src/systemconfiguration.cs @spouliot
+/src/System.Net.Http @mandel-macaque
 /src/UIKit @dalexsoto @spouliot @rolfbjarne
 /src/uikit.cs @dalexsoto @spouliot @rolfbjarne
 /src/UserNotifications @dalexsoto
@@ -187,12 +189,12 @@
 /src/WKWebKit @spouliot
 /src/wkwebkit.cs @spouliot
 
-/tests/xharness @rolfbjarne
+/tests/xharness @rolfbjarne @mandel-macaque
 /tests/xtro-sharpie @spouliot
 /tests/mmptest @chamons
 /tests/common/mac @chamons
 /tests/msbuild-mac @chamons
-
+/tests/bcl-tests @mandel-macaque
 
 /tools/common @rolfbjarne @chamons @spouliot
 /tools/common/StaticRegistrar.cs @rolfbjarne

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,7 +14,7 @@
 
 /mk @rolfbjarne
 
-/msbuild @jstedfast @emaf @rolfbjarne @chamons
+/msbuild @emaf @rolfbjarne @chamons
 
 /runtime @rolfbjarne
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,7 +14,7 @@
 
 /mk @rolfbjarne
 
-/msbuild @jstedfast @emaf @rolfbjarne @VincentDondain @chamons
+/msbuild @jstedfast @emaf @rolfbjarne @chamons
 
 /runtime @rolfbjarne
 
@@ -22,8 +22,8 @@
 /src/addressbook.cs @dalexsoto
 /src/AppKit @chamons @dalexsoto
 /src/appkit.cs @chamons @dalexsoto
-/src/ARKit @VincentDondain
-/src/arkit.cs @VincentDondain
+/src/ARKit
+/src/arkit.cs
 /src/AudioToolbox @dalexsoto
 /src/audiotoolbox.cs @dalexsoto
 /src/AudioUnit @dalexsoto
@@ -46,8 +46,8 @@
 /src/contacts.cs @dalexsoto @spouliot
 /src/CoreAudio @dalexsoto
 /src/coreaudio.cs @dalexsoto
-/src/CoreBluetooth @VincentDondain @dalexsoto
-/src/corebluetooth.cs @VincentDondain @dalexsoto
+/src/CoreBluetooth @dalexsoto
+/src/corebluetooth.cs @dalexsoto
 /src/CoreData @mandel-macaque
 /src/coredata.cs @mandel-macaque
 /src/CoreFoundation @rolfbjarne @spouliot
@@ -70,8 +70,8 @@
 /src/corespotlight.cs @dalexsoto @spouliot
 /src/CoreTelephony @spouliot
 /src/coretelephony.cs @spouliot
-/src/CoreText @VincentDondain
-/src/coretext.cs @VincentDondain
+/src/CoreText
+/src/coretext.cs
 /src/CoreVideo @dalexsoto @spouliot @rolfbjarne
 /src/corevideo.cs @dalexsoto @spouliot @rolfbjarne
 /src/EventKit @dalexsoto @spouliot
@@ -80,19 +80,19 @@
 /src/externalaccessory.cs @dalexsoto @spouliot
 /src/Foundation @spouliot @rolfbjarne @chamons
 /src/foundation.cs @spouliot @rolfbjarne @chamons
-/src/GameController @VincentDondain @spouliot
-/src/gamecontroller.cs @VincentDondain @spouliot
-/src/GameKit @VincentDondain
-/src/gamekit.cs @VincentDondain
+/src/GameController @spouliot
+/src/gamecontroller.cs @spouliot
+/src/GameKit
+/src/gamekit.cs
 /src/GameplayKit @dalexsoto
 /src/gameplaykit.cs @dalexsoto
-/src/generator* @dalexsoto @spouliot @rolf @VincentDondain
+/src/generator* @dalexsoto @spouliot @rolf
 /src/GLKit @dalexsoto @spouliot
 /src/glkit.cs @dalexsoto @spouliot
-/src/HealthKit @VincentDondain
-/src/healthkit.cs @VincentDondain
-/src/HomeKit @VincentDondain
-/src/homekit.cs @VincentDondain
+/src/HealthKit
+/src/healthkit.cs
+/src/HomeKit
+/src/homekit.cs
 /src/iad.cs @spouliot
 /src/iAd.framework @spouliot
 /src/identitylookup.cs @dalexsoto
@@ -113,12 +113,12 @@
 /src/localauthentication.cs @spouliot
 /src/MapKit @spouliot
 /src/mapkit.cs @spouliot
-/src/MediaPlayer @VincentDondain
-/src/mediaplayer.cs @VincentDondain
-/src/Messages @VincentDondain
-/src/messages.cs @VincentDondain
-/src/MessageUI @VincentDondain
-/src/messageui.cs @VincentDondain
+/src/MediaPlayer
+/src/mediaplayer.cs
+/src/Messages
+/src/messages.cs
+/src/MessageUI
+/src/messageui.cs
 /src/Metal @mandel-macaque
 /src/metal.cs @mandel-macaque
 /src/MetalKit @spouliot
@@ -127,8 +127,8 @@
 /src/metalperformanceshaders.cs @spouliot
 /src/MobileCoreServices @spouliot
 /src/mobilecoreservices.cs @spouliot
-/src/ModelIO @VincentDondain
-/src/modelio.cs @VincentDondain
+/src/ModelIO
+/src/modelio.cs
 /src/MultipeerConnectivity @spouliot
 /src/multipeerconnectivity.cs @spouliot
 /src/naturallanguage.cs @mandel-macaque
@@ -156,18 +156,18 @@
 /src/replaykit.cs @dalexsoto @spouliot
 /src/SafariServices @chamons @spouliot
 /src/safariservices.cs @chamons @spouliot
-/src/SceneKit @dalexsoto @VincentDondain
-/src/scenekit.cs @dalexsoto @VincentDondain
+/src/SceneKit @dalexsoto
+/src/scenekit.cs @dalexsoto
 /src/Security @dalexsoto @spouliot
 /src/security.cs @dalexsoto @spouliot
 /src/Speech @dalexsoto
 /src/speech.cs @dalexsoto
-/src/SpriteKit @VincentDondain
-/src/spritekit.cs @VincentDondain
+/src/SpriteKit
+/src/spritekit.cs
 /src/SystemConfiguration @spouliot
 /src/systemconfiguration.cs @spouliot
-/src/UIKit @dalexsoto @spouliot @rolfbjarne @VincentDondain
-/src/uikit.cs @dalexsoto @spouliot @rolfbjarne @VincentDondain
+/src/UIKit @dalexsoto @spouliot @rolfbjarne
+/src/uikit.cs @dalexsoto @spouliot @rolfbjarne
 /src/UserNotifications @dalexsoto
 /src/usernotifications.cs @dalexsoto
 /src/UserNotificationsUI @dalexsoto


### PR DESCRIPTION
Backport CODEOWNERS and .gitignore changes to make it easier to merge the
xcode12 branch into main in the fall.

Backports:

* CODEOWNERS: #8771, #8688, #8529
* .gitignore: #8747, #8704, #8683