### PR TITLE
[tests][intro] Split attributes typos from API typos tests

### DIFF
--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -738,14 +738,43 @@ namespace Introspection
 		}
 
 		[Test]
+		public virtual void AttributeTypoTest ()
+		{
+			var types = Assembly.GetTypes ();
+			int totalErrors = 0;
+			foreach (Type t in types)
+				AttributeTypo (t, ref totalErrors);
+
+			Assert.IsTrue ((totalErrors == 0), "Attributes have {0} typos!", totalErrors);
+		}
+
+		void AttributeTypo (Type t, ref int totalErrors)
+		{
+			AttributesMessageTypoRules (t, t.Name, ref totalErrors);
+
+			foreach (var f in t.GetFields ())
+				AttributesMessageTypoRules (f, t.Name, ref totalErrors);
+
+			foreach (var p in t.GetProperties ())
+				AttributesMessageTypoRules (p, t.Name, ref totalErrors);
+
+			foreach (var m in t.GetMethods ())
+				AttributesMessageTypoRules (m, t.Name, ref totalErrors);
+
+			foreach (var e in t.GetEvents ())
+				AttributesMessageTypoRules (e, t.Name, ref totalErrors);
+
+			foreach (var nt in t.GetNestedTypes ())
+				AttributeTypo (nt, ref totalErrors);
+		}
+
+		[Test]
 		public virtual void TypoTest ()
 		{
 			var types = Assembly.GetTypes ();
 			int totalErrors = 0;
 			foreach (Type t in types) {
 				if (t.IsPublic) {
-					AttributesMessageTypoRules (t, t.Name, ref totalErrors);
-
 					if (IsObsolete (t))
 						continue;
 
@@ -762,8 +791,6 @@ namespace Introspection
 					foreach (FieldInfo f in fields) {
 						if (!f.IsPublic && !f.IsFamily)
 							continue;
-
-						AttributesMessageTypoRules (f, t.Name, ref totalErrors);
 
 						if (IsObsolete (f))
 							continue;
@@ -782,8 +809,6 @@ namespace Introspection
 					foreach (MethodInfo m in methods) {
 						if (!m.IsPublic && !m.IsFamily)
 							continue;
-
-						AttributesMessageTypoRules (m, t.Name, ref totalErrors);
 
 						if (IsObsolete (m))
 							continue;

--- a/tests/introspection/Mac/MacApiTypoTest.cs
+++ b/tests/introspection/Mac/MacApiTypoTest.cs
@@ -13,13 +13,14 @@ namespace Introspection
 	{
 		NSSpellChecker checker;
 
-		[SetUp]
-		public void SetUp ()
+		public override void TypoTest ()
 		{
 			var sdk = new Version (Constants.SdkVersion);
 			if (!PlatformHelper.CheckSystemVersion (sdk.Major, sdk.Minor))
 				Assert.Ignore ("Typos only verified using the latest SDK");
 			checker = new NSSpellChecker ();
+
+			base.TypoTest ();
 		}
 
 		public override string GetTypo (string txt)

--- a/tests/introspection/iOS/iOSApiTypoTest.cs
+++ b/tests/introspection/iOS/iOSApiTypoTest.cs
@@ -13,20 +13,6 @@ namespace Introspection {
 		UITextChecker checker = new UITextChecker ();
 #endif
 
-		[SetUp]
-		public void SetUp ()
-		{
-#if __WATCHOS__
-			Assert.Ignore ("Need to find alternative for UITextChecker on WatchOS.");
-#else
-			// the dictionary used by iOS varies with versions and 
-			// we don't want to maintain special cases for each version
-			var sdk = new Version (Constants.SdkVersion);
-			if (!UIDevice.CurrentDevice.CheckSystemVersion (sdk.Major, sdk.Minor))
-				Assert.Ignore ("Typos only verified using the latest SDK");
-#endif
-		}
-
 		public override string GetTypo (string txt)
 		{
 #if __WATCHOS__
@@ -42,12 +28,22 @@ namespace Introspection {
 
 		public override void TypoTest ()
 		{
+#if __WATCHOS__
+			Assert.Ignore ("Need to find alternative for UITextChecker on WatchOS.");
+#else
+			// the dictionary used by iOS varies with versions and
+			// we don't want to maintain special cases for each version
+			var sdk = new Version (Constants.SdkVersion);
+			if (!UIDevice.CurrentDevice.CheckSystemVersion (sdk.Major, sdk.Minor))
+				Assert.Ignore ("Typos only verified using the latest SDK");
+
 			// that's slow and there's no value to run it on devices as the API names
 			// being verified won't change from the simulator
 			if (Runtime.Arch == Arch.DEVICE)
 				Assert.Ignore ("Typos only detected on simulator");
 
 			base.TypoTest ();
+#endif
 		}
 	}
 }


### PR DESCRIPTION
The latter requires the spellchecker which varies by OS versions, so we
only run it on the latest OS version (and simulator, except macOS).

The former are some internal rules and can be run on every commit and
avoid finding issues late in a release cycle.

Also changed to
- process members even if a type is obsoleted
- process the properties and events on types

Note: The PR doe snot include any fixes (to typos) since it would
make the xcode12 merge harder. They will be fixed later