### PR TITLE
[xharness] Implement Log.GetReader for all loggers.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Logging/AggregatedLog.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Logging/AggregatedLog.cs
@@ -36,7 +36,9 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging {
 
 			public override StreamReader GetReader ()
 			{
-				throw new NotSupportedException ();
+				if (logs.Length > 0)
+					return logs [0].GetReader ();
+				return null;
 			}
 
 			public override void Flush ()

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ConsoleLog.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ConsoleLog.cs
@@ -1,34 +1,11 @@
 ﻿using System;
-using System.IO;
-using System.Text;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging {
 	// A log that writes to standard output
-	public class ConsoleLog : Log {
-		readonly StringBuilder captured = new StringBuilder ();
+	public class ConsoleLog : CallbackLog {
 
-		protected override void WriteImpl (string value)
-		{
-			lock (captured)
-				captured.Append (value);
-			Console.Write (value);
-		}
-
-		public override string FullPath => throw new NotSupportedException ();
-
-		public override StreamReader GetReader ()
-		{
-			lock (captured) {
-				var str = new MemoryStream (Encoding.GetBytes (captured.ToString ()));
-				return new StreamReader (str, Encoding, false);
-			}
-		}
-
-		public override void Flush ()
-		{
-		}
-
-		public override void Dispose ()
+		public ConsoleLog ()
+			: base (Console.Write, "Console log")
 		{
 		}
 	}


### PR DESCRIPTION
This makes it easier to write code that parses logs, since that code won't
have to worry about if a particular log supports GetReader or not.