### PR TITLE
[DevOps] If we cannot clear the hd, continue.

### DIFF
--- a/tools/devops/device-tests/scripts/System.psm1
+++ b/tools/devops/device-tests/scripts/System.psm1
@@ -194,7 +194,7 @@ function Clear-HD {
                 Write-Debug "Path not found '$dir'"
             }
         } catch {
-            Write-Error "Could not remove dir $dir - $_"
+            Write-Debug "Could not remove dir $dir - $_"
         }
     }
     Get-PSDrive "/" | Format-Table -Wrap

--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -95,6 +95,7 @@ steps:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
   displayName: 'Check HD Free Space'
   timeoutInMinutes: 5
+  condition: succeededOrFailed() # we do not care about the previous step
 
 # if we got to this point, it means that we do have at least 50 Gb to run the test, should
 # be more than enough, else the above script would have stopped the pipeline


### PR DESCRIPTION
Few things:

1. Move from Write-Error to Write-Debug so that we do not set the exit
code and an error.
2. If we fail in the Clear-HD step, continue, we should be ok or cancel
if not enough space is found.