### PR TITLE
[mtouch/mmp] Move Application.BuildTarget, Application.IsDeviceBuild and Application.IsSimulatorBuild to shared code.

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -21,6 +21,12 @@ using PlatformResolver = Xamarin.Bundler.MonoMacResolver;
 
 namespace Xamarin.Bundler {
 
+	public enum BuildTarget {
+		None,
+		Simulator,
+		Device,
+	}
+
 	public enum MonoNativeMode {
 		None,
 		Compat,
@@ -88,6 +94,8 @@ namespace Xamarin.Bundler {
 		public List<Application> SharedCodeApps = new List<Application> (); // List of appexes we're sharing code with.
 		public string RegistrarOutputLibrary;
 
+		public BuildTarget BuildTarget;
+
 		bool RequiresXcodeHeaders {
 			get {
 				switch (Platform) {
@@ -132,6 +140,37 @@ namespace Xamarin.Bundler {
 				}
 			}
 		}
+
+		public bool IsDeviceBuild {
+			get {
+				switch (Platform) {
+				case ApplePlatform.iOS:
+				case ApplePlatform.TVOS:
+				case ApplePlatform.WatchOS:
+					return BuildTarget == BuildTarget.Device;
+				case ApplePlatform.MacOSX:
+					return false;
+				default:
+					throw ErrorHelper.CreateError (71, Errors.MX0071, Platform, ProductName);
+				}
+			}
+		}
+
+		public bool IsSimulatorBuild {
+			get {
+				switch (Platform) {
+				case ApplePlatform.iOS:
+				case ApplePlatform.TVOS:
+				case ApplePlatform.WatchOS:
+					return BuildTarget == BuildTarget.Simulator;
+				case ApplePlatform.MacOSX:
+					return false;
+				default:
+					throw ErrorHelper.CreateError (71, Errors.MX0071, Platform, ProductName);
+				}
+			}
+		}
+
 		public static int Concurrency => Driver.Concurrency;
 		public Version DeploymentTarget;
 		public Version SdkVersion;

--- a/tools/mmp/Application.mmp.cs
+++ b/tools/mmp/Application.mmp.cs
@@ -5,8 +5,6 @@ namespace Xamarin.Bundler {
 	public partial class Application
 	{
 		public string ProductName = "Xamarin.Mac";
-		public bool IsSimulatorBuild => false;
-		public bool IsDeviceBuild => false;
 		public bool IsTodayExtension => false;
 
 		public string CustomBundleName = "MonoBundle";

--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -25,11 +25,6 @@ namespace Xamarin.Bundler {
 		MarkerOnly = 3,
 	}
 
-	public enum BuildTarget {
-		Simulator,
-		Device,
-	}
-
 	public enum DlsymOptions
 	{
 		Default,
@@ -43,7 +38,6 @@ namespace Xamarin.Bundler {
 		public string ProductName = "Xamarin.iOS";
 
 		public string ExecutableName;
-		public BuildTarget BuildTarget;
 
 		public bool EnableCxx;
 		bool? enable_msym;
@@ -470,14 +464,6 @@ namespace Xamarin.Bundler {
 			default:
 				throw ErrorHelper.CreateError (71, Errors.MX0071, Platform, "Xamarin.iOS");
 			}
-		}
-
-		public bool IsDeviceBuild { 
-			get { return BuildTarget == BuildTarget.Device; } 
-		}
-
-		public bool IsSimulatorBuild { 
-			get { return BuildTarget == BuildTarget.Simulator; } 
 		}
 
 		public BitCodeMode BitCodeMode { get; set; }


### PR DESCRIPTION
Also add a 'None' build target for the BuildTarget enum for when we're
building for neither simulator nor device (i.e. macOS). This means the default
value will change (since 'Simulator' is no longer the first value), but as far
as I can tell we're always assigning a specific value and not relying on the
default, so this should not make any difference.

This will be needed when the .NET code starts using these classes.