### PR TITLE
Add AutoFill CredentialProvider NSExtensionPoint support

### DIFF
--- a/Versions-ios.plist.in
+++ b/Versions-ios.plist.in
@@ -133,6 +133,8 @@
 			<string>10.0</string>
 			<key>com.apple.usernotifications.service</key>
 			<string>10.0</string>
+			<key>com.apple.authentication-services-credential-provider-ui</key>
+			<string>12.0</string>
 		</dict>
 		<key>tvOS</key>
 		<dict>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
@@ -107,6 +107,7 @@ namespace Xamarin.iOS.Tasks
 			case "com.apple.usernotifications.content-extension": // iOS
 			case "com.apple.usernotifications.service": // iOS
 			case "com.apple.networkextension.packet-tunnel": // iOS+OSX
+			case "com.apple.authentication-services-credential-provider-ui": // iOS
 				break;
 			case "com.apple.watchkit": // iOS8.2
 				var attributes = extension.Get<PDictionary> ("NSExtensionAttributes");


### PR DESCRIPTION
This commit adds support for AutoFill Credential Provider extensions to be built. Specifically, this resolves the issue with unrecognized extension point warnings being issued during the build process for Credential Providers.  A related change to Xamarin.MacDev has already been merged.

For more information, see posted issue at: xamarin/xamarin-macios#9000