### PR TITLE
[tests][monotouch-test] Re-enable some tests with beta 2

### DIFF
--- a/tests/monotouch-test/AudioToolbox/SystemSoundTest.cs
+++ b/tests/monotouch-test/AudioToolbox/SystemSoundTest.cs
@@ -68,7 +68,6 @@ namespace MonoTouchFixtures.AudioToolbox {
 
 #if !MONOMAC // Currently no AppDelegate in xammac_test
 		[Test]
-		[Ignore ("broken with xcode12 beta 1 - https://github.com/xamarin/xamarin-macios/issues/8943")]
 		public void TestCallbackPlaySystem ()
 		{
 			TestRuntime.AssertSystemVersion (PlatformName.iOS, 9, 0, throwIfOtherPlatform: false);
@@ -88,7 +87,6 @@ namespace MonoTouchFixtures.AudioToolbox {
 		}
 
 		[Test]
-		[Ignore ("broken with xcode12 beta 1 - https://github.com/xamarin/xamarin-macios/issues/8943")]
 		public void TestCallbackPlayAlert ()
 		{
 			TestRuntime.AssertSystemVersion (PlatformName.iOS, 9, 0, throwIfOtherPlatform: false);

--- a/tests/monotouch-test/CoreText/FontTest.cs
+++ b/tests/monotouch-test/CoreText/FontTest.cs
@@ -84,11 +84,6 @@ namespace MonoTouchFixtures.CoreText {
 		[Test]
 		public void GetGlyphsForCharacters_35048 ()
 		{
-#if __TVOS__ || __WATCHOS__
-			// https://github.com/xamarin/xamarin-macios/issues/8943
-			if (Runtime.Arch == Arch.SIMULATOR && (TestRuntime.CheckXcodeVersion (12, 0)))
-				Assert.Ignore ("AppleColorEmoji missing from tvOS 14 and watchOS 7 simulator");
-#endif
 			using (var font = CGFont.CreateWithFontName ("AppleColorEmoji"))
 			using (var ctfont = font.ToCTFont ((nfloat) 10.0)) {
 				ushort[] gid = new ushort [2];

--- a/tests/monotouch-test/MapKit/AnnotationViewTest.cs
+++ b/tests/monotouch-test/MapKit/AnnotationViewTest.cs
@@ -62,9 +62,7 @@ namespace MonoTouchFixtures.MapKit {
 		{
 			var frame = new CGRect (10, 10, 100, 100);
 			using (MKAnnotationView av = new MKAnnotationView (frame)) {
-				// broke in xcode 12 beta 1
-				if (!TestRuntime.CheckXcodeVersion (12,0))
-					Assert.That (av.Frame, Is.EqualTo (frame), "Frame");
+				Assert.That (av.Frame, Is.EqualTo (frame), "Frame");
 				Assert.Null (av.Annotation, "Annotation");
 			}
 		}

--- a/tests/monotouch-test/MapKit/PinAnnotationViewTest.cs
+++ b/tests/monotouch-test/MapKit/PinAnnotationViewTest.cs
@@ -65,9 +65,7 @@ namespace MonoTouchFixtures.MapKit {
 
 			var frame = new CGRect (10, 10, 100, 100);
 			using (var av = new MKPinAnnotationView (frame)) {
-				// broke in xcode 12 beta 1
-				if (!TestRuntime.CheckXcodeVersion (12, 0))
-					Assert.That (av.Frame.ToString (), Is.EqualTo (frame.ToString ()), "Frame"); // fp comparison fails
+				Assert.That (av.Frame.ToString (), Is.EqualTo (frame.ToString ()), "Frame"); // fp comparison fails
 				Assert.Null (av.Annotation, "Annotation");
 				Assert.False (av.AnimatesDrop, "AnimatesDrop");
 

--- a/tests/monotouch-test/Network/NWBrowserTest.cs
+++ b/tests/monotouch-test/Network/NWBrowserTest.cs
@@ -73,11 +73,6 @@ namespace MonoTouchFixtures.Network {
 		[Test]
 		public void TestStateChangesHandler ()
 		{
-#if !__MACOS__
-			// xcode 12 beta 1
-			if ((Runtime.Arch == Arch.DEVICE) && TestRuntime.CheckXcodeVersion (12, 0))
-				Assert.Ignore ("hangs");
-#endif
 			// In the test we are doing the following:
 			//
 			// 1. Start a browser. At this point, we have no listeners (unless someone is exposing it in the lab)


### PR DESCRIPTION
Some issues we detected in beta 1 are not present in beta 2
https://github.com/xamarin/xamarin-macios/issues/8943