### PR TITLE
[d16-8] [Foundation] Avoid LINQ in bindings. Fixes #8773

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -427,9 +427,11 @@ namespace Foundation {
 		void AddManagedHeaders (NSMutableDictionary nativeHeaders, IEnumerable<KeyValuePair<string, IEnumerable<string>>> managedHeaders)
 		{
 			foreach (var keyValuePair in managedHeaders) {
-				var key = new NSString (keyValuePair.Key);
-				var value = new NSString (string.Join (GetHeaderSeparator (key), keyValuePair.Value));
-				nativeHeaders.Add (key, value);
+				var keyPtr = NSString.CreateNative (keyValuePair.Key);
+				var valuePtr = NSString.CreateNative (string.Join (GetHeaderSeparator (keyValuePair.Key), keyValuePair.Value));
+				nativeHeaders.LowlevelSetObject (valuePtr, keyPtr);
+				NSString.ReleaseNative (keyPtr);
+				NSString.ReleaseNative (valuePtr);
 			}
 		}
 
@@ -441,7 +443,11 @@ namespace Foundation {
 			if (session.Configuration.HttpCookieStorage != null) {
 				var cookies = cookieContainer?.GetCookieHeader (request.RequestUri); // as per docs: An HTTP cookie header, with strings representing Cookie instances delimited by semicolons.
 				if (!string.IsNullOrEmpty (cookies))
-					nativeHeaders.Add (new NSString (Cookie), new NSString (cookies));
+					var cookiePtr = NSString.CreateNative (Cookie);
+					var cookiesPtr = NSString.CreateNative (cookies);
+					nativeHeaders.LowlevelSetObject (cookiesPtr, cookiePtr);
+					NSString.ReleaseNative (cookiePtr);
+					NSString.ReleaseNative (cookiesPtr);
 			}
 
 			AddManagedHeaders (nativeHeaders, request.Headers);

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -29,7 +29,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -442,12 +442,13 @@ namespace Foundation {
 			// set header cookies if needed from the managed cookie container if we do use Cookies
 			if (session.Configuration.HttpCookieStorage != null) {
 				var cookies = cookieContainer?.GetCookieHeader (request.RequestUri); // as per docs: An HTTP cookie header, with strings representing Cookie instances delimited by semicolons.
-				if (!string.IsNullOrEmpty (cookies))
+				if (!string.IsNullOrEmpty (cookies)) {
 					var cookiePtr = NSString.CreateNative (Cookie);
 					var cookiesPtr = NSString.CreateNative (cookies);
 					nativeHeaders.LowlevelSetObject (cookiesPtr, cookiePtr);
 					NSString.ReleaseNative (cookiePtr);
 					NSString.ReleaseNative (cookiesPtr);
+				}
 			}
 
 			AddManagedHeaders (nativeHeaders, request.Headers);


### PR DESCRIPTION
LINQ was giving issues in a client application with the Link SDK
enabled. The root cause is that we had issues in the LINQ operations
that are used to create the headers for the native request.

We fix this by:

1. Do not modify the managed request headers. Do not modify an object we
   do not own.
2. Remove the use of LINQ

This issue was probelmatic when the client application was setting the
headers that are used by the HttpContent. If headers were not added in
the content, the issues did not happen.

Fixes: https://github.com/xamarin/xamarin-macios/issues/8773

Backport of #8991.

/cc @mandel-macaque 