### PR TITLE
[msbuild] Unify the logic to copy bundle resources to the app.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -123,7 +123,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<PropertyGroup>
 		<CreateAppBundleDependsOn Condition="'$(_UsingXamarinSdk)' != 'true'">
 			_DetectSigningIdentity;
-			_CopyContentToBundle;
+			_CopyResourcesToBundle;
 			_SmeltMetal;
 			_ForgeMetal;
 			_TemperMetal;
@@ -241,17 +241,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			Resource="$(AppBundleDir)"
 		>
 		</CodesignVerify>
-	</Target>
-
-	<!-- TODO: check for duplicate items -->
-	<Target Name="_CopyContentToBundle"
-		Inputs="@(_BundleResourceWithLogicalName)"
-		Outputs="@(_BundleResourceWithLogicalName -> '$(_AppResourcesPath)%(LogicalName)')">
-		<SmartCopy
-			Condition="'$(IsMacEnabled)' == 'true'"
-			SessionId="$(BuildSessionId)"
-			SourceFiles = "@(_BundleResourceWithLogicalName)"
-			DestinationFiles = "@(_BundleResourceWithLogicalName -> '$(_AppResourcesPath)%(LogicalName)')"/>
 	</Target>
 
 	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations;_ComputeTargetFrameworkMoniker;_GetMinimumOSVersion">

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ComputeBundleResourceOutputPathsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ComputeBundleResourceOutputPathsTaskBase.cs
@@ -12,7 +12,7 @@ namespace Xamarin.MacDev.Tasks
 	public abstract class ComputeBundleResourceOutputPathsTaskBase : XamarinTask
 	{
 		[Required]
-		public ITaskItem AppBundleDir { get; set; }
+		public ITaskItem AppResourcesPath { get; set; }
 
 		[Required]
 		public string BundleIdentifier { get; set; }
@@ -71,7 +71,7 @@ namespace Xamarin.MacDev.Tasks
 
 						outputPath = Path.Combine (assetpack, logicalName);
 					} else if (string.IsNullOrEmpty (outputPath)) {
-						outputPath = Path.Combine (AppBundleDir.ItemSpec, logicalName);
+						outputPath = Path.Combine (AppResourcesPath.ItemSpec, logicalName);
 					}
 
 					var bundleResource = new TaskItem (item);

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -140,6 +140,10 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<OptimizePropertyLists Condition="'$(IsBindingProject)' == 'true' And '$(OptimizePropertyLists)' == ''">false</OptimizePropertyLists>
 		<OptimizePropertyLists Condition="'$(_PlatformName)' == 'macOS' And '$(OptimizePropertyLists)' == ''">false</OptimizePropertyLists>
 		<OptimizePropertyLists Condition="'$(_PlatformName)' != 'macOS' And '$(OptimizePropertyLists)' == ''">true</OptimizePropertyLists>
+
+		<!-- EnableOnDemandResources: default to true for Xamarin.iOS and false for Xamarin.Mac -->
+		<EnableOnDemandResources Condition="'$(_PlatformName)' == 'macOS' And '$(EnableOnDemandResources)' == ''">false</EnableOnDemandResources>
+		<EnableOnDemandResources Condition="'$(_PlatformName)' != 'macOS' And '$(EnableOnDemandResources)' == ''">true</EnableOnDemandResources>
 	</PropertyGroup>
 
 	<Target Name="_ComputeTargetFrameworkMoniker" Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -23,6 +23,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<_TaskAssemblyName Condition="'$(_PlatformName)' == 'macOS'">Xamarin.Mac.Tasks.dll</_TaskAssemblyName>
 	</PropertyGroup>
 
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.ComputeBundleResourceOutputPaths" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetMinimumOSVersion" AssemblyFile="$(_TaskAssemblyName)" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
@@ -188,6 +189,33 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<!-- TextureAtlas output caches -->
 			<_TextureAtlasCache>$(DeviceSpecificIntermediateOutputPath)atlas\_BundleResourceWithLogicalName.items</_TextureAtlasCache>
 		</PropertyGroup>
+	</Target>
+
+	<!-- TODO: check for duplicate items -->
+	<Target Name="_ComputeBundleResourceOutputPaths" DependsOnTargets="_CollectBundleResources;_GenerateBundleName;_DetectSigningIdentity">
+		<ComputeBundleResourceOutputPaths
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			AppResourcesPath="$(_AppResourcesPath)"
+			BundleIdentifier="$(_BundleIdentifier)"
+			BundleResources="@(_BundleResourceWithLogicalName)"
+			EnableOnDemandResources="$(EnableOnDemandResources)"
+			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
+			OutputPath="$(DeviceSpecificOutputPath)"
+		>
+			<Output TaskParameter="BundleResourcesWithOutputPaths" ItemName="_BundleResourceWithOutputPath"/>
+		</ComputeBundleResourceOutputPaths>
+	</Target>
+
+	<Target Name="_CopyResourcesToBundle" DependsOnTargets="_ComputeBundleResourceOutputPaths"
+		Inputs = "@(_BundleResourceWithOutputPath)"
+		Outputs = "@(_BundleResourceWithOutputPath -> '%(OutputPath)')" >
+		<SmartCopy
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			SourceFiles = "@(_BundleResourceWithOutputPath)"
+			DestinationFiles = "@(_BundleResourceWithOutputPath -> '%(OutputPath)')"
+		/>
 	</Target>
 
 	<Target Name="_CreateAppBundle" Condition="'$(_CanOutputAppBundle)' == 'true' And '$(IsAppDistribution)' != 'true'" DependsOnTargets="$(CreateAppBundleDependsOn)" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
@@ -70,7 +70,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<IOSDebuggerPort Condition="'$(IOSDebuggerPort)' == ''">10000</IOSDebuggerPort>
 
 		<!-- On-Demand Resources -->
-		<EnableOnDemandResources Condition="'$(EnableOnDemandResources)' == ''">true</EnableOnDemandResources>
 		<OnDemandResourcesInitialInstallTags Condition="'$(OnDemandResourcesInitialInstallTags)' == '' Or '$(EnableOnDemandResources)' != 'true'"></OnDemandResourcesInitialInstallTags>
 		<OnDemandResourcesPrefetchOrder Condition="'$(OnDemandResourcesPrefetchOrder)' == '' Or '$(EnableOnDemandResources)' != 'true'"></OnDemandResourcesPrefetchOrder>
 		<EmbedOnDemandResources Condition="'$(EmbedOnDemandResources)' == ''">true</EmbedOnDemandResources>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -18,7 +18,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.ArTool" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.Codesign" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.CollectBundleResources" AssemblyFile="Xamarin.iOS.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.ComputeBundleResourceOutputPaths" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.CoreMLCompiler" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.CreateAssetPackManifest" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.CreatePkgInfo" AssemblyFile="Xamarin.iOS.Tasks.dll" />
@@ -440,33 +439,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</_CollectBundleResourcesDependsOn>
 	</PropertyGroup>
 
-	<!-- TODO: check for duplicate items -->
-	<Target Name="_ComputeBundleResourceOutputPaths" DependsOnTargets="_CollectBundleResources;_GenerateBundleName;_DetectSigningIdentity">
-		<ComputeBundleResourceOutputPaths
-			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true'"
-			AppBundleDir="$(AppBundleDir)"
-			BundleIdentifier="$(_BundleIdentifier)"
-			BundleResources="@(_BundleResourceWithLogicalName)"
-			EnableOnDemandResources="$(EnableOnDemandResources)"
-			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
-			OutputPath="$(DeviceSpecificOutputPath)"
-		>
-			<Output TaskParameter="BundleResourcesWithOutputPaths" ItemName="_BundleResourceWithOutputPath"/>
-		</ComputeBundleResourceOutputPaths>
-	</Target>
-
-	<Target Name="_CopyResourcesToBundle" DependsOnTargets="_ComputeBundleResourceOutputPaths"
-		Inputs = "@(_BundleResourceWithOutputPath)"
-		Outputs = "@(_BundleResourceWithOutputPath -> '%(OutputPath)')" >
-		<SmartCopy
-			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true'"
-			SourceFiles = "@(_BundleResourceWithOutputPath)"
-			DestinationFiles = "@(_BundleResourceWithOutputPath -> '%(OutputPath)')"
-		/>
-	</Target>
-
 	<Target Name="_CreateAssetPackManifest" DependsOnTargets="_CopyResourcesToBundle">
 		<CreateAssetPackManifest
 			SessionId="$(BuildSessionId)"
@@ -553,7 +525,11 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</UnpackLibraryResources>
 	</Target>
 
-	<Target Name="_GenerateBundleName" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_ComputeTargetArchitectures;_GenerateAppBundleName;_GenerateAppExBundleName" />
+	<Target Name="_GenerateBundleName" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_ComputeTargetArchitectures;_GenerateAppBundleName;_GenerateAppExBundleName">
+		<PropertyGroup>
+			<_AppResourcesPath>$(_AppBundlePath)</_AppResourcesPath>
+		</PropertyGroup>
+	</Target>
 
 	<Target Name="_GenerateAppBundleName" Condition="'$(_CanOutputAppBundle)' == 'true' And '$(IsAppExtension)' != 'true'" DependsOnTargets="_ComputeTargetArchitectures">
 		<PropertyGroup>


### PR DESCRIPTION
* For Xamarin.Mac, this means using the _ComputeBundleResourceOutputPaths and
  _CopyResourcesToBundle targets from Xamarin.iOS instead of the
  _CopyContentToBundle target (which is now unused and thus removed).

* Adapt the Xamarin.iOS logic (now shared) to handle the fact that the
  resources shouldn't always go into the root appbundle directory (since they
  go into Contents/Resources/ for macOS apps), by using the
  '_AppResourcesPath' variable to specify just this.

Once upon a time the Xamarin.iOS logic was identical to the Xamarin.Mac logic,
but then we implemented support for asset packs
(https://github.com/xamarin/maccore/commit/a98693f07e3f7675773e1f371392c05ff178d3d4)
and the code diverged. This means that unifying the logic again is a step
towards making asset packs work for Xamarin.Mac apps.