### PR TITLE
[xcode12] [msbuild] Dispose the AssemblyBuilder in the UnpackLibraryResource when done with it.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/UnpackLibraryResources.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/UnpackLibraryResources.cs
@@ -3,23 +3,28 @@ using System.Collections.Generic;
 
 using Mono.Cecil;
 
+#nullable enable
+
 namespace Xamarin.MacDev.Tasks
 {
 	public class UnpackLibraryResources : UnpackLibraryResourcesTaskBase
 	{
 		protected override IEnumerable<ManifestResource> GetAssemblyManifestResources (string fileName)
 		{
-			AssemblyDefinition assembly;
-
+			AssemblyDefinition? assembly = null;
 			try {
-				assembly = AssemblyDefinition.ReadAssembly (fileName);
-			} catch {
-				yield break;
-			}
+				try {
+					assembly = AssemblyDefinition.ReadAssembly (fileName);
+				} catch {
+					yield break;
+				}
 
-			foreach (var _r in assembly.MainModule.Resources.OfType<EmbeddedResource> ()) {
-				var r = _r;
-				yield return new ManifestResource (r.Name, r.GetResourceStream);
+				foreach (var _r in assembly.MainModule.Resources.OfType<EmbeddedResource> ()) {
+					var r = _r;
+					yield return new ManifestResource (r.Name, r.GetResourceStream);
+				}
+			} finally {
+				assembly?.Dispose ();
 			}
 		}
 	}

--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.1" />


### PR DESCRIPTION
This will ensure the file isn't kept open until the GC runs, and then
sometimes it can prevent other tasks or targets from opening it if the GC
hasn't run.

Fixes this problem:

    /Library/Frameworks/Mono.framework/Versions/6.10.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(4203,5): warning MSB3026: Could not copy "obj/Debug/Fantas.dll" to "../../../lib/Debug/MonoGame/xamarinios/Fantas.dll". Beginning retry 1 in 1000ms. Sharing violation on path [...]/lib/Debug/MonoGame/xamarinios/Fantas.dll
    /Library/Frameworks/Mono.framework/Versions/6.10.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(4203,5): warning MSB3026: Could not copy "obj/Debug/Fantas.dll" to "../../../lib/Debug/MonoGame/xamarinios/Fantas.dll". Beginning retry 2 in 1000ms. Sharing violation on path [...]/lib/Debug/MonoGame/xamarinios/Fantas.dll
    /Library/Frameworks/Mono.framework/Versions/6.10.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(4203,5): warning MSB3026: Could not copy "obj/Debug/Fantas.dll" to "../../../lib/Debug/MonoGame/xamarinios/Fantas.dll". Beginning retry 3 in 1000ms. Sharing violation on path [...]/lib/Debug/MonoGame/xamarinios/Fantas.dll
    /Library/Frameworks/Mono.framework/Versions/6.10.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(4203,5): warning MSB3026: Could not copy "obj/Debug/Fantas.dll" to "../../../lib/Debug/MonoGame/xamarinios/Fantas.dll". Beginning retry 4 in 1000ms. Sharing violation on path [...]/lib/Debug/MonoGame/xamarinios/Fantas.dll
    /Library/Frameworks/Mono.framework/Versions/6.10.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(4203,5): warning MSB3026: Could not copy "obj/Debug/Fantas.dll" to "../../../lib/Debug/MonoGame/xamarinios/Fantas.dll". Beginning retry 5 in 1000ms. Sharing violation on path [...]/lib/Debug/MonoGame/xamarinios/Fantas.dll
    /Library/Frameworks/Mono.framework/Versions/6.10.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(4203,5): warning MSB3026: Could not copy "obj/Debug/Fantas.dll" to "../../../lib/Debug/MonoGame/xamarinios/Fantas.dll". Beginning retry 6 in 1000ms. Sharing violation on path [...]/lib/Debug/MonoGame/xamarinios/Fantas.dll
    /Library/Frameworks/Mono.framework/Versions/6.10.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(4203,5): warning MSB3026: Could not copy "obj/Debug/Fantas.dll" to "../../../lib/Debug/MonoGame/xamarinios/Fantas.dll". Beginning retry 7 in 1000ms. Sharing violation on path [...]/lib/Debug/MonoGame/xamarinios/Fantas.dll
    /Library/Frameworks/Mono.framework/Versions/6.10.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(4203,5): warning MSB3026: Could not copy "obj/Debug/Fantas.dll" to "../../../lib/Debug/MonoGame/xamarinios/Fantas.dll". Beginning retry 8 in 1000ms. Sharing violation on path [...]/lib/Debug/MonoGame/xamarinios/Fantas.dll
    /Library/Frameworks/Mono.framework/Versions/6.10.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(4203,5): warning MSB3026: Could not copy "obj/Debug/Fantas.dll" to "../../../lib/Debug/MonoGame/xamarinios/Fantas.dll". Beginning retry 9 in 1000ms. Sharing violation on path [...]/lib/Debug/MonoGame/xamarinios/Fantas.dll
    /Library/Frameworks/Mono.framework/Versions/6.10.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(4203,5): warning MSB3026: Could not copy "obj/Debug/Fantas.dll" to "../../../lib/Debug/MonoGame/xamarinios/Fantas.dll". Beginning retry 10 in 1000ms. Sharing violation on path [...]/lib/Debug/MonoGame/xamarinios/Fantas.dll
    /Library/Frameworks/Mono.framework/Versions/6.10.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(4203,5): error MSB3027: Could not copy "obj/Debug/Fantas.dll" to "../../../lib/Debug/MonoGame/xamarinios/Fantas.dll". Exceeded retry count of 10. Failed.
    /Library/Frameworks/Mono.framework/Versions/6.10.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(4203,5): error MSB3021: Unable to copy file "obj/Debug/Fantas.dll" to "../../../lib/Debug/MonoGame/xamarinios/Fantas.dll". Sharing violation on path [...]/lib/Debug/MonoGame/xamarinios/Fantas.dll

Fixes https://github.com/xamarin/maccore/issues/2137.
Fixes https://github.com/xamarin/xamarin-macios/issues/8940.

Backport of #8941.

/cc @rolfbjarne 