### PR TITLE
[d16-8][Maccore] Bump maccore to pickup devop changes.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := ce861906d2c84dd19f216ea83eb47d23300bd43e
+NEEDED_MACCORE_VERSION := ca68ae4fef16b2b9deb3696bc6bd1503444c8e79
 NEEDED_MACCORE_BRANCH := d16-8
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
Commits:

* [Device Tests] Do not set the status when we ping. (#2292) https://github.com/xamarin/maccore/commit/ca68ae4fef16b2b9deb3696bc6bd1503444c8e79

Full diff: https://github.com/xamarin/maccore/compare/ce861906d2c84dd19f216ea83eb47d23300bd43e...ca68ae4fef16b2b9deb3696bc6bd1503444c8e79