### PR TITLE
[dotnet] Use net5.0-[ios|tvos|watchos|macos] TargetFrameworks.

### DIFF
--- a/dotnet/.gitignore
+++ b/dotnet/.gitignore
@@ -1,2 +1,3 @@
 nupkgs
+Microsoft.*.Sdk/targets/Microsoft.*.Sdk.SupportedTargetPlatforms.props
 

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -7,6 +7,7 @@ define DefineTargets
 $(1)_NUGET_TARGETS = \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/Sdk/Sdk.targets \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/Sdk/Sdk.props \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.SupportedTargetPlatforms.props \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.DefaultItems.props \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.props \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.targets \
@@ -61,8 +62,17 @@ targets/%.props: targets/%.template.props Makefile $(TOP)/Make.config.inc $(TOP)
 		-e "s/@CURRENT_HASH_LONG@/$(CURRENT_HASH_LONG)/g" \
 	$< > $@
 
+define SupportedTargetPlatforms
+Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.SupportedTargetPlatforms.props: $(TOP)/Versions-ios.plist.in $(TOP)/Versions-mac.plist.in Makefile ./generate-target-platforms.csharp Makefile
+	$(Q) rm -f $$@.tmp
+	$(Q) ./generate-target-platforms.csharp $(1) $$@.tmp
+	$(Q) mv $$@.tmp $$@
+endef
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call SupportedTargetPlatforms,$(platform))))
+
 TEMPLATED_FILES = \
 	targets/Xamarin.Shared.Sdk.Versions.props \
+	$(foreach platform,$(DOTNET_PLATFORMS),Microsoft.$(platform).Sdk/targets/Microsoft.$(platform).Sdk.SupportedTargetPlatforms.props) \
 
 nupkgs/$(IOS_NUGET).%.nupkg: CURRENT_VERSION_NO_METADATA=$(IOS_NUGET_VERSION_NO_METADATA)
 nupkgs/$(TVOS_NUGET).%.nupkg: CURRENT_VERSION_NO_METADATA=$(TVOS_NUGET_VERSION_NO_METADATA)

--- a/dotnet/generate-target-platforms.csharp
+++ b/dotnet/generate-target-platforms.csharp
@@ -25,7 +25,8 @@ doc.Load (plistPath);
 var nodes = doc.SelectNodes ($"/plist/dict/key[text()='KnownVersions']/following-sibling::dict[1]/key[text()='{platform}']/following-sibling::array[1]/string");
 
 using (TextWriter writer = new StreamWriter (outputPath)) {
-	writer.WriteLine ($"<!-- This file contains a list of the {platform} platform versions that are supported for this SDK -->");
+	writer.WriteLine ($"<!-- This file contains a generated list of the {platform} platform versions that are supported for this SDK -->");
+	writer.WriteLine ($"<!-- Generation script: https://github.com/xamarin/xamarin-macios/blob/main/dotnet/generate-target-platforms.csharp -->");
 	writer.WriteLine ("<Project>");
 	writer.WriteLine ("\t<ItemGroup>");
 

--- a/dotnet/generate-target-platforms.csharp
+++ b/dotnet/generate-target-platforms.csharp
@@ -31,11 +31,11 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ("\t<ItemGroup>");
 
 	foreach (XmlNode n in nodes)
-		writer.WriteLine ($"\t\t<_{platform}SupportedTargetPlatform Include=\"{n.InnerText}\" />");
+		writer.WriteLine ($"\t\t<{platform}SupportedTargetPlatform Include=\"{n.InnerText}\" />");
 
 	writer.WriteLine ("\t</ItemGroup>");
 	writer.WriteLine ("\t<ItemGroup>");
-	writer.WriteLine ($"\t\t<SupportedTargetPlatform Condition=\"'$(TargetPlatformIdentifier)' == '{platform}'\" Include=\"@(_{platform}SupportedTargetPlatform)\" />");
+	writer.WriteLine ($"\t\t<SupportedTargetPlatform Condition=\"'$(TargetPlatformIdentifier)' == '{platform}'\" Include=\"@({platform}SupportedTargetPlatform)\" />");
 	writer.WriteLine ("\t</ItemGroup>");
 	writer.WriteLine ("</Project>");
 }

--- a/dotnet/generate-target-platforms.csharp
+++ b/dotnet/generate-target-platforms.csharp
@@ -1,0 +1,42 @@
+#!/usr/bin/env /Library/Frameworks/Mono.framework/Commands/csharp
+
+// arguments are: <platform> <outputPath>
+
+using System.IO;
+using System.Xml;
+
+var args = Environment.GetCommandLineArgs ();
+var expectedArgumentCount = 2;
+if (args.Length != expectedArgumentCount + 2 /* 2 default arguments (executable + script) + 'expectedArgumentCount' arguments we're interested in */) {
+	// first arg is "/Library/Frameworks/Mono.framework/Versions/4.8.0/lib/mono/4.5/csharp.exe"
+	// second arg the script itself
+	// then comes the ones we care about
+	Console.WriteLine ($"Need {expectedArgumentCount} arguments, got {args.Length - 2}");
+	Environment.Exit (1);
+	return;
+}
+
+var platform = args [2];
+var outputPath = args [3];
+var plistPath = platform == "macOS" ? "../Versions-mac.plist.in" : "../Versions-ios.plist.in";
+
+var doc = new XmlDocument ();
+doc.Load (plistPath);
+var nodes = doc.SelectNodes ($"/plist/dict/key[text()='KnownVersions']/following-sibling::dict[1]/key[text()='{platform}']/following-sibling::array[1]/string");
+
+using (TextWriter writer = new StreamWriter (outputPath)) {
+	writer.WriteLine ($"<!-- This file contains a list of the {platform} platform versions that are supported for this SDK -->");
+	writer.WriteLine ("<Project>");
+	writer.WriteLine ("\t<ItemGroup>");
+
+	foreach (XmlNode n in nodes)
+		writer.WriteLine ($"\t\t<_{platform}SupportedTargetPlatform Include=\"{n.InnerText}\" />");
+
+	writer.WriteLine ("\t</ItemGroup>");
+	writer.WriteLine ("\t<ItemGroup>");
+	writer.WriteLine ($"\t\t<SupportedTargetPlatform Condition=\"'$(TargetPlatformIdentifier)' == '{platform}'\" Include=\"@(_{platform}SupportedTargetPlatform)\" />");
+	writer.WriteLine ("\t</ItemGroup>");
+	writer.WriteLine ("</Project>");
+}
+
+Environment.Exit (0);

--- a/dotnet/targets/Xamarin.Shared.Sdk.TargetFrameworkInference.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.TargetFrameworkInference.targets
@@ -17,4 +17,9 @@
     <TargetPlatformIdentifier Condition="'$(TargetPlatformIdentifier)' == 'watchos'">watchOS</TargetPlatformIdentifier>
     <TargetPlatformIdentifier Condition="'$(TargetPlatformIdentifier)' == 'macos'">macOS</TargetPlatformIdentifier>
   </PropertyGroup>
+
+  <!-- Set the default TargetPlatformVersion if it wasn't specified in the TargetFramework variable. This must be set after importing Sdk.targets (in Xamarin.Shared.Sdk.targets) -->
+  <PropertyGroup>
+    <TargetPlatformVersion Condition="'$(TargetPlatformVersion)' == ''">$(_DefaultTargetPlatformVersion)</TargetPlatformVersion>
+  </PropertyGroup>
 </Project>

--- a/dotnet/targets/Xamarin.Shared.Sdk.Versions.template.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.Versions.template.props
@@ -14,4 +14,18 @@
 		<_PackageVersion Condition=" '$(_PlatformName)' == 'watchOS' ">@WATCHOS_NUGET_VERSION_FULL@</_PackageVersion>
 		<_PackageVersion Condition=" '$(_PlatformName)' == 'macOS' ">@MACOS_NUGET_VERSION_FULL@</_PackageVersion>
 	</PropertyGroup>
+
+	<!-- Defines the default platform version if it's not specified in the TFM. The default should not change for a given .NET version:
+	     * We release support for iOS 14.5 with .NET 6
+	     * Apple releases iOS 15.0, we're still using .NET 6. This default continues to be iOS 14.5
+	     * .NET 7 is shipped, and at this point we bump the default to iOS 15.0
+	     Ref: https://github.com/dotnet/designs/blob/8e6394406d44f75f30ea2259a425cb9e38d75b69/accepted/2020/net5/net5.md#os-versions
+	-->
+	<PropertyGroup>
+		<!-- This section specifies the default platform version for .NET 5.0 -->
+		<_DefaultTargetPlatformVersion Condition=" '$(_PlatformName)' == 'iOS' ">13.6</_DefaultTargetPlatformVersion>
+		<_DefaultTargetPlatformVersion Condition=" '$(_PlatformName)' == 'tvOS' ">13.4</_DefaultTargetPlatformVersion>
+		<_DefaultTargetPlatformVersion Condition=" '$(_PlatformName)' == 'watchOS' ">6.2</_DefaultTargetPlatformVersion>
+		<_DefaultTargetPlatformVersion Condition=" '$(_PlatformName)' == 'macOS' ">10.15</_DefaultTargetPlatformVersion>
+	</PropertyGroup>
 </Project>

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -12,4 +12,7 @@
 
   <!-- Default item includes (globs and implicit references) -->
   <Import Project="Microsoft.$(_PlatformName).Sdk.DefaultItems.props" />
+
+  <!-- This contains the OS versions we support for target platform -->
+  <Import Project="Microsoft.$(_PlatformName).Sdk.SupportedTargetPlatforms.props" />
 </Project>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -83,6 +83,10 @@
 
 	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
+	<PropertyGroup>
+		<TargetPlatformSupported Condition=" '$(TargetPlatformIdentifier)' == '$(_PlatformName)' ">true</TargetPlatformSupported>
+	</PropertyGroup>
+
 	<!-- Default item includes (globs and implicit references) -->
 	<Import Project="Xamarin.Shared.Sdk.DefaultItems.targets" />
 	<Import Project="Xamarin.Shared.Sdk.TargetFrameworkInference.targets" />

--- a/tests/BundledResources/dotnet/iOS/BundledResources.csproj
+++ b/tests/BundledResources/dotnet/iOS/BundledResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-ios</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/tests/BundledResources/dotnet/macOS/BundledResources.csproj
+++ b/tests/BundledResources/dotnet/macOS/BundledResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.macOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-macos</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/tests/BundledResources/dotnet/tvOS/BundledResources.csproj
+++ b/tests/BundledResources/dotnet/tvOS/BundledResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.tvOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-tvos</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/tests/BundledResources/dotnet/watchOS/BundledResources.csproj
+++ b/tests/BundledResources/dotnet/watchOS/BundledResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.watchOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-watchos</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/tests/EmbeddedResources/dotnet/iOS/EmbeddedResources.csproj
+++ b/tests/EmbeddedResources/dotnet/iOS/EmbeddedResources.csproj
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0-ios</TargetFramework>
+  </PropertyGroup>
   <Import Project="..\shared.targets" />
 </Project>

--- a/tests/EmbeddedResources/dotnet/macOS/EmbeddedResources.csproj
+++ b/tests/EmbeddedResources/dotnet/macOS/EmbeddedResources.csproj
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.macOS.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0-macos</TargetFramework>
+  </PropertyGroup>
   <Import Project="..\shared.targets" />
 </Project>

--- a/tests/EmbeddedResources/dotnet/shared.targets
+++ b/tests/EmbeddedResources/dotnet/shared.targets
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 	<PropertyGroup>
-		<TargetFramework>net5.0</TargetFramework>
 		<SignAssembly>true</SignAssembly>
 		<LangVersion>latest</LangVersion>
 

--- a/tests/EmbeddedResources/dotnet/tvOS/EmbeddedResources.csproj
+++ b/tests/EmbeddedResources/dotnet/tvOS/EmbeddedResources.csproj
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.tvOS.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0-tvos</TargetFramework>
+  </PropertyGroup>
   <Import Project="..\shared.targets" />
 </Project>

--- a/tests/EmbeddedResources/dotnet/watchOS/EmbeddedResources.csproj
+++ b/tests/EmbeddedResources/dotnet/watchOS/EmbeddedResources.csproj
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.watchOS.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0-watchos</TargetFramework>
+  </PropertyGroup>
   <Import Project="..\shared.targets" />
 </Project>

--- a/tests/bindings-test/dotnet/iOS/bindings-test.csproj
+++ b/tests/bindings-test/dotnet/iOS/bindings-test.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
+    <TargetFramework>net5.0-ios</TargetFramework>
     <NativeLibName>ios-fat</NativeLibName>
   </PropertyGroup>
   <Import Project="..\shared.targets" />

--- a/tests/bindings-test/dotnet/macOS/bindings-test.csproj
+++ b/tests/bindings-test/dotnet/macOS/bindings-test.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.macOS.Sdk">
   <PropertyGroup>
+    <TargetFramework>net5.0-macos</TargetFramework>
     <NativeLibName>macos</NativeLibName>
   </PropertyGroup>
   <Import Project="..\shared.targets" />

--- a/tests/bindings-test/dotnet/shared.targets
+++ b/tests/bindings-test/dotnet/shared.targets
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>bindingstest</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\product.snk</AssemblyOriginatorKeyFile>

--- a/tests/bindings-test/dotnet/tvOS/bindings-test.csproj
+++ b/tests/bindings-test/dotnet/tvOS/bindings-test.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.tvOS.Sdk">
   <PropertyGroup>
+    <TargetFramework>net5.0-tvos</TargetFramework>
     <NativeLibName>tvos-fat</NativeLibName>
   </PropertyGroup>
   <Import Project="..\shared.targets" />

--- a/tests/bindings-test/dotnet/watchOS/bindings-test.csproj
+++ b/tests/bindings-test/dotnet/watchOS/bindings-test.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.watchOS.Sdk">
   <PropertyGroup>
+    <TargetFramework>net5.0-watchos</TargetFramework>
     <NativeLibName>watchos-fat</NativeLibName>
   </PropertyGroup>
   <Import Project="..\shared.targets" />

--- a/tests/bindings-test2/dotnet/iOS/bindings-test2.csproj
+++ b/tests/bindings-test2/dotnet/iOS/bindings-test2.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
+    <TargetFramework>net5.0-ios</TargetFramework>
     <NativeLibName>ios-fat</NativeLibName>
     <PlatformName>iOS</PlatformName>
     <RootTestsDirectory>..\..\..</RootTestsDirectory>

--- a/tests/bindings-test2/dotnet/macOS/bindings-test2.csproj
+++ b/tests/bindings-test2/dotnet/macOS/bindings-test2.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.macOS.Sdk">
   <PropertyGroup>
+    <TargetFramework>net5.0-macos</TargetFramework>
     <NativeLibName>macos</NativeLibName>
     <PlatformName>macOS</PlatformName>
     <RootTestsDirectory>..\..\..</RootTestsDirectory>

--- a/tests/bindings-test2/dotnet/shared.targets
+++ b/tests/bindings-test2/dotnet/shared.targets
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>bindingstest2</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\product.snk</AssemblyOriginatorKeyFile>

--- a/tests/bindings-test2/dotnet/tvOS/bindings-test2.csproj
+++ b/tests/bindings-test2/dotnet/tvOS/bindings-test2.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.tvOS.Sdk">
   <PropertyGroup>
+    <TargetFramework>net5.0-tvos</TargetFramework>
     <NativeLibName>tvos-fat</NativeLibName>
     <PlatformName>tvOS</PlatformName>
     <RootTestsDirectory>..\..\..</RootTestsDirectory>

--- a/tests/bindings-test2/dotnet/watchOS/bindings-test2.csproj
+++ b/tests/bindings-test2/dotnet/watchOS/bindings-test2.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.watchOS.Sdk">
   <PropertyGroup>
+    <TargetFramework>net5.0-watchos</TargetFramework>
     <NativeLibName>watchos-fat</NativeLibName>
     <PlatformName>watchOS</PlatformName>
     <RootTestsDirectory>..\..\..</RootTestsDirectory>

--- a/tests/dotnet/MyClassLibrary/MyClassLibrary.csproj
+++ b/tests/dotnet/MyClassLibrary/MyClassLibrary.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-ios</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/tests/dotnet/MyClassLibrary/iOS/MyClassLibrary.csproj
+++ b/tests/dotnet/MyClassLibrary/iOS/MyClassLibrary.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-ios</TargetFramework>
   </PropertyGroup>
 </Project>
 

--- a/tests/dotnet/MyClassLibrary/macOS/MyClassLibrary.csproj
+++ b/tests/dotnet/MyClassLibrary/macOS/MyClassLibrary.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.macOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-macos</TargetFramework>
   </PropertyGroup>
 </Project>
 

--- a/tests/dotnet/MyClassLibrary/tvOS/MyClassLibrary.csproj
+++ b/tests/dotnet/MyClassLibrary/tvOS/MyClassLibrary.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.tvOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-tvos</TargetFramework>
   </PropertyGroup>
 </Project>
 

--- a/tests/dotnet/MyClassLibrary/watchOS/MyClassLibrary.csproj
+++ b/tests/dotnet/MyClassLibrary/watchOS/MyClassLibrary.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.watchOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-watchos</TargetFramework>
   </PropertyGroup>
 </Project>
 

--- a/tests/dotnet/MyCocoaApp/MyCocoaApp.csproj
+++ b/tests/dotnet/MyCocoaApp/MyCocoaApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.macOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-macos</TargetFramework>
     <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/tests/dotnet/MySingleView/MySingleView.csproj
+++ b/tests/dotnet/MySingleView/MySingleView.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-ios</TargetFramework>
     <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/tests/dotnet/MyTVApp/MyTVApp.csproj
+++ b/tests/dotnet/MyTVApp/MyTVApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.tvOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-tvos</TargetFramework>
     <RuntimeIdentifier>tvos-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/tests/dotnet/MyWatchApp/MyWatchApp/MyWatchApp.csproj
+++ b/tests/dotnet/MyWatchApp/MyWatchApp/MyWatchApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.watchOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-watchos</TargetFramework>
     <RuntimeIdentifier>watchos-x86</RuntimeIdentifier>
     <IsWatchOSApp>true</IsWatchOSApp>
   </PropertyGroup>

--- a/tests/dotnet/MyWatchApp/MyWatchContainer/MyWatchContainer.csproj
+++ b/tests/dotnet/MyWatchApp/MyWatchContainer/MyWatchContainer.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-ios</TargetFramework>
     <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/tests/dotnet/MyWatchApp/MyWatchExtension/MyWatchExtension.csproj
+++ b/tests/dotnet/MyWatchApp/MyWatchExtension/MyWatchExtension.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.watchOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-watchos</TargetFramework>
     <RuntimeIdentifier>watchos-x86</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
   </PropertyGroup>

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -49,7 +49,7 @@ namespace Xamarin.Tests {
 			Clean (project_path);
 			var result = DotNet.AssertBuild (project_path, verbosity);
 			AssertThatLinkerExecuted (result);
-			AssertAppContents (platform, Path.Combine (Path.GetDirectoryName (project_path), "bin", "Debug", "net5.0", "ios-x64", "MySingleView.app"));
+			AssertAppContents (platform, Path.Combine (Path.GetDirectoryName (project_path), "bin", "Debug", "net5.0-ios", "ios-x64", "MySingleView.app"));
 		}
 
 		[Test]
@@ -60,7 +60,7 @@ namespace Xamarin.Tests {
 			Clean (project_path);
 			var result = DotNet.AssertBuild (project_path, verbosity);
 			AssertThatLinkerExecuted (result);
-			AssertAppContents (platform, Path.Combine (Path.GetDirectoryName (project_path), "bin", "Debug", "net5.0", "osx-x64", "MyCocoaApp.app"));
+			AssertAppContents (platform, Path.Combine (Path.GetDirectoryName (project_path), "bin", "Debug", "net5.0-macos", "osx-x64", "MyCocoaApp.app"));
 		}
 
 		[Test]
@@ -71,7 +71,7 @@ namespace Xamarin.Tests {
 			Clean (project_path);
 			var result = DotNet.AssertBuild (project_path, verbosity);
 			AssertThatLinkerExecuted (result);
-			AssertAppContents (platform, Path.Combine (Path.GetDirectoryName (project_path), "bin", "Debug", "net5.0", "tvos-x64", "MyTVApp.app"));
+			AssertAppContents (platform, Path.Combine (Path.GetDirectoryName (project_path), "bin", "Debug", "net5.0-tvos", "tvos-x64", "MyTVApp.app"));
 		}
 
 		[Test]

--- a/tests/fsharplibrary/dotnet/iOS/fsharplibrary.fsproj
+++ b/tests/fsharplibrary/dotnet/iOS/fsharplibrary.fsproj
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0-ios</TargetFramework>
+  </PropertyGroup>
   <Import Project="..\shared.targets" />
 </Project>

--- a/tests/fsharplibrary/dotnet/macOS/fsharplibrary.fsproj
+++ b/tests/fsharplibrary/dotnet/macOS/fsharplibrary.fsproj
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.macOS.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0-macos</TargetFramework>
+  </PropertyGroup>
   <Import Project="..\shared.targets" />
 </Project>

--- a/tests/fsharplibrary/dotnet/shared.targets
+++ b/tests/fsharplibrary/dotnet/shared.targets
@@ -1,6 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<TargetFramework>net5.0</TargetFramework>
 		<SignAssembly>true</SignAssembly>
 		<GenerateTailCalls>true</GenerateTailCalls>
 

--- a/tests/fsharplibrary/dotnet/tvOS/fsharplibrary.fsproj
+++ b/tests/fsharplibrary/dotnet/tvOS/fsharplibrary.fsproj
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.tvOS.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0-tvos</TargetFramework>
+  </PropertyGroup>
   <Import Project="..\shared.targets" />
 </Project>

--- a/tests/fsharplibrary/dotnet/watchOS/fsharplibrary.fsproj
+++ b/tests/fsharplibrary/dotnet/watchOS/fsharplibrary.fsproj
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.watchOS.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0-watchos</TargetFramework>
+  </PropertyGroup>
   <Import Project="..\shared.targets" />
 </Project>

--- a/tests/interdependent-binding-projects/dotnet/iOS/interdependent-binding-projects.csproj
+++ b/tests/interdependent-binding-projects/dotnet/iOS/interdependent-binding-projects.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-ios</TargetFramework>
     <OutputType>Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <LangVersion>latest</LangVersion>

--- a/tests/interdependent-binding-projects/dotnet/macOS/interdependent-binding-projects.csproj
+++ b/tests/interdependent-binding-projects/dotnet/macOS/interdependent-binding-projects.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.macOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-macos</TargetFramework>
     <OutputType>Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <LangVersion>latest</LangVersion>

--- a/tests/interdependent-binding-projects/dotnet/tvOS/interdependent-binding-projects.csproj
+++ b/tests/interdependent-binding-projects/dotnet/tvOS/interdependent-binding-projects.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.tvOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-tvos</TargetFramework>
     <OutputType>Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <LangVersion>latest</LangVersion>

--- a/tests/interdependent-binding-projects/dotnet/watchOS/interdependent-binding-projects.csproj
+++ b/tests/interdependent-binding-projects/dotnet/watchOS/interdependent-binding-projects.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.watchOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-watchos</TargetFramework>
     <OutputType>Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <LangVersion>latest</LangVersion>

--- a/tests/introspection/iOS/introspection-ios-dotnet.csproj
+++ b/tests/introspection/iOS/introspection-ios-dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-ios</TargetFramework>
     <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <DefineConstants>NET</DefineConstants>

--- a/tests/linker/ios/dont link/dotnet/iOS/dont link.csproj
+++ b/tests/linker/ios/dont link/dotnet/iOS/dont link.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-ios</TargetFramework>
     <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <DefineConstants>NET</DefineConstants>

--- a/tests/linker/ios/link all/dotnet/iOS/link all.csproj
+++ b/tests/linker/ios/link all/dotnet/iOS/link all.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-ios</TargetFramework>
     <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <DefineConstants>NET</DefineConstants>

--- a/tests/linker/ios/link sdk/dotnet/iOS/link sdk.csproj
+++ b/tests/linker/ios/link sdk/dotnet/iOS/link sdk.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-ios</TargetFramework>
     <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <DefineConstants>NET</DefineConstants>

--- a/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-ios</TargetFramework>
     <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <DefineConstants>NET</DefineConstants>

--- a/tests/xharness/Targets/MacTarget.cs
+++ b/tests/xharness/Targets/MacTarget.cs
@@ -110,6 +110,7 @@ namespace Xharness.Targets
 		public override string DotNetSdk => "Microsoft.macOS.Sdk";
 		public override string RuntimeIdentifier => "osx-x64";
 		public override DevicePlatform ApplePlatform => DevicePlatform.macOS;
+		public override string TargetFramework => "net5.0-macos";
 		public override string TargetFrameworkForNuGet => "xamarinmac10";
 
 		protected override bool FixProjectReference (string include, string subdir, string suffix, out string fixed_include)

--- a/tests/xharness/Targets/TVOSTarget.cs
+++ b/tests/xharness/Targets/TVOSTarget.cs
@@ -96,6 +96,7 @@ namespace Xharness.Targets {
 		public override string DotNetSdk => "Microsoft.tvOS.Sdk";
 		public override string RuntimeIdentifier => "tvos-x64";
 		public override DevicePlatform ApplePlatform => DevicePlatform.tvOS;
+		public override string TargetFramework => "net5.0-tvos";
 		public override string TargetFrameworkForNuGet => "xamarintvos10";
 
 		static Dictionary<string, string> project_guids = new Dictionary<string, string> ();

--- a/tests/xharness/Targets/Target.cs
+++ b/tests/xharness/Targets/Target.cs
@@ -74,6 +74,7 @@ namespace Xharness.Targets
 		public abstract string DotNetSdk { get; }
 		public abstract string RuntimeIdentifier { get; }
 		public abstract DevicePlatform ApplePlatform { get; }
+		public abstract string TargetFramework { get; }
 		public abstract string TargetFrameworkForNuGet { get; }
 
 		public static string ProjectsDir { get { return "generated-projects"; } }
@@ -128,6 +129,7 @@ namespace Xharness.Targets
 			inputProject.SetSdk (DotNetSdk);
 			inputProject.SetRuntimeIdentifier (RuntimeIdentifier);
 			inputProject.FixProjectReferences (Path.Combine (ProjectsDir, GetTargetSpecificDir ()), Suffix, FixProjectReference);
+			inputProject.SetNode ("TargetFramework", TargetFramework);
 			var fixedAssetTargetFallback = inputProject.GetAssetTargetFallback ()?.Replace ("xamarinios10", TargetFrameworkForNuGet);
 			if (fixedAssetTargetFallback != null)
 				inputProject.SetAssetTargetFallback (fixedAssetTargetFallback);

--- a/tests/xharness/Targets/UnifiedTarget.cs
+++ b/tests/xharness/Targets/UnifiedTarget.cs
@@ -127,6 +127,7 @@ namespace Xharness.Targets {
 		public override string DotNetSdk => "Microsoft.iOS.Sdk";
 		public override string RuntimeIdentifier => "ios-x64";
 		public override DevicePlatform ApplePlatform => DevicePlatform.iOS;
+		public override string TargetFramework => "net5.0-ios";
 		public override string TargetFrameworkForNuGet => "xamarinios10";
 	}
 }

--- a/tests/xharness/Targets/WatchOSTarget.cs
+++ b/tests/xharness/Targets/WatchOSTarget.cs
@@ -31,6 +31,7 @@ namespace Xharness.Targets {
 		public override string DotNetSdk => "Microsoft.watchOS.Sdk";
 		public override string RuntimeIdentifier => throw new NotImplementedException ();
 		public override DevicePlatform ApplePlatform => DevicePlatform.watchOS;
+		public override string TargetFramework => "net5.0-watchos";
 		public override string TargetFrameworkForNuGet => "xamarinwatch10";
 
 		void CreateWatchOSAppProject ()


### PR DESCRIPTION
After bumping to .NET 5.0.100-rc.1.20426.3, we can use the final TargetFramework values:

    <TargetFramework>net5.0-ios</TargetFramework>

Changes required on our side:

* Set TargetPlatformSupported to 'true' if the TargetPlatformIdentifier is one
  we support (ios/tvos/watchos/macos).
* Generate a list of valid OS versions for each of our four platforms, and
  then we set SupportedTargetPlatform to that list. This is similar to how
  it's done for Windows [1].
* Set TargetPlatformVersion if it's not already set to the default OS version
  we've defined.
* Update all the project files we have to use the new TargetFramework values.

Ref: https://github.com/xamarin/xamarin-android/pull/5007
[1]: https://github.com/dotnet/sdk/blob/18ee4eac8b3abe6d554d2e0c39d8952da0f23ce5/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.WindowsSupportedTargetPlatforms.props