### PR TITLE
[DevOps] Just clean the xamarin-macios dir to ensure we do not delete maccore creds.

### DIFF
--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -35,7 +35,7 @@ steps:
 - checkout: maccore
   persistCredentials: true  # hugely important, else there are some scripts that check a single file from maccore that will fail
 
-- bash: make -C $(System.DefaultWorkingDirectory)/xamarin-macios/ git-clean-all
+- bash: cd $(System.DefaultWorkingDirectory)/xamarin-macios/ && git clean -xdf
   displayName: 'Clean workspace'
 
 # Run the pipeline script tests to ensure that we will have not have an unexpected behaviour.


### PR DESCRIPTION
The credentials for maccore are downloaded to a pat file (to be found).
When we call make git-clean, because we do use the -x options, all
files are deleted, including the pat file.

We move to call git clean -xdf inside xamanrin-macios, which will delete
the test result files.

Once we find the exact path pattern, we can update the make git-clean to
not remove them but this commit unblocks the failing CI builds.