### PR TITLE
[On-demand resources] Make sure to Uri escape paths

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateAssetPackManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateAssetPackManifestTaskBase.cs
@@ -134,7 +134,7 @@ namespace Xamarin.MacDev.Tasks
 				}
 
 				// update AssetPackManifestTemplate.plist
-				resource.Add ("URL", new PString ("http://127.0.0.1" + Path.GetFullPath (dir)));
+				resource.Add ("URL", new PString ("http://127.0.0.1" + Uri.EscapeUriString (Path.GetFullPath (dir))));
 				resource.Add ("bundleKey", new PString (bundleIdentifier));
 
 				if (!double.IsNaN (priority))


### PR DESCRIPTION
If the path to the project or compiled app has spaces, then the URI that is generated for the on-demand resources in the AssetPackManifestTemplate.plist file is invalid.

 - Fixes https://github.com/xamarin/xamarin-macios/issues/8452

This issue is especially annoying since the IDE is the one that specifically creates the folder with a space.

Another thing I noticed is that this file is possibly not re-deployed between Debug/Release. This is because I can deploy a debug build, it will fail. But, if I then deploy a release build and then the debug build, it succeeds. Not sure what this means and maybe old files are being used in subsequent builds? See more repro steps here: https://github.com/xamarin/xamarin-macios/issues/8452#issuecomment-663256206