### PR TITLE
[d16-8] [SBApplication][Bug] SBApplication.FromBundleIdentifier<T> should return null when bundle ID is unknown

### DIFF
--- a/src/ScriptingBridge/SBApplication.cs
+++ b/src/ScriptingBridge/SBApplication.cs
@@ -7,23 +7,30 @@ using ObjCRuntime;
 namespace ScriptingBridge {
 	public partial class SBApplication
 	{
-		// We want to instance up a version of your derived class, not SBApplication
-		public static T FromBundleIdentifier<T> (string ident) where T : SBApplication, new()
-		{
-			using (var u = FromBundleIdentifier (ident))
-				return u == null ? (T)u : (T)System.Activator.CreateInstance (typeof(T), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new object [] { u.Handle }, null);
-		}
+#if XAMCORE_4_0
+		public static SBApplication GetApplicationFromBundleIdentifier (string ident)  => Runtime.GetNSObject<SBApplication> (_FromBundleIdentifier (ident));
 
-		public static T FromURL<T> (NSUrl url) where T : SBApplication
-		{
-			using (var u = FromURL (url))
-				return u == null ? (T)u : (T)System.Activator.CreateInstance (typeof(T), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new object [] { u.Handle }, null);
-		}
+		public static T GetApplicationFromBundleIdentifier<T> (string ident) where T : SBApplication => Runtime.GetNSObject<T> (_FromBundleIdentifier (ident));
 
-		public static T FromProcessIdentifier<T> (int /* pid_t = int */ pid) where T : SBApplication
-		{
-			using (var u = FromProcessIdentifier (pid))
-				return u == null ? (T)u : (T)System.Activator.CreateInstance (typeof(T), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new object [] { u.Handle }, null);
-		}
+		public static SBApplication GetApplicationFromUrl (NSUrl url)  => Runtime.GetNSObject<SBApplication> (_FromURL (url) ;
+
+		public static T GetApplicationFromUrl<T> (NSUrl url) where T : SBApplication => Runtime.GetNSObject<T> (_FromURL (url));
+
+		public static SBApplication GetApplicationFromProcessIdentifier (int pid)  => Runtime.GetNSObject<SBApplication> (_FromProcessIdentifier (pid));
+
+		public static T GetApplicationFromProcessIdentifier<T> (int pid) where T : SBApplication => Runtime.GetNSObject<T> (_FromProcessIdentifier (pid));
+#else
+		public static SBApplication FromBundleIdentifier (string ident)  => Runtime.GetNSObject<SBApplication> (_FromBundleIdentifier (ident));
+
+		public static T FromBundleIdentifier<T> (string ident) where T : SBApplication => Runtime.GetNSObject<T> (_FromBundleIdentifier (ident));
+
+		public static SBApplication FromURL (NSUrl url)  => Runtime.GetNSObject<SBApplication> (_FromURL (url));
+
+		public static T FromURL<T> (NSUrl url) where T : SBApplication => Runtime.GetNSObject<T> (_FromURL (url));
+
+		public static SBApplication FromProcessIdentifier (int pid)  => Runtime.GetNSObject<SBApplication> (_FromProcessIdentifier (pid));
+
+		public static T FromProcessIdentifier<T> (int pid) where T : SBApplication => Runtime.GetNSObject<T> (_FromProcessIdentifier (pid));
+#endif
 	}
 }

--- a/src/ScriptingBridge/SBApplication.cs
+++ b/src/ScriptingBridge/SBApplication.cs
@@ -10,27 +10,27 @@ namespace ScriptingBridge {
 #if XAMCORE_4_0
 		public static SBApplication GetApplicationFromBundleIdentifier (string ident)  => Runtime.GetNSObject<SBApplication> (_FromBundleIdentifier (ident));
 
-		public static T GetApplicationFromBundleIdentifier<T> (string ident) where T : SBApplication => Runtime.GetNSObject<T> (_FromBundleIdentifier (ident));
+		public static T GetApplicationFromBundleIdentifier<T> (string ident) where T : SBApplication => Runtime.GetINativeObject<T> (_FromBundleIdentifier (ident), forced_type: true, owns: false);
 
 		public static SBApplication GetApplicationFromUrl (NSUrl url)  => Runtime.GetNSObject<SBApplication> (_FromURL (url) ;
 
-		public static T GetApplicationFromUrl<T> (NSUrl url) where T : SBApplication => Runtime.GetNSObject<T> (_FromURL (url));
+		public static T GetApplicationFromUrl<T> (NSUrl url) where T : SBApplication => Runtime.GetINativeObject<T> (_FromURL (url), forced_type: true, owns: false);
 
 		public static SBApplication GetApplicationFromProcessIdentifier (int pid)  => Runtime.GetNSObject<SBApplication> (_FromProcessIdentifier (pid));
 
-		public static T GetApplicationFromProcessIdentifier<T> (int pid) where T : SBApplication => Runtime.GetNSObject<T> (_FromProcessIdentifier (pid));
+		public static T GetApplicationFromProcessIdentifier<T> (int pid) where T : SBApplication => Runtime.GetINativeObject<T> (_FromProcessIdentifier (pid), forced_type: true, owns: false);
 #else
 		public static SBApplication FromBundleIdentifier (string ident)  => Runtime.GetNSObject<SBApplication> (_FromBundleIdentifier (ident));
 
-		public static T FromBundleIdentifier<T> (string ident) where T : SBApplication => Runtime.GetNSObject<T> (_FromBundleIdentifier (ident));
+		public static T FromBundleIdentifier<T> (string ident) where T : SBApplication => Runtime.GetINativeObject<T> (_FromBundleIdentifier (ident), forced_type: true, owns: false);
 
 		public static SBApplication FromURL (NSUrl url)  => Runtime.GetNSObject<SBApplication> (_FromURL (url));
 
-		public static T FromURL<T> (NSUrl url) where T : SBApplication => Runtime.GetNSObject<T> (_FromURL (url));
+		public static T FromURL<T> (NSUrl url) where T : SBApplication => Runtime.GetINativeObject<T> (_FromURL (url), forced_type: true, owns: false);
 
 		public static SBApplication FromProcessIdentifier (int pid)  => Runtime.GetNSObject<SBApplication> (_FromProcessIdentifier (pid));
 
-		public static T FromProcessIdentifier<T> (int pid) where T : SBApplication => Runtime.GetNSObject<T> (_FromProcessIdentifier (pid));
+		public static T FromProcessIdentifier<T> (int pid) where T : SBApplication => Runtime.GetINativeObject<T> (_FromProcessIdentifier (pid), forced_type: true, owns: false);
 #endif
 	}
 }

--- a/src/ScriptingBridge/SBApplication.cs
+++ b/src/ScriptingBridge/SBApplication.cs
@@ -11,19 +11,19 @@ namespace ScriptingBridge {
 		public static T FromBundleIdentifier<T> (string ident) where T : SBApplication, new()
 		{
 			using (var u = FromBundleIdentifier (ident))
-				return (T)System.Activator.CreateInstance (typeof(T), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new object [] { u.Handle }, null);
+				return u == null ? (T)u : (T)System.Activator.CreateInstance (typeof(T), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new object [] { u.Handle }, null);
 		}
 
 		public static T FromURL<T> (NSUrl url) where T : SBApplication
 		{
 			using (var u = FromURL (url))
-				return (T)System.Activator.CreateInstance (typeof(T), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new object [] { u.Handle }, null);
+				return u == null ? (T)u : (T)System.Activator.CreateInstance (typeof(T), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new object [] { u.Handle }, null);
 		}
 
 		public static T FromProcessIdentifier<T> (int /* pid_t = int */ pid) where T : SBApplication
 		{
 			using (var u = FromProcessIdentifier (pid))
-				return (T)System.Activator.CreateInstance (typeof(T), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new object [] { u.Handle }, null);
+				return u == null ? (T)u : (T)System.Activator.CreateInstance (typeof(T), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new object [] { u.Handle }, null);
 		}
 	}
 }

--- a/src/ScriptingBridge/SBApplication.cs
+++ b/src/ScriptingBridge/SBApplication.cs
@@ -8,17 +8,17 @@ namespace ScriptingBridge {
 	public partial class SBApplication
 	{
 #if XAMCORE_4_0
-		public static SBApplication GetApplicationFromBundleIdentifier (string ident)  => Runtime.GetNSObject<SBApplication> (_FromBundleIdentifier (ident));
+		public static SBApplication GetApplication (string ident)  => Runtime.GetNSObject<SBApplication> (_FromBundleIdentifier (ident));
 
-		public static T GetApplicationFromBundleIdentifier<T> (string ident) where T : SBApplication => Runtime.GetINativeObject<T> (_FromBundleIdentifier (ident), forced_type: true, owns: false);
+		public static T GetApplication<T> (string ident) where T : SBApplication => Runtime.GetINativeObject<T> (_FromBundleIdentifier (ident), forced_type: true, owns: false);
 
-		public static SBApplication GetApplicationFromUrl (NSUrl url)  => Runtime.GetNSObject<SBApplication> (_FromURL (url) ;
+		public static SBApplication GetApplication (NSUrl url)  => Runtime.GetNSObject<SBApplication> (_FromURL (url) ;
 
-		public static T GetApplicationFromUrl<T> (NSUrl url) where T : SBApplication => Runtime.GetINativeObject<T> (_FromURL (url), forced_type: true, owns: false);
+		public static T GetApplication<T> (NSUrl url) where T : SBApplication => Runtime.GetINativeObject<T> (_FromURL (url), forced_type: true, owns: false);
 
-		public static SBApplication GetApplicationFromProcessIdentifier (int pid)  => Runtime.GetNSObject<SBApplication> (_FromProcessIdentifier (pid));
+		public static SBApplication GetApplication (int pid)  => Runtime.GetNSObject<SBApplication> (_FromProcessIdentifier (pid));
 
-		public static T GetApplicationFromProcessIdentifier<T> (int pid) where T : SBApplication => Runtime.GetINativeObject<T> (_FromProcessIdentifier (pid), forced_type: true, owns: false);
+		public static T GetApplication<T> (int pid) where T : SBApplication => Runtime.GetINativeObject<T> (_FromProcessIdentifier (pid), forced_type: true, owns: false);
 #else
 		public static SBApplication FromBundleIdentifier (string ident)  => Runtime.GetNSObject<SBApplication> (_FromBundleIdentifier (ident));
 

--- a/src/scriptingbridge.cs
+++ b/src/scriptingbridge.cs
@@ -112,17 +112,20 @@ namespace ScriptingBridge {
 		[Export ("initWithBundleIdentifier:")]
 		IntPtr Constructor (string ident);
 
+		[Internal]
 		[Static]
 		[Export ("applicationWithBundleIdentifier:")]
-		SBApplication FromBundleIdentifier (string ident );
+		IntPtr _FromBundleIdentifier (string ident );
 
+		[Internal]
 		[Static]
 		[Export ("applicationWithURL:")]
-		SBApplication FromURL (NSUrl url );
+		IntPtr _FromURL (NSUrl url );
 
+		[Internal]
 		[Static]
 		[Export ("applicationWithProcessIdentifier:")]
-		SBApplication FromProcessIdentifier (int /* pid_t = int */ pid );
+		IntPtr _FromProcessIdentifier (int /* pid_t = int */ pid );
 
 		[Export ("classForScriptingClass:")]
 		Class ClassForScripting (string className );

--- a/tests/apitest/apitest.csproj
+++ b/tests/apitest/apitest.csproj
@@ -57,6 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
+    <Folder Include="src\ScriptingBridge\" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="src\AppKit\NSAppearance.cs" />
@@ -156,6 +157,7 @@
     <Compile Include="..\common\TestRuntime.cs">
       <Link>shared\TestRuntime.cs</Link>
     </Compile>
+    <Compile Include="src\ScriptingBridge\SBApplicationTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">

--- a/tests/apitest/src/ScriptingBridge/SBApplicationTest.cs
+++ b/tests/apitest/src/ScriptingBridge/SBApplicationTest.cs
@@ -35,13 +35,13 @@ namespace Xamarin.Mac.Tests {
 #if !XAMCORE_4_0
 			using (var app1 = SBApplication.FromBundleIdentifier (knownBundle))
 			using (var app2 = SBApplication.FromBundleIdentifier<MySBApp> (knownBundle))
-			using (var app4 = SBApplication.FromBundleIdentifier<MySBApp> (unknownBundle))
 			using (var app3 = SBApplication.FromBundleIdentifier (unknownBundle))
+			using (var app4 = SBApplication.FromBundleIdentifier<MySBApp> (unknownBundle))
 #else
-			var (app1 = SBApplication.GetApplicationFromBundleIdentifier (knownBundle))
-			var (app2 = SBApplication.GetApplicationFromBundleIdentifier<MySbApp> (knownBundle))
-			var (app3 = SBApplication.GetApplicationFromBundleIdentifier (unknownBundle))
-			var (app4 = SBApplication.GetApplicationFromBundleIdentifier<MySbApp> (unknownBundle))
+			var (app1 = SBApplication.GetApplication (knownBundle))
+			var (app2 = SBApplication.GetApplication<MySbApp> (knownBundle))
+			var (app3 = SBApplication.GetApplication (unknownBundle))
+			var (app4 = SBApplication.GetApplication<MySbApp> (unknownBundle))
 #endif
 			{
 				Assert.IsNotNull (app1, "SBApplication from known bundle is null");
@@ -59,8 +59,8 @@ namespace Xamarin.Mac.Tests {
 			using (var app1 = SBApplication.FromURL (knownUrl))
 			using (var app2 = SBApplication.FromURL<MySBApp> (knownUrl))
 #else
-			using (var app1 = SBApplication.GetApplicationFromUrl (knownUrl))
-			using (var app2 = SBApplication.GetApplicationFromUrl<MySbApp> (knownUrl))
+			using (var app1 = SBApplication.GetApplication (knownUrl))
+			using (var app2 = SBApplication.GetApplication<MySbApp> (knownUrl))
 #endif
 			{
 				Assert.IsNotNull (app1, "SBApplication from known URL is null");
@@ -79,10 +79,10 @@ namespace Xamarin.Mac.Tests {
 			using (var app3 = SBApplication.FromProcessIdentifier (unknownPid))
 			using (var app4 = SBApplication.FromProcessIdentifier<MySBApp> (unknownPid))
 #else
-			using (var app1 = SBApplication.GetApplicationFromProcessIdentifier (knownPid))
-			using (var app2 = SBApplication.GetApplicationFromProcessIdentifier<MySbApp> (knownPid))
-			using (var app3 = SBApplication.GetApplicationFromProcessIdentifier (unknownPid))
-			using (var app4 = SBApplication.GetApplicationFromProcessIdentifier<MySbApp> (unknownPid)
+			using (var app1 = SBApplication.GetApplication (knownPid))
+			using (var app2 = SBApplication.GetApplication<MySbApp> (knownPid))
+			using (var app3 = SBApplication.GetApplication (unknownPid))
+			using (var app4 = SBApplication.GetApplication<MySbApp> (unknownPid)
 #endif
 			{
 				Assert.IsNotNull (app1, "SBApplication from known pid is null");

--- a/tests/apitest/src/ScriptingBridge/SBApplicationTest.cs
+++ b/tests/apitest/src/ScriptingBridge/SBApplicationTest.cs
@@ -8,105 +8,87 @@ using ScriptingBridge;
 
 namespace Xamarin.Mac.Tests {
 
-	public class MySbApp : SBApplication {
-		public MySbApp () : base (NSObjectFlag.Empty) { }
+	public class MySBApp : SBApplication {
+		public MySBApp () : base (NSObjectFlag.Empty) { }
 
-		public MySbApp (NSCoder coder) : base (coder) { }
+		public MySBApp (NSCoder coder) : base (coder) { }
 
-		public MySbApp (NSUrl url) : base (url) { }
+		public MySBApp (NSUrl url) : base (url) { }
 
-		public MySbApp (int pid) : base (pid) { }
+		public MySBApp (int pid) : base (pid) { }
 
-		public MySbApp (string ident) : base (ident) { }
+		public MySBApp (string ident) : base (ident) { }
 
-		protected MySbApp (NSObjectFlag t) : base (t) { }
+		protected MySBApp (NSObjectFlag t) : base (t) { }
 
-		protected internal MySbApp (IntPtr handle) : base (handle) { }
+		protected internal MySBApp (IntPtr handle) : base (handle) { }
 	}
 
 	[TestFixture]
 	public class SBApplicationTest {
 
-		[TestFixture]
-		public class GetSBApplicationTest {
-
-			[Test]
-			public void TestGetApplicationFromBundleIdentifier ()
-			{
-				const string knownBundle = "com.apple.finder";
-				const string unknownBundle = "com.unknown.bundle";
+		[Test]
+		public void TestGetApplicationFromBundleIdentifier ()
+		{
+			const string knownBundle = "com.apple.finder";
+			const string unknownBundle = "com.unknown.bundle";
 #if !XAMCORE_4_0
-				var app2 = SBApplication.FromBundleIdentifier<MySbApp> (knownBundle);
-				Assert.IsNotNull (app2);
-				var app1 = SBApplication.FromBundleIdentifier (unknownBundle);
-				Assert.IsNotNull (app1);
-				var app4 = SBApplication.FromBundleIdentifier<MySbApp> (unknownBundle);
-
-				var app3 = SBApplication.FromBundleIdentifier (unknownBundle);
-				Assert.IsNull (app3);
-				Assert.IsNull (app4);
+			using (var app1 = SBApplication.FromBundleIdentifier (knownBundle))
+			using (var app2 = SBApplication.FromBundleIdentifier<MySBApp> (knownBundle))
+			using (var app4 = SBApplication.FromBundleIdentifier<MySBApp> (unknownBundle))
+			using (var app3 = SBApplication.FromBundleIdentifier (unknownBundle))
 #else
-				var app1 = SBApplication.GetApplicationFromBundleIdentifier (knownBundle);
-				Assert.IsNotNull (app1);
-				var app2 = SBApplication.GetApplicationFromBundleIdentifier<MySbApp> (knownBundle);
-				Assert.IsNotNull (app2);
-				var app3 = SBApplication.GetApplicationFromBundleIdentifier (unknownBundle);
-				var app4 = SBApplication.GetApplicationFromBundleIdentifier<MySbApp> (unknownBundle);
-				Assert.IsNull (app3);
-				Assert.IsNull (app4);
+			var (app1 = SBApplication.GetApplicationFromBundleIdentifier (knownBundle))
+			var (app2 = SBApplication.GetApplicationFromBundleIdentifier<MySbApp> (knownBundle))
+			var (app3 = SBApplication.GetApplicationFromBundleIdentifier (unknownBundle))
+			var (app4 = SBApplication.GetApplicationFromBundleIdentifier<MySbApp> (unknownBundle))
 #endif
+			{
+				Assert.IsNotNull (app1, "SBApplication from known bundle is null");
+				Assert.IsNotNull (app2, "MySBApp from known bundle is null");
+				Assert.IsNull (app3, "SBApplication from unknown bundle is non-null");
+				Assert.IsNull (app4, "MySBApp from unknown bundle is non-null");
 			}
+		}
 
-			[Test]
-			public void TestGetApplicationFromUrl ()
-			{
-				NSUrl knownUrl = new NSUrl("http://www.xamarin.com");
-				NSUrl unknownUrl = new NSUrl ("thisisnotaurl");
+		[Test]
+		public void TestGetApplicationFromUrl ()
+		{
+			using (NSUrl knownUrl = new NSUrl ("http://www.xamarin.com"))
 #if !XAMCORE_4_0
-				var app1 = SBApplication.FromURL (knownUrl);
-				Assert.IsNotNull (app1);
-				var app2 = SBApplication.FromURL<MySbApp> (knownUrl);
-				Assert.IsNotNull (app2);
-				var app3 = SBApplication.FromURL (unknownUrl);
-				var app4 = SBApplication.FromURL<MySbApp> (unknownUrl);
-				Assert.IsNull (app3);
-				Assert.IsNull (app4);
+			using (var app1 = SBApplication.FromURL (knownUrl))
+			using (var app2 = SBApplication.FromURL<MySBApp> (knownUrl))
 #else
-				var app1 = SBApplication.GetApplicationFromUrl (knownUrl);
-				Assert.IsNotNull (app1);
-				var app2 = SBApplication.GetApplicationFromUrl<MySbApp> (knownUrl);
-				Assert.IsNotNull (app2);
-				var app3 = SBApplication.GetApplicationFromUrl (unknownUrl);
-				var app4 = SBApplication.GetApplicationFromUrl<MySbApp> (unknownUrl);
-				Assert.IsNull (app3);
-				Assert.IsNull (app4);
+			using (var app1 = SBApplication.GetApplicationFromUrl (knownUrl))
+			using (var app2 = SBApplication.GetApplicationFromUrl<MySbApp> (knownUrl))
 #endif
+			{
+				Assert.IsNotNull (app1, "SBApplication from known URL is null");
+				Assert.IsNotNull (app2, "MySBApp from known URL is null");
 			}
+		}
 
-			[Test]
-			public void TestGetApplicationFromPid ()
-			{
-				int knownPid = 1;
-				int unknownPid = -1; // valid pid is > 0?
+		[Test]
+		public void TestGetApplicationFromPid ()
+		{
+			int knownPid = System.Diagnostics.Process.GetCurrentProcess ().Id;
+			int unknownPid = -1; // valid pid is > 0
 #if !XAMCORE_4_0
-				var app1 = SBApplication.FromProcessIdentifier (knownPid);
-				Assert.IsNotNull (app1);
-				var app2 = SBApplication.FromProcessIdentifier<MySbApp> (knownPid);
-				Assert.IsNotNull (app2);
-				var app3 = SBApplication.FromProcessIdentifier (unknownPid);
-				var app4 = SBApplication.FromProcessIdentifier<MySbApp> (unknownPid);
-				Assert.IsNull (app3);
-				Assert.IsNull (app4);
+			using (var app1 = SBApplication.FromProcessIdentifier (knownPid))
+			using (var app2 = SBApplication.FromProcessIdentifier<MySBApp> (knownPid))
+			using (var app3 = SBApplication.FromProcessIdentifier (unknownPid))
+			using (var app4 = SBApplication.FromProcessIdentifier<MySBApp> (unknownPid))
 #else
-				var app1 = SBApplication.GetApplicationFromProcessIdentifier (knownPid);
-				Assert.IsNotNull (app1);
-				var app2 = SBApplication.GetApplicationFromProcessIdentifier<MySbApp> (knownPid);
-				Assert.IsNotNull (app2);
-				var app3 = SBApplication.GetApplicationFromProcessIdentifier (unknownPid);
-				var app4 = SBApplication.GetApplicationFromProcessIdentifier<MySbApp> (unknownPid);
-				Assert.IsNull (app3);
-				Assert.IsNull (app4);
+			using (var app1 = SBApplication.GetApplicationFromProcessIdentifier (knownPid))
+			using (var app2 = SBApplication.GetApplicationFromProcessIdentifier<MySbApp> (knownPid))
+			using (var app3 = SBApplication.GetApplicationFromProcessIdentifier (unknownPid))
+			using (var app4 = SBApplication.GetApplicationFromProcessIdentifier<MySbApp> (unknownPid)
 #endif
+			{
+				Assert.IsNotNull (app1, "SBApplication from known pid is null");
+				Assert.IsNotNull (app2, "MySBApp from known pid is null");
+				Assert.IsNotNull (app3, "SBApplication from unknown pid is null");
+				Assert.IsNotNull (app4, "MySBApp from unknown pid is null");
 			}
 		}
 	}

--- a/tests/apitest/src/ScriptingBridge/SBApplicationTest.cs
+++ b/tests/apitest/src/ScriptingBridge/SBApplicationTest.cs
@@ -1,0 +1,115 @@
+﻿using NUnit.Framework;
+using System;
+
+using AppKit;
+using ObjCRuntime;
+using Foundation;
+using ScriptingBridge;
+
+namespace Xamarin.Mac.Tests {
+
+	public class MySbApp : SBApplication {
+		public MySbApp () : base (NSObjectFlag.Empty) { }
+
+		public MySbApp (NSCoder coder) : base (coder) { }
+
+		public MySbApp (NSUrl url) : base (url) { }
+
+		public MySbApp (int pid) : base (pid) { }
+
+		public MySbApp (string ident) : base (ident) { }
+
+		protected MySbApp (NSObjectFlag t) : base (t) { }
+
+		protected internal MySbApp (IntPtr handle) : base (handle) { }
+	}
+
+	[TestFixture]
+	public class SBApplicationTest {
+
+		[TestFixture]
+		public class GetSBApplicationTest {
+
+			[Test]
+			public void TestGetApplicationFromBundleIdentifier ()
+			{
+				const string knownBundle = "com.apple.finder";
+				const string unknownBundle = "com.unknown.bundle";
+#if !XAMCORE_4_0
+				var app2 = SBApplication.FromBundleIdentifier<MySbApp> (knownBundle);
+				Assert.IsNotNull (app2);
+				var app1 = SBApplication.FromBundleIdentifier (unknownBundle);
+				Assert.IsNotNull (app1);
+				var app4 = SBApplication.FromBundleIdentifier<MySbApp> (unknownBundle);
+
+				var app3 = SBApplication.FromBundleIdentifier (unknownBundle);
+				Assert.IsNull (app3);
+				Assert.IsNull (app4);
+#else
+				var app1 = SBApplication.GetApplicationFromBundleIdentifier (knownBundle);
+				Assert.IsNotNull (app1);
+				var app2 = SBApplication.GetApplicationFromBundleIdentifier<MySbApp> (knownBundle);
+				Assert.IsNotNull (app2);
+				var app3 = SBApplication.GetApplicationFromBundleIdentifier (unknownBundle);
+				var app4 = SBApplication.GetApplicationFromBundleIdentifier<MySbApp> (unknownBundle);
+				Assert.IsNull (app3);
+				Assert.IsNull (app4);
+#endif
+			}
+
+			[Test]
+			public void TestGetApplicationFromUrl ()
+			{
+				NSUrl knownUrl = new NSUrl("http://www.xamarin.com");
+				NSUrl unknownUrl = new NSUrl ("thisisnotaurl");
+#if !XAMCORE_4_0
+				var app1 = SBApplication.FromURL (knownUrl);
+				Assert.IsNotNull (app1);
+				var app2 = SBApplication.FromURL<MySbApp> (knownUrl);
+				Assert.IsNotNull (app2);
+				var app3 = SBApplication.FromURL (unknownUrl);
+				var app4 = SBApplication.FromURL<MySbApp> (unknownUrl);
+				Assert.IsNull (app3);
+				Assert.IsNull (app4);
+#else
+				var app1 = SBApplication.GetApplicationFromUrl (knownUrl);
+				Assert.IsNotNull (app1);
+				var app2 = SBApplication.GetApplicationFromUrl<MySbApp> (knownUrl);
+				Assert.IsNotNull (app2);
+				var app3 = SBApplication.GetApplicationFromUrl (unknownUrl);
+				var app4 = SBApplication.GetApplicationFromUrl<MySbApp> (unknownUrl);
+				Assert.IsNull (app3);
+				Assert.IsNull (app4);
+#endif
+			}
+
+			[Test]
+			public void TestGetApplicationFromPid ()
+			{
+				int knownPid = 1;
+				int unknownPid = -1; // valid pid is > 0?
+#if !XAMCORE_4_0
+				var app1 = SBApplication.FromProcessIdentifier (knownPid);
+				Assert.IsNotNull (app1);
+				var app2 = SBApplication.FromProcessIdentifier<MySbApp> (knownPid);
+				Assert.IsNotNull (app2);
+				var app3 = SBApplication.FromProcessIdentifier (unknownPid);
+				var app4 = SBApplication.FromProcessIdentifier<MySbApp> (unknownPid);
+				Assert.IsNull (app3);
+				Assert.IsNull (app4);
+#else
+				var app1 = SBApplication.GetApplicationFromProcessIdentifier (knownPid);
+				Assert.IsNotNull (app1);
+				var app2 = SBApplication.GetApplicationFromProcessIdentifier<MySbApp> (knownPid);
+				Assert.IsNotNull (app2);
+				var app3 = SBApplication.GetApplicationFromProcessIdentifier (unknownPid);
+				var app4 = SBApplication.GetApplicationFromProcessIdentifier<MySbApp> (unknownPid);
+				Assert.IsNull (app3);
+				Assert.IsNull (app4);
+#endif
+			}
+		}
+	}
+}
+
+

--- a/tests/xtro-sharpie/macOS-ScriptingBridge.ignore
+++ b/tests/xtro-sharpie/macOS-ScriptingBridge.ignore
@@ -5,6 +5,3 @@
 !missing-null-allowed! 'Foundation.NSObject ScriptingBridge.SBObject::get_Get()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject[] ScriptingBridge.SBElementArray::Get()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'ObjCRuntime.Class ScriptingBridge.SBApplication::ClassForScripting(System.String)' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'ScriptingBridge.SBApplication ScriptingBridge.SBApplication::FromBundleIdentifier(System.String)' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'ScriptingBridge.SBApplication ScriptingBridge.SBApplication::FromProcessIdentifier(System.Int32)' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'ScriptingBridge.SBApplication ScriptingBridge.SBApplication::FromURL(Foundation.NSUrl)' is missing an [NullAllowed] on return type


### PR DESCRIPTION
Fix for https://github.com/xamarin/xamarin-macios/issues/9011


- [ ] Backport to d16-8
- [ ] Backport to xcode12

Any ideas for adding tests? Right now, tests/scriptingbridge contains one test, but it seems to be broken:

```
➜  scriptingbridge git:(SBFix) ✗ make
/Users/whitneyschmidt/Documents/xamarin-macios/xamarin-macios/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/bin/bmac --out=build/compat/finder.dll --outdir=build/compat/ -r:/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5/System.Drawing.dll -baselib:../../src/build/mac/compat/XamMac.dll finder.cs
error BI0087: bgen-classic: Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
make: *** [build/compat/finder.dll] Error 1
```

Backport of #9620.

/cc @whitneyschmidt 