### PR TITLE
[d16-8] Partial fix for AVAudioEngine.Connect(input, sink, format) crash when format == null

### DIFF
--- a/src/AVFoundation/AVAudioFormat.cs
+++ b/src/AVFoundation/AVAudioFormat.cs
@@ -14,11 +14,19 @@ namespace AVFoundation {
 	public partial class AVAudioFormat {
 		public static bool operator == (AVAudioFormat a, AVAudioFormat b)
 		{
+			if ((object) a == (object) b)
+				return true;
+			if ((object) a == null ^ (object) b == null)
+				return false;
 			return a.Equals (b);
 		}
 		
 		public static bool operator != (AVAudioFormat a, AVAudioFormat b)
 		{
+			if ((object) a != (object) b)
+				return true;
+			if ((object) a == null ^ (object) b == null)
+				return true;
 			return !a.Equals (b);
 		}
 	}

--- a/src/AVFoundation/AVAudioFormat.cs
+++ b/src/AVFoundation/AVAudioFormat.cs
@@ -23,11 +23,7 @@ namespace AVFoundation {
 		
 		public static bool operator != (AVAudioFormat a, AVAudioFormat b)
 		{
-			if ((object) a != (object) b)
-				return true;
-			if ((object) a == null ^ (object) b == null)
-				return true;
-			return !a.Equals (b);
+			return !(a == b);
 		}
 	}
 }

--- a/tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs
@@ -1,0 +1,49 @@
+﻿// Unit test for AVAudioFormat
+// Authors: 
+// 		Whitney Schmidt (whschm@microsoft.com)
+// Copyright 2020 Microsoft Corp.
+
+using System;
+using Foundation;
+using AVFoundation;
+using NUnit.Framework;
+namespace MonoTouchFixtures.AVFoundation {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class AVAudioFormatTest {
+
+		AVAudioFormat nullFormat = null;
+
+		[Test]
+		public void TestEqualOperatorSameInstace ()
+		{
+			using (var format = new AVAudioFormat ())
+				Assert.IsTrue (format == format, "format == format");
+		}
+
+		[Test]
+		public void TestEqualOperatorNull ()
+		{
+			using (var format = new AVAudioFormat ())
+			{
+				Assert.IsFalse (format == null, "format == null");
+				Assert.IsFalse (null == format, "null == format");
+			}
+			Assert.IsTrue (nullFormat == null, "nullFormat == null");
+			Assert.IsTrue (null == nullFormat, "null == nullFormat");
+		}
+
+		[Test]
+		public void TestNotEqualOperatorNull ()
+		{
+			using (var format = new AVAudioFormat ())
+			{
+				Assert.IsTrue (format != null, "format != null");
+				Assert.IsTrue (null != format, "null != format");
+			}
+			Assert.IsFalse (nullFormat != null, "nullFormat != null");
+			Assert.IsFalse (null != nullFormat, "null != nullFormat");
+		}
+	}
+}

--- a/tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs
@@ -13,8 +13,6 @@ namespace MonoTouchFixtures.AVFoundation {
 	[Preserve (AllMembers = true)]
 	public class AVAudioFormatTest {
 
-		AVAudioFormat nullFormat = null;
-
 		[Test]
 		public void TestEqualOperatorSameInstace ()
 		{
@@ -30,8 +28,11 @@ namespace MonoTouchFixtures.AVFoundation {
 				Assert.IsFalse (format == null, "format == null");
 				Assert.IsFalse (null == format, "null == format");
 			}
-			Assert.IsTrue (nullFormat == null, "nullFormat == null");
-			Assert.IsTrue (null == nullFormat, "null == nullFormat");
+			using (AVAudioFormat nullFormat = null)
+			{
+				Assert.IsTrue (nullFormat == null, "nullFormat == null");
+				Assert.IsTrue (null == nullFormat, "null == nullFormat");
+			}
 		}
 
 		[Test]
@@ -42,8 +43,12 @@ namespace MonoTouchFixtures.AVFoundation {
 				Assert.IsTrue (format != null, "format != null");
 				Assert.IsTrue (null != format, "null != format");
 			}
-			Assert.IsFalse (nullFormat != null, "nullFormat != null");
-			Assert.IsFalse (null != nullFormat, "null != nullFormat");
+			using (AVAudioFormat nullFormat = null)
+			{
+				Assert.IsFalse (nullFormat != null, "nullFormat != null");
+				Assert.IsFalse (null != nullFormat, "null != nullFormat");
+			}
+
 		}
 	}
 }


### PR DESCRIPTION
This fixes the crash which occurs when calling `AVAudioEngine.Connect(input, sink, null)` with null as the third parameter.

The crash occurred when we tried to check for equality using `.Equals` on `null` for the null check in this generated code:

`global::ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr_nuint_IntPtr (this.Handle, Selector.GetHandle ("connect:toConnectionPoints:fromBus:format:"), sourceNode.Handle, nsa_destNodes.Handle, sourceBus, format == null ? IntPtr.Zero : format.Handle);`

Backport of #9371.

/cc @whitneyschmidt 