### PR TITLE
[mtouch/mmp] Share Assembly.CopyAssembly.

### DIFF
--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -673,6 +673,56 @@ namespace Xamarin.Bundler {
 				CopyAssembly (a, target_s);
 			}
 		}
+
+		public delegate bool StripAssembly (string path);
+
+		// returns false if the assembly was not copied (because it was already up-to-date).
+		public bool CopyAssembly (string source, string target, bool copy_debug_symbols = true, StripAssembly strip = null)
+		{
+			var copied = false;
+
+			try {
+				var strip_assembly = strip != null && strip (source);
+				if (!Application.IsUptodate (source, target) && (strip_assembly || !Cache.CompareAssemblies (source, target))) {
+					copied = true;
+					if (strip_assembly) {
+						Driver.FileDelete (target);
+						Directory.CreateDirectory (Path.GetDirectoryName (target));
+						MonoTouch.Tuner.Stripper.Process (source, target);
+					} else {
+						Application.CopyFile (source, target);
+					}
+				} else {
+					Driver.Log (3, "Target '{0}' is up-to-date.", target);
+				}
+
+				// Update the debug symbols file even if the assembly didn't change.
+				if (copy_debug_symbols && HasValidSymbols) {
+					// Unfortunately Cecil won't tell us the path of the symbol file, so we have to try all we support (.pdb+.mdb)
+					if (File.Exists (source + ".mdb"))
+						Application.UpdateFile (source + ".mdb", target + ".mdb", true);
+
+					var spdb = Path.ChangeExtension (source, "pdb");
+					if (File.Exists (spdb))
+						Application.UpdateFile (spdb, Path.ChangeExtension (target, "pdb"), true);
+				}
+
+				CopyConfigToDirectory (Path.GetDirectoryName (target));
+			} catch (Exception e) {
+				throw new ProductException (1009, true, e, Errors.MX1009, source, target, e.Message);
+			}
+
+			return copied;
+		}
+
+		public void CopyConfigToDirectory (string directory)
+		{
+			string config_src = FullPath + ".config";
+			if (File.Exists (config_src)) {
+				string config_target = Path.Combine (directory, FileName + ".config");
+				Application.UpdateFile (config_src, config_target, true);
+			}
+		}
 	}
 
 	public sealed class NormalizedStringComparer : IEqualityComparer<string>

--- a/tools/mmp/Assembly.mmp.cs
+++ b/tools/mmp/Assembly.mmp.cs
@@ -4,22 +4,5 @@ using System.IO;
 namespace Xamarin.Bundler {
 	public partial class Assembly
 	{
-		// returns false if the assembly was not copied (because it was already up-to-date).
-		bool CopyAssembly (string source, string target)
-		{
-			// TODO - We should move to mtouch's code, shared in common
-			var copied = false;
-
-			try {
-				if (!Application.IsUptodate (source, target)) {
-					copied = true;
-					Application.CopyFile (source, target);
-				}
-			} catch (Exception e) {
-				throw new ProductException (1009, true, e, Errors.MX1009, source, target, e.Message);
-			}
-
-			return copied;
-		}
 	}
 }

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -452,6 +452,9 @@
     <Compile Include="..\common\Driver.execution.cs">
       <Link>tools\common\Driver.execution.cs</Link>
     </Compile>
+    <Compile Include="..\mtouch\Stripper.cs">
+      <Link>external\tools\mtouch\Stripper.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/tools/mtouch/Assembly.mtouch.cs
+++ b/tools/mtouch/Assembly.mtouch.cs
@@ -103,47 +103,6 @@ namespace Xamarin.Bundler {
 			ComputeDependencies (exceptions);
 		}
 
-		public delegate bool StripAssembly (string path);
-
-		// returns false if the assembly was not copied (because it was already up-to-date).
-		public bool CopyAssembly (string source, string target, bool copy_debug_symbols = true, StripAssembly strip = null)
-		{
-			var copied = false;
-
-			try {
-				var strip_assembly = strip != null && strip (source);
-				if (!Application.IsUptodate (source, target) && (strip_assembly || !Cache.CompareAssemblies (source, target))) {
-					copied = true;
-					if (strip_assembly) {
-						Driver.FileDelete (target);
-						Directory.CreateDirectory (Path.GetDirectoryName (target));
-						MonoTouch.Tuner.Stripper.Process (source, target);
-					} else {
-						Application.CopyFile (source, target);
-					}
-				} else {
-					Driver.Log (3, "Target '{0}' is up-to-date.", target);
-				}
-
-				// Update the debug symbols file even if the assembly didn't change.
-				if (copy_debug_symbols && HasValidSymbols) {
-					// Unfortunately Cecil won't tell us the path of the symbol file, so we have to try all we support (.pdb+.mdb)
-					if (File.Exists (source + ".mdb"))
-						Application.UpdateFile (source + ".mdb", target + ".mdb", true);
-
-					var spdb = Path.ChangeExtension (source, "pdb");
-					if (File.Exists (spdb))
-						Application.UpdateFile (spdb, Path.ChangeExtension (target, "pdb"), true);
-				}
-
-				CopyConfigToDirectory (Path.GetDirectoryName (target));
-			} catch (Exception e) {
-				throw new ProductException (1009, true, e, Errors.MX1009, source, target, e.Message);
-			}
-
-			return copied;
-		}
-
 		public void CopyDebugSymbolsToDirectory (string directory)
 		{
 			string mdb_src = FullPath + ".mdb";
@@ -174,15 +133,6 @@ namespace Xamarin.Bundler {
 					string temppath = Path.Combine (destPath, file.Name);
 					file.CopyTo(temppath, true);
 				}
-			}
-		}
-
-		public void CopyConfigToDirectory (string directory)
-		{
-			string config_src = FullPath + ".config";
-			if (File.Exists (config_src)) {
-				string config_target = Path.Combine (directory, FileName + ".config");
-				Application.UpdateFile (config_src, config_target, true);
 			}
 		}
 


### PR DESCRIPTION
The shared version isn't used by mmp yet as far as I can tell (mmp has its own logic
to copy assemblies), but sharing this code is the first step towards having the same
implementation as well.