### PR TITLE
Use provisionator built-ins for custom functions

### DIFF
--- a/tools/devops/device-tests-provisioning.csx.in
+++ b/tools/devops/device-tests-provisioning.csx.in
@@ -7,43 +7,11 @@ using System.Linq;
 using static Xamarin.Provisioning.ProvisioningScript;
 
 // Provision Xcode using the xip name declared in Make.config
-var xcodeItem = GetXcodeItem ("@XCODE_XIP_NAME@");
-Item (xcodeItem).XcodeSelect (allowUntrusted: true);
+Xcode ("@XCODE_XIP_NAME@").XcodeSelect (allowUntrusted: true);
 
 // provisionator knows how to deal with this items
 Item ("@MONO_PACKAGE@");
 Item ("@VS_PACKAGE@");
 Item ("@XI_PACKAGE@");
 
-BrewPackage ("p7zip");
-
-void BrewPackage (string name)
-{
-	// Assumes brew is already installed. 
-	// All Macs provisioned by Xamarin, VSEng, or DDFUN should have brew by default!
-	Item (name)
-		.Condition (i => !Exec ("brew", "list", "-1").Any (x => x.Trim () == i.Name))
-		.Action (i => Exec ("brew", "install", i.Name));
-}
-
-XreItem GetXcodeItem (string xipFileName)
-{
-	var items = (XreItem []) Enum.GetValues (typeof (XreItem));
-	var xreItemType = typeof (XreItem);
-	var itemAttrType = typeof (Xamarin.Provisioning.Model.ItemAttribute);
-
-	foreach (var item in items) {
-		var attr = xreItemType
-			.GetField (item.ToString ())
-			.GetCustomAttributes (itemAttrType, false)
-			?.Cast<Xamarin.Provisioning.Model.ItemAttribute> ()
-			.FirstOrDefault (a => a.Uri.EndsWith (xipFileName, StringComparison.Ordinal));
-
-		if (attr == null)
-			continue;
-
-		return item;
-	}
-
-	throw new Xamarin.Provisioning.ProvisioningException ($"'{xipFileName}' not found in 'XreItem' members.");
-}
+BrewPackages ("p7zip");


### PR DESCRIPTION
We had a few new features in provisionator that should make life a bit more easy for you:

1) We have built in syntax support for [`BrewPackages`](https://github.com/xamarin/provisionator/pull/342), a variadic Item which will install the specified packages or if they're already installed, upgrade to the latest version
2) We made it possible to specify the Xcode Version by passing the xip name through to the [`Xcode()`](https://github.com/xamarin/provisionator/pull/359) item, removing the need to look up and match things via XreItem. This also helps us achieve our goal of migrating off of XreItem.