### PR TITLE
[xharness] Process '$(RootTestsDirectory)' before bailing due to any other variables when resolving paths in project files.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs
@@ -971,14 +971,14 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities {
 				if (input [0] == '/')
 					return input; // This is already a full path.
 
-				// Don't process anything that starts with a variable, it's either a full path already, or the variable will be updated according to the new location
-				if (input.StartsWith ("$(", StringComparison.Ordinal))
-					return input;
-
 				input = input.Replace ('\\', '/'); // make unix-style
 
 				if (rootDirectory != null)
 					input = input.Replace ("$(RootTestsDirectory)", rootDirectory);
+
+				// Don't process anything that starts with a variable, it's either a full path already, or the variable will be updated according to the new location
+				if (input.StartsWith ("$(", StringComparison.Ordinal))
+					return input;
 
 				input = System.IO.Path.GetFullPath (System.IO.Path.Combine (dir, input));
 				input = input.Replace ('/', '\\'); // make windows-style again


### PR DESCRIPTION
While keeping '$(RootTestsDirectory)' as-is works fine when building the
project using MSBuild, xharness itself may end up encountering it (in
particular when listing referenced projects), and at that point will end up
confused. So just always resolve '$(RootTestsDirectory)' to the actual
directory to keep other parts of xharness happy.

Fixes this problem (as seen in PR #9460):

    Harness exception for 'interdependent-binding-projects': System.IO.DirectoryNotFoundException: Could not find a part of the path "/Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/external/Touch.Unit/Touch.Client/dotnet/iOS/Touch.Client-iOS.dotnet.csproj".
        at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) [0x0015e] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.IO/FileStream.cs:223
        at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean isAsync, System.Boolean anonymous) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.IO/FileStream.cs:149
        at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.IO/FileStream.cs:86
        at (wrapper remoting-invoke-with-check) System.IO.FileStream..ctor(string,System.IO.FileMode,System.IO.FileAccess)
        at Microsoft.DotNet.XHarness.iOS.Shared.Utilities.PListExtensions.LoadWithoutNetworkAccess (System.Xml.XmlDocument doc, System.String filename) [0x00001] in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/PlistExtensions.cs:17
        at Microsoft.DotNet.XHarness.iOS.Shared.TestProject.CreateCopyAsync (Microsoft.DotNet.XHarness.iOS.Shared.Logging.ILog log, Microsoft.DotNet.XHarness.iOS.Shared.Execution.IProcessManager processManager, Microsoft.DotNet.XHarness.iOS.Shared.Tasks.ITestTask test, System.String rootDirectory, System.Collections.Generic.Dictionary`2[TKey,TValue] allProjectReferences) [0x0010c] in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestProject.cs:98
        at Microsoft.DotNet.XHarness.iOS.Shared.TestProject.CreateCopyAsync (Microsoft.DotNet.XHarness.iOS.Shared.Logging.ILog log, Microsoft.DotNet.XHarness.iOS.Shared.Execution.IProcessManager processManager, Microsoft.DotNet.XHarness.iOS.Shared.Tasks.ITestTask test, System.String rootDirectory, System.Collections.Generic.Dictionary`2[TKey,TValue] allProjectReferences) [0x00811] in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestProject.cs:168
        at Microsoft.DotNet.XHarness.iOS.Shared.Tasks.TestTasks.RunInternalAsync () [0x00117] in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Tasks/TestTask.cs:274