### PR TITLE
[dotnet] Add support for building binding projects.

### DIFF
--- a/dotnet/DefaultCompilationIncludes.md
+++ b/dotnet/DefaultCompilationIncludes.md
@@ -17,4 +17,11 @@ the platform-specific variables `EnableDefaultiOSItems=false`,
 All \*.plist files in the root directory are included by default (as `None`
 items).
 
+## Binding projects
+
+Default compilation includes is turned off for binding projects, because
+typically there are C# source files (ApiDefinition.cs, StructsAndEnums.cs,
+etc.) in the binding project directory which should be compiled as binding
+source code, and not as normal C# source code.
+
 [1]: https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#default-compilation-includes-in-net-core-projects

--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -13,6 +13,9 @@
     <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'tvOS' ">$(EnableDefaulttvOSItems)</_EnableDefaultXamarinItems>
     <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'watchOS' ">$(EnableDefaultwatchOSItems)</_EnableDefaultXamarinItems>
     <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'macOS' ">$(EnableDefaultmacOSItems)</_EnableDefaultXamarinItems>
+
+    <!-- Don't include default Compile items for binding projects, because that would pick up ApiDefinition.cs and StructsAndEnums.cs -->
+    <EnableDefaultCompileItems Condition=" '$(IsBindingProject)' == 'true' ">false</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <!-- Default plist file inclusion -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -242,6 +242,7 @@
 		<PropertyGroup>
 			<BTouchToolPath>$(_XamarinSdkRootDirectory)/tools/bin</BTouchToolPath>
 			<BaseLibDllPath>$(_XamarinRefAssemblyPath)</BaseLibDllPath>
+			<_GeneratorAttributeAssembly>$(_XamarinSdkRootDirectory)/tools/lib/Xamarin.Apple.BindingAttributes.dll</_GeneratorAttributeAssembly>
 		</PropertyGroup>
 	</Target>
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -185,17 +185,22 @@
 
 	<!-- Native code -->
 
-	<Target Name="_ComputeVariables" DependsOnTargets="_GenerateBundleName;ResolveRuntimePackAssets">
+	<Target Name="_ComputeFrameworkVariables" DependsOnTargets="ResolveRuntimePackAssets">
 		<ItemGroup>
 			<!-- Look in the ResolvedFrameworkReference for our Microsoft.* package. This should only find a single package. -->
 			<_XamarinFrameworkReference Include="@(ResolvedFrameworkReference)" Condition="'%(ResolvedFrameworkReference.Identity)' == 'Microsoft.$(_PlatformName)'" />
 		</ItemGroup>
 		<PropertyGroup>
-			<_IntermediateNativeLibraryDir>$(IntermediateOutputPath)nativelibraries/</_IntermediateNativeLibraryDir>
-			<_NativeExecutableName>$(_AppBundleName)</_NativeExecutableName>
 			<_XamarinSdkRuntimePackDirectory>%(_XamarinFrameworkReference.RuntimePackPath)</_XamarinSdkRuntimePackDirectory>
 			<_XamarinNativeLibraryDirectory>$(_XamarinSdkRuntimePackDirectory)/runtimes/$(RuntimeIdentifier)/native</_XamarinNativeLibraryDirectory>
 			<_XamarinIncludeDirectory>$(_XamarinSdkRuntimePackDirectory)/runtimes/$(RuntimeIdentifier)/native</_XamarinIncludeDirectory>
+		</PropertyGroup>
+	</Target>
+
+	<Target Name="_ComputeVariables" DependsOnTargets="_GenerateBundleName;_ComputeFrameworkVariables">
+		<PropertyGroup>
+			<_IntermediateNativeLibraryDir>$(IntermediateOutputPath)nativelibraries/</_IntermediateNativeLibraryDir>
+			<_NativeExecutableName>$(_AppBundleName)</_NativeExecutableName>
 
 			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == '' And '$(ComputedPlatform)' != 'iPhone'">dylib</_LibMonoLinkMode>
 			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == ''">static</_LibMonoLinkMode>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -192,8 +192,11 @@
 		</ItemGroup>
 		<PropertyGroup>
 			<_XamarinSdkRuntimePackDirectory>%(_XamarinFrameworkReference.RuntimePackPath)</_XamarinSdkRuntimePackDirectory>
+			<_XamarinRefPackageDirectory>%(_XamarinFrameworkReference.TargetingPackPath)</_XamarinRefPackageDirectory>
 			<_XamarinNativeLibraryDirectory>$(_XamarinSdkRuntimePackDirectory)/runtimes/$(RuntimeIdentifier)/native</_XamarinNativeLibraryDirectory>
 			<_XamarinIncludeDirectory>$(_XamarinSdkRuntimePackDirectory)/runtimes/$(RuntimeIdentifier)/native</_XamarinIncludeDirectory>
+			<_XamarinRefAssemblyDirectory>$(_XamarinRefPackageDirectory)/ref/net5.0/</_XamarinRefAssemblyDirectory>
+			<_XamarinRefAssemblyPath>$(_XamarinRefAssemblyDirectory)$(_PlatformAssemblyName).dll</_XamarinRefAssemblyPath>
 		</PropertyGroup>
 	</Target>
 
@@ -226,6 +229,20 @@
 							"
 			/>
 		</ItemGroup>
+	</Target>
+
+	<PropertyGroup>
+		<_GenerateBindingsDependsOn>
+			_ComputeBindingVariables;
+			$(_GenerateBindingsDependsOn);
+		</_GenerateBindingsDependsOn>
+	</PropertyGroup>
+
+	<Target Name="_ComputeBindingVariables" DependsOnTargets="_ComputeFrameworkVariables" Condition="'$(IsBindingProject)' == 'true'">
+		<PropertyGroup>
+			<BTouchToolPath>$(_XamarinSdkRootDirectory)/tools/bin</BTouchToolPath>
+			<BaseLibDllPath>$(_XamarinRefAssemblyPath)</BaseLibDllPath>
+		</PropertyGroup>
 	</Target>
 
 	<Target Name="_CompileNativeExecutable"

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -23,25 +23,25 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 		<IsBindingProject>true</IsBindingProject>
 	</PropertyGroup>
 
-	<!-- Due to IDE/template bugs, many bindings projects exist in the wild withtout correct TFI/TFV tags.
+	<!-- Due to IDE/template bugs, many bindings projects exist in the wild without correct TFI/TFV tags.
 	In addition, System is not supported, so treat System as Modern or Full, depending on TFV being set.
 	Microsoft.CSharp.targets gives TargetFrameworkVersion / TargetFrameworkIdentifier default values, so we _must_ do this _before_ 
 	import Microsoft.CSharp.targets. However, we can't do most of Xamarin.Mac.ObjCBinding.CSharp.props before it. -->
 
 	<Choose>
-		<When Condition=" '$(UseXamMacFullFramework)' == '' And ( '$(TargetFrameworkVersion)' == 'v2.0' Or '$(TargetFrameworkVersion)' == '' )">
+		<When Condition=" '$(UseXamMacFullFramework)' == '' And ( '$(TargetFrameworkVersion)' == 'v2.0' Or '$(TargetFrameworkVersion)' == '' ) And '$(_UsingXamarinSdk)' != 'true'">
 			<PropertyGroup>
 				<TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
 				<TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
 			</PropertyGroup>
 		</When>
-		<Otherwise>
+		<When Condition="'$(_UsingXamarinSdk)' != 'true'">
 			<PropertyGroup>
 				<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
 				<UseXamMacFullFramework>true</UseXamMacFullFramework>
 				<TargetFrameworkIdentifier></TargetFrameworkIdentifier>
 			</PropertyGroup>
-		</Otherwise>
+		</When>
 	</Choose>
 
 	<PropertyGroup>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
@@ -33,6 +33,8 @@ namespace Xamarin.MacDev.Tasks {
 		[Required]
 		public ITaskItem[] ApiDefinitions { get; set; }
 
+		public string AttributeAssembly { get; set; }
+
 		public ITaskItem[] CoreSources { get; set; }
 
 		public string DefineConstants { get; set; }
@@ -92,6 +94,8 @@ namespace Xamarin.MacDev.Tasks {
 			cmd.AppendSwitch ("/nostdlib");
 			cmd.AppendSwitchIfNotNull ("/baselib:", BaseLibDll);
 			cmd.AppendSwitchIfNotNull ("/out:", OutputAssembly);
+
+			cmd.AppendSwitchIfNotNull ("/attributelib:", AttributeAssembly);
 
 			string dir;
 			if (!string.IsNullOrEmpty (BaseLibDll)) {

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
@@ -97,7 +97,6 @@ namespace Xamarin.MacDev.Tasks {
 			if (!string.IsNullOrEmpty (BaseLibDll)) {
 				dir = Path.GetDirectoryName (BaseLibDll);
 				cmd.AppendSwitchIfNotNull ("/lib:", dir);
-				cmd.AppendSwitchIfNotNull ("/r:", Path.Combine (dir, "mscorlib.dll"));
 			}
 
 			if (ProcessEnums)

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -428,6 +428,8 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<BTouchEmitDebugInformation Condition="'$(Debug)' != ''">true</BTouchEmitDebugInformation>
 		</PropertyGroup>
 
+		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(GeneratedSourcesDir)" />
+
 		<BTouch
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -438,6 +438,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			AdditionalLibPaths="$(AdditionalLibPaths)"
 			AllowUnsafeBlocks="$(AllowUnsafeBlocks)"
 			ApiDefinitions="@(ObjcBindingApiDefinition)"
+			AttributeAssembly="$(_GeneratorAttributeAssembly)"
 			BaseLibDll="$(BaseLibDllPath)"
 			CoreSources="@(ObjcBindingCoreSource)"
 			DefineConstants="$(DefineConstants)"

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -17,12 +17,28 @@ $(DOTNET_BUILD_DIR)/bgen/bgen:  $(generator_dependencies) Makefile.generator $(B
 	$(Q_DOTNET_BUILD) $(DOTNET) build $(XBUILD_VERBOSITY) /p:Configuration=Debug bgen/bgen.csproj /p:IntermediateOutputPath=$(abspath $(DOTNET_BUILD_DIR)/IDE/obj/common)/ /p:OutputPath=$(abspath $(DOTNET_BUILD_DIR)/IDE/bin/common)/
 	$(Q) $(CP) $(DOTNET_BUILD_DIR)/IDE/bin/common/bgen* $(dir $@)
 
+$(DOTNET_DESTDIR)/%.Sdk/tools/lib/bgen/bgen: $(DOTNET_BUILD_DIR)/bgen/bgen | $(DOTNET_DESTDIR)/%.Sdk/tools/lib/bgen
+	$(Q) rm -f $(dir $@)/bgen*
+	$(Q) $(CP) $<* $(dir $@)
+
+$(DOTNET_DESTDIR)/%.Sdk/tools/bin/bgen: bgen/bgen.dotnet | $(DOTNET_DESTDIR)/%.Sdk/tools/bin
+	$(Q) $(CP) $< $@
+
+$(DOTNET_DESTDIR)/%.Sdk/tools/lib/Xamarin.Apple.BindingAttributes.dll: $(DOTNET_BUILD_DIR)/Xamarin.Apple.BindingAttributes.dll | $(DOTNET_DESTDIR)/%.Sdk/tools/lib
+	$(Q) $(CP) $< $@
+
 DOTNET_TARGETS += \
 	$(DOTNET_BUILD_DIR)/bgen/bgen \
+	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/tools/bin/bgen) \
+	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/tools/lib/bgen/bgen) \
+	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/tools/lib/Xamarin.Apple.BindingAttributes.dll) \
 
 DOTNET_TARGETS_DIRS += \
 	$(DOTNET_BUILD_DIR) \
 	$(DOTNET_BUILD_DIR)/bgen \
+	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/tools/bin) \
+	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/tools/lib) \
+	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/tools/lib/bgen) \
 
 #
 # Common

--- a/src/bgen/bgen.dotnet
+++ b/src/bgen/bgen.dotnet
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+pushd "$(dirname "$0")/.." > /dev/null
+MONOTOUCH_PREFIX=$(pwd -P)
+popd > /dev/null
+
+exec "$MONOTOUCH_PREFIX/lib/bgen/bgen" "$@"

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -51,6 +51,7 @@ public class BindingTouch {
 	string attributedll;
 
 	List<string> libs = new List<string> ();
+	List<string> references = new List<string> ();
 
 	public Universe universe;
 	public TypeManager TypeManager = new TypeManager ();
@@ -169,6 +170,13 @@ public class BindingTouch {
 				return path;
 		}
 
+		// Look in our references to see if we were explicity passed a path to the library we're looking for
+		foreach (var reference in references) {
+			var refname = Path.GetFileName (reference);
+			if (refname == name || refname == name + ".dll")
+				return reference;
+		}
+
 		throw new FileNotFoundException ($"Could not find the assembly '{name}' in any of the directories: {string.Join (", ", GetLibraryDirectories ())}");
 	}
 
@@ -225,7 +233,6 @@ public class BindingTouch {
 		List<string> sources;
 		var resources = new List<string> ();
 		var linkwith = new List<string> ();
-		var references = new List<string> ();
 		var api_sources = new List<string> ();
 		var core_sources = new List<string> ();
 		var extra_sources = new List<string> ();

--- a/tests/bindings-test/dotnet/.gitignore
+++ b/tests/bindings-test/dotnet/.gitignore
@@ -1,0 +1,3 @@
+global.json
+NuGet.config
+

--- a/tests/bindings-test/dotnet/iOS/bindings-test.csproj
+++ b/tests/bindings-test/dotnet/iOS/bindings-test.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.iOS.Sdk">
+  <PropertyGroup>
+    <NativeLibName>ios-fat</NativeLibName>
+  </PropertyGroup>
+  <Import Project="..\shared.targets" />
+</Project>

--- a/tests/bindings-test/dotnet/macOS/bindings-test.csproj
+++ b/tests/bindings-test/dotnet/macOS/bindings-test.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.macOS.Sdk">
+  <PropertyGroup>
+    <NativeLibName>macos</NativeLibName>
+  </PropertyGroup>
+  <Import Project="..\shared.targets" />
+</Project>

--- a/tests/bindings-test/dotnet/shared.targets
+++ b/tests/bindings-test/dotnet/shared.targets
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>bindingstest</RootNamespace>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\..\..\product.snk</AssemblyOriginatorKeyFile>
+    <LangVersion>latest</LangVersion>
+    <IsBindingProject>true</IsBindingProject>
+
+    <RootTestsDirectory>$(MSBuildThisFileDirectory)\..\..</RootTestsDirectory>
+    <BindingsTestDirectory>$(RootTestsDirectory)\bindings-test</BindingsTestDirectory>
+    <TestLibrariesDirectory>$(RootTestsDirectory)\test-libraries</TestLibrariesDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnitLite" Version="3.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="$(BindingsTestDirectory)\ApiDefinition.cs" />
+    <ObjcBindingApiDefinition Include="$(RootTestsDirectory)\generator\tests\ref-out-parameters.cs" />
+    <ObjcBindingApiDefinition Include="$(BindingsTestDirectory)\ApiDefinition.generated.cs" />
+    <ObjcBindingApiDefinition Include="$(BindingsTestDirectory)\ApiProtocol.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ObjcBindingCoreSource Include="$(BindingsTestDirectory)\StructsAndEnums.cs" />
+    <ObjcBindingCoreSource Include="$(BindingsTestDirectory)\StructsAndEnums.generated.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ObjcBindingNativeLibrary Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\libtest.a">
+      <Link>libtest.a</Link>
+    </ObjcBindingNativeLibrary>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(RootTestsDirectory)\common\ConditionalCompilation.cs">
+      <Link>ConditionalCompilation.cs</Link>
+    </Compile>
+    <Compile Include="$(BindingsTestDirectory)\libtest.linkwith.cs">
+      <DependentUpon>libtest.a</DependentUpon>
+    </Compile>
+    <Compile Include="$(BindingsTestDirectory)\ProtocolTest.cs" />
+    <Compile Include="$(RootTestsDirectory)\api-shared\ObjCRuntime\Registrar.cs">
+      <Link>Registrar.cs</Link>
+    </Compile>
+    <Compile Include="..\..\RegistrarBindingTest.cs" />
+    <Compile Include="$(RootTestsDirectory)\common\TestRuntime.cs">
+      <Link>TestRuntime.cs</Link>
+    </Compile>
+    <Compile Include="$(BindingsTestDirectory)\RuntimeTest.cs" />
+    <Compile Include="$(BindingsTestDirectory)\CodeBehind.cs" />
+    <Compile Include="$(BindingsTestDirectory)\Messaging.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(TestLibrariesDirectory)\libtest.m">
+      <Link>libtest.m</Link>
+    </None>
+    <None Include="$(TestLibrariesDirectory)\libtest.h">
+      <Link>libtest.h</Link>
+    </None>
+    <None Include="$(TestLibrariesDirectory)\libtest.structs.h">
+      <Link>libtest.structs.h</Link>
+    </None>
+    <None Include="$(TestLibrariesDirectory)\libtest.properties.h">
+      <Link>libtest.properties.h</Link>
+    </None>
+    <None Include="$(TestLibrariesDirectory)\testgenerator.cs">
+      <Link>testgenerator.cs</Link>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <GeneratedTestInput Include="$(TestLibrariesDirectory)\*.m" />
+    <GeneratedTestInput Include="$(TestLibrariesDirectory)\*.h" />
+    <GeneratedTestInput Include="$(TestLibrariesDirectory)\*.cs" />
+    <GeneratedTestInput Include="$(TestLibrariesDirectory)\Makefile" />
+    <GeneratedTestOutput Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\libtest.a" />
+    <GeneratedTestOutput Include="$(BindingsTestDirectory)\ApiDefinition.generated.cs" />
+    <GeneratedTestOutput Include="$(BindingsTestDirectory)\StructsAndEnums.generated.cs" />
+  </ItemGroup>
+
+  <Target Name="BuildTestLibraries" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)" BeforeTargets="BeforeBuild">
+    <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />
+  </Target>
+</Project>

--- a/tests/bindings-test/dotnet/tvOS/bindings-test.csproj
+++ b/tests/bindings-test/dotnet/tvOS/bindings-test.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.tvOS.Sdk">
+  <PropertyGroup>
+    <NativeLibName>tvos-fat</NativeLibName>
+  </PropertyGroup>
+  <Import Project="..\shared.targets" />
+</Project>

--- a/tests/bindings-test/dotnet/watchOS/bindings-test.csproj
+++ b/tests/bindings-test/dotnet/watchOS/bindings-test.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.watchOS.Sdk">
+  <PropertyGroup>
+    <NativeLibName>watchos-fat</NativeLibName>
+  </PropertyGroup>
+  <Import Project="..\shared.targets" />
+</Project>

--- a/tests/bindings-test2/dotnet/.gitignore
+++ b/tests/bindings-test2/dotnet/.gitignore
@@ -1,0 +1,3 @@
+global.json
+NuGet.config
+

--- a/tests/bindings-test2/dotnet/iOS/bindings-test2.csproj
+++ b/tests/bindings-test2/dotnet/iOS/bindings-test2.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.iOS.Sdk">
+  <PropertyGroup>
+    <NativeLibName>ios-fat</NativeLibName>
+    <PlatformName>iOS</PlatformName>
+  </PropertyGroup>
+  <Import Project="..\shared.targets" />
+</Project>

--- a/tests/bindings-test2/dotnet/macOS/bindings-test2.csproj
+++ b/tests/bindings-test2/dotnet/macOS/bindings-test2.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.macOS.Sdk">
+  <PropertyGroup>
+    <NativeLibName>macos</NativeLibName>
+    <PlatformName>macOS</PlatformName>
+  </PropertyGroup>
+  <Import Project="..\shared.targets" />
+</Project>

--- a/tests/bindings-test2/dotnet/shared.targets
+++ b/tests/bindings-test2/dotnet/shared.targets
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>bindingstest2</RootNamespace>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\..\..\product.snk</AssemblyOriginatorKeyFile>
+    <LangVersion>latest</LangVersion>
+    <IsBindingProject>true</IsBindingProject>
+
+    <RootTestsDirectory>$(MSBuildThisFileDirectory)\..\..</RootTestsDirectory>
+    <BindingsTest2Directory>$(RootTestsDirectory)\bindings-test2</BindingsTest2Directory>
+    <TestLibrariesDirectory>$(RootTestsDirectory)\test-libraries</TestLibrariesDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnitLite" Version="3.12.0" />
+
+    <ProjectReference Include="$(RootTestsDirectory)\bindings-test\dotnet\$(PlatformName)\bindings-test.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="$(BindingsTest2Directory)\ApiDefinition.cs" />
+    <ObjcBindingApiDefinition Include="$(BindingsTest2Directory)\ApiProtocol.cs" />
+    <ObjcBindingCoreSource Include="$(BindingsTest2Directory)\StructsAndEnums.cs" />
+    <ObjcBindingNativeLibrary Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\libtest2.a">
+      <Link>libtest2.a</Link>
+    </ObjcBindingNativeLibrary>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(BindingsTest2Directory)\libtest2.linkwith.cs">
+      <DependentUpon>libtest2.a</DependentUpon>
+    </Compile>
+    <Compile Include="$(BindingsTest2Directory)\BindingTest.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(TestLibrariesDirectory)\libtest2.m">
+      <Link>libtest2.m</Link>
+    </None>
+    <None Include="$(TestLibrariesDirectory)\libtest2.h">
+      <Link>libtest2.h</Link>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <GeneratedTestInput Include="$(TestLibrariesDirectory)\*.m" />
+    <GeneratedTestInput Include="$(TestLibrariesDirectory)\*.h" />
+    <GeneratedTestInput Include="$(TestLibrariesDirectory)\*.cs" />
+    <GeneratedTestInput Include="$(TestLibrariesDirectory)\Makefile" />
+    <GeneratedTestOutput Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\libtest2.a" />
+  </ItemGroup>
+
+  <Target Name="BuildTestLibraries" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)" BeforeTargets="BeforeBuild">
+    <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />
+  </Target>
+</Project>

--- a/tests/bindings-test2/dotnet/tvOS/bindings-test2.csproj
+++ b/tests/bindings-test2/dotnet/tvOS/bindings-test2.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.tvOS.Sdk">
+  <PropertyGroup>
+    <NativeLibName>tvos-fat</NativeLibName>
+    <PlatformName>tvOS</PlatformName>
+  </PropertyGroup>
+  <Import Project="..\shared.targets" />
+</Project>

--- a/tests/bindings-test2/dotnet/watchOS/bindings-test2.csproj
+++ b/tests/bindings-test2/dotnet/watchOS/bindings-test2.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.watchOS.Sdk">
+  <PropertyGroup>
+    <NativeLibName>watchos-fat</NativeLibName>
+    <PlatformName>watchOS</PlatformName>
+  </PropertyGroup>
+  <Import Project="..\shared.targets" />
+</Project>

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -176,6 +176,44 @@ namespace Xamarin.Tests {
 			Assert.That (ad.MainModule.Resources.Count (), Is.EqualTo (2), "2 resources"); // There are 2 embedded resources by default by the F# compiler.
 		}
 
+		[TestCase ("iOS")]
+		public void BuildBindingsTest (string platform)
+		{
+			var assemblyName = "bindings-test";
+			var dotnet_bindings_dir = Path.Combine (Configuration.SourceRoot, "tests", assemblyName, "dotnet");
+			var project_dir = Path.Combine (dotnet_bindings_dir, platform);
+			var project_path = Path.Combine (project_dir, $"{assemblyName}.csproj");
+
+			Clean (project_path);
+			CopyDotNetSupportingFiles (dotnet_bindings_dir);
+			var result = DotNet.AssertBuild (project_path, verbosity);
+			var lines = result.StandardOutput.ToString ().Split ('\n');
+			// Find the resulting binding assembly from the build log
+			var assemblies = lines.
+				Select (v => v.Trim ()).
+				Where (v => {
+					if (v.Length < 10)
+						return false;
+					if (v [0] != '/')
+						return false;
+					if (!v.EndsWith ($"{assemblyName}.dll", StringComparison.Ordinal))
+						return false;
+					if (!v.Contains ("/bin/", StringComparison.Ordinal))
+						return false;
+					return true;
+				});
+			Assert.That (assemblies, Is.Not.Empty, "Assemblies");
+			// Make sure there's no other assembly confusing our logic
+			Assert.That (assemblies.Distinct ().Count (), Is.EqualTo (1), "Unique assemblies");
+			var asm = assemblies.First ();
+			Assert.That (asm, Does.Exist, "Assembly existence");
+
+			// Verify that there's one resource in the binding assembly, and its name
+			var ad = AssemblyDefinition.ReadAssembly (asm, new ReaderParameters { ReadingMode = ReadingMode.Deferred });
+			Assert.That (ad.MainModule.Resources.Count, Is.EqualTo (1), "1 resource");
+			Assert.That (ad.MainModule.Resources [0].Name, Is.EqualTo ("libtest.a"), "libtest.a");
+		}
+
 		void CopyDotNetSupportingFiles (string targetDirectory)
 		{
 			var srcDirectory = Path.Combine (Configuration.SourceRoot, "tests", "dotnet");

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -177,6 +177,8 @@ namespace Xamarin.Tests {
 		}
 
 		[TestCase ("iOS")]
+		[TestCase ("tvOS")]
+		[TestCase ("watchOS")]
 		[TestCase ("macOS")]
 		public void BuildBindingsTest (string platform)
 		{

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -217,6 +217,47 @@ namespace Xamarin.Tests {
 			Assert.That (ad.MainModule.Resources [0].Name, Is.EqualTo ("libtest.a"), "libtest.a");
 		}
 
+		[TestCase ("iOS")]
+		[TestCase ("tvOS")]
+		[TestCase ("watchOS")]
+		[TestCase ("macOS")]
+		public void BuildBindingsTest2 (string platform)
+		{
+			var assemblyName = "bindings-test2";
+			var dotnet_bindings_dir = Path.Combine (Configuration.SourceRoot, "tests", assemblyName, "dotnet");
+			var project_dir = Path.Combine (dotnet_bindings_dir, platform);
+			var project_path = Path.Combine (project_dir, $"{assemblyName}.csproj");
+
+			Clean (project_path);
+			CopyDotNetSupportingFiles (dotnet_bindings_dir);
+			var result = DotNet.AssertBuild (project_path, verbosity);
+			var lines = result.StandardOutput.ToString ().Split ('\n');
+			// Find the resulting binding assembly from the build log
+			var assemblies = lines.
+				Select (v => v.Trim ()).
+				Where (v => {
+					if (v.Length < 10)
+						return false;
+					if (v [0] != '/')
+						return false;
+					if (!v.EndsWith ($"{assemblyName}.dll", StringComparison.Ordinal))
+						return false;
+					if (!v.Contains ("/bin/", StringComparison.Ordinal))
+						return false;
+					return true;
+				});
+			Assert.That (assemblies, Is.Not.Empty, "Assemblies");
+			// Make sure there's no other assembly confusing our logic
+			Assert.That (assemblies.Distinct ().Count (), Is.EqualTo (1), "Unique assemblies");
+			var asm = assemblies.First ();
+			Assert.That (asm, Does.Exist, "Assembly existence");
+
+			// Verify that there's one resource in the binding assembly, and its name
+			var ad = AssemblyDefinition.ReadAssembly (asm, new ReaderParameters { ReadingMode = ReadingMode.Deferred });
+			Assert.That (ad.MainModule.Resources.Count, Is.EqualTo (1), "1 resource");
+			Assert.That (ad.MainModule.Resources [0].Name, Is.EqualTo ("libtest2.a"), "libtest2.a");
+		}
+
 		void CopyDotNetSupportingFiles (string targetDirectory)
 		{
 			var srcDirectory = Path.Combine (Configuration.SourceRoot, "tests", "dotnet");

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -177,6 +177,7 @@ namespace Xamarin.Tests {
 		}
 
 		[TestCase ("iOS")]
+		[TestCase ("macOS")]
 		public void BuildBindingsTest (string platform)
 		{
 			var assemblyName = "bindings-test";


### PR DESCRIPTION
* Ship bgen
* Fix a few issues in the generator.
* Modify some of the MSBuild logic to support binding projects.
* Port bindings-test[2] to .NET.

This PR is best reviewed commit-by-commit.