### PR TITLE
[registrar] Make the registrar code non-conditional.

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -68,6 +68,11 @@ namespace Xamarin.Bundler {
 		public SymbolMode SymbolMode;
 		public HashSet<string> IgnoredSymbols = new HashSet<string> ();
 
+		public string CompilerPath;
+
+		public Application ContainerApp; // For extensions, this is the containing app
+		public bool IsCodeShared { get; private set; }
+
 		public HashSet<string> Frameworks = new HashSet<string> ();
 		public HashSet<string> WeakFrameworks = new HashSet<string> ();
 

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -86,6 +86,14 @@ namespace Xamarin.Bundler {
 			this.StaticRegistrar = new StaticRegistrar (this);
 		}
 
+		// If this is an app extension, this returns the equivalent (32/64bit) target for the container app.
+		// This may be null (it's possible to build an extension for 32+64bit, and the main app only for 64-bit, for instance.
+		public Target ContainerTarget {
+			get {
+				return App.ContainerApp.Targets.FirstOrDefault ((v) => v.Is32Build == Is32Build);
+			}
+		}
+
 		public Assembly AddAssembly (AssemblyDefinition assembly)
 		{
 			var asm = new Assembly (this, assembly);

--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -48,7 +48,6 @@ namespace Xamarin.Bundler {
 
 		public List<string> Extensions = new List<string> (); // A list of the extensions this app contains.
 		public List<Application> AppExtensions = new List<Application> ();
-		public Application ContainerApp; // For extensions, this is the containing app
 
 		public bool? EnablePie;
 		public bool NativeStrip = true;
@@ -63,10 +62,8 @@ namespace Xamarin.Bundler {
 
 		public bool NoFastSim;
 		public bool NoDevCodeShare;
-		public bool IsCodeShared { get; private set; }
 
 		public string Compiler = string.Empty;
-		public string CompilerPath;
 
 		public string AotArguments = "static,asmonly,direct-icalls,";
 		public List<string> AotOtherArguments = null;

--- a/tools/mtouch/Target.mtouch.cs
+++ b/tools/mtouch/Target.mtouch.cs
@@ -52,14 +52,6 @@ namespace Xamarin.Bundler
 		// If the assemblies were symlinked.
 		public bool Symlinked;
 
-		// If this is an app extension, this returns the equivalent (32/64bit) target for the container app.
-		// This may be null (it's possible to build an extension for 32+64bit, and the main app only for 64-bit, for instance.
-		public Target ContainerTarget {
-			get {
-				return App.ContainerApp.Targets.FirstOrDefault ((v) => v.Is32Build == Is32Build);
-			}
-		}
-
 		// This is a list of all the architectures we need to build, which may include any architectures
 		// in any extensions (but not the main app).
 		List<Abi> all_architectures;


### PR DESCRIPTION
Some appextension mtouch code had to be moved to shared code. This code is currently
only used for iOS/tvOS/watchOS, but it will eventually be applicable to macOS as
well.

This makes it possible to re-use the registrar code in dotnet-linker.