### PR TITLE
[xharness] Look at the exact NUnit version an NUnit project is referencing to figure out how to run it in a makefile.

### DIFF
--- a/tools/nunit3-console-3.9.0
+++ b/tools/nunit3-console-3.9.0
@@ -1,0 +1,3 @@
+#!/bin/bash -eu
+
+exec mono ~/.nuget/packages/nunit.consolerunner/3.9.0/tools/nunit3-console.exe "$@"


### PR DESCRIPTION
This makes the makefile targets to run the mac NUnit tests work again.