### PR TITLE
Bump .NET 5 to preview.8.20359.11.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -446,9 +446,9 @@ DOTNET_FEED_DIR ?= $(DOTNET_DESTDIR)/nuget-feed
 # We're using preview versions, and there will probably be many of them, so install locally (into builds/downloads) if there's no system version to
 # avoid consuming a lot of disk space (since they're never automatically deleted). The system-dependencies.sh script will install locally as long
 # as there's a TARBALL url.
-DOTNET5_VERSION=5.0.100-preview.7.20317.11
-DOTNET5_URL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-preview.7.20317.11/dotnet-sdk-5.0.100-preview.7.20317.11-osx-x64.pkg
-DOTNET5_TARBALL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-preview.7.20317.11/dotnet-sdk-5.0.100-preview.7.20317.11-osx-x64.tar.gz
+DOTNET5_VERSION=5.0.100-preview.8.20359.11
+DOTNET5_URL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-preview.8.20359.11/dotnet-sdk-5.0.100-preview.8.20359.11-osx-x64.pkg
+DOTNET5_TARBALL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-preview.8.20359.11/dotnet-sdk-5.0.100-preview.8.20359.11-osx-x64.tar.gz
 # Use the system dotnet executable if the dotnet version we need is installed, otherwise use the local version.
 ifneq ($(wildcard /usr/local/share/dotnet/sdk/$(DOTNET5_VERSION)),)
 DOTNET5=$(DOTNET)


### PR DESCRIPTION
There are a few linker fixes we need in this version.