### PR TITLE
[tests] Add DYNAMIC_REGISTAR when we're using the dynamic registrar in the .NET version of monotouch-test.

### DIFF
--- a/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
@@ -13,6 +13,7 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <CodesignEntitlements>..\..\Entitlements.plist</CodesignEntitlements>
     <AssetTargetFallback>xamarinios10;$(AssetTargetFallback)</AssetTargetFallback>
+    <DefineConstants Condition="'$(Platform)' == 'iPhoneSimulator'">$(DefineConstants);DYNAMIC_REGISTRAR</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This makes sure the tests know which registrar we're using, and can act accordingly.