### PR TITLE
[tests] Migrate the generator tests to use package references.

### DIFF
--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -28,21 +28,9 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
-    </Reference>
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ErrorTests.cs" />
@@ -68,7 +56,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="tests\is-direct-binding.cs" />
-    <None Include="packages.config" />
     <None Include="tests\ref-out-parameters.cs" />
     <None Include="tests\return-release.cs" />
     <None Include="tests\vsts-970507.cs" />

--- a/tests/generator/packages.config
+++ b/tests/generator/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net461" />
-  <package id="NUnit" version="3.11.0" targetFramework="net461" />
-  <package id="NUnit.ConsoleRunner" version="3.9.0" targetFramework="net461" />
-  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
This also bumps Mono.Cecil to the latest available version (that way we use the same version as in other tests).