### PR TITLE
[msbuild] Emit binding resources to the EmbeddedResource item group instead of ManifestResourceWithNoCulture. Fixes #3876.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/PrepareNativeReferencesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/PrepareNativeReferencesTaskBase.cs
@@ -115,6 +115,8 @@ namespace Xamarin.MacDev.Tasks
 					nativeFrameworks.Add (item);
 				} else {
 					item.SetMetadata ("LogicalName", logicalName);
+					item.SetMetadata ("WithCulture", "false");
+					item.SetMetadata ("Type", "Non-Resx");
 					embeddedResources.Add (item);
 				}
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.ObjCBinding.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.ObjCBinding.targets
@@ -63,9 +63,12 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 			<Output TaskParameter="Include" ItemName="Compile" />
 		</CreateItem>
 
-		<CreateItem Include="@(ObjcBindingNativeLibrary)">
-			<Output TaskParameter="Include" ItemName="ManifestResourceWithNoCulture" />
-		</CreateItem>
+		<ItemGroup>
+			<EmbeddedResource Include="@(ObjcBindingNativeLibrary)">
+				<Type>Non-Resx</Type>
+				<WithCulture>false</WithCulture>
+			</EmbeddedResource>
+		</ItemGroup>
 	</Target>
 
 	<!--
@@ -125,9 +128,12 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 			WorkingDirectory="%(_NativeFrameworkResource.FrameworkPath)" >
 		</Zip>
 
-		<CreateItem Include="%(_NativeFrameworkResource.ZipFile)">
-			<Output TaskParameter="Include" ItemName="ManifestResourceWithNoCulture" />
-		</CreateItem>
+		<ItemGroup>
+			<EmbeddedResource Include="%(_NativeFrameworkResource.ZipFile)">
+				<Type>Non-Resx</Type>
+				<WithCulture>false</WithCulture>
+			</EmbeddedResource>
+		</ItemGroup>
 	</Target>
 
 	<Target Name="_PrepareNativeReferences" Condition="'$(DesignTimeBuild)' != 'true'">
@@ -137,7 +143,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			NativeReferences="@(NativeReference)"
 		>
-			<Output ItemName="ManifestResourceWithNoCulture" TaskParameter="EmbeddedResources" Condition="'$(NoBindingEmbedding)' != 'true'"/>
+			<Output ItemName="EmbeddedResource" TaskParameter="EmbeddedResources" Condition="'$(NoBindingEmbedding)' != 'true'"/>
 			<Output ItemName="_NativeFramework" TaskParameter="NativeFrameworks" Condition="'$(NoBindingEmbedding)' != 'true'"/>
 			<Output ItemName="Compile" TaskParameter="LinkWithAttributes" />
 		</PrepareNativeReferences>

--- a/tests/mmptest/src/BindingProjectTests.cs
+++ b/tests/mmptest/src/BindingProjectTests.cs
@@ -155,6 +155,8 @@ namespace Xamarin.MMP.Tests
 
 				Assert.False (logs.Item1.Contains ("CS1685"), "Binding should not contains CS1685 multiple definition warning:\n" + logs.Item1);
 
+				Assert.False (logs.Item1.Contains ("MSB9004"), "Binding should not contains MSB9004 warning:\n" + logs.Item1);
+
 				string bindingName = RemoveCSProj (projects.Item1.ProjectName);
 				string appName = RemoveCSProj (projects.Item2.ProjectName);
 				string libPath = Path.Combine (tmpDir, $"bin/Debug/{appName}.app/Contents/MonoBundle/{bindingName}.dll");


### PR DESCRIPTION
Fixes this warning:

    warning MSB9004: ManifestResourceWithNoCulture item type is deprecated. Emit EmbeddedResource items instead, with metadata WithCulture='false', Type='Resx', and optional LogicalName.

There is a slight difference with regards to the warning message: the Type
metadata is set to 'Non-Resx' instead of 'Resx' (because these resources
aren't resx files).

Fixes https://github.com/xamarin/xamarin-macios/issues/3876.