### PR TITLE
[mtouch] Don't try to copy invalid symbol files.

### DIFF
--- a/tests/common/ExecutionHelper.cs
+++ b/tests/common/ExecutionHelper.cs
@@ -216,8 +216,13 @@ namespace Xamarin.Tests
 
 		public int WarningCount {
 			get {
-				return messages.Count ((v) => v.IsWarning);
+				return GetWarningCount (messages);
 			}
+		}
+
+		public static int GetWarningCount (List<ToolMessage> messages)
+		{
+			return messages.Count ((v) => v.IsWarning);
 		}
 
 		public bool HasError (string prefix, int number, string message)
@@ -231,8 +236,13 @@ namespace Xamarin.Tests
 
 		public void AssertWarningCount (int count, string message = "warnings")
 		{
-			if (count != WarningCount)
-				Assert.Fail ($"{message}\nExpected: {count}\nBut was: {WarningCount}\nWarnings:\n\t{string.Join ("\n\t", this.Messages.Where ((v) => v.IsWarning).Select ((v) => v.ToString ()))}");
+			AssertWarningCount (messages, count, message);
+		}
+
+		public static void AssertWarningCount (List<ToolMessage> messages, int count, string message = "warnings")
+		{
+			if (count != GetWarningCount (messages))
+				Assert.Fail ($"{message}\nExpected: {count}\nBut was: { GetWarningCount (messages)}\nWarnings:\n\t{string.Join ("\n\t", messages.Where ((v) => v.IsWarning).Select ((v) => v.ToString ()))}");
 		}
 
 		public void AssertErrorCount (int count, string message = "errors")
@@ -284,6 +294,11 @@ namespace Xamarin.Tests
 
 		void AssertFilename (string prefix, int number, string message, IEnumerable<ToolMessage> matches, string filename, int? linenumber)
 		{
+			AssertFilename (messages, prefix, number, message, matches, filename, linenumber);
+		}
+
+		static void AssertFilename (List<ToolMessage> messages, string prefix, int number, string message, IEnumerable<ToolMessage> matches, string filename, int? linenumber)
+		{
 			if (filename != null) {
 				var hasDirectory = filename.IndexOf (Path.DirectorySeparatorChar) > -1;
 				if (!matches.Any ((v) => {
@@ -315,6 +330,11 @@ namespace Xamarin.Tests
 
 		public void AssertWarningPattern (string prefix, int number, string messagePattern)
 		{
+			AssertWarningPattern (messages, prefix, number, messagePattern);
+		}
+
+		public static void AssertWarningPattern (List<ToolMessage> messages, string prefix, int number, string messagePattern)
+		{
 			if (!messages.Any ((msg) => msg.Prefix == prefix && msg.Number == number))
 				Assert.Fail (string.Format ("The warning '{0}{1:0000}' was not found in the output.", prefix, number));
 
@@ -332,6 +352,11 @@ namespace Xamarin.Tests
 
 		public void AssertWarning (string prefix, int number, string message, string filename = null, int? linenumber = null)
 		{
+			AssertWarning (messages, prefix, number, message, filename, linenumber);
+		}
+
+		public static void AssertWarning (List<ToolMessage> messages, string prefix, int number, string message, string filename = null, int? linenumber = null)
+		{
 			if (!messages.Any ((msg) => msg.Prefix == prefix && msg.Number == number))
 				Assert.Fail (string.Format ("The warning '{0}{1:0000}' was not found in the output.", prefix, number));
 
@@ -341,7 +366,7 @@ namespace Xamarin.Tests
 				Assert.Fail (string.Format ("The warning '{0}{1:0000}: {2}' was not found in the output:\n{3}", prefix, number, message, string.Join ("\n", details.ToArray ())));
 			}
 
-			AssertFilename (prefix, number, message, matches, filename, linenumber);
+			AssertFilename (messages, prefix, number, message, matches, filename, linenumber);
 		}
 
 		public void AssertNoWarnings ()
@@ -394,39 +419,39 @@ namespace Xamarin.Tests
 			}
 		}
 
-		public static void BuildXM (string project, string configuration = "Debug", string platform = "iPhoneSimulator", string verbosity = null, TimeSpan? timeout = null, string [] arguments = null)
+		public static string BuildXM (string project, string configuration = "Debug", string platform = "iPhoneSimulator", string verbosity = null, TimeSpan? timeout = null, string [] arguments = null, string targets = "Clean,Build")
 		{
-			Build (project,
+			return Build (project,
 				new Dictionary<string, string> {
 					{ "MD_APPLE_SDK_ROOT", Path.GetDirectoryName (Path.GetDirectoryName (Configuration.xcode_root)) },
 					{ "TargetFrameworkFallbackSearchPaths", Path.Combine (Configuration.TargetDirectoryXM, "Library", "Frameworks", "Mono.framework", "External", "xbuild-frameworks") },
 					{ "MSBuildExtensionsPathFallbackPathsOverride", Path.Combine (Configuration.TargetDirectoryXM, "Library", "Frameworks", "Mono.framework", "External", "xbuild") },
 					{ "XamarinMacFrameworkRoot", Path.Combine (Configuration.TargetDirectoryXM, "Library", "Frameworks", "Xamarin.Mac.framework", "Versions", "Current") },
 					{ "XAMMAC_FRAMEWORK_PATH", Path.Combine (Configuration.TargetDirectoryXM, "Library", "Frameworks", "Xamarin.Mac.framework", "Versions", "Current") },
-				}, configuration, platform, verbosity, timeout, arguments);
+				}, configuration, platform, verbosity, timeout, arguments, targets);
 		}
 
-		public static void BuildXI (string project, string configuration = "Debug", string platform = "iPhoneSimulator", string verbosity = null, TimeSpan? timeout = null, string [] arguments = null)
+		public static string BuildXI (string project, string configuration = "Debug", string platform = "iPhoneSimulator", string verbosity = null, TimeSpan? timeout = null, string [] arguments = null, string targets = "Clean,Build")
 		{
-			Build (project,
+			return Build (project,
 				new Dictionary<string, string> {
 					{ "MD_APPLE_SDK_ROOT", Path.GetDirectoryName (Path.GetDirectoryName (Configuration.xcode_root)) },
 					{ "TargetFrameworkFallbackSearchPaths", Path.Combine (Configuration.TargetDirectoryXI, "Library", "Frameworks", "Mono.framework", "External", "xbuild-frameworks") },
 					{ "MSBuildExtensionsPathFallbackPathsOverride", Path.Combine (Configuration.TargetDirectoryXI, "Library", "Frameworks", "Mono.framework", "External", "xbuild") },
 					{ "MD_MTOUCH_SDK_ROOT", Path.Combine (Configuration.TargetDirectoryXI, "Library", "Frameworks", "Xamarin.iOS.framework", "Versions", "Current") },
-				}, configuration, platform, verbosity, timeout, arguments);
+				}, configuration, platform, verbosity, timeout, arguments, targets);
 		}
 
-		static void Build (string project, Dictionary<string, string> environmentVariables, string configuration = "Debug", string platform = "iPhoneSimulator", string verbosity = null, TimeSpan? timeout = null, string [] arguments = null)
+		static string Build (string project, Dictionary<string, string> environmentVariables, string configuration = "Debug", string platform = "iPhoneSimulator", string verbosity = null, TimeSpan? timeout = null, string [] arguments = null, string targets = "Clean,Build")
 		{
-			ExecutionHelper.Execute (ToolPath,
+			return ExecutionHelper.Execute (ToolPath,
 				new string [] {
 					"--",
 					$"/p:Configuration={configuration}",
 					$"/p:Platform={platform}",
 					$"/verbosity:{(string.IsNullOrEmpty (verbosity) ? "normal" : verbosity)}",
 					"/r:True", // restore nuget packages which are used in some test cases
-					"/t:Clean,Build", // clean and then build, in case we left something behind in a shared dir
+					$"/t:{targets}", // clean and then build, in case we left something behind in a shared dir
 					project
 				}.Union (arguments ?? new string [] { }).ToArray (),
 				environmentVariables: environmentVariables,

--- a/tests/common/ExecutionHelper.cs
+++ b/tests/common/ExecutionHelper.cs
@@ -220,7 +220,7 @@ namespace Xamarin.Tests
 			}
 		}
 
-		public static int GetWarningCount (List<ToolMessage> messages)
+		public static int GetWarningCount (IEnumerable<ToolMessage> messages)
 		{
 			return messages.Count ((v) => v.IsWarning);
 		}
@@ -239,7 +239,7 @@ namespace Xamarin.Tests
 			AssertWarningCount (messages, count, message);
 		}
 
-		public static void AssertWarningCount (List<ToolMessage> messages, int count, string message = "warnings")
+		public static void AssertWarningCount (IEnumerable<ToolMessage> messages, int count, string message = "warnings")
 		{
 			if (count != GetWarningCount (messages))
 				Assert.Fail ($"{message}\nExpected: {count}\nBut was: { GetWarningCount (messages)}\nWarnings:\n\t{string.Join ("\n\t", messages.Where ((v) => v.IsWarning).Select ((v) => v.ToString ()))}");
@@ -297,7 +297,7 @@ namespace Xamarin.Tests
 			AssertFilename (messages, prefix, number, message, matches, filename, linenumber);
 		}
 
-		static void AssertFilename (List<ToolMessage> messages, string prefix, int number, string message, IEnumerable<ToolMessage> matches, string filename, int? linenumber)
+		static void AssertFilename (IList<ToolMessage> messages, string prefix, int number, string message, IEnumerable<ToolMessage> matches, string filename, int? linenumber)
 		{
 			if (filename != null) {
 				var hasDirectory = filename.IndexOf (Path.DirectorySeparatorChar) > -1;
@@ -333,7 +333,7 @@ namespace Xamarin.Tests
 			AssertWarningPattern (messages, prefix, number, messagePattern);
 		}
 
-		public static void AssertWarningPattern (List<ToolMessage> messages, string prefix, int number, string messagePattern)
+		public static void AssertWarningPattern (IEnumerable<ToolMessage> messages, string prefix, int number, string messagePattern)
 		{
 			if (!messages.Any ((msg) => msg.Prefix == prefix && msg.Number == number))
 				Assert.Fail (string.Format ("The warning '{0}{1:0000}' was not found in the output.", prefix, number));
@@ -355,7 +355,7 @@ namespace Xamarin.Tests
 			AssertWarning (messages, prefix, number, message, filename, linenumber);
 		}
 
-		public static void AssertWarning (List<ToolMessage> messages, string prefix, int number, string message, string filename = null, int? linenumber = null)
+		public static void AssertWarning (IList<ToolMessage> messages, string prefix, int number, string message, string filename = null, int? linenumber = null)
 		{
 			if (!messages.Any ((msg) => msg.Prefix == prefix && msg.Number == number))
 				Assert.Fail (string.Format ("The warning '{0}{1:0000}' was not found in the output.", prefix, number));

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -4173,6 +4173,7 @@ class C {
 
 			var arguments = new string [] {
 				"/p:MtouchArch=x86_64",
+				"/p:MtouchExtraArgs=-vvvvvvvvvv", // make sure mtouch prints out the verbose text we're looking for in our asserts
 				"-consoleLoggerParameters:NoSummary", // this avoids duplicating the errors and warnings at the end of the build
 			};
 			var targets = "Build";

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -108,6 +108,12 @@ namespace Xamarin.Bundler {
 			this.FullPath = definition.MainModule.FileName;
 		}
 
+		public bool HasValidSymbols {
+			get {
+				return AssemblyDefinition.MainModule.HasSymbols;
+			}
+		}
+
 		public void LoadSymbols ()
 		{	
 			if (symbols_loaded.HasValue)

--- a/tools/common/CoreResolver.cs
+++ b/tools/common/CoreResolver.cs
@@ -85,6 +85,13 @@ namespace Xamarin.Bundler {
 				try {
 					assembly = ModuleDefinition.ReadModule (fileName, parameters).Assembly;
 					params_cache [assembly.Name.ToString ()] = parameters;
+					if (!assembly.MainModule.HasSymbols) {
+						// We Cecil didn't load symbols, but there's a pdb, then something went wrong loading it (maybe an old-style pdb?).
+						// Warn about this.
+						var pdb = Path.ChangeExtension (fileName, "pdb");
+						if (File.Exists (pdb))
+							ErrorHelper.Show (ErrorHelper.CreateWarning (178, Errors.MX0178, fileName));
+					}
 				}
 				catch (SymbolsNotMatchingException) {
 					parameters.ReadSymbols = false;

--- a/tools/mtouch/Assembly.mtouch.cs
+++ b/tools/mtouch/Assembly.mtouch.cs
@@ -126,7 +126,8 @@ namespace Xamarin.Bundler {
 				}
 
 				// Update the debug symbols file even if the assembly didn't change.
-				if (copy_debug_symbols) {
+				if (copy_debug_symbols && HasValidSymbols) {
+					// Unfortunately Cecil won't tell us the path of the symbol file, so we have to try all we support (.pdb+.mdb)
 					if (File.Exists (source + ".mdb"))
 						Application.UpdateFile (source + ".mdb", target + ".mdb", true);
 

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -689,6 +689,12 @@ namespace Xamarin.Bundler {
             }
         }
         
+        internal static string MX0178 {
+            get {
+                return ResourceManager.GetString("MX0178", resourceCulture);
+            }
+        }
+        
         internal static string MT0150 {
             get {
                 return ResourceManager.GetString("MT0150", resourceCulture);

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -571,6 +571,11 @@
 		</value>
 	</data>
 	
+    <data name="MX0178" xml:space="preserve">
+        <value>Debugging symbol file for '{0}' is not valid and was ignored.
+        </value>
+    </data>
+
 	<data name="MT0150" xml:space="preserve">
 		<value>Internal error: The interpreter is currently only available for 64 bits.
 		</value>

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -2932,6 +2932,13 @@
         <target state="new">Unknown platform: {0}. This usually indicates a bug; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MX0178">
+        <source>Debugging symbol file for '{0}' is not valid and was ignored.
+        </source>
+        <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
+        </target>
+        <note />
+      </trans-unit>
       <trans-unit id="MX1009">
         <source>Could not copy the assembly '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -2932,6 +2932,13 @@
         <target state="new">Unknown platform: {0}. This usually indicates a bug; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MX0178">
+        <source>Debugging symbol file for '{0}' is not valid and was ignored.
+        </source>
+        <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
+        </target>
+        <note />
+      </trans-unit>
       <trans-unit id="MX1009">
         <source>Could not copy the assembly '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -2932,6 +2932,13 @@
         <target state="new">Unknown platform: {0}. This usually indicates a bug; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MX0178">
+        <source>Debugging symbol file for '{0}' is not valid and was ignored.
+        </source>
+        <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
+        </target>
+        <note />
+      </trans-unit>
       <trans-unit id="MX1009">
         <source>Could not copy the assembly '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -2932,6 +2932,13 @@
         <target state="new">Unknown platform: {0}. This usually indicates a bug; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MX0178">
+        <source>Debugging symbol file for '{0}' is not valid and was ignored.
+        </source>
+        <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
+        </target>
+        <note />
+      </trans-unit>
       <trans-unit id="MX1009">
         <source>Could not copy the assembly '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -2932,6 +2932,13 @@
         <target state="new">Unknown platform: {0}. This usually indicates a bug; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MX0178">
+        <source>Debugging symbol file for '{0}' is not valid and was ignored.
+        </source>
+        <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
+        </target>
+        <note />
+      </trans-unit>
       <trans-unit id="MX1009">
         <source>Could not copy the assembly '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -2932,6 +2932,13 @@
         <target state="new">Unknown platform: {0}. This usually indicates a bug; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MX0178">
+        <source>Debugging symbol file for '{0}' is not valid and was ignored.
+        </source>
+        <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
+        </target>
+        <note />
+      </trans-unit>
       <trans-unit id="MX1009">
         <source>Could not copy the assembly '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -2932,6 +2932,13 @@
         <target state="new">Unknown platform: {0}. This usually indicates a bug; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MX0178">
+        <source>Debugging symbol file for '{0}' is not valid and was ignored.
+        </source>
+        <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
+        </target>
+        <note />
+      </trans-unit>
       <trans-unit id="MX1009">
         <source>Could not copy the assembly '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -2932,6 +2932,13 @@
         <target state="new">Unknown platform: {0}. This usually indicates a bug; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MX0178">
+        <source>Debugging symbol file for '{0}' is not valid and was ignored.
+        </source>
+        <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
+        </target>
+        <note />
+      </trans-unit>
       <trans-unit id="MX1009">
         <source>Could not copy the assembly '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -2932,6 +2932,13 @@
         <target state="new">Unknown platform: {0}. This usually indicates a bug; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MX0178">
+        <source>Debugging symbol file for '{0}' is not valid and was ignored.
+        </source>
+        <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
+        </target>
+        <note />
+      </trans-unit>
       <trans-unit id="MX1009">
         <source>Could not copy the assembly '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -2932,6 +2932,13 @@
         <target state="new">Unknown platform: {0}. This usually indicates a bug; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MX0178">
+        <source>Debugging symbol file for '{0}' is not valid and was ignored.
+        </source>
+        <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
+        </target>
+        <note />
+      </trans-unit>
       <trans-unit id="MX1009">
         <source>Could not copy the assembly '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -2932,6 +2932,13 @@
         <target state="new">Unknown platform: {0}. This usually indicates a bug; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MX0178">
+        <source>Debugging symbol file for '{0}' is not valid and was ignored.
+        </source>
+        <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
+        </target>
+        <note />
+      </trans-unit>
       <trans-unit id="MX1009">
         <source>Could not copy the assembly '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -2932,6 +2932,13 @@
         <target state="new">Unknown platform: {0}. This usually indicates a bug; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MX0178">
+        <source>Debugging symbol file for '{0}' is not valid and was ignored.
+        </source>
+        <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
+        </target>
+        <note />
+      </trans-unit>
       <trans-unit id="MX1009">
         <source>Could not copy the assembly '{0}' to '{1}': {2}
 		</source>

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -2932,6 +2932,13 @@
         <target state="new">Unknown platform: {0}. This usually indicates a bug; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MX0178">
+        <source>Debugging symbol file for '{0}' is not valid and was ignored.
+        </source>
+        <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
+        </target>
+        <note />
+      </trans-unit>
       <trans-unit id="MX1009">
         <source>Could not copy the assembly '{0}' to '{1}': {2}
 		</source>


### PR DESCRIPTION
This solves a rebuild problem if an assembly has an invalid or unsupported symbol
file, where we'd detect that the symbol file exists, and expect it to be copied,
but then the linker would drop it, causing us to always rebuild the app (this is
not the same as when a symbol file is out of date).

This happens for NUnitLite 3.12.0's nunit.framework.dll, which ships with an old-style
pdb.

Also add a warning that is shown when we detect that there's a symbol file, but it
couldn't be loaded for some reason.