### PR TITLE
[dotnet] Define and implement a 'framework' or 'sdk' assembly as an assembly that comes from the .NET BCL NuGet.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -125,7 +125,7 @@
 		<_AdditionalTaskAssemblyDirectory>$(_XamarinSdkRootDirectory)tools/dotnet-linker/</_AdditionalTaskAssemblyDirectory>
 		<_AdditionalTaskAssembly>$(_AdditionalTaskAssemblyDirectory)dotnet-linker.dll</_AdditionalTaskAssembly>
 	</PropertyGroup>
-	<Target Name="_ComputeLinkerArguments" DependsOnTargets="_ComputeLinkMode;_ComputeFrameworkVariables;ComputeResolvedFilesToPublishList">
+	<Target Name="_ComputeLinkerArguments" DependsOnTargets="_ComputeLinkMode;_ComputeFrameworkVariables;_ComputeFrameworkAssemblies;ComputeResolvedFilesToPublishList">
 		<!-- Validate the linker mode -->
 		<Error Text="Invalid link mode: '$(_LinkMode)'. Valid link modes are: 'None', 'SdkOnly' and 'Full'" Condition="'$(_LinkMode)' != 'None' And '$(_LinkMode)' != 'SdkOnly' And '$(_LinkMode)' != 'Full'" />
 
@@ -144,6 +144,7 @@
 				CacheDirectory=$(_LinkerCacheDirectory)
 				Debug=$(_BundlerDebug)
 				DeploymentTarget=$(_MinimumOSVersion)
+				@(_XamarinFrameworkAssemblies -> 'FrameworkAssembly=%(Filename)')
 				ItemsDirectory=$(_LinkerItemsDirectory)
 				IsSimulatorBuild=$(_SdkIsSimulator)
 				LinkMode=$(_LinkMode)
@@ -251,6 +252,13 @@
 
 			<_LibPartialStaticRegistrar>$(_XamarinNativeLibraryDirectory)/Microsoft.$(_PlatformName).registrar.a</_LibPartialStaticRegistrar>
 		</PropertyGroup>
+	</Target>
+
+	<Target Name="_ComputeFrameworkAssemblies" DependsOnTargets="_ComputeVariables;ComputeResolvedFilesToPublishList">
+		<ItemGroup>
+			<!-- Define 'framework assembly' or 'sdk assembly' as assemblies that comes from the .NET BCL NuGet -->
+			<_XamarinFrameworkAssemblies Include="@(ResolvedFileToPublish)" Condition="'%(ResolvedFileToPublish.Extension)' == '.dll' And '%(ResolvedFileToPublish.NuGetPackageId)' == '$(_MonoNugetPackageId)'" />
+		</ItemGroup>
 	</Target>
 
 	<Target Name="_ComputeVariables" DependsOnTargets="_GenerateBundleName;_ComputeFrameworkVariables">

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -261,7 +261,7 @@
 		</ItemGroup>
 	</Target>
 
-	<Target Name="_ComputeVariables" DependsOnTargets="_GenerateBundleName;_ComputeFrameworkVariables">
+	<Target Name="_ComputeVariables" DependsOnTargets="_GenerateBundleName;_ComputeFrameworkVariables;ComputeResolvedFilesToPublishList">
 		<PropertyGroup>
 			<_IntermediateNativeLibraryDir>$(IntermediateOutputPath)nativelibraries/</_IntermediateNativeLibraryDir>
 			<_NativeExecutableName>$(_AppBundleName)</_NativeExecutableName>

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -64,10 +64,10 @@ namespace Xamarin.Bundler {
 			set {
 				full_path = value;
 				if (!is_framework_assembly.HasValue && !string.IsNullOrEmpty (full_path)) {
-					var real_full_path = Target.GetRealPath (full_path);
 #if NET
-					// TODO: Figure out how to determine whether an assembly is a framework assembly or not (but it's not urgent to implement, it's just a performance improvement)
+					is_framework_assembly = Target.App.Configuration.FrameworkAssemblies.Contains (GetIdentity (full_path));
 #else
+					var real_full_path = Target.GetRealPath (full_path);
 					is_framework_assembly = real_full_path.StartsWith (Path.GetDirectoryName (Path.GetDirectoryName (Target.Resolver.FrameworkDirectory)), StringComparison.Ordinal);
 #endif
 				}

--- a/tools/dotnet-linker/Compat.cs
+++ b/tools/dotnet-linker/Compat.cs
@@ -6,6 +6,7 @@ using Mono.Cecil;
 using Mono.Linker;
 using Mono.Linker.Steps;
 
+using Xamarin.Bundler;
 using Xamarin.Linker;
 using Xamarin.Utils;
 
@@ -140,6 +141,11 @@ namespace Xamarin.Linker {
 		public bool IsProductAssembly (AssemblyDefinition assembly)
 		{
 			return assembly.Name.Name == Configuration.PlatformAssembly;
+		}
+
+		public bool IsSdkAssembly (AssemblyDefinition assembly)
+		{
+			return Configuration.FrameworkAssemblies.Contains (Assembly.GetIdentity (assembly));
 		}
 	}
 }

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Linker {
 		public string AssemblyName { get; private set; }
 		public string CacheDirectory { get; private set; }
 		public Version DeploymentTarget { get; private set; }
+		public HashSet<string> FrameworkAssemblies { get; private set; } = new HashSet<string> ();
 		public string ItemsDirectory { get; private set; }
 		public bool IsSimulatorBuild { get; private set; }
 		public LinkMode LinkMode => Application.LinkMode;
@@ -104,6 +105,9 @@ namespace Xamarin.Linker {
 					if (!Version.TryParse (value, out var deployment_target))
 						throw new InvalidOperationException ($"Unable to parse the {key} value: {value} in {linker_file}");
 					DeploymentTarget = deployment_target;
+					break;
+				case "FrameworkAssembly":
+					FrameworkAssemblies.Add (value);
 					break;
 				case "ItemsDirectory":
 					ItemsDirectory = value;
@@ -221,6 +225,9 @@ namespace Xamarin.Linker {
 				Console.WriteLine ($"    Debug: {Application.EnableDebug}");
 				Console.WriteLine ($"    DeploymentTarget: {DeploymentTarget}");
 				Console.WriteLine ($"    ItemsDirectory: {ItemsDirectory}");
+				Console.WriteLine ($"    {FrameworkAssemblies.Count} framework assemblies:");
+				foreach (var fw in FrameworkAssemblies.OrderBy (v => v))
+					Console.WriteLine ($"        {fw}");
 				Console.WriteLine ($"    IsSimulatorBuild: {IsSimulatorBuild}");
 				Console.WriteLine ($"    LinkMode: {LinkMode}");
 				Console.WriteLine ($"    MarshalManagedExceptions: {Application.MarshalManagedExceptions} (IsDefault: {Application.IsDefaultMarshalManagedExceptionMode})");


### PR DESCRIPTION
The Assembly.IsFrameworkAssembly property is used in two places:

* In Driver.IsBoundAssembly to return early when determining if an assembly has any NSObject subclasses: https://github.com/xamarin/xamarin-macios/blob/c1c5b9aac67461122a3b66334876ed9aeb4cd63c/tools/mtouch/mtouch.cs#L1155-L1168
* In Assembly.ExtractNativeLinkInfo to return early when looking for assemblies with LinkWith attributes: https://github.com/xamarin/xamarin-macios/blob/c1c5b9aac67461122a3b66334876ed9aeb4cd63c/tools/common/Assembly.cs#L150-L154

In both cases this definition of framework assembly works today and seems likely to work in the future as well.

I also went through and looked at all the usages of Profile.IsSdkAssembly, and it's used to:

* Decide which assemblies are selected for "link sdk"
* Decide which assemblies are considered an 'sdk' assembly for creating a user framework of all the sdk assemblies
* Bail out early when deciding whether:
    * An assembly references the product assembly (Xamarin.iOS.dll, etc.)
    * An assembly can contain references to UIWebView
    * An assembly can contain user resources
    * An assembly is a binding project / has third-party native resources
    * An assembly needs the dynamic registrar
    * An assembly has FieldAttributes whose native fields must be preserved by the native linker

In all cases our .NET definition of 'SDK' seems to work both for now and in the future.

There are also a few usages which does not apply to .NET, so I've ignored them:

* When looking for a few BCL APIs that must be preserved (MobileApplyPreserveAttribute.cs): this is to be done in the upstream .NET linker now, so it doesn't apply to our own code
* When linking away parameter names (MonoTouchMarkStep.cs): this is to be done in the upstream .NET linker now, so it doesn't apply to our own code

