### PR TITLE
nunit2 format for supported in MSBuild Tests Workaround

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -26,6 +26,7 @@
     <Reference Include="Xamarin.iOS.Tasks" HintPath="..\..\Xamarin.iOS.Tasks\bin\$(Configuration)\netstandard2.0\Xamarin.iOS.Tasks.dll" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
+    <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.6.0" />
   </ItemGroup>
 
   <Target Name="BuildTasksAssembly" AfterTargets="BeforeBuild">

--- a/tests/xharness/Jenkins/TestTasks/NUnitExecuteTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/NUnitExecuteTask.cs
@@ -142,7 +142,7 @@ namespace Xharness.Jenkins.TestTasks
 				args.Add (Path.GetFullPath (TestExecutable));
 				args.Add (Path.GetFullPath (TestLibrary));
 				if (IsNUnit3) {
-					args.Add ("-result=" + xmlLog + ";format=nunit2");
+					args.Add ("-result=" + xmlLog);
 					args.Add ("--labels=All");
 					if (InProcess)
 						args.Add ("--inprocess");

--- a/tests/xharness/Jenkins/TestTasks/NUnitExecuteTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/NUnitExecuteTask.cs
@@ -142,7 +142,7 @@ namespace Xharness.Jenkins.TestTasks
 				args.Add (Path.GetFullPath (TestExecutable));
 				args.Add (Path.GetFullPath (TestLibrary));
 				if (IsNUnit3) {
-					args.Add ("-result=" + xmlLog);
+					args.Add ("-result=" + xmlLog + ";format=nunit2");
 					args.Add ("--labels=All");
 					if (InProcess)
 						args.Add ("--inprocess");


### PR DESCRIPTION
Workaround for https://github.com/xamarin/xamarin-macios/issues/9544 where MSBuild tests are not being executed due to NUnitExecuteTask.cs requiring an nunit version of 3.9.0+ but tagging with a nunit2 format. Using this workaround, we are able to run the tests and see output in the HTML log (error 16 as of now).