### PR TITLE
[xcode12] [AVFoundation] Ignore a few compiler warnings about missing overrides for comparison support.

### DIFF
--- a/src/AVFoundation/AVAudioChannelLayout.cs
+++ b/src/AVFoundation/AVAudioChannelLayout.cs
@@ -4,6 +4,13 @@
 // Authors:
 //   Miguel de Icaza (miguel@xamarin.com)
 //
+
+// 'AVAudioChannelLayout' defines operator == or operator != but does not override Object.Equals(object o)
+#pragma warning disable 0660
+// 'AVAudioChannelLayout' defines operator == or operator != but does not override Object.GetHashCode()
+#pragma warning disable 0661
+// In both of these cases, the NSObject Equals/GetHashCode implementation works fine, so we can ignore these warnings.
+
 using Foundation;
 using ObjCRuntime;
 using AudioToolbox;

--- a/src/AVFoundation/AVAudioFormat.cs
+++ b/src/AVFoundation/AVAudioFormat.cs
@@ -4,6 +4,13 @@
 // Authors:
 //   Miguel de Icaza (miguel@xamarin.com)
 //
+
+// 'AVAudioFormat' defines operator == or operator != but does not override Object.Equals(object o)
+#pragma warning disable 0660
+// 'AVAudioFormat' defines operator == or operator != but does not override Object.GetHashCode()
+#pragma warning disable 0661
+// In both of these cases, the NSObject Equals/GetHashCode implementation works fine, so we can ignore these warnings.
+
 using Foundation;
 using ObjCRuntime;
 using System;


### PR DESCRIPTION


Backport of #9033.

/cc @mandel-macaque @rolfbjarne