### PR TITLE
[monotouch-test] Don't run the mono tests for the System.Drawing types in .NET

### DIFF
--- a/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
@@ -48,24 +48,6 @@
     </Compile>
     <Compile Include="..\..\..\..\tests\test-libraries\TrampolineTest.generated.cs" />
     <Compile Include="..\..\..\..\tests\test-libraries\RegistrarTest.generated.cs" />
-    <Compile Include="..\..\..\..\builds\mono-ios-sdk-destdir\ios-sources\mcs\class\System.Drawing\Test\System.Drawing\TestPoint.cs">
-      <Link>System.Drawing\TestPoint.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\..\builds\mono-ios-sdk-destdir\ios-sources\mcs\class\System.Drawing\Test\System.Drawing\TestPointF.cs">
-      <Link>System.Drawing\TestPointF.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\..\builds\mono-ios-sdk-destdir\ios-sources\mcs\class\System.Drawing\Test\System.Drawing\TestRectangle.cs">
-      <Link>System.Drawing\TestRectangle.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\..\builds\mono-ios-sdk-destdir\ios-sources\mcs\class\System.Drawing\Test\System.Drawing\TestRectangleF.cs">
-      <Link>System.Drawing\TestRectangleF.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\..\builds\mono-ios-sdk-destdir\ios-sources\mcs\class\System.Drawing\Test\System.Drawing\TestSize.cs">
-      <Link>System.Drawing\TestSize.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\..\builds\mono-ios-sdk-destdir\ios-sources\mcs\class\System.Drawing\Test\System.Drawing\TestSizeF.cs">
-      <Link>System.Drawing\TestSizeF.cs</Link>
-    </Compile>
     <Compile Include="..\..\..\api-shared\ObjCRuntime\RegistrarTest.cs">
       <Link>shared\ObjCRuntime\RegistrarTest.cs</Link>
     </Compile>


### PR DESCRIPTION
A System.Drawing.Point test fails because it tests GetHashCode, which returns
a different value in .NET. None of the System.Drawing tests actually test any
of our code (when using .NET), so the fix is to just not include the
System.Drawing tests in the first place.

Fixes this test failure:

    MonoTests.System.Drawing.PointTest
        [FAIL] GetHashCodeTest :   #1
            Expected: 32
            But was:  1527927283
                at MonoTests.System.Drawing.PointTest.GetHashCodeTest() in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/builds/mono-ios-sdk-destdir/ios-sources/mcs/class/System.Drawing/Test/System.Drawing/TestPoint.cs:line 198