### PR TITLE
[d16-7] [tests] Skip a few networking tests on macOS 10.9. Fixes #xamarin/maccore@2221.

### DIFF
--- a/tests/monotouch-test/Foundation/NSDataTest.cs
+++ b/tests/monotouch-test/Foundation/NSDataTest.cs
@@ -142,6 +142,9 @@ namespace MonoTouchFixtures.Foundation {
 				Assert.Ignore ("NSData.FromUrl doesn't seem to work in watchOS");
 			}
 #endif
+			// Https seems broken on our macOS 10.9 bot, so skip this test.
+			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+
 			// we have network issues, try several urls, if one works, be happy, else fail
 			for (var i = 0; i < NetworkResources.RobotsUrls.Length; i++) {
 				NSError error;

--- a/tests/monotouch-test/Foundation/UrlProtocolTest.cs
+++ b/tests/monotouch-test/Foundation/UrlProtocolTest.cs
@@ -70,6 +70,9 @@ namespace MonoTouchFixtures.Foundation {
 		[Test]
 		public void RegistrarTest ()
 		{
+			// Networking seems broken on our macOS 10.9 bot, so skip this test.
+			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+
 			Exception ex = null;
 			var done = new ManualResetEvent (false);
 			var success = false;

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -28,6 +28,12 @@ namespace MonoTests.System.Net.Http
 	[TestFixture]
 	public class MessageHandlerTest
 	{
+		public MessageHandlerTest ()
+		{
+			// Https seems broken on our macOS 10.9 bot, so skip this test.
+			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+		}
+
 		void PrintHandlerToTest ()
 		{
 #if !__WATCHOS__


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/2221.

Backport of #9012.

This is a test-only change.

/cc @rolfbjarne 