### PR TITLE
[tests] Skip the TypeDescriptorCanary test in .NET.

### DIFF
--- a/tests/linker/CommonDontLinkTest.cs
+++ b/tests/linker/CommonDontLinkTest.cs
@@ -11,6 +11,9 @@ namespace DontLink {
 	[TestFixture]
 	public class CommonDontLinkTest {
 
+#if NET
+		[Ignore ("This test accesses internal implementation details for TypeConverters, which has changed in .NET.")]
+#endif
 		[Test]
 		public void TypeDescriptorCanary ()
 		{
@@ -22,12 +25,7 @@ namespace DontLink {
 			var ht = (Hashtable) p.GetGetMethod (true).Invoke (null, null);
 			Assert.NotNull (ht, "Hashtable");
 
-#if NET
-			var expectedCount = 28;
-#else
-			var expectedCount = 26;
-#endif
-			Assert.That (ht.Count, Is.EqualTo (expectedCount), "Count");
+			Assert.That (ht.Count, Is.EqualTo (26), "Count");
 
 			foreach (var item in ht.Values) {
 				var name = item.ToString ();
@@ -57,10 +55,6 @@ namespace DontLink {
 				case "System.ComponentModel.UInt32Converter":
 				case "System.ComponentModel.ByteConverter":
 				case "System.ComponentModel.EnumConverter":
-#if NET
-				case "System.ComponentModel.VersionConverter":
-				case "System.UriTypeConverter":
-#endif
 					break;
 				default:
 					Assert.Fail ($"Unknown type descriptor {name}");


### PR DESCRIPTION
It tests internal implementation details, and those details have now changed
(https://github.com/dotnet/runtime/pull/39973). So just skip the entire test
for now.

Fixes this test failure:

    DontLink.CommonDontLinkTest
        [FAIL] TypeDescriptorCanary : System.InvalidCastException : Specified cast is not valid. :    at DontLink.CommonDontLinkTest.TypeDescriptorCanary() in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/linker/CommonDontLinkTest.cs:line 22
            at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)