### PR TITLE
[mtouch/mmp] Move a few Application.Is* properties to shared code.

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -9,6 +9,7 @@ using Mono.Cecil.Cil;
 using Mono.Linker;
 
 using Xamarin.Linker;
+using Xamarin.MacDev;
 using Xamarin.Utils;
 
 using ObjCRuntime;
@@ -59,6 +60,7 @@ namespace Xamarin.Bundler {
 		public HashSet<string> Frameworks = new HashSet<string> ();
 		public HashSet<string> WeakFrameworks = new HashSet<string> ();
 
+		public bool IsExtension;
 		public ApplePlatform Platform { get { return Driver.TargetFramework.Platform; } }
 
 		// Linker config
@@ -207,6 +209,38 @@ namespace Xamarin.Bundler {
 			}
 
 			I18n = assemblies;
+		}
+
+		public bool IsTodayExtension {
+			get {
+				return ExtensionIdentifier == "com.apple.widget-extension";
+			}
+		}
+
+		public bool IsWatchExtension {
+			get {
+				return ExtensionIdentifier == "com.apple.watchkit";
+			}
+		}
+
+		public bool IsTVExtension {
+			get {
+				return ExtensionIdentifier == "com.apple.tv-services";
+			}
+		}
+
+		public string ExtensionIdentifier {
+			get {
+				if (!IsExtension)
+					return null;
+
+				var info_plist = Path.Combine (AppDirectory, "Info.plist");
+				var plist = Driver.FromPList (info_plist);
+				var dict = plist.Get<PDictionary> ("NSExtension");
+				if (dict == null)
+					return null;
+				return dict.GetString ("NSExtensionPointIdentifier");
+			}
 		}
 
 		// This is just a name for this app to show in log/error messages, etc.

--- a/tools/mmp/Application.mmp.cs
+++ b/tools/mmp/Application.mmp.cs
@@ -7,7 +7,6 @@ namespace Xamarin.Bundler {
 		public string ProductName = "Xamarin.Mac";
 		public bool IsSimulatorBuild => false;
 		public bool IsDeviceBuild => false;
-		public bool IsTodayExtension => false;
 
 		public string CustomBundleName = "MonoBundle";
 		public AOTOptions AOTOptions;

--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -14,7 +14,6 @@ using Mono.Tuner;
 using Xamarin.Linker;
 
 using Xamarin.Utils;
-using Xamarin.MacDev;
 
 namespace Xamarin.Bundler {
 
@@ -53,7 +52,6 @@ namespace Xamarin.Bundler {
 		}
 		public bool EnableRepl;
 
-		public bool IsExtension;
 		public List<string> Extensions = new List<string> (); // A list of the extensions this app contains.
 		public List<Application> AppExtensions = new List<Application> ();
 		public Application ContainerApp; // For extensions, this is the containing app
@@ -502,24 +500,6 @@ namespace Xamarin.Bundler {
 			}
 		}
 
-		public bool IsTodayExtension {
-			get {
-				return ExtensionIdentifier == "com.apple.widget-extension";
-			}
-		}
-
-		public bool IsWatchExtension {
-			get {
-				return ExtensionIdentifier == "com.apple.watchkit";
-			}
-		}
-
-		public bool IsTVExtension {
-			get {
-				return ExtensionIdentifier == "com.apple.tv-services";
-			}
-		}
-
 		public bool HasFrameworksDirectory {
 			get {
 				if (!IsExtension)
@@ -532,19 +512,6 @@ namespace Xamarin.Bundler {
 			}
 		}
 
-		public string ExtensionIdentifier {
-			get {
-				if (!IsExtension)
-					return null;
-
-				var info_plist = Path.Combine (AppDirectory, "Info.plist");
-				var plist = Driver.FromPList (info_plist);
-				var dict = plist.Get<PDictionary> ("NSExtension");
-				if (dict == null)
-					return null;
-				return dict.GetString ("NSExtensionPointIdentifier");
-			}
-		}
 
 		public string BundleId {
 			get {


### PR DESCRIPTION
This will be needed when the .NET code starts using these classes.