### PR TITLE
[dotnet-linker] Add ApplyPreserveAttribute into the pipeline.

### DIFF
--- a/tools/dotnet-linker/ApplyPreserveAttributeBase.cs
+++ b/tools/dotnet-linker/ApplyPreserveAttributeBase.cs
@@ -1,0 +1,166 @@
+// This is copied from https://github.com/mono/linker/blob/fa9ccbdaf6907c69ef1bb117906f8f012218d57f/src/tuner/Mono.Tuner/ApplyPreserveAttributeBase.cs
+// and modified to work without a Profile class.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+using Mono.Linker;
+using Mono.Linker.Steps;
+
+using Mono.Cecil;
+
+namespace Mono.Tuner {
+
+	public abstract class ApplyPreserveAttributeBase : BaseSubStep {
+
+		// set 'removeAttribute' to true if you want the preserved attribute to be removed from the final assembly
+		protected abstract bool IsPreservedAttribute (ICustomAttributeProvider provider, CustomAttribute attribute, out bool removeAttribute);
+
+		public override SubStepTargets Targets {
+			get {
+				return SubStepTargets.Type
+					| SubStepTargets.Field
+					| SubStepTargets.Method
+					| SubStepTargets.Property
+					| SubStepTargets.Event;
+			}
+		}
+
+		public override bool IsActiveFor (AssemblyDefinition assembly)
+		{
+			return Annotations.GetAction (assembly) == AssemblyAction.Link;
+		}
+
+		public override void ProcessType (TypeDefinition type)
+		{
+			TryApplyPreserveAttribute (type);
+		}
+
+		public override void ProcessField (FieldDefinition field)
+		{
+			foreach (var attribute in GetPreserveAttributes (field))
+				Mark (field, attribute);
+		}
+
+		public override void ProcessMethod (MethodDefinition method)
+		{
+			MarkMethodIfPreserved (method);
+		}
+
+		public override void ProcessProperty (PropertyDefinition property)
+		{
+			foreach (var attribute in GetPreserveAttributes (property)) {
+				MarkMethod (property.GetMethod, attribute);
+				MarkMethod (property.SetMethod, attribute);
+			}
+		}
+
+		public override void ProcessEvent (EventDefinition @event)
+		{
+			foreach (var attribute in GetPreserveAttributes (@event)) {
+				MarkMethod (@event.AddMethod, attribute);
+				MarkMethod (@event.InvokeMethod, attribute);
+				MarkMethod (@event.RemoveMethod, attribute);
+			}
+		}
+
+		void MarkMethodIfPreserved (MethodDefinition method)
+		{
+			foreach (var attribute in GetPreserveAttributes (method)) 
+				MarkMethod (method, attribute);
+		}
+
+		void MarkMethod (MethodDefinition method, CustomAttribute preserve_attribute)
+		{
+			if (method == null)
+				return;
+
+			Mark (method, preserve_attribute);
+			Annotations.SetAction (method, MethodAction.Parse);
+		}
+
+		void Mark (IMetadataTokenProvider provider, CustomAttribute preserve_attribute)
+		{
+			if (IsConditionalAttribute (preserve_attribute)) {
+				PreserveConditional (provider);
+				return;
+			}
+
+			PreserveUnconditional (provider);
+		}
+
+		void PreserveConditional (IMetadataTokenProvider provider)
+		{
+			var method = provider as MethodDefinition;
+			if (method == null) {
+				// workaround to support (uncommon but valid) conditional fields form [Preserve]
+				PreserveUnconditional (provider);
+				return;
+			}
+
+			Annotations.AddPreservedMethod (method.DeclaringType, method);
+		}
+
+		static bool IsConditionalAttribute (CustomAttribute attribute)
+		{
+			if (attribute == null)
+				return false;
+
+			foreach (var named_argument in attribute.Fields)
+				if (named_argument.Name == "Conditional")
+					return (bool) named_argument.Argument.Value;
+
+			return false;
+		}
+
+		void PreserveUnconditional (IMetadataTokenProvider provider)
+		{
+			Annotations.Mark (provider);
+
+			var member = provider as IMemberDefinition;
+			if (member == null || member.DeclaringType == null)
+				return;
+
+			Mark (member.DeclaringType, null);
+		}
+
+		void TryApplyPreserveAttribute (TypeDefinition type)
+		{
+			foreach (var attribute in GetPreserveAttributes (type)) {
+				Annotations.Mark (type);
+
+				if (!attribute.HasFields)
+					continue;
+ 
+				foreach (var named_argument in attribute.Fields)
+					if (named_argument.Name == "AllMembers" && (bool)named_argument.Argument.Value)
+						Annotations.SetPreserve (type, TypePreserve.All);
+			}
+		}
+
+		List<CustomAttribute> GetPreserveAttributes (ICustomAttributeProvider provider)
+		{
+			List<CustomAttribute> attrs = new List<CustomAttribute> ();
+
+			if (!provider.HasCustomAttributes)
+				return attrs;
+
+			var attributes = provider.CustomAttributes;
+
+			for (int i = attributes.Count - 1; i >= 0; i--) {
+				var attribute = attributes [i];
+
+				bool remote_attribute;
+				if (!IsPreservedAttribute (provider, attribute, out remote_attribute))
+					continue;
+
+				attrs.Add (attribute);
+				if (remote_attribute)
+					attributes.RemoveAt (i);
+			}
+
+			return attrs;
+		}
+	}
+}

--- a/tools/dotnet-linker/Compat.cs
+++ b/tools/dotnet-linker/Compat.cs
@@ -127,7 +127,7 @@ namespace Mono.Linker {
 		}
 		public static IEnumerable<AssemblyDefinition> GetAssemblies (this LinkContext context)
 		{
-			throw new NotImplementedException ();
+			return LinkerConfiguration.GetInstance (context).Assemblies;
 		}
 		public static Dictionary<IMetadataTokenProvider, object> GetCustomAnnotations (this AnnotationStore self, string name)
 		{

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -39,6 +39,9 @@ namespace Xamarin.Linker {
 
 		public LinkContext Context { get; private set; }
 
+		// The list of assemblies is populated in CollectAssembliesStep.
+		public List<AssemblyDefinition> Assemblies = new List<AssemblyDefinition> ();
+
 		public static LinkerConfiguration GetInstance (LinkContext context)
 		{
 			if (!configurations.TryGetValue (context, out var instance)) {

--- a/tools/dotnet-linker/SetupStep.cs
+++ b/tools/dotnet-linker/SetupStep.cs
@@ -24,11 +24,27 @@ namespace Xamarin {
 			}
 		}
 
+		void InsertAfter (IStep step, string stepName)
+		{
+			for (int i = 0; i < Steps.Count;) {
+				if (Steps [i++].GetType ().Name == stepName) {
+					Steps.Insert (i, step);
+					return;
+				}
+			}
+			throw new InvalidOperationException ($"Could not insert {step} after {stepName} because {stepName} wasn't found.");
+		}
+
 		protected override void Process ()
 		{
 			// Don't use --custom-step to load each step, because this assembly
 			// is loaded into the current process once per --custom-step,
 			// which makes it very difficult to share state between steps.
+
+			// Load the list of assemblies loaded by the linker.
+			// This would not be needed of LinkContext.GetAssemblies () was exposed to us.
+			InsertAfter (new CollectAssembliesStep (), "LoadReferencesStep");
+
 			Steps.Add (new LoadNonSkippedAssembliesStep ());
 			Steps.Add (new ExtractBindingLibrariesStep ());
 			Steps.Add (new RegistrarStep ());

--- a/tools/dotnet-linker/Steps/CollectAssembliesStep.cs
+++ b/tools/dotnet-linker/Steps/CollectAssembliesStep.cs
@@ -1,0 +1,13 @@
+using Mono.Cecil;
+
+namespace Xamarin.Linker {
+	public class CollectAssembliesStep : ConfigurationAwareStep {
+		protected override void ProcessAssembly (AssemblyDefinition assembly)
+		{
+			base.ProcessAssembly (assembly);
+
+			Configuration.Assemblies.Add (assembly);
+		}
+	}
+}
+

--- a/tools/dotnet-linker/Steps/DotNetSubStepDispatcher.cs
+++ b/tools/dotnet-linker/Steps/DotNetSubStepDispatcher.cs
@@ -1,0 +1,8 @@
+using Mono.Linker.Steps;
+
+namespace Xamarin.Linker.Steps {
+	// SubStepsDispatcher is abstract, so create a subclass we can instantiate
+	class DotNetSubStepDispatcher : SubStepsDispatcher {
+	}
+}
+

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -134,6 +134,9 @@
     <Compile Include="..\..\src\ObjCRuntime\RuntimeOptions.cs">
       <Link>external\src\ObjCRuntime\RuntimeOptions.cs</Link>
     </Compile>
+    <Compile Include="..\linker\ApplyPreserveAttribute.cs">
+      <Link>external\tools\linker\ApplyPreserveAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\linker\MonoTouch.Tuner\Extensions.cs">
       <Link>external\tools\linker\MonoTouch.Tuner\Extensions.cs</Link>
     </Compile>

--- a/tools/linker/ApplyPreserveAttribute.cs
+++ b/tools/linker/ApplyPreserveAttribute.cs
@@ -13,19 +13,10 @@ namespace Xamarin.Linker.Steps {
 
 	public class ApplyPreserveAttribute : ApplyPreserveAttributeBase {
 
-		bool is_sdk;
 		HashSet<TypeDefinition> preserve_synonyms;
 
-		DerivedLinkContext LinkContext {
-			get { return (DerivedLinkContext) base.context; }
-		}
-
-		// System.ServiceModel.dll is an SDK assembly but it does contain types with [DataMember] attributes
-		// just like System.Xml.dll contais [Xml*] attributes - we do not want to keep them unless the application
-		// shows the feature is being used
 		public override bool IsActiveFor (AssemblyDefinition assembly)
 		{
-			is_sdk = Profile.IsSdkAssembly (assembly);
 			return Annotations.GetAction (assembly) == AssemblyAction.Link;
 		}
 
@@ -78,96 +69,13 @@ namespace Xamarin.Linker.Steps {
 			removeAttribute = false;
 			TypeReference type = attribute.Constructor.DeclaringType;
 
-			switch (type.Namespace) {
-			case "System.Runtime.Serialization":
-				bool srs = false;
-				// http://bugzilla.xamarin.com/show_bug.cgi?id=1415
-				// http://msdn.microsoft.com/en-us/library/system.runtime.serialization.datamemberattribute.aspx
-				if (provider is PropertyDefinition || provider is FieldDefinition || provider is EventDefinition)
-					srs = (type.Name == "DataMemberAttribute");
-				else if (provider is TypeDefinition)
-					srs = (type.Name == "DataContractAttribute");
-
-				if (srs) {
-					MarkDefaultConstructor (provider, is_sdk ? LinkContext.DataContract : null);
-					return !is_sdk;
-				}
-				break;
-			case "System.Xml.Serialization":
-				// http://msdn.microsoft.com/en-us/library/83y7df3e.aspx
-				string name = type.Name;
-				if ((name.StartsWith ("Xml", StringComparison.Ordinal) && name.EndsWith ("Attribute", StringComparison.Ordinal))) {
-					// but we do not have to keep things that XML serialization will ignore anyway!
-					if (name != "XmlIgnoreAttribute") {
-						// the default constructor of the type *being used* is needed
-						MarkDefaultConstructor (provider, is_sdk ? LinkContext.XmlSerialization : null);
-						return !is_sdk;
-					}
-				}
-				break;
-			default:
-				if (type.Name == "PreserveAttribute") {
-					// there's no need to keep the [Preserve] attribute in the assembly once it was processed
-					removeAttribute = true;
-					return true;
-				}
-				// we need to resolve (as many reference instances can exists)
-				return ((preserve_synonyms != null) && preserve_synonyms.Contains (type.Resolve ()));
+			if (type.Name == "PreserveAttribute") {
+				// there's no need to keep the [Preserve] attribute in the assembly once it was processed
+				removeAttribute = true;
+				return true;
 			}
-			// keep them (provider and attribute)
-			return false;
-		}
-
-		// xml serialization requires the default .ctor to be present
-		void MarkDefaultConstructor (ICustomAttributeProvider provider, IList<ICustomAttributeProvider> list)
-		{
-			if (list != null) {
-				list.Add (provider);
-				return;
-			}
-
-			TypeDefinition td = (provider as TypeDefinition);
-			if (td == null) {
-				PropertyDefinition pd = (provider as PropertyDefinition);
-				if (pd != null) {
-					MarkDefaultConstructor (pd.DeclaringType);					
-					MarkGenericType (pd.PropertyType as GenericInstanceType);
-					td = pd.PropertyType.Resolve ();
-				} else {
-					FieldDefinition fd = (provider as FieldDefinition);
-					if (fd != null) {
-						MarkDefaultConstructor (fd.DeclaringType);
-						MarkGenericType (fd.FieldType as GenericInstanceType);
-						td = (fd.FieldType as TypeReference).Resolve ();
-					}
-				}
-			}
-
-			// e.g. <T> property (see bug #5543) or field (see linkall unit tests)
-			if (td != null)
-				MarkDefaultConstructor (td);
-		}
-
-		void MarkGenericType (GenericInstanceType git)
-		{
-			if (git == null || !git.HasGenericArguments)
-				return;
-
-			foreach (TypeReference tr in git.GenericArguments)
-				MarkDefaultConstructor (tr.Resolve ());
-		}
-
-		void MarkDefaultConstructor (TypeDefinition type)
-		{
-			if ((type == null) || !type.HasMethods)
-				return;
-
-			foreach (MethodDefinition ctor in type.Methods) {
-				if (!ctor.IsConstructor || ctor.IsStatic || ctor.HasParameters)
-					continue;
-
-				Annotations.AddPreservedMethod (type, ctor);
-			}
+			// we need to resolve (as many reference instances can exists)
+			return ((preserve_synonyms != null) && preserve_synonyms.Contains (type.Resolve ()));
 		}
 	}
 }

--- a/tools/linker/MobileApplyPreserveAttribute.cs
+++ b/tools/linker/MobileApplyPreserveAttribute.cs
@@ -1,0 +1,122 @@
+// Copyright 2011-2013 Xamarin Inc. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+
+using Mono.Cecil;
+using Mono.Linker;
+using Mono.Tuner;
+
+using Xamarin.Tuner;
+
+namespace Xamarin.Linker.Steps {
+
+	public class MobileApplyPreserveAttribute : ApplyPreserveAttribute {
+
+		bool is_sdk;
+
+		DerivedLinkContext LinkContext {
+			get { return (DerivedLinkContext) base.context; }
+		}
+
+		// System.ServiceModel.dll is an SDK assembly but it does contain types with [DataMember] attributes
+		// just like System.Xml.dll contais [Xml*] attributes - we do not want to keep them unless the application
+		// shows the feature is being used
+		public override bool IsActiveFor (AssemblyDefinition assembly)
+		{
+			is_sdk = Profile.IsSdkAssembly (assembly);
+			return base.IsActiveFor (assembly);
+		}
+
+		protected override bool IsPreservedAttribute (ICustomAttributeProvider provider, CustomAttribute attribute, out bool removeAttribute)
+		{
+			removeAttribute = false;
+			TypeReference type = attribute.Constructor.DeclaringType;
+
+			switch (type.Namespace) {
+			case "System.Runtime.Serialization":
+				bool srs = false;
+				// http://bugzilla.xamarin.com/show_bug.cgi?id=1415
+				// http://msdn.microsoft.com/en-us/library/system.runtime.serialization.datamemberattribute.aspx
+				if (provider is PropertyDefinition || provider is FieldDefinition || provider is EventDefinition)
+					srs = (type.Name == "DataMemberAttribute");
+				else if (provider is TypeDefinition)
+					srs = (type.Name == "DataContractAttribute");
+
+				if (srs) {
+					MarkDefaultConstructor (provider, is_sdk ? LinkContext.DataContract : null);
+					return !is_sdk;
+				}
+				break;
+			case "System.Xml.Serialization":
+				// http://msdn.microsoft.com/en-us/library/83y7df3e.aspx
+				string name = type.Name;
+				if ((name.StartsWith ("Xml", StringComparison.Ordinal) && name.EndsWith ("Attribute", StringComparison.Ordinal))) {
+					// but we do not have to keep things that XML serialization will ignore anyway!
+					if (name != "XmlIgnoreAttribute") {
+						// the default constructor of the type *being used* is needed
+						MarkDefaultConstructor (provider, is_sdk ? LinkContext.XmlSerialization : null);
+						return !is_sdk;
+					}
+				}
+				break;
+			default:
+				return base.IsPreservedAttribute (provider, attribute, out removeAttribute);
+			}
+			// keep them (provider and attribute)
+			return false;
+		}
+
+		// xml serialization requires the default .ctor to be present
+		void MarkDefaultConstructor (ICustomAttributeProvider provider, IList<ICustomAttributeProvider> list)
+		{
+			if (list != null) {
+				list.Add (provider);
+				return;
+			}
+
+			TypeDefinition td = (provider as TypeDefinition);
+			if (td == null) {
+				PropertyDefinition pd = (provider as PropertyDefinition);
+				if (pd != null) {
+					MarkDefaultConstructor (pd.DeclaringType);					
+					MarkGenericType (pd.PropertyType as GenericInstanceType);
+					td = pd.PropertyType.Resolve ();
+				} else {
+					FieldDefinition fd = (provider as FieldDefinition);
+					if (fd != null) {
+						MarkDefaultConstructor (fd.DeclaringType);
+						MarkGenericType (fd.FieldType as GenericInstanceType);
+						td = (fd.FieldType as TypeReference).Resolve ();
+					}
+				}
+			}
+
+			// e.g. <T> property (see bug #5543) or field (see linkall unit tests)
+			if (td != null)
+				MarkDefaultConstructor (td);
+		}
+
+		void MarkGenericType (GenericInstanceType git)
+		{
+			if (git == null || !git.HasGenericArguments)
+				return;
+
+			foreach (TypeReference tr in git.GenericArguments)
+				MarkDefaultConstructor (tr.Resolve ());
+		}
+
+		void MarkDefaultConstructor (TypeDefinition type)
+		{
+			if ((type == null) || !type.HasMethods)
+				return;
+
+			foreach (MethodDefinition ctor in type.Methods) {
+				if (!ctor.IsConstructor || ctor.IsStatic || ctor.HasParameters)
+					continue;
+
+				Annotations.AddPreservedMethod (type, ctor);
+			}
+		}
+	}
+}

--- a/tools/mmp/Tuning.mmp.cs
+++ b/tools/mmp/Tuning.mmp.cs
@@ -148,7 +148,7 @@ namespace MonoMac.Tuner {
 		static SubStepDispatcher GetSubSteps ()
 		{
 			SubStepDispatcher sub = new SubStepDispatcher ();
-			sub.Add (new ApplyPreserveAttribute ());
+			sub.Add (new MobileApplyPreserveAttribute ());
 			sub.Add (new OptimizeGeneratedCodeSubStep ());
 			sub.Add (new RemoveUserResourcesSubStep ());
 			// OptimizeGeneratedCodeSubStep and RemoveUserResourcesSubStep needs [GeneratedCode] so it must occurs before RemoveAttributes

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -277,6 +277,9 @@
     <Compile Include="..\linker\CoreHttpMessageHandler.cs">
       <Link>tools\linker\CoreHttpMessageHandler.cs</Link>
     </Compile>
+    <Compile Include="..\linker\MobileApplyPreserveAttribute.cs">
+      <Link>tools\linker\MobileApplyPreserveAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\linker\MobileRemoveAttributes.cs">
       <Link>tools\linker\MobileRemoveAttributes.cs</Link>
     </Compile>

--- a/tools/mtouch/Tuning.mtouch.cs
+++ b/tools/mtouch/Tuning.mtouch.cs
@@ -84,7 +84,7 @@ namespace MonoTouch.Tuner {
 		static SubStepDispatcher GetSubSteps ()
 		{
 			SubStepDispatcher sub = new SubStepDispatcher ();
-			sub.Add (new ApplyPreserveAttribute ());
+			sub.Add (new MobileApplyPreserveAttribute ());
 			sub.Add (new CoreRemoveSecurity ());
 			sub.Add (new OptimizeGeneratedCodeSubStep ());
 			sub.Add (new RemoveUserResourcesSubStep ());

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -288,6 +288,9 @@
     <Compile Include="..\linker\CoreRemoveAttributes.cs">
       <Link>tools\linker\CoreRemoveAttributes.cs</Link>
     </Compile>
+    <Compile Include="..\linker\MobileApplyPreserveAttribute.cs">
+      <Link>tools\linker\MobileApplyPreserveAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\linker\MobileExtensions.cs">
       <Link>tools\linker\MobileExtensions.cs</Link>
     </Compile>


### PR DESCRIPTION
This means:

* Move the parts of the ApplyPreserveAttribute step that we don't need for.NET
  into a new MobileApplyPreserveAttribute step, and have mtouch and mmp use
  that step instead of the ApplyPreserveAttribute step.

* Copy ApplyPreserveAttributeBase into dotnet-linker from the upstream tuner
  source (with minor modifications) so that our ApplyPreserveAttribute step
  compiles.

* Create a DotNetSubStepDispatcher class that we're going to use as our
  substep dispatcher, create an instance of it and insert it into the list of
  linker steps.

* Also a workaround for the lack of LinkContext.GetAssemblies (): add a step
  that collects all the assemblies and stores them in a list, so that we can
  have our own GetAssemblies implementation.

  I filed a linker issue to see if we can get LinkContext.GetAssemblies ()
  exposed to us: https://github.com/mono/linker/issues/1455.

Fixes this startup crash with the linkall test:

     2020-08-26 19:47:10.219697+0200 link all[32709:6065783] Xamarin.iOS: Fatal error: failed to load the method 'ObjCRuntime.Runtime.Initialize'.

    =================================================================
      Native Crash Reporting
    =================================================================
    Got a abrt while executing native code. This usually indicates
    a fatal error in the mono runtime or one of the native libraries
    used by your application.
    =================================================================

    =================================================================
      Native stacktrace:
    =================================================================
      0x104007b0e - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/4A5F3968-6980-4E90-88A2-2E77AE039C40/link all.app/libmonosgen-2.0.dylib : mono_dump_native_crash_info
      0x103fb4437 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/4A5F3968-6980-4E90-88A2-2E77AE039C40/link all.app/libmonosgen-2.0.dylib : mono_handle_native_crash
      0x104007365 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/4A5F3968-6980-4E90-88A2-2E77AE039C40/link all.app/libmonosgen-2.0.dylib : sigabrt_signal_handler
      0x7fff51c005fd - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_platform.dylib : _sigtramp
      0x0 - Unknown
      0x7fff51af0b7c - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_c.dylib : abort
      0x103daad98 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/4A5F3968-6980-4E90-88A2-2E77AE039C40/link all.app/libxamarin-debug.dylib : xamarin_assertion_message
      0x103dade77 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/4A5F3968-6980-4E90-88A2-2E77AE039C40/link all.app/libxamarin-debug.dylib : xamarin_initialize
      0x103dbf80b - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/4A5F3968-6980-4E90-88A2-2E77AE039C40/link all.app/libxamarin-debug.dylib : xamarin_main
      0x103cd2f0d - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/4A5F3968-6980-4E90-88A2-2E77AE039C40/link all.app/link all : main
      0x7fff51a231fd - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libdyld.dylib : start

This is a partial/modified port of the initial linker support (bc88790201)

Co-authored-by: Sebastien Pouliot <sebastien@xamarin.com>