### PR TITLE
[dotnet] Bump .NET and the linker.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -445,9 +445,9 @@ DOTNET_FEED_DIR ?= $(DOTNET_DESTDIR)/nuget-feed
 # We're using preview versions, and there will probably be many of them, so install locally (into builds/downloads) if there's no system version to
 # avoid consuming a lot of disk space (since they're never automatically deleted). The system-dependencies.sh script will install locally as long
 # as there's a TARBALL url.
-DOTNET5_VERSION=5.0.100-preview.8.20359.11
-DOTNET5_URL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-preview.8.20359.11/dotnet-sdk-5.0.100-preview.8.20359.11-osx-x64.pkg
-DOTNET5_TARBALL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-preview.8.20359.11/dotnet-sdk-5.0.100-preview.8.20359.11-osx-x64.tar.gz
+DOTNET5_VERSION=5.0.100-rc.1.20414.5
+DOTNET5_URL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-rc.1.20414.5/dotnet-sdk-5.0.100-rc.1.20414.5-osx-x64.pkg
+DOTNET5_TARBALL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-rc.1.20414.5/dotnet-sdk-5.0.100-rc.1.20414.5-osx-x64.tar.gz
 # Use the system dotnet executable if the dotnet version we need is installed, otherwise use the local version.
 ifneq ($(wildcard /usr/local/share/dotnet/sdk/$(DOTNET5_VERSION)),)
 DOTNET5=$(DOTNET)

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -110,22 +110,11 @@ namespace Xamarin.Tests {
 			var result = DotNet.AssertBuild (project_path, verbosity);
 			var lines = result.StandardOutput.ToString ().Split ('\n');
 			// Find the resulting binding assembly from the build log
-			var assemblies = lines.
-				Select (v => v.Trim ()).
-				Where (v => {
-					if (v.Length < 10)
-						return false;
-					if (v [0] != '/')
-						return false;
-					if (!v.EndsWith ($"{assemblyName}.dll", StringComparison.Ordinal))
-						return false;
-					if (!v.Contains ("/bin/", StringComparison.Ordinal))
-						return false;
-					return true;
-				});
+			var assemblies = FilterToAssembly (lines, assemblyName);
 			Assert.That (assemblies, Is.Not.Empty, "Assemblies");
 			// Make sure there's no other assembly confusing our logic
-			Assert.That (assemblies.Distinct ().Count (), Is.EqualTo (1), "Unique assemblies");
+			assemblies = assemblies.Distinct ();
+			Assert.That (assemblies.Count (), Is.EqualTo (1), $"Unique assemblies\n\t{string.Join ("\n\t", assemblies)}");
 			var asm = assemblies.First ();
 			Assert.That (asm, Does.Exist, "Assembly existence");
 			// Verify that there's one resource in the assembly, and its name
@@ -153,19 +142,7 @@ namespace Xamarin.Tests {
 			var result = DotNet.AssertBuild (project_path, verbosity);
 			var lines = result.StandardOutput.ToString ().Split ('\n');
 			// Find the resulting binding assembly from the build log
-			var assemblies = lines.
-				Select (v => v.Trim ()).
-				Where (v => {
-					if (v.Length < 10)
-						return false;
-					if (v [0] != '/')
-						return false;
-					if (!v.EndsWith ($"{assemblyName}.dll", StringComparison.Ordinal))
-						return false;
-					if (!v.Contains ("/bin/", StringComparison.Ordinal))
-						return false;
-					return true;
-				});
+			var assemblies = FilterToAssembly (lines, assemblyName);
 			Assert.That (assemblies, Is.Not.Empty, "Assemblies");
 			// Make sure there's no other assembly confusing our logic
 			Assert.That (assemblies.Distinct ().Count (), Is.EqualTo (1), "Unique assemblies");
@@ -192,19 +169,7 @@ namespace Xamarin.Tests {
 			var result = DotNet.AssertBuild (project_path, verbosity);
 			var lines = result.StandardOutput.ToString ().Split ('\n');
 			// Find the resulting binding assembly from the build log
-			var assemblies = lines.
-				Select (v => v.Trim ()).
-				Where (v => {
-					if (v.Length < 10)
-						return false;
-					if (v [0] != '/')
-						return false;
-					if (!v.EndsWith ($"{assemblyName}.dll", StringComparison.Ordinal))
-						return false;
-					if (!v.Contains ("/bin/", StringComparison.Ordinal))
-						return false;
-					return true;
-				});
+			var assemblies = FilterToAssembly (lines, assemblyName);
 			Assert.That (assemblies, Is.Not.Empty, "Assemblies");
 			// Make sure there's no other assembly confusing our logic
 			Assert.That (assemblies.Distinct ().Count (), Is.EqualTo (1), "Unique assemblies");
@@ -233,19 +198,7 @@ namespace Xamarin.Tests {
 			var result = DotNet.AssertBuild (project_path, verbosity);
 			var lines = result.StandardOutput.ToString ().Split ('\n');
 			// Find the resulting binding assembly from the build log
-			var assemblies = lines.
-				Select (v => v.Trim ()).
-				Where (v => {
-					if (v.Length < 10)
-						return false;
-					if (v [0] != '/')
-						return false;
-					if (!v.EndsWith ($"{assemblyName}.dll", StringComparison.Ordinal))
-						return false;
-					if (!v.Contains ("/bin/", StringComparison.Ordinal))
-						return false;
-					return true;
-				});
+			var assemblies = FilterToAssembly (lines, assemblyName);
 			Assert.That (assemblies, Is.Not.Empty, "Assemblies");
 			// Make sure there's no other assembly confusing our logic
 			Assert.That (assemblies.Distinct ().Count (), Is.EqualTo (1), "Unique assemblies");
@@ -354,6 +307,25 @@ namespace Xamarin.Tests {
 				throw new NotImplementedException ($"Unknown platform: {platform}");
 			}
 			Assert.That (info_plist_path, Does.Exist, "Info.plist");
+		}
+
+		IEnumerable<string> FilterToAssembly (IEnumerable<string> lines, string assemblyName)
+		{
+			return lines.
+				Select (v => v.Trim ()).
+				Where (v => {
+					if (v.Length < 10)
+						return false;
+					if (v [0] != '/')
+						return false;
+					if (!v.EndsWith ($"{assemblyName}.dll", StringComparison.Ordinal))
+						return false;
+					if (!v.Contains ("/bin/", StringComparison.Ordinal))
+						return false;
+					if (v.Contains ("/ref/", StringComparison.Ordinal))
+						return false; // Skip reference assemblies
+					return true;
+				});
 		}
 	}
 }

--- a/tests/fsharplibrary/dotnet/shared.targets
+++ b/tests/fsharplibrary/dotnet/shared.targets
@@ -8,6 +8,9 @@
 		<FSharpLibraryDirectory>$(RootTestsDirectory)\fsharplibrary</FSharpLibraryDirectory>
 
 		<AssemblyOriginatorKeyFile>$(RootTestsDirectory)\..\product.snk</AssemblyOriginatorKeyFile>
+
+		<!-- Work around https://github.com/dotnet/sdk/issues/12954 -->
+		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="XliffTasks" Version="1.0.0-beta.20154.1" />
-    <PackageReference Include="Microsoft.NET.ILLink" Version="5.0.0-preview.3.20302.1" />
+    <PackageReference Include="Microsoft.NET.ILLink" Version="5.0.0-preview.3.20417.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\common\ApplePlatform.cs">


### PR DESCRIPTION
The old linker run into a problem that seems fixed in the new linker, so bump.

This also required a few other fixes to keep things working, since there's a
new bug in .NET + some difference in behavior we had to deal with.