### PR TITLE
CGRect, CGPoint, CGSize: add tuple deconstruction methods

### DIFF
--- a/src/NativeTypes/Drawing.tt
+++ b/src/NativeTypes/Drawing.tt
@@ -16,6 +16,7 @@
 //   Aaron Bockover <abock@xamarin.com>
 //   Miguel de Icaza <miguel@xamarin.com>
 //
+// Copyright 2020 Microsoft Corp. All Rights Reserved.
 // Copyright 2013 Xamarin, Inc. All rights reserved.
 //
 
@@ -212,6 +213,12 @@ namespace CoreGraphics
 			hash = hash * 31 + <#= type.X_Width #>.GetHashCode ();
 			hash = hash * 31 + <#= type.Y_Height #>.GetHashCode ();
 			return hash;
+		}
+
+		public void Deconstruct (out nfloat <#= type.X_Width #>, out nfloat <#= type.Y_Height #>)
+		{
+			<#= type.X_Width #> = <#= ucfirst (type.X_Width) #>;
+			<#= type.Y_Height #> = <#= ucfirst (type.Y_Height) #>;
 		}
 
 <# if (type.Name == "CGSize") { #>
@@ -571,6 +578,20 @@ namespace CoreGraphics
 		{
 			return String.Format ("{{X={0},Y={1},Width={2},Height={3}}}",
 				x, y, width, height);
+		}
+
+		public void Deconstruct (out nfloat x, out nfloat y, out nfloat width, out nfloat height)
+		{
+			x = X;
+			y = Y;
+			width = Width;
+			height = Height;
+		}
+
+		public void Deconstruct (out CGPoint location, out CGSize size)
+		{
+			location = Location;
+			size = Size;
 		}
 
 #if !COREBUILD


### PR DESCRIPTION
Adds tuple deconstruction support to `CGPoint`, `CGSize`, and `CGRect`. This helps writing terse code and can help avoid unnecessary native to managed transitions without storing the result struct in a temporary variable.

#### Bad: two managed to native transitions

```csharp
var width = View.Frame.Width;
var height = View.Frame.Height;
```

#### Verbose: temporary local

```csharp
var frame = view.Frame;
var width = frame.Width;
var height = frame.Height;
```

#### Ideal

```csharp
var (_, _, width, height) = view.Frame;
```

```csharp
var (width, height) = view.Frame.Size;
```

## New APIs

### CGPoint

```csharp
public void Deconstruct(
  out nfloat x,
  out nfloat y);
```

### CGSize

```csharp
public void Deconstruct(
  out nfloat width,
  out nfloat height);
```

### CGRect

```csharp
public void Deconstruct(
  out nfloat x,
  out nfloat y,
  out nfloat width,
  out nfloat height);

public void Deconstruct(
  out CGPoint location,
  out CGSize size);
```

## Example Usage

```csharp
var (location, size) = View.Frame;
```

```csharp
var (x, y, width, height) = View.Frame;
```

```csharp
var (x, y) = View.Frame.Location;
```

```csharp
var (width, height) = View.Frame.Size;
```

```csharp
var (_, _, width, height) = view.Frame;
```