### PR TITLE
[dotnet] Don't include the F# library in monotouch-test yet, it makes the linker crash.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2394,6 +2394,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		static extern IntPtr class_getInstanceMethod (IntPtr cls, IntPtr sel);
 
 #if !MONOMAC // Registrar_OutExportDerivedClass is from fsharp tests
+#if !NET // The F# test library makes the linker crash (https://github.com/mono/linker/issues/1435), so exclude this test because it requires the F# test library
 		[Test]
 		public void OutOverriddenWithoutOutAttribute ()
 		{
@@ -2406,6 +2407,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				}
 			}
 		}
+#endif // !NET
 #endif
 
 		class ProtocolArgumentClass : NSObject

--- a/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
@@ -122,7 +122,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\EmbeddedResources\dotnet\iOS\EmbeddedResources.csproj" />
     <ProjectReference Include="..\..\..\..\tests\bindings-test\dotnet\iOS\bindings-test.csproj" />
-    <ProjectReference Include="..\..\..\fsharplibrary\dotnet\iOS\fsharplibrary.fsproj" />
+    <!-- https://github.com/mono/linker/issues/1435 -->
+    <!-- <ProjectReference Include="..\..\..\fsharplibrary\dotnet\iOS\fsharplibrary.fsproj" /> -->
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="..\..\CoreImage\Xam.png">


### PR DESCRIPTION
The big question is of course why this compiled fine last week, and the answer is that I have no idea.

I first ran into this problem early last week, filed a [linker bug](https://github.com/mono/linker/issues/1435), updated dotnet and the problem went away, so I thought it was fixed. Then today I the same thing happens, with the updated dotnet version, so I decided to just exclude the F# test library until it's confirmed the linker bug has been fixed.