### PR TITLE
[xcode12][intro] Fix running introspection on old macOS versions

### DIFF
--- a/src/intents.cs
+++ b/src/intents.cs
@@ -57,6 +57,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -172,6 +173,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[NoTV]
 	[iOS (10, 0)]
@@ -372,6 +374,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -633,6 +636,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -657,6 +661,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -694,6 +699,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -851,6 +857,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'INStartCallIntentResponseCode' instead.")]
 	[Deprecated (PlatformName.WatchOS, 6, 0, message: "Use 'INStartCallIntentResponseCode' instead.")]
@@ -895,6 +902,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'INStartCallIntentResponseCode' instead.")]
 	[Deprecated (PlatformName.WatchOS, 6, 0, message: "Use 'INStartCallIntentResponseCode' instead.")]
@@ -1216,6 +1224,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Watch (3,2), NoTV, iOS (10,0)]
 	[Native]
@@ -1229,6 +1238,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Watch (4,0), NoTV, iOS (11,0)]
 	[Native]
@@ -1246,6 +1256,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Watch (3,2), NoTV, iOS (10,0)]
 	[Native]
@@ -1328,6 +1339,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Watch (4,0), NoTV, iOS (11,0)]
 	[Native]
@@ -1450,6 +1462,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Watch (4,0), NoTV, iOS (11,0)]
 	[Native]
@@ -2190,6 +2203,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 2)]
 	[Watch (3, 2)]
@@ -2499,6 +2513,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -2982,6 +2997,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -4014,6 +4030,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -4075,6 +4092,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -5629,6 +5647,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -5680,6 +5699,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -5725,6 +5745,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -5749,6 +5770,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -5843,6 +5865,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -5890,6 +5913,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -6008,6 +6032,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -6072,6 +6097,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -6124,6 +6150,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -6909,6 +6936,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[iOS (10, 0)]
 	[Watch (3, 2)]
@@ -6964,6 +6992,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'INStartCallIntent' instead.")]
 	[Deprecated (PlatformName.WatchOS, 6, 0, message: "Use 'INStartCallIntent' instead.")]
@@ -6996,8 +7025,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
-	[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'INStartCallIntentHandling' instead.")]
-	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'INStartCallIntentHandling' instead.")]
 	[Deprecated (PlatformName.WatchOS, 6, 0, message: "Use 'INStartCallIntentHandling' instead.")]
@@ -7032,6 +7060,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'INStartCallIntentResponse' instead.")]
 	[Deprecated (PlatformName.WatchOS, 6, 0, message: "Use 'INStartCallIntentResponse' instead.")]
@@ -7145,6 +7174,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'INStartCallIntent' instead.")]
 	[Deprecated (PlatformName.WatchOS, 6, 0, message: "Use 'INStartCallIntent' instead.")]
@@ -7193,6 +7223,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'INStartCallIntentResponse' instead.")]
 	[Deprecated (PlatformName.WatchOS, 6, 0, message: "Use 'INStartCallIntentResponse' instead.")]
@@ -8854,6 +8885,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Watch (4,0), NoTV, iOS (11,0)]
 	[BaseType (typeof (INIntentResolutionResult))]
@@ -8903,6 +8935,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Watch (4,0), iOS (11,0), NoTV]
 	[BaseType (typeof (NSObject))]
@@ -8950,6 +8983,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Watch (4,0), NoTV, iOS (11,0)]
 	[BaseType (typeof (INIntentResolutionResult))]
@@ -9517,6 +9551,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Watch (4,0), iOS (11,0), NoTV]
 	[BaseType (typeof (NSObject))]
@@ -9554,6 +9589,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Watch (4,0), NoTV, iOS (11,0)]
 	[BaseType (typeof (NSObject))]
@@ -9872,6 +9908,7 @@ namespace Intents {
 	[NoMac]
 #elif MONOMAC
 	[Obsolete ("Unavailable on macOS, will be removed in the future.")]
+	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
 #endif
 	[Watch (4,0), NoTV, iOS (11,0)]
 	[BaseType (typeof (INPersonResolutionResult))]

--- a/tests/monotouch-test/NaturalLanguage/NLTaggerTest.cs
+++ b/tests/monotouch-test/NaturalLanguage/NLTaggerTest.cs
@@ -52,6 +52,7 @@ namespace MonoTouchFixtures.NaturalLanguage {
 		[Test]
 		public void GetModels ()
 		{
+			TestRuntime.AssertXcodeVersion (11, 0);
 			using (var tagger = new NLTagger (NLTagScheme.LexicalClass) { String = Text }) {
 				foreach (var scheme in typeof (NLTagScheme).GetEnumValues ()) {
 					var constant = ((NLTagScheme) scheme).GetConstant ();


### PR DESCRIPTION
Most fixes are inside Intents. Some types were not available on macOS
and marked as such, except it backfired.

* Adding `[NoMac]` on `XAMCORE_4_0` was fine
* Adding `[Obsolete]` outside `XAMCORE_4_0` was fine
* Removing the `[Mac (x,y)]` was not quite fine. It's true (since it was never on macOS) but removing it means it default to the oldest (10.9) macOS version we support. This is what the introspection tests were expecting.

Adding an `[Obsoleted (..., 10,0, ...)]` solve this.