### PR TITLE
[dotnet-linker] Add MarkNSObjects into the pipeline.

### DIFF
--- a/tools/common/DerivedLinkContext.cs
+++ b/tools/common/DerivedLinkContext.cs
@@ -97,11 +97,13 @@ namespace Xamarin.Tuner
 			get; set;
 		}
 
+#if !NET
 		public DerivedLinkContext (Pipeline pipeline, AssemblyResolver resolver)
 			: base (pipeline, resolver)
 		{
 			UserAction = AssemblyAction.Link;
 		}
+#endif
 
 		public Dictionary<IMetadataTokenProvider, object> GetAllCustomAttributes (string storage_name)
 		{

--- a/tools/dotnet-linker/Compat.cs
+++ b/tools/dotnet-linker/Compat.cs
@@ -86,16 +86,10 @@ namespace Xamarin.Bundler {
 		}
 	}
 
+	// We can't make the linker use a LinkerContext subclass (DerivedLinkerContext), so we make DerivedLinkerContext
+	// derive from this class, and then we redirect to the LinkerContext instance here.
 	public class DotNetLinkContext {
-		public DotNetLinkContext ()
-		{
-			throw new NotImplementedException ();
-		}
-
-		public DotNetLinkContext (Pipeline pipeline, AssemblyResolver resolver)
-		{
-			throw new NotImplementedException ();
-		}
+		public LinkerConfiguration LinkerConfiguration;
 
 		public AssemblyAction UserAction {
 			get { throw new NotImplementedException (); }
@@ -104,13 +98,13 @@ namespace Xamarin.Bundler {
 
 		public AnnotationStore Annotations {
 			get {
-				throw new NotImplementedException ();
+				return LinkerConfiguration.Context.Annotations;
 			}
 		}
 
 		public AssemblyDefinition GetAssembly (string name)
 		{
-			throw new NotImplementedException ();
+			return LinkerConfiguration.Context.GetLoadedAssembly (name);
 		}
 	}
 
@@ -120,12 +114,27 @@ namespace Xamarin.Bundler {
 }
 
 namespace Xamarin.Linker {
+	public class BaseProfile : Profile {
+		public BaseProfile (LinkerConfiguration config)
+			: base (config)
+		{
+		}
+	}
+
 	public class Profile {
 		public LinkerConfiguration Configuration { get; private set; }
 
 		public Profile (LinkerConfiguration config)
 		{
 			Configuration = config;
+		}
+
+		public Profile Current {
+			get { return this; }
+		}
+
+		public string ProductAssembly {
+			get { return Configuration.PlatformAssembly; }
 		}
 
 		public bool IsProductAssembly (AssemblyDefinition assembly)

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -39,6 +39,7 @@ namespace Xamarin.Linker {
 		public CompilerFlags CompilerFlags;
 
 		public LinkContext Context { get; private set; }
+		public DerivedLinkContext DerivedLinkContext { get; private set; }
 		public Profile Profile { get; private set; }
 
 		// The list of assemblies is populated in CollectAssembliesStep.
@@ -64,7 +65,8 @@ namespace Xamarin.Linker {
 			if (!File.Exists (linker_file))
 				throw new FileNotFoundException ($"The custom linker file {linker_file} does not exist.");
 
-			Profile = new Profile (this);
+			Profile = new BaseProfile (this);
+			DerivedLinkContext = new DerivedLinkContext { LinkerConfiguration = this, };
 			Application = new Application (this);
 			Target = new Target (Application);
 			CompilerFlags = new CompilerFlags (Target);

--- a/tools/dotnet-linker/SetupStep.cs
+++ b/tools/dotnet-linker/SetupStep.cs
@@ -55,6 +55,7 @@ namespace Xamarin {
 				// [assembly: LinkSafe] attributes, which means we treat them as sdk assemblies and those may have
 				// Preserve attributes.
 				prelink_substeps.Add (new ApplyPreserveAttribute ());
+				prelink_substeps.Add (new MarkNSObjects ());
 				prelink_substeps.Add (new PreserveSmartEnumConversionsSubStep ());
 			}
 

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -149,6 +149,9 @@
     <Compile Include="..\linker\MobileExtensions.cs">
       <Link>external\tools\linker\MobileExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\linker\MarkNSObjects.cs">
+      <Link>external\tools\linker\MarkNSObjects.cs</Link>
+    </Compile>
     <Compile Include="..\linker\ObjCExtensions.cs">
       <Link>external\tools\linker\ObjCExtensions.cs</Link>
     </Compile>

--- a/tools/linker/ExceptionalSubStep.cs
+++ b/tools/linker/ExceptionalSubStep.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Linker {
 		protected DerivedLinkContext LinkContext {
 			get {
 #if NET
-				throw new NotImplementedException ();
+				return Configuration.DerivedLinkContext;
 #else
 				return (DerivedLinkContext) base.context;
 #endif

--- a/tools/linker/MarkNSObjects.cs
+++ b/tools/linker/MarkNSObjects.cs
@@ -33,6 +33,9 @@ using System;
 using Mono.Cecil;
 using Mono.Linker;
 using Mono.Tuner;
+#if NET
+using Mono.Linker.Steps;
+#endif
 
 namespace Xamarin.Linker.Steps {
 
@@ -95,7 +98,7 @@ namespace Xamarin.Linker.Steps {
 				return false;
 
 			var overrides = Annotations.GetOverrides (method);
-			if (overrides == null || overrides.Count == 0)
+			if (overrides == null)
 				return false;
 
 			foreach (var @override in overrides)


### PR DESCRIPTION
A few compat fixes were necessary to make the code compile and run correctly.

Fixes this startup crash with the linkall test:

    2020-08-27 18:15:09.648352+0200 link all[91128:1963430] *** Assertion failure in void _UIApplicationMainPreparations(int, char **, NSString *__strong, NSString *__strong)(), /Library/Caches/com.apple.xbs/Sources/UIKitCore_Sim/UIKit-3920.31.100/UIApplication.m:4765
    2020-08-27 18:15:09.697128+0200 link all[91128:1963430]
    Unhandled Exception:
    Foundation.MonoTouchException: Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: Unable to instantiate the UIApplication delegate instance. No class named AppDelegate is loaded.
    Native stack trace:
    	0   CoreFoundation                      0x00007fff23e3cf0e __exceptionPreprocess + 350
    	1   libobjc.A.dylib                     0x00007fff50ba89b2 objc_exception_throw + 48
    	2   CoreFoundation                      0x00007fff23e3cc88 +[NSException raise:format:arguments:] + 88
    	3   Foundation                          0x00007fff258b8c9b -[NSAssertionHandler handleFailureInFunction:file:lineNumber:description:] + 166
    	4   UIKitCore                           0x00007fff48c8baed UIApplicationMain + 1862
    	5   ???                                 0x00000001087d2504 0x0 + 4437386500
    	6   ???                                 0x00000001087d237b 0x0 + 4437386107
    	7   ???                                 0x00000001087cef93 0x0 + 4437372819
    	8   ???                                 0x00000001087cedcb 0x0 + 4437372363
    	9   ???                                 0x00000001087ceec1 0x0 + 4437372609
    	10  libmonosgen-2.0.dylib               0x00000001081a2d7e mono_jit_runtime_invoke + 1911
    	11  libmonosgen-2.0.dylib               0x000000010832ee0a do_runtime_invoke + 80
    	12  libmonosgen-2.0.dylib               0x0000000108331fd0 do_exec_main_checked + 92
    	13  libmonosgen-2.0.dylib               0x00000001081f191e mono_jit_exec + 369
    	14  libxamarin-debug.dylib              0x000000010802badd xamarin_main + 2685
    	15  link all                            0x0000000107f0cced main + 45
    	16  libdyld.dylib                       0x00007fff51a231fd start + 1

       at ObjCRuntime.Runtime.ThrowNSException(IntPtr ns_exception)
       at ObjCRuntime.Runtime.throw_ns_exception(IntPtr exc)
       at UIKit.UIApplication.Main(String[] args, IntPtr principal, IntPtr delegate)
       at UIKit.UIApplication.Main(String[] args, String principalClassName, String delegateClassName)
       at LinkAll.Application.Main(String[] args) in [...]/xamarin-macios/tests/linker/ios/link all/Main.cs:line 15
    --- End of stack trace from previous location ---
       at UIKit.UIApplication.Main(String[] args, IntPtr principal, IntPtr delegate)
       at UIKit.UIApplication.Main(String[] args, String principalClassName, String delegateClassName)
       at LinkAll.Application.Main(String[] args) in [...]/xamarin-macios/tests/linker/ios/link all/Main.cs:line 15	0   CoreFoundation                      0x00007fff23e3cf0e __exceptionPreprocess + 350
    	1   libobjc.A.dylib                     0x00007fff50ba89b2 objc_exception_throw + 48
    	2   CoreFoundation                      0x00007fff23e3cc88 +[NSException raise:format:arguments:] + 88
    	3   Foundation                          0x00007fff258b8c9b -[NSAssertionHandler handleFailureInFunction:file:lineNumber:description:] + 166
    	4   UIKitCore                           0x00007fff48c8baed UIApplicationMain + 1862
    	5   ???                                 0x00000001087d2504 0x0 + 4437386500
    	6   ???                                 0x00000001087d237b 0x0 + 4437386107
    	7   ???                                 0x00000001087cef93 0x0 + 4437372819
    	8   ???                                 0x00000001087cedcb 0x0 + 4437372363
    	9   ???                                 0x00000001087ceec1 0x0 + 4437372609
    	10  libmonosgen-2.0.dylib               0x00000001081a2d7e mono_jit_runtime_invoke + 1911
    	11  libmonosgen-2.0.dylib               0x000000010832ee0a do_runtime_invoke + 80
    	12  libmonosgen-2.0.dylib               0x0000000108331fd0 do_exec_main_checked + 92
    	13  libmonosgen-2.0.dylib               0x00000001081f191e mono_jit_exec + 369
    	14  libxamarin-debug.dylib              0x000000010802badd xamarin_main + 2685
    	15  link all                            0x0000000107f0cced main + 45
    	16  libdyld.dylib                       0x00007fff51a231fd start + 1
    2020-08-27 18:15:09.698283+0200 link all[91128:1963430] Unhandled managed exception: Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: Unable to instantiate the UIApplication delegate instance. No class named AppDelegate is loaded.
    Native stack trace:
    	0   CoreFoundation                      0x00007fff23e3cf0e __exceptionPreprocess + 350
    	1   libobjc.A.dylib                     0x00007fff50ba89b2 objc_exception_throw + 48
    	2   CoreFoundation                      0x00007fff23e3cc88 +[NSException raise:format:arguments:] + 88
    	3   Foundation                          0x00007fff258b8c9b -[NSAssertionHandler handleFailureInFunction:file:lineNumber:description:] + 166
    	4   UIKitCore                           0x00007fff48c8baed UIApplicationMain + 1862
    	5   ???                                 0x00000001087d2504 0x0 + 4437386500
    	6   ???                                 0x00000001087d237b 0x0 + 4437386107
    	7   ???                                 0x00000001087cef93 0x0 + 4437372819
    	8   ???                                 0x00000001087cedcb 0x0 + 4437372363
    	9   ???                                 0x00000001087ceec1 0x0 + 4437372609
    	10  libmonosgen-2.0.dylib               0x00000001081a2d7e mono_jit_runtime_invoke + 1911
    	11  libmonosgen-2.0.dylib               0x000000010832ee0a do_runtime_invoke + 80
    	12  libmonosgen-2.0.dylib               0x0000000108331fd0 do_exec_main_checked + 92
    	13  libmonosgen-2.0.dylib               0x00000001081f191e mono_jit_exec + 369
    	14  libxamarin-debug.dylib              0x000000010802badd xamarin_main + 2685
    	15  link all                            0x0000000107f0cced main + 45
    	16  libdyld.dylib                       0x00007fff51a231fd start + 1
     (Foundation.MonoTouchException)
       at ObjCRuntime.Runtime.ThrowNSException(IntPtr ns_exception)
       at ObjCRuntime.Runtime.throw_ns_exception(IntPtr exc)
       at UIKit.UIApplication.Main(String[] args, IntPtr principal, IntPtr delegate)
       at UIKit.UIApplication.Main(String[] args, String principalClassName, String delegateClassName)
       at LinkAll.Application.Main(String[] args) in [...]/xamarin-macios/tests/linker/ios/link all/Main.cs:line 15
    --- End of stack trace from previous location ---
       at UIKit.UIApplication.Main(String[] args, IntPtr principal, IntPtr delegate)
       at UIKit.UIApplication.Main(String[] args, String principalClassName, String delegateClassName)
       at LinkAll.Application.Main(String[] args) in [...]/xamarin-macios/tests/linker/ios/link all/Main.cs:line 15

    =================================================================
    	Native Crash Reporting
    =================================================================
    Got a abrt while executing native code. This usually indicates
    a fatal error in the mono runtime or one of the native libraries
    used by your application.
    =================================================================

    =================================================================
    	Native stacktrace:
    =================================================================
    	0x108273f92 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libmonosgen-2.0.dylib : mono_dump_native_crash_info
    	0x1082207bd - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libmonosgen-2.0.dylib : mono_handle_native_crash
    	0x1082737e9 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libmonosgen-2.0.dylib : sigabrt_signal_handler
    	0x7fff51c005fd - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_platform.dylib : _sigtramp
    	0x0 - Unknown
    	0x7fff51af0b7c - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_c.dylib : abort
    	0x10801979f - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libxamarin-debug.dylib : xamarin_unhandled_exception_handler
    	0x1082e4980 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libmonosgen-2.0.dylib : mono_invoke_unhandled_exception_hook
    	0x108220166 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libmonosgen-2.0.dylib : mono_handle_exception_internal
    	0x10821ea47 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libmonosgen-2.0.dylib : mono_handle_exception
    	0x10826ea06 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libmonosgen-2.0.dylib : mono_amd64_throw_exception
    	0x1086105b0 - Unknown
    	0x1080194fb - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libxamarin-debug.dylib : xamarin_process_managed_exception
    	0x108019377 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libxamarin-debug.dylib : xamarin_process_managed_exception_gchandle
    	0x108019333 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libxamarin-debug.dylib : xamarin_ftnptr_exception_handler
    	0x10821feeb - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libmonosgen-2.0.dylib : mono_handle_exception_internal
    	0x10821ea47 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libmonosgen-2.0.dylib : mono_handle_exception
    	0x10826ea06 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libmonosgen-2.0.dylib : mono_amd64_throw_exception
    	0x1086105b0 - Unknown
    	0x1087d264b - Unknown
    	0x10869439b - Unknown
    	0x108016c07 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libxamarin-debug.dylib : xamarin_throw_ns_exception
    	0x10801a1cb - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libxamarin-debug.dylib : _ZL17exception_handlerP11NSException
    	0x7fff23e3d36d - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation : __handleUncaughtException
    	0x7fff50ba8c05 - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libobjc.A.dylib : _ZL15_objc_terminatev
    	0x7fff4f9f6c87 - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libc++abi.dylib : _ZSt11__terminatePFvvE
    	0x7fff4f9f940b - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libc++abi.dylib : __cxa_get_exception_ptr
    	0x7fff4f9f93d2 - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libc++abi.dylib : _ZN10__cxxabiv1L22exception_cleanup_funcE19_Unwind_Reason_CodeP17_Unwind_Exception
    	0x7fff50ba8ad6 - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libobjc.A.dylib : _ZL26_objc_exception_destructorPv
    	0x7fff23e3cc88 - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation : +[NSException raise:format:arguments:]
    	0x7fff258b8c9b - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework/Foundation : -[NSAssertionHandler handleFailureInFunction:file:lineNumber:description:]
    	0x7fff48c8baed - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore : UIApplicationMain
    	0x1087d2504 - Unknown
    	0x1087d237b - Unknown
    	0x1087cef93 - Unknown
    	0x1087cedcb - Unknown
    	0x1087ceec1 - Unknown
    	0x1081a2d7e - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libmonosgen-2.0.dylib : mono_jit_runtime_invoke
    	0x10832ee0a - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libmonosgen-2.0.dylib : do_runtime_invoke
    	0x108331fd0 - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libmonosgen-2.0.dylib : do_exec_main_checked
    	0x1081f191e - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libmonosgen-2.0.dylib : mono_jit_exec
    	0x10802badd - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/libxamarin-debug.dylib : xamarin_main
    	0x107f0cced - /Users/rolf/Library/Developer/CoreSimulator/Devices/289E372A-501C-4499-A1A6-59C5B3B6A9AE/data/Containers/Bundle/Application/2394E0CC-9F77-4BAD-8ADE-6CEE69EF8D6C/link all.app/link all : main
    	0x7fff51a231fd - /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libdyld.dylib : start