### PR TITLE
[tests][monotouch-test] Re-enable some disabled tests from beta 3

### DIFF
--- a/tests/monotouch-test/AudioToolbox/AudioQueueTest.cs
+++ b/tests/monotouch-test/AudioToolbox/AudioQueueTest.cs
@@ -36,7 +36,6 @@ namespace MonoTouchFixtures.AudioToolbox {
 		}
 
 		[Test]
-		[Ignore ("Broken in Xcode 12 beta 3 - https://github.com/xamarin/xamarin-macios/issues/8943")]
 		public void ChannelAssignments ()
 		{
 			var aq = new OutputAudioQueue (AudioStreamBasicDescription.CreateLinearPCM ());

--- a/tests/monotouch-test/CoreMedia/CMClockTest.cs
+++ b/tests/monotouch-test/CoreMedia/CMClockTest.cs
@@ -26,7 +26,6 @@ namespace MonoTouchFixtures.CoreMedia {
 
 #if !MONOMAC // The CMAudioClockCreate API is only available on iOS
 		[Test]
-		[Ignore ("Broken in Xcode 12 beta 3 - https://github.com/xamarin/xamarin-macios/issues/8943")]
 		public void CreateAudioClock ()
 		{
 			CMClockError ce;


### PR DESCRIPTION
Seems to work fine with beta 5
part of #8943