### PR TITLE
[Tests] Fix fragile test. The value can be not null.

### DIFF
--- a/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
+++ b/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
@@ -74,11 +74,6 @@ namespace MonoTouchFixtures.SystemConfiguration {
 				return;
 
 			Assert.AreEqual (StatusCode.OK, status, "Status");
-			// To get a non-null dictionary back, we must (https://developer.apple.com/documentation/systemconfiguration/1614126-cncopycurrentnetworkinfo)
-			// * Use core location, and request (and get) authorization to use location information
-			// * Add the 'com.apple.developer.networking.wifi-info' entitlement
-			// I tried this, and still got null back, so just assert that we get null.
-			Assert.IsNull (dict, "Dictionary");
 #endif
 		}
 


### PR DESCRIPTION
The no null test fails as shown in
https://github.com/xamarin/maccore/issues/2276

As with https://github.com/xamarin/xamarin-macios/pull/9276 there is not
much value in testing agains null.

Fixes https://github.com/xamarin/xamarin-macios/pull/9276