### PR TITLE
[xharness] Make restoring nugets the default for all test projects.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Tasks/BuildProject.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Tasks/BuildProject.cs
@@ -27,6 +27,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tasks {
 
 		public bool RestoreNugets {
 			get {
+				if (TestProject.IsDotNetProject)
+					return false;
 				return TestProject.RestoreNugetsInProject || !string.IsNullOrEmpty (SolutionPath);
 			}
 		}

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestProject.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestProject.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared {
 		public string [] Configurations;
 		public Func<Task> Dependency;
 		public string FailureMessage;
-		public bool RestoreNugetsInProject;
+		public bool RestoreNugetsInProject = true;
 		public string MTouchExtraArgs;
 		public double TimeoutMultiplier = 1;
 


### PR DESCRIPTION
But don't do it for .NET projects, since 'dotnet build' automatically restores.