### PR TITLE
[scenekit] Update for Xcode 12 beta 5

### DIFF
--- a/tests/xtro-sharpie/common-SceneKit.ignore
+++ b/tests/xtro-sharpie/common-SceneKit.ignore
@@ -24,6 +24,7 @@
 !incorrect-protocol-member! SCNSceneRenderer::setTemporalAntialiasingEnabled: is REQUIRED and should be abstract
 !incorrect-protocol-member! SCNSceneRenderer::setUsesReverseZ: is REQUIRED and should be abstract
 !incorrect-protocol-member! SCNSceneRenderer::usesReverseZ is REQUIRED and should be abstract
+!incorrect-protocol-member! SCNSceneRenderer::currentRenderPassDescriptor is REQUIRED and should be abstract
 
 ## same for SCNActionable, it is required member of a protocol added to XAMCORE_4_0
 !incorrect-protocol-member! SCNActionable::actionKeys is REQUIRED and should be abstract

--- a/tests/xtro-sharpie/iOS-SceneKit.todo
+++ b/tests/xtro-sharpie/iOS-SceneKit.todo
@@ -1,1 +1,0 @@
-!incorrect-protocol-member! SCNSceneRenderer::currentRenderPassDescriptor is REQUIRED and should be abstract

--- a/tests/xtro-sharpie/macOS-SceneKit.todo
+++ b/tests/xtro-sharpie/macOS-SceneKit.todo
@@ -1,1 +1,0 @@
-!incorrect-protocol-member! SCNSceneRenderer::currentRenderPassDescriptor is REQUIRED and should be abstract

--- a/tests/xtro-sharpie/tvOS-SceneKit.todo
+++ b/tests/xtro-sharpie/tvOS-SceneKit.todo
@@ -1,1 +1,0 @@
-!incorrect-protocol-member! SCNSceneRenderer::currentRenderPassDescriptor is REQUIRED and should be abstract


### PR DESCRIPTION
The single new API was added in the bump PR
https://github.com/xamarin/xamarin-macios/pull/9406/files#diff-502c663627e50cc079cad31767bcb779R3200

but the xtro .todo was not entirely removed, so here it is.