### PR TITLE
[jenkins] Don't try to publish NuGet packages if there are no NuGet packages.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -509,6 +509,9 @@ timestamps {
                             }
                         }
 
+                        // Delete any packages we might have - the package directory might have packages from previous builds.
+                        sh (script: "rm -Rf ${workspace}/package", returnStatus: true /* don't throw exceptions if something goes wrong */)
+
                         stage ('Packaging') {
                             currentStage = "${STAGE_NAME}"
                             echo ("Building on ${env.NODE_NAME}")
@@ -726,16 +729,21 @@ timestamps {
                         stage ('Publish Nugets') {
                             currentStage = "${STAGE_NAME}"
                             withCredentials ([string (credentialsId: 'azdo-package-feed-token', variable: 'AZDO_PACKAGE_FEED_TOKEN')]) {
-                                def nugetResult = sh (script: "${workspace}/xamarin-macios/jenkins/publish-to-nuget.sh --apikey=${AZDO_PACKAGE_FEED_TOKEN} --source=https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json package/*.nupkg", returnStatus: true)
-                                if (nugetResult != 0) {
-                                    failedStages.add (currentStage)
-                                    manualException = true
-                                    def msg = "Failed to publish NuGet packages. Please review log for details."
-                                    echo ("⚠️ ${msg} ⚠️")
-                                    manager.addWarningBadge (msg)
-                                    appendFileComment ("⚠️ [${msg}](${env.RUN_DISPLAY_URL}) 🔥\n")
+                                def nupkgs = findFiles (glob: "package/notarized/*")
+                                if (nupkgs.size () == 0) {
+                                    echo ("No NuGet packages to publish.")
                                 } else {
-                                    echo ("${currentStage} succeeded")
+                                    def nugetResult = sh (script: "${workspace}/xamarin-macios/jenkins/publish-to-nuget.sh --apikey=${AZDO_PACKAGE_FEED_TOKEN} --source=https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json package/*.nupkg", returnStatus: true)
+                                    if (nugetResult != 0) {
+                                        failedStages.add (currentStage)
+                                        manualException = true
+                                        def msg = "Failed to publish NuGet packages. Please review log for details."
+                                        echo ("⚠️ ${msg} ⚠️")
+                                        manager.addWarningBadge (msg)
+                                        appendFileComment ("⚠️ [${msg}](${env.RUN_DISPLAY_URL}) 🔥\n")
+                                    } else {
+                                        echo ("${currentStage} succeeded")
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Also clean the package directory before creating any packages, otherwise we
might end up trying to upload packages from the previous build.

Diff best viewed by ignoring whitespace.