### PR TITLE
[tools] Honor the ENABLE_DOTNET variable. Fixes #9475.

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,8 +1,12 @@
 TOP=..
-SUBDIRS=mmp mtouch xibuild mlaunch siminstaller dotnet-linker
+SUBDIRS=mmp mtouch xibuild mlaunch siminstaller
 
 include $(TOP)/Make.config
 
 ifdef ENABLE_INSTALL_SOURCE
 SUBDIRS += install-source
+endif
+
+ifdef ENABLE_DOTNET
+SUBDIRS += dotnet-linker
 endif

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -26,7 +26,6 @@ MMP_TARGETS = \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/mmp.exe \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/Xamarin.Mac.registrar.mobile.a \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/Xamarin.Mac.registrar.full.a \
-	$(MMP_TARGETS_DOTNET) \
 
 MMP_DIRECTORIES_DOTNET = \
 	$(DOTNET_DESTDIR)/Microsoft.macOS.Runtime.osx-x64/runtimes/osx-x64/native \


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/9475.