### PR TITLE
[msbuild] Share three stub targets for Windows between Xamarin.iOS and Xamarin.Mac.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.Stubs.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.Stubs.targets
@@ -1,6 +1,6 @@
 <!--
 ***********************************************************************************************
-Xamarin.iOS.NativeReference.Stubs.targets
+Xamarin.Shared.Stubs.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
   created a backup copy.  Incorrect changes to this file will make it

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -614,6 +614,8 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<!-- Xamarin.ImplicitFacade.targets will detect if we need to add an implicit reference to netstandard.dll -->
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.ImplicitFacade.targets" Condition="!('$(_PlatformName)' == 'macOS' And '$(TargetFrameworkName)' == 'System')"/>
 
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Shared.Stubs.targets" />
+
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
 </Project>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1951,8 +1951,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</Archive>
 	</Target>
 
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.NativeReference.Stubs.targets" />
-
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.targets
@@ -20,8 +20,6 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets" 
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
 
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.NativeReference.Stubs.targets" />
-
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
 </Project>


### PR DESCRIPTION
These only apply to Xamarin.iOS right now, since they're Windows-specific (and
we don't support Xamarin.Mac binding projects on Windows), but if we ever do
end up supporting binding projects for Xamarin.Mac on Windows, we'll need
these targets there, so just make them shared code.