### PR TITLE
[msbuild] Add AdditionalAppExtensions extension point for 3rd party iOS extensions

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1664,7 +1664,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!--<Warning Text="_SplitAppExtensionReferencesByExistent: @(_AppExtensionReferenceWithConfigurationExistent)"/>-->
 	</Target>
 	
-	<Target Name="_ExtendAppExtensionReferences" DependsOnTargets="_ResolveAppExtensionReferences">
+	<Target Name="_ExtendAppExtensionReferences" DependsOnTargets="_ResolveAppExtensionReferences" Condition=" '@(AdditionalAppExtensions)' != ''">
 		<ItemGroup>
 			<_ResolvedAppExtensionReferences Include="%(AdditionalAppExtensions.Identity)/%(AdditionalAppExtensions.BuildOutput)/%(AdditionalAppExtensions.Name).appex" />
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -856,6 +856,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			_CompileEntitlements;
 			_CompileAppManifest;
 			_ResolveAppExtensionReferences;
+			_ExtendAppExtensionReferences;
 			_GetNativeExecutableName;
 			_GetCompileToNativeInputs;
 			_ExpandNativeReferences;
@@ -1661,6 +1662,23 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</CreateItem>
 
 		<!--<Warning Text="_SplitAppExtensionReferencesByExistent: @(_AppExtensionReferenceWithConfigurationExistent)"/>-->
+	</Target>
+	
+	<Target Name="_ExtendAppExtensionReferences" DependsOnTargets="_ResolveAppExtensionReferences">
+	    	<ItemGroup>
+			<_ResolvedAppExtensionReferences Include="%(AdditionalAppExtensions.Identity)/%(AdditionalAppExtensions.BuildOutput)/%(AdditionalAppExtensions.Name).appex" />
+
+			<_AppExtensionCodesignProperties Include="%(AdditionalAppExtensions.Name).appex">
+				<Entitlements>%(AdditionalAppExtensions.Identity)/%(AdditionalAppExtensions.Name).entitlements</Entitlements>
+				<SigningKey>$(CodesignKey)</SigningKey>
+				<Keychain>$(CodesignKeychain)</Keychain>
+				<DisableTimestamp>False</DisableTimestamp>
+				<DisableTimestamp Condition="'$(_SdkIsSimulator)' == 'true' Or '$(MtouchDebug)' == 'true'">True</DisableTimestamp>
+				<CodesignAllocate>$(_CodesignAllocate)</CodesignAllocate>
+				<ResourceRules>$(CodesignResourceRules)</ResourceRules>
+				<NativeExecutable>%(AdditionalAppExtensions.Filename)</NativeExecutable>
+			</_AppExtensionCodesignProperties> 
+	    	</ItemGroup>
 	</Target>
 
 	<Target Name="_ResolveAppExtensionReferences" DependsOnTargets="_SplitAppExtensionReferencesByExistent">

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1665,7 +1665,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 	
 	<Target Name="_ExtendAppExtensionReferences" DependsOnTargets="_ResolveAppExtensionReferences">
-	    	<ItemGroup>
+		<ItemGroup>
 			<_ResolvedAppExtensionReferences Include="%(AdditionalAppExtensions.Identity)/%(AdditionalAppExtensions.BuildOutput)/%(AdditionalAppExtensions.Name).appex" />
 
 			<_AppExtensionCodesignProperties Include="%(AdditionalAppExtensions.Name).appex">
@@ -1678,7 +1678,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 				<ResourceRules>$(CodesignResourceRules)</ResourceRules>
 				<NativeExecutable>%(AdditionalAppExtensions.Filename)</NativeExecutable>
 			</_AppExtensionCodesignProperties> 
-	    	</ItemGroup>
+		</ItemGroup>
 	</Target>
 
 	<Target Name="_ResolveAppExtensionReferences" DependsOnTargets="_SplitAppExtensionReferencesByExistent">


### PR DESCRIPTION
- This allows extensions written in non-Xamarin languages to be embedded easily
- Example: https://github.com/chamons/xamarin-ios-swift-extension/blob/master/App/TestApplication/TestApplication.csproj#L143
- Currently requires Name and BuildOutput metadata