### PR TITLE
[iOSurface] Remove warning from the generator.

### DIFF
--- a/src/iosurface.cs
+++ b/src/iosurface.cs
@@ -8,6 +8,7 @@
 //
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
@@ -198,10 +199,13 @@ namespace IOSurface {
 		[Export ("removeAttachmentForKey:")]
 		void RemoveAttachment (NSString key);
 	
-		// in ObjC it's not defined as a `@property` and the getter can return null but the setter does not accept it
-		[return: MaybeNull]
 		[Export ("allAttachments")]
-		NSDictionary<NSString, NSObject> AllAttachments { get; set; }
+		NSDictionary<NSString, NSObject> AllAttachments { 
+			// in ObjC it's not defined as a `@property` and the getter can return null but the setter does not accept it
+			[return: MaybeNull]
+			get;
+			set;
+		}
 	
 		[Export ("removeAllAttachments")]
 		void RemoveAllAttachments ();


### PR DESCRIPTION
The following warning was being raised:

```
iosurface.cs(202,4): warning CS0657: 'return' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
```

Moved the attr to the correct location and fixed a missing using with
the MaybeNull attrs.