### PR TITLE
[xharness] Add support for getting the default AssemblyName for projects.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/PlistExtensions.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/PlistExtensions.cs
@@ -1,8 +1,17 @@
 ﻿using System.IO;
+using System.Runtime.CompilerServices;
 using System.Xml;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 	public static class PListExtensions {
+		static ConditionalWeakTable<XmlDocument, string> doc_to_filename = new ConditionalWeakTable<XmlDocument, string> ();
+
+		public static string GetFilename (this XmlDocument doc)
+		{
+			doc_to_filename.TryGetValue (doc, out var rv);
+			return rv;
+		}
+
 		public static void LoadWithoutNetworkAccess (this XmlDocument doc, string filename)
 		{
 			using (var fs = new FileStream (filename, FileMode.Open, FileAccess.Read)) {
@@ -14,6 +23,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 					doc.Load (reader);
 				}
 			}
+			doc_to_filename.Add (doc, filename);
 		}
 
 		public static void LoadXmlWithoutNetworkAccess (this XmlDocument doc, string xml)

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs
@@ -246,7 +246,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 
 		public static string GetAssemblyName (this XmlDocument csproj)
 		{
-			return csproj.SelectSingleNode ("/*/*/*[local-name() = 'AssemblyName']").InnerText;
+			var assemblyNameNode = csproj.SelectSingleNode ("/*/*/*[local-name() = 'AssemblyName']");
+			if (assemblyNameNode != null)
+				return assemblyNameNode.InnerText;
+			return Path.GetFileNameWithoutExtension (csproj.GetFilename ());
 		}
 
 		public static void SetPlatformAssembly (this XmlDocument csproj, string value)


### PR DESCRIPTION
In .NET projects there's a default value for most properties, which means that
there won't necessarily be an AssemblyName property in a csproj. We need to know the
AssemblyName, so calculate it from the csproj filename (which is how .NET does it).

This turned out slighly complicated, because we're pass an XmlDocument around,
and the XmlDocument doesn't know the file from where it was loaded, so we need
to keep that information separately.