### PR TITLE
[xharness] Try to not have log directories with spaces in them.

### DIFF
--- a/tests/xharness/Jenkins/TestTasks/AppleTestTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/AppleTestTask.cs
@@ -17,7 +17,7 @@ namespace Xharness.Jenkins.TestTasks {
 
 		public override string LogDirectory {
 			get {
-				var rv = Path.Combine (Jenkins.LogDirectory, TestName, ID.ToString ());
+				var rv = Path.Combine (Jenkins.LogDirectory, TestName.Replace (" ", "-"), ID.ToString ());
 				Directory.CreateDirectory (rv);
 				return rv;
 			}


### PR DESCRIPTION
The simulators won't write stdout/stderr to a path with a space.