### PR TITLE
[dotnet] Use xcrun to execute install_name_tool.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -383,7 +383,7 @@
 	<Target Name="_UpdateDynamicLibraryId" DependsOnTargets="_ComputeVariables" Inputs="@(_MonoLibrary)" Outputs="@(_MonoLibrary -> '$(_IntermediateNativeLibraryDir)%(Filename)%(Extension)')">
 		<!-- install_name_tool modifies the file in-place, so copy it first to a temporary directory before we fix it -->
 		<Copy SourceFiles="%(_MonoLibrary.FullPath)" DestinationFolder="$(_IntermediateNativeLibraryDir)" />
-		<Exec Command="install_name_tool -id @executable_path/%(_MonoLibrary.Filename)%(_MonoLibrary.Extension) $(_IntermediateNativeLibraryDir)%(_MonoLibrary.Filename)%(_MonoLibrary.Extension)" />
+		<Exec Command="xcrun install_name_tool -id @executable_path/%(_MonoLibrary.Filename)%(_MonoLibrary.Extension) $(_IntermediateNativeLibraryDir)%(_MonoLibrary.Filename)%(_MonoLibrary.Extension)" EnvironmentVariables="DEVELOPER_DIR=$(_SdkDevPath)" />
 		<!-- Update our item groups -->
 		<ItemGroup>
 			<_MonoLibraryFixed Include="@(_MonoLibrary -> '$(_IntermediateNativeLibraryDir)%(Filename)%(Extension)')" />


### PR DESCRIPTION
This fixes an issue where install_name_tool couldn't be found:

    xcrun : error : sh -c '/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -find install_name_tool 2> /dev/null' failed with exit code 16384: (null) (errno=No such file or directory) [/Users/runner/work/1/s/HelloiOS/HelloiOS.csproj]
    xcrun : error : unable to find utility "install_name_tool", not a developer tool or in PATH [/Users/runner/work/1/s/HelloiOS/HelloiOS.csproj]
    /Users/runner/work/1/s/packages/microsoft.ios.sdk/13.6.100-ci.dotnet-xcrun-for-install-name-tool.387/targets/Xamarin.Shared.Sdk.targets(386,3): error MSB3073: The command "xcrun install_name_tool -id @executable_path/libSystem.IO.Compression.Native.dylib obj/Debug/net5.0-ios/ios-x64/nativelibraries/libSystem.IO.Compression.Native.dylib" exited with code 72. [/Users/runner/work/1/s/HelloiOS/HelloiOS.csproj]