### PR TITLE
[sensorkit] Update for Xcode 12 beta 4

### DIFF
--- a/src/sensorkit.cs
+++ b/src/sensorkit.cs
@@ -29,6 +29,15 @@ namespace SensorKit {
 	[NoWatch, NoTV, NoMac]
 	[iOS (14,0)]
 	[Native]
+	public enum SRAuthorizationStatus : long {
+		NotDetermined = 0,
+		Authorized,
+		Denied,
+	}
+
+	[NoWatch, NoTV, NoMac]
+	[iOS (14,0)]
+	[Native]
 	enum SRCrownOrientation : long
 	{
 		Left,
@@ -57,6 +66,7 @@ namespace SensorKit {
 		NoAuthorization,
 		DataInaccessible,
 		FetchRequestInvalid,
+		PromptDeclined,
 	}
 
 	[NoWatch, NoTV, NoMac]
@@ -619,7 +629,7 @@ namespace SensorKit {
 		void FetchingRequestFailed (SRSensorReader reader, SRFetchRequest fetchRequest, NSError error);
 
 		[Export ("sensorReader:didChangeAuthorizationStatus:")]
-		void DidChangeAuthorizationStatus (SRSensorReader reader, bool authorized);
+		void DidChangeAuthorizationStatus (SRSensorReader reader, SRAuthorizationStatus authorizationStatus);
 
 		[Export ("sensorReaderWillStartRecording:")]
 		void WillStartRecording (SRSensorReader reader);
@@ -652,8 +662,8 @@ namespace SensorKit {
 		[Field ("SRSensorAccelerometer")]
 		Accelerometer,
 
-		[Field ("SRSensorGyroscope")]
-		Gyroscope,
+		[Field ("SRSensorRotationRate")]
+		RotationRate,
 
 		[Field ("SRSensorVisits")]
 		Visits,
@@ -701,8 +711,8 @@ namespace SensorKit {
 		[Export ("fetch:")]
 		void Fetch (SRFetchRequest request);
 
-		[Export ("authorized")]
-		bool Authorized { [Bind ("isAuthorized")] get; }
+		[Export ("authorizationStatus")]
+		SRAuthorizationStatus AuthorizationStatus { get; }
 
 		[Export ("sensor")]
 		NSString WeakSensor { get; }

--- a/tests/xtro-sharpie/iOS-SensorKit.todo
+++ b/tests/xtro-sharpie/iOS-SensorKit.todo
@@ -1,4 +1,0 @@
-!missing-enum! SRAuthorizationStatus not bound
-!missing-field! SRSensorRotationRate not bound
-!missing-selector! SRSensorReader::authorizationStatus not bound
-!unknown-field! SRSensorGyroscope bound


### PR DESCRIPTION
beta 3 included a ton of bad update of availability. While it correctly
changed `13` to `14`, is also added `API_UNAVAILABLE(ios` to everything

```diff
-SR_EXTERN API_AVAILABLE(ios(13.0)) API_UNAVAILABLE(watchos) API_UNAVAILABLE(tvos, macos)
+SR_EXTERN API_AVAILABLE(ios(14.0)) API_UNAVAILABLE(ios, watchos) API_UNAVAILABLE(tvos, macos)
```

Those were corrected (lot of noise) if beta 4, along with few API
changes.