### PR TITLE
[d16-7][msbuild] Make sure to Uri escape paths

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateAssetPackManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateAssetPackManifestTaskBase.cs
@@ -136,7 +136,7 @@ namespace Xamarin.MacDev.Tasks
 				}
 
 				// update AssetPackManifestTemplate.plist
-				resource.Add ("URL", new PString ("http://127.0.0.1" + Path.GetFullPath (dir)));
+				resource.Add ("URL", new PString ("http://127.0.0.1" + Uri.EscapeUriString (Path.GetFullPath (dir))));
 				resource.Add ("bundleKey", new PString (bundleIdentifier));
 
 				if (!double.IsNaN (priority))


### PR DESCRIPTION
If the path to the project or compiled app has spaces, then the URI
that is generated for the on-demand resources in the
AssetPackManifestTemplate.plist file is invalid

Fixes #8452

Relates to #9198