### PR TITLE
[d16-8] [DevOps] Report the correct bot used.

### DIFF
--- a/tools/devops/device-tests/scripts/GitHub.psm1
+++ b/tools/devops/device-tests/scripts/GitHub.psm1
@@ -184,7 +184,7 @@ function New-GitHubComment {
         $msg.AppendLine($Message)
     }
     $msg.AppendLine()
-    $msg.AppendLine("[Pipeline]($targetUrl) on Agent $Env:AGENT_NAME") # Env:AGENT_NAME is added by the pipeline
+    $msg.AppendLine("[Pipeline]($targetUrl) on Agent $Env:TESTS_BOT") # Env:TESTS_BOT is added by the pipeline as a variable comming from the execute tests job
 
     $url = "https://api.github.com/repos/xamarin/xamarin-macios/commits/$Env:BUILD_REVISION/comments"
     $payload = @{

--- a/tools/devops/device-tests/scripts/GitHub.psm1
+++ b/tools/devops/device-tests/scripts/GitHub.psm1
@@ -184,7 +184,7 @@ function New-GitHubComment {
         $msg.AppendLine($Message)
     }
     $msg.AppendLine()
-    $msg.AppendLine("[Pipeline]($targetUrl) on Agent $Env:TESTS_BOT") # Env:TESTS_BOT is added by the pipeline as a variable comming from the execute tests job
+    $msg.AppendLine("[Pipeline]($targetUrl) on Agent $Env:TESTS_BOT") # Env:TESTS_BOT is added by the pipeline as a variable coming from the execute tests job
 
     $url = "https://api.github.com/repos/xamarin/xamarin-macios/commits/$Env:BUILD_REVISION/comments"
     $payload = @{

--- a/tools/devops/device-tests/templates/device-tests-stage.yml
+++ b/tools/devops/device-tests/templates/device-tests-stage.yml
@@ -68,6 +68,7 @@ stages:
       # Note the use of single quotes!
       XAMARIN_STORAGE_PATH: $[ dependencies.tests.outputs['runTests.XAMARIN_STORAGE_PATH'] ]
       XAMARIN_STORAGE_FAILED: $[ dependencies.tests.outputs['runTests.XAMARIN_STORAGE_FAILED'] ]
+      TESTS_BOT: $[ dependencies.tests.outputs['runTests.TESTS_BOT'] ]
       TESTS_JOBSTATUS: $[ dependencies.tests.outputs['runTests.TESTS_JOBSTATUS'] ]
     pool:
       name: ${{ parameters.WindowsDevicePool }}

--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -270,6 +270,9 @@ steps:
       fi
     fi
 
+    echo "Running tests on $AGENT_NAME"
+    echo "##vso[task.setvariable variable=TESTS_BOT;isOutput=true]$AGENT_NAME"
+
     make -C builds download -j || true
     make -C builds downloads -j || true
     make -C builds .stamp-mono-ios-sdk-destdir -j || true


### PR DESCRIPTION
The tests are not executed in the same agent that sets the github
status, for that reason, the github comment is not giving the correct
bot name, but the name of the bot that executed the commit message and
not the tests.

Add an output var in the runTests step to set the bot name and pass it
to the comment job in a different bot.

Backport of #9250.

/cc @mandel-macaque 