### PR TITLE
[dotnet] Implement resource bundling.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -90,6 +90,9 @@
 	<!-- Inject our custom logic into *DependsOn variables -->
 	<PropertyGroup>
 		<BuildDependsOn>
+			_CollectBundleResources;
+			_PackLibraryResources;
+			_UnpackLibraryResources;
 			$(BuildDependsOn);
 			_CreateAppBundle;
 		</BuildDependsOn>
@@ -97,7 +100,6 @@
 		<!-- We re-use ComputeFilesToPublish & CopyFilesToPublishDirectory to copy files to the .app -->
 		<!-- ComputeFilesToPublish will run ILLink -->
 		<CreateAppBundleDependsOn>
-			_CollectBundleResources;
 			_DetectAppManifest;
 			_CopyResourcesToBundle;
 			_CompileAppManifest;

--- a/tests/BundledResources/ResourcesTest.cs
+++ b/tests/BundledResources/ResourcesTest.cs
@@ -32,7 +32,12 @@ namespace BundledResources {
 			// resources are removed by the linker or an extra step (e.g. "link sdk" or "don't link") but that
 			// extra step is done only on device (to keep the simulator builds as fast as possible)
 			var resources = typeof(ResourcesTest).Assembly.GetManifestResourceNames ();
-			if (Runtime.Arch == Arch.DEVICE) {
+#if __MACOS__
+			var hasResources = false;
+#else
+			var hasResources = Runtime.Arch != Arch.DEVICE;
+#endif
+			if (!hasResources) {
 				Assert.That (resources.Length, Is.EqualTo (0), "No resources");
 			} else {
 				Assert.That (resources.Length, Is.GreaterThanOrEqualTo (2), "Resources");

--- a/tests/BundledResources/dotnet/iOS/BundledResources.csproj
+++ b/tests/BundledResources/dotnet/iOS/BundledResources.csproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.iOS.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnitLite" Version="3.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <BundleResource Include="..\..\..\monotouch-test\basn3p08.png">
+      <Link>basn3p08.png</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\..\monotouch-test\xamvideotest.mp4">
+      <Link>xamvideotest.mp4</Link>
+    </BundleResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\ResourcesTest.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/BundledResources/dotnet/macOS/BundledResources.csproj
+++ b/tests/BundledResources/dotnet/macOS/BundledResources.csproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.macOS.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnitLite" Version="3.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <BundleResource Include="..\..\..\monotouch-test\basn3p08.png">
+      <Link>basn3p08.png</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\..\monotouch-test\xamvideotest.mp4">
+      <Link>xamvideotest.mp4</Link>
+    </BundleResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\ResourcesTest.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/BundledResources/dotnet/tvOS/BundledResources.csproj
+++ b/tests/BundledResources/dotnet/tvOS/BundledResources.csproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.tvOS.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnitLite" Version="3.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <BundleResource Include="..\..\..\monotouch-test\basn3p08.png">
+      <Link>basn3p08.png</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\..\monotouch-test\xamvideotest.mp4">
+      <Link>xamvideotest.mp4</Link>
+    </BundleResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\ResourcesTest.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/BundledResources/dotnet/watchOS/BundledResources.csproj
+++ b/tests/BundledResources/dotnet/watchOS/BundledResources.csproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.watchOS.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnitLite" Version="3.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <BundleResource Include="..\..\..\monotouch-test\basn3p08.png">
+      <Link>basn3p08.png</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\..\monotouch-test\xamvideotest.mp4">
+      <Link>xamvideotest.mp4</Link>
+    </BundleResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\ResourcesTest.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
* Port the BundledResources test to .NET.
* Fix a minor issue in the BundledResources test to make sure it works on macOS.
* Add a unit test to make sure resources are bundled as expected.
* Modify the .NET build logic to bundle/unbundle resources.