### PR TITLE
[main][maccore] Bump maccore to support Xcode 12

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 8eee91b69c82f4a5549ed07bf0eb4a25c34909db
+NEEDED_MACCORE_VERSION := ce861906d2c84dd19f216ea83eb47d23300bd43e
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@ce861906d2 [mlaunch] Add new DVTAnalyticsKit dependency (#2242) (#2254) (#2255)

Diff: https://github.com/xamarin/maccore/compare/8eee91b69c82f4a5549ed07bf0eb4a25c34909db..ce861906d2c84dd19f216ea83eb47d23300bd43e