### PR TITLE
[msbuild] Add a Xamarin.Shared.ObjCBinding.targets file for shared binding code between Xamarin.iOS and Xamarin.Mac.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.targets
@@ -22,40 +22,6 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.msbuild.targets"/>
 
-	<!-- Add our own pre-build steps -->
-	<PropertyGroup Condition="'$(_UsingXamarinSdk)' != 'true'">
-		<BuildDependsOn>
-			BuildOnlySettings;
-			_CreateGeneratedSourcesDir;
-			_CreateEmbeddedResources;
-			$(BuildDependsOn)
-		</BuildDependsOn>
-	</PropertyGroup>
-
-	<!-- Add our own Clean steps -->
-	<PropertyGroup Condition="'$(_UsingXamarinSdk)' != 'true'">
-		<CleanDependsOn>
-			_CleanGeneratedSources;
-			$(CleanDependsOn)
-		</CleanDependsOn>
-	</PropertyGroup>
-
-	<!-- Create a directory to contain the generated sources -->
-	<Target Name="_CreateGeneratedSourcesDir">
-		<MakeDir Directories="$(GeneratedSourcesDir)" />
-	</Target>
-
-	<!-- Clean the generated sources -->
-	<Target Name="_CleanGeneratedSources">
-		<RemoveDir Directories="$(GeneratedSourcesDir)" Condition="Exists ('$(GeneratedSourcesDir)')" />
-	</Target>
-
-	<Target Name="_CreateEmbeddedResources" DependsOnTargets="_CollectBundleResources">
-		<CreateEmbeddedResources BundleResources="@(_BundleResourceWithLogicalName)" Prefix="xammac">
-			<Output ItemName="EmbeddedResource" TaskParameter="EmbeddedResources" />
-		</CreateEmbeddedResources>
-	</Target>
-
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
 </Project>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.ObjCBinding.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.ObjCBinding.targets
@@ -1,0 +1,59 @@
+<!--
+***********************************************************************************************
+Xamarin.Shared.ObjCBinding.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+This file imports the version- and platform-specific targets for the project importing
+this file. This file also defines targets to produce an error if the specified targets
+file does not exist, but the project is built anyway (command-line or IDE build).
+
+Copyright (C) 2020 Microsoft. All rights reserved.
+***********************************************************************************************
+-->
+
+<!-- This file is shared between Xamarin.iOS and Xamarin.Mac, but only included for binding projects -->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<!-- Add our own pre-build steps -->
+	<PropertyGroup Condition="'$(_UsingXamarinSdk)' != 'true'">
+		<BuildDependsOn>
+			BuildOnlySettings;
+			_CreateGeneratedSourcesDir;
+			_CreateEmbeddedResources;
+			$(BuildDependsOn)
+		</BuildDependsOn>
+	</PropertyGroup>
+
+	<!-- Add our own Clean steps -->
+	<PropertyGroup Condition="'$(_UsingXamarinSdk)' != 'true'">
+		<CleanDependsOn>
+			_CleanGeneratedSources;
+			$(CleanDependsOn)
+		</CleanDependsOn>
+	</PropertyGroup>
+
+	<!-- Create a directory to contain the generated sources -->
+	<Target Name="_CreateGeneratedSourcesDir">
+		<MakeDir Directories="$(GeneratedSourcesDir)" />
+	</Target>
+
+	<!-- Clean the generated sources -->
+	<Target Name="_CleanGeneratedSources">
+		<RemoveDir Directories="$(GeneratedSourcesDir)" Condition="Exists ('$(GeneratedSourcesDir)')" />
+	</Target>
+
+	<Target Name="_CreateEmbeddedResources" DependsOnTargets="_CollectBundleResources">
+		<PropertyGroup>
+			<_EmbeddedResourcePrefix Condition="'$(_PlatformName)' == 'macOS'">xammac</_EmbeddedResourcePrefix>
+			<_EmbeddedResourcePrefix Condition="'$(_PlatformName)' != 'macOS'">monotouch</_EmbeddedResourcePrefix>
+		</PropertyGroup>
+		<CreateEmbeddedResources BundleResources="@(_BundleResourceWithLogicalName)" Prefix="$(_EmbeddedResourcePrefix)">
+			<Output ItemName="EmbeddedResource" TaskParameter="EmbeddedResources" />
+		</CreateEmbeddedResources>
+	</Target>
+
+</Project>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -609,6 +609,8 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</PrepareResourceRules>
 	</Target>
 
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Shared.ObjCBinding.targets" Condition="'$(IsBindingProject)' == 'true'" />
+
 	<!-- Xamarin.ImplicitFacade.targets will detect if we need to add an implicit reference to netstandard.dll -->
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.ImplicitFacade.targets" Condition="!('$(_PlatformName)' == 'macOS' And '$(TargetFrameworkName)' == 'System')"/>
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.targets
@@ -20,40 +20,6 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets" 
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
 
-	<!-- Add our own pre-build steps -->
-	<PropertyGroup Condition="'$(_UsingXamarinSdk)' != 'true'">
-		<BuildDependsOn>
-			BuildOnlySettings;
-			_CreateGeneratedSourcesDir;
-			_CreateEmbeddedResources;
-			$(BuildDependsOn)
-		</BuildDependsOn>
-	</PropertyGroup>
-
-	<!-- Add our own Clean steps -->
-	<PropertyGroup Condition="'$(_UsingXamarinSdk)' != 'true'">
-		<CleanDependsOn>
-			_CleanGeneratedSources;
-			$(CleanDependsOn)
-		</CleanDependsOn>
-	</PropertyGroup>
-
-	<!-- Create a directory to contain the generated sources -->
-	<Target Name="_CreateGeneratedSourcesDir">
-		<MakeDir Directories="$(GeneratedSourcesDir)" />
-	</Target>
-
-	<!-- Clean the generated sources -->
-	<Target Name="_CleanGeneratedSources">
-		<RemoveDir Directories="$(GeneratedSourcesDir)" Condition="Exists ('$(GeneratedSourcesDir)')" />
-	</Target>
-
-	<Target Name="_CreateEmbeddedResources" DependsOnTargets="_CollectBundleResources">
-		<CreateEmbeddedResources BundleResources="@(_BundleResourceWithLogicalName)" Prefix="monotouch">
-			<Output ItemName="EmbeddedResource" TaskParameter="EmbeddedResources" />
-		</CreateEmbeddedResources>
-	</Target>
-
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.NativeReference.Stubs.targets" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"


### PR DESCRIPTION
Add a Xamarin.Shared.ObjCBinding.targets file for shared binding code between
Xamarin.iOS and Xamarin.Mac and start sharing some of the binding code.