### PR TITLE
[mtouch] Don't validate the --target-framework argument if we're just calling mlaunch.

### DIFF
--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -318,7 +318,12 @@ namespace Xamarin.Bundler {
 
 			LogArguments (args);
 
-			ValidateTargetFramework ();
+			var validateFramework = true;
+#if MTOUCH
+			validateFramework = !IsMlaunchAction (action);
+#endif
+			if (validateFramework)
+				ValidateTargetFramework ();
 
 			return false;
 		}

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -922,28 +922,8 @@ namespace Xamarin.Bundler
 			var accept_any_xcode_version = action == Action.ListDevices || action == Action.ListCrashReports || action == Action.ListApps || action == Action.LogDev;
 			ValidateXcode (app, accept_any_xcode_version, false);
 
-			switch (action) {
-			/* Device actions */
-			case Action.LogDev:
-			case Action.InstallDevice:
-			case Action.ListDevices:
-			case Action.IsAppInstalled:
-			case Action.ListCrashReports:
-			case Action.DownloadCrashReport:
-			case Action.KillApp:
-			case Action.KillAndLaunch:
-			case Action.LaunchDevice:
-			case Action.DebugDevice:
-			case Action.ListApps:
-			/* Simulator actions */
-			case Action.DebugSim:
-			case Action.LaunchSim:
-			case Action.InstallSim:
-			case Action.LaunchWatchApp:
-			case Action.KillWatchApp:
-			case Action.ListSimulators:
+			if (IsMlaunchAction (action))
 				return CallMlaunch (app);
-			}
 
 			if (app.SdkVersion == null)
 				throw new ProductException (25, true, Errors.MT0025, app.PlatformName);
@@ -1015,6 +995,34 @@ namespace Xamarin.Bundler
 			}
 
 			return 0;
+		}
+
+		static bool IsMlaunchAction (Action action)
+		{
+			switch (action) {
+			/* Device actions */
+			case Action.LogDev:
+			case Action.InstallDevice:
+			case Action.ListDevices:
+			case Action.IsAppInstalled:
+			case Action.ListCrashReports:
+			case Action.DownloadCrashReport:
+			case Action.KillApp:
+			case Action.KillAndLaunch:
+			case Action.LaunchDevice:
+			case Action.DebugDevice:
+			case Action.ListApps:
+			/* Simulator actions */
+			case Action.DebugSim:
+			case Action.LaunchSim:
+			case Action.InstallSim:
+			case Action.LaunchWatchApp:
+			case Action.KillWatchApp:
+			case Action.ListSimulators:
+				return true;
+			}
+
+			return false;
 		}
 
 		static void RedirectStream (StreamReader @in, StreamWriter @out)


### PR DESCRIPTION
This fixes an issue where mtouch would complain about a missing --target-framework argument when it's not actually needed:

    /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mtouch  --launchsim bin/iPhoneSimulator/Release/MyApp.app [...]
  	error MT0086: A target framework (--target-framework) must be specified.

what makes this worse is that passing --target-framework to mtouch makes
mlaunch fail, because mlaunch doesn't accept a --target-framework argument.