### PR TITLE
[Accelerate] Ignore the new bindings for Xcode12 beta 5.

### DIFF
--- a/tests/xtro-sharpie/common-Accelerate.ignore
+++ b/tests/xtro-sharpie/common-Accelerate.ignore
@@ -509,3 +509,8 @@
 !missing-pinvoke! vImageVerticalShearD_ARGBFFFF is not bound
 !missing-pinvoke! vImageVerticalShearD_Planar8 is not bound
 !missing-pinvoke! vImageVerticalShearD_PlanarF is not bound
+!missing-pinvoke! vImageConverter_CreateWithCGColorConversionInfo is not bound
+!missing-pinvoke! vImageSepConvolve_Planar16U is not bound
+!missing-pinvoke! vImageSepConvolve_Planar8 is not bound
+!missing-pinvoke! vImageSepConvolve_Planar8to16U is not bound
+!missing-pinvoke! vImageSepConvolve_PlanarF is not bound

--- a/tests/xtro-sharpie/iOS-Accelerate.todo
+++ b/tests/xtro-sharpie/iOS-Accelerate.todo
@@ -1,5 +1,0 @@
-!missing-pinvoke! vImageConverter_CreateWithCGColorConversionInfo is not bound
-!missing-pinvoke! vImageSepConvolve_Planar16U is not bound
-!missing-pinvoke! vImageSepConvolve_Planar8 is not bound
-!missing-pinvoke! vImageSepConvolve_Planar8to16U is not bound
-!missing-pinvoke! vImageSepConvolve_PlanarF is not bound

--- a/tests/xtro-sharpie/macOS-Accelerate.todo
+++ b/tests/xtro-sharpie/macOS-Accelerate.todo
@@ -1,5 +1,0 @@
-!missing-pinvoke! vImageConverter_CreateWithCGColorConversionInfo is not bound
-!missing-pinvoke! vImageSepConvolve_Planar16U is not bound
-!missing-pinvoke! vImageSepConvolve_Planar8 is not bound
-!missing-pinvoke! vImageSepConvolve_Planar8to16U is not bound
-!missing-pinvoke! vImageSepConvolve_PlanarF is not bound

--- a/tests/xtro-sharpie/tvOS-Accelerate.todo
+++ b/tests/xtro-sharpie/tvOS-Accelerate.todo
@@ -1,5 +1,0 @@
-!missing-pinvoke! vImageConverter_CreateWithCGColorConversionInfo is not bound
-!missing-pinvoke! vImageSepConvolve_Planar16U is not bound
-!missing-pinvoke! vImageSepConvolve_Planar8 is not bound
-!missing-pinvoke! vImageSepConvolve_Planar8to16U is not bound
-!missing-pinvoke! vImageSepConvolve_PlanarF is not bound

--- a/tests/xtro-sharpie/watchOS-Accelerate.todo
+++ b/tests/xtro-sharpie/watchOS-Accelerate.todo
@@ -1,5 +1,0 @@
-!missing-pinvoke! vImageConverter_CreateWithCGColorConversionInfo is not bound
-!missing-pinvoke! vImageSepConvolve_Planar16U is not bound
-!missing-pinvoke! vImageSepConvolve_Planar8 is not bound
-!missing-pinvoke! vImageSepConvolve_Planar8to16U is not bound
-!missing-pinvoke! vImageSepConvolve_PlanarF is not bound


### PR DESCRIPTION
Checked and the other functions that are similar to the new ones are not
bound. We only do this framework partially, so I'm adding them to the
ignore until we have a customer that requires them.