### PR TITLE
[CloudKit] Add support for Xcode 12 beta 2.

### DIFF
--- a/src/CloudKit/Enums.cs
+++ b/src/CloudKit/Enums.cs
@@ -155,8 +155,10 @@ namespace CloudKit
 
 	[NoWatch]
 	[iOS (8, 0)]
+	[Obsoleted (PlatformName.iOS, 14, 0, message : "Use 'CKQuerySubscriptionOptions' instead.")]
 	[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'CKQuerySubscriptionOptions' instead.")]
 	[Mac (10, 10)]
+	[Obsoleted (PlatformName.MacOSX, 10, 16, message : "Use 'CKQuerySubscriptionOptions' instead.")]
 	[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'CKQuerySubscriptionOptions' instead.")]
 	[Flags]
 	[Native]

--- a/src/cloudkit.cs
+++ b/src/cloudkit.cs
@@ -428,7 +428,9 @@ namespace CloudKit {
 
 	[NoWatch]
 	[NoTV]
+	[Obsoleted (PlatformName.iOS, 14, 0, message : "Use 'CKDiscoverAllUserIdentitiesOperation' instead.")]
 	[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'CKDiscoverAllUserIdentitiesOperation' instead.")]
+	[Obsoleted (PlatformName.MacOSX, 10, 16, message : "Use 'CKDiscoverAllUserIdentitiesOperation' instead.")]
 	[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'CKDiscoverAllUserIdentitiesOperation' instead.")]
 	[iOS (8,0), Mac (10,10)]
 	[BaseType (typeof (CKOperation))]
@@ -444,7 +446,9 @@ namespace CloudKit {
 		Action<CKDiscoveredUserInfo[], NSError> DiscoverAllContactsHandler { get; set; }
 	}
 
+	[Obsoleted (PlatformName.iOS, 14, 0, message : "Use 'CKUserIdentity' instead.")]
 	[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'CKUserIdentity' instead.")]
+	[Obsoleted (PlatformName.MacOSX, 10, 16, message : "Use 'CKUserIdentity' instead.")]
 	[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'CKUserIdentity' instead.")]
 	[iOS (8,0), Mac (10,10)]
 	[NoWatch]
@@ -488,6 +492,7 @@ namespace CloudKit {
 	[iOS (8,0), Mac (10,10)]
 	delegate void CKDiscoverUserInfosCompletionHandler (NSDictionary emailsToUserInfos, NSDictionary userRecordIdsToUserInfos, NSError operationError);
 
+	[Obsoleted (PlatformName.iOS, 14, 0, message : "Use 'CKDiscoverUserIdentitiesOperation' instead.")]
 	[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'CKDiscoverUserIdentitiesOperation' instead.")]
 	[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'CKDiscoverUserIdentitiesOperation' instead.")]
 	[iOS (8,0), Mac (10,10)]
@@ -1144,6 +1149,10 @@ namespace CloudKit {
 		[Watch (4, 0), NoTV, Mac (10, 13), iOS (11, 0)]
 		[NullAllowed, Export ("subtitleLocalizationArgs", ArgumentSemantic.Copy)]
 		string[] SubtitleLocalizationArgs { get; }
+
+		[Watch (7, 0), TV (14, 0), Mac (10, 16), iOS (14, 0)]
+		[NullAllowed, Export ("subscriptionOwnerUserRecordID", ArgumentSemantic.Copy)]
+		CKRecordID SubscriptionOwnerUserRecordId { get; }
 	}
 
 	[Watch (3,0)]

--- a/tests/xtro-sharpie/common-CloudKit.ignore
+++ b/tests/xtro-sharpie/common-CloudKit.ignore
@@ -12,3 +12,9 @@
 
 ## NSInvalidArgumentException Reason: You must call -[CKMarkNotificationsReadOperation initWithNotificationIDsToMarkRead:]
 !missing-selector! CKMarkNotificationsReadOperation::init not bound
+
+# all of them deprecated and marked with the [Obsoleted] attr.
+!unknown-native-enum! CKSubscriptionOptions bound
+!unknown-type! CKDiscoverAllContactsOperation bound
+!unknown-type! CKDiscoveredUserInfo bound
+!unknown-type! CKDiscoverUserInfosOperation bound

--- a/tests/xtro-sharpie/iOS-CloudKit.todo
+++ b/tests/xtro-sharpie/iOS-CloudKit.todo
@@ -1,5 +1,0 @@
-!missing-selector! CKNotification::subscriptionOwnerUserRecordID not bound
-!unknown-native-enum! CKSubscriptionOptions bound
-!unknown-type! CKDiscoverAllContactsOperation bound
-!unknown-type! CKDiscoveredUserInfo bound
-!unknown-type! CKDiscoverUserInfosOperation bound

--- a/tests/xtro-sharpie/macOS-CloudKit.todo
+++ b/tests/xtro-sharpie/macOS-CloudKit.todo
@@ -1,5 +1,0 @@
-!missing-selector! CKNotification::subscriptionOwnerUserRecordID not bound
-!unknown-native-enum! CKSubscriptionOptions bound
-!unknown-type! CKDiscoverAllContactsOperation bound
-!unknown-type! CKDiscoveredUserInfo bound
-!unknown-type! CKDiscoverUserInfosOperation bound

--- a/tests/xtro-sharpie/tvOS-CloudKit.todo
+++ b/tests/xtro-sharpie/tvOS-CloudKit.todo
@@ -1,4 +1,0 @@
-!missing-selector! CKNotification::subscriptionOwnerUserRecordID not bound
-!unknown-native-enum! CKSubscriptionOptions bound
-!unknown-type! CKDiscoveredUserInfo bound
-!unknown-type! CKDiscoverUserInfosOperation bound

--- a/tests/xtro-sharpie/watchOS-CloudKit.todo
+++ b/tests/xtro-sharpie/watchOS-CloudKit.todo
@@ -1,1 +1,0 @@
-!missing-selector! CKNotification::subscriptionOwnerUserRecordID not bound


### PR DESCRIPTION
Added support for the Xcode 12 beta 2. There are a number of methods
that should be obsoleted, but have not been. Added issue
https://github.com/xamarin/maccore/issues/2265 to let apple know and
track it.