### PR TITLE
[dotnet/msbuild] Add support for compiling and embedding entitlements to .NET apps.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -103,6 +103,7 @@
 		<CreateAppBundleDependsOn>
 			_DetectAppManifest;
 			_CopyResourcesToBundle;
+			_CompileEntitlements;
 			_CompileAppManifest;
 			_ComputeLinkerArguments;
 			ComputeFilesToPublish;
@@ -362,6 +363,7 @@
 
 		<LinkNativeCode
 			SessionId="$(BuildSessionId)"
+			EntitlementsInExecutable="$(_CompiledEntitlements)"
 			Frameworks="@(_NativeExecutableFrameworks);@(_BindingLibraryFrameworks)"
 			LinkerFlags="@(_BindingLibraryLinkerFlags)"
 			LinkWithLibraries="@(_XamarinMainLibraries);@(_BindingLibraryLinkWith);@(_MainLinkWith)"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -180,30 +180,6 @@ namespace Xamarin.iOS.Tasks
 			}
 		}
 
-		static bool EntitlementsRequireLinkerFlags (string path)
-		{
-			try {
-				var plist = PDictionary.FromFile (path);
-
-				// FIXME: most keys do not require linking in the entitlements file, so we
-				// could probably add some smarter logic here to iterate over all of the
-				// keys in order to determine whether or not we really need to link with
-				// the entitlements or not.
-				return plist.Count != 0;
-			} catch {
-				return false;
-			}
-		}
-
-		void BuildEntitlementFlags (GccOptions gcc)
-		{
-			if (SdkIsSimulator && !string.IsNullOrEmpty (CompiledEntitlements) && EntitlementsRequireLinkerFlags (CompiledEntitlements)) {
-				gcc.Arguments.AddQuoted (new [] { "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__entitlements" });
-				gcc.Arguments.Add ("-Xlinker");
-				gcc.Arguments.AddQuoted (Path.GetFullPath (CompiledEntitlements));
-			}
-		}
-
 		static string Unquote (string text, int startIndex)
 		{
 			if (startIndex >= text.Length)
@@ -420,7 +396,7 @@ namespace Xamarin.iOS.Tasks
 			}
 
 			BuildNativeReferenceFlags (gcc);
-			BuildEntitlementFlags (gcc);
+			gcc.Arguments.AddQuoted (LinkNativeCodeTaskBase.GetEmbedEntitlementsInExecutableLinkerFlags (CompiledEntitlements));
 
 			foreach (var framework in gcc.Frameworks)
 				args.AddQuotedLine ($"--framework={framework}");


### PR DESCRIPTION
First move the logic to compute the linker arguments for embedding
entitlements into the executable to shared code, so that it can be used from
platform-agnostic .NET code as well.

There is one difference: the code no longer checks if we're building for the
simulator, because the 'CompiledEntitlements' variable won't be set unless
we're in the simulator, so it's no longer needed (it's also not applicable for
Xamarin.Mac).

Also call the _CompileEntitlements target from the .NET build logic, and embed
the result into the executable.

This fixes the following 10 monotouch-tests:

    MonoTouchFixtures.Security.CertificateTest
        [FAIL] GenerateKeyPairTest :   GenerateKeyPair
            Expected: Success
            But was:  MissingEntitlement
                at MonoTouchFixtures.Security.CertificateTest.GenerateKeyPairTest() in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/Security/CertificateTest.cs:line 597

    MonoTouchFixtures.Security.KeyChainTest
        [FAIL] AddQueryRemove_Identity :   code
            Expected: DuplicateItem or Success
            But was:  MissingEntitlement
                at MonoTouchFixtures.Security.KeyChainTest.AddQueryRemove_Identity() in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/Security/KeyChainTest.cs:line 49

        [FAIL] Add_Certificate :   Add_Certificate
            Expected: Success or DuplicateItem
            But was:  MissingEntitlement
                at MonoTouchFixtures.Security.KeyChainTest.Add_Certificate() in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/Security/KeyChainTest.cs:line 38

        [FAIL] CheckId :   same guid
            Expected: 00000000-0000-0000-0000-000000000000
            But was:  9c3f0fd6-5c94-46a3-8193-a9fb45209a48
                at MonoTouchFixtures.Security.KeyChainTest.CheckId() in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/Security/KeyChainTest.cs:line 171

        [FAIL] SecItemAdd_Identity :   Expected: DuplicateItem or Success
            But was:  MissingEntitlement
                at MonoTouchFixtures.Security.KeyChainTest.SecItemAdd_Identity() in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/Security/KeyChainTest.cs:line 91

    MonoTouchFixtures.Security.RecordTest
        [FAIL] Accessible_17579 :   Add
            Expected: Success
            But was:  MissingEntitlement
                at MonoTouchFixtures.Security.RecordTest.Accessible(SecAccessible access) in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/Security/RecordTest.cs:line 56
                at MonoTouchFixtures.Security.RecordTest.Accessible_17579() in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/Security/RecordTest.cs:line 93

        [FAIL] AuthenticationType_17579 :   Add
            Expected: Success
            But was:  MissingEntitlement
                at MonoTouchFixtures.Security.RecordTest.AuthenticationType(SecAuthenticationType type) in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/Security/RecordTest.cs:line 174
                at MonoTouchFixtures.Security.RecordTest.AuthenticationType_17579() in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/Security/RecordTest.cs:line 186

        [FAIL] DeskCase_83099_InmutableDictionary :   Password could not be saved to keychain
            Expected: True
            But was:  False
                at MonoTouchFixtures.Security.RecordTest.DeskCase_83099_InmutableDictionary() in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/Security/RecordTest.cs:line 205

        [FAIL] IdentityRecordTest :   Identity added
            Expected: True
            But was:  False
                at MonoTouchFixtures.Security.RecordTest.IdentityRecordTest() in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/Security/RecordTest.cs:line 294

        [FAIL] Protocol_17579 :   Add
            Expected: Success
            But was:  MissingEntitlement
                at MonoTouchFixtures.Security.RecordTest.Protocol(SecProtocol protocol) in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/Security/RecordTest.cs:line 115
                at MonoTouchFixtures.Security.RecordTest.Protocol_17579() in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/Security/RecordTest.cs:line 127