### PR TITLE
[DevOps] Add error handling for incorrect storage path

### DIFF
--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -256,10 +256,11 @@ steps:
         eval $MKSTORAGE || EC=$?
         if [ $EC -eq 0 ]; then
           echo '##vso[task.setvariable variable=XAMARIN_STORAGE_PATH;isOutput=true]$XAMARIN_STORAGE_PATH'
-        else
           echo '##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]false'
+          export TESTS_PERIODIC_COMMAND="--periodic-interval 10 --periodic-command rsync --periodic-command-arguments '-avz -e \"ssh\" $PWD/jenkins-results builder@xamarin-storage:/volume1/storage/$XAMARIN_STORAGE_PATH'"
+        else
+          echo '##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]true'
         fi
-        export TESTS_PERIODIC_COMMAND="--periodic-interval 10 --periodic-command rsync --periodic-command-arguments '-avz -e \"ssh\" $PWD/jenkins-results builder@xamarin-storage:/volume1/storage/$XAMARIN_STORAGE_PATH'"
       else
         echo '##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]true'
         echo '##vso[task.setvariable variable=XAMARIN_STORAGE_PATH;isOutput=true]""'

--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -7,12 +7,12 @@
 parameters:
 
 - name: statusContext
-  type: string 
-  default: 'iOS Device Tests' # default context, since we started dealing with iOS devices. 
+  type: string
+  default: 'iOS Device Tests' # default context, since we started dealing with iOS devices.
 
 - name: testsLabels
-  type: string 
-  default: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests' # default context, since we started dealing with iOS devices. 
+  type: string
+  default: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests' # default context, since we started dealing with iOS devices.
 
 - name: disableProvisionatorCache
   type: boolean
@@ -23,7 +23,7 @@ parameters:
   default: false
 
 - name: useXamarinStorage
-  type: boolean 
+  type: boolean
   default: false  # xamarin-storage will disappear, so by default do not use it
 
 - name: vsdropsPrefix
@@ -68,8 +68,8 @@ steps:
 # we might hit issue https://github.com/PowerShell/PowerShell/issues/9246, so we always do exit 0
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/device-tests/scripts/System.psm1
-    Clear-HD 
-    exit 0  
+    Clear-HD
+    exit 0
   displayName: 'Disk cleanup'
   timeoutInMinutes: 5
 
@@ -108,12 +108,12 @@ steps:
     set -e
     rm -f ~/Library/Caches/com.xamarin.provisionator/Provisions/*p12
     rm -f ~/Library/Caches/com.xamarin.provisionator/Provisions/*mobileprovision
-    ./maccore/tools/install-qa-provisioning-profiles.sh -v 
+    ./maccore/tools/install-qa-provisioning-profiles.sh -v
   displayName: 'Add provisioning profiles'
   env:
     LOGIN_KEYCHAIN_PASSWORD: $(OSX_KEYCHAIN_PASS)
 
-# Executed ONLY when the profisioning profiles step failed. At this point, we do know that 
+# Executed ONLY when the profisioning profiles step failed. At this point, we do know that
 # we cannot run the tests, therefore:
 # 1. Set the status to error.
 # 2. Add a comment letting the monitoring person know that there was an issue with the profiles.
@@ -175,7 +175,7 @@ steps:
 # remove any old processes that might have been left behind.
 - pwsh : |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/device-tests/scripts/System.psm1
-    Clear-XamarinProcesses 
+    Clear-XamarinProcesses
   displayName: 'Process cleanup'
 
 - bash: |
@@ -188,19 +188,19 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/device-tests/scripts/MLaunch.psm1
     Set-MLaunchVerbosity -Verbosity 10
   displayName: 'Make mlaunch verbose'
-  condition: succeededOrFailed() # we do not care about the previous step 
+  condition: succeededOrFailed() # we do not care about the previous step
 
 # Re-start the daemon used to find the devices in the bot.
 - pwsh : |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/device-tests/scripts/MLaunch.psm1
-    Optimize-DeviceDiscovery 
+    Optimize-DeviceDiscovery
   displayName: 'Fix device discovery (reset launchctl)'
   condition: succeededOrFailed() # making mlaunch verbose should be a non blocker
 
-# Update the status to pending, that way the monitoring person knows that we started running the tests. Up to this 
+# Update the status to pending, that way the monitoring person knows that we started running the tests. Up to this
 # point we were just setting up the agent.
 - pwsh: |
-    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/device-tests/scripts/GitHub.psm1 
+    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/device-tests/scripts/GitHub.psm1
     Set-GitHubStatus -Status "pending" -Context "$Env:CONTEXT" -Description "Running device tests on $Env:CONTEXT"
   env:
     BUILD_REVISION: $(BUILD_REVISION)
@@ -251,9 +251,14 @@ steps:
     cd $WORKING_DIR/xamarin-macios
     if [[ "$USE_XAMARIN_STORAGE" == "True" ]]; then
       if nc -z xamarin-storage 22 2>/dev/null; then
-        ssh builder@xamarin-storage "mkdir -p /volume1/storage/$XAMARIN_STORAGE_PATH"
-        echo '##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]false'
-        echo '##vso[task.setvariable variable=XAMARIN_STORAGE_PATH;isOutput=true]$XAMARIN_STORAGE_PATH'
+        EC=0
+        MKSTORAGE="ssh builder@xamarin-storage "mkdir -p /volume1/storage/$XAMARIN_STORAGE_PATH""
+        eval $MKSTORAGE || EC=$?
+        if [ $EC -eq 0 ]; then
+          echo '##vso[task.setvariable variable=XAMARIN_STORAGE_PATH;isOutput=true]$XAMARIN_STORAGE_PATH'
+        else
+          echo '##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]false'
+        fi
         export TESTS_PERIODIC_COMMAND="--periodic-interval 10 --periodic-command rsync --periodic-command-arguments '-avz -e \"ssh\" $PWD/jenkins-results builder@xamarin-storage:/volume1/storage/$XAMARIN_STORAGE_PATH'"
       else
         echo '##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]true'
@@ -272,7 +277,7 @@ steps:
       echo '##vso[task.setvariable variable=TESTS_JOBSTATUS;isOutput=true]Failed'
     fi
   env:
-    WORKING_DIR: $(System.DefaultWorkingDirectory) 
+    WORKING_DIR: $(System.DefaultWorkingDirectory)
     XAMARIN_STORAGE_PATH: $(XAMARIN_STORAGE_PATH)
     TESTS_EXTRA_ARGUMENTS: ${{ parameters.testsLabels }}
     USE_XAMARIN_STORAGE: '${{ parameters.useXamarinStorage }}'

--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -7,12 +7,12 @@
 parameters:
 
 - name: statusContext
-  type: string
-  default: 'iOS Device Tests' # default context, since we started dealing with iOS devices.
+  type: string 
+  default: 'iOS Device Tests' # default context, since we started dealing with iOS devices. 
 
 - name: testsLabels
-  type: string
-  default: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests' # default context, since we started dealing with iOS devices.
+  type: string 
+  default: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests' # default context, since we started dealing with iOS devices. 
 
 - name: disableProvisionatorCache
   type: boolean
@@ -23,7 +23,7 @@ parameters:
   default: false
 
 - name: useXamarinStorage
-  type: boolean
+  type: boolean 
   default: false  # xamarin-storage will disappear, so by default do not use it
 
 - name: vsdropsPrefix
@@ -68,8 +68,8 @@ steps:
 # we might hit issue https://github.com/PowerShell/PowerShell/issues/9246, so we always do exit 0
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/device-tests/scripts/System.psm1
-    Clear-HD
-    exit 0
+    Clear-HD 
+    exit 0  
   displayName: 'Disk cleanup'
   timeoutInMinutes: 5
 
@@ -108,12 +108,12 @@ steps:
     set -e
     rm -f ~/Library/Caches/com.xamarin.provisionator/Provisions/*p12
     rm -f ~/Library/Caches/com.xamarin.provisionator/Provisions/*mobileprovision
-    ./maccore/tools/install-qa-provisioning-profiles.sh -v
+    ./maccore/tools/install-qa-provisioning-profiles.sh -v 
   displayName: 'Add provisioning profiles'
   env:
     LOGIN_KEYCHAIN_PASSWORD: $(OSX_KEYCHAIN_PASS)
 
-# Executed ONLY when the profisioning profiles step failed. At this point, we do know that
+# Executed ONLY when the profisioning profiles step failed. At this point, we do know that 
 # we cannot run the tests, therefore:
 # 1. Set the status to error.
 # 2. Add a comment letting the monitoring person know that there was an issue with the profiles.
@@ -175,7 +175,7 @@ steps:
 # remove any old processes that might have been left behind.
 - pwsh : |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/device-tests/scripts/System.psm1
-    Clear-XamarinProcesses
+    Clear-XamarinProcesses 
   displayName: 'Process cleanup'
 
 - bash: |
@@ -188,19 +188,19 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/device-tests/scripts/MLaunch.psm1
     Set-MLaunchVerbosity -Verbosity 10
   displayName: 'Make mlaunch verbose'
-  condition: succeededOrFailed() # we do not care about the previous step
+  condition: succeededOrFailed() # we do not care about the previous step 
 
 # Re-start the daemon used to find the devices in the bot.
 - pwsh : |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/device-tests/scripts/MLaunch.psm1
-    Optimize-DeviceDiscovery
+    Optimize-DeviceDiscovery 
   displayName: 'Fix device discovery (reset launchctl)'
   condition: succeededOrFailed() # making mlaunch verbose should be a non blocker
 
-# Update the status to pending, that way the monitoring person knows that we started running the tests. Up to this
+# Update the status to pending, that way the monitoring person knows that we started running the tests. Up to this 
 # point we were just setting up the agent.
 - pwsh: |
-    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/device-tests/scripts/GitHub.psm1
+    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/device-tests/scripts/GitHub.psm1 
     Set-GitHubStatus -Status "pending" -Context "$Env:CONTEXT" -Description "Running device tests on $Env:CONTEXT"
   env:
     BUILD_REVISION: $(BUILD_REVISION)
@@ -251,14 +251,9 @@ steps:
     cd $WORKING_DIR/xamarin-macios
     if [[ "$USE_XAMARIN_STORAGE" == "True" ]]; then
       if nc -z xamarin-storage 22 2>/dev/null; then
-        EC=0
-        MKSTORAGE="ssh builder@xamarin-storage "mkdir -p /volume1/storage/$XAMARIN_STORAGE_PATH""
-        eval $MKSTORAGE || EC=$?
-        if [ $EC -eq 0 ]; then
-          echo '##vso[task.setvariable variable=XAMARIN_STORAGE_PATH;isOutput=true]$XAMARIN_STORAGE_PATH'
-        else
-          echo '##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]false'
-        fi
+        ssh builder@xamarin-storage "mkdir -p /volume1/storage/$XAMARIN_STORAGE_PATH"
+        echo '##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]false'
+        echo '##vso[task.setvariable variable=XAMARIN_STORAGE_PATH;isOutput=true]$XAMARIN_STORAGE_PATH'
         export TESTS_PERIODIC_COMMAND="--periodic-interval 10 --periodic-command rsync --periodic-command-arguments '-avz -e \"ssh\" $PWD/jenkins-results builder@xamarin-storage:/volume1/storage/$XAMARIN_STORAGE_PATH'"
       else
         echo '##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]true'
@@ -277,7 +272,7 @@ steps:
       echo '##vso[task.setvariable variable=TESTS_JOBSTATUS;isOutput=true]Failed'
     fi
   env:
-    WORKING_DIR: $(System.DefaultWorkingDirectory)
+    WORKING_DIR: $(System.DefaultWorkingDirectory) 
     XAMARIN_STORAGE_PATH: $(XAMARIN_STORAGE_PATH)
     TESTS_EXTRA_ARGUMENTS: ${{ parameters.testsLabels }}
     USE_XAMARIN_STORAGE: '${{ parameters.useXamarinStorage }}'

--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -251,9 +251,14 @@ steps:
     cd $WORKING_DIR/xamarin-macios
     if [[ "$USE_XAMARIN_STORAGE" == "True" ]]; then
       if nc -z xamarin-storage 22 2>/dev/null; then
-        ssh builder@xamarin-storage "mkdir -p /volume1/storage/$XAMARIN_STORAGE_PATH"
-        echo '##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]false'
-        echo '##vso[task.setvariable variable=XAMARIN_STORAGE_PATH;isOutput=true]$XAMARIN_STORAGE_PATH'
+        EC=0
+        MKSTORAGE="ssh builder@xamarin-storage "mkdir -p /volume1/storage/$XAMARIN_STORAGE_PATH""
+        eval $MKSTORAGE || EC=$?
+        if [ $EC -eq 0 ]; then
+          echo '##vso[task.setvariable variable=XAMARIN_STORAGE_PATH;isOutput=true]$XAMARIN_STORAGE_PATH'
+        else
+          echo '##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]false'
+        fi
         export TESTS_PERIODIC_COMMAND="--periodic-interval 10 --periodic-command rsync --periodic-command-arguments '-avz -e \"ssh\" $PWD/jenkins-results builder@xamarin-storage:/volume1/storage/$XAMARIN_STORAGE_PATH'"
       else
         echo '##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]true'


### PR DESCRIPTION
Add error handling so that we continue to execute when the following issue occurs:

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3841066&view=logs&j=8dce0938-6154-51dc-3f74-a72db5aff65a&t=cc57090b-774f-5444-2e3f-e88cfe4adb9e

```
+ ssh builder@xamarin-storage 'mkdir -p /volume1/storage/jenkins/xamarin-macios/main/00a8a13df86c63ef4d829dc63cd210f62a174bd5/3841066/device-tests'\'''
sh: -c: line 0: unexpected EOF while looking for matching `''
sh: -c: line 1: syntax error: unexpected end of file

##[error]Bash exited with code '1'.
```

If we cannot create the dir, we do not add the rsync call to be executed by xharness. The rest of execution continues as normal.