### PR TITLE
[msbuild] Don't include Execution.cs in the test project.

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -53,9 +53,6 @@
     <Compile Include="..\..\..\tests\common\ExecutionHelper.cs">
       <Link>ExecutionHelper.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\tools\common\Execution.cs">
-      <Link>Execution.cs</Link>
-    </Compile>
     <Compile Include="..\..\..\tests\mtouch\Cache.cs">
       <Link>Cache.cs</Link>
     </Compile>


### PR DESCRIPTION
Fixes numerous compiler warnings like this:

    msbuild/xamarin-macios/tools/common/Execution.cs(35,57): warning CS0436: The type 'Execution' in 'msbuild/xamarin-macios/msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs' conflicts with the imported type 'Execution' in 'Xamarin.iOS.Tasks, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs'. [msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj]
    msbuild/xamarin-macios/tools/common/Execution.cs(60,15): warning CS0436: The type 'Execution' in 'msbuild/xamarin-macios/msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs' conflicts with the imported type 'Execution' in 'Xamarin.iOS.Tasks, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs'. [msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj]
    msbuild/xamarin-macios/tools/common/Execution.cs(170,22): warning CS0436: The type 'Execution' in 'msbuild/xamarin-macios/msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs' conflicts with the imported type 'Execution' in 'Xamarin.iOS.Tasks, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs'. [msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj]
    msbuild/xamarin-macios/tools/common/Execution.cs(185,22): warning CS0436: The type 'Execution' in 'msbuild/xamarin-macios/msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs' conflicts with the imported type 'Execution' in 'Xamarin.iOS.Tasks, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs'. [msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj]
    msbuild/xamarin-macios/tools/common/Execution.cs(157,22): warning CS0436: The type 'Execution' in 'msbuild/xamarin-macios/msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs' conflicts with the imported type 'Execution' in 'Xamarin.iOS.Tasks, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs'. [msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj]
    msbuild/xamarin-macios/tools/common/Execution.cs(192,22): warning CS0436: The type 'Execution' in 'msbuild/xamarin-macios/msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs' conflicts with the imported type 'Execution' in 'Xamarin.iOS.Tasks, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs'. [msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj]
    msbuild/xamarin-macios/tests/common/ExecutionHelper.cs(491,13): warning CS0436: The type 'Execution' in 'msbuild/xamarin-macios/msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs' conflicts with the imported type 'Execution' in 'Xamarin.iOS.Tasks, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs'. [msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj]
    msbuild/xamarin-macios/tests/common/ExecutionHelper.cs(505,13): warning CS0436: The type 'Execution' in 'msbuild/xamarin-macios/msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs' conflicts with the imported type 'Execution' in 'Xamarin.iOS.Tasks, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs'. [msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj]
    msbuild/xamarin-macios/tools/common/Execution.cs(62,39): warning CS0436: The type 'Execution' in 'msbuild/xamarin-macios/msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs' conflicts with the imported type 'Execution' in 'Xamarin.iOS.Tasks, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs'. [msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj]
    msbuild/xamarin-macios/tests/common/ExecutionHelper.cs(527,13): warning CS0436: The type 'Execution' in 'msbuild/xamarin-macios/msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs' conflicts with the imported type 'Execution' in 'Xamarin.iOS.Tasks, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs'. [msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj]
    msbuild/xamarin-macios/tools/common/Execution.cs(172,15): warning CS0436: The type 'Execution' in 'msbuild/xamarin-macios/msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs' conflicts with the imported type 'Execution' in 'Xamarin.iOS.Tasks, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'msbuild/tests/Xamarin.iOS.Tasks.Tests/../../../tools/common/Execution.cs'. [msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj]