### PR TITLE
[xharness] Allow for null environment variables to mlaunch.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Execution/Mlaunch/Arguments.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Execution/Mlaunch/Arguments.cs
@@ -181,10 +181,11 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution.Mlaunch {
 		public SetEnvVariableArgument (string variableName, object variableValue)
 		{
 			this.variableName = variableName ?? throw new ArgumentNullException (nameof (variableName));
-			this.variableValue = variableValue?.ToString () ?? throw new ArgumentNullException (nameof (variableValue));
 
-			if (variableValue is bool)
-				this.variableValue = this.variableValue.ToLower ();
+			if (variableValue is bool b)
+				this.variableValue = b.ToString ().ToLower ();
+			else
+				this.variableValue = variableValue?.ToString ();
 		}
 
 		public override string AsCommandLineArgument () => Escape ($"-setenv={variableName}={variableValue}");

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Execution/Mlaunch/Arguments.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Execution/Mlaunch/Arguments.cs
@@ -183,7 +183,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution.Mlaunch {
 			this.variableName = variableName ?? throw new ArgumentNullException (nameof (variableName));
 
 			if (variableValue is bool b)
-				this.variableValue = b.ToString ().ToLower ();
+				this.variableValue = b.ToString ().ToLowerInvariant ();
 			else
 				this.variableValue = variableValue?.ToString ();
 		}


### PR DESCRIPTION
It's a valid scenario to set a null environment variable.

This happens when changing InCI to always return true (to test locally what's
done on the bots), in which case we try to forward BUILD_REVISION to mlaunch,
but BUILD_REVISION isn't necessarily set. Not forwarding it to mlaunch should
not cause problems in most tests, so just allow this scenario.