### PR TITLE
[d16-8][msbuild] Avoids running GetMinimumOSVersion if no Mac is connected

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -204,6 +204,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<Target Name="_GetMinimumOSVersion" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_ComputeTargetFrameworkMoniker">
 		<GetMinimumOSVersion
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			AppManifest="$(_AppManifest)"
 			SdkVersion="$(_SdkVersion)"


### PR DESCRIPTION
`GetMinimumOSVersion` should not be run if there's no Mac available because it depends on `_DetectSdkLocations` to calculate the value of `_SdkVersion`, and this will only happen if there's a Mac connected. This change fixes offline builds (plain IL builds) and Hot Restart builds on Windows.