### PR TITLE
[apitest] Sleep for 0.05s instead of 0.5s.

### DIFF
--- a/tests/apitest/src/Darwin/KernelNotificationTest.cs
+++ b/tests/apitest/src/Darwin/KernelNotificationTest.cs
@@ -26,7 +26,7 @@ namespace apitest
 		public void KEvent ()
 		{
 			// (KernelEvent[], KernelEvent[])
-			using (var sleep = Process.Start ("/bin/sleep", "0.5")) {
+			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					Assert.IsTrue (kqueue.KEvent (events, events), "kevent");
@@ -34,7 +34,7 @@ namespace apitest
 			}
 
 			// (KernelEvent[], KernelEvent[], TimeSpan?)
-			using (var sleep = Process.Start ("/bin/sleep", "0.5")) {
+			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					Assert.AreEqual (1, kqueue.KEvent (events, events, TimeSpan.FromSeconds (5)), "kevent");
@@ -42,7 +42,7 @@ namespace apitest
 			}
 
 			// (KernelEvent[], KernelEvent[], TimeSpan?)
-			using (var sleep = Process.Start ("/bin/sleep", "0.5")) {
+			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					Assert.AreEqual (1, kqueue.KEvent (events, events, null), "kevent");
@@ -50,7 +50,7 @@ namespace apitest
 			}
 
 			// (KernelEvent[], int, KernelEvent[], int, TimeSpec?)
-			using (var sleep = Process.Start ("/bin/sleep", "0.5")) {
+			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					TimeSpec ts = new TimeSpec
@@ -62,7 +62,7 @@ namespace apitest
 			}
 
 			// (KernelEvent[], int, KernelEvent[], int, TimeSpec?)
-			using (var sleep = Process.Start ("/bin/sleep", "0.5")) {
+			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					Assert.AreEqual (1, kqueue.KEvent (events, events.Length, events, events.Length, null), "kevent");
@@ -70,7 +70,7 @@ namespace apitest
 			}
 
 			// (KernelEvent[], int, KernelEvent[], int, ref TimeSpec)
-			using (var sleep = Process.Start ("/bin/sleep", "0.5")) {
+			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					TimeSpec ts = new TimeSpec
@@ -82,7 +82,7 @@ namespace apitest
 			}
 
 			// (KernelEvent[], KernelEvent[], ref TimeSpec)
-			using (var sleep = Process.Start ("/bin/sleep", "0.5")) {
+			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					TimeSpec ts = new TimeSpec
@@ -94,7 +94,7 @@ namespace apitest
 			}
 
 			// (KernelEvent[], int, KernelEvent[], int)
-			using (var sleep = Process.Start ("/bin/sleep", "0.5")) {
+			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					Assert.IsTrue (kqueue.KEvent (events, events.Length, events, events.Length), "kevent");

--- a/tests/apitest/src/Darwin/KernelNotificationTest.cs
+++ b/tests/apitest/src/Darwin/KernelNotificationTest.cs
@@ -25,8 +25,9 @@ namespace apitest
 		[Test]
 		public void KEvent ()
 		{
+			var sleep_duration = "0.05";
 			// (KernelEvent[], KernelEvent[])
-			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
+			using (var sleep = Process.Start ("/bin/sleep", sleep_duration)) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					Assert.IsTrue (kqueue.KEvent (events, events), "kevent");
@@ -34,7 +35,7 @@ namespace apitest
 			}
 
 			// (KernelEvent[], KernelEvent[], TimeSpan?)
-			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
+			using (var sleep = Process.Start ("/bin/sleep", sleep_duration)) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					Assert.AreEqual (1, kqueue.KEvent (events, events, TimeSpan.FromSeconds (5)), "kevent");
@@ -42,7 +43,7 @@ namespace apitest
 			}
 
 			// (KernelEvent[], KernelEvent[], TimeSpan?)
-			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
+			using (var sleep = Process.Start ("/bin/sleep", sleep_duration)) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					Assert.AreEqual (1, kqueue.KEvent (events, events, null), "kevent");
@@ -50,7 +51,7 @@ namespace apitest
 			}
 
 			// (KernelEvent[], int, KernelEvent[], int, TimeSpec?)
-			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
+			using (var sleep = Process.Start ("/bin/sleep", sleep_duration)) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					TimeSpec ts = new TimeSpec
@@ -62,7 +63,7 @@ namespace apitest
 			}
 
 			// (KernelEvent[], int, KernelEvent[], int, TimeSpec?)
-			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
+			using (var sleep = Process.Start ("/bin/sleep", sleep_duration)) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					Assert.AreEqual (1, kqueue.KEvent (events, events.Length, events, events.Length, null), "kevent");
@@ -70,7 +71,7 @@ namespace apitest
 			}
 
 			// (KernelEvent[], int, KernelEvent[], int, ref TimeSpec)
-			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
+			using (var sleep = Process.Start ("/bin/sleep", sleep_duration)) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					TimeSpec ts = new TimeSpec
@@ -82,7 +83,7 @@ namespace apitest
 			}
 
 			// (KernelEvent[], KernelEvent[], ref TimeSpec)
-			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
+			using (var sleep = Process.Start ("/bin/sleep", sleep_duration)) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					TimeSpec ts = new TimeSpec
@@ -94,7 +95,7 @@ namespace apitest
 			}
 
 			// (KernelEvent[], int, KernelEvent[], int)
-			using (var sleep = Process.Start ("/bin/sleep", "0.05")) {
+			using (var sleep = Process.Start ("/bin/sleep", sleep_duration)) {
 				using (var kqueue = new KernelQueue ()) {
 					var events = CreateEvents (sleep);
 					Assert.IsTrue (kqueue.KEvent (events, events.Length, events, events.Length), "kevent");


### PR DESCRIPTION
This makes these tests exactly 3.6s faster.