### PR TITLE
[xharness] Improve restoring NuGets for Xamarin.Mac projects in the makefile by depending on the csproj files in addition to the packages.conf files.

### DIFF
--- a/tests/xharness/MakefileGenerator.cs
+++ b/tests/xharness/MakefileGenerator.cs
@@ -66,7 +66,7 @@ namespace Xharness
 				writer.WriteLine ("\t$(Q) touch $@");
 				writer.WriteLine ();
 				var nuget_restore_dependency = ".stamp-nuget-restore-mac";
-				writer.WriteLine ("PACKAGES_CONFIG:=$(shell find . -name packages.config)");
+				writer.WriteLine ("PACKAGES_CONFIG:=$(shell git ls-files -- '*.csproj' '*/packages.config' | sed 's/ /\\\\ /g')");
 				writer.WriteLine ($"{nuget_restore_dependency}: tests-mac.sln $(PACKAGES_CONFIG)");
 				writer.WriteLine ("\t$(Q_XBUILD) $(SYSTEM_XIBUILD) -t -- /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore tests-mac.sln");
 				writer.WriteLine ("\t$(Q) touch $@");


### PR DESCRIPTION
Packages are listed in the csproj when we're using package references.

Also only list files in git, otherwise we pick up all the generated project files as well.