### PR TITLE
[main] [msbuild] Fix AdditionalAppExtensions entitlement logic

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -606,9 +606,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<_ResolvedAppExtensionReferences Include="%(AdditionalAppExtensions.Identity)/%(AdditionalAppExtensions.BuildOutput)/%(AdditionalAppExtensions.Name).appex" />
 
 			<_AppExtensionCodesignProperties Include="%(AdditionalAppExtensions.Name).appex">
-				<Entitlements Condition="Exists('$(_ExtensionEntitlementPath)')">
-					$(_ExtensionEntitlementPath)
-				</Entitlements>
+				<Entitlements Condition="Exists('$(_ExtensionEntitlementPath)')">$(_ExtensionEntitlementPath)</Entitlements>
 				<SigningKey>$(CodesignKey)</SigningKey>
 				<Keychain>$(CodesignKeychain)</Keychain>
 				<DisableTimestamp>False</DisableTimestamp>


### PR DESCRIPTION
- Fixes https://github.com/xamarin/xamarin-macios/issues/9458
- Defining the variable over multiple lines changes output to include incorrect newline
- Auto tests did not catch, as they don't sign on bots due to infrastructure issues.
- Was refactored _after_ manual tests and not retested

Backport of #9477.

/cc @chamons 