### PR TITLE
[tests] Add test case for issue #9566.

### DIFF
--- a/tests/linker/ios/link all/InterfacesTest.cs
+++ b/tests/linker/ios/link all/InterfacesTest.cs
@@ -91,6 +91,14 @@ namespace LinkAll.Interfaces {
 			Assert.Null (type_b.GetMethod ("Bar", BindingFlags.Instance | BindingFlags.Public), "B::Bar");
 		}
 
+		[Test]
+		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/9566")]
+		public void Issue9566 ()
+		{
+			var ifaces = (I[]) (object) new B[0];
+			Assert.IsNotNull (ifaces, "Array cast");
+		}
+
 		[DllImport ("/usr/lib/system/libsystem_dnssd.dylib")]
 		public static extern int DNSServiceGetProperty (
 			[MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof (UTF8Marshaler))] string name,


### PR DESCRIPTION
This is the failure when the test is enabled:

    LinkAll.Interfaces.InterfaceTest
        [FAIL] Issue9566 : System.InvalidCastException : Specified cast is not valid.
            at LinkAll.Interfaces.InterfaceTest.Issue9566 () [0x00001] in /Users/rolf/work/maccore/whatever/xamarin-macios/tests/linker/ios/link all/InterfacesTest.cs:97
            at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
            at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in

Ref: https://github.com/xamarin/xamarin-macios/issues/9566