### PR TITLE
[DevOps] Add the agent name to find the provisioning issues faster.

### DIFF
--- a/tools/devops/device-tests/scripts/GitHub.psm1
+++ b/tools/devops/device-tests/scripts/GitHub.psm1
@@ -184,7 +184,7 @@ function New-GitHubComment {
         $msg.AppendLine($Message)
     }
     $msg.AppendLine()
-    $msg.AppendLine("[Pipeline](targetUrl)")
+    $msg.AppendLine("[Pipeline](targetUrl) on Agent $Env:AGENT_NAME") # Env:AGENT_NAME is added by the pipeline
 
     $url = "https://api.github.com/repos/xamarin/xamarin-macios/commits/$Env:BUILD_REVISION/comments"
     $payload = @{


### PR DESCRIPTION
Add the name of the agent that is added by the pipeline on the comments
posted in github.