### PR TITLE
[xcode12] [runtime] Remove memcpy usage from Runtime.CloneMemory

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1627,10 +1627,10 @@ namespace ObjCRuntime {
 			return true;
 		}
 
-		internal static IntPtr CloneMemory (IntPtr source, nint length)
+		internal unsafe static IntPtr CloneMemory (IntPtr source, long length)
 		{
-			var rv = Marshal.AllocHGlobal (new IntPtr (length));
-			memcpy (rv, source, length);
+			var rv = Marshal.AllocHGlobal ((IntPtr) length);
+			Buffer.MemoryCopy ((void*) source, (void*) rv, length, length);
 			return rv;
 		}
 


### PR DESCRIPTION
instead use `Buffer.MemoryCopy`.

Currently only used from `CGDataProvider`. Added unit tests for the
public/indirect, usage of the API (we had none).

Backport of #8880.

/cc @rolfbjarne @spouliot