### PR TITLE
[tests] Adjust resources test to cope with the fact that only the invariant culture is currently shipping in .NET 5.

### DIFF
--- a/tests/EmbeddedResources/ResourcesTest.cs
+++ b/tests/EmbeddedResources/ResourcesTest.cs
@@ -44,10 +44,14 @@ namespace EmbeddedResources {
 			Assert.AreEqual ("Welcome", manager.GetString ("String1", new CultureInfo ("en")), "en");
 			Assert.AreEqual ("G'day", manager.GetString ("String1", new CultureInfo ("en-AU")), "en-AU");
 			Assert.AreEqual ("Willkommen", manager.GetString ("String1", new CultureInfo ("de")), "de");
+#if !NET // https://github.com/xamarin/xamarin-macios/issues/8906
 			Assert.AreEqual ("Willkommen", manager.GetString ("String1", new CultureInfo ("de-DE")), "de-DE");
+#endif
 			Assert.AreEqual ("Bienvenido", manager.GetString ("String1", new CultureInfo ("es")), "es");
+#if !NET // https://github.com/xamarin/xamarin-macios/issues/8906
 			Assert.AreEqual ("Bienvenido", manager.GetString ("String1", new CultureInfo ("es-AR")), "es-AR");
 			Assert.AreEqual ("Bienvenido", manager.GetString ("String1", new CultureInfo ("es-ES")), "es-ES");
+#endif
 		}
 	}
 }


### PR DESCRIPTION
Ref: https://github.com/xamarin/xamarin-macios/issues/8906

This is the third of three steps to fix this test failure:

    EmbeddedResources.ResourcesTest
        [FAIL] Embedded :   en-AU
            Expected string length 5 but was 7. Strings differ at index 0.
            Expected: "G'day"
            But was:  "Welcome"
            -----------^
                at EmbeddedResources.ResourcesTest.Embedded() in [...]/xamarin-macios/tests/EmbeddedResources/ResourcesTest.cs:line 45