### PR TITLE
[d16-8] [Bug] AVAudioSourceNodeRenderHandler delegate is incorrectly bound

### DIFF
--- a/src/AVFoundation/AVCompat.cs
+++ b/src/AVFoundation/AVCompat.cs
@@ -11,17 +11,19 @@ namespace AVFoundation {
 #if !XAMCORE_4_0
 	public delegate int AVAudioSourceNodeRenderHandler (bool isSilence, AudioToolbox.AudioTimeStamp timestamp, uint frameCount, ref AudioToolbox.AudioBuffers outputData);
 
+	partial class AVAudioNode {
+		internal AVAudioNode() {}
+	}
+
 	partial class AVAudioSourceNode {
 		[Obsolete("Use 'AVAudioSourceNode (AVAudioSourceNodeRenderHandler2)' instead.")]
 		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler renderHandler)
-			: base (NSObjectFlag.Empty)
 		{
 			throw new InvalidOperationException ("Do not use this constructor. Use the 'AVAudioSourceNode (AVAudioSourceNodeRenderHandler2)' constructor instead.");
 		}
 
 		[Obsolete("Use 'AVAudioSourceNode (AVAudioFormat, AVAudioSourceNodeRenderHandler2)' instead.")]
 		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler)
-			: base (NSObjectFlag.Empty)
 		{
 			throw new InvalidOperationException ("Do not use this constructor. Use the 'AVAudioSourceNode (AVAudioFormat, AVAudioSourceNodeRenderHandler2)' constructor instead.");
 		}

--- a/src/AVFoundation/AVCompat.cs
+++ b/src/AVFoundation/AVCompat.cs
@@ -169,6 +169,22 @@ namespace AVFoundation {
 		}
 	}
 
+	public delegate int AVAudioSourceNodeRenderHandler (bool isSilence, AudioToolbox.AudioTimeStamp timestamp, uint frameCount, ref AudioToolbox.AudioBuffers outputData);
+
+	partial class AVAudioSourceNode {
+		[Obsolete("Use 'AVAudioSourceNode (AVAudioSourceNodeRenderHandler2)' instead.")]
+		public IntPtr Constructor (AVAudioSourceNodeRenderHandler renderHandler)
+		{
+			throw new NotImplementedException ();
+		}
+
+		[Obsolete("Use 'AVAudioSourceNode (AVAudioFormat, AVAudioSourceNodeRenderHandler2)' instead.")]
+		public IntPtr Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+
 #if !MONOMAC
 	partial class AVSampleBufferAudioRenderer
 	{

--- a/src/AVFoundation/AVCompat.cs
+++ b/src/AVFoundation/AVCompat.cs
@@ -173,13 +173,15 @@ namespace AVFoundation {
 
 	partial class AVAudioSourceNode {
 		[Obsolete("Use 'AVAudioSourceNode (AVAudioSourceNodeRenderHandler2)' instead.")]
-		public IntPtr Constructor (AVAudioSourceNodeRenderHandler renderHandler)
+		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler renderHandler)
+			: base (NSObjectFlag.Empty)
 		{
 			throw new NotImplementedException ();
 		}
 
 		[Obsolete("Use 'AVAudioSourceNode (AVAudioFormat, AVAudioSourceNodeRenderHandler2)' instead.")]
-		public IntPtr Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler)
+		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler)
+			: base (NSObjectFlag.Empty)
 		{
 			throw new NotImplementedException ();
 		}

--- a/src/AVFoundation/AVCompat.cs
+++ b/src/AVFoundation/AVCompat.cs
@@ -1,7 +1,5 @@
 // Copyright 2014-2016 Xamarin Inc. All rights reserved.
 
-#if !WATCH
-
 using System;
 using System.ComponentModel;
 using OpenTK;
@@ -10,6 +8,26 @@ using Foundation;
 using ObjCRuntime;
 
 namespace AVFoundation {
+#if !XAMCORE_4_0
+	public delegate int AVAudioSourceNodeRenderHandler (bool isSilence, AudioToolbox.AudioTimeStamp timestamp, uint frameCount, ref AudioToolbox.AudioBuffers outputData);
+
+	partial class AVAudioSourceNode {
+		[Obsolete("Use 'AVAudioSourceNode (AVAudioSourceNodeRenderHandler2)' instead.")]
+		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler renderHandler)
+			: base (NSObjectFlag.Empty)
+		{
+			throw new InvalidOperationException ("Do not use this constructor. Use the 'AVAudioSourceNode (AVAudioSourceNodeRenderHandler2)' constructor instead.");
+		}
+
+		[Obsolete("Use 'AVAudioSourceNode (AVAudioFormat, AVAudioSourceNodeRenderHandler2)' instead.")]
+		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler)
+			: base (NSObjectFlag.Empty)
+		{
+			throw new InvalidOperationException ("Do not use this constructor. Use the 'AVAudioSourceNode (AVAudioFormat, AVAudioSourceNodeRenderHandler2)' constructor instead.");
+		}
+	}
+#endif // !XAMCORE_4_0
+#if !WATCH
 #if MONOMAC && !XAMCORE_4_0
 	[Obsolete ("This API is not available on this platform.")]
 	public partial class AVCaptureDataOutputSynchronizer : NSObject
@@ -166,24 +184,6 @@ namespace AVFoundation {
 		[Obsolete ("Please use the static 'SharedInstance' property as this type is not meant to be created.")]
 		public AVAudioUnitComponentManager ()
 		{
-		}
-	}
-
-	public delegate int AVAudioSourceNodeRenderHandler (bool isSilence, AudioToolbox.AudioTimeStamp timestamp, uint frameCount, ref AudioToolbox.AudioBuffers outputData);
-
-	partial class AVAudioSourceNode {
-		[Obsolete("Use 'AVAudioSourceNode (AVAudioSourceNodeRenderHandler2)' instead.")]
-		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler renderHandler)
-			: base (NSObjectFlag.Empty)
-		{
-			throw new NotImplementedException ();
-		}
-
-		[Obsolete("Use 'AVAudioSourceNode (AVAudioFormat, AVAudioSourceNodeRenderHandler2)' instead.")]
-		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler)
-			: base (NSObjectFlag.Empty)
-		{
-			throw new NotImplementedException ();
 		}
 	}
 
@@ -514,6 +514,5 @@ namespace AVFoundation {
 
 #endif // TVOS
 #endif // !XAMCORE_4_0
+#endif // !WATCH
 }
-
-#endif

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -13513,7 +13513,7 @@ namespace AVFoundation {
 		CMFormatDescription ReplacementFormatDescription { get; }
 	}
 
-	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler (bool isSilence, AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
+	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler (ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
 
 	[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 	[BaseType (typeof(AVAudioNode))]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -13513,12 +13513,12 @@ namespace AVFoundation {
 		CMFormatDescription ReplacementFormatDescription { get; }
 	}
 
-	    delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler2 (ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
+	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler2 (ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
 
-	    [Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
-	    [BaseType (typeof(AVAudioNode))]
-	    [DisableDefaultCtor]
-	    interface AVAudioSourceNode : AVAudioMixing {
+	[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+	[BaseType (typeof(AVAudioNode))]
+	[DisableDefaultCtor]
+	interface AVAudioSourceNode : AVAudioMixing {
 		[Export ("initWithRenderBlock:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (AVAudioSourceNodeRenderHandler2 renderHandler);
@@ -13526,7 +13526,7 @@ namespace AVFoundation {
 		[Export ("initWithFormat:renderBlock:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler2 renderHandler);
-	    }
+	}	
 
 	delegate int AVAudioSinkNodeReceiverHandler (AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers inputData);
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -13512,20 +13512,31 @@ namespace AVFoundation {
 		[Export ("replacementFormatDescription")]
 		CMFormatDescription ReplacementFormatDescription { get; }
 	}
-
+#if XAMCORE_4_0
+	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler (ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
+#else
+	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler (bool isSilence, AudioToolbox.AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
 	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler2 (ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
-
+#endif
 	[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 	[BaseType (typeof(AVAudioNode))]
 	[DisableDefaultCtor]
 	interface AVAudioSourceNode : AVAudioMixing {
 		[Export ("initWithRenderBlock:")]
 		[DesignatedInitializer]
+#if XAMCORE_4_0
+		IntPtr Constructor (AVAudioSourceNodeRenderHandler renderHandler);
+#else
 		IntPtr Constructor (AVAudioSourceNodeRenderHandler2 renderHandler);
+#endif
 
 		[Export ("initWithFormat:renderBlock:")]
 		[DesignatedInitializer]
+#if XAMCORE_4_0
+                IntPtr Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler);
+#else
 		IntPtr Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler2 renderHandler);
+#endif
 	}
 
 	delegate int AVAudioSinkNodeReceiverHandler (AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers inputData);

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -13526,7 +13526,7 @@ namespace AVFoundation {
 		[Export ("initWithFormat:renderBlock:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler2 renderHandler);
-	}	
+	}
 
 	delegate int AVAudioSinkNodeReceiverHandler (AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers inputData);
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -13533,7 +13533,7 @@ namespace AVFoundation {
 		[Export ("initWithFormat:renderBlock:")]
 		[DesignatedInitializer]
 #if XAMCORE_4_0
-                IntPtr Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler);
+		IntPtr Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler);
 #else
 		IntPtr Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler2 renderHandler);
 #endif

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -13513,20 +13513,20 @@ namespace AVFoundation {
 		CMFormatDescription ReplacementFormatDescription { get; }
 	}
 
-	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler (ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
+	    delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler2 (ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
 
-	[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
-	[BaseType (typeof(AVAudioNode))]
-	[DisableDefaultCtor]
-	interface AVAudioSourceNode : AVAudioMixing {
+	    [Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+	    [BaseType (typeof(AVAudioNode))]
+	    [DisableDefaultCtor]
+	    interface AVAudioSourceNode : AVAudioMixing {
 		[Export ("initWithRenderBlock:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AVAudioSourceNodeRenderHandler renderHandler);
+		IntPtr Constructor (AVAudioSourceNodeRenderHandler2 renderHandler);
 
 		[Export ("initWithFormat:renderBlock:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler);
-	}
+		IntPtr Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler2 renderHandler);
+	    }
 
 	delegate int AVAudioSinkNodeReceiverHandler (AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers inputData);
 


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/9538

Header:

```
typedef OSStatus (^AVAudioSourceNodeRenderBlock)(BOOL *isSilence, const AudioTimeStamp *timestamp, AVAudioFrameCount frameCount, AudioBufferList *outputData) API_AVAILABLE(macos(10.15), ios(13.0), tvos(13.0), watchos(6.0)) ;
```

Original delegate binding:

```
delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler (bool isSilence, AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
```

Verified fix locally.

Should be back ported to d16-8.


Backport of #9565.

/cc @whitneyschmidt 