### PR TITLE
[xcode12] [Foundation] Fix NSUrl's implicit Uri operators. Fixes #9607.

### DIFF
--- a/src/Foundation/NSUrl.cs
+++ b/src/Foundation/NSUrl.cs
@@ -47,10 +47,10 @@ namespace Foundation {
 		// Converts from an NSURL to a System.Uri
 		public static implicit operator Uri (NSUrl url)
 		{
-			if (url.RelativePath == url.Path)
-				return new Uri (url.AbsoluteString, UriKind.Absolute);
+			if (Uri.TryCreate (url.AbsoluteString, UriKind.Absolute, out var uri))
+				return uri;
 			else
-				return new Uri (url.RelativePath, UriKind.Relative);
+				return new Uri (url.AbsoluteString, UriKind.Relative);
 		}
 
 		public static implicit operator NSUrl (Uri uri)
@@ -58,7 +58,7 @@ namespace Foundation {
 			if (uri.IsAbsoluteUri)
 				return new NSUrl (uri.AbsoluteUri);
 			else
-				return new NSUrl (uri.PathAndQuery);
+				return new NSUrl (uri.OriginalString);
 		}
 
 		public static NSUrl FromFilename (string url)

--- a/tests/monotouch-test/Foundation/UrlTest.cs
+++ b/tests/monotouch-test/Foundation/UrlTest.cs
@@ -319,5 +319,21 @@ namespace MonoTouchFixtures.Foundation {
 			using (var url2 = NSUrl.FromString ("http://www.xamarin.com/foo"))
 				Assert.AreEqual (url1 != url2, !url1.IsEqual (url2));
 		}
+
+		[TestCase ("http://microsoft.com/", UriKind.Absolute)]
+		[TestCase ("https://microsoft.com/", UriKind.Absolute)]
+		[TestCase ("https://microsoft.com/some/path", UriKind.Absolute)]
+		[TestCase ("https://microsoft.com/page?value=foo", UriKind.Absolute)]
+		[TestCase ("relative", UriKind.Relative)]
+		[TestCase ("relative/to/some/page", UriKind.Relative)]
+		[TestCase ("relative?value=foo", UriKind.Relative)]
+		public void ImplicitOperatorRoundTrip (string value, UriKind kind)
+		{
+			var nsurl = new NSUrl (value);
+			Assert.AreEqual (nsurl.ToString (), ((NSUrl) (Uri) nsurl).ToString (), "RoundTrip NSUrl");
+
+			var url = new Uri (value, kind);
+			Assert.AreEqual (url.ToString (), ((Uri) (NSUrl) url).ToString (), "RoundTrip Uri");
+		}
 	}
 }


### PR DESCRIPTION
Calling Uri.PathAndQuery is not allowed on a relative Uri, which made the
previous Uri -> NSUrl implicit operator always throw if given a relative
NSUrl.

So I fixed that, added several tests, and found another issue (it turns out
that 'url.RelativePath == url.Path' is not a reliable way to detect absolute
urls, because it's true for relative urls as well) and fixed that too.

Fixes https://github.com/xamarin/xamarin-macios/issues/9607.

Backport of #9610.

/cc @rolfbjarne 