### PR TITLE
[dotnet] Mark our platform assemblies as linkable.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -77,6 +77,7 @@
                             RuntimePackNamePatterns="Microsoft.$(_PlatformName).Runtime.**RID**"
                             RuntimePackRuntimeIdentifiers="$(_RuntimePackRuntimeIdentifiers)"
                             Profile="$(_PlatformName)"
+                            IsTrimmable="true"
                             />
   </ItemGroup>
 


### PR DESCRIPTION
Setting IsTrimmable will mark our assemblies as linkable.

This way we get closer to using the .NET way of choosing what the linker
should do.