### PR TITLE
[DevOps] Add debugging messages from when we fail the ./configure

### DIFF
--- a/configure
+++ b/configure
@@ -138,3 +138,4 @@ while test x$1 != x; do
 		;;
 	esac
 done
+exit 0

--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -98,7 +98,17 @@ steps:
 
 # if we got to this point, it means that we do have at least 50 Gb to run the test, should
 # be more than enough, else the above script would have stopped the pipeline
-- bash: cd xamarin-macios && ./configure --enable-xamarin
+- bash: |
+    set -x
+    set -e
+    cd xamarin-macios
+    ./configure --enable-xamarin
+    if [[ $? = 0 ]]; then
+      echo "Xamarin private packages configured."
+    else
+      echo "Xamarin packages configuration failed."
+      echo "Configuration exit code $?"
+    fi
   displayName: 'Enable Xamarin'
   timeoutInMinutes: 1
 


### PR DESCRIPTION
Some bots are giving error with this step. Try to add some verbosity and
ensure that $? is 0 when done.