### PR TITLE
[jenkins] Don't try to run the packaged Xamarin.Mac tests if none were built.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -86,6 +86,35 @@ def githubGetPullRequestLabels ()
     return github_pull_request_labels
 }
 
+custom_labels = null
+def getCustomLabels ()
+{
+    if (custom_labels == null) {
+        custom_labels = []
+        def custom_labels_file = "${workspace}/xamarin-macios/jenkins/custom-labels.txt"
+        if (fileExists (custom_labels_file)) {
+            def contents = sh (script: "grep -v '^[[:space:]]*#' ${custom_labels_file} | grep -v '^[[:space:]]*\$' | tr \$'\n' ' ' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*\$//'", returnStdout: true)
+            custom_labels += contents.tokenize (' ')
+            echo ("Found labels ${custom_labels} in ${custom_labels_file}")
+        } else {
+            echo ("The custom labels file ${custom_labels_file} does not exist")
+        }
+    }
+    return custom_labels
+}
+
+labels = null
+def getLabels ()
+{
+    if (labels == null) {
+        labels = []
+        labels += githubGetPullRequestLabels ()
+        labels += getCustomLabels ()
+        echo ("Found labels: ${labels}")
+    }
+    return labels
+}
+
 def githubAddComment (url, markdown)
 {
     if (markdown.length () > 32768) {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -736,15 +736,21 @@ timestamps {
                             stage ("Package XM tests") {
                                 currentStage = "${STAGE_NAME}"
                                 echo ("Building on ${env.NODE_NAME}")
-                                def exitCode = sh (script: "make -C ${workspace}/xamarin-macios/tests package-tests", returnStatus: true)
-                                if (exitCode != 0) {
+                                def skipPackagedXamarinMacTests = getLabels ().contains ("skip-packaged-xamarin-mac-tests")
+                                if (skipPackagedXamarinMacTests) {
+                                    echo ("Skipping packaged Xamarin.Mac tests because the label 'skip-packaged-xamarin-mac-tests' was found")
                                     hasXamarinMacTests = false
-                                    echoError ("Failed to package Xamarin.Mac tests (exit code: ${exitCode})")
-                                    failedStages.add (currentStage)
                                 } else {
-                                    def packaged_xm_tests = findFiles (glob: "tests/*.7z")
-                                    if (packaged_xm_tests.size () > 0)
-                                        uploadFiles ("tests/*.7z", "wrench", virtualPath)
+                                    def exitCode = sh (script: "make -C ${workspace}/xamarin-macios/tests package-tests", returnStatus: true)
+                                    if (exitCode != 0) {
+                                        hasXamarinMacTests = false
+                                        echoError ("Failed to package Xamarin.Mac tests (exit code: ${exitCode})")
+                                        failedStages.add (currentStage)
+                                    } else {
+                                        def packaged_xm_tests = findFiles (glob: "tests/*.7z")
+                                        if (packaged_xm_tests.size () > 0)
+                                            uploadFiles ("tests/*.7z", "wrench", virtualPath)
+                                    }
                                 }
                             }
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -735,6 +735,7 @@ timestamps {
                             def hasXamarinMacTests = true
                             stage ("Package XM tests") {
                                 currentStage = "${STAGE_NAME}"
+                                echo ("Building on ${env.NODE_NAME}")
                                 def exitCode = sh (script: "make -C ${workspace}/xamarin-macios/tests package-tests", returnStatus: true)
                                 if (exitCode != 0) {
                                     hasXamarinMacTests = false

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -748,8 +748,13 @@ timestamps {
                                         failedStages.add (currentStage)
                                     } else {
                                         def packaged_xm_tests = findFiles (glob: "tests/*.7z")
-                                        if (packaged_xm_tests.size () > 0)
+                                        if (packaged_xm_tests.size () > 0) {
                                             uploadFiles ("tests/*.7z", "wrench", virtualPath)
+                                        } else {
+                                            // This may happen if the Xamarin.Mac build has been disabled
+                                            manager.addWarningBadge("Could not find any packaged Xamarin.Mac tests to upload")
+                                            hasXamarinMacTests = false
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
This is a backport of #8447 and #9170 (to avoid merge conflicts later) + a fix
to not try to run the Xamarin.Mac tests if none were built (which doesn't
happen when the Xamarin.Mac build is disabled).

This fixes a problem where we'd try to run the packaged Xamarin.Mac tests on
older macOS bots, and fail to do so because there were no Xamarin.Mac tests to
run.