### PR TITLE
[d16-7] Bump API diff to latest released stable

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -31,7 +31,7 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 
 include $(TOP)/Make.versions
 
-APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-6/ce0cc74a3bae25dbe29762f500a38b0325d2ea70/7/package/bundle.zip
+APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-6-xcode11.6/ce0cc74a3bae25dbe29762f500a38b0325d2ea70/7/package/bundle.zip
 
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 

--- a/Make.config
+++ b/Make.config
@@ -31,7 +31,7 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 
 include $(TOP)/Make.versions
 
-APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-6/8dff1138e0ef9823c568fb3f3176ec91621a85ec/6/package/bundle.zip
+APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-6/ce0cc74a3bae25dbe29762f500a38b0325d2ea70/7/package/bundle.zip
 
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 

--- a/Make.config
+++ b/Make.config
@@ -31,7 +31,7 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 
 include $(TOP)/Make.versions
 
-APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-6/b3eedfed9b6c05bf8642cebe9704159ce340d600/45/package/bundle.zip
+APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-6/8dff1138e0ef9823c568fb3f3176ec91621a85ec/6/package/bundle.zip
 
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 


### PR DESCRIPTION
The latest release of stable (13.18.3) is based off d16-6 ce0cc74a3bae25dbe29762f500a38b0325d2ea70.

d16-6 release notes: https://github.com/MicrosoftDocs/xamarin-engineering-docs-pr/pull/294

Will need to be ported to:
 [ ] d16-7
 [ ] d16-8
 [ ] xcode12

Backport of #9150.

/cc @whitneyschmidt 