### PR TITLE
[mtouch] Move Driver.IsFrameworkAvailableInSimulator to shared Application code.

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -880,5 +880,13 @@ namespace Xamarin.Bundler {
 			foreach (var t in Targets)
 				t.LoadSymbols ();
 		}
+
+		public bool IsFrameworkAvailableInSimulator (string framework)
+		{
+			if (!Driver.GetFrameworks (this).TryGetValue (framework, out var fw))
+				return true; // Unknown framework, assume it's valid for the simulator
+
+			return fw.IsFrameworkAvailableInSimulator (this);
+		}
 	}
 }

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -493,7 +493,7 @@ namespace Xamarin.Bundler {
 					string file = Path.GetFileNameWithoutExtension (name);
 
 #if !MONOMAC
-					if (App.IsSimulatorBuild && !Driver.IsFrameworkAvailableInSimulator (App, file)) {
+					if (App.IsSimulatorBuild && !App.IsFrameworkAvailableInSimulator (file)) {
 						Driver.Log (3, "Not linking with {0} (referenced by a module reference in {1}) because it's not available in the simulator.", file, FileName);
 						continue;
 					}

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2105,7 +2105,7 @@ namespace Registrar {
 			namespaces.Add (ns);
 
 #if !MMP
-			if (App.IsSimulatorBuild && !Driver.IsFrameworkAvailableInSimulator (App, ns)) {
+			if (App.IsSimulatorBuild && !App.IsFrameworkAvailableInSimulator (ns)) {
 				Driver.Log (5, "Not importing the framework {0} in the generated registrar code because it's not available in the simulator.", ns);
 				return;
 			}
@@ -2617,7 +2617,7 @@ namespace Registrar {
 		bool IsTypeAllowedInSimulator (ObjCType type)
 		{
 			var ns = type.Type.Namespace;
-			return Driver.IsFrameworkAvailableInSimulator (App, ns);
+			return App.IsFrameworkAvailableInSimulator (ns);
 		}
 #endif
 

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1158,13 +1158,5 @@ namespace Xamarin.Bundler
 
 			return false;
 		}
-
-		public static bool IsFrameworkAvailableInSimulator (Application app, string framework)
-		{
-			if (!GetFrameworks (app).TryGetValue (framework, out var fw))
-				return true; // Unknown framework, assume it's valid for the simulator
-
-			return fw.IsFrameworkAvailableInSimulator (app);
-		}
 	}
 }


### PR DESCRIPTION
This will be needed when the .NET code starts using these classes.