### PR TITLE
[generator] Add nullability `?` when [BindAs] is used with an array type

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3557,7 +3557,10 @@ public partial class Generator : IMemberGatherer {
 			var bindAsAtt = GetBindAsAttribute (pi);
 			if (bindAsAtt != null) {
 				PrintBindAsAttribute (pi, sb);
-				sb.Append (FormatType (bindAsAtt.Type.DeclaringType, bindAsAtt.Type, protocolized));
+				var bt = bindAsAtt.Type;
+				sb.Append (FormatType (bt.DeclaringType, bt, protocolized));
+				if (!bt.IsValueType && AttributeManager.HasAttribute<NullAllowedAttribute> (pi))
+					sb.Append ('?');
 			} else {
 				sb.Append (FormatType (declaringType, parType, protocolized));
 				// some `IntPtr` are decorated with `[NullAttribute]`

--- a/tests/xtro-sharpie/common-AVFoundation.ignore
+++ b/tests/xtro-sharpie/common-AVFoundation.ignore
@@ -72,5 +72,3 @@
 
 # Initial result from new rule missing-null-allowed
 !missing-null-allowed! 'System.Boolean AVFoundation.AVPlayerItem::Seek(Foundation.NSDate,AVFoundation.AVCompletion)' is missing an [NullAllowed] on parameter #1
-!missing-null-allowed! 'System.Void AVFoundation.AVPlayerMediaSelectionCriteria::.ctor(AVFoundation.AVMediaCharacteristics[],AVFoundation.AVMediaCharacteristics[],System.String[])' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void AVFoundation.AVPlayerMediaSelectionCriteria::.ctor(AVFoundation.AVMediaCharacteristics[],AVFoundation.AVMediaCharacteristics[],System.String[])' is missing an [NullAllowed] on parameter #1


### PR DESCRIPTION
Fix two false positives in AVFoundation.
Needed for xcode12 too (to be backported)