### PR TITLE
[dotnet] Add support for setting the exception marshalling mode in the GenerateMain step.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -143,6 +143,8 @@
 				ItemsDirectory=$(_LinkerItemsDirectory)
 				IsSimulatorBuild=$(_SdkIsSimulator)
 				LinkMode=$(_LinkMode)
+				MarshalManagedExceptionMode=$(_MarshalManagedExceptionMode)
+				MarshalObjectiveCExceptionMode=$(_MarshalObjectiveCExceptionMode)
 				PartialStaticRegistrarLibrary=$(_LibPartialStaticRegistrar)
 				Platform=$(_PlatformName)
 				PlatformAssembly=$(_PlatformAssemblyName).dll

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -108,6 +108,20 @@ namespace Xamarin.Linker {
 						throw new InvalidOperationException ($"Unable to parse the {key} value: {value} in {linker_file}");
 					Application.LinkMode = lm;
 					break;
+				case "MarshalManagedExceptionMode":
+					if (!string.IsNullOrEmpty (value)) {
+						if (!Application.TryParseManagedExceptionMode (value, out var mode))
+							throw new InvalidOperationException ($"Unable to parse the {key} value: {value} in {linker_file}");
+						Application.MarshalManagedExceptions = mode;
+					}
+					break;
+				case "MarshalObjectiveCExceptionMode":
+					if (!string.IsNullOrEmpty (value)) {
+						if (!Application.TryParseObjectiveCExceptionMode (value, out var mode))
+							throw new InvalidOperationException ($"Unable to parse the {key} value: {value} in {linker_file}");
+						Application.MarshalObjectiveCExceptions = mode;
+					}
+					break;
 				case "PartialStaticRegistrarLibrary":
 					PartialStaticRegistrarLibrary = value;
 					break;
@@ -183,6 +197,9 @@ namespace Xamarin.Linker {
 
 			if (Driver.TargetFramework.Platform != Platform)
 				throw ErrorHelper.CreateError (99, "Inconsistent platforms. TargetFramework={0}, Platform={1}", Driver.TargetFramework.Platform, Platform);
+
+			Application.SetManagedExceptionMode ();
+			Application.SetObjectiveCExceptionMode ();
 		}
 
 		public void Write ()
@@ -197,6 +214,8 @@ namespace Xamarin.Linker {
 				Console.WriteLine ($"    ItemsDirectory: {ItemsDirectory}");
 				Console.WriteLine ($"    IsSimulatorBuild: {IsSimulatorBuild}");
 				Console.WriteLine ($"    LinkMode: {LinkMode}");
+				Console.WriteLine ($"    MarshalManagedExceptions: {Application.MarshalManagedExceptions} (IsDefault: {Application.IsDefaultMarshalManagedExceptionMode})");
+				Console.WriteLine ($"    MarshalObjectiveCExceptions: {Application.MarshalObjectiveCExceptions}");
 				Console.WriteLine ($"    PartialStaticRegistrarLibrary: {PartialStaticRegistrarLibrary}");
 				Console.WriteLine ($"    Platform: {Platform}");
 				Console.WriteLine ($"    PlatformAssembly: {PlatformAssembly}.dll");

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -182,6 +182,7 @@ namespace Xamarin.Linker {
 			Application.CreateCache (significantLines.ToArray ());
 			Application.Cache.Location = CacheDirectory;
 			Application.DeploymentTarget = DeploymentTarget;
+			Application.EnableCoopGC ??= Platform == ApplePlatform.WatchOS;
 			Application.SdkVersion = SdkVersion;
 
 			switch (Platform) {

--- a/tools/dotnet-linker/Steps/GenerateMainStep.cs
+++ b/tools/dotnet-linker/Steps/GenerateMainStep.cs
@@ -13,6 +13,7 @@ namespace Xamarin {
 			var registration_methods = Configuration.RegistrationMethods;
 			var items = new List<MSBuildItem> ();
 
+			var app = Configuration.Application;
 			foreach (var abi in Configuration.Abis) {
 
 				var file = Path.Combine (Configuration.CacheDirectory, $"main.{abi.AsArchString ()}.mm");
@@ -38,6 +39,9 @@ namespace Xamarin {
 						contents.WriteLine ("();");
 					}
 				}
+				if (!app.IsDefaultMarshalManagedExceptionMode)
+					contents.WriteLine ("\txamarin_marshal_managed_exception_mode = MarshalManagedExceptionMode{0};", app.MarshalManagedExceptions);
+				contents.WriteLine ("\txamarin_marshal_objectivec_exception_mode = MarshalObjectiveCExceptionMode{0};", app.MarshalObjectiveCExceptions);
 				contents.WriteLine ("}");
 				contents.WriteLine ();
 				contents.WriteLine ("void xamarin_initialize_callbacks () __attribute__ ((constructor));");


### PR DESCRIPTION
This fixes these monotouch-test tests:

    MonoTouchFixtures.ObjCRuntime.ExceptionsTest
        [FAIL] ManagedExceptionPassthrough :   1 objc mode
            Expected: UnwindManagedCode
            But was:  Default
                at MonoTouchFixtures.ObjCRuntime.ExceptionsTest.ManagedExceptionPassthrough() in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs:line 165
    
        [FAIL] ObjCException :   objc mode
            Expected: UnwindManagedCode
            But was:  Default
                at MonoTouchFixtures.ObjCRuntime.ExceptionsTest.ObjCException() in /Users/rolf/work/maccore/squashed-onedotnet/xamarin-macios/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs:line 114