### PR TITLE
[xharness] Do not mark DeviceLoaders as loaded when loading fails

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/HardwareDeviceLoader.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/HardwareDeviceLoader.cs
@@ -52,8 +52,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware {
 				connectedDevices.Reset ();
 			}
 
-			loaded = true;
-
 			var tmpfile = Path.GetTempFileName ();
 			try {
 				using (var process = new Process ()) {
@@ -92,6 +90,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware {
 						}
 						connectedDevices.Add (d);
 					}
+
+					loaded = true;
 				}
 			} finally {
 				connectedDevices.SetCompleted ();

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/HardwareDeviceLoader.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/HardwareDeviceLoader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.DotNet.XHarness.iOS.Shared.Collections;

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -49,7 +49,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware {
 				available_devices.Reset ();
 				available_device_pairs.Reset ();
 			}
-			loaded = true;
 
 			await Task.Run (async () => {
 				var tmpfile = Path.GetTempFileName ();
@@ -115,6 +114,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware {
 							});
 						}
 					}
+
+					loaded = true;
 				} finally {
 					supported_runtimes.SetCompleted ();
 					supported_device_types.SetCompleted ();


### PR DESCRIPTION
1. When listing of devices would fail for some reason (timeout which was set to 30 seconds), we would mark the state as `loaded` but no devices are stored in the memory.
2. Since no devices would fit our requirements when asking for one, we would create a new device. There would probably be a duplicate one that we have created previously already but we wouldn't know.

This starts a viscous circle of:
- Loading devices now takes a little bit longer with more devices to enumerate -> increasing the chance that it would time out again.
- With increasing probability of failure (timeout), we create a new device for each failure, increasing the probability even more until some machines get cluttered with duplicate devices.
- With about 15-20 devices the `xcrun simctl list devices` command takes about 3-4 minutes to complete and mlaunch times out at every attempt from there.