### PR TITLE
[tests] Use Assert.Throws instead of the ExpectedException attribute.

### DIFF
--- a/tests/apitest/src/Foundation/NSScriptCommandArgumentDescriptionTest.cs
+++ b/tests/apitest/src/Foundation/NSScriptCommandArgumentDescriptionTest.cs
@@ -36,34 +36,30 @@ namespace MonoTouchFixtures.Foundation {
 		
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestConstructorNameNullOrEmpty (string name)
 		{
-			new NSScriptCommandArgumentDescription (name, "eeee", "NSString", false);
+			Assert.Throws<ArgumentException> (() => new NSScriptCommandArgumentDescription (name, "eeee", "NSString", false));
 		}
 		
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestConstructorEventCodeNullOrEmpty (string eventCode)
 		{
-			new NSScriptCommandArgumentDescription ("name", eventCode, "NSString", false);
+			Assert.Throws<ArgumentException> (() => new NSScriptCommandArgumentDescription ("name", eventCode, "NSString", false));
 		}
 		
 		[TestCase ("srf")]
 		[TestCase ("TooLong")]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestConstructorEventCodeWrongLength (string eventCode)
 		{
-			new NSScriptCommandArgumentDescription ("name", eventCode, "NSString", false);
+			Assert.Throws<ArgumentException> (() => new NSScriptCommandArgumentDescription ("name", eventCode, "NSString", false));
 		}
 		
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestConstructorTypeNullOrEmpty (string type)
 		{
-			new NSScriptCommandArgumentDescription ("name", "****", type, false);
+			Assert.Throws<ArgumentException> (() => new NSScriptCommandArgumentDescription ("name", "****", type, false));
 		}
 		
 		[TestCase ("name", "cdfd", "NSString", true)]

--- a/tests/apitest/src/Foundation/NSScriptCommandDescriptionTest.cs
+++ b/tests/apitest/src/Foundation/NSScriptCommandDescriptionTest.cs
@@ -56,89 +56,79 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestCreateWithDictWrongArgDescription ()
 		{
 			var description = new NSScriptCommandDescriptionDictionary ();
-			NSScriptCommandDescription.Create (suiteName, commandName, description);
+			Assert.Throws<ArgumentException> (() => NSScriptCommandDescription.Create (suiteName, commandName, description));
 		}
 		
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestCreateWithDictNullOrEmptySuitName (string code)
 		{
 			var description = new NSScriptCommandDescriptionDictionary ();
-			NSScriptCommandDescription.Create (code, commandName, description);
+			Assert.Throws<ArgumentException> (() => NSScriptCommandDescription.Create (code, commandName, description));
 		}
 	
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestCreateWithDictNullOrEmptyCommandName (string code)
 		{
 			var description = new NSScriptCommandDescriptionDictionary ();
-			NSScriptCommandDescription.Create (suiteName, code, description);
+			Assert.Throws<ArgumentException> (() => NSScriptCommandDescription.Create (suiteName, code, description));
 		}
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void TestCreateWithDictNullDict ()
 		{
 			NSScriptCommandDescriptionDictionary dict = null;
-			NSScriptCommandDescription.Create (suiteName, commandName, dict);
+			Assert.Throws<ArgumentNullException> (() => NSScriptCommandDescription.Create (suiteName, commandName, dict));
 		}
 		
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestCreateSuiteNameNullOrEmpty (string code)
 		{
-			NSScriptCommandDescription.Create (code, commandName, dict);
+			Assert.Throws<ArgumentException> (() => NSScriptCommandDescription.Create (code, commandName, dict));
 		}
 		
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestCreateCommandNameNullOrEmpty (string code)
 		{
-			NSScriptCommandDescription.Create (suiteName, code, dict);
+			Assert.Throws<ArgumentException> (() => NSScriptCommandDescription.Create (suiteName, code, dict));
 		}
 		
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestCreateCmdClassNullOrEmpty (string code)
 		{
 			dict.CommandClass = code;
-			NSScriptCommandDescription.Create (suiteName, commandName, dict);
+			Assert.Throws<ArgumentException> (() => NSScriptCommandDescription.Create (suiteName, commandName, dict));
 		}
 		
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestCreateEventCodeNullOrEmpty (string code)
 		{
 			dict.AppleEventCode = code; 
-			NSScriptCommandDescription.Create (suiteName, commandName, dict);
+			Assert.Throws<ArgumentException> (() => NSScriptCommandDescription.Create (suiteName, commandName, dict));
 		}
 		
 		[TestCase ("TooLong")]
 		[TestCase ("srt")]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestCreateEventCodeWrongLength (string code)
 		{
 			dict.AppleEventCode = code; 
-			NSScriptCommandDescription.Create (suiteName, commandName, dict);
+			Assert.Throws<ArgumentException> (() => NSScriptCommandDescription.Create (suiteName, commandName, dict));
 		}
 		
 		[TestCase ("TooLong")]
 		[TestCase ("srt")]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestCreateResultAppleEventWrongLength (string code)
 		{
 			dict.ResultAppleEventCode = code;
-			NSScriptCommandDescription.Create (suiteName, commandName, dict);
+			Assert.Throws<ArgumentException> (() => NSScriptCommandDescription.Create (suiteName, commandName, dict));
 		}
 		
 		[Test]

--- a/tests/linker/ios/link all/LinkAllTest.cs
+++ b/tests/linker/ios/link all/LinkAllTest.cs
@@ -297,17 +297,18 @@ namespace LinkAll {
 		}
 
 		[Test]
-#if __WATCHOS__
-		[ExpectedException (typeof (PlatformNotSupportedException))]
-#endif
 		public void SystemDataSqlClient ()
 		{
+#if __WATCHOS__
+			Assert.Throws<PlatformNotSupportedException> (() => new System.Data.SqlClient.SqlConnection ());
+#else
 			// notes:
 			// * this test is mean to fail when building the application using a Community or Indie licenses
 			// * linksdk.app references System.Data (assembly) but not types in SqlClient namespace
 			using (var sc = new System.Data.SqlClient.SqlConnection ()) {
 				Assert.NotNull (sc);
 			}
+#endif
 		}
 		
 #if !__TVOS__ && !__WATCHOS__

--- a/tests/linker/ios/link sdk/AotBugs.cs
+++ b/tests/linker/ios/link sdk/AotBugs.cs
@@ -415,12 +415,11 @@ namespace LinkSdk.Aot {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void AsEnumerable_4114 ()
 		{
 			Enumbers<string> e = new Enumbers<string> ();
 			//  Attempting to JIT compile method 'System.Collections.Generic.List`1<System.Collections.Generic.KeyValuePair`2<string, string>>:ToArray ()' while running with --aot-only.
-			e.Enumerate (null);
+			Assert.Throws<NullReferenceException> (() => e.Enumerate (null));
 		}
 
 		static object mInstance = null;

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -721,10 +721,9 @@ namespace LinkSdk {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void LinkedAway ()
 		{
-			new System.Runtime.Remoting.RemotingException ();
+			Assert.Throws<NotSupportedException> (() => new System.Runtime.Remoting.RemotingException ());
 		}
 
 		[Test]

--- a/tests/monotouch-test/Compression/CompressionStreamTest.cs
+++ b/tests/monotouch-test/Compression/CompressionStreamTest.cs
@@ -41,21 +41,19 @@ namespace MonoTouchFixtures.Compression {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Constructor_Null ()
 		{
 			if (!TestRuntime.CheckXcodeVersion (7, 0))
 				Assert.Ignore ("Requires iOS 9.0+ or macOS 10.11+");
-			DeflateStream ds = new DeflateStream (null, CompressionMode.Compress, CompressionAlgorithm.Zlib);
+			Assert.Throws<ArgumentNullException> (() => new DeflateStream (null, CompressionMode.Compress, CompressionAlgorithm.Zlib));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Constructor_InvalidCompressionMode ()
 		{
 			if (!TestRuntime.CheckXcodeVersion (7, 0))
 				Assert.Ignore ("Requires iOS 9.0+ or macOS 10.11+");
-			DeflateStream ds = new DeflateStream (new MemoryStream (), (CompressionMode)Int32.MinValue, CompressionAlgorithm.Zlib);
+			Assert.Throws<ArgumentException> (() => new DeflateStream (new MemoryStream (), (CompressionMode)Int32.MinValue, CompressionAlgorithm.Zlib));
 		}
 
 		[TestCase (CompressionAlgorithm.LZ4)]
@@ -99,18 +97,16 @@ namespace MonoTouchFixtures.Compression {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void CheckNullRead ()
 		{
 			if (!TestRuntime.CheckXcodeVersion (7, 0))
 				Assert.Ignore ("Requires iOS 9.0+ or macOS 10.11+");
 			MemoryStream backing = new MemoryStream (compressed_data);
 			DeflateStream decompressing = new DeflateStream (backing, CompressionMode.Decompress, CompressionAlgorithm.Zlib);
-			decompressing.Read (null, 0, 20);
+			Assert.Throws<ArgumentNullException> (() => decompressing.Read (null, 0, 20));
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidOperationException))]
 		public void CheckCompressingRead ()
 		{
 			if (!TestRuntime.CheckXcodeVersion (7, 0))
@@ -118,11 +114,10 @@ namespace MonoTouchFixtures.Compression {
 			byte [] dummy = new byte[20];
 			MemoryStream backing = new MemoryStream ();
 			DeflateStream compressing = new DeflateStream (backing, CompressionMode.Compress, CompressionAlgorithm.Zlib);
-			compressing.Read (dummy, 0, 20);
+			Assert.Throws<InvalidOperationException> (() => compressing.Read (dummy, 0, 20));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void CheckRangeRead ()
 		{
 			if (!TestRuntime.CheckXcodeVersion (7, 0))
@@ -130,11 +125,10 @@ namespace MonoTouchFixtures.Compression {
 			byte [] dummy = new byte[20];
 			MemoryStream backing = new MemoryStream (compressed_data);
 			DeflateStream decompressing = new DeflateStream (backing, CompressionMode.Decompress, CompressionAlgorithm.Zlib);
-			decompressing.Read (dummy, 10, 20);
+			Assert.Throws<ArgumentException> (() => decompressing.Read (dummy, 10, 20));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ObjectDisposedException))]
 		public void CheckClosedRead ()
 		{
 			if (!TestRuntime.CheckXcodeVersion (7, 0))
@@ -143,11 +137,10 @@ namespace MonoTouchFixtures.Compression {
 			MemoryStream backing = new MemoryStream (compressed_data);
 			DeflateStream decompressing = new DeflateStream (backing, CompressionMode.Decompress, CompressionAlgorithm.Zlib);
 			decompressing.Close ();
-			decompressing.Read (dummy, 0, 20);
+			Assert.Throws<ObjectDisposedException> (() => decompressing.Read (dummy, 0, 20));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ObjectDisposedException))]
 		public void CheckClosedFlush ()
 		{
 			if (!TestRuntime.CheckXcodeVersion (7, 0))
@@ -155,29 +148,27 @@ namespace MonoTouchFixtures.Compression {
 			MemoryStream backing = new MemoryStream ();
 			DeflateStream compressing = new DeflateStream (backing, CompressionMode.Compress, CompressionAlgorithm.Zlib);
 			compressing.Close ();
-			compressing.Flush ();
+			Assert.Throws<ObjectDisposedException> (() => compressing.Flush ());
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void CheckSeek ()
 		{
 			if (!TestRuntime.CheckXcodeVersion (7, 0))
 				Assert.Ignore ("Requires iOS 9.0+ or macOS 10.11+");
 			MemoryStream backing = new MemoryStream (compressed_data);
 			DeflateStream decompressing = new DeflateStream (backing, CompressionMode.Decompress, CompressionAlgorithm.Zlib);
-			decompressing.Seek (20, SeekOrigin.Current);
+			Assert.Throws<NotSupportedException> (() => decompressing.Seek (20, SeekOrigin.Current));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void CheckSetLength ()
 		{
 			if (!TestRuntime.CheckXcodeVersion (7, 0))
 				Assert.Ignore ("Requires iOS 9.0+ or macOS 10.11+");
 			MemoryStream backing = new MemoryStream (compressed_data);
 			DeflateStream decompressing = new DeflateStream (backing, CompressionMode.Decompress, CompressionAlgorithm.Zlib);
-			decompressing.SetLength (20);
+			Assert.Throws<NotSupportedException> (() => decompressing.SetLength (20));
 		}
 
 		[Test]
@@ -247,36 +238,33 @@ namespace MonoTouchFixtures.Compression {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void CheckSetLengthProp ()
 		{
 			if (!TestRuntime.CheckXcodeVersion (7, 0))
 				Assert.Ignore ("Requires iOS 9.0+ or macOS 10.11+");
 			MemoryStream backing = new MemoryStream (compressed_data);
 			DeflateStream decompressing = new DeflateStream (backing, CompressionMode.Decompress, CompressionAlgorithm.Zlib);
-			decompressing.SetLength (20);
+			Assert.Throws<NotSupportedException> (() => decompressing.SetLength (20));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void CheckGetLengthProp ()
 		{
 			if (!TestRuntime.CheckXcodeVersion (7, 0))
 				Assert.Ignore ("Requires iOS 9.0+ or macOS 10.11+");
 			MemoryStream backing = new MemoryStream (compressed_data);
 			DeflateStream decompressing = new DeflateStream (backing, CompressionMode.Decompress, CompressionAlgorithm.Zlib);
-			long length = decompressing.Length;
+			Assert.Throws<NotSupportedException> (() => { var length = decompressing.Length; });
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void CheckGetPositionProp ()
 		{
 			if (!TestRuntime.CheckXcodeVersion (7, 0))
 				Assert.Ignore ("Requires iOS 9.0+ or macOS 10.11+");
 			MemoryStream backing = new MemoryStream (compressed_data);
 			DeflateStream decompressing = new DeflateStream (backing, CompressionMode.Decompress, CompressionAlgorithm.Zlib);
-			long position = decompressing.Position;
+			Assert.Throws<NotSupportedException> (() => { var position = decompressing.Position; });
 		}
 
 		[Test]

--- a/tests/monotouch-test/CoreData/ManagedObjectContextTest.cs
+++ b/tests/monotouch-test/CoreData/ManagedObjectContextTest.cs
@@ -57,22 +57,20 @@ namespace MonoTouchFixtures.CoreData {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Perform_Null ()
 		{
 			using (var moc = new NSManagedObjectContext (NSManagedObjectContextConcurrencyType.MainQueue)) {
 				// a NULL results in a native crash - but not immediate
-				moc.Perform (null);
+				Assert.Throws<ArgumentNullException> (() => moc.Perform (null));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void PerformAndWait_Null ()
 		{
 			using (var moc = new NSManagedObjectContext (NSManagedObjectContextConcurrencyType.MainQueue)) {
 				// a NULL results in a *immediate* native crash
-				moc.PerformAndWait (null);
+				Assert.Throws<ArgumentNullException> (() => moc.PerformAndWait (null));
 			}
 		}
 

--- a/tests/monotouch-test/CoreFoundation/BundleTest.cs
+++ b/tests/monotouch-test/CoreFoundation/BundleTest.cs
@@ -59,10 +59,9 @@ namespace MonoTouchFixtures.CoreFoundation {
 
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestGetBundleIdNull (string id)
 		{
-			var bundle = CFBundle.Get (id);
+			Assert.Throws<ArgumentException> (() => CFBundle.Get (id));
 		}
 
 		[Test]
@@ -163,10 +162,9 @@ namespace MonoTouchFixtures.CoreFoundation {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void TestLocalizationsNull ()
 		{
-			var localizations = CFBundle.GetLocalizations (null);
+			Assert.Throws<ArgumentNullException> (() => CFBundle.GetLocalizations (null));
 		}
 
 		[Test]
@@ -180,19 +178,17 @@ namespace MonoTouchFixtures.CoreFoundation {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void TestPreferredLocalizationsNull ()
 		{
-			var used = CFBundle.GetPreferredLocalizations (null);
+			Assert.Throws<ArgumentNullException> (() => CFBundle.GetPreferredLocalizations (null));
 		}
 
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestAuxiliaryExecutableUrlNull (string executable)
 		{
 			var main = CFBundle.GetMain ();
-			main.GetAuxiliaryExecutableUrl (executable);
+			Assert.Throws<ArgumentException> (() => main.GetAuxiliaryExecutableUrl (executable));
 		}
 
 		[Test]
@@ -205,156 +201,138 @@ namespace MonoTouchFixtures.CoreFoundation {
 
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestResourceUrlNullName (string resourceName)
 		{
 			var main = CFBundle.GetMain ();
-			main.GetResourceUrl (resourceName, "type", null);
+			Assert.Throws<ArgumentException> (() => main.GetResourceUrl (resourceName, "type", null));
 		}
 
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestResourceUrlNullType (string resourceType)
 		{
 			var main = CFBundle.GetMain ();
-			main.GetResourceUrl ("resourceName", resourceType, null);
+			Assert.Throws<ArgumentException> (() => main.GetResourceUrl ("resourceName", resourceType, null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void TestStaticResourceUrlNull ()
 		{
 			NSUrl url = null;
-			CFBundle.GetResourceUrl (url, "resourceName", "resourceType", null);
+			Assert.Throws<ArgumentNullException> (() => CFBundle.GetResourceUrl (url, "resourceName", "resourceType", null));
 		}
 
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestStaticResourceUrlNullName (string resourceName)
 		{
 			var main = CFBundle.GetMain ();
-			CFBundle.GetResourceUrl (main.Url, resourceName, "resourceType", null);
+			Assert.Throws<ArgumentException> (() => CFBundle.GetResourceUrl (main.Url, resourceName, "resourceType", null));
 		}
 
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestStaticResourceUrlNullType (string resourceType)
 		{
 			var main = CFBundle.GetMain ();
-			CFBundle.GetResourceUrl (main.Url, "resourceName", resourceType, null);
+			Assert.Throws<ArgumentException> (() => CFBundle.GetResourceUrl (main.Url, "resourceName", resourceType, null));
 		}
 
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestResourceUrlsNullType (string resourceType)
 		{
 			var main = CFBundle.GetMain ();
-			main.GetResourceUrls (resourceType, null);
+			Assert.Throws<ArgumentException> (() => main.GetResourceUrls (resourceType, null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void TestStaticResourceUrlsNullType ()
 		{
 			NSUrl url = null;
-			CFBundle.GetResourceUrls (url, "resourceType", null);
+			Assert.Throws<ArgumentNullException> (() => CFBundle.GetResourceUrls (url, "resourceType", null));
 		}
 		
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestStaticResourceUrlsNullType (string resourceType)
 		{
 			var main = CFBundle.GetMain ();
-			CFBundle.GetResourceUrls (main.Url, resourceType, null);
+			Assert.Throws<ArgumentException> (() => CFBundle.GetResourceUrls (main.Url, resourceType, null));
 		}
 
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestResourceUrlLocalNameNullName (string resourceName)
 		{
 			var main = CFBundle.GetMain ();
-			main.GetResourceUrl (resourceName, "resourceType", null, "en");
+			Assert.Throws<ArgumentException> (() => main.GetResourceUrl (resourceName, "resourceType", null, "en"));
 		}
 
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestResourceUrlLocalNameNullType (string resourceType)
 		{
 			var main = CFBundle.GetMain ();
-			main.GetResourceUrl ("resourceName", resourceType, null, "en");
+			Assert.Throws<ArgumentException> (() => main.GetResourceUrl ("resourceName", resourceType, null, "en"));
 		}
 
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestResourceUrlLocalNameNullLocale (string locale)
 		{
 			var main = CFBundle.GetMain ();
-			main.GetResourceUrl ("resourceName", "resourceType", null, locale);
+			Assert.Throws<ArgumentException> (() => main.GetResourceUrl ("resourceName", "resourceType", null, locale));
 		}
 
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestResourceUrlsLocalNameNullType (string type)
 		{
 			var main = CFBundle.GetMain ();
-			main.GetResourceUrls (type, null, "en");
+			Assert.Throws<ArgumentException> (() => main.GetResourceUrls (type, null, "en"));
 		}
 
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestResourceUrlsLocalNameNullLocale (string locale)
 		{
 			var main = CFBundle.GetMain ();
-			main.GetResourceUrls ("jpg", null, locale);
+			Assert.Throws<ArgumentException> (() => main.GetResourceUrls ("jpg", null, locale));
 		}
 
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestLocalizedStringNullKey (string key)
 		{
 			var main = CFBundle.GetMain ();
-			main.GetLocalizedString (key, null, "tableName");
+			Assert.Throws<ArgumentException> (() => main.GetLocalizedString (key, null, "tableName"));
 		} 
 
 		[TestCase ("")]
 		[TestCase (null)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestLocalizedStringNullTable (string tableName)
 		{
 			var main = CFBundle.GetMain ();
-			main.GetLocalizedString ("key", null, tableName);
+			Assert.Throws<ArgumentException> (() => main.GetLocalizedString ("key", null, tableName));
 		} 
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void TestGetLocalizationsForPreferencesNullLocalArray ()
 		{
-			CFBundle.GetLocalizationsForPreferences (null, new string [0]);
+			Assert.Throws<ArgumentNullException> (() => CFBundle.GetLocalizationsForPreferences (null, new string [0]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void TestGetLocalizationsForPreferencesNullPrefArray ()
 		{
-			CFBundle.GetLocalizationsForPreferences (new string [0], null);
+			Assert.Throws<ArgumentNullException> (() => CFBundle.GetLocalizationsForPreferences (new string [0], null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void TestGetInfoDictionaryNull ()
 		{
-			CFBundle.GetInfoDictionary (null);
+			Assert.Throws<ArgumentNullException> (() => CFBundle.GetInfoDictionary (null));
 		}
 	}
 }

--- a/tests/monotouch-test/CoreFoundation/UrlTest.cs
+++ b/tests/monotouch-test/CoreFoundation/UrlTest.cs
@@ -20,10 +20,9 @@ namespace MonoTouchFixtures.CoreFoundation {
 	public class CFUrlTest {
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void FromFile_Null ()
 		{
-			CFUrl.FromFile (null);
+			Assert.Throws<ArgumentNullException> (() => CFUrl.FromFile (null));
 		}
 
 		[Test]
@@ -37,10 +36,9 @@ namespace MonoTouchFixtures.CoreFoundation {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void FromUrlString_Null ()
 		{
-			CFUrl.FromUrlString (null, CFUrl.FromFile ("/"));
+			Assert.Throws<ArgumentNullException> (() => CFUrl.FromUrlString (null, CFUrl.FromFile ("/")));
 		}
 
 		[Test]

--- a/tests/monotouch-test/CoreText/FontManagerTest.cs
+++ b/tests/monotouch-test/CoreText/FontManagerTest.cs
@@ -221,11 +221,10 @@ namespace MonoTouchFixtures.CoreText {
 #endif
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void GetFontsNullUrl ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			CTFontManager.GetFonts (null);
+			Assert.Throws<ArgumentNullException> (() => CTFontManager.GetFonts (null));
 		}
 
 		[Test]

--- a/tests/monotouch-test/EventKit/CalendarTest.cs
+++ b/tests/monotouch-test/EventKit/CalendarTest.cs
@@ -143,13 +143,12 @@ namespace MonoTouchFixtures.EventKit {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void FromEventStore_Null ()
 		{
 #if MONOMAC
-			EKCalendar.Create (EKEntityType.Event, null);
+			Assert.Throws<ArgumentNullException> (() => EKCalendar.Create (EKEntityType.Event, null));
 #else
-			EKCalendar.FromEventStore (null);
+			Assert.Throws<ArgumentNullException> (() => EKCalendar.FromEventStore (null));
 #endif
 		}
 	}

--- a/tests/monotouch-test/Foundation/BlockOperationTest.cs
+++ b/tests/monotouch-test/Foundation/BlockOperationTest.cs
@@ -19,20 +19,18 @@ namespace MonoTouchFixtures.Foundation {
 	public class BlockOperationTest {
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Create_Null ()
 		{
 			// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[NSBlockOperation addExecutionBlock:]: block is nil
-			NSBlockOperation.Create (null);
+			Assert.Throws<ArgumentNullException> (() => NSBlockOperation.Create (null));
 		}
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Add_Null ()
 		{
 			using (var bo = NSBlockOperation.Create (Create_Null)) {
 				// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[NSBlockOperation addExecutionBlock:]: block is nil
-				bo.AddExecutionBlock (null);
+				Assert.Throws<ArgumentNullException> (() => bo.AddExecutionBlock (null));
 			}
 		}
 

--- a/tests/monotouch-test/Foundation/BundleTest.cs
+++ b/tests/monotouch-test/Foundation/BundleTest.cs
@@ -98,24 +98,21 @@ namespace MonoTouchFixtures.Foundation {
 		// I guess no one ever used them since they don't work...
 		// commented (selectors removed from MT bindings) - can be re-enabled to test newer iOS releases
 		[Test]
-		[ExpectedException (typeof (MonoTouchException))]
 		public void PathForImageResource ()
 		{
-			main.PathForImageResource ("basn3p08.png");
+			Assert.Throws<MonoTouchException> (() => main.PathForImageResource ("basn3p08.png"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (MonoTouchException))]
 		public void PathForSoundResource ()
 		{
-			main.PathForSoundResource ("basn3p08.png");
+			Assert.Throws<MonoTouchException> (() => main.PathForSoundResource ("basn3p08.png"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (MonoTouchException))]
 		public void LoadNib ()
 		{
-			NSBundle.LoadNib (String.Empty, main);
+			Assert.Throws<MonoTouchException> (() => NSBundle.LoadNib (String.Empty, main));
 		}
 #endif
 		[Test]

--- a/tests/monotouch-test/Foundation/FileCoordinatorTest.cs
+++ b/tests/monotouch-test/Foundation/FileCoordinatorTest.cs
@@ -45,7 +45,6 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void CoordinateRead_Null ()
 		{
 			using (var url = GetUrl ())
@@ -53,7 +52,7 @@ namespace MonoTouchFixtures.Foundation {
 				NSError err;
 				// NULL is not documented by Apple but it crash the app with:
 				// NSFileCoordinator: A surprising server error was signaled. Details: Connection invalid
-				fc.CoordinateRead (url, NSFileCoordinatorReadingOptions.WithoutChanges, out err, null);
+				Assert.Throws<ArgumentNullException> (() => fc.CoordinateRead (url, NSFileCoordinatorReadingOptions.WithoutChanges, out err, null));
 			}
 		}
 
@@ -71,7 +70,6 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void CoordinateWrite_Null ()
 		{
 			using (var url = GetUrl ())
@@ -79,7 +77,7 @@ namespace MonoTouchFixtures.Foundation {
 				NSError err;
 				// NULL is not documented by Apple but it crash the app with:
 				// NSFileCoordinator: A surprising server error was signaled. Details: Connection invalid
-				fc.CoordinateWrite (url, NSFileCoordinatorWritingOptions.ForDeleting, out err, null);
+				Assert.Throws<ArgumentNullException> (() => fc.CoordinateWrite (url, NSFileCoordinatorWritingOptions.ForDeleting, out err, null));
 			}
 		}
 		
@@ -102,7 +100,6 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void CoordinateReadWrite_Null ()
 		{
 			using (var url = GetUrl ())
@@ -110,7 +107,7 @@ namespace MonoTouchFixtures.Foundation {
 				NSError err;
 				// NULL is not documented by Apple but it crash the app with:
 				// NSFileCoordinator: A surprising server error was signaled. Details: Connection invalid
-				fc.CoordinateReadWrite (url, NSFileCoordinatorReadingOptions.WithoutChanges, url, NSFileCoordinatorWritingOptions.ForDeleting, out err, null);
+				Assert.Throws<ArgumentNullException> (() => fc.CoordinateReadWrite (url, NSFileCoordinatorReadingOptions.WithoutChanges, url, NSFileCoordinatorWritingOptions.ForDeleting, out err, null));
 			}
 		}
 
@@ -128,7 +125,6 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void CoordinateWriteWrite_Null ()
 		{
 			using (var url = GetUrl ())
@@ -136,7 +132,7 @@ namespace MonoTouchFixtures.Foundation {
 				NSError err;
 				// NULL is not documented by Apple but it crash the app with:
 				// NSFileCoordinator: A surprising server error was signaled. Details: Connection invalid
-				fc.CoordinateWriteWrite (url, NSFileCoordinatorWritingOptions.ForMoving, url, NSFileCoordinatorWritingOptions.ForDeleting, out err, null);
+				Assert.Throws<ArgumentNullException> (() => fc.CoordinateWriteWrite (url, NSFileCoordinatorWritingOptions.ForMoving, url, NSFileCoordinatorWritingOptions.ForDeleting, out err, null));
 			}
 		}
 		
@@ -159,7 +155,6 @@ namespace MonoTouchFixtures.Foundation {
 		}
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void CoordinateBatch_Action_Null ()
 		{
 			using (var url = GetUrl ())
@@ -167,7 +162,7 @@ namespace MonoTouchFixtures.Foundation {
 				NSError err;
 				// NULL is not documented by Apple but it crash the app with:
 				// NSFileCoordinator: A surprising server error was signaled. Details: Connection invalid
-				fc.CoordinateBatc (new NSUrl[] { url }, NSFileCoordinatorReadingOptions.WithoutChanges, new NSUrl[] { url }, NSFileCoordinatorWritingOptions.ForDeleting, out err, null);
+				Assert.Throws<ArgumentNullException> (() => fc.CoordinateBatc (new NSUrl[] { url }, NSFileCoordinatorReadingOptions.WithoutChanges, new NSUrl[] { url }, NSFileCoordinatorWritingOptions.ForDeleting, out err, null));
 			}
 		}
 	}

--- a/tests/monotouch-test/Foundation/OperationQueueTest.cs
+++ b/tests/monotouch-test/Foundation/OperationQueueTest.cs
@@ -20,12 +20,11 @@ namespace MonoTouchFixtures.Foundation {
 	public class OperationQueueTest {
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Add_NSAction_Null ()
 		{
 			using (var q = new NSOperationQueue ()) {
 				// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[NSBlockOperation addExecutionBlock:]: block is nil
-				q.AddOperation ((Action) null);
+				Assert.Throws<ArgumentNullException> (() => q.AddOperation ((Action) null));
 			}
 		}
 

--- a/tests/monotouch-test/Foundation/StringTest.cs
+++ b/tests/monotouch-test/Foundation/StringTest.cs
@@ -30,11 +30,10 @@ namespace MonoTouchFixtures.Foundation {
 	public class StringTest {
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Compare_Null ()
 		{
 			using (NSString s = new NSString ("s")) {
-				s.Compare (null);
+				Assert.Throws<ArgumentNullException> (() => s.Compare (null));
 			}
 		}
 		

--- a/tests/monotouch-test/GameplayKit/GKEntityTests.cs
+++ b/tests/monotouch-test/GameplayKit/GKEntityTests.cs
@@ -45,24 +45,22 @@ namespace MonoTouchFixtures.GamePlayKit {
 			Assert.IsNull (entity.GetComponent (typeof (NameComponent)), "Component typeof NameComponent must be null");
 		}
 
-		[ExpectedException (typeof (ArgumentNullException))]
 		[Test]
 		public void BadGetComponent ()
 		{
 			TestRuntime.AssertXcodeVersion (7, 0);
 
 			var entity = GKEntity.GetEntity ();
-			entity.GetComponent (null);
+			Assert.Throws<ArgumentNullException> (() => entity.GetComponent (null));
 		}
 
-		[ExpectedException (typeof (ArgumentNullException))]
 		[Test]
 		public void BadRemoval ()
 		{
 			TestRuntime.AssertXcodeVersion (7, 0);
 
 			var entity = GKEntity.GetEntity ();
-			entity.RemoveComponent (null);
+			Assert.Throws<ArgumentNullException> (() => entity.RemoveComponent (null));
 		}
 	}
 

--- a/tests/monotouch-test/Intents/INIntentResolutionResultTests.cs
+++ b/tests/monotouch-test/Intents/INIntentResolutionResultTests.cs
@@ -186,12 +186,13 @@ namespace MonoTouchFixtures.Intents {
 		}
 
 		[Test]
-#if __WATCHOS__
-		[ExpectedException (typeof (PlatformNotSupportedException))]
-#endif
 		public void INCarAirCirculationModeResolutionResultPropertyTest ()
 		{
-		
+#if __WATCHOS__
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INCarAirCirculationModeResolutionResult.NeedsValue; });
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INCarAirCirculationModeResolutionResult.NotRequired; });
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INCarAirCirculationModeResolutionResult.Unsupported; });
+#else
 			using (var needsValue = INCarAirCirculationModeResolutionResult.NeedsValue)
 			using (var notRequired = INCarAirCirculationModeResolutionResult.NotRequired)
 			using (var unsupported = INCarAirCirculationModeResolutionResult.Unsupported) {
@@ -203,14 +204,17 @@ namespace MonoTouchFixtures.Intents {
 				Assert.IsInstanceOfType (typeof (INCarAirCirculationModeResolutionResult), notRequired, "NotRequired");
 				Assert.IsInstanceOfType (typeof (INCarAirCirculationModeResolutionResult), unsupported, "Unsupported");
 			}
+#endif
 		}
 
 		[Test]
-#if __WATCHOS__
-		[ExpectedException (typeof (PlatformNotSupportedException))]
-#endif
 		public void INCarAudioSourceResolutionResultPropertyTest ()
 		{
+#if __WATCHOS__
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INCarAudioSourceResolutionResult.NeedsValue; });
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INCarAudioSourceResolutionResult.NotRequired; });
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INCarAudioSourceResolutionResult.Unsupported; });
+#else
 			using (var needsValue = INCarAudioSourceResolutionResult.NeedsValue)
 			using (var notRequired = INCarAudioSourceResolutionResult.NotRequired)
 			using (var unsupported = INCarAudioSourceResolutionResult.Unsupported) {
@@ -222,14 +226,17 @@ namespace MonoTouchFixtures.Intents {
 				Assert.IsInstanceOfType (typeof (INCarAudioSourceResolutionResult), notRequired, "NotRequired");
 				Assert.IsInstanceOfType (typeof (INCarAudioSourceResolutionResult), unsupported, "Unsupported");
 			}
+#endif
 		}
 
 		[Test]
-#if __WATCHOS__
-		[ExpectedException (typeof (PlatformNotSupportedException))]
-#endif
 		public void INCarDefrosterResolutionResultPropertyTest ()
 		{
+#if __WATCHOS__
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INCarDefrosterResolutionResult.NeedsValue; });
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INCarDefrosterResolutionResult.NotRequired; });
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INCarDefrosterResolutionResult.Unsupported; });
+#else
 			using (var needsValue = INCarDefrosterResolutionResult.NeedsValue)
 			using (var notRequired = INCarDefrosterResolutionResult.NotRequired)
 			using (var unsupported = INCarDefrosterResolutionResult.Unsupported) {
@@ -241,14 +248,17 @@ namespace MonoTouchFixtures.Intents {
 				Assert.IsInstanceOfType (typeof (INCarDefrosterResolutionResult), notRequired, "NotRequired");
 				Assert.IsInstanceOfType (typeof (INCarDefrosterResolutionResult), unsupported, "Unsupported");
 			}
+#endif
 		}
 
 		[Test]
-#if __WATCHOS__
-		[ExpectedException (typeof (PlatformNotSupportedException))]
-#endif
 		public void INCarSeatResolutionResultPropertyTest ()
 		{
+#if __WATCHOS__
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INCarSeatResolutionResult.NeedsValue; });
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INCarSeatResolutionResult.NotRequired; });
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INCarSeatResolutionResult.Unsupported; });
+#else
 			using (var needsValue = INCarSeatResolutionResult.NeedsValue)
 			using (var notRequired = INCarSeatResolutionResult.NotRequired)
 			using (var unsupported = INCarSeatResolutionResult.Unsupported) {
@@ -260,6 +270,7 @@ namespace MonoTouchFixtures.Intents {
 				Assert.IsInstanceOfType (typeof (INCarSeatResolutionResult), notRequired, "NotRequired");
 				Assert.IsInstanceOfType (typeof (INCarSeatResolutionResult), unsupported, "Unsupported");
 			}
+#endif
 		}
 
 		[Test]
@@ -327,11 +338,13 @@ namespace MonoTouchFixtures.Intents {
 		}
 
 		[Test]
-#if __WATCHOS__
-		[ExpectedException (typeof (PlatformNotSupportedException))]
-#endif
 		public void INRadioTypeResolutionResultPropertyTest ()
 		{
+#if __WATCHOS__
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INRadioTypeResolutionResult.NeedsValue; });
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INRadioTypeResolutionResult.NotRequired; });
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INRadioTypeResolutionResult.Unsupported; });
+#else
 			using (var needsValue = INRadioTypeResolutionResult.NeedsValue)
 			using (var notRequired = INRadioTypeResolutionResult.NotRequired)
 			using (var unsupported = INRadioTypeResolutionResult.Unsupported) {
@@ -343,14 +356,17 @@ namespace MonoTouchFixtures.Intents {
 				Assert.IsInstanceOfType (typeof (INRadioTypeResolutionResult), notRequired, "NotRequired");
 				Assert.IsInstanceOfType (typeof (INRadioTypeResolutionResult), unsupported, "Unsupported");
 			}
+#endif
 		}
 
 		[Test]
-#if __WATCHOS__
-		[ExpectedException (typeof (PlatformNotSupportedException))]
-#endif
 		public void INRelativeReferenceResolutionResultPropertyTest ()
 		{
+#if __WATCHOS__
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INRelativeReferenceResolutionResult.NeedsValue; });
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INRelativeReferenceResolutionResult.NotRequired; });
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INRelativeReferenceResolutionResult.Unsupported; });
+#else
 			using (var needsValue = INRelativeReferenceResolutionResult.NeedsValue)
 			using (var notRequired = INRelativeReferenceResolutionResult.NotRequired)
 			using (var unsupported = INRelativeReferenceResolutionResult.Unsupported) {
@@ -362,14 +378,17 @@ namespace MonoTouchFixtures.Intents {
 				Assert.IsInstanceOfType (typeof (INRelativeReferenceResolutionResult), notRequired, "NotRequired");
 				Assert.IsInstanceOfType (typeof (INRelativeReferenceResolutionResult), unsupported, "Unsupported");
 			}
+#endif
 		}
 
 		[Test]
-#if __WATCHOS__
-		[ExpectedException (typeof (PlatformNotSupportedException))]
-#endif
 		public void INRelativeSettingResolutionResultPropertyTest ()
 		{
+#if __WATCHOS__
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INRelativeSettingResolutionResult.NeedsValue; });
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INRelativeSettingResolutionResult.NotRequired; });
+			Assert.Throws<PlatformNotSupportedException> (() => { var v = INRelativeSettingResolutionResult.Unsupported; });
+#else
 			using (var needsValue = INRelativeSettingResolutionResult.NeedsValue)
 			using (var notRequired = INRelativeSettingResolutionResult.NotRequired)
 			using (var unsupported = INRelativeSettingResolutionResult.Unsupported) {
@@ -381,6 +400,7 @@ namespace MonoTouchFixtures.Intents {
 				Assert.IsInstanceOfType (typeof (INRelativeSettingResolutionResult), notRequired, "NotRequired");
 				Assert.IsInstanceOfType (typeof (INRelativeSettingResolutionResult), unsupported, "Unsupported");
 			}
+#endif
 		}
 
 #if !__WATCHOS__
@@ -415,7 +435,7 @@ namespace MonoTouchFixtures.Intents {
 				Assert.IsInstanceOfType (typeof (INRestaurantResolutionResult), unsupported, "Unsupported");
 			}
 		}
-#endif
+#endif // !__WATCHOS__
 
 		[Test]
 		public void INTemperatureResolutionResultPropertyTest ()

--- a/tests/monotouch-test/MapKit/PolygonTest.cs
+++ b/tests/monotouch-test/MapKit/PolygonTest.cs
@@ -22,10 +22,9 @@ namespace MonoTouchFixtures.MapKit {
 		}
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void FromPoints_Null ()
 		{
-			MKPolygon.FromPoints (null);
+			Assert.Throws<ArgumentNullException> (() => MKPolygon.FromPoints (null));
 		}
 
 		[Test]
@@ -69,10 +68,9 @@ namespace MonoTouchFixtures.MapKit {
 		}
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void FromCoordinates_Null ()
 		{
-			MKPolygon.FromCoordinates (null);
+			Assert.Throws<ArgumentNullException> (() => MKPolygon.FromCoordinates (null));
 		}
 
 		[Test]

--- a/tests/monotouch-test/MapKit/PolylineTest.cs
+++ b/tests/monotouch-test/MapKit/PolylineTest.cs
@@ -22,10 +22,9 @@ namespace MonoTouchFixtures.MapKit {
 		}
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void FromPoints_Null ()
 		{
-			MKPolyline.FromPoints (null);
+			Assert.Throws<ArgumentNullException> (() => MKPolyline.FromPoints (null));
 		}
 		
 		void CheckEmpty (MKPolyline pl)
@@ -63,10 +62,9 @@ namespace MonoTouchFixtures.MapKit {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void FromCoordinates_Null ()
 		{
-			MKPolyline.FromCoordinates (null);
+			Assert.Throws<ArgumentNullException> (() => MKPolyline.FromCoordinates (null));
 		}
 		
 		[Test]

--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -76,10 +76,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void RegisterAssembly_null ()
 		{
-			Runtime.RegisterAssembly (null);
+			Assert.Throws<ArgumentNullException> (() => Runtime.RegisterAssembly (null));
 		}
 
 #if !__WATCHOS__ && !__TVOS__ && !MONOMAC

--- a/tests/monotouch-test/Security/SecSharedCredentialTest.cs
+++ b/tests/monotouch-test/Security/SecSharedCredentialTest.cs
@@ -29,31 +29,21 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddSharedWebCredentialNullDomain ()
 		{
 			domainName = null;
 			Action<NSError> handler = (NSError e) =>  {
-				Assert.IsNull (e);
-				waitEvent.Set ();
 			};
-			SecSharedCredential.AddSharedWebCredential (domainName, account, password, handler); 
-			waitEvent.WaitOne ();
-			Assert.Pass ("Block was correctly executed.");
+			Assert.Throws<ArgumentNullException> (() => SecSharedCredential.AddSharedWebCredential (domainName, account, password, handler));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddSharedWebCredentialNullAccount ()
 		{
 			account = null;
 			Action<NSError> handler = (NSError e) =>  {
-				Assert.IsNull (e);
-				waitEvent.Set ();
 			};
-			SecSharedCredential.AddSharedWebCredential (domainName, account, password, handler); 
-			waitEvent.WaitOne ();
-			Assert.Pass ("Block was correctly executed.");
+			Assert.Throws<ArgumentNullException> (() => SecSharedCredential.AddSharedWebCredential (domainName, account, password, handler));
 		}
 
 		[Test]

--- a/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
+++ b/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
@@ -48,43 +48,32 @@ namespace MonoTouchFixtures.SystemConfiguration {
 
 #if !MONOMAC // TryCopyCurrentNetworkInfo and fields checked are not on Mac
 		[Test]
-#if __TVOS__
-		[ExpectedException (typeof (NotSupportedException))]
-#else
-		[ExpectedException (typeof (ArgumentNullException))]
-#endif
 		public void TryCopyCurrentNetworkInfo_Null ()
 		{
 			NSDictionary dict;
-			CaptiveNetwork.TryCopyCurrentNetworkInfo (null, out dict);
+#if __TVOS__
+			Assert.Throws<NotSupportedException> (() => CaptiveNetwork.TryCopyCurrentNetworkInfo (null, out dict));
+#else
+			Assert.Throws<ArgumentNullException> (() => CaptiveNetwork.TryCopyCurrentNetworkInfo (null, out dict));
+#endif
 		}
 		
 		[Test]
-#if __TVOS__
-		[ExpectedException (typeof (NotSupportedException))]
-#endif
 		public void TryCopyCurrentNetworkInfo ()
 		{
-			if (Runtime.Arch == Arch.SIMULATOR) {
-#if __IOS__
-				if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 6, 0))
-					Assert.Inconclusive ("This test throws EntryPointNotFoundException on the iOS 6 simulator with Lion");
-#endif
-			}
-
 			NSDictionary dict;
-			var status = CaptiveNetwork.TryCopyCurrentNetworkInfo ("en0", out dict);
+			StatusCode status;
+
+#if __TVOS__
+			Assert.Throws<NotSupportedException> (() => { status = CaptiveNetwork.TryCopyCurrentNetworkInfo ("en0", out dict); });
+#else
+			status = CaptiveNetwork.TryCopyCurrentNetworkInfo ("en0", out dict);
 
 			// No network, ignore test
 			if (status == StatusCode.NoKey)
 				return;
 
 			Assert.AreEqual (StatusCode.OK, status, "Status");
-
-#if __TVOS__
-			Assert.IsNull (dict, "Dictionary"); // null?
-			return;
-#endif
 
 			if ((dict == null) && (Runtime.Arch == Arch.DEVICE) && TestRuntime.CheckSystemVersion (PlatformName.iOS, 9, 0))
 				Assert.Ignore ("null on iOS9 devices - CaptiveNetwork is being deprecated ?!?");
@@ -96,68 +85,66 @@ namespace MonoTouchFixtures.SystemConfiguration {
 			} else {
 				Assert.Fail ("Unexpected dictionary result with {0} items", dict.Count);
 			}
+#endif
 		}
 #endif
 
 		[Test]
-#if __TVOS__
-		[ExpectedException (typeof (NotSupportedException))]
-#else
-		[ExpectedException (typeof (ArgumentNullException))]
-#endif
 		public void MarkPortalOnline_Null ()
 		{
-			CaptiveNetwork.MarkPortalOnline (null);
+#if __TVOS__
+			Assert.Throws<NotSupportedException> (() => CaptiveNetwork.MarkPortalOnline (null));
+#else
+			Assert.Throws<ArgumentNullException> (() => CaptiveNetwork.MarkPortalOnline (null));
+#endif
 		}
 
 		[Test]
-#if __TVOS__
-		[ExpectedException (typeof (NotSupportedException))]
-#endif
 		public void MarkPortalOnline ()
 		{
 			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
+
+#if __TVOS__
+			Assert.Throws<NotSupportedException> (() => CaptiveNetwork.MarkPortalOnline ("xamxam"));
+#else
 			Assert.False (CaptiveNetwork.MarkPortalOnline ("xamxam"));
+#endif
 		}
 		
 		[Test]
-#if __TVOS__
-		[ExpectedException (typeof (NotSupportedException))]
-#else
-		[ExpectedException (typeof (ArgumentNullException))]
-#endif
 		public void MarkPortalOffline_Null ()
 		{
-			CaptiveNetwork.MarkPortalOffline (null);
+#if __TVOS__
+			Assert.Throws<NotSupportedException> (() => CaptiveNetwork.MarkPortalOffline (null));
+#else
+			Assert.Throws<ArgumentNullException> (() => CaptiveNetwork.MarkPortalOffline (null));
+#endif
 		}
 
 		[Test]
-#if __TVOS__
-		[ExpectedException (typeof (NotSupportedException))]
-#endif
 		public void MarkPortalOffline ()
 		{
 			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
+#if __TVOS__
+			Assert.Throws<NotSupportedException> (() => CaptiveNetwork.MarkPortalOffline ("xamxam"));
+#else
 			Assert.False (CaptiveNetwork.MarkPortalOffline ("xamxam"));
+#endif
 		}
 		
 		[Test]
-#if __TVOS__
-		[ExpectedException (typeof (NotSupportedException))]
-#else
-		[ExpectedException (typeof (ArgumentNullException))]
-#endif
 		public void SetSupportedSSIDs_Null ()
 		{
-			CaptiveNetwork.SetSupportedSSIDs (null);
+#if __TVOS__
+			Assert.Throws<NotSupportedException> (() => CaptiveNetwork.SetSupportedSSIDs (null));
+#else
+			Assert.Throws<ArgumentNullException> (() => CaptiveNetwork.SetSupportedSSIDs (null));
+#endif
 		}
 
 		[Test]
-#if __TVOS__
-		[ExpectedException (typeof (NotSupportedException))]
-#endif
 		public void SetSupportedSSIDs ()
 		{
 			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
@@ -168,7 +155,11 @@ namespace MonoTouchFixtures.SystemConfiguration {
 			// that API is deprecated in iOS9 - and it might be why it returns false (or not)
 			bool supported = !TestRuntime.CheckXcodeVersion (7, 0);
 #endif
-			Assert.That (CaptiveNetwork.SetSupportedSSIDs (new string [2] { "one", "two" } ), Is.EqualTo (supported), "set");
+#if __TVOS__
+			Assert.Throws<NotSupportedException> (() => CaptiveNetwork.SetSupportedSSIDs (new string [2] { "one", "two" } ), "set");
+#else
+			Assert.That (CaptiveNetwork.SetSupportedSSIDs (new string [2] { "one", "two" }), Is.EqualTo (supported), "set");
+#endif
 		}
 	}
 }

--- a/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
+++ b/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
@@ -74,18 +74,25 @@ namespace MonoTouchFixtures.SystemConfiguration {
 				return;
 
 			Assert.AreEqual (StatusCode.OK, status, "Status");
-
-			if ((dict == null) && (Runtime.Arch == Arch.DEVICE) && TestRuntime.CheckSystemVersion (PlatformName.iOS, 9, 0))
-				Assert.Ignore ("null on iOS9 devices - CaptiveNetwork is being deprecated ?!?");
-
-			if (dict.Count == 3) {
-				Assert.NotNull (dict [CaptiveNetwork.NetworkInfoKeyBSSID], "NetworkInfoKeyBSSID");
-				Assert.NotNull (dict [CaptiveNetwork.NetworkInfoKeySSID], "NetworkInfoKeySSID");
-				Assert.NotNull (dict [CaptiveNetwork.NetworkInfoKeySSIDData], "NetworkInfoKeySSIDData");
-			} else {
-				Assert.Fail ("Unexpected dictionary result with {0} items", dict.Count);
-			}
+			// To get a non-null dictionary back, we must (https://developer.apple.com/documentation/systemconfiguration/1614126-cncopycurrentnetworkinfo)
+			// * Use core location, and request (and get) authorization to use location information
+			// * Add the 'com.apple.developer.networking.wifi-info' entitlement
+			// I tried this, and still got null back, so just assert that we get null.
+			Assert.IsNull (dict, "Dictionary");
 #endif
+		}
+
+		[Test]
+		public void TryGetSupportedInterfaces ()
+		{
+			StatusCode status;
+#if __TVOS__
+			Assert.Throws<NotSupportedException> (() => CaptiveNetwork.TryGetSupportedInterfaces (out var ifaces));
+#else
+			status = CaptiveNetwork.TryGetSupportedInterfaces (out var ifaces);
+			Assert.AreEqual (StatusCode.OK, status, "Status");
+			Assert.IsNull (ifaces, "Null Interfaces");
+#endif // __TVOS__
 		}
 #endif
 

--- a/tests/monotouch-test/UIKit/PopoverControllerTest.cs
+++ b/tests/monotouch-test/UIKit/PopoverControllerTest.cs
@@ -40,7 +40,6 @@ namespace MonoTouchFixtures.UIKit {
 		}
 
 		[Test]
-		[ExpectedException (typeof (MonoTouchException))]
 		public void PresentFromBarButtonItem_BadButton ()
 		{
 			if (UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Pad)
@@ -53,7 +52,7 @@ namespace MonoTouchFixtures.UIKit {
 			using (var bbi = new UIBarButtonItem (UIBarButtonSystemItem.Action))
 			using (var pc = new UIPopoverController (vc)) {
 				// UIBarButtonItem is itself 'ok' but it's not assigned to a view
-				pc.PresentFromBarButtonItem (bbi, UIPopoverArrowDirection.Down, true);
+				Assert.Throws<MonoTouchException> (() => pc.PresentFromBarButtonItem (bbi, UIPopoverArrowDirection.Down, true));
 				// fails with:
 				// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: -[UIPopoverController presentPopoverFromBarButtonItem:permittedArrowDirections:animated:]: Popovers cannot be presented from a view which does not have a window.
 			}
@@ -76,7 +75,6 @@ namespace MonoTouchFixtures.UIKit {
 		}
 
 		[Test]
-		[ExpectedException (typeof (MonoTouchException))]
 		public void PresentFromRect_BadView ()
 		{
 			if (UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Pad)
@@ -89,7 +87,7 @@ namespace MonoTouchFixtures.UIKit {
 			using (var bbi = new UIBarButtonItem (UIBarButtonSystemItem.Action))
 			using (var pc = new UIPopoverController (vc)) {
 				// 'vc' has never been shown
-				pc.PresentFromRect (new CGRect (10, 10, 100, 100), vc.View, UIPopoverArrowDirection.Down, true);
+				Assert.Throws<MonoTouchException> (() => pc.PresentFromRect (new CGRect (10, 10, 100, 100), vc.View, UIPopoverArrowDirection.Down, true));
 				// fails with:
 				// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: -[UIPopoverController presentPopoverFromRect:inView:permittedArrowDirections:animated:]: Popovers cannot be presented from a view which does not have a window.
 			}

--- a/tests/monotouch-test/UIKit/UIDocumentTest.cs
+++ b/tests/monotouch-test/UIKit/UIDocumentTest.cs
@@ -108,14 +108,13 @@ namespace MonoTouchFixtures.UIKit {
 		}
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void PerformAsynchronousFileAccess_Null ()
 		{
 			using (NSUrl url = NSUrl.FromFilename (GetFileName ()))
 			using (var doc = new MyDocument (url)) {
 				// NULL value is not documented by Apple but adding a
 				// [NullAllowed] would throw an Objective-C exception (bad)
-				doc.PerformAsynchronousFileAccess (null);
+				Assert.Throws<ArgumentNullException> (() => doc.PerformAsynchronousFileAccess (null));
 			}
 		}
 

--- a/tests/monotouch-test/UIKit/ViewTest.cs
+++ b/tests/monotouch-test/UIKit/ViewTest.cs
@@ -79,38 +79,33 @@ namespace MonoTouchFixtures.UIKit {
 		}
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Animate_Null_a1 ()
 		{
-			UIView.Animate (1.0, null);
+			Assert.Throws<ArgumentNullException> (() => UIView.Animate (1.0, null));
 		}
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Animate_Null_a2 ()
 		{
-			UIView.Animate (1.0, null, Completion);
+			Assert.Throws<ArgumentNullException> (() => UIView.Animate (1.0, null, Completion));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Animate_Null_a3 ()
 		{
-			UIView.Animate (1.0, 2.0, UIViewAnimationOptions.Autoreverse, null, Completion);
+			Assert.Throws<ArgumentNullException> (() => UIView.Animate (1.0, 2.0, UIViewAnimationOptions.Autoreverse, null, Completion));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AnimateNotify_Null_a1 ()
 		{
-			UIView.AnimateNotify (1.0, null, CompletionHandler);
+			Assert.Throws<ArgumentNullException> (() => UIView.AnimateNotify (1.0, null, CompletionHandler));
 		}
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AnimateNotify_Null_a2 ()
 		{
-			UIView.AnimateNotify (1.0, 2.0, UIViewAnimationOptions.Autoreverse, null, CompletionHandler);
+			Assert.Throws<ArgumentNullException> (() => UIView.AnimateNotify (1.0, 2.0, UIViewAnimationOptions.Autoreverse, null, CompletionHandler));
 		}
 		
 		[Test]


### PR DESCRIPTION
The ExpectedExceptionAttribute doesn't exist in newer versions of NUnit[Lite] anymore.