### PR TITLE
[monotouch-test] Comparing uint to int for inequality doesn't work newer versions of NUnit[Lite].

### DIFF
--- a/tests/monotouch-test/Network/NWEstablishmentReportTest.cs
+++ b/tests/monotouch-test/Network/NWEstablishmentReportTest.cs
@@ -89,7 +89,7 @@ namespace MonoTouchFixtures.Network {
 		}
 
 		[Test]
-		public void TestPreviousAttemptCount () => Assert.AreNotEqual (-1, report.PreviousAttemptCount);
+		public void TestPreviousAttemptCount () => Assert.AreNotEqual (uint.MaxValue, report.PreviousAttemptCount);
 
 		[Test]
 		public void TestDuration () => Assert.IsTrue (report.Duration > TimeSpan.MinValue);


### PR DESCRIPTION
So make sure we pass two values of the same type to Assert.AreNotEqual.