### PR TITLE
[monotouch-test] Ignore an autoreleasepool threadpool test which is a known issue in .NET.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -456,6 +456,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		}
 
 		[Test]
+#if NET
+		[Ignore ("https://github.com/dotnet/runtime/issues/32543")]
+#endif
 		public void NSAutoreleasePoolInThreadPool ()
 		{
 			var count = 100;


### PR DESCRIPTION
Fixes this test failure:

    MonoTouchFixtures.ObjCRuntime.RuntimeTest
		[FAIL] NSAutoreleasePoolInThreadPool :   RC. Iterations: 101
			Expected: not greater than 50
			But was:  101
				at MonoTouchFixtures.ObjCRuntime.RuntimeTest.NSAutoreleasePoolInThreadPool() in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs:line 484