### PR TITLE
[xharness] Fix finding testable types in test assemblies. Fixes #xamarin/maccore@2267.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/ProjectDefinition.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/ProjectDefinition.cs
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.TestImporter {
 					if (t.HasGenericParameters)
 						return false;
 
-					if (t.Namespace == null)
+					if (string.IsNullOrEmpty (t.Namespace))
 						return false;
 
 					if (!t.FullName.EndsWith ("Test", StringComparison.OrdinalIgnoreCase) && !t.FullName.EndsWith ("Tests", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Apparently a null namespace when using Reflection can be an empty namespace in Cecil.

Fixes https://github.com/xamarin/maccore/issues/2267.