### PR TITLE
[xharness] Don't access the simulator tasks if we failed to created them.

### DIFF
--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -149,7 +149,14 @@ namespace Xharness.Jenkins {
 
 			var simTasksFactory = new RunSimulatorTasksFactory ();
 			var loadsim = simTasksFactory.CreateAsync (this, processManager, testVariationsFactory)
-				.ContinueWith ((v) => { Console.WriteLine ("Simulator tasks created"); Tasks.AddRange (v.Result); });
+				.ContinueWith ((v) => {
+					if (v.Status == TaskStatus.RanToCompletion) {
+						Console.WriteLine ("Simulator tasks created");
+						Tasks.AddRange (v.Result);
+					} else {
+						Console.WriteLine ($"Failed to create simulator tasks: {v.Exception}");
+					}
+				});
 			
 			//Tasks.AddRange (await CreateRunSimulatorTasksAsync ());
 


### PR DESCRIPTION
This fixes this:

    Unexpected exception: System.AggregateException: One or more errors occurred. (One or more errors occurred. (ApplicationName='[...]/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch', CommandLine='--listsim=/var/folders/43/h027tm1n101cdrq2_b6n9n2m0000gn/T/tmp12c3d415.tmp --output-format=XML', CurrentDirectory='', Native error= Cannot find the specified file)) ---> System.AggregateException: One or more errors occurred. (ApplicationName='[...]/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch', CommandLine='--listsim=/var/folders/43/h027tm1n101cdrq2_b6n9n2m0000gn/T/tmp12c3d415.tmp --output-format=XML', CurrentDirectory='', Native error= Cannot find the specified file) ---> System.ComponentModel.Win32Exception: ApplicationName='[...]/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch', CommandLine='--listsim=/var/folders/43/h027tm1n101cdrq2_b6n9n2m0000gn/T/tmp12c3d415.tmp --output-format=XML', CurrentDirectory='', Native error= Cannot find the specified file
      at System.Diagnostics.Process.StartWithCreateProcess (System.Diagnostics.ProcessStartInfo startInfo) [0x0029f] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/System/System.Diagnostics/Process.cs:778
      at System.Diagnostics.Process.Start () [0x0003a] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/System/services/monitoring/system/diagnosticts/Process.cs:2006
      at (wrapper remoting-invoke-with-check) System.Diagnostics.Process.Start()
      at Microsoft.DotNet.XHarness.iOS.Shared.Execution.ProcessManager.RunAsyncInternal (System.Diagnostics.Process process, Microsoft.DotNet.XHarness.iOS.Shared.Logging.ILog log, Microsoft.DotNet.XHarness.iOS.Shared.Logging.ILog stdout, Microsoft.DotNet.XHarness.iOS.Shared.Logging.ILog stderr, System.Nullable`1[T] timeout, System.Collections.Generic.Dictionary`2[TKey,TValue] environmentVariables, System.Nullable`1[T] cancellationToken, System.Nullable`1[T] diagnostics) [0x00469] in [...]/xamarin-macios/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Execution/ProcessManager.cs:185
      at Microsoft.DotNet.XHarness.iOS.Shared.Hardware.SimulatorLoader+<>c__DisplayClass16_0.<LoadDevices>b__0 () [0x00107] in [...]/xamarin-macios/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs:65
      at Microsoft.DotNet.XHarness.iOS.Shared.Hardware.SimulatorLoader.LoadDevices (Microsoft.DotNet.XHarness.iOS.Shared.Logging.ILog log, System.Boolean includeLocked, System.Boolean forceRefresh, System.Boolean listExtraData) [0x00155] in [...]/xamarin-macios/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs:54
      at Microsoft.DotNet.XHarness.iOS.Shared.Hardware.SimulatorLoader.FindOrCreateDevicesAsync (Microsoft.DotNet.XHarness.iOS.Shared.Logging.ILog log, System.String runtime, System.String devicetype, System.Boolean force) [0x0023c] in [...]/xamarin-macios/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs:156
      at Microsoft.DotNet.XHarness.iOS.Shared.Hardware.SimulatorLoader.FindSimulators (Microsoft.DotNet.XHarness.iOS.Shared.TestTarget target, Microsoft.DotNet.XHarness.iOS.Shared.Logging.ILog log, System.Boolean create_if_needed, System.Boolean min_version) [0x00267] in [...]/xamarin-macios/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs:277
      at Xharness.Jenkins.TestTasks.RunSimulatorTask.FindSimulatorAsync () [0x0005a] in [...]/xamarin-macios/tests/xharness/Jenkins/TestTasks/RunSimulatorTask.cs:53
      at Xharness.Jenkins.Jenkins.CreateRunSimulatorTasksAsync () [0x004ee] in [...]/xamarin-macios/tests/xharness/Jenkins/Jenkins.cs:558
       --- End of inner exception stack trace ---
      at System.Threading.Tasks.Task.ThrowIfExceptional (System.Boolean includeTaskCanceledExceptions) [0x00011] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs:2027
      at System.Threading.Tasks.Task`1[TResult].GetResultCore (System.Boolean waitCompletionNotification) [0x0002b] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs:496
      at System.Threading.Tasks.Task`1[TResult].get_Result () [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs:466
      at Xharness.Jenkins.Jenkins+<>c__DisplayClass72_0.<PopulateTasksAsync>b__0 (System.Threading.Tasks.Task`1[TResult] v) [0x0001e] in [...]/xamarin-macios/tests/xharness/Jenkins/Jenkins.cs:941
      at System.Threading.Tasks.ContinuationTaskFromResultTask`1[TAntecedentResult].InnerInvoke () [0x00024] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs:155
      at System.Threading.Tasks.Task.Execute () [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs:2319
    --- End of stack trace from previous location where exception was thrown ---