### PR TITLE
[dotnet] Preserve relative directory when deciding where in the app bundle files should be copied.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -407,7 +407,7 @@
 		<ItemGroup>
 			<ResolvedFileToPublish
 				Update="@(ResolvedFileToPublish)"
-				RelativePath="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_AssemblyPublishDir)))%(Filename)%(Extension)"
+				RelativePath="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_AssemblyPublishDir)))%(ResolvedFileToPublish.DestinationSubDirectory)%(Filename)%(Extension)"
 				Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.pdb' Or '%(Extension)' == '.exe'" />
 			<!-- Copy the app.config file to the app bundle -->
 			<ResolvedFileToPublish


### PR DESCRIPTION
There may be multiple satellite assemblies with the same name, so make sure to
put them all in the corresponding subdirectory.

This is the second of three steps to fix this test failure:

    EmbeddedResources.ResourcesTest
        [FAIL] Embedded :   en-AU
            Expected string length 5 but was 7. Strings differ at index 0.
            Expected: "G'day"
            But was:  "Welcome"
            -----------^
                at EmbeddedResources.ResourcesTest.Embedded() in [...]/xamarin-macios/tests/EmbeddedResources/ResourcesTest.cs:line 45