### PR TITLE
[DevOps] Fix issues with the xm storage path.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -29,7 +29,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -425,21 +424,38 @@ namespace Foundation {
 			return value;
 		}
 
+		void AddManagedHeaders (NSMutableDictionary nativeHeaders, IEnumerable<KeyValuePair<string, IEnumerable<string>>> managedHeaders)
+		{
+			foreach (var keyValuePair in managedHeaders) {
+				var keyPtr = NSString.CreateNative (keyValuePair.Key);
+				var valuePtr = NSString.CreateNative (string.Join (GetHeaderSeparator (keyValuePair.Key), keyValuePair.Value));
+				nativeHeaders.LowlevelSetObject (valuePtr, keyPtr);
+				NSString.ReleaseNative (keyPtr);
+				NSString.ReleaseNative (valuePtr);
+			}
+		}
+
 		async Task<NSUrlRequest> CreateRequest (HttpRequestMessage request)
 		{
 			var stream = Stream.Null;
+			var nativeHeaders = new NSMutableDictionary ();
 			// set header cookies if needed from the managed cookie container if we do use Cookies
 			if (session.Configuration.HttpCookieStorage != null) {
 				var cookies = cookieContainer?.GetCookieHeader (request.RequestUri); // as per docs: An HTTP cookie header, with strings representing Cookie instances delimited by semicolons.
-				if (!string.IsNullOrEmpty (cookies))
-					request.Headers.TryAddWithoutValidation (Cookie, cookies); 
+				if (!string.IsNullOrEmpty (cookies)) {
+					var cookiePtr = NSString.CreateNative (Cookie);
+					var cookiesPtr = NSString.CreateNative (cookies);
+					nativeHeaders.LowlevelSetObject (cookiesPtr, cookiePtr);
+					NSString.ReleaseNative (cookiePtr);
+					NSString.ReleaseNative (cookiesPtr);
+				}
 			}
 
-			var headers = request.Headers as IEnumerable<KeyValuePair<string, IEnumerable<string>>>;
+			AddManagedHeaders (nativeHeaders, request.Headers);
 
 			if (request.Content != null) {
 				stream = await request.Content.ReadAsStreamAsync ().ConfigureAwait (false);
-				headers = System.Linq.Enumerable.ToArray(headers.Union (request.Content.Headers));
+				AddManagedHeaders (nativeHeaders, request.Content.Headers);
 			}
 
 			var nsrequest = new NSMutableUrlRequest {
@@ -447,10 +463,7 @@ namespace Foundation {
 				CachePolicy = DisableCaching ? NSUrlRequestCachePolicy.ReloadIgnoringCacheData : NSUrlRequestCachePolicy.UseProtocolCachePolicy,
 				HttpMethod = request.Method.ToString ().ToUpperInvariant (),
 				Url = NSUrl.FromString (request.RequestUri.AbsoluteUri),
-				Headers = headers.Aggregate (new NSMutableDictionary (), (acc, x) => {
-					acc.Add (new NSString (x.Key), new NSString (string.Join (GetHeaderSeparator (x.Key), x.Value)));
-					return acc;
-				})
+				Headers = nativeHeaders,
 			};
 
 			if (stream != Stream.Null) {

--- a/tools/devops/device-tests/scripts/GitHub.psm1
+++ b/tools/devops/device-tests/scripts/GitHub.psm1
@@ -195,7 +195,9 @@ function New-GitHubComment {
         Authorization = ("token {0}" -f $Env:GITHUB_TOKEN)
     }
 
-    return Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body ($payload | ConvertTo-Json) -ContentType 'application/json' -PreserveAuthorizationOnRedirect
+    $request = Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body ($payload | ConvertTo-Json) -ContentType 'application/json' -PreserveAuthorizationOnRedirect
+    Write-Host $request
+    return $request
 }
 
 <#
@@ -351,6 +353,7 @@ function New-GitHubSummaryComment {
     $request = $null
 
     if (-not (Test-Path $TestSummaryPath -PathType Leaf)) {
+        Write-Host "Not test summary found"
         Set-GitHubStatus -Status "failure" -Description "Tests failed catastrophically on $Context (no summary found)." -Context "$Context"
         $request = New-GitHubComment -Header "Tests failed catastrophically on $Context (no summary found)." -Emoji ":fire:" -Description "Result file $TestSummaryPath not found. $headerLinks"
     } else {

--- a/tools/devops/device-tests/scripts/GitHub.psm1
+++ b/tools/devops/device-tests/scripts/GitHub.psm1
@@ -353,7 +353,7 @@ function New-GitHubSummaryComment {
     $request = $null
 
     if (-not (Test-Path $TestSummaryPath -PathType Leaf)) {
-        Write-Host "Not test summary found"
+        Write-Host "No test summary found"
         Set-GitHubStatus -Status "failure" -Description "Tests failed catastrophically on $Context (no summary found)." -Context "$Context"
         $request = New-GitHubComment -Header "Tests failed catastrophically on $Context (no summary found)." -Emoji ":fire:" -Description "Result file $TestSummaryPath not found. $headerLinks"
     } else {

--- a/tools/devops/device-tests/templates/device-tests-stage.yml
+++ b/tools/devops/device-tests/templates/device-tests-stage.yml
@@ -67,8 +67,6 @@ stages:
       vmImage: ${{ parameters.WindowsDevicePool }}
     steps:
     - template: upload-vsdrops.yml
-      parameters:
-        vsdropsPrefix: ${{ parameters.vsdropsPrefix }} 
 
   - job: upload_vsts_tests
     displayName: 'Upload xml to vsts'
@@ -94,10 +92,10 @@ stages:
       XAMARIN_STORAGE_PATH: $[ dependencies.tests.outputs['runTests.XAMARIN_STORAGE_PATH'] ]
       XAMARIN_STORAGE_FAILED: $[ dependencies.tests.outputs['runTests.XAMARIN_STORAGE_FAILED'] ]
       TESTS_JOBSTATUS: $[ dependencies.tests.outputs['runTests.TESTS_JOBSTATUS'] ]
-      VSDROPS_INDEX: $[ dependencies.upload_vsdrops.outputs['vsdrops.VSDROPS_INDEX'] ]
     pool:
       vmImage: ${{ parameters.WindowsDevicePool }}
     steps:
     - template: publish-html.yml
       parameters:
         statusContext: ${{ parameters.statusContext }}
+        vsdropsPrefix: ${{ parameters.vsdropsPrefix }} 

--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -280,7 +280,7 @@ steps:
   env:
     WORKING_DIR: $(System.DefaultWorkingDirectory) 
     TESTS_EXTRA_ARGUMENTS: ${{ parameters.testsLabels }}
-    USE_XAMARIN_STORAGE: '${{ parameters.useXamarinStorage }}'
+    USE_XAMARIN_STORAGE: ${{ parameters.useXamarinStorage }}
     VSDROPS_URI: '${{ parameters.vsdropsPrefix }}/$(Build.BuildNumber)/$(Build.BuildId);/tests/' # uri used to create the vsdrops index using full uri
   displayName: 'Run tests'
   name: runTests # not to be confused with the displayName, this is used to later use the name of the step to access the output variables from an other job

--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -230,7 +230,7 @@ steps:
 
     P=jenkins/xamarin-macios/$BUILD_LANE/$BUILD_REVISION/$ID/device-tests
 
-    echo "##vso[task.setvariable variable=XAMARIN_STORAGE_PATH]$P"
+    echo "##vso[task.setvariable variable=XM_STORAGE_PATH]$P"
 
     X="#vso"
     set +x
@@ -246,24 +246,24 @@ steps:
 - bash: |
     set -x
     set -e
-    echo 'Use xamarin storage $USE_XAMARIN_STORAGE'
+    P=$(echo $XM_STORAGE_PATH | tr -d \'\")
 
     cd $WORKING_DIR/xamarin-macios
     if [[ "$USE_XAMARIN_STORAGE" == "True" ]]; then
       if nc -z xamarin-storage 22 2>/dev/null; then
-        EC=0
-        MKSTORAGE='ssh builder@xamarin-storage "mkdir -p /volume1/storage/$XAMARIN_STORAGE_PATH"'
-        eval $MKSTORAGE || EC=$?
-        if [ $EC -eq 0 ]; then
-          echo '##vso[task.setvariable variable=XAMARIN_STORAGE_PATH;isOutput=true]$XAMARIN_STORAGE_PATH'
-          echo '##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]false'
-          export TESTS_PERIODIC_COMMAND="--periodic-interval 10 --periodic-command rsync --periodic-command-arguments '-avz -e \"ssh\" $PWD/jenkins-results builder@xamarin-storage:/volume1/storage/$XAMARIN_STORAGE_PATH'"
+        ssh builder@xamarin-storage "mkdir -p /volume1/storage/$P"
+        if [[ $? = 1 ]]; then
+          echo "Remote mkdir failed"
+          echo "##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]true"
+          echo "##vso[task.setvariable variable=XAMARIN_STORAGE_PATH;isOutput=true]"
         else
-          echo '##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]true'
+          echo "##vso[task.setvariable variable=XAMARIN_STORAGE_PATH;isOutput=true]$P"
+          echo "##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]false"
+          export TESTS_PERIODIC_COMMAND="--periodic-interval 10 --periodic-command rsync --periodic-command-arguments '-avz -e \"ssh\" $PWD/jenkins-results builder@xamarin-storage:/volume1/storage/$P'"
         fi
       else
-        echo '##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]true'
-        echo '##vso[task.setvariable variable=XAMARIN_STORAGE_PATH;isOutput=true]""'
+        echo "##vso[task.setvariable variable=XAMARIN_STORAGE_FAILED;isOutput=true]true"
+        echo "##vso[task.setvariable variable=XAMARIN_STORAGE_PATH;isOutput=true]"
       fi
     fi
 
@@ -279,7 +279,6 @@ steps:
     fi
   env:
     WORKING_DIR: $(System.DefaultWorkingDirectory) 
-    XAMARIN_STORAGE_PATH: $(XAMARIN_STORAGE_PATH)
     TESTS_EXTRA_ARGUMENTS: ${{ parameters.testsLabels }}
     USE_XAMARIN_STORAGE: '${{ parameters.useXamarinStorage }}'
     VSDROPS_URI: '${{ parameters.vsdropsPrefix }}/$(Build.BuildNumber)/$(Build.BuildId);/tests/' # uri used to create the vsdrops index using full uri

--- a/tools/devops/device-tests/templates/publish-html.yml
+++ b/tools/devops/device-tests/templates/publish-html.yml
@@ -27,6 +27,7 @@ steps:
 # Use the cmdlet to post a new summary comment. The cmdlet checks if we have the TestSummary.md file or not. It will also add the appropriate links to the commnet. 
 # this step uses variables that have been set by the tests job dependency via output variables, those variables contain if the xamarin-storage could be used and its path
 - pwsh: |
+    Write-HOST "Xamarin storage path is $Env:XAMARIN_STORAGE_PATH"
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\device-tests\scripts\GitHub.psm1 
     New-GitHubSummaryComment -Context "$Env:CONTEXT" -XamarinStoragePath "$Env:XAMARIN_STORAGE_PATH" -TestSummaryPath "$Env:TESTS_SUMMARY"
   env:

--- a/tools/devops/device-tests/templates/publish-html.yml
+++ b/tools/devops/device-tests/templates/publish-html.yml
@@ -29,7 +29,8 @@ steps:
 - pwsh: |
     Write-HOST "Xamarin storage path is $Env:XAMARIN_STORAGE_PATH"
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\device-tests\scripts\GitHub.psm1 
-    New-GitHubSummaryComment -Context "$Env:CONTEXT" -XamarinStoragePath "$Env:XAMARIN_STORAGE_PATH" -TestSummaryPath "$Env:TESTS_SUMMARY"
+    $response = New-GitHubSummaryComment -Context "$Env:CONTEXT" -XamarinStoragePath "$Env:XAMARIN_STORAGE_PATH" -TestSummaryPath "$Env:TESTS_SUMMARY"
+    Write-Host $response
   env:
     BUILD_REVISION: $(BUILD_REVISION)
     CONTEXT: ${{ parameters.statusContext }}

--- a/tools/devops/device-tests/templates/publish-html.yml
+++ b/tools/devops/device-tests/templates/publish-html.yml
@@ -31,7 +31,6 @@ steps:
 # this step uses variables that have been set by the tests job dependency via output variables, those variables contain if the xamarin-storage could be used and its path
 - pwsh: |
     $env:VSDROPS_INDEX="$Env:VSDROPSPREFIX/$Env:BUILD_BUILDNUMER/$Env:BUILD_BUILDID;/tests/vsdrops_index.html"
-    Get-ChildItem env:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\device-tests\scripts\GitHub.psm1 
     $response = New-GitHubSummaryComment -Context "$Env:CONTEXT" -XamarinStoragePath "$Env:XAMARIN_STORAGE_PATH" -TestSummaryPath "$Env:TESTS_SUMMARY"
     Write-Host $response

--- a/tools/devops/device-tests/templates/publish-html.yml
+++ b/tools/devops/device-tests/templates/publish-html.yml
@@ -17,6 +17,9 @@ parameters:
   type: string 
   default: 'iOS Device Tests' # default context, since we started dealing with iOS devices. 
 
+- name: vsdropsPrefix
+  type: string
+
 steps:
 
 - checkout: self
@@ -27,6 +30,7 @@ steps:
 # Use the cmdlet to post a new summary comment. The cmdlet checks if we have the TestSummary.md file or not. It will also add the appropriate links to the commnet. 
 # this step uses variables that have been set by the tests job dependency via output variables, those variables contain if the xamarin-storage could be used and its path
 - pwsh: |
+    $env:VSDROPS_INDEX="$Env:VSDROPSPREFIX/$Env:BUILD_BUILDNUMER/$Env:BUILD_BUILDID;/tests/vsdrops_index.html"
     Get-ChildItem env:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\device-tests\scripts\GitHub.psm1 
     $response = New-GitHubSummaryComment -Context "$Env:CONTEXT" -XamarinStoragePath "$Env:XAMARIN_STORAGE_PATH" -TestSummaryPath "$Env:TESTS_SUMMARY"
@@ -38,7 +42,6 @@ steps:
     XAMARIN_STORAGE_PATH: $(XAMARIN_STORAGE_PATH) # could be null if the step was not executed if we use vsdrops, the cmdlet will know how to handle that case
     XAMARIN_STORAGE_FAILED: $(XAMARIN_STORAGE_FAILED) # could not reach xamarin-storage, either the bot is not in the vpn or it finally failed
     TESTS_JOBSTATUS: $(TESTS_JOBSTATUS) # set by the runTests step
-    VSDROPS_INDEX: $(VSDROPS_INDEX)
     TESTS_SUMMARY: $(TEST_SUMMARY_PATH)
   displayName: 'Add summaries'
   condition: always()

--- a/tools/devops/device-tests/templates/publish-html.yml
+++ b/tools/devops/device-tests/templates/publish-html.yml
@@ -27,7 +27,7 @@ steps:
 # Use the cmdlet to post a new summary comment. The cmdlet checks if we have the TestSummary.md file or not. It will also add the appropriate links to the commnet. 
 # this step uses variables that have been set by the tests job dependency via output variables, those variables contain if the xamarin-storage could be used and its path
 - pwsh: |
-    Write-HOST "Xamarin storage path is $Env:XAMARIN_STORAGE_PATH"
+    Get-ChildItem env:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\device-tests\scripts\GitHub.psm1 
     $response = New-GitHubSummaryComment -Context "$Env:CONTEXT" -XamarinStoragePath "$Env:XAMARIN_STORAGE_PATH" -TestSummaryPath "$Env:TESTS_SUMMARY"
     Write-Host $response

--- a/tools/devops/device-tests/templates/publish-html.yml
+++ b/tools/devops/device-tests/templates/publish-html.yml
@@ -30,7 +30,7 @@ steps:
 # Use the cmdlet to post a new summary comment. The cmdlet checks if we have the TestSummary.md file or not. It will also add the appropriate links to the comment. 
 # this step uses variables that have been set by the tests job dependency via output variables, those variables contain if the xamarin-storage could be used and its path
 - pwsh: |
-    $env:VSDROPS_INDEX="$Env:VSDROPSPREFIX/$Env:BUILD_BUILDNUMER/$Env:BUILD_BUILDID;/tests/vsdrops_index.html"
+    $env:VSDROPS_INDEX="$Env:VSDROPSPREFIX/$Env:BUILD_BUILDNUMBER/$Env:BUILD_BUILDID;/tests/vsdrops_index.html"
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\device-tests\scripts\GitHub.psm1 
     $response = New-GitHubSummaryComment -Context "$Env:CONTEXT" -XamarinStoragePath "$Env:XAMARIN_STORAGE_PATH" -TestSummaryPath "$Env:TESTS_SUMMARY"
     Write-Host $response

--- a/tools/devops/device-tests/templates/upload-vsdrops.yml
+++ b/tools/devops/device-tests/templates/upload-vsdrops.yml
@@ -23,8 +23,9 @@ steps:
     usePat: true 
 
 - pwsh: |
-    echo "##vso[task.setvariable variable=VSDROPS_INDEX];isOutput=true]$Env:VSDROPS_INDEX"
+    Get-ChildItem env:
+    Write-Host '##vso[task.setvariable variable=VSDROPS_INDEX];isOutput=true]$Env:VS_INDEX'
   displayName: Publis vsdrops path
   name: vsdrops # not to be confused with the displayName, this is used to later use the name of the step to access the output variables from an other job
   env:
-    VSDROPS_INDEX: '${{ parameters.vsdropsPrefix }}/$(Build.BuildNumber)/$(Build.BuildId);/tests/vsdrops_index.html' # url to the vsdrops generated index file
+    VS_INDEX: '${{ parameters.vsdropsPrefix }}/$(Build.BuildNumber)/$(Build.BuildId);/tests/vsdrops_index.html' # url to the vsdrops generated index file

--- a/tools/devops/device-tests/templates/upload-vsdrops.yml
+++ b/tools/devops/device-tests/templates/upload-vsdrops.yml
@@ -1,10 +1,5 @@
 
 # job that downloads the html report from the artifacts and uploads them into vsdrops.
-parameters:
-
-- name: vsdropsPrefix
-  type: string
-
 steps:
 
 - checkout: self
@@ -21,11 +16,3 @@ steps:
     sourcePath: $(HTML_REPORT_PATH)
     detailedLog: true
     usePat: true 
-
-- pwsh: |
-    Get-ChildItem env:
-    Write-Host '##vso[task.setvariable variable=VSDROPS_INDEX];isOutput=true]$Env:VS_INDEX'
-  displayName: Publis vsdrops path
-  name: vsdrops # not to be confused with the displayName, this is used to later use the name of the step to access the output variables from an other job
-  env:
-    VS_INDEX: '${{ parameters.vsdropsPrefix }}/$(Build.BuildNumber)/$(Build.BuildId);/tests/vsdrops_index.html' # url to the vsdrops generated index file


### PR DESCRIPTION
For some reason, and it is very probably a bug in the azurepipelines,
the following bash code creates a path with an extra single quote at the
end:

```bash
 P=jenkins/xamarin-macios/$BUILD_LANE/$BUILD_REVISION/$ID/device-tests

echo "##vso[task.setvariable variable=XM_STORAGE_PATH]$P"
```

* Should it do it? Not, it should not.
* Does it do it? Yes, it does.

We work around it via td -d \'\" and remove all single and double quotes
in the string. How long did it take to discover this? More than it
should have.

There is another interesting bug with the variable expansion, the
following
```bash
echo '##vso[task.setvariable variable=XAMARIN_STORAGE_PATH;isOutput=true]$P'
```
Does not equal
```bash
echo '##vso[task.setvariable variable=XAMARIN_STORAGE_PATH;isOutput=true]'$P
```

The first will not expand the variable, the second one will. We do need
the value of $P not '$P'.