### PR TITLE
[d16-7] [Foundation] Do expose server errors.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -637,6 +637,7 @@ namespace Foundation {
 			public override void DidCompleteWithError (NSUrlSession session, NSUrlSessionTask task, NSError error)
 			{
 				var inflight = GetInflightData (task);
+				var serverError = task.Error;
 
 				// this can happen if the HTTP request times out and it is removed as part of the cancellation process
 				if (inflight != null) {
@@ -644,12 +645,12 @@ namespace Foundation {
 					inflight.Stream.TrySetReceivedAllData ();
 
 					// send the error or send the response back
-					if (error != null) {
+					if (error != null || serverError != null) {
 						// got an error, cancel the stream operatios before we do anything
 						inflight.CancellationTokenSource.Cancel (); 
 						inflight.Errored = true;
 
-						var exc = inflight.Exception ?? createExceptionForNSError (error);
+						var exc = inflight.Exception ?? createExceptionForNSError (error ?? serverError);  // client errors wont happen if we get server errors
 						inflight.CompletionSource.TrySetException (exc);
 						inflight.Stream.TrySetException (exc);
 					} else {


### PR DESCRIPTION
Creating a good API is hard. The delegate DOES return two different
errors.

1. Client errors in the error variable in the delegate method.
2. Server errros in the error in the task in the delegate method.

We need to expose both of them to the user in case there is an issue in
any of them. An exception should be thrown ig any is not null.

PD: As per apple docs:

> The only errors your delegate receives through the error parameter are
> client-side errors, such as being unable to resolve the hostname or
> connect to the host. To check for server-side errors, inspect the
> response property of the task parameter received by this callback.

Backport of #8990.

/cc @mandel-macaque 