### PR TITLE
[xharness] Don't replace existing files, instead add new files, when providing human-readable logs.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
@@ -318,12 +318,9 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared {
 					}
 					path = newFilename;
 
-					// write the human readable results in a tmp file, which we later use to step on the logs
-					var tmpFile = Path.Combine (Path.GetTempPath (), Guid.NewGuid ().ToString ());
-					(parseResult.resultLine, parseResult.failed) = resultParser.GenerateHumanReadableResults (path, tmpFile, xmlType);
-					File.Copy (tmpFile, test_log_path, true);
-					File.Delete (tmpFile);
-
+					var humanReadableLog = logs.CreateFile (Path.GetFileNameWithoutExtension (test_log_path) + ".log", LogType.NUnitResult.ToString ());
+					(parseResult.resultLine, parseResult.failed) = resultParser.GenerateHumanReadableResults (path, humanReadableLog, xmlType);
+					
 					// we do not longer need the tmp file
 					logs.AddFile (path, LogType.XmlLog.ToString ());
 					return parseResult;


### PR DESCRIPTION
This makes understanding what's going on much easier.