### PR TITLE
[xharness] Fix main log parsing by not requiring it to come from a file.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
@@ -172,7 +172,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared {
 		// return if the tcp connection with the device failed
 		async Task<bool> TcpConnectionFailed ()
 		{
-			using var reader = new StreamReader (mainLog.FullPath);
+			using var reader = mainLog.GetReader ();
 			string line;
 			while ((line = await reader.ReadLineAsync ()) != null) {
 				if (line.Contains ("Couldn't establish a TCP connection with any of the hostnames")) {


### PR DESCRIPTION
Not all types of logs have files, but all types of logs have a reader (or will
have soon due to PR #9257).