### PR TITLE
[xharness] Fix BCL project generation for watchOS projects.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/XamariniOSTemplate.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/XamariniOSTemplate.cs
@@ -504,10 +504,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.TestImporter.Templates.Managed {
 					using (var file = new StreamWriter (infoPlistPath, false)) { // false is do not append
 						await file.WriteAsync (rootPlist);
 					}
-
-					using (var file = new StreamWriter (rootProjectPath, false)) // false is do not append
-					using (var reader = new StreamReader (GetProjectTemplate (Platform.WatchOS))) {
-						var template = await reader.ReadToEndAsync ();
+					using (var file = new StreamWriter (rootProjectPath, false)) { // false is do not append
+						var template = GetProjectTemplate (Platform.WatchOS);
 						var generatedRootProject = GenerateWatchProject (def.Name, template, infoPlistPath);
 						await file.WriteAsync (generatedRootProject);
 					}


### PR DESCRIPTION
Reading from a file named as the actual content of the watchOS template doesn't
_quite_ work. Instead just use the content directly.

This regressed in c394c12c5.