### PR TITLE
[Foundation] Fix code to not cause a potential null error when compiling using the .NET 5 BCL.

### DIFF
--- a/src/Foundation/DictionaryContainer.cs
+++ b/src/Foundation/DictionaryContainer.cs
@@ -27,7 +27,6 @@
 //
 
 using System;
-using System.Linq;
 using System.Runtime.InteropServices;
 
 #if !COREBUILD
@@ -326,8 +325,12 @@ namespace Foundation {
 
 		protected void SetArrayValue<T> (NSString key, T[]? values)
 		{
-			if (NullCheckAndRemoveKey (key, values == null))
-				Dictionary [key] = NSArray.FromNSObjects (values.Select (x => NSObject.FromObject (x)).ToArray ());
+			if (NullCheckAndRemoveKey (key, values == null)) {
+				var nsValues = new NSObject [values!.Length];
+				for (var i = 0; i < values.Length; i++)
+					nsValues [i] = NSObject.FromObject (values [i]);
+				Dictionary [key] = NSArray.FromNSObjects (nsValues);
+			}
 		}
 
 		protected void SetArrayValue (NSString key, string[]? values)


### PR DESCRIPTION
Fix code to not cause a potential null reference error from csc when compiling
using the .NET 5 BCL:

> Foundation/DictionaryContainer.cs(330,47): error CS8604: Possible null reference argument for parameter 'source' in 'IEnumerable<NSObject> Enumerable.Select<T, NSObject>(IEnumerable<T> source, Func<T, NSObject> selector)'.

And do so by rewriting Linq code, which also makes the code much less memory
hungry and more performant.