### PR TITLE
[introspection] Some P/Invokes have moved to a QCall library in .NET 5 preview 8+.

### DIFF
--- a/tests/introspection/ApiPInvokeTest.cs
+++ b/tests/introspection/ApiPInvokeTest.cs
@@ -209,13 +209,13 @@ namespace Introspection
 					case "__Internal":
 						// load from executable
 						path = null;
+						break;
 #if NET
+					case "QCall":
 						// Globalization hasn't been implemented yet: https://github.com/xamarin/xamarin-macios/issues/8906
 						if (name.StartsWith ("GlobalizationNative_", StringComparison.Ordinal))
 							continue;
-#endif
 						break;
-#if NET
 					case "libhostpolicy":
 						// There's no libhostpolicy library.
 						// https://github.com/dotnet/runtime/issues/38543


### PR DESCRIPTION
This fixes numerous P/Invoke test failures like this:

    Could not find the symbol 'GlobalizationNative_GetCalendars' in QCall
    Could not find the symbol 'GlobalizationNative_GetCalendarInfo' in QCall
    Could not find the symbol 'GlobalizationNative_EnumCalendarInfo' in QCall
    Could not find the symbol 'GlobalizationNative_GetLatestJapaneseEra' in QCall
    [...]

Ref: https://github.com/dotnet/runtime/commit/a56d6a8034f5cb5ad58f9e29eb61edcc792f4b86
Ref: https://github.com/dotnet/runtime/commit/fae477f34b2185135f543af14d828fcd6789fee3