### PR TITLE
[GameController] Remove warnings from the generator.

### DIFF
--- a/src/gamecontroller.cs
+++ b/src/gamecontroller.cs
@@ -334,14 +334,13 @@ namespace GameController {
 		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use the Menu button found on the controller's profile, if it exists.")]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use the Menu button found on the controller's profile, if it exists.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use the Menu button found on the controller's profile, if it exists.")]
-
 		[NullAllowed]
 		[Export ("controllerPausedHandler", ArgumentSemantic.Copy)]
 		Action<GCController> ControllerPausedHandler { get; set; }
 
 		[NullAllowed]
 		[Export ("vendorName", ArgumentSemantic.Copy)]
-		string VendorName { get; }
+		new string VendorName { get; }
 
 		[Export ("attachedToDevice")]
 		bool AttachedToDevice { [Bind ("isAttachedToDevice")] get; }
@@ -393,11 +392,11 @@ namespace GameController {
 
 		[iOS (9,0)][Mac (10,11)]
 		[Export ("handlerQueue", ArgumentSemantic.Retain)]
-		DispatchQueue HandlerQueue { get; set; }
+		new DispatchQueue HandlerQueue { get; set; }
 
 		[TV (13, 0), Mac (10, 15), iOS (13, 0)]
 		[Export ("productCategory")]
-		string ProductCategory { get; }
+		new string ProductCategory { get; }
 
 		[TV (13, 0), Mac (10, 15), iOS (13, 0)]
 		[Export ("snapshot")]


### PR DESCRIPTION
Remove the following warnings when generating the GameController
bindings.

```
gamecontroller.cs(344,10): warning CS0108: 'GCController.VendorName' hides inherited member 'GCDevice.VendorName'. Use the new keyword if hiding was intended.
gamecontroller.cs(396,17): warning CS0108: 'GCController.HandlerQueue' hides inherited member 'GCDevice.HandlerQueue'. Use the new keyword if hiding was intended.
gamecontroller.cs(400,10): warning CS0108: 'GCController.ProductCategory' hides inherited member 'GCDevice.ProductCategory'. Use the new keyword if hiding was intended.
```