### PR TITLE
[msbuild] Make sure to restore the binding project before trying to build it.

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/BindingProject.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/BindingProject.cs
@@ -26,6 +26,8 @@ namespace Xamarin.iOS.Tasks
 
 			Engine.ProjectCollection.SetGlobalProperty ("Platform", Platform);
 
+			RunTarget (proj, "Restore", 0);
+
 			RunTarget (proj, "Build", 0);
 			Assert.IsTrue (File.Exists (dllPath), "{1} binding dll does not exist: {0} ", dllPath, Platform);
 


### PR DESCRIPTION
Fixes numerous build failures like this:

    The type or namespace name 'NUnit' could not be found (are you missing a using directive or an assembly reference?)
    The type or namespace name 'NUnit' could not be found (are you missing a using directive or an assembly reference?)
    The type or namespace name 'NUnit' could not be found (are you missing a using directive or an assembly reference?)
    The type or namespace name 'TestFixtureAttribute' could not be found (are you missing a using directive or an assembly reference?)
    The type or namespace name 'TestFixtureAttribute' could not be found (are you missing a using directive or an assembly reference?)