### PR TITLE
[xharness] Make it possible to include .NET tests by setting a label.

### DIFF
--- a/tests/xharness/Jenkins/TestSelector.cs
+++ b/tests/xharness/Jenkins/TestSelector.cs
@@ -216,6 +216,7 @@ namespace Xharness.Jenkins {
 			SetEnabled (labels, "xtro", ref jenkins.IncludeXtro);
 			SetEnabled (labels, "cecil", ref jenkins.IncludeCecil);
 			SetEnabled (labels, "old-simulator", ref jenkins.IncludeOldSimulatorTests);
+			SetEnabled (labels, "dotnet", ref jenkins.IncludeDotNet);
 			SetEnabled (labels, "all", ref jenkins.IncludeAll);
 
 			// enabled by default


### PR DESCRIPTION
This also means that setting 'run-all-tests' enables the .NET tests, which
means they'll now start running on internal Jenkins (as was the intention from
the beginning).