### PR TITLE
[msbuild] Make the ParseExtraMtouchArgs task platform-agnostic, and share it between Xamarin.iOS and Xamarin.Mac.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -72,7 +72,6 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 		<PackagingExtraArgs Condition="'$(PackagingExtraArgs)' == ''"></PackagingExtraArgs>
 		<I18n Condition="'$(I18n)' == ''"></I18n>
 		<IncludeMonoRuntime Condition="'$(IncludeMonoRuntime)' == ''">true</IncludeMonoRuntime>
-		<MonoBundlingExtraArgs Condition="'$(MonoBundlingExtraArgs)' == ''"></MonoBundlingExtraArgs>
 		<IsAppExtension Condition="'$(IsAppExtension)' == ''">False</IsAppExtension>
 		<EnableSGenConc Condition="'$(EnableSGenConc)' == ''">false</EnableSGenConc>
 		<AotScope Condition="'$(AotScope)' == ''">None</AotScope>
@@ -90,7 +89,7 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 	</PropertyGroup>
 
 	<!-- Do not resolve from the GAC in Modern or Full unless allow-unsafe-gac-resolution is passed in -->
-	<PropertyGroup Condition="'$(TargetFrameworkName)' != 'System' And !$(MonoBundlingExtraArgs.Contains('--allow-unsafe-gac-resolution'))" >
+	<PropertyGroup Condition="'$(TargetFrameworkName)' != 'System' And !$(_BundlerArguments.Contains('--allow-unsafe-gac-resolution'))" >
 		<AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}',''))</AssemblySearchPaths>
 		<AssemblySearchPaths Condition="'$(MSBuildRuntimeVersion)' != ''">$(AssemblySearchPaths.Split(';'))</AssemblySearchPaths>
 	</PropertyGroup>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -87,6 +87,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			_TemperMetal;
 			_CompileEntitlements;
 			_CompileAppManifest;
+			_ParseBundlerArguments;
 			_CompileToNative;
 			_CreatePkgInfo;
 			_CopyAppExtensionsToBundle;
@@ -371,7 +372,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			HttpClientHandler="$(HttpClientHandler)"
 			I18n="$(I18n)"
 			Profiling="$(Profiling)"
-			ExtraArgs="$(MonoBundlingExtraArgs)"
+			ExtraArgs="$(_BundlerArguments)"
 			NativeReferences="@(NativeReference)"
 			References="@(ReferencePath);@(ReferenceCopyLocalAssemblyPaths)"
 			ResponseFilePath="$(IntermediateOutputPath)response-file.rsp"

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ParseBundlerArgumentsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ParseBundlerArgumentsTaskBase.cs
@@ -1,15 +1,10 @@
-﻿using System;
+using System;
 
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 
-using Xamarin.MacDev;
-using Xamarin.MacDev.Tasks;
-
-namespace Xamarin.iOS.Tasks
-{
-	public abstract class ParseExtraMtouchArgsTaskBase : XamarinTask
-	{
+namespace Xamarin.MacDev.Tasks {
+	public abstract class ParseBundlerArgumentsTaskBase : XamarinTask {
 		public string ExtraArgs { get; set; }
 
 		[Output]
@@ -30,44 +25,46 @@ namespace Xamarin.iOS.Tasks
 				var args = CommandLineArgumentBuilder.Parse (ExtraArgs);
 
 				for (int i = 0; i < args.Length; i++) {
-					string arg;
+					var arg = args [i];
 
-					if (string.IsNullOrEmpty (args[i]))
+					if (string.IsNullOrEmpty (arg))
 						continue;
 
-					if (args[i][0] == '/') {
-						arg = args[i].Substring (1);
-					} else if (args[i][0] == '-') {
-						if (args[i].Length >= 2 && args[i][1] == '-')
-							arg = args[i].Substring (2);
-						else
-							arg = args[i].Substring (1);
+					var index = 1;
+					if (arg [0] == '/') {
+						// nothing to do
+					} else if (arg [0] == '-') {
+						if (arg.Length >= 2 && arg [1] == '-')
+							index++;
 					} else {
 						continue;
 					}
+					arg = arg.Substring (index);
 
-					switch (arg) {
+					var eq = arg.IndexOfAny (new char [] { ':', '=' });
+					var value = string.Empty;
+					var name = arg;
+					if (eq >= 0) {
+						name = arg.Substring (0, eq);
+						value = arg.Substring (eq + 1);
+					}
+
+					switch (name) {
 					case "nosymbolstrip":
-						NoSymbolStrip = "true";
 						// There's also a version that takes symbols as arguments:
 						// --nosymbolstrip:symbol1,symbol2
 						// in that case we do want to run the SymbolStrip target, so we
 						// do not set the MtouchNoSymbolStrip property to 'true' in that case.
+						NoSymbolStrip = string.IsNullOrEmpty (value) ? "true" : "false";
 						break;
 					case "dsym":
-						NoDSymUtil = "false";
+						NoDSymUtil = ParseBool (arg.Substring (5)) ? "false" : "true";
 						break;
 					default:
-						if (arg.StartsWith ("dsym:", StringComparison.Ordinal) || arg.StartsWith ("dsym=", StringComparison.Ordinal)) {
-							NoDSymUtil = ParseBool (arg.Substring (5)) ? "false" : "true";
-						}
 						break;
 					}
 				}
 			}
-
-			Log.LogTaskProperty ("NoSymbolStrip Output", NoSymbolStrip);
-			Log.LogTaskProperty ("NoDSymUtil Output", NoDSymUtil);
 
 			return !Log.HasLoggedErrors;
 		}
@@ -98,3 +95,4 @@ namespace Xamarin.iOS.Tasks
 		}
 	}
 }
+

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ParseBundlerArgumentsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ParseBundlerArgumentsTaskBase.cs
@@ -58,7 +58,7 @@ namespace Xamarin.MacDev.Tasks {
 						NoSymbolStrip = string.IsNullOrEmpty (value) ? "true" : "false";
 						break;
 					case "dsym":
-						NoDSymUtil = ParseBool (arg.Substring (5)) ? "false" : "true";
+						NoDSymUtil = ParseBool (value) ? "false" : "true";
 						break;
 					default:
 						break;

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ParseBundlerArguments.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ParseBundlerArguments.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace Xamarin.MacDev.Tasks {
+	public class ParseBundlerArguments : ParseBundlerArgumentsTaskBase {
+	}
+}
+

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -141,6 +141,22 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<!-- The default is false for all platforms -->
 		<_BundlerDebug Condition="'$(_BundlerDebug)' == ''">false</_BundlerDebug>
 
+		<!-- Extra arguments -->
+		<_BundlerArguments Condition="'$(_PlatformName)' == 'macOS'">$(MonoBundlingExtraArgs)</_BundlerArguments>
+		<_BundlerArguments Condition="'$(_PlatformName)' != 'macOS'">$(MtouchExtraArgs)</_BundlerArguments>
+
+		<!-- NoSymbolStrip -->
+		<!-- Xamarin.Mac never had an equivalent for MtouchNoSymbolStrip -->
+		<!-- in either case default to 'false' -->
+		<_NoSymbolStrip Condition="'$(_PlatformName)' != 'macOS'">$(MtouchNoSymbolStrip)</_NoSymbolStrip>
+		<_NoSymbolStrip Condition="'$(_NoSymbolStrip)' == ''">false</_NoSymbolStrip>
+
+		<!-- NoDSymUtil -->
+		<!-- Xamarin.Mac never had an equivalent for MtouchNoDSymUtil -->
+		<!-- in either case default to 'false' -->
+		<_NoDSymUtil Condition="'$(_PlatformName)' != 'macOS'">$(MtouchNoDSymUtil)</_NoDSymUtil>
+		<_NoDSymUtil Condition="'$(_NoDSymUtil)' == ''">false</_NoDSymUtil>
+
 		<!-- DeviceSpecificIntermediateOutputPath -->
 		<!--
 			We don't need this value for Xamarin.Mac, but many of the targets

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -69,7 +69,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.OptimizeImage" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.OptimizePropertyList" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.ParseDeviceSpecificBuildInformation" AssemblyFile="$(_TaskAssemblyName)" />
-	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.ParseExtraMtouchArgs" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.PrepareNativeReferences" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.PrepareResourceRules" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.ResolveNativeWatchApp" AssemblyFile="$(_TaskAssemblyName)" />
@@ -116,6 +115,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetNativeExecutableName" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetPropertyListValue" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.PackLibraryResources" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.ParseBundlerArguments" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.PropertyListEditor" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.ReadItemsFromFile" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.SmartCopy" AssemblyFile="$(_TaskAssemblyName)" />
@@ -466,6 +466,17 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<Output TaskParameter="IsXcode8" PropertyName="_IsXcode8" />
 			<Output TaskParameter="XamarinSdkRoot" PropertyName="_XamarinSdkRoot" />
 		</DetectSdkLocations>
+	</Target>
+
+	<Target Name="_ParseBundlerArguments">
+		<ParseBundlerArguments
+			ExtraArgs="$(_BundlerArguments)"
+			NoSymbolStrip="$(_NoSymbolStrip)"
+			NoDSymUtil="$(_NoDSymUtil)"
+			>
+			<Output TaskParameter="NoSymbolStrip" PropertyName="_NoSymbolStrip"/>
+			<Output TaskParameter="NoDSymUtil" PropertyName="_NoDSymUtil"/>
+		</ParseBundlerArguments>
 	</Target>
 
 	<!-- Code signing -->

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
@@ -42,7 +42,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<MtouchProfiling Condition="'$(MtouchProfiling)' == ''">False</MtouchProfiling>
 		<MtouchLinkerDumpDependencies Condition="'$(MtouchLinkerDumpDependencies)' == ''">False</MtouchLinkerDumpDependencies>
 		<MtouchUseLlvm Condition="'$(MtouchUseLlvm)' == ''">False</MtouchUseLlvm>
-		<MtouchNoSymbolStrip Condition="'$(MtouchNoSymbolStrip)' == ''">False</MtouchNoSymbolStrip>
 		<MtouchFloat32 Condition="'$(MtouchFloat32)' == ''">False</MtouchFloat32>
 		<MtouchEnableBitcode Condition="'$(MtouchEnableBitcode)' == ''">False</MtouchEnableBitcode>
 		<MtouchUseThumb Condition="'$(MtouchUseThumb)' == ''">False</MtouchUseThumb>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -222,7 +222,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			_CompileEntitlements;
 			_CompileAppManifest;
 			_GetNativeExecutableName;
-			_ParseExtraMtouchArgs;
+			_ParseBundlerArguments;
 			_CompileToNative;
 			_CompileITunesMetadata;
 			_CollectITunesArtwork;
@@ -604,7 +604,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			ExecutableName="$(_ExecutableName)"
 			CompiledEntitlements="$(_CompiledEntitlements)"
 			Debug="$(_BundlerDebug)"
-			ExtraArgs="$(MtouchExtraArgs)"
+			ExtraArgs="$(_BundlerArguments)"
 			FastDev="$(MtouchFastDev)"
 			HttpClientHandler="$(MtouchHttpClientHandler)"
 			I18n="$(MtouchI18n)"
@@ -651,17 +651,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</Touch>
 	</Target>
 
-	<Target Name="_ParseExtraMtouchArgs">
-		<ParseExtraMtouchArgs
-			ExtraArgs="$(MTouchExtraArgs)"
-			NoSymbolStrip="$(MtouchNoSymbolStrip)"
-			NoDSymUtil="$(MtouchNoDSymUtil)"
-			>
-			<Output TaskParameter="NoSymbolStrip" PropertyName="MtouchNoSymbolStrip"/>
-			<Output TaskParameter="NoDSymUtil" PropertyName="MtouchNoDSymUtil"/>
-		</ParseExtraMtouchArgs>
-	</Target>
-
 	<Target Name="_ReadAppExtensionDebugSymbolProperties">
 		<ReadItemsFromFile File="%(_ResolvedAppExtensionReferences.Identity)\..\dsym.items" Condition="Exists('%(_ResolvedAppExtensionReferences.Identity)\..\dsym.items')">
 			<Output TaskParameter="Items" ItemName="_AppExtensionDebugSymbolProperties" />
@@ -669,7 +658,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_GenerateAppExtensionDebugSymbols" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsAppExtension)' == 'false'"
-		DependsOnTargets="_ParseExtraMtouchArgs;_CompileToNative;_ReadAppExtensionDebugSymbolProperties"
+		DependsOnTargets="_ParseBundlerArguments;_CompileToNative;_ReadAppExtensionDebugSymbolProperties"
 		Inputs="$(_AppBundlePath)PlugIns\%(_AppExtensionDebugSymbolProperties.Identity)\%(_AppExtensionDebugSymbolProperties.NativeExecutable)"
 		Outputs="$(AppBundleDir)\..\%(_AppExtensionDebugSymbolProperties.Identity).dSYM\Contents\Info.plist">
 
@@ -707,7 +696,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</Touch>
 	</Target>
 
-	<Target Name="_GenerateFrameworkDebugSymbols" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_CompileToNative;_ParseExtraMtouchArgs;_CollectFrameworks"
+	<Target Name="_GenerateFrameworkDebugSymbols" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_CompileToNative;_ParseBundlerArguments;_CollectFrameworks"
 		Inputs="%(_Frameworks.Identity)"
 		Outputs="$(AppBundleDir)\..\%(_Frameworks.Filename).framework.dSYM\Contents\Info.plist"
 		>
@@ -717,7 +706,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- run dsymutil on embedded frameworks -->
 		<DSymUtil
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true' And '$(MtouchNoDSymUtil)' == 'false'"
+			Condition="'$(IsMacEnabled)' == 'true' And '$(_NoDSymUtil)' == 'false'"
 			AppBundleDir="$(AppBundleDir)"
 			Architectures=""
 			DSymDir="$(AppBundleDir)\..\%(_Frameworks.Filename).framework.dSYM"
@@ -739,7 +728,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- _GenerateDebugSymbols will run spotlight to index the dSYMs -->
 	</Target>
 
-	<Target Name="_PrepareDebugSymbolGeneration" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsAppExtension)' == 'true' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_CompileToNative;_ParseExtraMtouchArgs"
+	<Target Name="_PrepareDebugSymbolGeneration" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsAppExtension)' == 'true' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_CompileToNative;_ParseBundlerArguments"
 			Inputs="$(_NativeExecutable)" Outputs="$(DeviceSpecificOutputPath)dsym.items">
 		<!-- For App Extensions, we delay running dsymutil & strip until it has been copied into the main app bundle... -->
 		<GetFullPath SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" RelativePath="$(_MtouchSymbolsList)">
@@ -760,7 +749,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 				<NativeExecutable>$(_NativeExecutableFileName)</NativeExecutable>
 				<NoSymbolStrip>$(MtouchNoSymbolStrip)</NoSymbolStrip>
 				<SymbolsList>$(_SymbolsListFullPath)</SymbolsList>
-				<NoDSymUtil>$(MtouchNoDSymUtil)</NoDSymUtil>
+				<NoDSymUtil>$(_NoDSymUtil)</NoDSymUtil>
 			</_AppExtensionDebugSymbolProperties>
 		</ItemGroup>
 
@@ -774,7 +763,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		/>
 	</Target>
 
-	<Target Name="_GenerateDebugSymbols" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_CompileToNative;_ParseExtraMtouchArgs;_GenerateFrameworkDebugSymbols;_GenerateAppExtensionDebugSymbols;_PrepareDebugSymbolGeneration"
+	<Target Name="_GenerateDebugSymbols" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_CompileToNative;_ParseBundlerArguments;_GenerateFrameworkDebugSymbols;_GenerateAppExtensionDebugSymbols;_PrepareDebugSymbolGeneration"
 		Inputs="$(_NativeExecutable)" Outputs="$(AppBundleDir).dSYM\Contents\Info.plist">
 
 		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '$(IsAppExtension)' == 'false'" Directories="$(AppBundleDir).dSYM" />
@@ -783,7 +772,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- run dsymutil on the main bundle -->
 		<DSymUtil
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true' And '$(MtouchNoDSymUtil)' == 'false' And '$(IsAppExtension)' == 'false'"
+			Condition="'$(IsMacEnabled)' == 'true' And '$(_NoDSymUtil)' == 'false' And '$(IsAppExtension)' == 'false'"
 			AppBundleDir="$(AppBundleDir)"
 			Architectures="$(_CompiledArchitectures)"
 			DSymDir="$(AppBundleDir).dSYM"
@@ -814,7 +803,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- make sure spotlight indexes everything we've built -->
 		<SpotlightIndexer
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true' And '$(MtouchNoDSymUtil)' == 'false' And '$(IsAppExtension)' == 'false'"
+			Condition="'$(IsMacEnabled)' == 'true' And '$(_NoDSymUtil)' == 'false' And '$(IsAppExtension)' == 'false'"
 			Input="$(AppBundleDir)/../"
 		>
 		</SpotlightIndexer>

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ParseExtraMtouchArgs.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ParseExtraMtouchArgs.cs
@@ -1,6 +1,0 @@
-﻿namespace Xamarin.iOS.Tasks
-{
-	public class ParseExtraMtouchArgs : ParseExtraMtouchArgsTaskBase
-	{
-	}
-}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/ParseBundlerArgumentsTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/ParseBundlerArgumentsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using NUnit.Framework;
 
@@ -7,19 +7,19 @@ using Xamarin.MacDev.Tasks;
 namespace Xamarin.iOS.Tasks
 {
 	[TestFixture]
-	public class ParseMtouchExtraArgsTests : TestBase
+	public class ParseBundlerArgumentsTests : TestBase
 	{
-		class CustomMtouchExtraArgs : ParseExtraMtouchArgsTaskBase {}
+		class CustomParseBundlerArguments : ParseBundlerArgumentsTaskBase {}
 
 		[Test]
 		public void NoExtraArgs ()
 		{
-			var task = CreateTask<CustomMtouchExtraArgs> ();
+			var task = CreateTask<CustomParseBundlerArguments> ();
 			Assert.IsTrue (task.Execute (), "execute");
 			Assert.AreEqual ("false", task.NoSymbolStrip, "nosymbolstrip");
 			Assert.AreEqual ("false", task.NoDSymUtil, "nodsymutil");
 
-			task = CreateTask<CustomMtouchExtraArgs> ();
+			task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = string.Empty;
 			Assert.IsTrue (task.Execute (), "execute");
 			Assert.AreEqual ("false", task.NoSymbolStrip, "nosymbolstrip");
@@ -40,7 +40,7 @@ namespace Xamarin.iOS.Tasks
 			};
 
 			foreach (var variation in false_variations) {
-				var task = CreateTask<CustomMtouchExtraArgs> ();
+				var task = CreateTask<CustomParseBundlerArguments> ();
 				task.ExtraArgs = variation;
 				Assert.IsTrue (task.Execute (), "execute: " + variation);
 				Assert.AreEqual ("false", task.NoSymbolStrip, "nosymbolstrip: " + variation);
@@ -48,7 +48,7 @@ namespace Xamarin.iOS.Tasks
 			}
 
 			foreach (var variation in true_variations) {
-				var task = CreateTask<CustomMtouchExtraArgs> ();
+				var task = CreateTask<CustomParseBundlerArguments> ();
 				task.ExtraArgs = variation;
 				Assert.IsTrue (task.Execute (), "execute: " + variation);
 				Assert.AreEqual ("true", task.NoSymbolStrip, "nosymbolstrip: " + variation);
@@ -71,7 +71,7 @@ namespace Xamarin.iOS.Tasks
 			};
 
 			foreach (var variation in false_variations) {
-				var task = CreateTask<CustomMtouchExtraArgs> ();
+				var task = CreateTask<CustomParseBundlerArguments> ();
 				task.ExtraArgs = variation;
 				Assert.IsTrue (task.Execute (), "execute: " + variation);
 				Assert.AreEqual ("false", task.NoSymbolStrip, "nosymbolstrip: " + variation);
@@ -79,7 +79,7 @@ namespace Xamarin.iOS.Tasks
 			}
 
 			foreach (var variation in true_variations) {
-				var task = CreateTask<CustomMtouchExtraArgs> ();
+				var task = CreateTask<CustomParseBundlerArguments> ();
 				task.ExtraArgs = variation;
 				Assert.IsTrue (task.Execute (), "execute: " + variation);
 				Assert.AreEqual ("false", task.NoSymbolStrip, "nosymbolstrip: " + variation);


### PR DESCRIPTION
* Change the parsing code slightly, to make it easier to parse other arguments
  (coming soon).
* Add the parsing task to Xamarin.Mac projects, and use it there as well. The
  parsed result isn't used yet, but it will be soon.
* Unify a few related MSBuild properties (MtouchNoSymbolStrip and
  MtouchNoDSymUtil).