### PR TITLE
[DevOp] Allow $XamarinStorage to be empty.

### DIFF
--- a/tools/devops/device-tests/scripts/GitHub.psm1
+++ b/tools/devops/device-tests/scripts/GitHub.psm1
@@ -308,11 +308,10 @@ function New-GitHubSummaryComment {
 
         [Parameter(Mandatory)]
         [String]
-        $XamarinStoragePath,
-
-        [Parameter(Mandatory)]
-        [String]
         $TestSummaryPath
+
+        [String]
+        $XamarinStoragePath,
     )
 
     $envVars = @{


### PR DESCRIPTION
pwsh will complain if a mandatory parameter is empty. Remove the attr
and allow it to be empty since the if statements do check for it.