### PR TITLE
[xharness] Make monotouch-test (all optimization) aware of IncludesiOS32

### DIFF
--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -332,11 +332,12 @@ namespace Xharness.Jenkins {
 
 				switch (test.TestName) {
 				case "monotouch-test":
+					// iOS 32 bits is broken on recent Xcode 12 betas (and this fails on internal jenkins)
+					if ((test.Platform == TestPlatform.iOS_Unified32) && !IncludeiOS32)
+						break;
 					if (supports_dynamic_registrar_on_device)
 						yield return new TestData { Variation = "Debug (dynamic registrar)", MTouchExtraArgs = "--registrar:dynamic", Debug = true, Profiling = false };
-					// iOS 32 bits is broken on recent Xcode 12 betas (and this fails on internal jenkins)
-					if ((test.Platform != TestPlatform.iOS_Unified32) || IncludeiOS32)
-						yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, Defines = "OPTIMIZEALL" };
+					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, Defines = "OPTIMIZEALL" };
 					if (supports_debug) {
 						yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = true, Profiling = false, Defines = "OPTIMIZEALL" };
 						yield return new TestData { Variation = "Debug: SGenConc", MTouchExtraArgs = "", Debug = true, Profiling = false, MonoNativeLinkMode = MonoNativeLinkMode.Static, EnableSGenConc = true};

--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -332,9 +332,6 @@ namespace Xharness.Jenkins {
 
 				switch (test.TestName) {
 				case "monotouch-test":
-					// iOS 32 bits is broken on recent Xcode 12 betas (and this fails on internal jenkins)
-					if ((test.Platform == TestPlatform.iOS_Unified32) && !IncludeiOS32)
-						break;
 					if (supports_dynamic_registrar_on_device)
 						yield return new TestData { Variation = "Debug (dynamic registrar)", MTouchExtraArgs = "--registrar:dynamic", Debug = true, Profiling = false };
 					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, Defines = "OPTIMIZEALL" };
@@ -366,6 +363,9 @@ namespace Xharness.Jenkins {
 			case "iPhoneSimulator":
 				switch (test.TestName) {
 				case "monotouch-test":
+					// Xcode 12 beta 3 broke iOS 32 bits simulators
+					if (test.Platform == TestPlatform.iOS_Unified32)
+						break;
 					// The default is to run monotouch-test with the dynamic registrar (in the simulator), so that's already covered
 					yield return new TestData { Variation = "Debug (LinkSdk)", Debug = true, Profiling = false, LinkMode = "LinkSdk" };
 					yield return new TestData { Variation = "Debug (static registrar)", MTouchExtraArgs = "--registrar:static", Debug = true, Profiling = false, Undefines = "DYNAMIC_REGISTRAR" };

--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -334,7 +334,9 @@ namespace Xharness.Jenkins {
 				case "monotouch-test":
 					if (supports_dynamic_registrar_on_device)
 						yield return new TestData { Variation = "Debug (dynamic registrar)", MTouchExtraArgs = "--registrar:dynamic", Debug = true, Profiling = false };
-					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, Defines = "OPTIMIZEALL" };
+					// iOS 32 bits is broken on recent Xcode 12 betas (and this fails on internal jenkins)
+					if ((test.Platform != TestPlatform.iOS_Unified32) || IncludeiOS32)
+						yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, Defines = "OPTIMIZEALL" };
 					if (supports_debug) {
 						yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = true, Profiling = false, Defines = "OPTIMIZEALL" };
 						yield return new TestData { Variation = "Debug: SGenConc", MTouchExtraArgs = "", Debug = true, Profiling = false, MonoNativeLinkMode = MonoNativeLinkMode.Static, EnableSGenConc = true};


### PR DESCRIPTION
Only happens on internal Jenkins
ref: https://github.com/xamarin/maccore/issues/2284