### PR TITLE
Improve the layout of the table of old packages in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,24 +31,16 @@ The team also [strongly recommends](https://docs.microsoft.com/xamarin/ios/troub
 
 However, we provide links to older Xamarin.iOS and Mac packages for macOS downgrades and build machine configuration.
 
-| Platform        | Link |
-|-----------------|--------|
-| Xamarin.iOS d16.7 | [13.20.2.2](https://download.visualstudio.microsoft.com/download/pr/b089be2f-932a-40ab-904b-b626f9e6427b/186357848bab70642927eaf17410a051/xamarin.ios-13.20.2.2.pkg) |
-| Xamarin.Mac d16.7 | [6.20.2.2](https://download.visualstudio.microsoft.com/download/pr/b089be2f-932a-40ab-904b-b626f9e6427b/6aad9f3ea4fbfb92ce267e0f60b34797/xamarin.mac-6.20.2.2.pkg) |
-| Xamarin.iOS d16.6 | [13.18.2.1](https://download.visualstudio.microsoft.com/download/pr/68ffa29a-6a5b-41f7-af7b-506ddcf4bbfc/35159cac3be1910e87309c0094a8ec8a/xamarin.ios-13.18.2.1.pkg) |
-| Xamarin.Mac d16.6 | [6.18.2.1](https://download.visualstudio.microsoft.com/download/pr/68ffa29a-6a5b-41f7-af7b-506ddcf4bbfc/9e1be52d9bff3599b796cfbab3f3d463/xamarin.mac-6.18.2.1.pkg) |
-| Xamarin.iOS d16.5 | [13.16.0.13](https://download.visualstudio.microsoft.com/download/pr/fb168f8a-b44e-4582-8147-eefdf1562110/0a25988a5b9f502f4facd875c1b2072b/xamarin.ios-13.16.0.13.pkg) |
-| Xamarin.Mac d16.5 | [6.16.0.13](https://download.visualstudio.microsoft.com/download/pr/fb168f8a-b44e-4582-8147-eefdf1562110/30f09915995da752f30f432760e4ddbe/xamarin.mac-6.16.0.13.pkg) |
-| Xamarin.iOS d16.4 | [13.10.0.21](https://download.visualstudio.microsoft.com/download/pr/16ae715b-ae37-47be-a5dc-c7abd236fbef/185ba3460c06e3fa2e7aa4609e63d57a/xamarin.ios-13.10.0.21.pkg) |
-| Xamarin.Mac d16.4 | [6.10.0.21](https://download.visualstudio.microsoft.com/download/pr/16ae715b-ae37-47be-a5dc-c7abd236fbef/90d9e8f056c51a45d9e649ec81b38126/xamarin.mac-6.10.0.21.pkg) |
-| Xamarin.iOS d16.3 | [13.6.0.12](https://download.visualstudio.microsoft.com/download/pr/ae8e9044-57e0-4500-bc58-6fe41d5f711d/71a1316dcca8c4cbcfb070aff9f738d2/xamarin.ios-13.6.0.12.pkg) |
-| Xamarin.Mac d16.3 | [6.6.0.12](https://download.visualstudio.microsoft.com/download/pr/c66cc733-8129-4551-8f59-4483f636931b/52194acdeb070158d49fe14cd1453062/xamarin.mac-6.6.0.12.pkg) |
-| Xamarin.iOS d16.2 | [12.14.0.114](https://download.visualstudio.microsoft.com/download/pr/cce6ebe1-dd65-472c-9d01-d83561f341bd/a6ab5d414cdb3e85c9283a954e182b9d/xamarin.ios-12.14.0.114.pkg) |
-| Xamarin.Mac d16.2 | [5.14.0.114](https://download.visualstudio.microsoft.com/download/pr/9753ad10-d060-4427-880b-b4e0288878e1/140f9d84b62b3c57f00279f2b32360ce/xamarin.mac-5.14.0.114.pkg) |
-| Xamarin.iOS d16.1 | [12.10.0.157](https://download.visualstudio.microsoft.com/download/pr/87d63fb1-c713-4c5f-b2c8-ae309a3b829c/91c05c2d5587f8f7efc5f7959f55eddf/xamarin.ios-12.10.0.157.pkg) |
-| Xamarin.Mac d16.1 | [5.10.0.157](https://download.visualstudio.microsoft.com/download/pr/fdaee266-06e3-46f0-bd67-5081279dd1cf/577697f6fbddd9542d1c862a8603d362/xamarin.mac-5.10.0.157.pkg) |
-| Xamarin.iOS d16.0 | [12.8.0.2](https://download.visualstudio.microsoft.com/download/pr/1fdd2124-10f8-40f3-9d9a-101c7953aa9d/5aa052be7fd1de213a6b7a8a96bea72b/xamarin.ios-12.8.0.2.pkg) |
-| Xamarin.Mac d16.0 | [5.8.0.0](https://download.visualstudio.microsoft.com/download/pr/a5bac460-0a54-4fea-9010-464b1ef8ee6f/9ccfa18c4ed093ee879c02a321965521/xamarin.mac-5.8.0.0.pkg) |
+| Version | Xamarin.iOS       | Xamarin.Mac       |
+|---------|-------------------|-------------------|
+| d16.7   | [13.20.2.2][15]   | [6.20.2.2][16]    |
+| d16.6   | [13.18.2.1][13]   | [6.18.2.1][14]    |
+| d16.5   | [13.16.0.13][11]  | [6.16.0.13][12]   |
+| d16.4   | [13.10.0.21][9]   | [6.10.0.21][10]   |
+| d16.3   | [13.6.0.12][7]    | [6.6.0.12][8]     |
+| d16.2   | [12.14.0.114][5]  | [5.14.0.114][6]   |
+| d16.1   | [12.10.0.157][3]  | [5.10.0.157][4]   |
+| d16.0   | [12.8.0.2][1]     | [5.8.0.0][2]      |
 
 ## Feedback
 
@@ -64,3 +56,20 @@ However, we provide links to older Xamarin.iOS and Mac packages for macOS downgr
 
 Copyright (c) .NET Foundation Contributors. All rights reserved.
 Licensed under the [MIT](https://github.com/xamarin/xamarin-macios/blob/main/LICENSE) License.
+
+[1]: https://download.visualstudio.microsoft.com/download/pr/1fdd2124-10f8-40f3-9d9a-101c7953aa9d/5aa052be7fd1de213a6b7a8a96bea72b/xamarin.ios-12.8.0.2.pkg
+[2]: https://download.visualstudio.microsoft.com/download/pr/a5bac460-0a54-4fea-9010-464b1ef8ee6f/9ccfa18c4ed093ee879c02a321965521/xamarin.mac-5.8.0.0.pkg
+[3]: https://download.visualstudio.microsoft.com/download/pr/87d63fb1-c713-4c5f-b2c8-ae309a3b829c/91c05c2d5587f8f7efc5f7959f55eddf/xamarin.ios-12.10.0.157.pkg
+[4]: https://download.visualstudio.microsoft.com/download/pr/fdaee266-06e3-46f0-bd67-5081279dd1cf/577697f6fbddd9542d1c862a8603d362/xamarin.mac-5.10.0.157.pkg
+[5]: https://download.visualstudio.microsoft.com/download/pr/cce6ebe1-dd65-472c-9d01-d83561f341bd/a6ab5d414cdb3e85c9283a954e182b9d/xamarin.ios-12.14.0.114.pkg
+[6]: https://download.visualstudio.microsoft.com/download/pr/9753ad10-d060-4427-880b-b4e0288878e1/140f9d84b62b3c57f00279f2b32360ce/xamarin.mac-5.14.0.114.pkg
+[7]: https://download.visualstudio.microsoft.com/download/pr/ae8e9044-57e0-4500-bc58-6fe41d5f711d/71a1316dcca8c4cbcfb070aff9f738d2/xamarin.ios-13.6.0.12.pkg
+[8]: https://download.visualstudio.microsoft.com/download/pr/c66cc733-8129-4551-8f59-4483f636931b/52194acdeb070158d49fe14cd1453062/xamarin.mac-6.6.0.12.pkg
+[9]: https://download.visualstudio.microsoft.com/download/pr/16ae715b-ae37-47be-a5dc-c7abd236fbef/185ba3460c06e3fa2e7aa4609e63d57a/xamarin.ios-13.10.0.21.pkg
+[10]: https://download.visualstudio.microsoft.com/download/pr/16ae715b-ae37-47be-a5dc-c7abd236fbef/90d9e8f056c51a45d9e649ec81b38126/xamarin.mac-6.10.0.21.pkg
+[11]: https://download.visualstudio.microsoft.com/download/pr/fb168f8a-b44e-4582-8147-eefdf1562110/0a25988a5b9f502f4facd875c1b2072b/xamarin.ios-13.16.0.13.pkg
+[12]: https://download.visualstudio.microsoft.com/download/pr/fb168f8a-b44e-4582-8147-eefdf1562110/30f09915995da752f30f432760e4ddbe/xamarin.mac-6.16.0.13.pkg
+[13]: https://download.visualstudio.microsoft.com/download/pr/68ffa29a-6a5b-41f7-af7b-506ddcf4bbfc/35159cac3be1910e87309c0094a8ec8a/xamarin.ios-13.18.2.1.pkg
+[14]: https://download.visualstudio.microsoft.com/download/pr/68ffa29a-6a5b-41f7-af7b-506ddcf4bbfc/9e1be52d9bff3599b796cfbab3f3d463/xamarin.mac-6.18.2.1.pkg
+[15]: https://download.visualstudio.microsoft.com/download/pr/b089be2f-932a-40ab-904b-b626f9e6427b/186357848bab70642927eaf17410a051/xamarin.ios-13.20.2.2.pkg
+[16]: https://download.visualstudio.microsoft.com/download/pr/b089be2f-932a-40ab-904b-b626f9e6427b/6aad9f3ea4fbfb92ce267e0f60b34797/xamarin.mac-6.20.2.2.pkg


### PR DESCRIPTION
Old layout:

<img width="304" alt="Screen Shot 2020-09-14 at 14 21 47" src="https://user-images.githubusercontent.com/249268/93085305-aeb6d880-f695-11ea-861c-afb6ef3c07ce.png">

New layout:

<img width="357" alt="Screen Shot 2020-09-14 at 14 21 38" src="https://user-images.githubusercontent.com/249268/93085299-aced1500-f695-11ea-8cbd-16fa88f0544a.png">
