### PR TITLE
[MTouch] Add a workaround for a failing tests in the Xcode 12 betas.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2821,7 +2821,9 @@ public class TestApp {
 				mtouch.GccFlags = lib;
 				mtouch.TargetVer = "10.3"; // otherwise 32-bit build isn't possible
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build a");
-				if (Configuration.XcodeVersion.Major >= 11) {
+				if (Configuration.XcodeVersion.Major >= 12) { // fb ticket: https://github.com/xamarin/maccore/issues/2264
+					mtouch.AssertWarning (5203, $"Native linking warning: warning: ignoring file {lib}, building for iOS Simulator-i386 but attempting to link with file built for unknown-x86_64");
+				} else if (Configuration.XcodeVersion.Major >= 11) {
 					mtouch.AssertWarning (5203, $"Native linking warning: warning: ignoring file {lib}, building for iOS Simulator-i386 but attempting to link with file built for iOS Simulator-x86_64");
 				} else {
 					mtouch.AssertWarning (5203, $"Native linking warning: warning: ignoring file {lib}, file was built for archive which is not the architecture being linked (i386): {lib}");


### PR DESCRIPTION
There is an issue in the linker warnings (https://github.com/xamarin/maccore/issues/2264) which makes our CI red. Added a workaround in the test for the Xcode version until is fixed by Apple.