### PR TITLE
[runtime] Give a better error message if we can't load ObjCRuntime.Runtime.Initialize ()

### DIFF
--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -547,7 +547,7 @@ run_application_init (xamarin_initialize_data *data)
 
 	MonoMethod *initialize = mono_class_get_method_from_name (app_class, "Init", 0);
 	if (!initialize)
-		xamarin_assertion_message ("Fatal error: failed to load the NSApplication.Init method");
+		xamarin_assertion_message ("Fatal error: failed to load the %s.%s method", "NSApplication", "Init");
 
 	mono_runtime_invoke (initialize, NULL, NULL, NULL);
 }

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1324,7 +1324,7 @@ xamarin_initialize ()
 	runtime_initialize = mono_class_get_method_from_name (runtime_class, "Initialize", 1);
 
 	if (runtime_initialize == NULL)
-		xamarin_assertion_message ("Fatal error: failed to load the method '%s.%s.%s'\n.", objcruntime, "Runtime", "Initialize");
+		xamarin_assertion_message ("Fatal error: failed to load the %s.%s method", "Runtime", "Initialize");
 
 	options.size = sizeof (options);
 #if MONOTOUCH && (defined(__i386__) || defined (__x86_64__))

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1323,6 +1323,9 @@ xamarin_initialize ()
 
 	runtime_initialize = mono_class_get_method_from_name (runtime_class, "Initialize", 1);
 
+	if (runtime_initialize == NULL)
+		xamarin_assertion_message ("Fatal error: failed to load the method '%s.%s.%s'\n.", objcruntime, "Runtime", "Initialize");
+
 	options.size = sizeof (options);
 #if MONOTOUCH && (defined(__i386__) || defined (__x86_64__))
 	options.flags = (enum InitializationFlags) (options.flags | InitializationFlagsIsSimulator);


### PR DESCRIPTION
Otherwise we'll get a SIGSEGV due to dereferencing NULL.