### PR TITLE
[UIKit] Remove warning from intermediate compilation.

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -22826,7 +22826,7 @@ namespace UIKit {
 		IntPtr Constructor (UITraitCollection traitCollection);
 
 		[Export ("traitCollection", ArgumentSemantic.Strong)]
-		UITraitCollection TraitCollection { get; set; }
+		new UITraitCollection TraitCollection { get; set; }
 
 		[Export ("disabled")]
 		bool Disabled { [Bind ("isDisabled")] get; set; }


### PR DESCRIPTION
Remove the following warning:
```
uikit.cs(22829,21): warning CS0108: 'UIViewConfigurationState.TraitCollection' hides inherited member 'UIConfigurationState.TraitCollection'. Use the new keyword if hiding was intended.
```