### PR TITLE
[mtouch/mmp] Remove the Error91LinkerSuggestion and implement it using two different error codes.

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -389,7 +389,17 @@ namespace Xamarin.Bundler {
 			RuntimeOptions = RuntimeOptions.Create (this, HttpMessageHandler, TlsProvider);
 
 			if (RequiresXcodeHeaders && SdkVersion < SdkVersions.GetVersion (this)) {
-				throw ErrorHelper.CreateError (91, Errors.MX0091, ProductName, PlatformName, SdkVersions.GetVersion (this), SdkVersions.Xcode, Error91LinkerSuggestion);
+				switch (Platform) {
+				case ApplePlatform.iOS:
+				case ApplePlatform.TVOS:
+				case ApplePlatform.WatchOS:
+					throw ErrorHelper.CreateError (180, Errors.MX0179, ProductName, PlatformName, SdkVersions.GetVersion (this), SdkVersions.Xcode);
+				case ApplePlatform.MacOSX:
+					throw ErrorHelper.CreateError (179, Errors.MX0180, ProductName, PlatformName, SdkVersions.GetVersion (this), SdkVersions.Xcode);
+				default:
+					// Default to the iOS error message, it's better than showing MX0071 (unknown platform), which would be completely unrelated
+					goto case ApplePlatform.iOS;
+				}
 			}
 
 			if (DeploymentTarget != null) {

--- a/tools/mmp/Application.mmp.cs
+++ b/tools/mmp/Application.mmp.cs
@@ -5,8 +5,6 @@ namespace Xamarin.Bundler {
 	public partial class Application
 	{
 		public string ProductName = "Xamarin.Mac";
-		public const string Error91LinkerSuggestion = "use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options > Linker Behavior";
-
 		public bool IsSimulatorBuild => false;
 		public bool IsDeviceBuild => false;
 		public bool IsTodayExtension => false;

--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -41,7 +41,6 @@ namespace Xamarin.Bundler {
 	public partial class Application
 	{
 		public string ProductName = "Xamarin.iOS";
-		public const string Error91LinkerSuggestion = "set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options > Linker Behavior";
 
 		public string ExecutableName;
 		public BuildTarget BuildTarget;

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -599,12 +599,6 @@ namespace Xamarin.Bundler {
             }
         }
         
-        internal static string MX0091 {
-            get {
-                return ResourceManager.GetString("MX0091", resourceCulture);
-            }
-        }
-        
         internal static string MT0093 {
             get {
                 return ResourceManager.GetString("MT0093", resourceCulture);
@@ -1088,6 +1082,18 @@ namespace Xamarin.Bundler {
         internal static string MX0178 {
             get {
                 return ResourceManager.GetString("MX0178", resourceCulture);
+            }
+        }
+        
+        internal static string MX0179 {
+            get {
+                return ResourceManager.GetString("MX0179", resourceCulture);
+            }
+        }
+        
+        internal static string MX0180 {
+            get {
+                return ResourceManager.GetString("MX0180", resourceCulture);
             }
         }
         

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -490,11 +490,7 @@
 		</value>
 	</data>
 
-	<data name="MX0091" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</value>
-	</data>
-
+	<!-- MX0091 has been used in the past -->
 	<!-- MT0092 has been used in the past -->
 
 	<data name="MT0093" xml:space="preserve">
@@ -910,6 +906,14 @@
         <value>Debugging symbol file for '{0}' is not valid and was ignored.
         </value>
     </data>
+
+	<data name="MX0179" xml:space="preserve">
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options > Linker Behavior} (to try to avoid the new APIs).</value>
+	</data>
+
+	<data name="MX0180" xml:space="preserve">
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options > Linker Behavior (to try to avoid the new APIs).</value>
+	</data>
 
 	<data name="MX1009" xml:space="preserve">
 		<value>Could not copy the assembly '{0}' to '{1}': {2}

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -2506,13 +2506,6 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MX0091">
-        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</source>
-        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MX0099">
         <source>Internal error: {0}. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.
 		</source>
@@ -2586,6 +2579,16 @@
         </source>
         <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
         </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0179">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0180">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</target>
         <note />
       </trans-unit>
       <trans-unit id="MX1009">

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -2506,13 +2506,6 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MX0091">
-        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</source>
-        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MX0099">
         <source>Internal error: {0}. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.
 		</source>
@@ -2586,6 +2579,16 @@
         </source>
         <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
         </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0179">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0180">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</target>
         <note />
       </trans-unit>
       <trans-unit id="MX1009">

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -2506,13 +2506,6 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MX0091">
-        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</source>
-        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MX0099">
         <source>Internal error: {0}. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.
 		</source>
@@ -2586,6 +2579,16 @@
         </source>
         <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
         </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0179">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0180">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</target>
         <note />
       </trans-unit>
       <trans-unit id="MX1009">

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -2506,13 +2506,6 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MX0091">
-        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</source>
-        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MX0099">
         <source>Internal error: {0}. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.
 		</source>
@@ -2586,6 +2579,16 @@
         </source>
         <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
         </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0179">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0180">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</target>
         <note />
       </trans-unit>
       <trans-unit id="MX1009">

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -2506,13 +2506,6 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MX0091">
-        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</source>
-        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MX0099">
         <source>Internal error: {0}. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.
 		</source>
@@ -2586,6 +2579,16 @@
         </source>
         <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
         </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0179">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0180">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</target>
         <note />
       </trans-unit>
       <trans-unit id="MX1009">

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -2506,13 +2506,6 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MX0091">
-        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</source>
-        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MX0099">
         <source>Internal error: {0}. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.
 		</source>
@@ -2586,6 +2579,16 @@
         </source>
         <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
         </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0179">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0180">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</target>
         <note />
       </trans-unit>
       <trans-unit id="MX1009">

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -2506,13 +2506,6 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MX0091">
-        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</source>
-        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MX0099">
         <source>Internal error: {0}. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.
 		</source>
@@ -2586,6 +2579,16 @@
         </source>
         <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
         </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0179">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0180">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</target>
         <note />
       </trans-unit>
       <trans-unit id="MX1009">

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -2506,13 +2506,6 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MX0091">
-        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</source>
-        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MX0099">
         <source>Internal error: {0}. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.
 		</source>
@@ -2586,6 +2579,16 @@
         </source>
         <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
         </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0179">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0180">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</target>
         <note />
       </trans-unit>
       <trans-unit id="MX1009">

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -2506,13 +2506,6 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MX0091">
-        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</source>
-        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MX0099">
         <source>Internal error: {0}. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.
 		</source>
@@ -2586,6 +2579,16 @@
         </source>
         <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
         </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0179">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0180">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</target>
         <note />
       </trans-unit>
       <trans-unit id="MX1009">

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -2506,13 +2506,6 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MX0091">
-        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</source>
-        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MX0099">
         <source>Internal error: {0}. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.
 		</source>
@@ -2586,6 +2579,16 @@
         </source>
         <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
         </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0179">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0180">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</target>
         <note />
       </trans-unit>
       <trans-unit id="MX1009">

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -2506,13 +2506,6 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MX0091">
-        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</source>
-        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MX0099">
         <source>Internal error: {0}. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.
 		</source>
@@ -2586,6 +2579,16 @@
         </source>
         <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
         </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0179">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0180">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</target>
         <note />
       </trans-unit>
       <trans-unit id="MX1009">

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -2506,13 +2506,6 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MX0091">
-        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</source>
-        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MX0099">
         <source>Internal error: {0}. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.
 		</source>
@@ -2586,6 +2579,16 @@
         </source>
         <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
         </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0179">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0180">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</target>
         <note />
       </trans-unit>
       <trans-unit id="MX1009">

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -2506,13 +2506,6 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MX0091">
-        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</source>
-        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MX0099">
         <source>Internal error: {0}. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.
 		</source>
@@ -2586,6 +2579,16 @@
         </source>
         <target state="new">Debugging symbol file for '{0}' is not valid and was ignored.
         </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0179">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MX0180">
+        <source>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</source>
+        <target state="new">This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</target>
         <note />
       </trans-unit>
       <trans-unit id="MX1009">


### PR DESCRIPTION
* It makes the error message localizable.
* It makes the implementation shared between mtouch and mmp.