### PR TITLE
[xcode12] Add AutoFill CredentialProvider NSExtensionPoint support

### DIFF
--- a/Versions-ios.plist.in
+++ b/Versions-ios.plist.in
@@ -136,6 +136,8 @@
 			<string>10.0</string>
 			<key>com.apple.usernotifications.service</key>
 			<string>10.0</string>
+			<key>com.apple.authentication-services-credential-provider-ui</key>
+			<string>12.0</string>
 		</dict>
 		<key>tvOS</key>
 		<dict>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
@@ -116,6 +116,7 @@ namespace Xamarin.iOS.Tasks
 			case "com.apple.usernotifications.content-extension": // iOS
 			case "com.apple.usernotifications.service": // iOS
 			case "com.apple.networkextension.packet-tunnel": // iOS+OSX
+			case "com.apple.authentication-services-credential-provider-ui": // iOS
 				break;
 			case "com.apple.watchkit": // iOS8.2
 				var attributes = extension.Get<PDictionary> ("NSExtensionAttributes");


### PR DESCRIPTION
Backport of #9030.

* Fix unrecognized extension build warning for credential providers

* Bump Xamarin.MacDev.

New commits in xamarin/Xamarin.MacDev:

* xamarin/Xamarin.MacDev@af50d97 Add AutoFill CredentialProvider NSExtensionPoint support (#75) (#77)

Diff: https://github.com/xamarin/Xamarin.MacDev/compare/7e9075cab0b959b739e840cc76250665b32efb6f..af50d97218b9c35cbe25bb68b9a3def5dcc13bd6

* Add IDE deployment target for credential provider