### PR TITLE
[main] [msbuild] Allow overriding CompileAppManifestTaskBase Execute method

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -70,7 +70,7 @@ namespace Xamarin.MacDev.Tasks
 
 		protected TargetArchitecture architectures;
 
-		public sealed override bool Execute ()
+		public override bool Execute ()
 		{
 			PDictionary plist;
 


### PR DESCRIPTION
If the Execute method of a task is sealed the Windows side tasks won't be able to "inject" the code that executes the tasks remotely.

Backport of #9088.

/cc @rolfbjarne @emaf