### PR TITLE
[d16-8] [Bug] Fix AVAudioFormat failure on older OS

### DIFF
--- a/tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs
@@ -7,6 +7,8 @@ using System;
 using Foundation;
 using AVFoundation;
 using NUnit.Framework;
+using ObjCRuntime;
+
 namespace MonoTouchFixtures.AVFoundation {
 
 	[TestFixture]
@@ -16,7 +18,8 @@ namespace MonoTouchFixtures.AVFoundation {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertXcodeVersion (6, 0);
+			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs
@@ -13,6 +13,12 @@ namespace MonoTouchFixtures.AVFoundation {
 	[Preserve (AllMembers = true)]
 	public class AVAudioFormatTest {
 
+		[SetUp]
+		public void Setup ()
+		{
+			TestRuntime.AssertXcodeVersion (6, 0);
+		}
+
 		[Test]
 		public void TestEqualOperatorSameInstace ()
 		{


### PR DESCRIPTION
Add version check.

Fix https://github.com/xamarin/xamarin-macios/issues/9428

Will need to be backported to d16-8 & xcode12

Backport of #9433.

/cc @whitneyschmidt 