### PR TITLE
[xharness] Backport Touch.Unit fix for command line parsing.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/common/ApplicationOptions.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/common/ApplicationOptions.cs
@@ -72,9 +72,9 @@ namespace BCLTests {
 				{ "use_tcp_tunnel", "Use a tcp tunnel to connect to the host.", v => UseTcpTunnel = true },
 				{ "enablenetwork", "Enable the network reporter.", v => EnableNetwork = true },
 				{ "transport=", "Select transport method. Either TCP (default), HTTP or FILE.", v => Transport = v },
-				{ "enablexml", "Enable the xml reported.", v => EnableXml = false },
-				{ "xmlmode", "The xml mode.", v => XmlMode = (XmlMode) Enum.Parse (typeof (XmlMode), v, false) },
-				{ "xmlversion", "The xml version.", v => XmlVersion = (XmlVersion) Enum.Parse (typeof (XmlVersion), v, false) },
+				{ "enablexml:", "Enable the xml reported.", v => EnableXml = string.IsNullOrEmpty (v) ? true : bool.Parse (v) },
+				{ "xmlmode=", "The xml mode.", v => XmlMode = (XmlMode) Enum.Parse (typeof (XmlMode), v, true) },
+				{ "xmlversion=", "The xml version.", v => XmlVersion = (XmlVersion) Enum.Parse (typeof (XmlVersion), v, true) },
 				{ "logfile=", "A path where output will be saved.", v => LogFile = v },
 				{ "result=", "The path to be used to store the result", v => ResultFile = v},
 			};


### PR DESCRIPTION
Apply https://github.com/spouliot/Touch.Unit/pull/78 to the duplicated file.