### PR TITLE
[d16-8] [DevOps] Set the status to pending once the checks have started.

### DIFF
--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -90,8 +90,9 @@ steps:
       Set-GitHubStatus -Status "error" -Description "Not enough free space in the host." -Context "$Env:CONTEXT"
       New-GitHubComment -Header "Tests failed catastrophically on $Env:CONTEXT" -Emoji ":fire:" -Description "Not enough free space in the host."
       Stop-Pipeline
+    } else {
+      Set-GitHubStatus -Status "pending" -Description "Device tests on VSTS have been started." -Context "$Env:CONTEXT"
     }
-    Set-GitHubStatus -Status "pending" -Description "Device tests on VSTS have been started." -Context "$Env:CONTEXT"
   env:
     BUILD_REVISION: $(BUILD_REVISION)
     CONTEXT: ${{ parameters.statusContext }}


### PR DESCRIPTION
Once we have done all the check of the bot, set the status of the commit
to pending since the next task is going to run the tests.

This way we ensure that the pending status should be cleaned at the end
rather than be left behind.

Backport of #9444.

/cc @mandel-macaque 