### PR TITLE
[xharness] Improve process killing a bit.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Execution/ProcessManager.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Execution/ProcessManager.cs
@@ -277,12 +277,19 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution {
 
 			// Send SIGABRT since that produces a crash report
 			// lldb may fail to attach to system processes, but crash reports will still be produced with potentially helpful stack traces.
-			for (int i = 0; i < pids.Count; i++)
+			for (int i = 0; i < pids.Count; i++) {
+				log.WriteLine ($"kill -6 {pids [i]}");
 				kill (pids [i], 6);
+			}
+
+			// Wait a little bit for the OS to process the SIGABRTs
+			await Task.Delay (TimeSpan.FromSeconds (5));
 
 			// send kill -9 anyway as a last resort
-			for (int i = 0; i < pids.Count; i++)
+			for (int i = 0; i < pids.Count; i++) {
+				log.WriteLine ($"kill -9 {pids [i]}");
 				kill (pids [i], 9);
+			}
 		}
 
 		static async Task<bool> WaitForExitAsync (Process process, TimeSpan? timeout = null)


### PR DESCRIPTION
* Log what we're doing.
* Wait a bit after sending SIGABRT, to allow for the OS to create any crash
  reports.