### PR TITLE
[dotnet-linker] Make Driver.Verbosity the single source of truth.

### DIFF
--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Linker {
 		public ApplePlatform Platform { get; private set; }
 		public string PlatformAssembly { get; private set; }
 		public Version SdkVersion { get; private set; }
-		public int Verbosity { get; private set; }
+		public int Verbosity => Driver.Verbosity;
 
 		static ConditionalWeakTable<LinkContext, LinkerConfiguration> configurations = new ConditionalWeakTable<LinkContext, LinkerConfiguration> ();
 
@@ -136,7 +136,7 @@ namespace Xamarin.Linker {
 				case "Verbosity":
 					if (!int.TryParse (value, out var verbosity))
 						throw new InvalidOperationException ($"Invalid Verbosity '{value}' in {linker_file}");
-					Verbosity = verbosity;
+					Driver.Verbosity += verbosity;
 					break;
 				default:
 					throw new InvalidOperationException ($"Unknown key '{key}' in {linker_file}");
@@ -165,9 +165,6 @@ namespace Xamarin.Linker {
 
 			if (Driver.TargetFramework.Platform != Platform)
 				throw ErrorHelper.CreateError (99, "Inconsistent platforms. TargetFramework={0}, Platform={1}", Driver.TargetFramework.Platform, Platform);
-
-			Driver.Verbosity = Verbosity;
-			ErrorHelper.Verbosity = Verbosity;
 		}
 
 		public void Write ()


### PR DESCRIPTION
* Make Driver.Verbosity the single place where we store the verbosity level.
* Respect any default verbosity by adding to the existing verbosity instead of
  setting it directly.
* There's no need to set ErrorHelper.Verbosity, the Driver.Verbosity setter
  already does it.

This means that for the .NET linker code we'll treat
~/.xamarin-bundler-verbosity like we treat ~/.mtouch-verbosity for mtouch, and
parse it to set the verbosity.