### PR TITLE
[d16-8] [DevOps] As with jenkins, remove old simulators.

### DIFF
--- a/tools/devops/device-tests/scripts/System.Tests.ps1
+++ b/tools/devops/device-tests/scripts/System.Tests.ps1
@@ -12,6 +12,7 @@ Describe 'Clear-HD' {
             # call the method, and check that remove-item was correctly called with each of the files we want to remove
 
             Mock Remove-Item
+            Mock Remove-InstalledSimulators
             # mock test path to always return true, that is all dirs are present
             Mock Test-Path {
                 return $True
@@ -38,6 +39,7 @@ Describe 'Clear-HD' {
 
             Clear-HD
 
+            Assert-MockCalled -CommandName Remove-InstalledSimulators -Times 1
             Assert-MockCalled -CommandName Remove-Item -Times $directories.Count -Scope It 
 
         }
@@ -77,9 +79,11 @@ Describe 'Clear-HD' {
             Mock Test-Path {
                 return $Path -in $presentDirectories
             }
+            Mock Remove-InstalledSimulators
 
             Clear-HD
 
+            Assert-MockCalled -CommandName Remove-InstalledSimulators -Times 1 
             $debugCalls = $directories.Count - $presentDirectories.Count
             Assert-MockCalled -CommandName Remove-Item -Times $presentDirectories.Count -Scope It 
             Assert-MockCalled -CommandName Write-Debug -Times $debugCalls -Scope It 

--- a/tools/devops/device-tests/scripts/System.psm1
+++ b/tools/devops/device-tests/scripts/System.psm1
@@ -86,6 +86,25 @@ function Get-MonoVersion {
 
 <#
     .SYNOPSIS
+        Removes all the installed simulators in the system.
+#>
+function Remove-InstalledSimulators {
+    param()
+    # use the .Net libs to execute the process
+    $pinfo = New-Object System.Diagnostics.ProcessStartInfo
+    $pinfo.FileName = "/Applications/Xcode.app/Contents/Developer/usr/bin/simctl"
+    $pinfo.RedirectStandardOutput = $true
+    $pinfo.UseShellExecute = $false
+    $pinfo.Arguments = "delete all"
+
+    $p = New-Object System.Diagnostics.Process
+    $p.StartInfo = $pinfo
+    $p.Start() | Out-Null
+    $p.WaitForExit()
+}
+
+<#
+    .SYNOPSIS
         Returns the details of the system that is currently executing the
         pipeline.
     .DESCRIPTION
@@ -162,6 +181,10 @@ function Clear-XamarinProcesses {
         Remove known paths and directories that are not needed for the tests.
 #>
 function Clear-HD {
+
+    # Delete all the simulator devices. Rolf: These can take up a lot of space over time (I've seen 100+GB on the bots)
+    Remove-InstalledSimulators 
+
     # print the current state of the HD
     Get-PSDrive "/" | Format-Table -Wrap
 
@@ -197,6 +220,7 @@ function Clear-HD {
             Write-Error "Could not remove dir $dir - $_"
         }
     }
+
     Get-PSDrive "/" | Format-Table -Wrap
 }
 
@@ -253,3 +277,4 @@ Export-ModuleMember -Function Clear-XamarinProcesses
 Export-ModuleMember -Function Clear-HD
 Export-ModuleMember -Function Test-HDFreeSpace
 Export-ModuleMember -Function Clear-AfterTests
+Export-ModuleMember -Function Remove-InstalledSimulators 


### PR DESCRIPTION
Follow the changes in Jenkins: https://github.com/xamarin/xamarin-macios/pull/9548

Backport of #9551.

/cc @mandel-macaque 