### PR TITLE
[msbuild] Share the logic to implicitly include netstandard.dll in the build.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
@@ -23,6 +23,4 @@ Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.TargetFrameworkFix.targets"/>
-
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.Common.ImplicitFacade.msbuild.targets" Condition="'$(TargetFrameworkName)' == 'Modern' Or '$(TargetFrameworkName)' == 'Full'"/>
 </Project>

--- a/msbuild/Xamarin.Shared/Xamarin.ImplicitFacade.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.ImplicitFacade.targets
@@ -1,26 +1,29 @@
-﻿<!--
+<!--
 ***********************************************************************************************
-Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
+Xamarin.ImplicitFacade.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
   created a backup copy.  Incorrect changes to this file will make it
   impossible to load or build your projects from the command-line or the IDE.
 
-This file imports the version- and platform-specific targets for the project importing
-this file. This file also defines targets to produce an error if the specified targets
-file does not exist, but the project is built anyway (command-line or IDE build).
-
-Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
+Copyright (c) 2017, 2020 Microsoft Corp. (www.microsoft.com)
 ***********************************************************************************************
 -->
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<!-- All of this logic copied directly from Microsoft.NETFramework.CurrentVersion.targets -->
-	<!-- XM Mobile/Modern builds do not import it since their TVI is not NETFramework -->
-	<!-- However it is needed to successfully consume netstandard nuget packages -->
-	
+	<!-- Support for netstandard
+		 This logic is a modified copy of the logic in Microsoft.NETFramework.CurrentVersion.targets.
+		 XI/XM Mobile/XM Modern builds do not import Microsoft.NETFramework.CurrentVersion.targets,
+		 since their TVI is not NETFramework. However it is needed to successfully consume netstandard
+		 nuget packages.
+	-->
+
+	<!-- Implicitly references all portable design-time facades if the user is referencing a System.Runtime-based portable library -->
 	<PropertyGroup>
+		<ImplicitlyExpandDesignTimeFacades>true</ImplicitlyExpandDesignTimeFacades>
+		<CheckForSystemRuntimeDependency>true</CheckForSystemRuntimeDependency>
+
 		<ResolveReferencesDependsOn>
 			$(ResolveReferencesDependsOn);
 			ImplicitlyExpandDesignTimeFacades
@@ -43,15 +46,17 @@ Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 
 	<Target Name="ImplicitlyExpandDesignTimeFacades" DependsOnTargets="$(ImplicitlyExpandDesignTimeFacadesDependsOn)">
 		<ItemGroup>
-			<XM_CandidateNETStandardReferences Include="@(Reference);@(_ResolvedProjectReferencePaths)" />
-			<XM_InboxNETStandardFolders Include="$(TargetFrameworkDirectory)" />
+			<_Xamarin_CandidateNETStandardReferences Include="@(Reference);@(_ResolvedProjectReferencePaths)" />
+			<_Xamarin_InboxNETStandardFolders Include="$(TargetFrameworkDirectory)" />
 		</ItemGroup>
 
 		<PropertyGroup>
 			<!-- Does one of our dependencies reference a System.Runtime-based portable library? -->
-			<_HasReferenceToSystemRuntime Condition="'$(DependsOnSystemRuntime)' == 'true' or '%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable'">true</_HasReferenceToSystemRuntime>
+			<_HasReferenceToSystemRuntime Condition="'$(DependsOnSystemRuntime)' == 'true'">true</_HasReferenceToSystemRuntime>
+			<_HasReferenceToSystemRuntime Condition="'%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable'">true</_HasReferenceToSystemRuntime>
+			<_HasReferenceToSystemRuntime Condition="'%(ReferenceDependencyPaths.Filename)' == 'System.Runtime'">true</_HasReferenceToSystemRuntime>
 
-			<XM_NETStandardInbox Condition="'$(XM_NETStandardInbox)' == '' and Exists('%(XM_InboxNETStandardFolders.Identity)\netstandard.dll')">true</XM_NETStandardInbox>
+			<_Xamarin_NETStandardInbox Condition="'$(_Xamarin_NETStandardInbox)' == '' and Exists('%(_Xamarin_InboxNETStandardFolders.Identity)\netstandard.dll')">true</_Xamarin_NETStandardInbox>
 
 			<!--
 				This is `true` if any of the references depends on `netstandard`.
@@ -59,27 +64,28 @@ Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 				In cases where `ResolveAssemblyReference` task does get run, it populates `$(_DependsOnNETStandard)` property, so we don't
 				need to check this again.
 			-->
-			<XM_DependsOnNETStandard Condition="'$(XM_DependsOnNETStandard)' == ''">$(_DependsOnNETStandard)</XM_DependsOnNETStandard>
+			<_Xamarin_DependsOnNETStandard Condition="'$(_Xamarin_DependsOnNETStandard)' == ''">$(_DependsOnNETStandard)</_Xamarin_DependsOnNETStandard>
 		</PropertyGroup>
 
 		<!--
 		     Facades are expanded if we have a reference that depends on System.Runtime .
 
-		     This file is imported for Modern projects, which have have `$(TargetFrameworkIdentifier) != .NETFramework`, so Microsoft.NET.Build.Extensions
-		     (which provides support for ns 2.0 projects) doesn't get imported. And netstandard.dll reference, even if required, doesn't get added.
+		     XI, XM/Mobile and XM/Modern projects have `$(TargetFrameworkIdentifier) != .NETFramework`, so Microsoft.NET.Build.Extensions
+		     (which provides support for ns 2.0 projects) doesn't get imported. And netstandard.dll reference, even if required, doesn't
+		     get added.
 
 		     So, we need to check if any references depend on `netstandard`. And if so, expand the facades, which include netstandard.dll .
 
 		     If $(_HasReferenceToSystemRuntime) is true, then the facades are going to be expanded anyway, so don't run this.
 		-->
 		<GetDependsOnNETStandard
-			Condition="'$(_HasReferenceToSystemRuntime)' != 'true' and '$(XM_DependsOnNETStandard)' == '' and '@(XM_CandidateNETStandardReferences)' != ''
+			Condition="'$(_HasReferenceToSystemRuntime)' != 'true' and '$(_Xamarin_DependsOnNETStandard)' == '' and '@(_Xamarin_CandidateNETStandardReferences)' != ''
 				and Exists('$(_NETBuildExtensionsTaskAssembly)')"
-			References="@(XM_CandidateNETStandardReferences)">
-			<Output TaskParameter="DependsOnNETStandard" PropertyName="XM_DependsOnNETStandard" />
+			References="@(_Xamarin_CandidateNETStandardReferences)">
+			<Output TaskParameter="DependsOnNETStandard" PropertyName="_Xamarin_DependsOnNETStandard" />
 		</GetDependsOnNETStandard>
 
-		<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true' or ('$(XM_NETStandardInbox)' == 'true' and '$(XM_DependsOnNETStandard)' == 'true')">
+		<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true' or ('$(_Xamarin_NETStandardInbox)' == 'true' and '$(_Xamarin_DependsOnNETStandard)' == 'true')">
 			<_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
 
 			<_DesignTimeFacadeAssemblies_Names Include="@(_DesignTimeFacadeAssemblies->'%(FileName)')">

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -528,6 +528,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</ItemGroup>
 	</Target>
 
+	<!-- Xamarin.ImplicitFacade.targets will detect if we need to add an implicit reference to netstandard.dll -->
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.ImplicitFacade.targets" Condition="!('$(_PlatformName)' == 'macOS' And '$(TargetFrameworkName)' == 'System')"/>
+
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
 </Project>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -52,23 +52,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<AppBundleExtension Condition="'$(AppBundleExtension)' == ''">.app</AppBundleExtension>
 	</PropertyGroup>
-	
-	<PropertyGroup>
-		<ImplicitlyExpandDesignTimeFacades>true</ImplicitlyExpandDesignTimeFacades>
-		<CheckForSystemRuntimeDependency>true</CheckForSystemRuntimeDependency>
-
-		<ResolveReferencesDependsOn>
-			_SeparateAppExtensionReferences;
-			_SeparateWatchAppReferences;
-			$(ResolveReferencesDependsOn);
-			ImplicitlyExpandDesignTimeFacades
-		</ResolveReferencesDependsOn>
-
-		<ImplicitlyExpandDesignTimeFacadesDependsOn>
-			$(ImplicitlyExpandDesignTimeFacadesDependsOn);
-			GetReferenceAssemblyPaths
-		</ImplicitlyExpandDesignTimeFacadesDependsOn>
-	</PropertyGroup>
 
 	<ItemDefinitionGroup>
 		<!-- MSBuild will honor this default metadata, but xbuild will not, so we still need to use CreateItem -->
@@ -76,61 +59,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<Optimize />
 		</_BundleResourceWithLogicalName>
 	</ItemDefinitionGroup>
-
-	<UsingTask
-		TaskName="GetDependsOnNETStandard"
-		AssemblyFile="$(MicrosoftNETBuildExtensionsTasksAssembly)" />
-
-	<Target Name="ImplicitlyExpandDesignTimeFacades" Condition="'$(ImplicitlyExpandDesignTimeFacades)' == 'true'" DependsOnTargets="$(ImplicitlyExpandDesignTimeFacadesDependsOn)">
-		<ItemGroup>
-			<XI_CandidateNETStandardReferences Include="@(Reference);@(_ResolvedProjectReferencePaths)" />
-			<XI_InboxNETStandardFolders Include="$(TargetFrameworkDirectory)" />
-		</ItemGroup>
-
-		<PropertyGroup>
-			<_HasReferenceToSystemRuntime Condition="'$(DependsOnSystemRuntime)' == 'true' or '%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable' 
-								or '%(ReferenceDependencyPaths.Filename)' == 'System.Runtime'">true</_HasReferenceToSystemRuntime>
-
-			<XI_NETStandardInbox Condition="'$(XI_NETStandardInbox)' == '' and Exists('%(XI_InboxNETStandardFolders.Identity)\netstandard.dll')">true</XI_NETStandardInbox>
-
-			<!--
-				This is `true` if any of the references depends on `netstandard`.
-
-				In cases where `ResolveAssemblyReference` task does get run, it populates `$(_DependsOnNETStandard)` property, so we don't
-				need to check this again.
-			-->
-			<XI_DependsOnNETStandard Condition="'$(XI_DependsOnNETStandard)' == ''">$(_DependsOnNETStandard)</XI_DependsOnNETStandard>
-		</PropertyGroup>
-
-		<!--
-		     Facades are expanded if we have a reference that depends on System.Runtime .
-
-		     XI projects have `$(TargetFrameworkIdentifier) != .NETFramework`, so Microsoft.NET.Build.Extensions (which provides support for ns 2.0 projects) doesn't get
-		     imported. And netstandard.dll reference, even if required, doesn't get added.
-
-		     So, we need to check if any references depend on `netstandard`. And if so, expand the facades, which include netstandard.dll .
-
-		     If $(_HasReferenceToSystemRuntime) is true, then the facades are going to be expanded anyway, so don't run this.
-		-->
-		<GetDependsOnNETStandard
-			Condition="'$(_HasReferenceToSystemRuntime)' != 'true' and '$(XI_DependsOnNETStandard)' == '' and '@(XI_CandidateNETStandardReferences)' != ''"
-			References="@(XI_CandidateNETStandardReferences)">
-			<Output TaskParameter="DependsOnNETStandard" PropertyName="XI_DependsOnNETStandard" />
-		</GetDependsOnNETStandard>
-
-		<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true' or ('$(XI_NETStandardInbox)' == 'true' and '$(XI_DependsOnNETStandard)' == 'true')">
-			<_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
-			<ReferencePath Remove="@(_DesignTimeFacadeAssemblies)"/>
-			<ReferencePath Include="%(_DesignTimeFacadeAssemblies.Identity)">
-				<WinMDFile>false</WinMDFile>
-				<CopyLocal>false</CopyLocal>
-				<ResolvedFrom>ImplicitlyExpandDesignTimeFacades</ResolvedFrom>
-			</ReferencePath>
-			<ReferenceDependencyPath Include="@(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandDesignTimeFacades'" />
-		</ItemGroup>
-
-		<Message Importance="Low" Text="Including @(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandDesignTimeFacades'" />
-	</Target>
 
 	<!-- Insert our app bundle generation step -->
 	<PropertyGroup Condition="'$(_UsingXamarinSdk)' != 'true'">


### PR DESCRIPTION
In addition to the obvious benefit of reducing code duplication, this also
means that implicit inclusion of netstandard.dll works for binding projects as
well.

The existing implementations were slightly different between Xamarin.iOS and
Xamarin.Mac, so I tried to figure out the best merging strategy based on git
history and looking at the original implementation of this code in MSBuild. I
tried to keep close to the original implementation whenever I couldn't find a
good reason to do otherwise.