### PR TITLE
[corenfc] Add NFCNdefTag (protocol) to NFCIso15693Tag (protocol)

### DIFF
--- a/src/corenfc.cs
+++ b/src/corenfc.cs
@@ -140,7 +140,7 @@ namespace CoreNFC {
 	//[iOS (11,0), NoTV, NoWatch, NoMac]
 	[iOS (11,0)]
 	[Protocol (Name = "NFCISO15693Tag")]
-	interface NFCIso15693Tag : NFCTag {
+	interface NFCIso15693Tag : NFCTag, NFCNdefTag {
 
 		[Abstract]
 		[Export ("identifier", ArgumentSemantic.Copy)]


### PR DESCRIPTION
We missed that one last year with iOS 13

https://github.com/xamarin/xamarin-macios/issues/9159