### PR TITLE
[mtouch/mmp] Move Target.Is32Build and Target.Is64Build to shared code.

### DIFF
--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -54,10 +54,25 @@ namespace Xamarin.Bundler {
 		// Note that each 'Target' can have multiple abis: armv7+armv7s for instance.
 		public List<Abi> Abis;
 
-#if MONOMAC
-		public bool Is32Build { get { return false; } }
-		public bool Is64Build { get { return true; } }
-#endif
+		// If we're targetting a 32 bit arch for this target.
+		bool? is32bits;
+		public bool Is32Build {
+			get {
+				if (!is32bits.HasValue)
+					is32bits = Application.IsArchEnabled (Abis, Abi.Arch32Mask);
+				return is32bits.Value;
+			}
+		}
+
+		// If we're targetting a 64 bit arch for this target.
+		bool? is64bits;
+		public bool Is64Build {
+			get {
+				if (!is64bits.HasValue)
+					is64bits = Application.IsArchEnabled (Abis, Abi.Arch64Mask);
+				return is64bits.Value;
+			}
+		}
 
 		public Target (Application app)
 		{

--- a/tools/mtouch/Target.mtouch.cs
+++ b/tools/mtouch/Target.mtouch.cs
@@ -52,26 +52,6 @@ namespace Xamarin.Bundler
 		// If the assemblies were symlinked.
 		public bool Symlinked;
 
-		// If we're targetting a 32 bit arch for this target.
-		bool? is32bits;
-		public bool Is32Build {
-			get {
-				if (!is32bits.HasValue)
-					is32bits = Application.IsArchEnabled (Abis, Abi.Arch32Mask);
-				return is32bits.Value;
-			}
-		}
-
-		// If we're targetting a 64 bit arch for this target.
-		bool? is64bits;
-		public bool Is64Build {
-			get {
-				if (!is64bits.HasValue)
-					is64bits = Application.IsArchEnabled (Abis, Abi.Arch64Mask);
-				return is64bits.Value;
-			}
-		}
-
 		// If this is an app extension, this returns the equivalent (32/64bit) target for the container app.
 		// This may be null (it's possible to build an extension for 32+64bit, and the main app only for 64-bit, for instance.
 		public Target ContainerTarget {


### PR DESCRIPTION
We'll need the iOS implementation for .NET, so use that everywhere.