### PR TITLE
[xcode12] Rename master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository is where we do development for the Xamarin.iOS and Xamarin.Mac S
 If you are interested in fixing issues and contributing directly to the code base, please see the document [How to Contribute](https://github.com/xamarin/xamarin-macios/wiki/How-to-Contribute), which covers the following:
 
 - How to [build and run](https://github.com/xamarin/xamarin-macios/wiki/Build-&-Run) from source
-- The [development workflow](https://github.com/xamarin/xamarin-macios/wiki/How-to-Contribute#work-branches), including [debugging](https://github.com/xamarin/xamarin-macios/wiki/Build-&-Run#debugging-applications-from-source) and [running tests](https://github.com/xamarin/xamarin-macios/blob/master/tests/README.md)
+- The [development workflow](https://github.com/xamarin/xamarin-macios/wiki/How-to-Contribute#work-branches), including [debugging](https://github.com/xamarin/xamarin-macios/wiki/Build-&-Run#debugging-applications-from-source) and [running tests](https://github.com/xamarin/xamarin-macios/blob/main/tests/README.md)
 - [Coding Guidelines](https://github.com/xamarin/xamarin-macios/wiki/How-to-Contribute#coding-guidelines)
 - [Submitting pull requests](https://github.com/xamarin/xamarin-macios/wiki/How-to-Contribute#pull-requests)
 
@@ -36,4 +36,4 @@ If you are interested in fixing issues and contributing directly to the code bas
 ## License
 
 Copyright (c) .NET Foundation Contributors. All rights reserved.
-Licensed under the [MIT](https://github.com/xamarin/xamarin-macios/blob/master/LICENSE) License.
+Licensed under the [MIT](https://github.com/xamarin/xamarin-macios/blob/main/LICENSE) License.

--- a/docs/website/binding_objc_libs.md
+++ b/docs/website/binding_objc_libs.md
@@ -34,7 +34,7 @@ Mac bindings are very similar.
 **Sample Code for iOS**
 
 You can use the
-[iOS Binding Sample](https://github.com/xamarin/monotouch-samples/tree/master/BindingSample)
+[iOS Binding Sample](https://github.com/xamarin/monotouch-samples/tree/main/BindingSample)
 project to experiment with bindings.
 
 <a name="Getting_Started" />

--- a/docs/website/binding_types_reference_guide.md
+++ b/docs/website/binding_types_reference_guide.md
@@ -2083,7 +2083,7 @@ If the value of `doAdd` is true, then the parameter is added to the
 `listName`. You must declare this backing field in your complementary partial
 class to the API.
 
-For an example see [foundation.cs](https://github.com/mono/maccore/blob/master/src/foundation.cs) and [NSNotificationCenter.cs](https://github.com/mono/maccore/blob/master/src/Foundation/NSNotificationCenter.cs)
+For an example see [foundation.cs](https://github.com/mono/maccore/blob/main/src/foundation.cs) and [NSNotificationCenter.cs](https://github.com/mono/maccore/blob/main/src/Foundation/NSNotificationCenter.cs)
 
 
 ### TransientAttribute
@@ -2309,7 +2309,7 @@ public class LinkWithAttribute : Attribute {
 ```
 
 This attribute is applied at the assembly level, for example, this is what
-the [CorePlot bindings](https://github.com/mono/monotouch-bindings/tree/master/CorePlot) use:
+the [CorePlot bindings](https://github.com/mono/monotouch-bindings/tree/main/CorePlot) use:
 
 ```csharp
 [assembly: LinkWith ("libCorePlot-CocoaTouch.a", LinkTarget.ArmV7 | LinkTarget.ArmV7s | LinkTarget.Simulator, Frameworks = "CoreGraphics QuartzCore", ForceLoad = true)]

--- a/docs/website/generator-errors.md
+++ b/docs/website/generator-errors.md
@@ -4,9 +4,9 @@ title: "Xamarin.iOS/Xamarin.Mac binding errors"
 dateupdated: 2017-06-26
 ---
 
-[//]: # (The original file resides under https://github.com/xamarin/xamarin-macios/tree/master/docs/website/)
+[//]: # (The original file resides under https://github.com/xamarin/xamarin-macios/tree/main/docs/website/)
 [//]: # (This allows all contributors (including external) to submit, using a PR, updates to the documentation that match the tools changes)
-[//]: # (Modifications outside of xamarin-macios/master will be lost on future updates)
+[//]: # (Modifications outside of xamarin-macios/main will be lost on future updates)
 
 # BI0xxx: binding error messages
 

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -17,7 +17,7 @@ E.g. parameters, environment, missing tools.
 
 <!--
  MT0xxx mtouch itself, e.g. parameters, environment (e.g. missing tools)
- https://github.com/xamarin/xamarin-macios/blob/master/tools/mtouch/error.cs
+ https://github.com/xamarin/xamarin-macios/blob/main/tools/mtouch/error.cs
 	-->
 
 <a name="MT0000" />
@@ -676,7 +676,7 @@ For further information see bug #[51634](https://bugzilla.xamarin.com/show_bug.c
 
 ### MT0112: Native code sharing has been disabled because *
 
-There are multiple reasons [native code sharing](https://github.com/xamarin/xamarin-macios/blob/master/docs/code-sharing-with-user-frameworks.md) can be disabled:
+There are multiple reasons [native code sharing](https://github.com/xamarin/xamarin-macios/blob/main/docs/code-sharing-with-user-frameworks.md) can be disabled:
 
 * because the container app's deployment target is earlier than iOS 8.0 (it's *)).
 
@@ -694,7 +694,7 @@ Native code sharing requires is not supported for projects that use custom xml d
 
 ### MT0113: Native code sharing has been disabled for the extension '*' because *.
 
-There are multiple reasons [native code sharing](https://github.com/xamarin/xamarin-macios/blob/master/docs/code-sharing-with-user-frameworks.md) can be disabled:
+There are multiple reasons [native code sharing](https://github.com/xamarin/xamarin-macios/blob/main/docs/code-sharing-with-user-frameworks.md) can be disabled:
 
 * because the bitcode options differ between the container app (\*) and the extension (\*).
 

--- a/docs/website/optimizations.md
+++ b/docs/website/optimizations.md
@@ -775,4 +775,4 @@ The default behavior can be overridden by passing
 `--optimize=[+|-]force-rejected-types-removal` to `mtouch`.
 
 The exact list of types might change over time and is best read directly from
-the [source code](https://github.com/xamarin/xamarin-macios/blob/master/tools/linker/RemoveRejectedTypesStep.cs).
+the [source code](https://github.com/xamarin/xamarin-macios/blob/main/tools/linker/RemoveRejectedTypesStep.cs).

--- a/docs/website/xamarin-analysis-doc-tool/xamarin-analysis-doc.cs
+++ b/docs/website/xamarin-analysis-doc-tool/xamarin-analysis-doc.cs
@@ -34,9 +34,9 @@ namespace XamarinAnalysisDoc
 			section += "title: Xamarin.iOS Analysis Rules\n";
 			section += "dateupdated: " + DateTime.Now.ToString("yyyy-MM-dd") + "\n";
 			section += "---\n\n";
-			section += "[//]: # (The original file resides under https://github.com/xamarin/xamarin-macios/tree/master/docs/website/)\n";
+			section += "[//]: # (The original file resides under https://github.com/xamarin/xamarin-macios/tree/main/docs/website/)\n";
 			section += "[//]: # (This allows all contributors (including external) to submit, using a PR, updates to the documentation that match the tools changes)\n";
-			section += "[//]: # (Modifications outside of xamarin-macios/master will be lost on future updates)\n\n";
+			section += "[//]: # (Modifications outside of xamarin-macios/main will be lost on future updates)\n\n";
 			section += "Xamarin.iOS analysis is a set of rules that check your project settings to help you determine if better/more optimized settings are available.\n\n";
 			section += "Run the analysis rules as often as possible to find possible improvements early on and save development time.\n\n";
 			section += "To run the rules, in Visual Studio for Mac's menu, select **Project > Run Code Analysis**.\n\n";

--- a/src/README.md
+++ b/src/README.md
@@ -32,7 +32,7 @@ corresponding profile.
 Two special `make` targets can be used to compare the generated code (.g.cs files) changes between two branches.  
 This is **required** when making changes to the generator.
 
-1. Checkout the clean base branch (e.g master's HEAD) the feature (target) branch is based on.
+1. Checkout the clean base branch (e.g main's HEAD) the feature (target) branch is based on.
 2. Do `make generator-reference` in `xamarin-macios/src`.
 3. Checkout the feature branch that requires the diff.
 4. Do `make generator-diff`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -74,7 +74,7 @@ Con
 
 ### Xamarin.Mac
 
-Many tests when run for macOS use a integration [hack](https://github.com/xamarin/xamarin-macios/blob/master/tests/common/mac/MacTestMain.cs) which helps handle a number of issues:
+Many tests when run for macOS use a integration [hack](https://github.com/xamarin/xamarin-macios/blob/main/tests/common/mac/MacTestMain.cs) which helps handle a number of issues:
 
 - Allowing command line arguments to tests while excluding "psn" arguments passed in while debugging with Visual Studio for Mac
 - Optionally integrating with the macOS message loop for tests that require it (anything that uses most Cocoa primitives).

--- a/tests/sampletester/BaseTester.cs
+++ b/tests/sampletester/BaseTester.cs
@@ -42,6 +42,19 @@ namespace Xamarin.Tests {
 			}
 		}
 
+		string default_branch;
+		public virtual string DefaultBranch {
+			get {
+				if (default_branch == null)
+					default_branch = (string) GetType ().GetField ("DEFAULT_BRANCH", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)?.GetValue (null);
+				return default_branch;
+
+			}
+			set {
+				default_branch = value;
+			}
+		}
+
 		protected BaseTester ()
 		{
 		}

--- a/tests/sampletester/README.md
+++ b/tests/sampletester/README.md
@@ -5,12 +5,12 @@ projects, and build all the relevant projects in those repositories.
 
 It is executed automatically in [Azure DevOps][1] every [Saturday][2] for the listed branches. This includes:
 
-* `master`
+* `main`
 * `d16-x` - i.e. one or many active release branches
 * `xcodeY` - i.e. the current xcode *beta* feature branch
 * `mono-202z-zz` - i.e. the mono integration branches (new one every two months)
 
-where `x`, `Y` and `z` needs to be periodically updated as new branches are created (e.g. `d16-x`) and old ones are merged into `master` (e.g. `xcodeY` and `mono-202z-zz`).
+where `x`, `Y` and `z` needs to be periodically updated as new branches are created (e.g. `d16-x`) and old ones are merged into `main` (e.g. `xcodeY` and `mono-202z-zz`).
 
 It can also be triggered manually, but have in mind that the commit in
 question must already have packages (as GitHub statuses).

--- a/tests/sampletester/SampleTester.cs
+++ b/tests/sampletester/SampleTester.cs
@@ -183,14 +183,14 @@ namespace Samples {
 		}
 
 		static Dictionary<string, ProjectInfo []> projects = new Dictionary<string, ProjectInfo []> ();
-		protected static ProjectInfo [] GetExecutableProjects (string org, string repo, string hash)
+		protected static ProjectInfo [] GetExecutableProjects (string org, string repo, string hash, string default_branch)
 		{
 			if (!projects.TryGetValue (repo, out var rv)) {
-				var project_paths = GitHub.GetProjects (org, repo, hash);
+				var project_paths = GitHub.GetProjects (org, repo, hash, default_branch);
 
 				// We can filter out project we don't care about.
 				rv = project_paths.
-					Select ((v) => GetProjectInfo (v, Path.Combine (GitHub.CloneRepository (org, repo, hash, false), v))).
+					Select ((v) => GetProjectInfo (v, Path.Combine (GitHub.CloneRepository (org, repo, hash, default_branch, false), v))).
 					Where ((v) => v.IsApplicable (false)).
 					ToArray ();
 			
@@ -199,7 +199,7 @@ namespace Samples {
 			return rv;
 		}
 
-		protected static IEnumerable<SampleTestData> GetSampleTestData (Dictionary<string, SampleTest> samples, string org, string repo, string hash, TimeSpan timeout)
+		protected static IEnumerable<SampleTestData> GetSampleTestData (Dictionary<string, SampleTest> samples, string org, string repo, string hash, string default_branch, TimeSpan timeout)
 		{
 			var defaultDebugConfigurations = new string [] { "Debug" };
 			var defaultReleaseConfigurations = new string [] { "Release" };
@@ -212,7 +212,7 @@ namespace Samples {
 
 			// If a project's filename is unique in this repo, use the filename (without extension) as the name of the test.
 			// Otherwise use the project's relative path.
-			var executable_projects = GetExecutableProjects (org, repo, hash);
+			var executable_projects = GetExecutableProjects (org, repo, hash, default_branch);
 			var duplicateProjects = executable_projects.GroupBy ((v) => Path.GetFileNameWithoutExtension (v.RelativePath)).Where ((v) => v.Count () > 1);
 			foreach (var group in duplicateProjects) {
 				foreach (var proj in group) {
@@ -276,7 +276,7 @@ namespace Samples {
 
 		string CloneRepo ()
 		{
-			return GitHub.CloneRepository (Org, Repository, Hash);
+			return GitHub.CloneRepository (Org, Repository, Hash, DefaultBranch);
 		}
 	}
 

--- a/tests/sampletester/Samples.cs
+++ b/tests/sampletester/Samples.cs
@@ -10,6 +10,7 @@ namespace Samples {
 		const string REPO = "ios-samples"; // monotouch-samples redirects to ios-samples
 		const string CATEGORY = "iossamples"; // categories can't contain dashes
 		const string HASH = "150f0e6167e2133182924114a3b36e8384f632f1";
+		const string DEFAULT_BRANCH = "main";
 
 		static Dictionary<string, SampleTest> test_data = new Dictionary<string, SampleTest> {
 				// Build solution instead of csproj
@@ -45,7 +46,7 @@ namespace Samples {
 
 		static IEnumerable<SampleTestData> GetSampleData ()
 		{
-			return GetSampleTestData (test_data, ORG, REPO, HASH, DefaultTimeout);
+			return GetSampleTestData (test_data, ORG, REPO, HASH, DEFAULT_BRANCH, DefaultTimeout);
 		}
 	}
 
@@ -55,6 +56,7 @@ namespace Samples {
 		const string REPO = "mac-ios-samples";
 		const string CATEGORY = "maciossamples"; // categories can't contain dashes
 		const string HASH = "2ab4faf9254cecdf5766af573e508f9ac8691663";
+		const string DEFAULT_BRANCH = "main";
 
 		static Dictionary<string, SampleTest> test_data = new Dictionary<string, SampleTest> {
 				// Build solution instead of csproj
@@ -66,7 +68,7 @@ namespace Samples {
 
 		static IEnumerable<SampleTestData> GetSampleData ()
 		{
-			return GetSampleTestData (test_data, ORG, REPO, HASH, DefaultTimeout);
+			return GetSampleTestData (test_data, ORG, REPO, HASH, DEFAULT_BRANCH, DefaultTimeout);
 		}
 	}
 
@@ -76,13 +78,14 @@ namespace Samples {
 		const string REPO = "mac-samples";
 		const string CATEGORY = "macsamples"; // categories can't contain dashes
 		const string HASH = "6f905972c98e64759ff84a25e4e2b42366fa197b";
+		const string DEFAULT_BRANCH = "main";
 
 		static Dictionary<string, SampleTest> test_data = new Dictionary<string, SampleTest> {
 		};
 
 		static IEnumerable<SampleTestData> GetSampleData ()
 		{
-			return GetSampleTestData (test_data, ORG, REPO, HASH, DefaultTimeout);
+			return GetSampleTestData (test_data, ORG, REPO, HASH, DEFAULT_BRANCH, DefaultTimeout);
 		}
 	}
 
@@ -92,6 +95,7 @@ namespace Samples {
 		const string REPO = "mobile-samples";
 		const string CATEGORY = "mobilesamples"; // categories can't contain dashes
 		const string HASH = "45182f311db77bb05971a22d58edfdef44a4b657";
+		const string DEFAULT_BRANCH = "master";
 
 		static Dictionary<string, SampleTest> test_data = new Dictionary<string, SampleTest> {
 				// Build solution instead of csproj
@@ -116,7 +120,7 @@ namespace Samples {
 
 		static IEnumerable<SampleTestData> GetSampleData ()
 		{
-			return GetSampleTestData (test_data, ORG, REPO, HASH, DefaultTimeout);
+			return GetSampleTestData (test_data, ORG, REPO, HASH, DEFAULT_BRANCH, DefaultTimeout);
 		}
 	}
 
@@ -126,6 +130,7 @@ namespace Samples {
 		const string REPO = "prebuilt-apps";
 		const string CATEGORY = "prebuiltapps"; // categories can't contain dashes
 		const string HASH = "f111672bc6915ceb402abb47dedfe3480e111720";
+		const string DEFAULT_BRANCH = "master";
 
 		static Dictionary<string, SampleTest> test_data = new Dictionary<string, SampleTest> {
 				// Known failures
@@ -134,7 +139,7 @@ namespace Samples {
 
 		static IEnumerable<SampleTestData> GetSampleData ()
 		{
-			return GetSampleTestData (test_data, ORG, REPO, HASH, DefaultTimeout);
+			return GetSampleTestData (test_data, ORG, REPO, HASH, DEFAULT_BRANCH, DefaultTimeout);
 		}
 	}
 
@@ -144,6 +149,7 @@ namespace Samples {
 		const string REPO = "xamarin-forms-samples";
 		const string CATEGORY = "xamarinformssamples"; // categories can't contain dashes
 		const string HASH = "d196d3f7ba418d06ef799074eb4f6120e26a9cf4";
+		const string DEFAULT_BRANCH = "master";
 
 		static Dictionary<string, SampleTest> test_data = new Dictionary<string, SampleTest> {
 				// avoid building unneeded projects since they require a lot of nuget packages (and cause a lot of unrelated/network build issues)
@@ -155,7 +161,7 @@ namespace Samples {
 
 		static IEnumerable<SampleTestData> GetSampleData ()
 		{
-			return GetSampleTestData (test_data, ORG, REPO, HASH, DefaultTimeout);
+			return GetSampleTestData (test_data, ORG, REPO, HASH, DEFAULT_BRANCH, DefaultTimeout);
 		}
 	}
 
@@ -165,6 +171,7 @@ namespace Samples {
 		const string REPO = "xamarin-forms-book-samples";
 		const string CATEGORY = "xamarinformsbookssamples"; // categories can't contain dashes
 		const string HASH = "c215bab3324d77e13bd80a0c20e60786d2bd344b";
+		const string DEFAULT_BRANCH = "master";
 
 		static Dictionary<string, SampleTest> test_data = new Dictionary<string, SampleTest> {
 				// Build solution instead of csproj,
@@ -179,7 +186,7 @@ namespace Samples {
 
 		static IEnumerable<SampleTestData> GetSampleData ()
 		{
-			return GetSampleTestData (test_data, ORG, REPO, HASH, DefaultTimeout);
+			return GetSampleTestData (test_data, ORG, REPO, HASH, DEFAULT_BRANCH, DefaultTimeout);
 		}
 	}
 
@@ -189,6 +196,7 @@ namespace Samples {
 		const string REPO = "embedded-frameworks";
 		const string CATEGORY = "embeddedframeworks"; // categories can't contain dashes
 		const string HASH = "faaad6f9dcda53b2c49cec567eca769cb534307f";
+		const string DEFAULT_BRANCH = "main";
 
 		static Dictionary<string, SampleTest> test_data = new Dictionary<string, SampleTest> {
 				// Known failures
@@ -197,7 +205,7 @@ namespace Samples {
 
 		static IEnumerable<SampleTestData> GetSampleData ()
 		{
-			return GetSampleTestData (test_data, ORG, REPO, HASH, DefaultTimeout);
+			return GetSampleTestData (test_data, ORG, REPO, HASH, DEFAULT_BRANCH, DefaultTimeout);
 		}
 	}
 
@@ -207,6 +215,7 @@ namespace Samples {
 		const string REPO = "Xappy";
 		const string CATEGORY = "davidortinauxappy"; // categories can't contain dashes
 		const string HASH = "46e5897bac974e000fcc7e1d10d01ab8d3072eb2";
+		const string DEFAULT_BRANCH = "master";
 
 		static Dictionary<string, SampleTest> test_data = new Dictionary<string, SampleTest> {
 			{ "Xappy/Xappy.iOS/Xappy.iOS.csproj", new SampleTest { BuildSolution = true, Solution = "Xappy.sln", RemoveProjects = new [] { "Xappy.Android", "Xappy.UWP" } } },
@@ -214,7 +223,7 @@ namespace Samples {
 
 		static IEnumerable<SampleTestData> GetSampleData ()
 		{
-			return GetSampleTestData (test_data, ORG, REPO, HASH, DefaultTimeout);
+			return GetSampleTestData (test_data, ORG, REPO, HASH, DEFAULT_BRANCH, DefaultTimeout);
 		}
 	}
 
@@ -224,6 +233,7 @@ namespace Samples {
 		const string REPO = "SmartHotel360-Mobile";
 		const string CATEGORY = "microsoftsmarthotel"; // categories can't contain dashes
 		const string HASH = "4004b32c955f8340a0306bad2b180ecf5adaf117";
+		const string DEFAULT_BRANCH = "master";
 
 		static Dictionary<string, SampleTest> test_data = new Dictionary<string, SampleTest> {
 			// Override CodesignKey key
@@ -233,7 +243,7 @@ namespace Samples {
 
 		static IEnumerable<SampleTestData> GetSampleData ()
 		{
-			return GetSampleTestData (test_data, ORG, REPO, HASH, timeout: TimeSpan.FromMinutes (10));
+			return GetSampleTestData (test_data, ORG, REPO, HASH, DEFAULT_BRANCH, timeout: TimeSpan.FromMinutes (10));
 		}
 	}
 
@@ -243,6 +253,7 @@ namespace Samples {
 		const string REPO = "ConferenceVision";
 		const string CATEGORY = "microsoftconferencevision"; // categories can't contain dashes
 		const string HASH = "b477f99c9e23097b31168697b2c168e90c34fd4d";
+		const string DEFAULT_BRANCH = "master";
 
 		static Dictionary<string, SampleTest> test_data = new Dictionary<string, SampleTest> {
 
@@ -250,7 +261,7 @@ namespace Samples {
 
 		static IEnumerable<SampleTestData> GetSampleData ()
 		{
-			return GetSampleTestData (test_data, ORG, REPO, HASH, DefaultTimeout);
+			return GetSampleTestData (test_data, ORG, REPO, HASH, DEFAULT_BRANCH, DefaultTimeout);
 		}
 	}
 

--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/common/TestRunner/Core/TcpTextWriter.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/common/TestRunner/Core/TcpTextWriter.cs
@@ -1,7 +1,7 @@
 ﻿// this is an adaptation of NUnitLite's TcpWriter.cs with an additional 
 // overrides and with network-activity UI enhancement
 // This code is a small modification of 
-// https://github.com/spouliot/Touch.Unit/blob/master/NUnitLite/TouchRunner/TcpTextWriter.cs
+// https://github.com/spouliot/Touch.Unit/blob/main/NUnitLite/TouchRunner/TcpTextWriter.cs
 using System;
 using System.IO;
 using System.Net;

--- a/tools/devops/azure-pipelines.yml
+++ b/tools/devops/azure-pipelines.yml
@@ -1,5 +1,5 @@
 trigger:
-  - master
+  - main
 
 jobs:
 - job: macOS

--- a/tools/devops/build-samples.yml
+++ b/tools/devops/build-samples.yml
@@ -19,12 +19,12 @@ resources:
   - repository: xamarin-macios-data
     type: github
     name: xamarin/xamarin-macios-data
-    ref: refs/heads/master
+    ref: refs/heads/main
     endpoint: xamarin
   - repository: maccore
     type: github
     name: xamarin/maccore
-    ref: refs/heads/master
+    ref: refs/heads/main
     endpoint: xamarin
 
 ###

--- a/tools/devops/push-performance-data.sh
+++ b/tools/devops/push-performance-data.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 cd xamarin-macios-data
-git checkout master
+git checkout main
 cp -cr ../logs/ ./
 
 mv ./*/*.zip .


### PR DESCRIPTION
* Fix links that point to master to point to main instead.
* Implement support in the sample tester for specifying the default branch for
  each sample repo.
* Fix various text / documentation to say 'main' instead of 'master.'
* Push to 'main' instead of 'master' in xamarin-macios-data.
* Fix xharness to make 'main' the special branch with regards to documentation tests as opposed to 'master'.
* Fix various CI to use 'main' instead of 'master'.

This is a backport of PR #9561