### PR TITLE
[DevOps] Move back to self hosted windows pools.

### DIFF
--- a/tools/devops/device-tests/templates/cambridge-variables.yml
+++ b/tools/devops/device-tests/templates/cambridge-variables.yml
@@ -3,7 +3,7 @@ variables:
   value: 'VSEng-Xamarin-QA'
 
 - name: WindowsDevicePool
-  value: 'windows-2019'
+  value: 'VSEng-Xamarin-Win-XMA'
 
 - name: useXamarinStorage
   value: ${{ true }}  # the cambridge lab DOES have access to xamarin-storage

--- a/tools/devops/device-tests/templates/ddfun-variables.yml
+++ b/tools/devops/device-tests/templates/ddfun-variables.yml
@@ -3,7 +3,7 @@ variables:
   value: 'VSEng-Xamarin-Mac-Devices'
 
 - name: WindowsDevicePool
-  value: 'windows-2019'
+  value: 'VSEng-Xamarin-Mac-Devices'
 
 - name: useXamarinStorage
   value: ${{ false }} # ddfun does not have access to xamarin-storage

--- a/tools/devops/device-tests/templates/device-tests-stage.yml
+++ b/tools/devops/device-tests/templates/device-tests-stage.yml
@@ -66,7 +66,7 @@ stages:
     dependsOn: tests # can start as soon as the tests are done
     condition: succeededOrFailed()
     pool:
-      vmImage: ${{ parameters.WindowsDevicePool }}
+      name: ${{ parameters.WindowsDevicePool }}
       workspace:
         clean: all
     steps:
@@ -80,7 +80,7 @@ stages:
     dependsOn: tests # can start as soon as the tests are done
     condition: succeededOrFailed()
     pool:
-      vmImage: ${{ parameters.WindowsDevicePool }}
+      name: ${{ parameters.WindowsDevicePool }}
       workspace:
         clean: all
     steps:
@@ -102,7 +102,7 @@ stages:
       TESTS_JOBSTATUS: $[ dependencies.tests.outputs['runTests.TESTS_JOBSTATUS'] ]
       VSDROPS_INDEX: $[ dependencies.upload_vsdrops.outputs['vsdrops.VSDROPS_INDEX'] ]
     pool:
-      vmImage: ${{ parameters.WindowsDevicePool }}
+      name: ${{ parameters.WindowsDevicePool }}
       workspace:
         clean: all
     steps:


### PR DESCRIPTION
The microsoft hosted images have a limit of 10gb, or logs are getting
close to that size when expanded, therefore we will get into issues.
Move back to the self-hosted pool before we have problems.