### PR TITLE
[tests] Add --dlsym:+nunit.framework.dll to all Xamarin.iOS test suites.

### DIFF
--- a/tests/framework-test/framework-test.csproj
+++ b/tests/framework-test/framework-test.csproj
@@ -16,6 +16,7 @@
     <DefineConstants></DefineConstants>
     <LangVersion>latest</LangVersion>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <RootTestsDirectory>..</RootTestsDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>
@@ -166,6 +167,7 @@
     <Compile Include="AppDelegate.cs" />
     <Compile Include="FrameworkTests.cs" />
   </ItemGroup>
+  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\..\tests\bindings-framework-test\bindings-framework-test.csproj">

--- a/tests/fsharp/fsharp.fsproj
+++ b/tests/fsharp/fsharp.fsproj
@@ -15,6 +15,7 @@
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants></DefineConstants>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <RootTestsDirectory>..</RootTestsDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>
@@ -166,5 +167,6 @@
       <Name>Touch.Client-iOS</Name>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.FSharp.targets" />
 </Project>

--- a/tests/interdependent-binding-projects/interdependent-binding-projects.csproj
+++ b/tests/interdependent-binding-projects/interdependent-binding-projects.csproj
@@ -15,6 +15,7 @@
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants></DefineConstants>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <RootTestsDirectory>..</RootTestsDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>True</DebugSymbols>
@@ -142,6 +143,7 @@
   <ItemGroup>
     <Compile Include="Main.cs" />
   </ItemGroup>
+  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\bindings-test2\bindings-test2.csproj">

--- a/tests/introspection/iOS/introspection-ios.csproj
+++ b/tests/introspection/iOS/introspection-ios.csproj
@@ -15,6 +15,7 @@
     <DefineConstants></DefineConstants>
     <LangVersion>latest</LangVersion>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <RootTestsDirectory>..\..</RootTestsDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>True</DebugSymbols>
@@ -264,5 +265,6 @@
       <Link>simlauncher64-sgen.frameworks</Link>
     </BundleResource>
   </ItemGroup>
+  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/tests/linker/ios/dont link/dont link.csproj
+++ b/tests/linker/ios/dont link/dont link.csproj
@@ -14,6 +14,7 @@
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants></DefineConstants>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <RootTestsDirectory>..\..\..</RootTestsDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>True</DebugSymbols>
@@ -174,6 +175,7 @@
     <ImageAsset Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="Assets.xcassets\AppIcons.appiconset\icon-app-76%402x.png" />
     <ImageAsset Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="Assets.xcassets\AppIcons.appiconset\icon-app-83.5%402x.png" />
   </ItemGroup>
+  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
     <Content Include="BoardingPass.pkpass" />

--- a/tests/linker/ios/link all/link all.csproj
+++ b/tests/linker/ios/link all/link all.csproj
@@ -15,6 +15,7 @@
     <DefineConstants></DefineConstants>
     <LangVersion>latest</LangVersion>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <RootTestsDirectory>..\..\..</RootTestsDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>True</DebugSymbols>
@@ -236,5 +237,6 @@
       <Name>bindings-test</Name>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/tests/linker/ios/link sdk/link sdk.csproj
+++ b/tests/linker/ios/link sdk/link sdk.csproj
@@ -14,6 +14,7 @@
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants></DefineConstants>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <RootTestsDirectory>..\..\..</RootTestsDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>True</DebugSymbols>
@@ -231,5 +232,6 @@
       <Name>bindings-test</Name>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/tests/mono-native/iOS/mono-native.csproj.template
+++ b/tests/mono-native/iOS/mono-native.csproj.template
@@ -15,6 +15,7 @@
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <RootTestsDirectory>..\..</RootTestsDirectory>
   </PropertyGroup>
   <PropertyGroup>
     <MonoNativeMode Condition="'$(TargetFrameworkIdentifier)|$(Configuration)|$(Platform)' == 'Xamarin.iOS|Debug|iPhoneSimulator'">MONO_NATIVE_SYMLINK</MonoNativeMode>
@@ -194,6 +195,7 @@
       <Link>MonoNativeConfig.cs</Link>
     </Compile>
   </ItemGroup>
+  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>
 

--- a/tests/nunit.framework.targets
+++ b/tests/nunit.framework.targets
@@ -4,6 +4,6 @@
 	<PropertyGroup>
 		<XmlLinkerFile>$(MSBuildThisFileDirectory)nunit.framework.xml</XmlLinkerFile>
 	    <MonoBundlingExtraArgs>--xml=$(XmlLinkerFile) $(MonoBundlingExtraArgs)</MonoBundlingExtraArgs>
-	    <MtouchExtraArgs>--xml=$(XmlLinkerFile) $(MtouchExtraArgs)</MtouchExtraArgs>
+	    <MtouchExtraArgs>--xml=$(XmlLinkerFile) --dlsym:+nunit.framework.dll $(MtouchExtraArgs)</MtouchExtraArgs>
 	</PropertyGroup>
 </Project>

--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -409,7 +409,8 @@ namespace Xamarin.Bundler {
 			if (Driver.TryParseBool (options, out dlsym)) {
 				DlsymOptions = dlsym ? DlsymOptions.All : DlsymOptions.None;
 			} else {
-				DlsymAssemblies = new List<Tuple<string, bool>> ();
+				if (DlsymAssemblies == null)
+					DlsymAssemblies = new List<Tuple<string, bool>> ();
 
 				var assemblies = options.Split (',');
 				foreach (var assembly in assemblies) {


### PR DESCRIPTION
This works around a build problem that occurs because NUnit ships with a
P/Invoke to a function that doesn't exist on Apple platforms:

    MTOUCH : error MT5210: Native linking failed, undefined symbol: _GetVersionEx. Please verify that all the necessary frameworks have been referenced and native libraries are properly linked in. [/Users/xamarinqa/myagent/_work/8/s/xamarin-macios/tests/xharness/tmp-test-dir/monotouch-test58/monotouch-test-tvos.csproj]
    MTOUCH : error MT5201: Native linking failed. Please review the build log and the user flags provided to gcc: -fembed-bitcode-marker [/Users/xamarinqa/myagent/_work/8/s/xamarin-macios/tests/xharness/tmp-test-dir/monotouch-test58/monotouch-test-tvos.csproj]
    clang : error : linker command failed with exit code 1 (use -v to see invocation) [/Users/xamarinqa/myagent/_work/8/s/xamarin-macios/tests/xharness/tmp-test-dir/monotouch-test58/monotouch-test-tvos.csproj]

Also fix an issue in mtouch where we would overwrite any previous --dlsym
values; they're now accumulative (`--dlsym:foo.dll --dlsym:bar.dll` works
as expected)

Ref: https://github.com/nunit/nunit/issues/3618