### PR TITLE
[xcode12] Bump maccore to get provisioning changes

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 87698cc7570f8f0d7b14020f2d590bceedb330ce
+NEEDED_MACCORE_VERSION := 87a96d21c9fd8e15fd157201e6836db97c8b6e67
 NEEDED_MACCORE_BRANCH := xcode12
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@87a96d21c9 [certificates] Remove unused expired certs and renewed macOS installer cert (#2308)
* xamarin/maccore@15d35c5f55 [certificates] Use Apple Certs, One certificate to rule them all (more like two) (#2299)

Diff: https://github.com/xamarin/maccore/compare/87698cc7570f8f0d7b14020f2d590bceedb330ce..87a96d21c9fd8e15fd157201e6836db97c8b6e67