### PR TITLE
[apitest] Refactor tests to not be async.

### DIFF
--- a/tests/apitest/src/AudioUnit/AUGraphTest.cs
+++ b/tests/apitest/src/AudioUnit/AUGraphTest.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Threading.Tasks;
+using System.Threading;
 using NUnit.Framework;
 
 using AppKit;
@@ -49,7 +49,7 @@ namespace Xamarin.Mac.Tests
 		}
 
 		[Test]
-		public async Task DoTest ()
+		public void DoTest ()
 		{
 			SetupAUGraph ();
 
@@ -60,7 +60,7 @@ namespace Xamarin.Mac.Tests
 			AudioUnitStatus status = mMixer.SetRenderCallback (MixerRenderCallback);
 			Assert.AreEqual (AudioUnitStatus.OK, status );
 
-			await WaitOnGraphAndMixerCallbacks ();
+			WaitOnGraphAndMixerCallbacks ();
 		}
 
 		AudioUnitStatus GraphRenderCallback (AudioUnitRenderActionFlags actionFlags, AudioTimeStamp timeStamp, uint busNumber, uint numberFrames, AudioBuffers data)
@@ -75,7 +75,7 @@ namespace Xamarin.Mac.Tests
 			return AudioUnitStatus.NoError;
 		}
 
-		async Task WaitOnGraphAndMixerCallbacks ()
+		void WaitOnGraphAndMixerCallbacks ()
 		{
 			graph.Initialize ();
 			graph.Start ();
@@ -85,7 +85,7 @@ namespace Xamarin.Mac.Tests
 				for (int i = 0; i < 100; ++i) {
 					if (graphRenderCallbackCount > 0 && mixerRenderCallbackCount > 0)
 						return;
-					await Task.Delay (10);
+					Thread.Sleep (10);
 				}
 				Assert.Fail ("Did not see events after 1 second");
 			}

--- a/tests/apitest/src/Foundation/NSObject.cs
+++ b/tests/apitest/src/Foundation/NSObject.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Threading.Tasks;
+using System.Threading;
 using NUnit.Framework;
 
 using AppKit;
@@ -13,17 +13,12 @@ namespace Xamarin.Mac.Tests
 	public class NSObjectTests
 	{
 		[Test]
-		async public Task NSObjectTests_InvokeTest ()
+		public void NSObjectTests_InvokeTest ()
 		{
 			bool hit = false;
 			NSApplication.SharedApplication.Invoke (() => hit = true, 1);
-			// Wait for 10 second, then give up
-			for (int i = 0; i < 1000; ++i) {
-				if (hit)
-					return;
-				await Task.Delay (10);
-			}
-			Assert.Fail ("Did not see events after 10 second");
+			TestRuntime.RunAsync (TimeSpan.FromSeconds (10), () => { }, () => hit);
+			Assert.IsTrue (hit, "Did not see events after 10 second");
 		}
 	}
 }

--- a/tests/apitest/src/Foundation/NSObject.cs
+++ b/tests/apitest/src/Foundation/NSObject.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Mac.Tests
 			bool hit = false;
 			NSApplication.SharedApplication.Invoke (() => hit = true, 1);
 			TestRuntime.RunAsync (TimeSpan.FromSeconds (10), () => { }, () => hit);
-			Assert.IsTrue (hit, "Did not see events after 10 second");
+			Assert.IsTrue (hit, "Did not see events after 10 seconds");
 		}
 	}
 }


### PR DESCRIPTION
The macOS tests will soon be upgraded to use the official NUnit[Lite], and in
that case we can't use async tests, because they end up deadlocking the
processes.

So refactor the two tests this affect to not be async, but instead use other
methods of accomplishing the same thing.