### PR TITLE
[CoreServices] Update framework for Xcode 12 beta 4.

### DIFF
--- a/src/mobilecoreservices.cs
+++ b/src/mobilecoreservices.cs
@@ -3,6 +3,9 @@ using ObjCRuntime;
 
 namespace MobileCoreServices {
 
+	[Deprecated (PlatformName.iOS, 14, 0, message : "Use the 'UniformTypeIdentifiers.UTType' API instead.")]
+	[Deprecated (PlatformName.TvOS, 14, 0, message : "Use the 'UniformTypeIdentifiers.UTType' API instead.")]
+	[Deprecated (PlatformName.WatchOS, 7, 0, message : "Use the 'UniformTypeIdentifiers.UTType' API instead.")]
 	[Partial]
 	interface UTType {
 		[Field ("kUTTypeItem", "+CoreServices")]


### PR DESCRIPTION
All C functions AND fields have been deprecated in favour of the new API.