### PR TITLE
[Maccore] Bump maccore to get devops changes.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := ce861906d2c84dd19f216ea83eb47d23300bd43e
+NEEDED_MACCORE_VERSION := 2e387cf810318c386d8b4cd730fdee80e2879c5e
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
Commits:

* [provisioning] Add option to ignore the login keychain (#2256) https://github.com/xamarin/maccore/commit/8a61d151611054907b1218ff922549244607400c
* [Device Tests] Do not set the status when we ping. (#2292) https://github.com/xamarin/maccore/commit/2e387cf810318c386d8b4cd730fdee80e2879c5e

Full diff: https://github.com/xamarin/maccore/compare/ce861906d2c84dd19f216ea83eb47d23300bd43e...2e387cf810318c386d8b4cd730fdee80e2879c5e