### PR TITLE
[xharness] Try harder to make lldb quit after trying to get a backtrace.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Execution/ProcessManager.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Execution/ProcessManager.cs
@@ -250,6 +250,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution {
 
 				foreach (var diagnose_pid in pids) {
 					var template = Path.GetTempFileName ();
+					var templateQuit = Path.GetTempFileName ();
 					try {
 						var commands = new StringBuilder ();
 						using (var dbg = new Process ()) {
@@ -259,8 +260,9 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution {
 							commands.AppendLine ("detach");
 							commands.AppendLine ("quit");
 							dbg.StartInfo.FileName = "/usr/bin/lldb";
-							dbg.StartInfo.Arguments = StringUtils.FormatArguments ("--source", template);
+							dbg.StartInfo.Arguments = StringUtils.FormatArguments ("--source", template, "--source", templateQuit);
 							File.WriteAllText (template, commands.ToString ());
+							File.WriteAllText (templateQuit, "quit\n");
 
 							log.WriteLine ($"Printing backtrace for pid={pid}");
 							await RunAsyncInternal (dbg, log, log, log, TimeSpan.FromSeconds (30), diagnostics: false);
@@ -268,6 +270,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution {
 					} finally {
 						try {
 							File.Delete (template);
+							File.Delete (templateQuit);
 						} catch {
 							// Don't care
 						}


### PR DESCRIPTION
When a process times out, we try to print a stack trace for all threads. This
involves executing "lldb --source <script>", where the script contains:

	process attach --pid 1234
	thread list
	thread backtrace all
	detach
	quit

Basically we attach to the project, and ask lldb to print stack traces.

The problem:

    16:09:02.9522580 Printing backtrace for pid=25276
    16:09:02.9528060 /usr/bin/lldb --source /var/folders/q7/mkzwrzcn7bzf3g2v38f3c1cw0000gn/T/tmp58e75d85.tmp
    16:09:04.6127570 (lldb) command source -s 0 '/var/folders/q7/mkzwrzcn7bzf3g2v38f3c1cw0000gn/T/tmp58e75d85.tmp'
    16:09:04.6130020 Executing commands in '/var/folders/q7/mkzwrzcn7bzf3g2v38f3c1cw0000gn/T/tmp58e75d85.tmp'.
    16:09:04.6130200 (lldb) process attach --pid 25276
    16:09:05.6458750 error: attach failed: Error 1
    16:09:05.7529100 25276 Execution timed out after 1200 seconds and the process was killed.
    16:09:05.7588770 Execution timed out after 1200 seconds.

If any of those commands fail, the subsequent commands aren't executed. This
includes the final "quit" command, which means we end up waiting forever for
lldb to do its thing, when lldb doesn't think it needs to do anything at all.

The fix: pass two different scripts. It turns out subsequent scripts are
executed even if previous scripts fail, so we do the equivalent of:

     lldb --source <attach script> --source <quit script>

And now lldb will quit no matter what the attach script does (it still works
even if the attach script succeeds, in which case we'll ask lldb to quit
twice).