### PR TITLE
[msbuild] Share a few binding variables: BaseLibDllPath, BTouchToolPath and BTouchToolExe.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -88,27 +88,6 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 		<XamarinMacFrameworkRoot>/Library/Frameworks/Xamarin.Mac.framework/Versions/Current</XamarinMacFrameworkRoot>
 	</PropertyGroup>
 
-	<Choose>
-		<When Condition=" '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
-			<PropertyGroup>
-				<TargetFrameworkName>Modern</TargetFrameworkName>
-				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/Xamarin.Mac</MacBclPath>
-			</PropertyGroup>
-		</When>
-		<When Condition=" '$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(UseXamMacFullFramework)' == 'true'">
-			<PropertyGroup>
-				<TargetFrameworkName>Full</TargetFrameworkName>
-				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
-			</PropertyGroup>
-		</When>
-		<Otherwise>
-			<PropertyGroup>
-				<TargetFrameworkName>System</TargetFrameworkName>
-				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
-			</PropertyGroup>
-		</Otherwise>
-	</Choose>
-
 	<PropertyGroup Condition="'$(TargetFrameworkName)' == 'Full'">
 		<AssemblySearchPaths>$(XamarinMacFrameworkRoot)/lib/reference/full;$(XamarinMacFrameworkRoot)/lib/mono;$(AssemblySearchPaths)</AssemblySearchPaths>
 		<ImplicitlyExpandNETStandardFacades>False</ImplicitlyExpandNETStandardFacades>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -25,6 +25,11 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
 	
+	<!-- This is used to set that we're a binding project. It must be set before including Xamarin.Shared.props -->
+	<PropertyGroup>
+		<IsBindingProject>true</IsBindingProject>
+	</PropertyGroup>
+
 	<!-- Due to IDE/template bugs, many bindings projects exist in the wild withtout correct TFI/TFV tags.
 	In addition, System is not supported, so treat System as Modern or Full, depending on TFV being set.
 	Microsoft.CSharp.targets gives TargetFrameworkVersion / TargetFrameworkIdentifier default values, so we _must_ do this _before_ 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.props
@@ -24,15 +24,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<_XamarinCommonBindingPropsHasBeenImported>true</_XamarinCommonBindingPropsHasBeenImported>
 	</PropertyGroup>
 
-	<!-- This is used to set that we're a binding project. It must be set before including Xamarin.Shared.props -->
 	<PropertyGroup>
-		<IsBindingProject>true</IsBindingProject>
-	</PropertyGroup>
-
-	<PropertyGroup>
-		<BaseLibDllPath>$(MacBclPath)/Xamarin.Mac.dll</BaseLibDllPath>
-		<BTouchToolPath>$(XamarinMacFrameworkRoot)/bin/</BTouchToolPath>
-		<BTouchToolExe>bgen</BTouchToolExe>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 
 		<DefineConstants>__UNIFIED__;__MACOS__;$(DefineConstants)</DefineConstants>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -47,6 +47,30 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<ComputedPlatform Condition="'$(_PlatformName)' != 'macOS' And '$(ComputedPlatform)' == 'AnyCPU'">iPhone</ComputedPlatform>
 	</PropertyGroup>
 
+	<Choose>
+		<!-- If TargetFrameworkIdentifier is 'Xamarin.Mac', then we're in Modern mode -->
+		<When Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
+			<PropertyGroup>
+				<TargetFrameworkName>Modern</TargetFrameworkName>
+				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/Xamarin.Mac</MacBclPath>
+			</PropertyGroup>
+		</When>
+		<!-- If TargetFrameworkIdentifier is not 'Xamarin.Mac', but we're still a macOS app and UseXamMacFullFramework is true, then we're in Full mode -->
+		<When Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(_PlatformName)' == 'macOS' And '$(UseXamMacFullFramework)' == 'true'">
+			<PropertyGroup>
+				<TargetFrameworkName>Full</TargetFrameworkName>
+				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
+			</PropertyGroup>
+		</When>
+		<!-- If the two other conditions don't match, but we're still a macOS app, then we're in System mode -->
+		<When Condition="'$(_PlatformName)' == 'macOS'">
+			<PropertyGroup>
+				<TargetFrameworkName>System</TargetFrameworkName>
+				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
+			</PropertyGroup>
+		</When>
+	</Choose>
+
 	<!-- Sometimes we've used different variable names for the same thing for Xamarin.iOS and Xamarin.Mac projects. Here we try to unify those variables -->
 	<PropertyGroup>
 		<!-- ResourcePrefix -->
@@ -140,6 +164,20 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<OptimizePropertyLists Condition="'$(IsBindingProject)' == 'true' And '$(OptimizePropertyLists)' == ''">false</OptimizePropertyLists>
 		<OptimizePropertyLists Condition="'$(_PlatformName)' == 'macOS' And '$(OptimizePropertyLists)' == ''">false</OptimizePropertyLists>
 		<OptimizePropertyLists Condition="'$(_PlatformName)' != 'macOS' And '$(OptimizePropertyLists)' == ''">true</OptimizePropertyLists>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(IsBindingProject)' == 'true'">
+		<BaseLibDllPath Condition="'$(OS)' == 'Unix' And '$(_PlatformName)' == 'iOS'">$(MonoTouchSdkRoot)/lib/mono/Xamarin.iOS/Xamarin.iOS.dll</BaseLibDllPath>
+		<BaseLibDllPath Condition="'$(OS)' == 'Unix' And '$(_PlatformName)' == 'tvOS'">$(MonoTouchSdkRoot)/lib/mono/Xamarin.TVOS/Xamarin.TVOS.dll</BaseLibDllPath>
+		<BaseLibDllPath Condition="'$(OS)' == 'Unix' And '$(_PlatformName)' == 'watchOS'">$(MonoTouchSdkRoot)/lib/mono/Xamarin.WatchOS/Xamarin.WatchOS.dll</BaseLibDllPath>
+		<BaseLibDllPath Condition="'$(OS)' == 'Unix' And '$(_PlatformName)' == 'macOS'">$(MacBclPath)/Xamarin.Mac.dll</BaseLibDllPath>
+
+		<BTouchToolPath Condition="'$(OS)' == 'Unix' And '$(_PlatformName)' == 'macOS' And '$(BTouchToolPath)' == ''">$(XamarinMacFrameworkRoot)/bin/</BTouchToolPath>
+		<BTouchToolPath Condition="'$(OS)' == 'Unix' And '$(_PlatformName)' != 'macOS' And '$(BTouchToolPath)' == ''">$(MonoTouchSdkRoot)/bin/</BTouchToolPath>
+		<BTouchToolPath Condition="'$(OS)' != 'Unix' And '$(_PlatformName)' != 'macOS' And '$(BTouchToolPath)' == ''">$(MSBuildExtensionsPath)\Xamarin\iOS\</BTouchToolPath>
+
+		<BTouchToolExe  Condition="'$(OS)' == 'Unix' And '$(BTouchToolExe)' == ''">bgen</BTouchToolExe>
+		<BTouchToolExe  Condition="'$(OS)' != 'Unix' And '$(BTouchToolExe)' == ''">bgen.exe</BTouchToolExe>
 	</PropertyGroup>
 
 	<Target Name="_ComputeTargetFrameworkMoniker" Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.props
@@ -29,21 +29,6 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-
-		<BaseLibDllPath Condition="'$(OS)' == 'Unix' And '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">$(MonoTouchSdkRoot)/lib/mono/Xamarin.iOS/Xamarin.iOS.dll</BaseLibDllPath>
-		<BaseLibDllPath Condition="'$(OS)' != 'Unix' And '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">$(MSBuildExtensionsPath)\Xamarin\DontKnowWhereYet\Xamarin.iOS.dll</BaseLibDllPath>
-		<BTouchToolPath Condition="'$(OS)' == 'Unix' And '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' And '$(BTouchToolPath)' == ''">$(MonoTouchSdkRoot)/bin/</BTouchToolPath>
-		<BTouchToolPath Condition="'$(OS)' != 'Unix' And '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' And '$(BTouchToolPath)' == ''">$(MSBuildExtensionsPath)\Xamarin\iOS\</BTouchToolPath>
-		<BTouchToolExe  Condition="'$(OS)' == 'Unix' And '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' And '$(BTouchToolExe)' == ''">btouch-native</BTouchToolExe>
-		<BTouchToolExe  Condition="'$(OS)' != 'Unix' And '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' And '$(BTouchToolExe)' == ''">btouch-native.exe</BTouchToolExe>
-
-		<BaseLibDllPath Condition="'$(OS)' == 'Unix' And '$(TargetFrameworkIdentifier)' == 'Xamarin.TVOS'">$(MonoTouchSdkRoot)/lib/mono/Xamarin.TVOS/Xamarin.TVOS.dll</BaseLibDllPath>
-		<BTouchToolPath Condition="'$(OS)' == 'Unix' And '$(TargetFrameworkIdentifier)' == 'Xamarin.TVOS' And '$(BTouchToolPath)' == ''">$(MonoTouchSdkRoot)/bin/</BTouchToolPath>
-		<BTouchToolExe  Condition="'$(OS)' == 'Unix' And '$(TargetFrameworkIdentifier)' == 'Xamarin.TVOS' And '$(BTouchToolExe)' == ''">btv</BTouchToolExe>
-
-		<BaseLibDllPath Condition="'$(OS)' == 'Unix' And '$(TargetFrameworkIdentifier)' == 'Xamarin.WatchOS'">$(MonoTouchSdkRoot)/lib/mono/Xamarin.WatchOS/Xamarin.WatchOS.dll</BaseLibDllPath>
-		<BTouchToolPath Condition="'$(OS)' == 'Unix' And '$(TargetFrameworkIdentifier)' == 'Xamarin.WatchOS' And '$(BTouchToolPath)' == ''">$(MonoTouchSdkRoot)/bin/</BTouchToolPath>
-		<BTouchToolExe  Condition="'$(OS)' == 'Unix' And '$(TargetFrameworkIdentifier)' == 'Xamarin.WatchOS' And '$(BTouchToolExe)' == ''">bwatch</BTouchToolExe>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.props"


### PR DESCRIPTION
Also switch to invoking bgen instead of the btouch-native/btv/bwatch wrapper
scripts, since the wrapper scripts just call bgen with an additional
--target-framework argument, which our BTouch task already does anyway, which
means it's not necessary to call the wrapper scripts anymore.

This also required:

* Moving the code to detect which Xamarin.Mac profile we're building for into
  Xamarin.Shared.props, since the binding variable logic need to know which
  Xamarin.Mac profile we're building for.

* Setting IsBindingProject property earlier in the build process, to make sure
  it's set before importing Xamarin.Shared.props.