### PR TITLE
[d16-7][maccore] Bump maccore to support Xcode 12

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 4d48f851ace736c88c19af00bf4a3a4fcfdbf80f
+NEEDED_MACCORE_VERSION := c7b48ac49168893edbab1ce5164812b59f4be02b
 NEEDED_MACCORE_BRANCH := d16-7
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@c7b48ac491 [mlaunch] Add new DVTAnalyticsKit dependency (#2242) (#2254)

Diff: https://github.com/xamarin/maccore/compare/4d48f851ace736c88c19af00bf4a3a4fcfdbf80f..c7b48ac49168893edbab1ce5164812b59f4be02b