### PR TITLE
[msbuild] Pass the full path to the output file to the native linker.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/LinkNativeCodeTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/LinkNativeCodeTaskBase.cs
@@ -88,7 +88,7 @@ namespace Xamarin.MacDev.Tasks {
 					arguments.Add (Path.GetFullPath (obj.ItemSpec));
 
 			arguments.Add ("-o");
-			arguments.Add (OutputFile);
+			arguments.Add (Path.GetFullPath (OutputFile));
 
 			ExecuteAsync ("xcrun", arguments, sdkDevPath: SdkDevPath).Wait ();
 


### PR DESCRIPTION
This makes it easier to copy-paste commands to debug them.