### PR TITLE
[tests] Make the .NET bgen tests actually reference the .NET BCL.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -99,6 +99,7 @@ test.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk
 	@echo "TVOS_SDK_VERSION=$(TVOS_SDK_VERSION)" >> $@
 	@echo "WATCH_SDK_VERSION=$(WATCH_SDK_VERSION)" >> $@
 	@echo "OSX_SDK_VERSION=$(OSX_SDK_VERSION)" >> $@
+	@echo "DOTNET5_BCL_DIR=$(DOTNET5_BCL_DIR)" >> $@
 
 test-system.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk
 	@rm -f $@

--- a/tests/cecil-tests/cecil-tests.csproj
+++ b/tests/cecil-tests/cecil-tests.csproj
@@ -34,5 +34,11 @@
     <Compile Include="..\..\tools\common\Execution.cs">
       <Link>Execution.cs</Link>
     </Compile>
+    <Compile Include="..\..\tools\common\ApplePlatform.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
+    <Compile Include="..\..\tools\common\TargetFramework.cs">
+      <Link>TargetFramework.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/tests/dotnet/UnitTests/DotNetUnitTests.csproj
+++ b/tests/dotnet/UnitTests/DotNetUnitTests.csproj
@@ -33,6 +33,9 @@
     <Compile Include="..\..\..\tools\common\Execution.cs">
       <Link>external\Execution.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tools\common\TargetFramework.cs">
+      <Link>external\TargetFramework.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="external\" />

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -17,59 +17,73 @@ namespace GeneratorTests
 	public class BGenTests
 	{
 		[Test]
+#if !NET
 		[TestCase (Profile.macOSFull)]
-		[TestCase (Profile.macOSMobile)]
 		[TestCase (Profile.macOSSystem)]
+#endif
+		[TestCase (Profile.macOSMobile)]
 		public void BMac_Smoke (Profile profile)
 		{
 			BuildFile (profile, "bmac_smoke.cs");
 		}
 
+#if !NET // There's no System.Drawing in the .NET BCL
 		[Test]
 		[TestCase (Profile.macOSSystem)]
 		public void BMac_NonAbsoluteReference_StillBuilds (Profile profile)
 		{
 			BuildFile (profile, true, false, new List<string> () { "System.Drawing" }, "bmac_smoke.cs");
 		}
+#endif
 
+#if !NET
 		[Test]
 		[TestCase (Profile.macOSSystem)]
 		public void BMac_AbsoluteSystemReference_StillBuilds (Profile profile)
 		{
 			BuildFile (profile, true, false, new List<string> () { "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5/System.Drawing.dll" }, "bmac_smoke.cs");
 		}
+#endif
 
 		[Test]
+#if !NET
 		[TestCase (Profile.macOSFull)]
-		[TestCase (Profile.macOSMobile)]
 		[TestCase (Profile.macOSSystem)]
+#endif
+		[TestCase (Profile.macOSMobile)]
 		public void BMac_With_Hyphen_In_Name (Profile profile)
 		{
 			BuildFile (profile, "bmac-with-hyphen-in-name.cs");
 		}
 
 		[Test]
+#if !NET
 		[TestCase (Profile.macOSFull)]
-		[TestCase (Profile.macOSMobile)]
 		[TestCase (Profile.macOSSystem)]
+#endif
+		[TestCase (Profile.macOSMobile)]
 		public void PropertyRedefinitionMac (Profile profile)
 		{
 			BuildFile (profile, "property-redefination-mac.cs");
 		}
 
 		[Test]
+#if !NET
 		[TestCase (Profile.macOSFull)]
-		[TestCase (Profile.macOSMobile)]
 		[TestCase (Profile.macOSSystem)]
+#endif
+		[TestCase (Profile.macOSMobile)]
 		public void NSApplicationPublicEnsureMethods (Profile profile)
 		{
 			BuildFile (profile, "NSApplicationPublicEnsureMethods.cs");
 		}
 
 		[Test]
+#if !NET
 		[TestCase (Profile.macOSFull)]
-		[TestCase (Profile.macOSMobile)]
 		[TestCase (Profile.macOSSystem)]
+#endif
+		[TestCase (Profile.macOSMobile)]
 		public void ProtocolDuplicateAbstract (Profile profile)
 		{
 			BuildFile (profile, "protocol-duplicate-abstract.cs");
@@ -170,9 +184,11 @@ namespace GeneratorTests
 		}
 
 		[Test]
+#if !NET
 		[TestCase (Profile.macOSFull)]
-		[TestCase (Profile.macOSMobile)]
 		[TestCase (Profile.macOSSystem)]
+#endif
+		[TestCase (Profile.macOSMobile)]
 		public void Bug31788 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -581,7 +597,7 @@ namespace GeneratorTests
 		public void GHIssue5692 () => BuildFile (Profile.iOS, "ghissue5692.cs");
 
 		[Test]
-		public void GHIssue7304 () => BuildFile (Profile.macOSFull, "ghissue7304.cs");
+		public void GHIssue7304 () => BuildFile (Profile.macOSMobile, "ghissue7304.cs");
 
 		[Test]
 		public void RefOutParameters ()

--- a/tests/generator/ErrorTests.cs
+++ b/tests/generator/ErrorTests.cs
@@ -29,6 +29,7 @@ namespace GeneratorTests
 			bgen.AssertError (86, "A target framework (--target-framework) must be specified.");
 		}
 
+#if !NET
 		[Test]
 		public void BI0087 ()
 		{
@@ -38,6 +39,7 @@ namespace GeneratorTests
 			bgen.AssertExecuteError ("build");
 			bgen.AssertError (87, "Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.");
 		}
+#endif
 
 		[Test]
 		[TestCase (Profile.iOS)]
@@ -53,7 +55,9 @@ namespace GeneratorTests
 		}
 
 		[Test]
+#if !NET
 		[TestCase (Profile.macOSFull)]
+#endif
 		[TestCase (Profile.macOSMobile)]
 		public void BI1037 (Profile profile)
 		{
@@ -66,7 +70,9 @@ namespace GeneratorTests
 		}
 
 		[Test]
+#if !NET
 		[TestCase (Profile.macOSFull)]
+#endif
 		[TestCase (Profile.macOSMobile)]
 		public void BI1038 (Profile profile)
 		{
@@ -79,7 +85,9 @@ namespace GeneratorTests
 		}
 
 		[Test]
+#if !NET
 		[TestCase (Profile.macOSFull)]
+#endif
 		[TestCase (Profile.macOSMobile)]
 		public void BI1039 (Profile profile)
 		{
@@ -92,7 +100,9 @@ namespace GeneratorTests
 		}
 
 		[Test]
+#if !NET
 		[TestCase (Profile.macOSFull)]
+#endif
 		[TestCase (Profile.macOSMobile)]
 		public void BI1040 (Profile profile)
 		{
@@ -105,7 +115,9 @@ namespace GeneratorTests
 		}
 
 		[Test]
+#if !NET
 		[TestCase (Profile.macOSFull)]
+#endif
 		[TestCase (Profile.macOSMobile)]
 		public void BI1041 (Profile profile)
 		{
@@ -744,7 +756,9 @@ namespace BI1066Errors
 
 		[Test]
 		[TestCase (Profile.iOS)]
+#if !NET
 		[TestCase (Profile.macOSFull)]
+#endif
 		[TestCase (Profile.macOSMobile)]
 		public void WarnAsError (Profile profile)
 		{
@@ -795,7 +809,9 @@ namespace BI1066Errors
 
 		[Test]
 		[TestCase (Profile.iOS)]
+#if !NET
 		[TestCase (Profile.macOSFull)]
+#endif
 		[TestCase (Profile.macOSMobile)]
 		public void NoWarn (Profile profile)
 		{
@@ -846,7 +862,9 @@ namespace BI1066Errors
 
 		[Test]
 		[TestCase (Profile.iOS)]
+#if !NET
 		[TestCase (Profile.macOSFull)]
+#endif
 		[TestCase (Profile.macOSMobile)]
 		public void MissingExportOnProperty (Profile profile)
 		{

--- a/tests/generator/bug17232.cs
+++ b/tests/generator/bug17232.cs
@@ -1,5 +1,4 @@
 using System;
-using MonoTouch;
 using Foundation;
 using ObjCRuntime;
 

--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>generatortests</RootNamespace>
     <AssemblyName>generator-tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -18,12 +18,14 @@
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/msbuild-mac/msbuild-mac.csproj
+++ b/tests/msbuild-mac/msbuild-mac.csproj
@@ -73,6 +73,12 @@
     <Compile Include="..\mtouch\Cache.cs">
       <Link>Cache.cs</Link>
     </Compile>
+    <Compile Include="..\..\tools\common\TargetFramework.cs">
+      <Link>TargetFramework.cs</Link>
+    </Compile>
+    <Compile Include="..\..\tools\common\ApplePlatform.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="CustomBuildActions.targets" />

--- a/tests/mtouch/mtouch.csproj
+++ b/tests/mtouch/mtouch.csproj
@@ -109,6 +109,9 @@
     <Compile Include="..\..\tools\common\Execution.cs">
       <Link>Execution.cs</Link>
     </Compile>
+    <Compile Include="..\..\tools\common\TargetFramework.cs">
+      <Link>TargetFramework.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\tools\mtouch\Errors.resx">

--- a/tests/sampletester/sampletester.csproj
+++ b/tests/sampletester/sampletester.csproj
@@ -62,6 +62,12 @@
     <Compile Include="..\..\tools\common\Execution.cs">
       <Link>external\Execution.cs</Link>
     </Compile>
+    <Compile Include="..\..\tools\common\ApplePlatform.cs">
+      <Link>external\ApplePlatform.cs</Link>
+    </Compile>
+    <Compile Include="..\..\tools\common\TargetFramework.cs">
+      <Link>external\TargetFramework.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="external\" />

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -115,6 +115,12 @@
     <Compile Include="..\..\tools\common\Execution.cs">
       <Link>Execution.cs</Link>
     </Compile>
+    <Compile Include="..\..\tools\common\TargetFramework.cs">
+      <Link>TargetFramework.cs</Link>
+    </Compile>
+    <Compile Include="..\..\tools\common\ApplePlatform.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tools/common/TargetFramework.cs
+++ b/tools/common/TargetFramework.cs
@@ -14,6 +14,11 @@ namespace Xamarin.Utils
 {
 	public struct TargetFramework : IEquatable<TargetFramework>
 	{
+		public const string DotNet_5_0_iOS_String = ".NETCoreApp,Version=5.0,Profile=ios"; // Short form: net5.0-ios
+		public const string DotNet_5_0_tvOS_String = ".NETCoreApp,Version=5.0,Profile=tvos"; // Short form: net5.0-tvos
+		public const string DotNet_5_0_watchOS_String = ".NETCoreApp,Version=5.0,Profile=watchos"; // Short form: net5.0-watchos
+		public const string DotNet_5_0_macOS_String = ".NETCoreApp,Version=5.0,Profile=macos"; // Short form: net5.0-macos
+
 		public static readonly TargetFramework Empty = new TargetFramework ();
 		public static readonly TargetFramework Net_2_0 = Parse ("2.0");
 		public static readonly TargetFramework Net_3_0 = Parse ("3.0");
@@ -30,10 +35,10 @@ namespace Xamarin.Utils
 		public static readonly TargetFramework Xamarin_Mac_4_5_Full = Parse ("Xamarin.Mac,Version=v4.5,Profile=Full");
 		public static readonly TargetFramework Xamarin_Mac_4_5_System = Parse ("Xamarin.Mac,Version=v4.5,Profile=System");
 
-		public static readonly TargetFramework DotNet_5_0_iOS = Parse (".NETCoreApp,Version=5.0,Profile=ios"); // Short form: net5.0-ios
-		public static readonly TargetFramework DotNet_5_0_tvOS = Parse (".NETCoreApp,Version=5.0,Profile=tvos"); // Short form: net5.0-tvos
-		public static readonly TargetFramework DotNet_5_0_watchOS = Parse (".NETCoreApp,Version=5.0,Profile=watchos"); // Short form: net5.0-watchos
-		public static readonly TargetFramework DotNet_5_0_macOS = Parse (".NETCoreApp,Version=5.0,Profile=macos"); // Short form: net5.0-macos
+		public static readonly TargetFramework DotNet_5_0_iOS = Parse (DotNet_5_0_iOS_String);
+		public static readonly TargetFramework DotNet_5_0_tvOS = Parse (DotNet_5_0_tvOS_String);
+		public static readonly TargetFramework DotNet_5_0_watchOS = Parse (DotNet_5_0_watchOS_String);
+		public static readonly TargetFramework DotNet_5_0_macOS = Parse (DotNet_5_0_macOS_String);
 
 		public static readonly TargetFramework [] ValidFrameworksMac = new [] {
 			Xamarin_Mac_2_0_Mobile, Xamarin_Mac_4_5_Full, Xamarin_Mac_4_5_System,


### PR DESCRIPTION
Make the bgen tests pass in the path to the attribute library, platform
assembly and all the .NET reference assemblies to bgen. This way we execute
these tests using the .NET version of everything.