### PR TITLE
[mtouch/mmp] Add CoreFoundation and GSS to our list of known frameworks.

### DIFF
--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -92,6 +92,7 @@ public class Frameworks : Dictionary <string, Framework>
 				mac_frameworks = new Frameworks () {
 					{ "Accelerate", 10, 0 },
 					{ "AppKit", 10, 0 },
+					{ "CoreFoundation", "CoreFoundation", 10, 0 },
 					{ "CoreGraphics", "QuartzCore", 10, 0 },
 					{ "CoreImage", "QuartzCore", 10, 0 },
 					{ "Foundation", 10, 0 },
@@ -190,6 +191,7 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "VideoSubscriberAccount", "VideoSubscriberAccount", 10,14 },
 					{ "UserNotifications", "UserNotifications", 10,14 },
 					{ "iTunesLibrary", "iTunesLibrary", 10,14 },
+					{ "GSS", "GSS", 10, 14 },
 
 					{ "AuthenticationServices", "AuthenticationServices", 10,15 },
 					{ "CoreMotion", "CoreMotion", 10,15 },
@@ -227,6 +229,7 @@ public class Frameworks : Dictionary <string, Framework>
 				{ "CFNetwork", "CFNetwork", 3 },
 				{ "CoreAnimation", "QuartzCore", 3 },
 				{ "CoreData", "CoreData", 3 },
+				{ "CoreFoundation", "CoreFoundation", 3 },
 				{ "CoreGraphics", "CoreGraphics", 3 },
 				{ "CoreLocation", "CoreLocation", 3 },
 				{ "ExternalAccessory", "ExternalAccessory", 3 },
@@ -261,6 +264,7 @@ public class Frameworks : Dictionary <string, Framework>
 				{ "CoreImage", "CoreImage", 5 },
 				{ "CoreBluetooth", "CoreBluetooth", 5 },
 				{ "Twitter", "Twitter", 5 },
+				{ "GSS", "GSS", 5 },
 
 				{ "MediaToolbox", "MediaToolbox", 6 },
 				{ "PassKit", "PassKit", 6 },
@@ -430,6 +434,7 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "CoreAudio", "CoreAudio", 9 },
 					{ "CoreBluetooth", "CoreBluetooth", 9 },
 					{ "CoreData", "CoreData", 9 },
+					{ "CoreFoundation", "CoreFoundation", 9 },
 					{ "CoreGraphics", "CoreGraphics", 9 },
 					{ "CoreImage", "CoreImage", 9 },
 					{ "CoreLocation", "CoreLocation", 9 },

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -100,6 +100,8 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "PdfKit", "Quartz", 10, 0 },
 					{ "Security", 10, 0 },
 
+					{ "GSS", "GSS", 10, 1 },
+
 					{ "AudioUnit", 10, 2 },
 					{ "CoreMidi", "CoreMIDI", 10, 2 },
 					{ "WebKit", 10, 2},
@@ -191,7 +193,6 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "VideoSubscriberAccount", "VideoSubscriberAccount", 10,14 },
 					{ "UserNotifications", "UserNotifications", 10,14 },
 					{ "iTunesLibrary", "iTunesLibrary", 10,14 },
-					{ "GSS", "GSS", 10, 14 },
 
 					{ "AuthenticationServices", "AuthenticationServices", 10,15 },
 					{ "CoreMotion", "CoreMotion", 10,15 },


### PR DESCRIPTION
Putting these frameworks in our known list of frameworks means we won't try to
weak link them unless needed (when the deployment target is earlier than when
they were introduced), because if we encounter a framework we don't know
about, we'll weak link them to be on the safe side.