### PR TITLE
[CarPlay] Remove warnings when building the intermediate dlls.

### DIFF
--- a/src/carplay.cs
+++ b/src/carplay.cs
@@ -440,7 +440,7 @@ namespace CarPlay {
 		IntPtr Constructor ([NullAllowed] string text, [NullAllowed] string detailText, [NullAllowed] UIImage image, [NullAllowed] UIImage accessoryImage, CPListItemAccessoryType accessoryType);
 
 		[NullAllowed, Export ("text")]
-		string Text { get; }
+		new string Text { get; }
 
 		[NullAllowed, Export ("detailText")]
 		string DetailText { get; }
@@ -453,7 +453,7 @@ namespace CarPlay {
 		bool ShowsDisclosureIndicator { get; }
 
 		[NullAllowed, Export ("userInfo", ArgumentSemantic.Strong)]
-		NSObject UserInfo { get; set; }
+		new NSObject UserInfo { get; set; }
 
 		[iOS (14, 0)]
 		[Export ("explicitContent")]
@@ -502,7 +502,7 @@ namespace CarPlay {
 
 		[NullAllowed, iOS (14, 0)]
 		[Export ("handler", ArgumentSemantic.Copy)]
-		CPSelectableListItemHandler Handler { get; set; }
+		new CPSelectableListItemHandler Handler { get; set; }
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (12,0)]
@@ -1434,7 +1434,7 @@ namespace CarPlay {
 
 		[Export ("handler", ArgumentSemantic.Copy)]
 		[NullAllowed]
-		CPSelectableListItemHandler Handler { get; set; }
+		new CPSelectableListItemHandler Handler { get; set; }
 
 		[Static]
 		[Export ("maximumImageSize")]
@@ -1444,10 +1444,10 @@ namespace CarPlay {
 		nuint MaximumNumberOfGridImages { get; }
 
 		[NullAllowed, Export ("text")]
-		string Text { get; set; }
+		new string Text { get; set; }
 
 		[NullAllowed, Export ("userInfo", ArgumentSemantic.Strong)]
-		NSObject UserInfo { get; set; }
+		new NSObject UserInfo { get; set; }
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (14,0)]
@@ -1513,10 +1513,10 @@ namespace CarPlay {
 		CGSize MaximumMessageItemImageSize { get; }
 
 		[NullAllowed, Export ("text")]
-		string Text { get; set; }
+		new string Text { get; set; }
 
 		[NullAllowed, Export ("userInfo", ArgumentSemantic.Strong)]
-		NSObject UserInfo { get; set; }
+		new NSObject UserInfo { get; set; }
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (14,0)]


### PR DESCRIPTION
The following warnings are printed during the build:

```
carplay.cs(443,10): warning CS0108: 'CPListItem.Text' hides inherited member 'CPListTemplateItem.Text'. Use the new keyword if hiding was intended.
carplay.cs(456,12): warning CS0108: 'CPListItem.UserInfo' hides inherited member 'CPListTemplateItem.UserInfo'. Use the new keyword if hiding was intended.
carplay.cs(505,31): warning CS0108: 'CPListItem.Handler' hides inherited member 'CPSelectableListItem.Handler'. Use the new keyword if hiding was intended.
carplay.cs(1437,31): warning CS0108: 'CPListImageRowItem.Handler' hides inherited member 'CPSelectableListItem.Handler'. Use the new keyword if hiding was intended.
carplay.cs(1447,10): warning CS0108: 'CPListImageRowItem.Text' hides inherited member 'CPListTemplateItem.Text'. Use the new keyword if hiding was intended.
carplay.cs(1450,12): warning CS0108: 'CPListImageRowItem.UserInfo' hides inherited member 'CPListTemplateItem.UserInfo'. Use the new keyword if hiding was intended.
carplay.cs(1516,10): warning CS0108: 'CPMessageListItem.Text' hides inherited member 'CPListTemplateItem.Text'. Use the new keyword if hiding was intended.
carplay.cs(1519,12): warning CS0108: 'CPMessageListItem.UserInfo' hides inherited member 'CPListTemplateItem.UserInfo'. Use the new keyword if hiding was intended.
```