### PR TITLE
[dotnet/monotouch-test] Disable tests that require Crypto for .NET.

### DIFF
--- a/tests/monotouch-test/Foundation/UrlCredentialTest.cs
+++ b/tests/monotouch-test/Foundation/UrlCredentialTest.cs
@@ -35,6 +35,9 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
+#if NET
+		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_X509ImportCertificate")] // https://github.com/dotnet/runtime/issues/36897
+#endif
 		public void Ctor_Trust ()
 		{
 			using (var trust = GetTrust ())
@@ -54,6 +57,9 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
+#if NET
+		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_X509ImportCertificate")] // https://github.com/dotnet/runtime/issues/36897
+#endif
 		public void FromTrust ()
 		{
 			using (var trust = GetTrust ())

--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -537,6 +537,9 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
+#if NET
+		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_X509ImportCertificate")] // https://github.com/dotnet/runtime/issues/36897
+#endif
 		public void MailX1 ()
 		{
 			using (var cert = new X509Certificate (mail_google_com)) {

--- a/tests/monotouch-test/Security/KeyTest.cs
+++ b/tests/monotouch-test/Security/KeyTest.cs
@@ -47,6 +47,9 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
+#if NET
+		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainCreate")] // https://github.com/dotnet/runtime/issues/36897
+#endif
 		public void Encrypt_Old ()
 		{
 			// the old API was not working but the crash was fixed, still you need to provide an adequatly sized buffer
@@ -63,6 +66,9 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
+#if NET
+		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainCreate")] // https://github.com/dotnet/runtime/issues/36897
+#endif
 		public void Encrypt_Empty ()
 		{
 			using (SecPolicy p = SecPolicy.CreateBasicX509Policy ())
@@ -79,6 +85,9 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
+#if NET
+		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainCreate")] // https://github.com/dotnet/runtime/issues/36897
+#endif
 		public void Encrypt_New ()
 		{
 			using (SecPolicy p = SecPolicy.CreateBasicX509Policy ())

--- a/tests/monotouch-test/Security/RecordTest.cs
+++ b/tests/monotouch-test/Security/RecordTest.cs
@@ -304,6 +304,9 @@ namespace MonoTouchFixtures.Security {
 
 #if !MONOMAC // Works different on Mac
 		[Test]
+#if NET
+		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_X509ImportCertificate")] // https://github.com/dotnet/runtime/issues/36897
+#endif
 		public void SecRecordRecordTest ()
 		{
 			using (var cert = new X509Certificate (CertificateTest.mail_google_com))
@@ -322,6 +325,9 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
+#if NET
+		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainCreate")] // https://github.com/dotnet/runtime/issues/36897
+#endif
 		public void KeyRecordTest ()
 		{
 			using (var cert = new X509Certificate2 (ImportExportTest.farscape_pfx, "farscape"))

--- a/tests/monotouch-test/Security/TrustTest.cs
+++ b/tests/monotouch-test/Security/TrustTest.cs
@@ -32,6 +32,9 @@ namespace MonoTouchFixtures.Security {
 	[TestFixture]
 	// we want the test to be availble if we use the linker
 	[Preserve (AllMembers = true)]
+#if NET
+	[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_X509ImportCertificate")] // https://github.com/dotnet/runtime/issues/36897
+#endif
 	public class TrustTest {
 
 		[DllImport (Constants.CoreFoundationLibrary)]

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -85,6 +85,9 @@ namespace MonoTests.System.Net.Http
 #if !__WATCHOS__
 		// ensure that we do get the same cookies as the managed handler
 		[Test]
+#if NET
+		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain")] // https://github.com/dotnet/runtime/issues/36897
+#endif
 		public void TestNSUrlSessionHandlerCookies ()
 		{
 			var managedCookieResult = false;
@@ -130,6 +133,9 @@ namespace MonoTests.System.Net.Http
 
 		// ensure that we can use a cookie container to set the cookies for a url
 		[Test]
+#if NET
+		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain")] // https://github.com/dotnet/runtime/issues/36897
+#endif
 		public void TestNSUrlSessionHandlerCookieContainer ()
 		{
 			var url = NetworkResources.Httpbin.CookiesUrl;
@@ -308,6 +314,9 @@ namespace MonoTests.System.Net.Http
 
 #endif
 
+#if NET
+		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain")] // https://github.com/dotnet/runtime/issues/36897
+#endif
 		// ensure that if we have a redirect, we do not have the auth headers in the following requests
 #if !__WATCHOS__
 		[TestCase (typeof (HttpClientHandler))]
@@ -355,6 +364,9 @@ namespace MonoTests.System.Net.Http
 			}
 		}
 
+#if NET
+		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain")] // https://github.com/dotnet/runtime/issues/36897
+#endif
 #if !__WATCHOS__
 		[TestCase (typeof (HttpClientHandler))]
 #endif
@@ -430,6 +442,9 @@ namespace MonoTests.System.Net.Http
 			}
 		}
 
+#if NET
+		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain")] // https://github.com/dotnet/runtime/issues/36897
+#endif
 #if !__WATCHOS__
 		[TestCase (typeof (HttpClientHandler))]
 #endif


### PR DESCRIPTION
Crypto hasn't been implemented yet in .NET for iOS.

This fixes a crash because these tests cause an unhandled exception on the
finalizer thread (which crashes the process):

    Unhandled Exception:
    System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain assembly:<unknown assembly> type:<unknown type> member:(null)
       at Interop.AppleCrypto.SecKeychainItemCopyKeychain(IntPtr item)
       at System.Security.Cryptography.Apple.SafeTemporaryKeychainHandle.UntrackItem(IntPtr keychainItem)
       at System.Security.Cryptography.Apple.SafeKeychainItemHandle.ReleaseHandle()
       at System.Runtime.InteropServices.SafeHandle.InternalRelease(Boolean disposeOrFinalizeOperation)
       at System.Runtime.InteropServices.SafeHandle.Dispose(Boolean disposing)
       at System.Runtime.InteropServices.SafeHandle.Finalize()

    =================================================================
    	Native Crash Reporting
    =================================================================
    Got a abrt while executing native code. This usually indicates
    a fatal error in the mono runtime or one of the native libraries
    used by your application.
    =================================================================

    =================================================================
    	Native stacktrace:
    =================================================================
    	0x108bfc396 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/A23AD847-E868-4895-ADBA-036D4E87BA35/monotouchtest.app/libmonosgen-2.0.dylib : mono_dump_native_crash_info
    	0x108ba878f - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/A23AD847-E868-4895-ADBA-036D4E87BA35/monotouchtest.app/libmonosgen-2.0.dylib : mono_handle_native_crash
    	0x108bfbbed - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/A23AD847-E868-4895-ADBA-036D4E87BA35/monotouchtest.app/libmonosgen-2.0.dylib : sigabrt_signal_handler
    	0x7fff51c005fd - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_platform.dylib : _sigtramp
    	0x0 - Unknown
    	0x7fff51af0b7c - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_c.dylib : abort
    	0x1089bf7ef - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/A23AD847-E868-4895-ADBA-036D4E87BA35/monotouchtest.app/libxamarin-debug.dylib : xamarin_unhandled_exception_handler
    	0x108c69548 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/A23AD847-E868-4895-ADBA-036D4E87BA35/monotouchtest.app/libmonosgen-2.0.dylib : mono_invoke_unhandled_exception_hook
    	0x108cc688c - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/A23AD847-E868-4895-ADBA-036D4E87BA35/monotouchtest.app/libmonosgen-2.0.dylib : mono_thread_internal_unhandled_exception
    	0x108cf5ad5 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/A23AD847-E868-4895-ADBA-036D4E87BA35/monotouchtest.app/libmonosgen-2.0.dylib : mono_gc_run_finalize
    	0x108d0f095 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/A23AD847-E868-4895-ADBA-036D4E87BA35/monotouchtest.app/libmonosgen-2.0.dylib : sgen_gc_invoke_finalizers
    	0x108cf73cf - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/A23AD847-E868-4895-ADBA-036D4E87BA35/monotouchtest.app/libmonosgen-2.0.dylib : finalizer_thread
    	0x108cc7081 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/A23AD847-E868-4895-ADBA-036D4E87BA35/monotouchtest.app/libmonosgen-2.0.dylib : start_wrapper_internal
    	0x108cc6f39 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/A23AD847-E868-4895-ADBA-036D4E87BA35/monotouchtest.app/libmonosgen-2.0.dylib : start_wrapper
    	0x7fff51c0c109 - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_pthread.dylib : _pthread_start
    	0x7fff51c07b8b - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_pthread.dylib : thread_start