### PR TITLE
[tests] Disable some of linkall's SealerTest in .NET/Release until we can implement them.

### DIFF
--- a/tests/linker/ios/link all/SealerTest.cs
+++ b/tests/linker/ios/link all/SealerTest.cs
@@ -36,6 +36,9 @@ namespace Linker.Sealer {
 	[Preserve (AllMembers = true)]
 	public class SealerTest {
 
+#if !DEBUG && NET
+		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/9573")]
+#endif
 		[Test]
 		public void Sealed ()
 		{
@@ -59,6 +62,9 @@ namespace Linker.Sealer {
 #endif
 		}
 
+#if !DEBUG && NET
+		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/9573")]
+#endif
 		[Test]
 		public void Final ()
 		{
@@ -79,6 +85,9 @@ namespace Linker.Sealer {
 #endif
 		}
 
+#if !DEBUG && NET
+		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/9573")]
+#endif
 		[Test]
 		public void Virtual ()
 		{


### PR DESCRIPTION
Fixes these test failures:

    Linker.Sealer.SealerTest
    [FAIL] Final :   A
        Expected: True
        But was:  False
            at Linker.Sealer.SealerTest.Final()

    [FAIL] Sealed :   Sealable
        Expected: True
        But was:  False
            at Linker.Sealer.SealerTest.Sealed()

    [FAIL] Virtual :   C
        Expected: False
        But was:  True
            at Linker.Sealer.SealerTest.Virtual()

Ref: https://github.com/xamarin/xamarin-macios/issues/9573