### PR TITLE
[dotnet] Tell the linker about any xml descriptors we might have.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -221,6 +221,8 @@
 				<BeforeStep>LoadReferencesStep</BeforeStep>
 				<Type>Xamarin.SetupStep</Type>
 			</_TrimmerCustomSteps>
+
+			<TrimmerRootDescriptor Include="@(_BundlerXmlDefinitions)" />
 		</ItemGroup>
 
 		<!-- Create the file with our custom linker options -->

--- a/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
@@ -14,6 +14,7 @@
     <CodesignEntitlements>..\..\Entitlements.plist</CodesignEntitlements>
     <AssetTargetFallback>xamarinios10;$(AssetTargetFallback)</AssetTargetFallback>
     <DefineConstants Condition="'$(Platform)' == 'iPhoneSimulator'">$(DefineConstants);DYNAMIC_REGISTRAR</DefineConstants>
+    <RootTestsDirectory>..\..\..</RootTestsDirectory>
   </PropertyGroup>
 
   <ItemGroup>
@@ -198,4 +199,5 @@
   <Target Name="BeforeBuild" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)" DependsOnTargets="CustomMetalSmelting" >
     <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />
   </Target>
+  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
 </Project>


### PR DESCRIPTION
Also add a linker descriptor to the monotouch-test/.NET project file to
preserve the parts of nunit.framework.dll that aren't linker safe.

This fixes an unhandled exception that causes a crash during the
monotouch-test test run when the linker is enabled:

    Unhandled Exception:
    System.NullReferenceException: Object reference not set to an instance of an object

    Thread 11 Crashed:: tid_15403  Dispatch queue: com.apple.root.default-qos
    0   libsystem_kernel.dylib        	0x00007fff5220c33a __pthread_kill + 10
    1   libsystem_pthread.dylib       	0x00007fff522b6e60 pthread_kill + 430
    2   libsystem_c.dylib             	0x00007fff5219bb7c abort + 120
    3   libxamarin-debug.dylib        	0x000000010c93979f xamarin_unhandled_exception_handler + 47
    4   libmonosgen-2.0.dylib         	0x000000010cc04980 mono_invoke_unhandled_exception_hook + 131
    5   libmonosgen-2.0.dylib         	0x000000010cb40166 mono_handle_exception_internal + 5915
    6   libmonosgen-2.0.dylib         	0x000000010cb3ea47 mono_handle_exception + 11
    7   libmonosgen-2.0.dylib         	0x000000010cb8ea06 mono_amd64_throw_exception + 158
    8   ???                           	0x000000010d4125b0 0 + 4517340592
    9   libxamarin-debug.dylib        	0x000000010c9394fb xamarin_process_managed_exception + 379 (runtime.m:2361)
    10  libxamarin-debug.dylib        	0x000000010c939377 xamarin_process_managed_exception_gchandle + 55 (runtime.m:1144)
    11  libxamarin-debug.dylib        	0x000000010c939333 xamarin_ftnptr_exception_handler + 19 (runtime.m:1133)
    12  libmonosgen-2.0.dylib         	0x000000010cb3feeb mono_handle_exception_internal + 5280
    13  libmonosgen-2.0.dylib         	0x000000010cb3ea47 mono_handle_exception + 11
    14  libmonosgen-2.0.dylib         	0x000000010cb8f2dd handle_signal_exception + 67
    15  ???                           	0x000070000fd730d8 0 + 123145568071896
    16  ???                           	0x000000011a3ab99b 0 + 4735023515
    17  ???                           	0x000000011a3aa643 0 + 4735018563
    18  libdispatch.dylib             	0x00007fff52090a0f _dispatch_queue_override_invoke + 1071
    19  libdispatch.dylib             	0x00007fff5209dcc5 _dispatch_root_queue_drain + 350
    20  libdispatch.dylib             	0x00007fff5209e46a _dispatch_worker_thread2 + 102
    21  libsystem_pthread.dylib       	0x00007fff522b39f7 _pthread_wqthread + 220
    22  libsystem_pthread.dylib       	0x00007fff522b2b77 start_wqthread + 15