### PR TITLE
[monotouch-test] Adjust tests based on Environment.OSVersion

### DIFF
--- a/tests/monotouch-test/MetalPerformanceShaders/ImageScaleTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/ImageScaleTest.cs
@@ -22,8 +22,8 @@ namespace MonoTouchFixtures.MetalPerformanceShaders {
 			TestRuntime.AssertXcodeVersion (9,0);
 
 #if !MONOMAC
-			if (Runtime.Arch == Arch.SIMULATOR && Environment.OSVersion.Version.Major >= 15)
-				Assert.Inconclusive ("Metal is not supported in the simulator on macOS 10.15");
+			if (Runtime.Arch == Arch.SIMULATOR)
+				Assert.Inconclusive ("Metal Performance Shaders is not supported in the simulator");
 #endif
 
 			device = MTLDevice.SystemDefault;

--- a/tests/monotouch-test/MetalPerformanceShaders/KernelTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/KernelTest.cs
@@ -24,8 +24,8 @@ namespace MonoTouchFixtures.MetalPerformanceShaders {
 #if !MONOMAC
 			TestRuntime.AssertXcodeVersion (7, 0);
 
-			if (Runtime.Arch == Arch.SIMULATOR && Environment.OSVersion.Version.Major >= 15)
-				Assert.Inconclusive ("Metal is not supported in the simulator on macOS 10.15");
+			if (Runtime.Arch == Arch.SIMULATOR)
+				Assert.Inconclusive ("Metal Performance Shaders is not supported in the simulator");
 #else
 			TestRuntime.AssertXcodeVersion (9, 0);
 #endif

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramEqualizationTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramEqualizationTest.cs
@@ -24,8 +24,8 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 #if !MONOMAC
 			TestRuntime.AssertXcodeVersion (7, 0);
 
-			if (Runtime.Arch == Arch.SIMULATOR && Environment.OSVersion.Version.Major >= 15)
-				Assert.Inconclusive ("Metal is not supported in the simulator on macOS 10.15");
+			if (Runtime.Arch == Arch.SIMULATOR)
+				Assert.Inconclusive ("Metal Performance Shaders is not supported in the simulator");
 #else
 			TestRuntime.AssertXcodeVersion (9, 0);
 #endif

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramSpecificationTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramSpecificationTest.cs
@@ -24,8 +24,8 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 #if !MONOMAC
 			TestRuntime.AssertXcodeVersion (7, 0);
 
-			if (Runtime.Arch == Arch.SIMULATOR && Environment.OSVersion.Version.Major >= 15)
-				Assert.Inconclusive ("Metal is not supported in the simulator on macOS 10.15");
+			if (Runtime.Arch == Arch.SIMULATOR)
+				Assert.Inconclusive ("Metal Performance Shaders is not supported in the simulator");
 #else
 			TestRuntime.AssertXcodeVersion (9, 0);
 #endif

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramTest.cs
@@ -24,8 +24,8 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 #if !MONOMAC
 			TestRuntime.AssertXcodeVersion (7, 0);
 
-			if (Runtime.Arch == Arch.SIMULATOR && Environment.OSVersion.Version.Major >= 15)
-				Assert.Inconclusive ("Metal is not supported in the simulator on macOS 10.15");
+			if (Runtime.Arch == Arch.SIMULATOR)
+				Assert.Inconclusive ("Metal Performance Shaders is not supported in the simulator");
 #else
 			TestRuntime.AssertXcodeVersion (9, 0);
 #endif

--- a/tests/monotouch-test/ModelIO/MDLLight.cs
+++ b/tests/monotouch-test/ModelIO/MDLLight.cs
@@ -55,28 +55,12 @@ namespace MonoTouchFixtures.ModelIO {
 		{
 			using (var obj = new MDLLight ()) {
 				var color = obj.GetIrradiance (new Vector3 (1, 2, 3));
-#if MONOMAC
 				Assert.IsNotNull (color, "color 1");
-#else
-				if (Runtime.Arch == Arch.SIMULATOR && Environment.OSVersion.Version.Major < 15) {
-					Assert.IsNull (color, "color 1");
-				} else {
-					Assert.IsNotNull (color, "color 1");
-				}
-#endif
 			}
 
 			using (var obj = new MDLLight ()) {
 				var color = obj.GetIrradiance (new Vector3 (1, 2, 3), CGColorSpace.CreateGenericRgb ());
-#if MONOMAC
 				Assert.IsNotNull (color, "color 2");
-#else
-				if (Runtime.Arch == Arch.SIMULATOR && Environment.OSVersion.Version.Major < 15) {
-					Assert.IsNull (color, "color 2");
-				} else {
-					Assert.IsNotNull (color, "color 2");
-				}
-#endif
 			}
 		}
 	}


### PR DESCRIPTION
With Mono, Environment.OSVersion returns the macOS version when running in the
simulator. On Catalina, Mono returns 19.* as the Environment.OSVersion, which
means that the check for major version = 15 in the simulator turns out to be a
constant value now (since we don't support running in the simulator on a
4-year-old macOS version).

With .NET, Environment.OSVersion returns the iOS version instead, which means
that the check would have to be reworked.

However, since these version checks have effectively been constant for a few
years now, we can just remove the checks and the resulting unreachable code.