### PR TITLE
Revert "[MTouch] Add a workaround for a failing tests in the Xcode 12 betas. (#9073)"

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2821,9 +2821,7 @@ public class TestApp {
 				mtouch.GccFlags = lib;
 				mtouch.TargetVer = "10.3"; // otherwise 32-bit build isn't possible
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build a");
-				if (Configuration.XcodeVersion.Major >= 12) { // fb ticket: https://github.com/xamarin/maccore/issues/2264
-					mtouch.AssertWarning (5203, $"Native linking warning: warning: ignoring file {lib}, building for iOS Simulator-i386 but attempting to link with file built for unknown-x86_64");
-				} else if (Configuration.XcodeVersion.Major >= 11) {
+				if (Configuration.XcodeVersion.Major >= 11) {
 					mtouch.AssertWarning (5203, $"Native linking warning: warning: ignoring file {lib}, building for iOS Simulator-i386 but attempting to link with file built for iOS Simulator-x86_64");
 				} else {
 					mtouch.AssertWarning (5203, $"Native linking warning: warning: ignoring file {lib}, file was built for archive which is not the architecture being linked (i386): {lib}");


### PR DESCRIPTION
This reverts commit c170ba2fe0d53cdd735b028aed488212893a03ce.

This was fixed with beta 5/6, i.e. return to "normal"

Fix https://github.com/xamarin/maccore/issues/2263