### PR TITLE
[tests] Migrate the xtro sharpie project to use package references.

### DIFF
--- a/tests/xtro-sharpie/ObjCInterfaceCheck.cs
+++ b/tests/xtro-sharpie/ObjCInterfaceCheck.cs
@@ -158,11 +158,7 @@ namespace Extrospection {
 			if (td.HasInterfaces) {
 				foreach (var intf in td.Interfaces) {
 					TypeReference ifaceType;
-#if CECIL_0_10
 					ifaceType = intf?.InterfaceType;
-#else
-					ifaceType = intf;
-#endif
 					if (protocol == GetProtocolName (ifaceType?.Resolve ()))
 						return true;
 				}

--- a/tests/xtro-sharpie/packages.config
+++ b/tests/xtro-sharpie/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net45" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net47" />
-</packages>

--- a/tests/xtro-sharpie/xtro-sharpie.csproj
+++ b/tests/xtro-sharpie/xtro-sharpie.csproj
@@ -56,21 +56,8 @@
     <Reference Include="Clang">
       <HintPath>\Library\Frameworks\ObjectiveSharpie.framework\Versions\Current\Clang.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
-    </Reference>
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net47\System.ValueTuple.dll</HintPath>
-    </Reference>
+    <PackageReference Include="Mono.Cecil" Version="0.11.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <Reference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>
@@ -93,9 +80,6 @@
     <Compile Include="VersionHelpers.cs" />
     <Compile Include="ReleaseAttributeCheck.cs" />
     <Compile Include="NullabilityCheck.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">


### PR DESCRIPTION
This also bumps Mono.Cecil to the latest available version (that way we use
the same version as in other tests).