### PR TITLE
[monotouch-test] Rework CBCentralManagerTest to handle not having permissions.

### DIFF
--- a/tests/monotouch-test/CoreBluetooth/CentralManagerTest.cs
+++ b/tests/monotouch-test/CoreBluetooth/CentralManagerTest.cs
@@ -27,17 +27,13 @@ namespace MonoTouchFixtures.CoreBluetooth {
 	public class CBCentralManagerTest {
 
 		class ManagerDelegate : CBCentralManagerDelegate {
-			public AutoResetEvent Event { get; private set; }
-
-			public ManagerDelegate (AutoResetEvent e) : base ()
-			{
-				Event = e;
-			}
+			public AutoResetEvent PoweredOnEvent { get; private set; } = new AutoResetEvent (false);
 
 			#region implemented abstract members of MonoTouch.CoreBluetooth.CBCentralManagerDelegate
 			public override void UpdatedState (CBCentralManager central)
 			{
-				Event.Set ();
+				if (central.State == CBCentralManagerState.PoweredOn)
+					PoweredOnEvent.Set ();
 			}
 
 #if !XAMCORE_3_0
@@ -77,14 +73,15 @@ namespace MonoTouchFixtures.CoreBluetooth {
 		{
 			// iOS 13 and friends require bluetooth permission
 			if (TestRuntime.CheckXcodeVersion (11, 0))
-				TestRuntime.CheckBluetoothPermission ();
+				TestRuntime.CheckBluetoothPermission (true);
 			//known UUID for a heart monitor, more common, we want to find something and make sure we do not crash
 			heartRateMonitorUUID = CBUUID.FromPartial (0x180D);
 			// Required API is available in macOS 10.8, but it doesn't work (hangs in 10.8-10.9, randomly crashes in 10.10) on the bots.
 			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
-			var e = new AutoResetEvent (false);
-			mgrDelegate = new ManagerDelegate (e);
+			mgrDelegate = new ManagerDelegate ();
 			mgr = new CBCentralManager (mgrDelegate, new DispatchQueue ("com.xamarin.tests." + TestContext.CurrentContext.Test.Name));
+			if (!mgrDelegate.PoweredOnEvent.WaitOne (TimeSpan.FromSeconds (5)))
+				Assert.Inconclusive ("Bluetooth never turned on. Authorization state: {0}", CBCentralManager.Authorization);
 		}
 
 		[TearDown]
@@ -95,41 +92,23 @@ namespace MonoTouchFixtures.CoreBluetooth {
 			mgr?.Dispose ();
 		}
 			
-		[Test, Timeout (5000)]
+		[Test]
 		public void Constructors ()
 		{
-			if (mgr.State == CBCentralManagerState.Unknown) {
-				// ensure we do get called
-				Assert.IsTrue (mgrDelegate.Event.WaitOne (TimeSpan.FromSeconds (5)), "Initialization");
-			}
-
 			// Manager creates it, we'll simply check it has a non-null delegate
 			Assert.NotNull (mgr.Delegate, "Delegate");
 		}
 
-		[Test, Timeout (5000)]
+		[Test]
 		public void ScanForPeripherals ()
 		{
-			if (mgr.State == CBCentralManagerState.Unknown) {
-				// ensure we do get called
-				Assert.IsTrue (mgrDelegate.Event.WaitOne (TimeSpan.FromSeconds (5)), "Initialization");
-			}
-			if (mgr.State != CBCentralManagerState.PoweredOn)
-				Assert.Inconclusive ("Bluetooth is off and therefore the test cannot be ran. State == {0}.", mgr.State);
 			mgr.ScanForPeripherals ((CBUUID[])null, (NSDictionary)null);
 		}
 
 #if !XAMCORE_3_0
-		[Test, Timeout (5000)]
+		[Test]
 		public void RetrievePeripherals ()
 		{
-			if (mgr.State == CBCentralManagerState.Unknown) {
-				// ensure we do get called
-				Assert.IsTrue (mgrDelegate.Event.WaitOne (TimeSpan.FromSeconds (5)), "Initialization");
-			}
-			if (mgr.State != CBCentralManagerState.PoweredOn)
-				Assert.Inconclusive ("Bluetooth is off and therefore the test cannot be ran. State == {0}.", mgr.State);
-
 			if (TestRuntime.CheckXcodeVersion (7, 0)) {
 				// ToString in a CBUUID with true returns the full uuid which can be used to create a NSUuid
 				using (var uuid = new NSUuid (heartRateMonitorUUID.ToString (true)))

--- a/tests/monotouch-test/CoreBluetooth/CentralManagerTest.cs
+++ b/tests/monotouch-test/CoreBluetooth/CentralManagerTest.cs
@@ -81,7 +81,7 @@ namespace MonoTouchFixtures.CoreBluetooth {
 			mgrDelegate = new ManagerDelegate ();
 			mgr = new CBCentralManager (mgrDelegate, new DispatchQueue ("com.xamarin.tests." + TestContext.CurrentContext.Test.Name));
 			if (!mgrDelegate.PoweredOnEvent.WaitOne (TimeSpan.FromSeconds (5)))
-				Assert.Inconclusive ("Bluetooth never turned on. Authorization state: {0}", CBCentralManager.Authorization);
+				Assert.Inconclusive ("Bluetooth never turned on.");
 		}
 
 		[TearDown]


### PR DESCRIPTION
1. Assert that we got permission to CoreBluetooth before doing anything. This
   makes it so that if permission has been denied, or if we're running on the
   bots and permission has not been granted, these tests won't run. It does
   not affect local test runs where permissions haven't been granted nor
   denied.

2. Rework the code to wait for CoreBluetooth to power on in the SetUp method.
   Mark the test as inconclusive if CoreBluetooth never powers on (this
   happens if nobody answers the bluetooth permission dialog, quite typical
   when running tests locally).

Fixes these tests when running locally on a tvOS device:

    MonoTouchFixtures.CoreBluetooth.CBCentralManagerTest
        [FAIL] Constructors
        [FAIL] ScanForPeripherals