### PR TITLE
[main] [msbuild] Makes the xcarchive folder name culture independent

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ArchiveTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ArchiveTaskBase.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 using Xamarin.MacDev;
+using System.Globalization;
 
 namespace Xamarin.MacDev.Tasks
 {
@@ -62,7 +63,7 @@ namespace Xamarin.MacDev.Tasks
 
 		protected string CreateArchiveDirectory ()
 		{
-			var timestamp = Now.ToString ("M-dd-yy h.mm tt");
+			var timestamp = Now.ToString ("M-dd-yy h.mm tt", CultureInfo.InvariantCulture);
 			var folder = Now.ToString ("yyyy-MM-dd");
 			var baseArchiveDir = XcodeArchivesDir;
 			string archiveDir, name;


### PR DESCRIPTION
Fixes https://developercommunity.visualstudio.com/content/problem/934833/xamarinforms-cant-create-archive-for-ios.html

Depending on the default language of the running OS this could cause translating AM/PM to symbols that are not supported on folder names on Windows.

For instance, the value of `timestamp` without this change for an user that sets Chinese as it's main language would be `8-18-15 1.31 下午`, where `下午` represent PM.

Backport of #9174.

/cc @emaf 