### PR TITLE
[DevOps] Release device bots as soon as possible.

### DIFF
--- a/tools/devops/device-tests/scripts/GitHub.psm1
+++ b/tools/devops/device-tests/scripts/GitHub.psm1
@@ -337,7 +337,7 @@ function New-GitHubSummaryComment {
     $headerSb = [System.Text.StringBuilder]::new()
     $headerSb.AppendLine(); # new line to start the list
     $headerSb.AppendLine("* [Azure DevOps]($vstsTargetUrl)")
-    if ($XamarinStoragePath -and $Env:XAMARIN_STORAGE_FAILED) { # if we do have the storage path but we failed. first part of the -and check string is not null or empty, second check presence of the env var
+    if ([string]::IsNullOrEmpty($XamarinStoragePath)) { # if we do have the storage path but we failed. first part of the -and check string is not null or empty, second check presence of the env var
         $headerSb.AppendLine("* :warning: xamarin-storage could not be reached :warning:")
     } else {
         $xamarinStorageUrl = Get-XamarinStorageIndexUrl -Path $XamarinStoragePath

--- a/tools/devops/device-tests/scripts/GitHub.psm1
+++ b/tools/devops/device-tests/scripts/GitHub.psm1
@@ -311,6 +311,7 @@ function New-GitHubSummaryComment {
         $TestSummaryPath,
 
         [String]
+        [AllowEmptyString()]
         $XamarinStoragePath
     )
 

--- a/tools/devops/device-tests/templates/cambridge-variables.yml
+++ b/tools/devops/device-tests/templates/cambridge-variables.yml
@@ -3,7 +3,7 @@ variables:
   value: 'VSEng-Xamarin-QA'
 
 - name: WindowsDevicePool
-  value: 'VSEng-Xamarin-Win-XMA'
+  value: 'windows-2019'
 
 - name: useXamarinStorage
   value: ${{ true }}  # the cambridge lab DOES have access to xamarin-storage

--- a/tools/devops/device-tests/templates/ddfun-variables.yml
+++ b/tools/devops/device-tests/templates/ddfun-variables.yml
@@ -3,7 +3,7 @@ variables:
   value: 'VSEng-Xamarin-Mac-Devices'
 
 - name: WindowsDevicePool
-  value: 'VSEng-Xamarin-Mac-Devices'
+  value: 'windows-2019'
 
 - name: useXamarinStorage
   value: ${{ false }} # ddfun does not have access to xamarin-storage

--- a/tools/devops/device-tests/templates/device-tests-stage.yml
+++ b/tools/devops/device-tests/templates/device-tests-stage.yml
@@ -65,7 +65,6 @@ stages:
     condition: succeededOrFailed()
     pool:
       vmImage: ${{ parameters.WindowsDevicePool }}
-      demands: agent.os -equals Windows_NT # we need to use a windows machine since vsdrops just works on them and the pool might have diff OS in the agents
     steps:
     - template: upload-vsdrops.yml
       parameters:
@@ -78,7 +77,6 @@ stages:
     condition: succeededOrFailed()
     pool:
       vmImage: ${{ parameters.WindowsDevicePool }}
-      demands: agent.os -equals Windows_NT # we need to use a windows machine since vsdrops just works on them and the pool might have diff OS in the agents
     steps:
     - template: upload-vsts-tests.yml
 
@@ -99,7 +97,6 @@ stages:
       VSDROPS_INDEX: $[ dependencies.upload_vsdrops.outputs['vsdrops.VSDROPS_INDEX'] ]
     pool:
       vmImage: ${{ parameters.WindowsDevicePool }}
-      demands: agent.os -equals Windows_NT # we need to use a windows machine since vsdrops just works on them and the pool might have diff OS in the agents
     steps:
     - template: publish-html.yml
       parameters:

--- a/tools/devops/device-tests/templates/device-tests-stage.yml
+++ b/tools/devops/device-tests/templates/device-tests-stage.yml
@@ -58,10 +58,37 @@ stages:
         useXamarinStorage: ${{ parameters.useXamarinStorage }}
         vsdropsPrefix: ${{ parameters.vsdropsPrefix }} 
 
+  - job: upload_vsdrops
+    displayName: 'Upload report to vsdrops'
+    timeoutInMinutes: 1000
+    dependsOn: tests # can start as soon as the tests are done
+    condition: succeededOrFailed()
+    pool:
+      name: ${{ parameters.WindowsDevicePool }}
+      demands: agent.os -equals Windows_NT # we need to use a windows machine since vsdrops just works on them and the pool might have diff OS in the agents
+    steps:
+    - template: upload-vsdrops.yml
+      parameters:
+        vsdropsPrefix: ${{ parameters.vsdropsPrefix }} 
+
+  - job: upload_vsts_tests
+    displayName: 'Upload xml to vsts'
+    timeoutInMinutes: 1000
+    dependsOn: tests # can start as soon as the tests are done
+    condition: succeededOrFailed()
+    pool:
+      name: ${{ parameters.WindowsDevicePool }}
+      demands: agent.os -equals Windows_NT # we need to use a windows machine since vsdrops just works on them and the pool might have diff OS in the agents
+    steps:
+    - template: upload-vsts-tests.yml
+
   - job: publish_html
     displayName: 'Publish Html report in VSDrops'
     timeoutInMinutes: 1000
-    dependsOn: tests
+    dependsOn: # has to wait for the tests to be done AND the data to be uploaded
+    - tests
+    - upload_vsdrops
+    - upload_vsts_tests 
     condition: succeededOrFailed()
     variables:
       # Define the variable FOO from the previous job
@@ -69,6 +96,7 @@ stages:
       XAMARIN_STORAGE_PATH: $[ dependencies.tests.outputs['runTests.XAMARIN_STORAGE_PATH'] ]
       XAMARIN_STORAGE_FAILED: $[ dependencies.tests.outputs['runTests.XAMARIN_STORAGE_FAILED'] ]
       TESTS_JOBSTATUS: $[ dependencies.tests.outputs['runTests.TESTS_JOBSTATUS'] ]
+      VSDROPS_INDEX: $[ dependencies.upload_vsdrops.outputs['vsdrops.VSDROPS_INDEX'] ]
     pool:
       name: ${{ parameters.WindowsDevicePool }}
       demands: agent.os -equals Windows_NT # we need to use a windows machine since vsdrops just works on them and the pool might have diff OS in the agents
@@ -76,4 +104,3 @@ stages:
     - template: publish-html.yml
       parameters:
         statusContext: ${{ parameters.statusContext }}
-        vsdropsPrefix: ${{ parameters.vsdropsPrefix }} 

--- a/tools/devops/device-tests/templates/device-tests-stage.yml
+++ b/tools/devops/device-tests/templates/device-tests-stage.yml
@@ -64,7 +64,7 @@ stages:
     dependsOn: tests # can start as soon as the tests are done
     condition: succeededOrFailed()
     pool:
-      name: ${{ parameters.WindowsDevicePool }}
+      vmImage: ${{ parameters.WindowsDevicePool }}
       demands: agent.os -equals Windows_NT # we need to use a windows machine since vsdrops just works on them and the pool might have diff OS in the agents
     steps:
     - template: upload-vsdrops.yml
@@ -77,7 +77,7 @@ stages:
     dependsOn: tests # can start as soon as the tests are done
     condition: succeededOrFailed()
     pool:
-      name: ${{ parameters.WindowsDevicePool }}
+      vmImage: ${{ parameters.WindowsDevicePool }}
       demands: agent.os -equals Windows_NT # we need to use a windows machine since vsdrops just works on them and the pool might have diff OS in the agents
     steps:
     - template: upload-vsts-tests.yml
@@ -98,7 +98,7 @@ stages:
       TESTS_JOBSTATUS: $[ dependencies.tests.outputs['runTests.TESTS_JOBSTATUS'] ]
       VSDROPS_INDEX: $[ dependencies.upload_vsdrops.outputs['vsdrops.VSDROPS_INDEX'] ]
     pool:
-      name: ${{ parameters.WindowsDevicePool }}
+      vmImage: ${{ parameters.WindowsDevicePool }}
       demands: agent.os -equals Windows_NT # we need to use a windows machine since vsdrops just works on them and the pool might have diff OS in the agents
     steps:
     - template: publish-html.yml

--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -296,16 +296,6 @@ steps:
   continueOnError: true
   condition: succeededOrFailed()
 
-# Upload test results to vsts.
-- task: PublishTestResults@2
-  displayName: 'Publish NUnit Device Test Results'
-  inputs:
-    testResultsFormat: NUnit
-    testResultsFiles: '**/vsts-*.xml'
-    failTaskOnFailedTests: true
-  continueOnError: true
-  condition: succeededOrFailed()
-
 # Archive files for the Html Report so that the report can be easily uploaded as artifacts of the build.
 - task: ArchiveFiles@1
   displayName: 'Archive HtmlReport'

--- a/tools/devops/device-tests/templates/download-artifacts.yml
+++ b/tools/devops/device-tests/templates/download-artifacts.yml
@@ -1,0 +1,43 @@
+# common steps to download the artifacts from the test results.
+
+steps:
+
+- checkout: self
+  persistCredentials: true
+
+- pwsh: |
+    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\device-tests\scripts\System.psm1
+    Get-SystemInfo | Format-Table -Wrap -HideTableHeaders
+    Write-Host "Env variables are:"
+    Get-ChildItem env:
+  displayName: 'Dump Environment'
+  timeoutInMinutes: 1
+
+# Download the Html Report that was added by the tests job.
+- task: DownloadPipelineArtifact@2
+  displayName: Download html report 
+  inputs:
+    patterns: '**/HtmlReport.zip'
+    allowFailedBuilds: true
+    path: $(System.DefaultWorkingDirectory)/Reports
+
+# Unzip report.
+- task: ExtractFiles@1
+  displayName: 'Extract HmlReport'
+  inputs:
+    archiveFilePatterns: '$(System.DefaultWorkingDirectory)/Reports/HtmlReport/HtmlReport.zip'
+    destinationFolder: '$(System.DefaultWorkingDirectory)/HtmlReport'
+
+# Download the test report to write the comment.
+- task: DownloadPipelineArtifact@2
+  displayName: Download Test Summary
+  inputs:
+    patterns: '**/TestSummary.md'
+    allowFailedBuilds: true
+    path: $(System.DefaultWorkingDirectory)\Reports
+
+- pwsh: |
+    echo "##vso[task.setvariable variable=TEST_SUMMARY_PATH]$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\Reports\TestSummary\TestSummary.md"
+    echo "##vso[task.setvariable variable=HTML_REPORT_PATH]$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\HtmlReport"
+  displayName: Pusblish artifact paths
+  name: artifacts # not to be confused with the displayName, this is used to later use the name of the step to access the output variables from an other job

--- a/tools/devops/device-tests/templates/publish-html.yml
+++ b/tools/devops/device-tests/templates/publish-html.yml
@@ -17,59 +17,17 @@ parameters:
   type: string 
   default: 'iOS Device Tests' # default context, since we started dealing with iOS devices. 
 
-- name: vsdropsPrefix
-  type: string
-
 steps:
 
 - checkout: self
   persistCredentials: true
 
-- pwsh: |
-    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\tools\devops\device-tests\scripts\System.psm1
-    Get-SystemInfo | Format-Table -Wrap -HideTableHeaders
-    Write-Host "Env variables are:"
-    Get-ChildItem env:
-  displayName: 'Dump Environment'
-  timeoutInMinutes: 1
-
-# Download the Html Report that was added by the tests job.
-- task: DownloadPipelineArtifact@2
-  displayName: Download html report 
-  inputs:
-    patterns: '**/HtmlReport.zip'
-    allowFailedBuilds: true
-    path: $(System.DefaultWorkingDirectory)/Reports
-
-# Unzip report.
-- task: ExtractFiles@1
-  displayName: 'Extract HmlReport'
-  inputs:
-    archiveFilePatterns: '$(System.DefaultWorkingDirectory)/Reports/HtmlReport/HtmlReport.zip'
-    destinationFolder: '$(System.DefaultWorkingDirectory)/HtmlReport'
-
-# Upload full report to vsdrops using the the build numer and id as uudis.
-- task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
-  displayName: 'Publish to Artifact Services Drop'
-  inputs:
-    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
-    buildNumber: 'xamarin-macios/device-tests/$(Build.BuildNumber)/$(Build.BuildId)'
-    sourcePath: '$(System.DefaultWorkingDirectory)\HtmlReport'
-    detailedLog: true
-    usePat: true 
-
-# Download the test report to write the comment.
-- task: DownloadPipelineArtifact@2
-  displayName: Download Test Summary
-  inputs:
-    patterns: '**/TestSummary.md'
-    allowFailedBuilds: true
-    path: $(System.DefaultWorkingDirectory)\Reports
+- template: download-artifacts.yml 
 
 # Use the cmdlet to post a new summary comment. The cmdlet checks if we have the TestSummary.md file or not. It will also add the appropriate links to the commnet. 
 # this step uses variables that have been set by the tests job dependency via output variables, those variables contain if the xamarin-storage could be used and its path
 - pwsh: |
-    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\tools\devops\device-tests\scripts\GitHub.psm1 
+    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\device-tests\scripts\GitHub.psm1 
     New-GitHubSummaryComment -Context "$Env:CONTEXT" -XamarinStoragePath "$Env:XAMARIN_STORAGE_PATH" -TestSummaryPath "$Env:TESTS_SUMMARY"
   env:
     BUILD_REVISION: $(BUILD_REVISION)
@@ -78,8 +36,8 @@ steps:
     XAMARIN_STORAGE_PATH: $(XAMARIN_STORAGE_PATH) # could be null if the step was not executed if we use vsdrops, the cmdlet will know how to handle that case
     XAMARIN_STORAGE_FAILED: $(XAMARIN_STORAGE_FAILED) # could not reach xamarin-storage, either the bot is not in the vpn or it finally failed
     TESTS_JOBSTATUS: $(TESTS_JOBSTATUS) # set by the runTests step
-    VSDROPS_INDEX: '${{ parameters.vsdropsPrefix }}/$(Build.BuildNumber)/$(Build.BuildId);/tests/vsdrops_index.html' # url to the vsdrops generated index file
-    TESTS_SUMMARY: $(System.DefaultWorkingDirectory)\Reports\TestSummary\TestSummary.md
+    VSDROPS_INDEX: $(VSDROPS_INDEX)
+    TESTS_SUMMARY: $(TEST_SUMMARY_PATH)
   displayName: 'Add summaries'
   condition: always()
   timeoutInMinutes: 1

--- a/tools/devops/device-tests/templates/upload-vsdrops.yml
+++ b/tools/devops/device-tests/templates/upload-vsdrops.yml
@@ -1,0 +1,30 @@
+
+# job that downloads the html report from the artifacts and uploads them into vsdrops.
+parameters:
+
+- name: vsdropsPrefix
+  type: string
+
+steps:
+
+- checkout: self
+  persistCredentials: true
+
+- template: download-artifacts.yml 
+
+# Upload full report to vsdrops using the the build numer and id as uudis.
+- task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
+  displayName: 'Publish to Artifact Services Drop'
+  inputs:
+    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
+    buildNumber: 'xamarin-macios/device-tests/$(Build.BuildNumber)/$(Build.BuildId)'
+    sourcePath: $(HTML_REPORT_PATH)
+    detailedLog: true
+    usePat: true 
+
+- pwsh: |
+    echo "##vso[task.setvariable variable=VSDROPS_INDEX];isOutput=true]$Env:VSDROPS_INDEX"
+  displayName: Publis vsdrops path
+  name: vsdrops # not to be confused with the displayName, this is used to later use the name of the step to access the output variables from an other job
+  env:
+    VSDROPS_INDEX: '${{ parameters.vsdropsPrefix }}/$(Build.BuildNumber)/$(Build.BuildId);/tests/vsdrops_index.html' # url to the vsdrops generated index file

--- a/tools/devops/device-tests/templates/upload-vsts-tests.yml
+++ b/tools/devops/device-tests/templates/upload-vsts-tests.yml
@@ -1,0 +1,18 @@
+# imports the xml to the vsts test results for the job
+
+steps:
+
+- checkout: self
+  persistCredentials: true
+
+- template: download-artifacts.yml 
+
+# Upload test results to vsts.
+- task: PublishTestResults@2
+  displayName: 'Publish NUnit Device Test Results'
+  inputs:
+    testResultsFormat: NUnit
+    testResultsFiles: '**/vsts-*.xml'
+    failTaskOnFailedTests: true
+  continueOnError: true
+  condition: succeededOrFailed()


### PR DESCRIPTION
The upload of the results takes 2 hours:

* 1 hour uploading to vsts test results.
* 1 hour uploading to vsdrops.

This means that we are blocking a device bot for an extra hours (since
the vsdrops is done in a windows bot) when it is not needed. We could
add both uploads to the vsdrops job, but since steps cannot be ran in
parallel, it means that we re waiting for 2 hours when we really do not
have to.

We create two jobs to parallilize the upload of files and we release the
device bot ASAP. That means that our device bots can be free to get new
jobs (and they are the bottle neck) while the windows bots perform the
different uploads.

To make things easier a template that downloads the artifacts was added
so that there is not much code repetition.