### PR TITLE
[dotnet] Make sure the 'BuildOnlySettings' target has been called before any other .NET target we depend on.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -90,6 +90,7 @@
 	<!-- Inject our custom logic into *DependsOn variables -->
 	<PropertyGroup>
 		<BuildDependsOn>
+			BuildOnlySettings;
 			_CollectBundleResources;
 			_PackLibraryResources;
 			_UnpackLibraryResources;


### PR DESCRIPTION
The 'BuildOnlySettings' target flips a switch that indicates we're doing a
real build, which makes the .NET build logic resolve and publish satellite
assemblies (the switch probably controls a lot of other stuff as well, but
this is where I ran into it).

This is the first of three steps to fix this test failure:

    EmbeddedResources.ResourcesTest
        [FAIL] Embedded :   en-AU
            Expected string length 5 but was 7. Strings differ at index 0.
            Expected: "G'day"
            But was:  "Welcome"
            -----------^
                at EmbeddedResources.ResourcesTest.Embedded() in [...]/xamarin-macios/tests/EmbeddedResources/ResourcesTest.cs:line 45