### PR TITLE
[mtouch/mmp] Move the Driver.PRODUCT constant to an Application.ProductName instance field.

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -388,15 +388,15 @@ namespace Xamarin.Bundler {
 
 			RuntimeOptions = RuntimeOptions.Create (this, HttpMessageHandler, TlsProvider);
 
-			if (RequiresXcodeHeaders && SdkVersion < SdkVersions.GetVersion (Platform)) {
-				throw ErrorHelper.CreateError (91, Errors.MX0091, ProductName, PlatformName, SdkVersions.GetVersion (Platform), SdkVersions.Xcode, Error91LinkerSuggestion);
+			if (RequiresXcodeHeaders && SdkVersion < SdkVersions.GetVersion (this)) {
+				throw ErrorHelper.CreateError (91, Errors.MX0091, ProductName, PlatformName, SdkVersions.GetVersion (this), SdkVersions.Xcode, Error91LinkerSuggestion);
 			}
 
 			if (DeploymentTarget != null) {
-				if (DeploymentTarget < Xamarin.SdkVersions.GetMinVersion (Platform))
-					throw new ProductException (73, true, Errors.MT0073, Constants.Version, DeploymentTarget, Xamarin.SdkVersions.GetMinVersion (Platform), PlatformName, ProductName);
-				if (DeploymentTarget > Xamarin.SdkVersions.GetVersion (Platform))
-					throw new ProductException (74, true, Errors.MX0074, Constants.Version, DeploymentTarget, Xamarin.SdkVersions.GetVersion (Platform), PlatformName, ProductName);
+				if (DeploymentTarget < Xamarin.SdkVersions.GetMinVersion (this))
+					throw new ProductException (73, true, Errors.MT0073, Constants.Version, DeploymentTarget, Xamarin.SdkVersions.GetMinVersion (this), PlatformName, ProductName);
+				if (DeploymentTarget > Xamarin.SdkVersions.GetVersion (this))
+					throw new ProductException (74, true, Errors.MX0074, Constants.Version, DeploymentTarget, Xamarin.SdkVersions.GetVersion (this), PlatformName, ProductName);
 			}
 
 			if (Platform == ApplePlatform.WatchOS && EnableCoopGC.HasValue && !EnableCoopGC.Value)

--- a/tools/common/SdkVersions.cs.in
+++ b/tools/common/SdkVersions.cs.in
@@ -63,39 +63,39 @@ namespace Xamarin {
 		public static Version XcodeVersion { get { return new Version (Xcode); }}
 
 #if MTOUCH || MMP
-		public static Version GetVersion (ApplePlatform platform)
+		public static Version GetVersion (Application app)
 		{
-			switch (platform) {
+			switch (app.Platform) {
 			case ApplePlatform.MacOSX: return OSXVersion;
 			case ApplePlatform.iOS: return iOSVersion;
 			case ApplePlatform.WatchOS: return WatchOSVersion;
 			case ApplePlatform.TVOS: return TVOSVersion;
 			default:
-				throw ErrorHelper.CreateError (71, "Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.", platform, Application.ProductName);
+				throw ErrorHelper.CreateError (71, "Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.", app.Platform, app.ProductName);
 			}
 		}
 
-		public static Version GetTargetVersion (ApplePlatform platform)
+		public static Version GetTargetVersion (Application app)
 		{
-			switch (platform) {
+			switch (app.Platform) {
 			case ApplePlatform.MacOSX: return OSXVersion;
 			case ApplePlatform.iOS: return iOSTargetVersion;
 			case ApplePlatform.WatchOS: return WatchOSTargetVersion;
 			case ApplePlatform.TVOS: return TVOSTargetVersion;
 			default:
-				throw ErrorHelper.CreateError (71, "Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.", platform, Application.ProductName);
+				throw ErrorHelper.CreateError (71, "Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.", app.Platform, app.ProductName);
 			}
 		}
 
-		public static Version GetMinVersion (ApplePlatform platform)
+		public static Version GetMinVersion (Application app)
 		{
-			switch (platform) {
+			switch (app.Platform) {
 			case ApplePlatform.MacOSX: return MinOSXVersion;
 			case ApplePlatform.iOS: return MiniOSVersion;
 			case ApplePlatform.WatchOS: return MinWatchOSVersion;
 			case ApplePlatform.TVOS: return MinTVOSVersion;
 			default:
-				throw ErrorHelper.CreateError (71, "Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.", platform, Application.ProductName);
+				throw ErrorHelper.CreateError (71, "Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case.", app.Platform, app.ProductName);
 			}
 		}
 #endif

--- a/tools/mmp/Application.mmp.cs
+++ b/tools/mmp/Application.mmp.cs
@@ -4,7 +4,7 @@ using System.Linq;
 namespace Xamarin.Bundler {
 	public partial class Application
 	{
-		public const string ProductName = "Xamarin.Mac";
+		public string ProductName = "Xamarin.Mac";
 		public const string Error91LinkerSuggestion = "use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options > Linker Behavior";
 
 		public bool IsSimulatorBuild => false;

--- a/tools/mmp/aot.cs
+++ b/tools/mmp/aot.cs
@@ -177,7 +177,7 @@ namespace Xamarin.Bundler {
 		// Allows tests to stub out actual compilation and parallelism
 		public RunCommandDelegate RunCommand { get; set; } = Driver.RunCommand; 
 		public ParallelOptions ParallelOptions { get; set; } = new ParallelOptions () { MaxDegreeOfParallelism = Driver.Concurrency };
-		public string XamarinMacPrefix { get; set; } = Driver.FrameworkDirectory; // FrameworkDirectory assumes GetExecutingAssembly in ways that are not valid for tests, so we must stub out
+		public string XamarinMacPrefix { get; set; } = Driver.GetFrameworkDirectory (null); // GetFrameworkDirectory assumes GetExecutingAssembly in ways that are not valid for tests, so we must stub out
 
 		AOTOptions options;
 		AOTCompilerType compilerType;

--- a/tools/mmp/aot.cs
+++ b/tools/mmp/aot.cs
@@ -177,8 +177,19 @@ namespace Xamarin.Bundler {
 		// Allows tests to stub out actual compilation and parallelism
 		public RunCommandDelegate RunCommand { get; set; } = Driver.RunCommand; 
 		public ParallelOptions ParallelOptions { get; set; } = new ParallelOptions () { MaxDegreeOfParallelism = Driver.Concurrency };
-		public string XamarinMacPrefix { get; set; } = Driver.GetFrameworkDirectory (null); // GetFrameworkDirectory assumes GetExecutingAssembly in ways that are not valid for tests, so we must stub out
 
+		string xamarin_mac_prefix;
+		public string XamarinMacPrefix {
+			get {
+				if (xamarin_mac_prefix == null)
+					xamarin_mac_prefix = Driver.GetFrameworkCurrentDirectory (Driver.App);
+				return xamarin_mac_prefix;
+			}
+			set {
+				xamarin_mac_prefix = value;
+			}
+		}
+		
 		AOTOptions options;
 		AOTCompilerType compilerType;
 		bool IsRelease;

--- a/tools/mtouch/BuildTasks.mtouch.cs
+++ b/tools/mtouch/BuildTasks.mtouch.cs
@@ -601,6 +601,7 @@ namespace Xamarin.Bundler
 
 	public class LipoTask : BuildTask
 	{
+		public Application App;
 		public IEnumerable<string> InputFiles { get; set; }
 		public string OutputFile { get; set; }
 
@@ -618,7 +619,7 @@ namespace Xamarin.Bundler
 
 		protected override void Execute ()
 		{
-			Application.Lipo (OutputFile, InputFiles.ToArray ());
+			Application.Lipo (App, OutputFile, InputFiles.ToArray ());
 		}
 
 		public override string ToString ()

--- a/tools/mtouch/Target.mtouch.cs
+++ b/tools/mtouch/Target.mtouch.cs
@@ -1661,7 +1661,7 @@ namespace Xamarin.Bundler
 			}
 		}
 
-		public static void AdjustDylibs (string output)
+		public void AdjustDylibs (string output)
 		{
 			var sb = new List<string> ();
 			foreach (var dependency in Xamarin.MachO.GetNativeDependencies (output)) {
@@ -1674,7 +1674,7 @@ namespace Xamarin.Bundler
 			}
 			if (sb.Count > 0) {
 				sb.Add (output);
-				Driver.RunInstallNameTool (sb);
+				Driver.RunInstallNameTool (App, sb);
 				sb.Clear ();
 			}
 		}
@@ -1705,7 +1705,7 @@ namespace Xamarin.Bundler
 
 			try {
 				var launcher = new StringBuilder ();
-				launcher.Append (Path.Combine (Driver.FrameworkBinDirectory, "simlauncher"));
+				launcher.Append (Path.Combine (Driver.GetFrameworkBinDirectory (App), "simlauncher"));
 				if (Is32Build)
 					launcher.Append ("32");
 				else if (Is64Build)

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -80,7 +80,6 @@ namespace Xamarin.Bundler
 {
 	public partial class Driver {
 		internal const string NAME = "mtouch";
-		internal const string PRODUCT = "Xamarin.iOS";
 		const string LOCAL_BUILD_DIR = "_ios-build";
 		const string FRAMEWORK_LOCATION_VARIABLE = "MD_MTOUCH_SDK_ROOT";
 
@@ -290,7 +289,7 @@ namespace Xamarin.Bundler
 			}
 
 			if (enable_llvm)
-				aot.Append ("llvm-path=").Append (FrameworkDirectory).Append ("/LLVM/bin/,");
+				aot.Append ("llvm-path=").Append (GetFrameworkCurrentDirectory (app)).Append ("/LLVM/bin/,");
 
 			aot.Append ("outfile=").Append (outputFile);
 			if (enable_llvm)
@@ -944,7 +943,7 @@ namespace Xamarin.Bundler
 			
 			// Allow a few actions, since these seem to always work no matter the Xcode version.
 			var accept_any_xcode_version = action == Action.ListDevices || action == Action.ListCrashReports || action == Action.ListApps || action == Action.LogDev;
-			ValidateXcode (accept_any_xcode_version, false);
+			ValidateXcode (app, accept_any_xcode_version, false);
 
 			switch (action) {
 			/* Device actions */
@@ -966,7 +965,7 @@ namespace Xamarin.Bundler
 			case Action.LaunchWatchApp:
 			case Action.KillWatchApp:
 			case Action.ListSimulators:
-				return CallMlaunch ();
+				return CallMlaunch (app);
 			}
 
 			if (app.SdkVersion == null)
@@ -1007,7 +1006,7 @@ namespace Xamarin.Bundler
 				throw new ProductException (82, true, Errors.MT0082);
 
 			if (cross_prefix == null)
-				cross_prefix = FrameworkDirectory;
+				cross_prefix = GetFrameworkCurrentDirectory (app);
 
 			Watch ("Setup", 1);
 
@@ -1054,23 +1053,22 @@ namespace Xamarin.Bundler
 			{ IsBackground = true }.Start ();
 		}
 
-		static string MlaunchPath {
-			get {
-				// check next to mtouch first
-				var path = Path.Combine (FrameworkBinDirectory, "mlaunch");
-				if (File.Exists (path))
-					return path;
+		static string GetMlaunchPath (Application app)
+		{
+			// check next to mtouch first
+			var path = Path.Combine (GetFrameworkBinDirectory (app), "mlaunch");
+			if (File.Exists (path))
+				return path;
 
-				// check an environment variable
-				path = Environment.GetEnvironmentVariable ("MLAUNCH_PATH");
-				if (File.Exists (path))
-					return path;
+			// check an environment variable
+			path = Environment.GetEnvironmentVariable ("MLAUNCH_PATH");
+			if (File.Exists (path))
+				return path;
 
-				throw ErrorHelper.CreateError (93, Errors.MT0093);
-			}
+			throw ErrorHelper.CreateError (93, Errors.MT0093);
 		}
 
-		static int CallMlaunch ()
+		static int CallMlaunch (Application app)
 		{
 			Log (1, "Forwarding to mlaunch");
 			using (var p = new Process ()) {
@@ -1078,7 +1076,7 @@ namespace Xamarin.Bundler
 				p.StartInfo.RedirectStandardError = true;
 				p.StartInfo.RedirectStandardInput = true;
 				p.StartInfo.RedirectStandardOutput = true;
-				p.StartInfo.FileName = MlaunchPath;
+				p.StartInfo.FileName = GetMlaunchPath (app);
 
 				var sb = Environment.GetCommandLineArgs ().Skip (1).ToList ();
 				p.StartInfo.Arguments = StringUtils.FormatArguments (sb);


### PR DESCRIPTION
A few changes are required to have an Application instance at hand when we need to
get the ProductName from it.

This is necessary for .NET, since there will be a single linker library for all platforms,
which means we can't use a constant.