### PR TITLE
[Tests] Fix TryGetSupportedInterfaces when we have values. Fixes #2273

### DIFF
--- a/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
+++ b/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
@@ -14,7 +14,6 @@ using System.IO;
 using Foundation;
 using ObjCRuntime;
 using SystemConfiguration;
-using System.Runtime.InteropServices;
 #if !MONOMAC
 using UIKit;
 #endif
@@ -83,9 +82,6 @@ namespace MonoTouchFixtures.SystemConfiguration {
 #endif
 		}
 
-		[DllImport (Constants.SystemConfigurationLibrary)]
-		extern static IntPtr /* CFArrayRef __nullable */ CNCopySupportedInterfaces ();
-
 		[Test]
 		public void TryGetSupportedInterfaces ()
 		{
@@ -93,17 +89,8 @@ namespace MonoTouchFixtures.SystemConfiguration {
 #if __TVOS__
 			Assert.Throws<NotSupportedException> (() => CaptiveNetwork.TryGetSupportedInterfaces (out var ifaces));
 #else
-
 			status = CaptiveNetwork.TryGetSupportedInterfaces (out var ifaces);
 			Assert.AreEqual (StatusCode.OK, status, "Status");
-
-			IntPtr array = CNCopySupportedInterfaces ();
-			if (array == IntPtr.Zero) {
-				Assert.IsNull (ifaces, "Null Interfaces");
-			} else {
-				var supportedInterfaces = NSArray.StringArrayFromHandle (array);
-				Assert.AreEqual (supportedInterfaces.Length, ifaces.Length, "Not null interfaces");
-			}
 #endif // __TVOS__
 		}
 #endif

--- a/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
+++ b/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
@@ -14,6 +14,7 @@ using System.IO;
 using Foundation;
 using ObjCRuntime;
 using SystemConfiguration;
+using System.Runtime.InteropServices;
 #if !MONOMAC
 using UIKit;
 #endif
@@ -82,6 +83,9 @@ namespace MonoTouchFixtures.SystemConfiguration {
 #endif
 		}
 
+		[DllImport (Constants.SystemConfigurationLibrary)]
+		extern static IntPtr /* CFArrayRef __nullable */ CNCopySupportedInterfaces ();
+
 		[Test]
 		public void TryGetSupportedInterfaces ()
 		{
@@ -89,9 +93,17 @@ namespace MonoTouchFixtures.SystemConfiguration {
 #if __TVOS__
 			Assert.Throws<NotSupportedException> (() => CaptiveNetwork.TryGetSupportedInterfaces (out var ifaces));
 #else
+
 			status = CaptiveNetwork.TryGetSupportedInterfaces (out var ifaces);
 			Assert.AreEqual (StatusCode.OK, status, "Status");
-			Assert.IsNull (ifaces, "Null Interfaces");
+
+			IntPtr array = CNCopySupportedInterfaces ();
+			if (array == IntPtr.Zero) {
+				Assert.IsNull (ifaces, "Null Interfaces");
+			} else {
+				var supportedInterfaces = NSArray.StringArrayFromHandle (array);
+				Assert.AreEqual (supportedInterfaces.Length, ifaces.Length, "Not null interfaces");
+			}
 #endif // __TVOS__
 		}
 #endif


### PR DESCRIPTION
Make the test check against the value returned by the native API rather
than expect the result to always be null.

Fixes https://github.com/xamarin/maccore/issues/2273