### PR TITLE
[d16-8] Add AutoFill CredentialProvider NSExtensionPoint support

### DIFF
--- a/Versions-ios.plist.in
+++ b/Versions-ios.plist.in
@@ -133,6 +133,8 @@
 			<string>10.0</string>
 			<key>com.apple.usernotifications.service</key>
 			<string>10.0</string>
+			<key>com.apple.authentication-services-credential-provider-ui</key>
+			<string>12.0</string>
 		</dict>
 		<key>tvOS</key>
 		<dict>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
@@ -107,6 +107,7 @@ namespace Xamarin.iOS.Tasks
 			case "com.apple.usernotifications.content-extension": // iOS
 			case "com.apple.usernotifications.service": // iOS
 			case "com.apple.networkextension.packet-tunnel": // iOS+OSX
+			case "com.apple.authentication-services-credential-provider-ui": // iOS
 				break;
 			case "com.apple.watchkit": // iOS8.2
 				var attributes = extension.Get<PDictionary> ("NSExtensionAttributes");


### PR DESCRIPTION
Backport of #9030.

* Fix unrecognized extension build warning for credential providers

* Bump Xamarin.MacDev.

New commits in xamarin/Xamarin.MacDev:

* xamarin/Xamarin.MacDev@8208733 Add AutoFill CredentialProvider NSExtensionPoint support (#75) (#76)

Diff: https://github.com/xamarin/Xamarin.MacDev/compare/a1bc6f39b3efe5d817c60d78eaff3f4c2de720ea..8208733cd627aaddb6ffe8d112e51526200f2acc

* Add IDE deployment target for credential provider