### PR TITLE
[d16-7] Bump maccore to get provisioning changes

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := c7b48ac49168893edbab1ce5164812b59f4be02b
+NEEDED_MACCORE_VERSION := f08af6cc5c27f066de65d17a62bae39ef7ae23d5
 NEEDED_MACCORE_BRANCH := d16-7
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@f08af6cc5c [certificates] Remove unused expired certs and renewed macOS installer cert (#2308)
* xamarin/maccore@3cda873ef0 [certificates] Use Apple Certs, One certificate to rule them all (more like two) (#2299)

Diff: https://github.com/xamarin/maccore/compare/c7b48ac49168893edbab1ce5164812b59f4be02b..f08af6cc5c27f066de65d17a62bae39ef7ae23d5