### PR TITLE
[msbuild] Default 'BundlerDebug' to 'true' if no other option is set and we're building for a 'Debug' configuration.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -138,7 +138,9 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<_BundlerDebug Condition="'$(_PlatformName)' == 'macOS' And '$(_BundlerDebug)' == ''">$(DebugSymbols)</_BundlerDebug>
 		<!-- Xamarin.iOS: Use MtouchDebug -->
 		<_BundlerDebug Condition="'$(_PlatformName)' != 'macOS'">$(MtouchDebug)</_BundlerDebug>
-		<!-- The default is false for all platforms -->
+		<!-- Otherwise the default is true if we're building a Debug configuration -->
+		<_BundlerDebug Condition="'$(_BundlerDebug)' == '' And '$(Configuration)' == 'Debug'">true</_BundlerDebug>
+		<!-- As a last resort, the default is false for all platforms -->
 		<_BundlerDebug Condition="'$(_BundlerDebug)' == ''">false</_BundlerDebug>
 
 		<!-- Extra arguments -->


### PR DESCRIPTION
It's somewhat of a breaking change, since previously Xamarin.Mac would default
to 'false' if no value was set. It should be exceedingly rare though, since
it's set in all the template projects.

It makes the behavior a bit more intuitive for .NET projects, since then the
values might not be set because of the simplified project files.