### PR TITLE
[d16-7-xcode11.7] [tests] Disable currently broken System.Tests.DateTimeTests mono tests

### DIFF
--- a/tests/bcl-test/common-monotouch_corlib_xunit-test.dll.ignore
+++ b/tests/bcl-test/common-monotouch_corlib_xunit-test.dll.ignore
@@ -435,3 +435,6 @@ Platform32:System.Tests.ConvertToBooleanTests.FromDouble
 Platform32:System.Tests.ConvertToBooleanTests.FromSingle
 Platform32:System.Tests.BitConverterArray.ConvertFromFloat(num: 0, expected: [1, 0, 0, 0])
 Platform32:System.Tests.BitConverterSpan.ConvertFromFloat(num: 0, expected: [1, 0, 0, 0])
+
+# https://github.com/xamarin/maccore/issues/2296
+KLASS:System.Tests.DateTimeTests

--- a/tests/bcl-test/macOS-xammac_net_4_5_corlib_xunit-test.dll.ignore
+++ b/tests/bcl-test/macOS-xammac_net_4_5_corlib_xunit-test.dll.ignore
@@ -190,3 +190,6 @@ System.IO.Tests.FileInfo_Exists.UnsharedFileExists
 Expected: True
 Actual:   False   Exception stack traces:   at System.Diagnostics.RemoteExecutorTestBase+RemoteInvokeHandle.Dispose (System.Boolean disposing) [0x0002d] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/external/corefx/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs:241 
 System.IO.Tests.FileInfo_Exists.UnsharedFileExists
+
+# https://github.com/xamarin/maccore/issues/2296
+KLASS:System.Tests.DateTimeTests

--- a/tests/bcl-test/macOSModern-xammac_net_4_5_corlib_xunit-test.dll.ignore
+++ b/tests/bcl-test/macOSModern-xammac_net_4_5_corlib_xunit-test.dll.ignore
@@ -1,2 +1,5 @@
 # blocks test app
 KLASS:System.Threading.ThreadPools.Tests.ThreadPoolTests
+
+# https://github.com/xamarin/maccore/issues/2296
+KLASS:System.Tests.DateTimeTests


### PR DESCRIPTION
Details in https://github.com/mono/mono/issues/16623#issuecomment-678248447

This affects all internal bots running mscorlib xunit tests

Done at type level since it seems we can't ignore individual tests
when unicode/RTL is used in the string output

ref: https://github.com/xamarin/maccore/issues/2296

Backport of #9536.

/cc @dalexsoto @spouliot