### PR TITLE
[mtouch/mmp] Add a few instructions to the list of instructions that we don't know how to calculate a constant value for.

### DIFF
--- a/tools/linker/CoreOptimizeGeneratedCode.cs
+++ b/tools/linker/CoreOptimizeGeneratedCode.cs
@@ -236,6 +236,10 @@ namespace Xamarin.Linker {
 			case Code.Conv_I1:
 			case Code.Conv_I2:
 			case Code.Conv_I4:
+			case Code.Conv_U:
+			case Code.Sizeof:
+			case Code.Ldfld:
+			case Code.Ldflda:
 				return null; // just to not hit the CWL below
 #endif
 			default:


### PR DESCRIPTION
This improves (shrinks) the debug spew when running mtouch or mmp in the IDE.