### PR TITLE
[xcode12][mediaplayer] Fix MPMusicPlayerController NowPlayingItem on recent iOS versions

### DIFF
--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -934,7 +934,9 @@ namespace Registrar {
 					UnlockRegistrar ();
 			}
 
-			throw ErrorHelper.CreateError (4143, "The ObjectiveC class '{0}' could not be registered, it does not seem to derive from any known ObjectiveC class (including NSObject).", Marshal.PtrToStringAuto (Class.class_getName (original_class)));
+			if (throw_on_error)
+				throw ErrorHelper.CreateError (4143, "The ObjectiveC class '{0}' could not be registered, it does not seem to derive from any known ObjectiveC class (including NSObject).", Marshal.PtrToStringAuto (Class.class_getName (original_class)));
+			return null;
 		}
 
 		bool RegisterMethod (ObjCMethod method)

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1330,7 +1330,7 @@ namespace ObjCRuntime {
 			return ConstructNSObject<NSObject> (ptr, target_type, MissingCtorResolution.ThrowConstructor1NotFound);
 		}
 
-		static Type LookupINativeObjectImplementation (IntPtr ptr, Type target_type, Type implementation = null)
+		static Type LookupINativeObjectImplementation (IntPtr ptr, Type target_type, Type implementation = null, bool forced_type = false)
 		{
 			if (!typeof (NSObject).IsAssignableFrom (target_type)) {
 				// If we're not expecting an NSObject, we can't do a dynamic lookup of the type of ptr,
@@ -1347,7 +1347,8 @@ namespace ObjCRuntime {
 					if (implementation == null)
 						implementation = target_type;
 				} else {
-					var runtime_type = Class.Lookup (p);
+					// only throw if we're not forcing the type we want to expose
+					var runtime_type = Class.Lookup (p, throw_on_error: !forced_type);
 					// Check if the runtime type can actually be used.
 					if (target_type.IsAssignableFrom (runtime_type)) {
 						implementation = runtime_type;
@@ -1436,7 +1437,7 @@ namespace ObjCRuntime {
 			}
 
 			// Lookup the ObjC type of the ptr and see if we can use it.
-			var implementation = LookupINativeObjectImplementation (ptr, typeof (T));
+			var implementation = LookupINativeObjectImplementation (ptr, typeof (T), forced_type: forced_type);
 
 			if (implementation.IsSubclassOf (typeof (NSObject))) {
 				if (o != null && !forced_type) {

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -1206,6 +1206,7 @@ namespace MediaPlayer {
 		[Export ("indexOfNowPlayingItem")]
 		nuint IndexOfNowPlayingItem { get; }
 
+		[ForcedType]
 		[Export ("nowPlayingItem", ArgumentSemantic.Copy), NullAllowed]
 		MPMediaItem NowPlayingItem { get; set; }
 


### PR DESCRIPTION
Rolf nailed the issue in https://github.com/xamarin/xamarin-macios/issues/9578#issuecomment-688409802
> The problem is that iOS returns an instance of a private type (_MPMusicPlayerMediaItemProxy) which is an NSProxy subclass, and currently we don't support NSProxy.

https://github.com/rolfbjarne/xamarin-macios/commit/873a1e1 was on the
right track but it turns out `[ForcedType]` on properties don't need, nor
work (same generated code), with `return:`.

Inside `DynamicRegistrar.cs` the method
```csharp
public Type Lookup (IntPtr @class, bool throw_on_error)
```
did not respect (was unused) the `throw_on_error`. That made it
impossible to force the type to the pointer we got.

In `Runtime.cs` the method `LookupINativeObjectImplementation` must also
be able to work without an exception (from the `Lookup`) at least when we
want to force the type.

backport of https://github.com/xamarin/xamarin-macios/pull/9604
reference: https://github.com/xamarin/xamarin-macios/issues/9578