### PR TITLE
[dotnet-linker] Set the dynamic registration mode at runtime.

### DIFF
--- a/tools/dotnet-linker/Steps/GenerateMainStep.cs
+++ b/tools/dotnet-linker/Steps/GenerateMainStep.cs
@@ -42,6 +42,7 @@ namespace Xamarin {
 				if (!app.IsDefaultMarshalManagedExceptionMode)
 					contents.WriteLine ("\txamarin_marshal_managed_exception_mode = MarshalManagedExceptionMode{0};", app.MarshalManagedExceptions);
 				contents.WriteLine ("\txamarin_marshal_objectivec_exception_mode = MarshalObjectiveCExceptionMode{0};", app.MarshalObjectiveCExceptions);
+				contents.WriteLine ("\txamarin_supports_dynamic_registration = {0};", app.DynamicRegistrationSupported ? "TRUE" : "FALSE");
 				contents.WriteLine ("}");
 				contents.WriteLine ();
 				contents.WriteLine ("void xamarin_initialize_callbacks () __attribute__ ((constructor));");


### PR DESCRIPTION
This way we know at runtime what's available and what's not, which means that
the runtime won't try to register assemblies when the dynamic registrar has
been linked away.

Fixes this startup crash in monotouch-test when all optimizations have been enabled:

    Unhandled Exception:
    ObjCRuntime.RuntimeException: The runtime function register_assembly has been linked away.