### PR TITLE
[dotnet-linker] Add PreserveSmartEnumConversionsSubStep into the pipeline.

### DIFF
--- a/tools/dotnet-linker/Compat.cs
+++ b/tools/dotnet-linker/Compat.cs
@@ -119,6 +119,22 @@ namespace Xamarin.Bundler {
 	}
 }
 
+namespace Xamarin.Linker {
+	public class Profile {
+		public LinkerConfiguration Configuration { get; private set; }
+
+		public Profile (LinkerConfiguration config)
+		{
+			Configuration = config;
+		}
+
+		public bool IsProductAssembly (AssemblyDefinition assembly)
+		{
+			return assembly.Name.Name == Configuration.PlatformAssembly;
+		}
+	}
+}
+
 namespace Mono.Linker {
 	public static class LinkContextExtensions {
 		public static void LogMessage (this LinkContext context, string messsage)

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -10,6 +10,7 @@ using Mono.Linker;
 
 using Xamarin.Bundler;
 using Xamarin.Utils;
+using Xamarin.Tuner;
 
 using ObjCRuntime;
 
@@ -38,6 +39,7 @@ namespace Xamarin.Linker {
 		public CompilerFlags CompilerFlags;
 
 		public LinkContext Context { get; private set; }
+		public Profile Profile { get; private set; }
 
 		// The list of assemblies is populated in CollectAssembliesStep.
 		public List<AssemblyDefinition> Assemblies = new List<AssemblyDefinition> ();
@@ -62,6 +64,7 @@ namespace Xamarin.Linker {
 			if (!File.Exists (linker_file))
 				throw new FileNotFoundException ($"The custom linker file {linker_file} does not exist.");
 
+			Profile = new Profile (this);
 			Application = new Application (this);
 			Target = new Target (Application);
 			CompilerFlags = new CompilerFlags (Target);

--- a/tools/dotnet-linker/SetupStep.cs
+++ b/tools/dotnet-linker/SetupStep.cs
@@ -55,6 +55,7 @@ namespace Xamarin {
 				// [assembly: LinkSafe] attributes, which means we treat them as sdk assemblies and those may have
 				// Preserve attributes.
 				prelink_substeps.Add (new ApplyPreserveAttribute ());
+				prelink_substeps.Add (new PreserveSmartEnumConversionsSubStep ());
 			}
 
 			Steps.Add (new LoadNonSkippedAssembliesStep ());

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -137,6 +137,9 @@
     <Compile Include="..\linker\ApplyPreserveAttribute.cs">
       <Link>external\tools\linker\ApplyPreserveAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\linker\ExceptionalSubStep.cs">
+      <Link>external\tools\linker\ExceptionalSubStep.cs</Link>
+    </Compile>
     <Compile Include="..\linker\MonoTouch.Tuner\Extensions.cs">
       <Link>external\tools\linker\MonoTouch.Tuner\Extensions.cs</Link>
     </Compile>

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -140,6 +140,9 @@
     <Compile Include="..\linker\MonoTouch.Tuner\Extensions.cs">
       <Link>external\tools\linker\MonoTouch.Tuner\Extensions.cs</Link>
     </Compile>
+    <Compile Include="..\linker\MonoTouch.Tuner\PreserveSmartEnumConversionsSubStep.cs">
+      <Link>external\tools\linker\MonoTouch.Tuner\PreserveSmartEnumConversionsSubStep.cs</Link>
+    </Compile>
     <Compile Include="..\linker\MobileExtensions.cs">
       <Link>external\tools\linker\MobileExtensions.cs</Link>
     </Compile>

--- a/tools/linker/ExceptionalSubStep.cs
+++ b/tools/linker/ExceptionalSubStep.cs
@@ -7,15 +7,40 @@ using Xamarin.Bundler;
 
 using Xamarin.Tuner;
 
+#if NET
+using Mono.Linker;
+using Mono.Linker.Steps;
+#endif
+
 namespace Xamarin.Linker {
 
 	public abstract class ExceptionalSubStep : BaseSubStep {
 
 		protected DerivedLinkContext LinkContext {
 			get {
+#if NET
+				throw new NotImplementedException ();
+#else
 				return (DerivedLinkContext) base.context;
+#endif
 			}
 		}
+
+#if NET
+		protected LinkContext context {
+			get { return Context; }
+		}
+
+		protected LinkerConfiguration Configuration {
+			get { return LinkerConfiguration.GetInstance (Context);  }
+		}
+
+		protected Profile Profile {
+			get {
+				return Configuration.Profile;
+			}
+		}
+#endif
 
 		public override sealed void ProcessAssembly (AssemblyDefinition assembly)
 		{

--- a/tools/linker/MonoTouch.Tuner/PreserveSmartEnumConversionsSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/PreserveSmartEnumConversionsSubStep.cs
@@ -7,7 +7,11 @@ using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Linker;
 using Mono.Tuner;
+#if NET
+using Mono.Linker.Steps;
+#else
 using MonoTouch.Tuner;
+#endif
 
 using Xamarin.Bundler;
 

--- a/tools/linker/MonoTouch.Tuner/PreserveSmartEnumConversionsSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/PreserveSmartEnumConversionsSubStep.cs
@@ -45,6 +45,18 @@ namespace Xamarin.Linker.Steps
 
 		void Preserve (Tuple<MethodDefinition, MethodDefinition> pair, MethodDefinition conditionA, MethodDefinition conditionB = null)
 		{
+#if NET
+			// The AddPreservedMethod (MethodDefinition, MethodDefinition) has not been exposed yet, so preserve the entire containing type instead.
+			// https://github.com/mono/linker/issues/1456
+			if (conditionA != null) {
+				context.Annotations.AddPreservedMethod (conditionA.DeclaringType, pair.Item1);
+				context.Annotations.AddPreservedMethod (conditionA.DeclaringType, pair.Item2);
+			}
+			if (conditionB != null) {
+				context.Annotations.AddPreservedMethod (conditionB.DeclaringType, pair.Item1);
+				context.Annotations.AddPreservedMethod (conditionB.DeclaringType, pair.Item2);
+			}
+#else
 			if (conditionA != null) {
 				context.Annotations.AddPreservedMethod (conditionA, pair.Item1);
 				context.Annotations.AddPreservedMethod (conditionA, pair.Item2);
@@ -53,6 +65,7 @@ namespace Xamarin.Linker.Steps
 				context.Annotations.AddPreservedMethod (conditionB, pair.Item1);
 				context.Annotations.AddPreservedMethod (conditionB, pair.Item2);
 			}
+#endif
 		}
 
 		void ProcessAttributeProvider (ICustomAttributeProvider provider, MethodDefinition conditionA, MethodDefinition conditionB = null)

--- a/tools/linker/MonoTouch.Tuner/PreserveSmartEnumConversionsSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/PreserveSmartEnumConversionsSubStep.cs
@@ -25,7 +25,10 @@ namespace Xamarin.Linker.Steps
 
 		public override SubStepTargets Targets {
 			get {
-				return SubStepTargets.Method | SubStepTargets.Property;
+				return
+					SubStepTargets.Method
+					| SubStepTargets.Type // SubStepTargets.Type is only needed to work around a linker bug: https://github.com/mono/linker/issues/1458
+					| SubStepTargets.Property;
 			}
 		}
 


### PR DESCRIPTION
This also means:

* Adding the ExceptionalSubStep step to the build.
* Adding a few workarounds for missing/different linker API.

This fixes this startup crash in link all:

    2020-08-26 19:56:03.936330+0200 link all[45665:6121665] Could not register the assembly 'link all': ObjCRuntime.RuntimeException: The registrar can't convert from 'LinkAll.Attributes.SmartEnum' to 'Foundation.NSString' for the parameter 'value' in the method LinkAll.Attributes.SmartConsumer.SetSmartEnumValue.
       at Registrar.Registrar.ObjCMethod.get_NativeParameters()
       at Registrar.Registrar.ComputeSignature(Type DeclaringType, MethodBase Method, ObjCMember member, Boolean isCategoryInstance, Boolean isBlockSignature)
       at Registrar.Registrar.ObjCMethod.ComputeSignature()
       at Registrar.Registrar.ObjCMethod.get_Signature()
       at Registrar.Registrar.ObjCMethod.get_Trampoline()
       at Registrar.DynamicRegistrar.RegisterMethod(ObjCMethod method)
       at Registrar.DynamicRegistrar.OnRegisterType(ObjCType type)
       at Registrar.Registrar.RegisterTypeUnsafe(Type type, List`1& exceptions)
       at Registrar.Registrar.RegisterAssembly(Assembly assembly)
    2020-08-26 19:56:03.939327+0200 link all[45665:6121665] System.AggregateException: One or more errors occurred. (The registrar can't convert from 'LinkAll.Attributes.SmartEnum' to 'Foundation.NSString' for the return value in the method LinkAll.Attributes.SmartConsumer.GetSmartEnumValue.) (The registrar can't convert from 'LinkAll.Attributes.SmartEnum' to 'Foundation.NSString' for the return value in the method LinkAll.Attributes.SmartConsumer.GetSmartEnumValue.) (The registrar can't convert from 'LinkAll.Attributes.SmartEnum' to 'Foundation.NSString' for the parameter 'value' in the method LinkAll.Attributes.SmartConsumer.SetSmartEnumValue.)
     ---> ObjCRuntime.RuntimeException: The registrar can't convert from 'LinkAll.Attributes.SmartEnum' to 'Foundation.NSString' for the return value in the method LinkAll.Attributes.SmartConsumer.GetSmartEnumValue.
       at Registrar.Registrar.ObjCMethod.get_NativeReturnType()
       at Registrar.Registrar.ComputeSignature(Type DeclaringType, MethodBase Method, ObjCMember member, Boolean isCategoryInstance, Boolean isBlockSignature)
       at Registrar.Registrar.ObjCMethod.ComputeSignature()
       at Registrar.Registrar.ObjCMethod.ValidateSignature(List`1& exceptions)
       --- End of inner exception stack trace ---
     ---> (Inner Exception #1) ObjCRuntime.RuntimeException: The registrar can't convert from 'LinkAll.Attributes.SmartEnum' to 'Foundation.NSString' for the return value in the method LinkAll.Attributes.SmartConsumer.GetSmartEnumValue.
       at Registrar.Registrar.ObjCMethod.get_NativeReturnType()
       at Registrar.Registrar.VerifyInSdk(List`1& exceptions, ObjCMethod method)
       at Registrar.Registrar.ObjCType.Add(ObjCMethod method, List`1& exceptions)
       at Registrar.Registrar.RegisterTypeUnsafe(Type type, List`1& exceptions)<---

     ---> (Inner Exception #2) ObjCRuntime.RuntimeException: The registrar can't convert from 'LinkAll.Attributes.SmartEnum' to 'Foundation.NSString' for the parameter 'value' in the method LinkAll.Attributes.SmartConsumer.SetSmartEnumValue.
       at Registrar.Registrar.ObjCMethod.get_NativeParameters()
       at Registrar.Registrar.ComputeSignature(Type DeclaringType, MethodBase Method, ObjCMember member, Boolean isCategoryInstance, Boolean isBlockSignature)
       at Registrar.Registrar.ObjCMethod.ComputeSignature()
       at Registrar.Registrar.ObjCMethod.ValidateSignature(List`1& exceptions)<---

    =================================================================
      Native Crash Reporting
    =================================================================
    Got a abrt while executing native code. This usually indicates
    a fatal error in the mono runtime or one of the native libraries
    used by your application.
    =================================================================

    =================================================================
      Native stacktrace:
    =================================================================
      0x10d57eb0e - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/5CB344E3-EC61-4720-92E6-4C8B91A67A85/link all.app/libmonosgen-2.0.dylib : mono_dump_native_crash_info
      0x10d52b437 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/5CB344E3-EC61-4720-92E6-4C8B91A67A85/link all.app/libmonosgen-2.0.dylib : mono_handle_native_crash
      0x10d57e365 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/5CB344E3-EC61-4720-92E6-4C8B91A67A85/link all.app/libmonosgen-2.0.dylib : sigabrt_signal_handler
      0x7fff51c005fd - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_platform.dylib : _sigtramp
      0x0 - Unknown
      0x7fff51af0b7c - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_c.dylib : abort
      0x10d32478f - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/5CB344E3-EC61-4720-92E6-4C8B91A67A85/link all.app/libxamarin-debug.dylib : xamarin_unhandled_exception_handler
      0x10d5eef68 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/5CB344E3-EC61-4720-92E6-4C8B91A67A85/link all.app/libmonosgen-2.0.dylib : mono_invoke_unhandled_exception_hook
      0x10d52ade0 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/5CB344E3-EC61-4720-92E6-4C8B91A67A85/link all.app/libmonosgen-2.0.dylib : mono_handle_exception_internal
      0x10d5296c1 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/5CB344E3-EC61-4720-92E6-4C8B91A67A85/link all.app/libmonosgen-2.0.dylib : mono_handle_exception
      0x10d579582 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/5CB344E3-EC61-4720-92E6-4C8B91A67A85/link all.app/libmonosgen-2.0.dylib : mono_amd64_throw_exception
      0x10d91b5b0 - Unknown
      0x10d3244eb - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/5CB344E3-EC61-4720-92E6-4C8B91A67A85/link all.app/libxamarin-debug.dylib : xamarin_process_managed_exception
      0x10d324367 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/5CB344E3-EC61-4720-92E6-4C8B91A67A85/link all.app/libxamarin-debug.dylib : xamarin_process_managed_exception_gchandle
      0x10d336851 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/5CB344E3-EC61-4720-92E6-4C8B91A67A85/link all.app/libxamarin-debug.dylib : xamarin_main
      0x10d217ced - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/5CB344E3-EC61-4720-92E6-4C8B91A67A85/link all.app/link all : main
      0x7fff51a231fd - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libdyld.dylib : start