### PR TITLE
[ARKit] Remove warning from intermediate compilation.

### DIFF
--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -2053,7 +2053,7 @@ namespace ARKit {
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("indexForJointName:")]
-		nuint GetJointIndex (NSString? jointName);
+		nuint GetJointIndex (NSString jointName);
 
 		[Wrap ("GetJointIndex (jointName.GetConstant()!)")]
 		nuint GetJointIndex (ARSkeletonJointName jointName);


### PR DESCRIPTION
Remove the following warning:
```
arkit.cs(2056,32): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
```