### PR TITLE
[xharness] Generate makefile targets for non-executable projects.

### DIFF
--- a/tests/xharness/MakefileGenerator.cs
+++ b/tests/xharness/MakefileGenerator.cs
@@ -80,9 +80,6 @@ namespace Xharness
 				// special case for those targets that are auto generated from the mono assemblies
 				allTargets.RemoveAll (v => v.IsBCLProject);
 
-				// we can only execute executable projects
-				allTargets.RemoveAll (v => !v.IsExe);
-
 				// build/[install/]run targets for specific test projects.
 				foreach (var target in allTargets) {
 					var make_escaped_simplified_name = target.SimplifiedName.Replace (" ", "\\ ");


### PR DESCRIPTION
It turns out some Xamarin.Mac projects are library projects (for unit tests),
and we still need to generate makefile targets for those (because we use them
to build Xamarin.Mac tests to run on older macOS bots).