### PR TITLE
[tests] Prebuilt the Touch.Client projects when packaging the Xamarin.Mac tests.

### DIFF
--- a/tests/package-mac-tests.sh
+++ b/tests/package-mac-tests.sh
@@ -25,6 +25,8 @@ export MSBuildExtensionsPathFallbackPathsOverride=$MAC_DESTDIR/Library/Framework
 
 make
 make .stamp-configure-projects-mac
+../tools/xibuild/xibuild -- /r ../external/Touch.Unit/Touch.Client/macOS/mobile/Touch.Client-macOS-mobile.csproj
+../tools/xibuild/xibuild -- /r ../external/Touch.Unit/Touch.Client/macOS/full/Touch.Client-macOS-full.csproj
 ../tools/xibuild/xibuild -- /r bindings-test/macOS/bindings-test.csproj
 make build-mac-dontlink build-mac-apitest build-mac-introspection build-mac-linksdk build-mac-linkall build-mac-xammac_tests build-mac-system-dontlink -j8
 


### PR DESCRIPTION
Prebuild the Touch.Client projects for macOS when packaging the Xamarin.Mac
tests, so that when we try to build all the Xamarin.Mac test projects in
parallel, we don't end up trying to build the Touch.Client projects from
multiple build processes at the same time, causing numerous random failures
because all the processes are stomping on eachother.