### PR TITLE
[xharness] Disable default inclusion behavior for the introspection .NET tests.

### DIFF
--- a/tests/introspection/iOS/introspection-ios-dotnet.csproj
+++ b/tests/introspection/iOS/introspection-ios-dotnet.csproj
@@ -12,6 +12,7 @@
     <AssetTargetFallback>xamarinios10;$(AssetTargetFallback)</AssetTargetFallback>
     <!-- This is needed because the packages/ directory might be in the same folder as this project file, and some some packages might have C# files, which would then automatically be included -->
     <DefaultItemExcludes>$(DefaultItemExcludes);packages/**;</DefaultItemExcludes>
+    <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +34,18 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="Main.cs" />
+    <Compile Include="AppDelegate.cs" />
+    <Compile Include="iOSApiCtorInitTest.cs" />
+    <Compile Include="iOSApiFieldTest.cs" />
+    <Compile Include="iOSApiSelectorTest.cs" />
+    <Compile Include="iOSApiSignatureTest.cs" />
+    <Compile Include="iOSApiProtocolTest.cs" />
+    <Compile Include="iOSApiWeakPropertyTest.cs" />
+    <Compile Include="iOSApiPInvokeTest.cs" />
+    <Compile Include="iOSApiClassPtrTest.cs" />
+    <Compile Include="iOSApiTypoTest.cs" />
+    <Compile Include="iOSCoreImageFiltersTest.cs" />
     <Compile Include="..\ApiBaseTest.cs">
       <Link>ApiBaseTest.cs</Link>
     </Compile>
@@ -102,6 +115,26 @@
     <Compile Include="..\ApiTypeTest.cs">
       <Link>ApiTypeTest.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist">
+      <LogicalName>Info.plist</LogicalName>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <InterfaceDefinition Include="LaunchScreen.storyboard" Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" />
+  </ItemGroup>
+  <ItemGroup>
+    <ImageAsset Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="Assets.xcassets\AppIcons.appiconset\Contents.json" />
+    <ImageAsset Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="Assets.xcassets\AppIcons.appiconset\Icon-app-60%403x.png" />
+    <ImageAsset Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="Assets.xcassets\AppIcons.appiconset\icon-app-57.png" />
+    <ImageAsset Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="Assets.xcassets\AppIcons.appiconset\icon-app-57%402x.png" />
+    <ImageAsset Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="Assets.xcassets\AppIcons.appiconset\icon-app-60%402x.png" />
+    <ImageAsset Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="Assets.xcassets\AppIcons.appiconset\icon-app-72.png" />
+    <ImageAsset Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="Assets.xcassets\AppIcons.appiconset\icon-app-72%402x.png" />
+    <ImageAsset Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="Assets.xcassets\AppIcons.appiconset\icon-app-76.png" />
+    <ImageAsset Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="Assets.xcassets\AppIcons.appiconset\icon-app-76%402x.png" />
+    <ImageAsset Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="Assets.xcassets\AppIcons.appiconset\icon-app-83.5%402x.png" />
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="..\xamarin1.png">

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs
@@ -588,6 +588,14 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 			return attrib != null;
 		}
 
+		public static bool? GetEnableDefaultItems (this XmlDocument csproj)
+		{
+			var node = csproj.SelectSingleNode ($"/*/*/*[local-name() = 'EnableDefaultItems']");
+			if (node == null)
+				return null;
+			return string.Equals (node.InnerText, "true", StringComparison.OrdinalIgnoreCase);
+		}
+
 		static XmlNode GetInfoPListNode (this XmlDocument csproj, bool throw_if_not_found = false)
 		{
 			var logicalNames = csproj.SelectNodes ("//*[local-name() = 'LogicalName']");


### PR DESCRIPTION
It gets too annoying to keep track of which files are where with the project
cloning we're doing, if files are implicitly included.