### PR TITLE
[msbuild] Remove the _AssignBundleResourceNames target, it's not used anymore.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.targets
@@ -51,12 +51,6 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 		<RemoveDir Directories="$(GeneratedSourcesDir)" Condition="Exists ('$(GeneratedSourcesDir)')" />
 	</Target>
 
-	<Target Name="_AssignBundleResourceNames">
-		<AssignBundleResourceNames BundleResources="@(BundleResource)" ResourceDirectoryPrefixes="$(_ResourcePrefix)">
-			<Output ItemName="_BundleResourceWithName" TaskParameter="BundleResourcesWithNames" />
-		</AssignBundleResourceNames>
-	</Target>
-
 	<Target Name="_CreateEmbeddedResources" DependsOnTargets="_CollectBundleResources">
 		<CreateEmbeddedResources BundleResources="@(_BundleResourceWithLogicalName)" Prefix="xammac">
 			<Output ItemName="EmbeddedResource" TaskParameter="EmbeddedResources" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.targets
@@ -49,12 +49,6 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 		<RemoveDir Directories="$(GeneratedSourcesDir)" Condition="Exists ('$(GeneratedSourcesDir)')" />
 	</Target>
 
-	<Target Name="_AssignBundleResourceNames">
-		<AssignBundleResourceNames BundleResources="@(BundleResource)" ResourceDirectoryPrefixes="$(_ResourcePrefix)">
-			<Output ItemName="_BundleResourceWithName" TaskParameter="BundleResourcesWithNames" />
-		</AssignBundleResourceNames>
-	</Target>
-
 	<Target Name="_CreateEmbeddedResources" DependsOnTargets="_CollectBundleResources">
 		<CreateEmbeddedResources BundleResources="@(_BundleResourceWithLogicalName)" Prefix="monotouch">
 			<Output ItemName="EmbeddedResource" TaskParameter="EmbeddedResources" />


### PR DESCRIPTION
It was used in Classic code, and that was removed some time ago (c4b5fa5f444a629c47a68dc80fab29e86fd61fbc).