### PR TITLE
[msbuild] Compute variables for where the platform assembly is, and the platform assembly name.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.TargetFrameworkFix.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.TargetFrameworkFix.targets
@@ -21,19 +21,19 @@ Copyright (c) 2018 Microsoft Corp. (www.microsoft.com)
 	<Target Name="FixTargetFrameworkDirectory" AfterTargets="FixDesignTimeFacades" Condition="('$(OS)' != 'Windows_NT')">
 		<PropertyGroup>
 			<!-- For Modern / Full we overwrite TargetFrameworkDirectory to resolve non XM assemblies from our location only -->
-			<TargetFrameworkDirectory Condition="'$(TargetFrameworkName)' != 'System'">$(MacBclPath);@(DesignTimeFacadeDirectories)</TargetFrameworkDirectory>
+			<TargetFrameworkDirectory Condition="'$(TargetFrameworkName)' != 'System'">$(_XamarinBclPath);@(DesignTimeFacadeDirectories)</TargetFrameworkDirectory>
 
 			<!-- For system we extend, not overwrite TargetFrameworkDirectory. -->
 			<!-- mscorlib, System, and other BCL libs must come from Mono System to prevent corlib mistmatches. Xamarin.Mac.dll must come from XM/lib/mono/4.5/ -->
 			<!-- If we find cases of other non-XM assemblies being resolved from XM paths, we can look into using CandidateAssemblyFiles but it is msbuild only. -->
-			<TargetFrameworkDirectory Condition="'$(TargetFrameworkName)' == 'System'">$(TargetFrameworkDirectory);$(MacBclPath)</TargetFrameworkDirectory>
+			<TargetFrameworkDirectory Condition="'$(TargetFrameworkName)' == 'System'">$(TargetFrameworkDirectory);$(_XamarinBclPath)</TargetFrameworkDirectory>
 		</PropertyGroup>
 	</Target>
 
 	<Target Name="FixDesignTimeFacades" AfterTargets="GetReferenceAssemblyPaths" Condition="('$(OS)' != 'Windows_NT')">
 		<ItemGroup>
 			<DesignTimeFacadeDirectories Remove="@(DesignTimeFacadeDirectories)" />
-			<DesignTimeFacadeDirectories Include="$(MacBclPath)/Facades/" />
+			<DesignTimeFacadeDirectories Include="$(_XamarinBclPath)/Facades/" />
 		</ItemGroup>
 	</Target>
 </Project>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
@@ -19,7 +19,7 @@ Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 
 	<!-- Location of mscorlib -->
 	<PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-		<FrameworkPathOverride Condition="'$(TargetFrameworkName)' != 'System'">$(MacBclPath)</FrameworkPathOverride>
+		<FrameworkPathOverride Condition="'$(TargetFrameworkName)' != 'System'">$(_XamarinBclPath)</FrameworkPathOverride>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.TargetFrameworkFix.targets"/>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -64,24 +64,36 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<When Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
 			<PropertyGroup>
 				<TargetFrameworkName>Modern</TargetFrameworkName>
-				<MacBclPath>$(_XamarinSdkRoot)/lib/mono/Xamarin.Mac</MacBclPath>
+				<_XamarinBclPath>$(_XamarinSdkRoot)/lib/mono/Xamarin.Mac/</_XamarinBclPath>
 			</PropertyGroup>
 		</When>
 		<!-- If TargetFrameworkIdentifier is not 'Xamarin.Mac', but we're still a macOS app and UseXamMacFullFramework is true, then we're in Full mode -->
 		<When Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(_PlatformName)' == 'macOS' And '$(UseXamMacFullFramework)' == 'true'">
 			<PropertyGroup>
 				<TargetFrameworkName>Full</TargetFrameworkName>
-				<MacBclPath>$(_XamarinSdkRoot)/lib/mono/4.5</MacBclPath>
+				<_XamarinBclPath>$(_XamarinSdkRoot)/lib/mono/4.5/</_XamarinBclPath>
 			</PropertyGroup>
 		</When>
 		<!-- If the two other conditions don't match, but we're still a macOS app, then we're in System mode -->
 		<When Condition="'$(_PlatformName)' == 'macOS'">
 			<PropertyGroup>
 				<TargetFrameworkName>System</TargetFrameworkName>
-				<MacBclPath>$(_XamarinSdkRoot)/lib/mono/4.5</MacBclPath>
+				<_XamarinBclPath>$(_XamarinSdkRoot)/lib/mono/4.5/</_XamarinBclPath>
 			</PropertyGroup>
 		</When>
 	</Choose>
+	<PropertyGroup Condition="'$(_XamarinBclPath)' == ''">
+		<_XamarinBclPath Condition="'$(_PlatformName)' == 'iOS'">$(_XamarinSdkRoot)/lib/mono/Xamarin.iOS/</_XamarinBclPath>
+		<_XamarinBclPath Condition="'$(_PlatformName)' == 'tvOS'">$(_XamarinSdkRoot)/lib/mono/Xamarin.TVOS/</_XamarinBclPath>
+		<_XamarinBclPath Condition="'$(_PlatformName)' == 'watchOS'">$(_XamarinSdkRoot)/lib/mono/Xamarin.WatchOS/</_XamarinBclPath>
+	</PropertyGroup>
+	<PropertyGroup>
+		<_XamarinPlatformAssemblyName Condition="'$(_PlatformName)' == 'iOS'">Xamarin.iOS.dll</_XamarinPlatformAssemblyName>
+		<_XamarinPlatformAssemblyName Condition="'$(_PlatformName)' == 'tvOS'">Xamarin.TVOS.dll</_XamarinPlatformAssemblyName>
+		<_XamarinPlatformAssemblyName Condition="'$(_PlatformName)' == 'watchOS'">Xamarin.WatchOS.dll</_XamarinPlatformAssemblyName>
+		<_XamarinPlatformAssemblyName Condition="'$(_PlatformName)' == 'macOS'">Xamarin.Mac.dll</_XamarinPlatformAssemblyName>
+		<_XamarinPlatformAssemblyPath>$(_XamarinBclPath)$(_XamarinPlatformAssemblyName)</_XamarinPlatformAssemblyPath>
+	</PropertyGroup>
 
 	<!-- Sometimes we've used different variable names for the same thing for Xamarin.iOS and Xamarin.Mac projects. Here we try to unify those variables -->
 	<PropertyGroup>
@@ -201,10 +213,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(IsBindingProject)' == 'true'">
-		<BaseLibDllPath Condition="'$(OS)' == 'Unix' And '$(_PlatformName)' == 'iOS'">$(_XamarinSdkRoot)/lib/mono/Xamarin.iOS/Xamarin.iOS.dll</BaseLibDllPath>
-		<BaseLibDllPath Condition="'$(OS)' == 'Unix' And '$(_PlatformName)' == 'tvOS'">$(_XamarinSdkRoot)/lib/mono/Xamarin.TVOS/Xamarin.TVOS.dll</BaseLibDllPath>
-		<BaseLibDllPath Condition="'$(OS)' == 'Unix' And '$(_PlatformName)' == 'watchOS'">$(_XamarinSdkRoot)/lib/mono/Xamarin.WatchOS/Xamarin.WatchOS.dll</BaseLibDllPath>
-		<BaseLibDllPath Condition="'$(OS)' == 'Unix' And '$(_PlatformName)' == 'macOS'">$(MacBclPath)/Xamarin.Mac.dll</BaseLibDllPath>
+		<BaseLibDllPath Condition="'$(OS)' == 'Unix'">$(_XamarinPlatformAssemblyPath)</BaseLibDllPath>
 
 		<BTouchToolPath Condition="'$(OS)' == 'Unix' And '$(BTouchToolPath)' == ''">$(_XamarinSdkRoot)/bin/</BTouchToolPath>
 		<BTouchToolPath Condition="'$(OS)' != 'Unix' And '$(_PlatformName)' != 'macOS' And '$(BTouchToolPath)' == ''">$(MSBuildExtensionsPath)\Xamarin\iOS\</BTouchToolPath>


### PR DESCRIPTION
This will be more useful later, because these variables will be used in more places
in the .NET code.