### PR TITLE
[DevOps] If test fail but pipeline builds, set the correct status.

### DIFF
--- a/tools/devops/device-tests/scripts/VSTS.Tests.ps1
+++ b/tools/devops/device-tests/scripts/VSTS.Tests.ps1
@@ -91,3 +91,91 @@ Describe 'Stop-Pipeline' {
         }
     }
 }
+
+Describe 'Set-PipelineResult' {
+    Context 'with all the env vars present' {
+
+        BeforeAll {
+            $Script:envVariables = @{
+                "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI" = "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI";
+                "SYSTEM_TEAMPROJECT" = "SYSTEM_TEAMPROJECT";
+                "BUILD_BUILDID" = "BUILD_BUILDID";
+                "SYSTEM_ACCESSTOKEN" = "SYSTEM_ACCESSTOKEN"
+            }
+
+            $envVariables.GetEnumerator() | ForEach-Object { 
+                $key = $_.Key
+                Set-Item -Path "Env:$key" -Value $_.Value
+            }
+        }
+
+        It 'performs the rest call' {
+            Mock Invoke-RestMethod {
+                return @{"status"=200;}
+            }
+
+            Set-PipelineResult "succeeded"
+
+            $expectedUri = "SYSTEM_TEAMFOUNDATIONCOLLECTIONURISYSTEM_TEAMPROJECT/_apis/build/builds/BUILD_BUILDID?api-version=5.1"
+            Assert-MockCalled -CommandName Invoke-RestMethod -Times 1 -Scope It -ParameterFilter {
+                # validate the paremters
+                if ($Uri -ne $expectedUri) {
+                    return $False
+                }
+                
+                if ($Headers.Authorization -ne ("Bearer {0}" -f $envVariables["SYSTEM_ACCESSTOKEN"])) {
+                    return $False
+                }
+
+                if ($Method -ne "PATCH") {
+                    return $False
+                }
+
+                if ($ContentType -ne "application/json") {
+                    return $False
+                }
+
+                # compare the payload
+                $bodyObj = ConvertFrom-Json $Body
+                if ($bodyObj.result -ne "succeeded") {
+                    return $False
+                }
+                return $True
+            }
+        }
+
+        It 'performs the rest method with an error' {
+            Mock Invoke-RestMethod {
+                throw [System.Exception]::("Test")
+            }
+            #set env vars
+            { Set-PipelineResult "failed" } | Should -Throw
+        }
+    }
+
+    Context 'without an env var' {
+        BeforeAll {
+            $Script:envVariables = @{
+                "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI" = "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI";
+                "SYSTEM_TEAMPROJECT" = "SYSTEM_TEAMPROJECT";
+                "BUILD_BUILDID" = "BUILD_BUILDID";
+                "SYSTEM_ACCESSTOKEN" = "SYSTEM_ACCESSTOKEN" 
+            }
+
+            $Script:envVariables.GetEnumerator() | ForEach-Object { 
+                $key = $_.Key
+                Set-Item -Path "Env:$key" -Value $_.Value
+                Remove-Item -Path "Env:$key"
+            }
+        }
+
+        It 'fails calling the rest method' {
+            Mock Invoke-RestMethod {
+                return @{"status"=200;}
+            }
+
+            { Set-PipelineResult "failed" } | Should -Throw
+            Assert-MockCalled -CommandName Invoke-RestMethod -Times 0 -Scope It 
+        }
+    }
+}

--- a/tools/devops/device-tests/scripts/VSTS.psm1
+++ b/tools/devops/device-tests/scripts/VSTS.psm1
@@ -52,5 +52,68 @@ function Stop-Pipeline {
     return Invoke-RestMethod -Uri $url -Headers $headers -Method "PATCH" -Body ($payload | ConvertTo-json) -ContentType 'application/json' -PreserveAuthorizationOnRedirect
 }
 
+<#
+    .SYNOPSIS
+        Allows to set the final status of the pipeline.
+
+    .EXAMPLE
+        Set-PipelineResult  "failed"
+    
+    .NOTES
+        The cmdlet depends on the following environment variables. If they are not present
+        an InvalidOperationException will be thrown.
+
+        * SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: Contains the full uri of the VSTS for the team.
+        * SYSTEM_TEAMPROJECT: Contains the name of the team in VSTS.
+        * BUILD_BUILDID: The id of the build to cancel.
+        * SYSTEM_ACCESSTOKEN: The PAT used to be able to perform the rest call to the VSTS API.
+
+        The valid values of status are:
+        * "canceled" The build was canceled before starting.
+        * "failed" The build completed unsuccessfully. 
+        * "none" No result
+        * "partiallySucceeded" The build completed compilation successfully but had other errors.
+        * "succeeded" The build completed successfully.
+#>
+function Set-PipelineResult {
+    param
+    (
+        [Parameter(Mandatory)]
+        [String]
+        [ValidateScript({
+            $("canceled", "failed", "none", "partiallySucceeded", "succeeded").Contains($_) #validate that the status is in the range of valid values
+        })]
+        $Status
+    )
+
+    # assert that all the env vars that are needed are present, else we do have an error
+    $envVars = @{
+        "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI" = $Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI;
+        "SYSTEM_TEAMPROJECT" = $Env:SYSTEM_TEAMPROJECT;
+        "BUILD_BUILDID" = $Env:BUILD_BUILDID;
+        "SYSTEM_ACCESSTOKEN" = $Env:SYSTEM_ACCESSTOKEN
+    }
+
+    foreach ($key in $envVars.Keys) {
+        if (-not($envVars[$key])) {
+            Write-Debug "Environment variable missing: $key"
+            throw [System.InvalidOperationException]::new("Environment variable missing: $key")
+        }
+    }
+
+    $url = Get-BuildUrl
+
+    $headers = @{
+        Authorization = ("Bearer {0}" -f $Env:SYSTEM_ACCESSTOKEN)
+    }
+
+    $payload = @{
+        result = $Status
+    }
+
+    return Invoke-RestMethod -Uri $url -Headers $headers -Method "PATCH" -Body ($payload | ConvertTo-json) -ContentType 'application/json' -PreserveAuthorizationOnRedirect
+}
+
 # export public functions, other functions are private and should not be used ouside the module.
 Export-ModuleMember -Function Stop-Pipeline
+Export-ModuleMember -Function Set-PipelineResult 

--- a/tools/devops/device-tests/scripts/VSTS.psm1
+++ b/tools/devops/device-tests/scripts/VSTS.psm1
@@ -81,7 +81,7 @@ function Set-PipelineResult {
         [Parameter(Mandatory)]
         [String]
         [ValidateScript({
-            $("canceled", "failed", "none", "partiallySucceeded", "succeeded").Contains($_) #validate that the status is in the range of valid values
+            $("canceled", "failed", "none", "partiallySucceeded", "succeeded").Contains($_) # validate that the status is in the range of valid values
         })]
         $Status
     )

--- a/tools/devops/device-tests/templates/publish-html.yml
+++ b/tools/devops/device-tests/templates/publish-html.yml
@@ -32,8 +32,13 @@ steps:
 - pwsh: |
     $env:VSDROPS_INDEX="$Env:VSDROPSPREFIX/$Env:BUILD_BUILDNUMBER/$Env:BUILD_BUILDID;/tests/vsdrops_index.html"
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\device-tests\scripts\GitHub.psm1 
+    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\device-tests\scripts\VSTS.psm1 
     $response = New-GitHubSummaryComment -Context "$Env:CONTEXT" -XamarinStoragePath "$Env:XAMARIN_STORAGE_PATH" -TestSummaryPath "$Env:TESTS_SUMMARY"
     Write-Host $response
+    if($Env:TESTS_JOBSTATUS -ne "Succeeded")
+    {
+      Set-PipelineResult -Status partiallySucceeded
+    }
   env:
     BUILD_REVISION: $(BUILD_REVISION)
     CONTEXT: ${{ parameters.statusContext }}


### PR DESCRIPTION
Depending on the pipeline run, we should have the following result:

* failed: issues with bots or provisioning (red in the UI)
* partiallySucceeded: no issues with bots but failing tests.
* succeeded: no issues with bots and all tests pass.

This adds a wsh cmdlet that allows to set the result AND sets the
correct result when we have test failures.