### PR TITLE
[tests] mmptest doesn't need to include MacTestMain.cs

### DIFF
--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -123,9 +123,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
-    <None Include="..\common\mac\MacTestMain.cs">
-      <Link>MacTestMain.cs</Link>
-    </None>
     <None Include="packages.config" />
     <None Include="..\..\tools\mtouch\Errors.resx">
       <Link>Errors.resx</Link>


### PR DESCRIPTION
Because mmptest is a library, not an executable.