### PR TITLE
[monotouch-test] Don't assert any specific value for the ReusedConnection value in UrlSessionTaskTransactionMetricsTest. Fixes #xamarin/maccore@2281.

### DIFF
--- a/tests/monotouch-test/Foundation/UrlSessionTaskTransactionMetricsTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTaskTransactionMetricsTest.cs
@@ -58,12 +58,7 @@ namespace MonoTouchFixtures.Foundation {
 					Assert.Null (sttm.ResponseEndDate, "ResponseEndDate");
 					Assert.Null (sttm.ResponseStartDate, "ResponseStartDate");
 				}
-#if __IOS__
-				if (TestRuntime.CheckXcodeVersion (11, 6)) // Returns true in iOS 13.6
-					Assert.True (sttm.ReusedConnection, "ReusedConnection");
-				else
-#endif
-					Assert.False (sttm.ReusedConnection, "ReusedConnection");
+				Assert.That (sttm.ReusedConnection, Is.EqualTo (true).Or.EqualTo (false), "ReusedConnection");
 				Assert.Null (sttm.SecureConnectionEndDate, "SecureConnectionEndDate");
 				Assert.Null (sttm.SecureConnectionStartDate, "SecureConnectionStartDate");
 			}


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/2281.