### PR TITLE
[xharness] Don't group simulators when running in server mode.

### DIFF
--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -361,6 +361,12 @@ namespace Xharness.Jenkins {
 							continue;
 						}
 
+						var simulator = task as RunSimulatorTask;
+						if (simulator != null) {
+							allSimulatorTasks.Add (simulator);
+							continue;
+						}
+
 						if (task is DotNetTestTask dotnet) {
 							allDotNetTestTasks.Add (dotnet);
 							continue;

--- a/tests/xharness/Jenkins/RunSimulatorTasksFactory.cs
+++ b/tests/xharness/Jenkins/RunSimulatorTasksFactory.cs
@@ -72,6 +72,9 @@ namespace Xharness.Jenkins {
 					tunnelBore: jenkins.TunnelBore,
 					candidates: candidates?.Cast<SimulatorDevice> () ?? test.Candidates)).ToList ();
 
+			if (jenkins.IsServerMode)
+				return testVariations;
+
 			foreach (var tv in testVariations) {
 				if (!tv.Ignored)
 					await tv.FindSimulatorAsync ();


### PR DESCRIPTION
Grouping simulators means we have to wait until we know which simulators are
available, because we group by the simulator's UDID.

When running in server mode, we don't need to group simulator test runs,
because we run the as the user chooses, not in any particular order.

This way the test list loads faster at startup, since we don't have to wait
until we've loaded the simulators before we can show the list.