### PR TITLE
[monotouch-test] Use a normal thread instead of MulticastDelegate.BeginInvoke in AVAssetImageGeneratorTest.

### DIFF
--- a/tests/monotouch-test/AVFoundation/AVAssetImageGeneratorTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVAssetImageGeneratorTest.cs
@@ -113,8 +113,10 @@ namespace MonoTouchFixtures.AVFoundation {
 					mre.WaitOne ();
 				}
 			};
-			var asyncResult = main.BeginInvoke (null, null);
-			main.EndInvoke (asyncResult);
+			var thread = new Thread (main) {
+				IsBackground = true,
+			};
+			thread.Start ();
 			Assert.True (mre.WaitOne (2000), "wait");
 			Assert.True (handled, "handled");
 		}


### PR DESCRIPTION
MulticastDelegate.BeginInvoke isn't supported in .NET.

Ref: https://github.com/dotnet/runtime/issues/16312