### PR TITLE
[dotnet] Add support for resolving Mono's runtime pack.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -84,4 +84,24 @@
     <FrameworkReference Include="Microsoft.$(_PlatformName)" IsImplicitlyDefined="true" Pack="false" PrivateAssets="All" />
   </ItemGroup>
 
+  <!-- This a workaround until https://github.com/dotnet/runtime/issues/34193 is fixed and a proper solution can be implemented.
+       The problem is that by default we get the 'Microsoft.NETCore.App.Runtime.osx-x64' runtime pack (the core clr version), when we want the 'Microsoft.NETCore.App.Mono.Runtime.osx-x64' runtime pack.
+       This works around that by declaring a new known framework for mono's runtime pack, removing the default 'Microsoft.NETCore.App' framework reference, and adding the mono one.
+   -->
+  <ItemGroup Condition="'$(_PlatformName)' == 'macOS'">
+    <KnownFrameworkReference Include="Microsoft.NETCore.App.Mono"
+                              TargetFramework="netcoreapp5.0"
+                              RuntimeFrameworkName="Microsoft.NETCore.App.Mono"
+                              DefaultRuntimeFrameworkVersion="$(BundledNETCorePlatformsPackageVersion)"
+                              LatestRuntimeFrameworkVersion="$(BundledNETCorePlatformsPackageVersion)"
+                              TargetingPackName="Microsoft.NETCore.App.Ref"
+                              TargetingPackVersion="$(BundledNETCorePlatformsPackageVersion)"
+                              RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.Mono.**RID**"
+                              RuntimePackRuntimeIdentifiers="osx-x64"
+                              IsTrimmable="true"
+                              />
+    <FrameworkReference Remove="Microsoft.NETCore.App" />
+    <FrameworkReference Include="Microsoft.NETCore.App.Mono" IsImplicitlyDefined="true" Pack="false" PrivateAssets="All" />
+  </ItemGroup>
+
 </Project>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -218,7 +218,7 @@
 			<_IntermediateNativeLibraryDir>$(IntermediateOutputPath)nativelibraries/</_IntermediateNativeLibraryDir>
 			<_NativeExecutableName>$(_AppBundleName)</_NativeExecutableName>
 
-			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == '' And '$(ComputedPlatform)' != 'iPhone'">dylib</_LibMonoLinkMode>
+			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == '' And ('$(ComputedPlatform)' != 'iPhone' Or '$(_PlatformName)' == 'macOS')">dylib</_LibMonoLinkMode>
 			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == ''">static</_LibMonoLinkMode>
 			<_LibMonoExtension Condition="'$(_LibMonoLinkMode)' == 'dylib'">dylib</_LibMonoExtension>
 			<_LibMonoExtension Condition="'$(_LibMonoLinkMode)' == 'static'">a</_LibMonoExtension>
@@ -229,6 +229,9 @@
 			<_LibXamarinExtension Condition="'$(_LibXamarinLinkMode)' == 'static'">a</_LibXamarinExtension>
 			<_LibXamarinName Condition="'$(_LibXamarinName)' == '' And '$(_BundlerDebug)' == 'true'">libxamarin-debug.$(_LibXamarinExtension)</_LibXamarinName>
 			<_LibXamarinName Condition="'$(_LibXamarinName)' == '' And '$(_BundlerDebug)' != 'true'">libxamarin.$(_LibXamarinExtension)</_LibXamarinName>
+
+			<_MonoNugetPackageId Condition="'$(_PlatformName)' != 'macOS'">Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)</_MonoNugetPackageId>
+			<_MonoNugetPackageId Condition="'$(_PlatformName)' == 'macOS'">Microsoft.NETCore.App.Runtime.Mono.$(RuntimeIdentifier)</_MonoNugetPackageId>
 		</PropertyGroup>
 
 		<ItemGroup>
@@ -238,7 +241,7 @@
 				Condition=" '%(ResolvedFileToPublish.AssetType)' == 'native' And
 							'%(ResolvedFileToPublish.RuntimeIdentifier)' == '$(RuntimeIdentifier)' And
 							'%(ResolvedFileToPublish.Extension)' == '.$(_LibMonoExtension)' And
-							'%(ResolvedFileToPublish.NuGetPackageId)' == 'Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)'
+							'%(ResolvedFileToPublish.NuGetPackageId)' == '$(_MonoNugetPackageId)'
 							"
 			/>
 		</ItemGroup>


### PR DESCRIPTION
This is a temporary solution, until .NET provides a way for us to select which
runtime pack to use.

Also ensure that we're using Mono's dynamic libraries (as opposed to static
libraries) when building for macOS.