### PR TITLE
[tools] Refactor the Optimizations class to have no conditionally compiled code.

### DIFF
--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -612,7 +612,6 @@ namespace Xamarin.MMP.Tests
 		}
 
 		[Test]
-		[TestCase ("inline-runtime-arch")] // This is valid for Xamarin.iOS
 		[TestCase ("foo")]
 		public void MM0132 (string opt)
 		{
@@ -686,6 +685,20 @@ namespace Xamarin.MMP.Tests
 			});
 		}
 
+		[Test]
+		[TestCase ("inline-runtime-arch")] // This is valid for iOS, tvOS and watchOS.
+		public void MM2003 (string opt)
+		{
+			RunMMPTest (tmpDir => {
+				var test = new TI.UnifiedTestConfig (tmpDir) {
+					CSProjConfig = $"<MonoBundlingExtraArgs>--optimize={opt}</MonoBundlingExtraArgs>" +
+						"<LinkMode>Full</LinkMode>",
+				};
+				var rv = TI.TestUnifiedExecutable (test, shouldFail: false);
+				rv.Messages.AssertWarning (2003, $"Option '--optimize={opt}' will be ignored since it's only applicable to iOS, watchOS, tvOS.");
+				rv.Messages.AssertErrorCount (0);
+			});
+		}
 		[Test]
 		public void BuildingSameSolutionTwice_ShouldNotRunACToolTwice ()
 		{

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1768,7 +1768,7 @@ public class TestApp {
 				mtouch.Linker = MTouchLinker.LinkSdk;
 				mtouch.Optimize = new string [] { "foo" };
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build");
-				mtouch.AssertWarning (132, "Unknown optimization: 'foo'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size, inline-runtime-arch, blockliteral-setupblock, register-protocols, inline-dynamic-registration-supported, static-block-to-delegate-lookup, remove-dynamic-registrar, remove-unsupported-il-for-bitcode, inline-is-arm64-calling-convention, seal-and-devirtualize, cctor-beforefieldinit, custom-attributes-removal, experimental-xforms-product-type, force-rejected-types-removal.");
+				mtouch.AssertWarning (132, "Unknown optimization: 'foo'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size, inline-runtime-arch, blockliteral-setupblock, register-protocols, inline-dynamic-registration-supported, static-block-to-delegate-lookup, remove-dynamic-registrar, inline-is-arm64-calling-convention, seal-and-devirtualize, cctor-beforefieldinit, custom-attributes-removal, experimental-xforms-product-type, force-rejected-types-removal.");
 			}
 		}
 

--- a/tools/common/ApplePlatform.cs
+++ b/tools/common/ApplePlatform.cs
@@ -12,4 +12,24 @@ namespace Xamarin.Utils
 		WatchOS,
 		TVOS,
 	}
+
+	public static class ApplePlatformExtensions {
+		public static string AsString (this ApplePlatform @this)
+		{
+			switch (@this) {
+			case ApplePlatform.iOS:
+				return "iOS";
+			case ApplePlatform.MacOSX:
+				return "macOS";
+			case ApplePlatform.WatchOS:
+				return "watchOS";
+			case ApplePlatform.TVOS:
+				return "tvOS";
+			case ApplePlatform.None:
+				return "None";
+			default:
+				return "Unknown";
+			}
+		}
+	}
 }

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -59,6 +59,7 @@ namespace Xamarin.Bundler {
 		public bool EnableDebug;
 		// The list of assemblies that we do generate debugging info for.
 		public bool DebugAll;
+		public bool UseInterpreter;
 		public List<string> DebugAssemblies = new List<string> ();
 		internal RuntimeOptions RuntimeOptions;
 		public Optimizations Optimizations = new Optimizations ();
@@ -578,7 +579,10 @@ namespace Xamarin.Bundler {
 				ErrorHelper.Warning (3007, Errors.MX3007);
 			}
 
-			Optimizations.Initialize (this);
+			Optimizations.Initialize (this, out var messages);
+			ErrorHelper.Show (messages);
+			if (Driver.Verbosity > 3)
+				Driver.Log (4, $"Enabled optimizations: {Optimizations}");
 		}
 
 		void SelectMonoNative ()

--- a/tools/common/Optimizations.cs
+++ b/tools/common/Optimizations.cs
@@ -1,4 +1,9 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+
+using Xamarin.Utils;
 
 namespace Xamarin.Bundler
 {
@@ -10,44 +15,41 @@ namespace Xamarin.Bundler
 			"dead-code-elimination",
 			"inline-isdirectbinding",
 			"inline-intptr-size",
-#if MONOTOUCH
 			"inline-runtime-arch",
-#else
-			"", // dummy value to make indices match up between XM and XI
-#endif
 			"blockliteral-setupblock",
 			"register-protocols",
 			"inline-dynamic-registration-supported",
 			"static-block-to-delegate-lookup",
-#if MONOTOUCH
 			"remove-dynamic-registrar",
-#else
-			"", // dummy value to make indices match up between XM and XI
-#endif
-#if MONOTOUCH
-			"", // dummy value to make indices match up between XM and XI
-#else
 			"trim-architectures",
-#endif
-#if MONOTOUCH
 			"remove-unsupported-il-for-bitcode",
-#else
-			"", // dummy value to make indices match up between XM and XI
-#endif
 			"inline-is-arm64-calling-convention",
-#if MONOTOUCH
 			"seal-and-devirtualize",
-#else
-			"", // dummy value to make indices match up between XM and XI
-#endif
 			"cctor-beforefieldinit",
 			"custom-attributes-removal",
 			"experimental-xforms-product-type",
-#if MONOTOUCH
 			"force-rejected-types-removal",
-#else
-			"", // dummy value to make indices match up between XM and XI
-#endif
+		};
+		
+		static ApplePlatform [][] valid_platforms = new ApplePlatform [][] {
+			/* Opt.RemoveUIThreadChecks               */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.WatchOS, ApplePlatform.TVOS },
+			/* Opt.DeadCodeElimination                */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.WatchOS, ApplePlatform.TVOS },
+			/* Opt.InlineIsDirectBinding              */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.WatchOS, ApplePlatform.TVOS },
+			/* Opt.InlineIntPtrSize                   */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.WatchOS, ApplePlatform.TVOS },
+			/* Opt.InlineRuntimeArch                  */ new ApplePlatform [] { ApplePlatform.iOS,                       ApplePlatform.WatchOS, ApplePlatform.TVOS },
+			/* Opt.BlockLiteralSetupBlock             */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.WatchOS, ApplePlatform.TVOS },
+			/* Opt.RegisterProtocols                  */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.WatchOS, ApplePlatform.TVOS },
+			/* Opt.InlineDynamicRegistrationSupported */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.WatchOS, ApplePlatform.TVOS },
+			/* Opt.StaticBlockToDelegateLookup        */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.WatchOS, ApplePlatform.TVOS },
+			/* Opt.RemoveDynamicRegistrar             */ new ApplePlatform [] { ApplePlatform.iOS,                       ApplePlatform.WatchOS, ApplePlatform.TVOS },
+			/* Opt.TrimArchitectures                  */ new ApplePlatform [] {                    ApplePlatform.MacOSX,                                           },
+			/* Opt.RemoveUnsupportedILForBitcode      */ new ApplePlatform [] {                                          ApplePlatform.WatchOS,                    },
+			/* Opt.InlineIsARM64CallingConvention     */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.WatchOS, ApplePlatform.TVOS },
+			/* Opt.SealAndDevirtualize                */ new ApplePlatform [] { ApplePlatform.iOS,                       ApplePlatform.WatchOS, ApplePlatform.TVOS },
+			/* Opt.StaticConstructorBeforeFieldInit   */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.WatchOS, ApplePlatform.TVOS },
+			/* Opt.CustomAttributesRemoval            */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.WatchOS, ApplePlatform.TVOS },
+			/* Opt.ExperimentalFormsProductType       */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.WatchOS, ApplePlatform.TVOS },
+			/* Opt.ForceRejectedTypesRemoval          */ new ApplePlatform [] { ApplePlatform.iOS,                       ApplePlatform.WatchOS, ApplePlatform.TVOS },
 		};
 
 		enum Opt
@@ -72,7 +74,6 @@ namespace Xamarin.Bundler
 			ForceRejectedTypesRemoval,
 		}
 
-		bool? all;
 		bool? [] values;
 
 		public bool? RemoveUIThreadChecks {
@@ -122,24 +123,20 @@ namespace Xamarin.Bundler
 			set { values [(int) Opt.TrimArchitectures] = value; }
 		}
 
-#if MONOTOUCH
 		public bool? RemoveUnsupportedILForBitcode {
 			get { return values [(int) Opt.RemoveUnsupportedILForBitcode]; }
 			set { values [(int) Opt.RemoveUnsupportedILForBitcode] = value; }
 		}
-#endif
 
 		public bool? InlineIsARM64CallingConvention {
 			get { return values [(int) Opt.InlineIsARM64CallingConvention]; }
 			set { values [(int) Opt.InlineIsARM64CallingConvention] = value; }
 		}
 
-#if MONOTOUCH
 		public bool? SealAndDevirtualize {
 			get { return values [(int) Opt.SealAndDevirtualize]; }
 			set { values [(int) Opt.SealAndDevirtualize] = value; }
 		}
-#endif
 
 		public bool? StaticConstructorBeforeFieldInit {
 			get { return values [(int) Opt.StaticConstructorBeforeFieldInit]; }
@@ -156,28 +153,36 @@ namespace Xamarin.Bundler
 			set { }
 		}
 
-#if MONOTOUCH
 		public bool? ForceRejectedTypesRemoval {
 			get { return values [(int) Opt.ForceRejectedTypesRemoval]; }
 			set { values [(int) Opt.ForceRejectedTypesRemoval] = value; }
 		}
-#endif
 
 		public Optimizations ()
 		{
 			values = new bool? [opt_names.Length];
 		}
 
-		public void Initialize (Application app)
+		public void Initialize (Application app, out List<ProductException> messages)
 		{
+			messages = new List<ProductException> ();
 			// warn if the user asked to optimize something when the optimization can't be applied
 			for (int i = 0; i < values.Length; i++) {
 				if (!values [i].HasValue)
 					continue;
+
+				// check if the optimization is valid for the current platform
+				var valid = valid_platforms [i];
+				if (Array.IndexOf (valid, app.Platform) < 0) {
+					messages.Add (ErrorHelper.CreateWarning (2003, Errors.MT2003_C, opt_names [i], string.Join (", ", valid.Select (v => v.AsString ()))));
+					values [i] = false;
+					continue;
+				}
+
 				switch ((Opt) i) {
 				case Opt.StaticBlockToDelegateLookup:
 					if (app.Registrar != RegistrarMode.Static) {
-						ErrorHelper.Warning (2003, Errors.MT2003,  (values [i].Value ? "" : "-"), opt_names [i]);
+						messages.Add (ErrorHelper.CreateWarning (2003, Errors.MT2003,  (values [i].Value ? "" : "-"), opt_names [i]));
 						values [i] = false;
 						continue;
 					}
@@ -187,23 +192,14 @@ namespace Xamarin.Bundler
 				case Opt.RegisterProtocols:
 				case Opt.RemoveDynamicRegistrar:
 					if (app.Registrar != RegistrarMode.Static) {
-						ErrorHelper.Warning(2003, Errors.MT2003, (values[i].Value ? "" : "-"), opt_names[i]);
+						messages.Add (ErrorHelper.CreateWarning (2003, Errors.MT2003, (values[i].Value ? "" : "-"), opt_names[i]));
 						values [i] = false;
 						continue;
 					}
 					goto default; // also requires the linker
-#if MONOTOUCH
-				case Opt.RemoveUnsupportedILForBitcode:
-					if (app.Platform != Utils.ApplePlatform.WatchOS) {
-						if (!all.HasValue) // Don't show this warning if it was enabled with --optimize=all
-							ErrorHelper.Warning (2003, Errors.MT2003_A, opt_names [(int) Opt.RemoveUnsupportedILForBitcode]);
-						values [i] = false;
-					}
-					break;
-#endif
 				default:
 					if (app.LinkMode == LinkMode.None) {
-						ErrorHelper.Warning (2003, Errors.MT2003_B, (values [i].Value ? "" : "-"), opt_names [i]);
+						messages.Add (ErrorHelper.CreateWarning (2003, Errors.MT2003_B, (values [i].Value ? "" : "-"), opt_names [i]));
 						values [i] = false;
 					}
 					break;
@@ -220,25 +216,25 @@ namespace Xamarin.Bundler
 				DeadCodeElimination = true;
 
 			if (!InlineIsDirectBinding.HasValue) {
-#if MONOTOUCH
-				// By default we always inline calls to NSObject.IsDirectBinding
-				// unless the interpreter is enabled (we can't predict if code will be subclassed)
-				InlineIsDirectBinding = !app.UseInterpreter;
-#else
-				// NSObject.IsDirectBinding is not a safe optimization to apply to XM apps,
-				// because there may be additional code/assemblies we don't know about at build time.
-				InlineIsDirectBinding = false;
-#endif
+				if (app.Platform != ApplePlatform.MacOSX) {
+					// By default we always inline calls to NSObject.IsDirectBinding
+					// unless the interpreter is enabled (we can't predict if code will be subclassed)
+					InlineIsDirectBinding = !app.UseInterpreter;
+				} else {
+					// NSObject.IsDirectBinding is not a safe optimization to apply to XM apps,
+					// because there may be additional code/assemblies we don't know about at build time.
+					InlineIsDirectBinding = false;
+				}
 			}
 
 			// The default behavior for InlineIntPtrSize depends on the assembly being linked,
 			// which means we can't set it to a global constant. It's handled in the OptimizeGeneratedCodeSubStep directly.
 
-#if MONOTOUCH
-			// By default we always inline calls to Runtime.Arch
-			if (!InlineRuntimeArch.HasValue)
-				InlineRuntimeArch = true;
-#endif
+			if (app.Platform != ApplePlatform.MacOSX) {
+				// By default we always inline calls to Runtime.Arch
+				if (!InlineRuntimeArch.HasValue)
+					InlineRuntimeArch = true;
+			}
 
 			// We try to optimize calls to BlockLiteral.SetupBlock if the static registrar is enabled
 			if (!OptimizeBlockLiteralSetupBlock.HasValue) {
@@ -247,11 +243,11 @@ namespace Xamarin.Bundler
 
 			// We will register protocols if the static registrar is enabled and loading assemblies is not possible
 			if (!RegisterProtocols.HasValue) {
-#if MONOTOUCH
-				RegisterProtocols = (app.Registrar == RegistrarMode.Static) && !app.UseInterpreter;
-#else
-				RegisterProtocols = false;
-#endif
+				if (app.Platform != ApplePlatform.MacOSX) {
+					RegisterProtocols = (app.Registrar == RegistrarMode.Static) && !app.UseInterpreter;
+				} else {
+					RegisterProtocols = false;
+				}
 			} else if (app.Registrar != RegistrarMode.Static && RegisterProtocols == true) {
 				RegisterProtocols = false; // we've already shown a warning for this.
 			}
@@ -275,37 +271,38 @@ namespace Xamarin.Bundler
 					// Both the linker and the static registrar are also required
 					RemoveDynamicRegistrar = false;
 				} else {
-#if MONOTOUCH
-					// we can't predict is unknown (at build time) code will require registration (at runtime)
-					if (app.UseInterpreter) {
+					if (app.Platform != ApplePlatform.MacOSX) {
+						// we can't predict is unknown (at build time) code will require registration (at runtime)
+						if (app.UseInterpreter) {
+							RemoveDynamicRegistrar = false;
+						}
+						// We don't have enough information yet to determine if we can remove the dynamic
+						// registrar or not, so let the value stay unset until we do know (when running the linker).
+					} else {
+						// By default disabled for XM apps
 						RemoveDynamicRegistrar = false;
 					}
-					// We don't have enough information yet to determine if we can remove the dynamic
-					// registrar or not, so let the value stay unset until we do know (when running the linker).
-#else
-					// By default disabled for XM apps
-					RemoveDynamicRegistrar = false;
-#endif
 				}
 			}
 
-#if !MONOTOUCH
-			// By default on macOS trim-architectures for Release and not for debug 
-			if (!TrimArchitectures.HasValue)
-				TrimArchitectures = !app.EnableDebug;
-#endif
-
-#if MONOTOUCH
-			if (!RemoveUnsupportedILForBitcode.HasValue) {
-				// By default enabled for watchOS device builds.
-				RemoveUnsupportedILForBitcode = app.Platform == Utils.ApplePlatform.WatchOS && app.IsDeviceBuild;
+			if (app.Platform == ApplePlatform.MacOSX) {
+				// By default on macOS trim-architectures for Release and not for debug 
+				if (!TrimArchitectures.HasValue)
+					TrimArchitectures = !app.EnableDebug;
 			}
 
-			if (!SealAndDevirtualize.HasValue) {
-				// by default run the linker SealerSubStep unless the interpreter is enabled
-				SealAndDevirtualize = !app.UseInterpreter;
+			if (app.Platform != ApplePlatform.MacOSX) {
+				if (!RemoveUnsupportedILForBitcode.HasValue) {
+					// By default enabled for watchOS device builds.
+					RemoveUnsupportedILForBitcode = app.Platform == ApplePlatform.WatchOS && app.IsDeviceBuild;
+				}
+
+				if (!SealAndDevirtualize.HasValue) {
+					// by default run the linker SealerSubStep unless the interpreter is enabled
+					SealAndDevirtualize = !app.UseInterpreter;
+				}
 			}
-#endif
+
 			// By default Runtime.IsARM64CallingConvention inlining is always enabled.
 			if (!InlineIsARM64CallingConvention.HasValue)
 				InlineIsARM64CallingConvention = true;
@@ -317,22 +314,21 @@ namespace Xamarin.Bundler
 			// by default we remove rarely used custom attributes
 			if (!CustomAttributesRemoval.HasValue)
 				CustomAttributesRemoval = true;
-
-			if (Driver.Verbosity > 3)
-				Driver.Log (4, "Enabled optimizations: {0}", string.Join (", ", values.Select ((v, idx) => v == true ? opt_names [idx] : string.Empty).Where ((v) => !string.IsNullOrEmpty (v))));
 		}
 
-		public void Parse (string options)
+		public void Parse (ApplePlatform platform, string options, List<ProductException> messages)
 		{
 			foreach (var option in options.Split (',')) {
-				if (option == null || option.Length < 2)
-					throw ErrorHelper.CreateError (10, Errors.MX0010, $"'--optimize={options}'");
+				if (option == null || option.Length < 2) {
+					messages.Add (ErrorHelper.CreateError (10, Errors.MX0010, $"'--optimize={options}'"));
+					return;
+				}
 
-				ParseOption (option);
+				ParseOption (platform, option, messages);
 			}
 		}
 
-		void ParseOption (string option)
+		void ParseOption (ApplePlatform platform, string option, List<ProductException> messages)
 		{
 			bool enabled;
 			string opt;
@@ -352,10 +348,11 @@ namespace Xamarin.Bundler
 			}
 
 			if (opt == "all") {
-				all = enabled;
 				for (int i = 0; i < values.Length; i++) {
-					if (!string.IsNullOrEmpty (opt_names [i]))
-						values [i] = enabled;
+					var valid = valid_platforms [i];
+					if (Array.IndexOf (valid, platform) < 0)
+						continue; // Don't apply 'all' to optimizations that aren't valid for the current platform
+					values [i] = enabled;
 				}
 			} else {
 				var found = false;
@@ -366,8 +363,24 @@ namespace Xamarin.Bundler
 					values [i] = enabled;
 				}
 				if (!found)
-					ErrorHelper.Warning (132, Errors.MX0132, opt, string.Join (", ", opt_names.Where ((v) => !string.IsNullOrEmpty (v))));
+					messages.Add (ErrorHelper.CreateWarning (132, Errors.MX0132, opt, string.Join (", ", Enum.GetValues (typeof (Opt)).Cast<Opt> ().Where (o => Array.IndexOf (valid_platforms [(int) o], platform) >= 0).Select (o => opt_names [(int) o]))));
 			}
+		}
+
+		public override string ToString ()
+		{
+			var sb = new StringBuilder ();
+			for (var i = 0; i < values.Length; i++) {
+				if (values [i] == null)
+					continue;
+				if (sb.Length > 0)
+					sb.Append (' ');
+				sb.Append (values [i].Value ? "+" : "-");
+				sb.Append (opt_names [i]);
+			}
+			if (sb.Length == 0)
+				return "<default>";
+			return sb.ToString ();
 		}
 	}
 }

--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -72,7 +72,6 @@ namespace Xamarin.Bundler {
 		public List<string> AotOtherArguments = null;
 		public bool? LLVMAsmWriter;
 		public Dictionary<string, string> LLVMOptimizations = new Dictionary<string, string> ();
-		public bool UseInterpreter;
 		public List<string> InterpretedAssemblies = new List<string> ();
 
 		// Xamarin.Mac options available here to minimize ifdefs

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -1301,15 +1301,15 @@ namespace Xamarin.Bundler {
             }
         }
         
-        internal static string MT2003_A {
-            get {
-                return ResourceManager.GetString("MT2003_A", resourceCulture);
-            }
-        }
-        
         internal static string MT2003_B {
             get {
                 return ResourceManager.GetString("MT2003_B", resourceCulture);
+            }
+        }
+        
+        internal static string MT2003_C {
+            get {
+                return ResourceManager.GetString("MT2003_C", resourceCulture);
             }
         }
         

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -1084,15 +1084,20 @@
 		<value>Option '--optimize={0}{1}' will be ignored since the static registrar is not enabled
 		</value>
 	</data>
-	
-	<data name="MT2003_A" xml:space="preserve">
-		<value>Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</value>
-	</data>
+
+	<!-- MT2003_A is not in use anymore -->
 
 	<data name="MT2003_B" xml:space="preserve">
 		<value>Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</value>
+	</data>
+
+	<data name="MT2003_C" xml:space="preserve">
+		<value>Option '--optimize={0}' will be ignored since it's only applicable to {1}.</value>
+		<comment>This is a warning that is shown when the command-line option --optimize=... is not valid for a particular platform
+{0} - The optimization option that is not valid for the current platform
+{1} - The platforms in question, such as 'iOS'.
+		</comment>
 	</data>
 
 	<data name="MX2004" xml:space="preserve">

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -1357,19 +1357,20 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MT2003_A">
-        <source>Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</source>
-        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MT2003_B">
         <source>Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</source>
         <target state="new">Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="MT2003_C">
+        <source>Option '--optimize={0}' will be ignored since it's only applicable to {1}.</source>
+        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to {1}.</target>
+        <note>This is a warning that is shown when the command-line option --optimize=... is not valid for a particular platform
+{0} - The optimization option that is not valid for the current platform
+{1} - The platforms in question, such as 'iOS'.
+		</note>
       </trans-unit>
       <trans-unit id="MT2006">
         <source>Can not load mscorlib.dll from: '{0}'. Please reinstall Xamarin.iOS.

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -1357,19 +1357,20 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MT2003_A">
-        <source>Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</source>
-        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MT2003_B">
         <source>Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</source>
         <target state="new">Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="MT2003_C">
+        <source>Option '--optimize={0}' will be ignored since it's only applicable to {1}.</source>
+        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to {1}.</target>
+        <note>This is a warning that is shown when the command-line option --optimize=... is not valid for a particular platform
+{0} - The optimization option that is not valid for the current platform
+{1} - The platforms in question, such as 'iOS'.
+		</note>
       </trans-unit>
       <trans-unit id="MT2006">
         <source>Can not load mscorlib.dll from: '{0}'. Please reinstall Xamarin.iOS.

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -1357,19 +1357,20 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MT2003_A">
-        <source>Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</source>
-        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MT2003_B">
         <source>Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</source>
         <target state="new">Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="MT2003_C">
+        <source>Option '--optimize={0}' will be ignored since it's only applicable to {1}.</source>
+        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to {1}.</target>
+        <note>This is a warning that is shown when the command-line option --optimize=... is not valid for a particular platform
+{0} - The optimization option that is not valid for the current platform
+{1} - The platforms in question, such as 'iOS'.
+		</note>
       </trans-unit>
       <trans-unit id="MT2006">
         <source>Can not load mscorlib.dll from: '{0}'. Please reinstall Xamarin.iOS.

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -1357,19 +1357,20 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MT2003_A">
-        <source>Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</source>
-        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MT2003_B">
         <source>Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</source>
         <target state="new">Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="MT2003_C">
+        <source>Option '--optimize={0}' will be ignored since it's only applicable to {1}.</source>
+        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to {1}.</target>
+        <note>This is a warning that is shown when the command-line option --optimize=... is not valid for a particular platform
+{0} - The optimization option that is not valid for the current platform
+{1} - The platforms in question, such as 'iOS'.
+		</note>
       </trans-unit>
       <trans-unit id="MT2006">
         <source>Can not load mscorlib.dll from: '{0}'. Please reinstall Xamarin.iOS.

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -1357,19 +1357,20 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MT2003_A">
-        <source>Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</source>
-        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MT2003_B">
         <source>Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</source>
         <target state="new">Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="MT2003_C">
+        <source>Option '--optimize={0}' will be ignored since it's only applicable to {1}.</source>
+        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to {1}.</target>
+        <note>This is a warning that is shown when the command-line option --optimize=... is not valid for a particular platform
+{0} - The optimization option that is not valid for the current platform
+{1} - The platforms in question, such as 'iOS'.
+		</note>
       </trans-unit>
       <trans-unit id="MT2006">
         <source>Can not load mscorlib.dll from: '{0}'. Please reinstall Xamarin.iOS.

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -1357,19 +1357,20 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MT2003_A">
-        <source>Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</source>
-        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MT2003_B">
         <source>Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</source>
         <target state="new">Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="MT2003_C">
+        <source>Option '--optimize={0}' will be ignored since it's only applicable to {1}.</source>
+        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to {1}.</target>
+        <note>This is a warning that is shown when the command-line option --optimize=... is not valid for a particular platform
+{0} - The optimization option that is not valid for the current platform
+{1} - The platforms in question, such as 'iOS'.
+		</note>
       </trans-unit>
       <trans-unit id="MT2006">
         <source>Can not load mscorlib.dll from: '{0}'. Please reinstall Xamarin.iOS.

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -1357,19 +1357,20 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MT2003_A">
-        <source>Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</source>
-        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MT2003_B">
         <source>Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</source>
         <target state="new">Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="MT2003_C">
+        <source>Option '--optimize={0}' will be ignored since it's only applicable to {1}.</source>
+        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to {1}.</target>
+        <note>This is a warning that is shown when the command-line option --optimize=... is not valid for a particular platform
+{0} - The optimization option that is not valid for the current platform
+{1} - The platforms in question, such as 'iOS'.
+		</note>
       </trans-unit>
       <trans-unit id="MT2006">
         <source>Can not load mscorlib.dll from: '{0}'. Please reinstall Xamarin.iOS.

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -1357,19 +1357,20 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MT2003_A">
-        <source>Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</source>
-        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MT2003_B">
         <source>Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</source>
         <target state="new">Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="MT2003_C">
+        <source>Option '--optimize={0}' will be ignored since it's only applicable to {1}.</source>
+        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to {1}.</target>
+        <note>This is a warning that is shown when the command-line option --optimize=... is not valid for a particular platform
+{0} - The optimization option that is not valid for the current platform
+{1} - The platforms in question, such as 'iOS'.
+		</note>
       </trans-unit>
       <trans-unit id="MT2006">
         <source>Can not load mscorlib.dll from: '{0}'. Please reinstall Xamarin.iOS.

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -1357,19 +1357,20 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MT2003_A">
-        <source>Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</source>
-        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MT2003_B">
         <source>Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</source>
         <target state="new">Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="MT2003_C">
+        <source>Option '--optimize={0}' will be ignored since it's only applicable to {1}.</source>
+        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to {1}.</target>
+        <note>This is a warning that is shown when the command-line option --optimize=... is not valid for a particular platform
+{0} - The optimization option that is not valid for the current platform
+{1} - The platforms in question, such as 'iOS'.
+		</note>
       </trans-unit>
       <trans-unit id="MT2006">
         <source>Can not load mscorlib.dll from: '{0}'. Please reinstall Xamarin.iOS.

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -1357,19 +1357,20 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MT2003_A">
-        <source>Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</source>
-        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MT2003_B">
         <source>Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</source>
         <target state="new">Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="MT2003_C">
+        <source>Option '--optimize={0}' will be ignored since it's only applicable to {1}.</source>
+        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to {1}.</target>
+        <note>This is a warning that is shown when the command-line option --optimize=... is not valid for a particular platform
+{0} - The optimization option that is not valid for the current platform
+{1} - The platforms in question, such as 'iOS'.
+		</note>
       </trans-unit>
       <trans-unit id="MT2006">
         <source>Can not load mscorlib.dll from: '{0}'. Please reinstall Xamarin.iOS.

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -1357,19 +1357,20 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MT2003_A">
-        <source>Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</source>
-        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MT2003_B">
         <source>Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</source>
         <target state="new">Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="MT2003_C">
+        <source>Option '--optimize={0}' will be ignored since it's only applicable to {1}.</source>
+        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to {1}.</target>
+        <note>This is a warning that is shown when the command-line option --optimize=... is not valid for a particular platform
+{0} - The optimization option that is not valid for the current platform
+{1} - The platforms in question, such as 'iOS'.
+		</note>
       </trans-unit>
       <trans-unit id="MT2006">
         <source>Can not load mscorlib.dll from: '{0}'. Please reinstall Xamarin.iOS.

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -1357,19 +1357,20 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MT2003_A">
-        <source>Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</source>
-        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MT2003_B">
         <source>Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</source>
         <target state="new">Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="MT2003_C">
+        <source>Option '--optimize={0}' will be ignored since it's only applicable to {1}.</source>
+        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to {1}.</target>
+        <note>This is a warning that is shown when the command-line option --optimize=... is not valid for a particular platform
+{0} - The optimization option that is not valid for the current platform
+{1} - The platforms in question, such as 'iOS'.
+		</note>
       </trans-unit>
       <trans-unit id="MT2006">
         <source>Can not load mscorlib.dll from: '{0}'. Please reinstall Xamarin.iOS.

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -1357,19 +1357,20 @@
 		</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="MT2003_A">
-        <source>Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</source>
-        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to watchOS.
-		</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="MT2003_B">
         <source>Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</source>
         <target state="new">Option '--optimize={0}{1}' will be ignored since linking is disabled
 		</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="MT2003_C">
+        <source>Option '--optimize={0}' will be ignored since it's only applicable to {1}.</source>
+        <target state="new">Option '--optimize={0}' will be ignored since it's only applicable to {1}.</target>
+        <note>This is a warning that is shown when the command-line option --optimize=... is not valid for a particular platform
+{0} - The optimization option that is not valid for the current platform
+{1} - The platforms in question, such as 'iOS'.
+		</note>
       </trans-unit>
       <trans-unit id="MT2006">
         <source>Can not load mscorlib.dll from: '{0}'. Please reinstall Xamarin.iOS.


### PR DESCRIPTION
Refactor the Optimizations class to have no conditionally compiled code, which makes
it re-usable from our dotnet-linker code.

Also return any errors or warnings instead of showing/throwing them, which makes
the caller able to show them using whatever means is easiest for the caller.

One test needed an update to the list of valid optimizations, because we now have
a per-platform map of valid optimizations, instead of just a iOS/tvOS/watchOS vs
macOS split ('remove-unsupported-il-for-bitcode' is only valid for watchOS, and now
we say so, while we previously said it was a valid optimization for iOS and tvOS
as well, even though we'd warn about it and do nothing if you tried to set it).