### PR TITLE
[dotnet-linker] Add a RemoveAttributesStep that will remove some of the attributes we don't need.

### DIFF
--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -213,6 +213,7 @@ namespace Xamarin.Linker {
 
 			DerivedLinkContext.Target = Target;
 			Target.Abis = Abis;
+			Target.LinkContext = DerivedLinkContext;
 			Application.Abis = Abis;
 
 			switch (Platform) {

--- a/tools/dotnet-linker/SetupStep.cs
+++ b/tools/dotnet-linker/SetupStep.cs
@@ -63,6 +63,9 @@ namespace Xamarin {
 			var prelink_substeps = new DotNetSubStepDispatcher ();
 			InsertAfter (prelink_substeps, "RemoveSecurityStep");
 
+			var post_sweep_substeps = new DotNetSubStepDispatcher ();
+			InsertAfter (post_sweep_substeps, "SweepStep");
+
 			if (Configuration.LinkMode != LinkMode.None) {
 				pre_dynamic_dependency_lookup_substeps.Add (new PreserveBlockCodeSubStep ());
 
@@ -74,6 +77,8 @@ namespace Xamarin {
 				prelink_substeps.Add (new OptimizeGeneratedCodeSubStep ());
 				prelink_substeps.Add (new MarkNSObjects ());
 				prelink_substeps.Add (new PreserveSmartEnumConversionsSubStep ());
+
+				post_sweep_substeps.Add (new RemoveAttributesStep ());
 			}
 
 			Steps.Add (new LoadNonSkippedAssembliesStep ());

--- a/tools/dotnet-linker/Steps/RemoveAttributesStep.cs
+++ b/tools/dotnet-linker/Steps/RemoveAttributesStep.cs
@@ -1,0 +1,61 @@
+using System;
+
+using Mono.Cecil;
+using Mono.Tuner;
+using Xamarin.Tuner;
+
+namespace Xamarin.Linker.Steps {
+	// The .NET linker comes with a way to remove attributes (by passing '--link-attributes
+	// some.xml' as a command-line argument), but this has a few problems:
+	// 
+	// * We'd need to figure out which attributes to remove before running the linker,
+	//   but the code to figure out which optimizations have been enabled (and which attributes
+	//   should be removed) is in our custom linker code. We'd need to refactor a big chunk
+	//   of code to move this logic out of our custom linker code.
+	// * We need to keep the removed attributes around, because the static registrar needs
+	//   them. Our custom linker logic is not notified for removed attributes, which means
+	//   we'd need to store all attributes for the attribute types we're interested in (as
+	//   opposed to this solution, where we only store attributes that are actually removed).
+	// * The attributes we want removed may contain references to types we don't want
+	//   linked away. If we ask the linker to remove those attributes, then the types may
+	//   be linked away as well, and there's no good way around this.
+	// 
+	// The end result is that a custom step is the best solution for now.
+
+	public class RemoveAttributesStep : RemoveAttributesBase {
+		protected DerivedLinkContext LinkContext {
+			get {
+				return LinkerConfiguration.GetInstance (Context).DerivedLinkContext;
+			}
+		}
+
+		protected override bool IsRemovedAttribute (CustomAttribute attribute)
+		{
+			// this avoids calling FullName (which allocates a string)
+			var attr_type = attribute.Constructor.DeclaringType;
+			switch (attr_type.Namespace) {
+			case Namespaces.ObjCRuntime:
+				switch (attr_type.Name) {
+				case "AdoptsAttribute":
+					return LinkContext.App.Optimizations.RegisterProtocols == true;
+				}
+				goto default;
+			case Namespaces.Foundation:
+				switch (attr_type.Name) {
+				case "ProtocolAttribute":
+				case "ProtocolMemberAttribute":
+					return LinkContext.App.Optimizations.RegisterProtocols == true;
+				}
+				goto default;
+			default:
+				return false;
+			}
+		}
+
+		protected override void WillRemoveAttribute (ICustomAttributeProvider provider, CustomAttribute attribute)
+		{
+			LinkContext.StoreCustomAttribute (provider, attribute);
+			base.WillRemoveAttribute (provider, attribute);
+		}
+	}
+}

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -176,6 +176,9 @@
     <Compile Include="..\..\builds\mono-ios-sdk-destdir\ios-sources\external\linker\src\tuner\Mono.Tuner\CecilRocks.cs">
       <Link>external\mono-archive\Mono.Tuner\CecilRocks.cs</Link>
     </Compile>
+    <Compile Include="..\..\builds\mono-ios-sdk-destdir\ios-sources\external\linker\src\tuner\Mono.Tuner\RemoveAttributesBase.cs">
+      <Link>external\mono-archive\Mono.Tuner\RemoveAttributesBase.cs</Link>
+    </Compile>
     <Compile Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\PListObject.cs">
       <Link>external\Xamarin.MacDev\Xamarin.MacDev\PListObject.cs</Link>
     </Compile>


### PR DESCRIPTION
The .NET linker comes with a way to remove attributes (by passing '--link-attributes
some.xml' as a command-line argument), but this has a few problems:

* We'd need to figure out which attributes to remove before running the linker,
  but the code to figure out which optimizations have been enabled (and which attributes
  should be removed) is in our custom linker code. We'd need to refactor a big chunk
  of code to move this logic out of our custom linker code.
* We need to keep the removed attributes around, because the static registrar needs
  them. Our custom linker logic is not notified for removed attributes, which means
  we'd need to store all attributes for the attribute types we're interested in (as
  opposed to this solution, where we only store attributes that are actually removed).
* The attributes we want removed may contain references to types we don't want
  linked away. If we ask the linker to remove those attributes, then the types may
  be linked away as well, and there's no good way around this.

The end result is that a custom step is the best solution for now.

Fixes these monotouch-test tests when enabling all optimizations:

    Xamarin.BindingTests.ProtocolTest
        [FAIL] OnlyProtocol :   [Protocol] IP1
            Expected: 0
            But was:  1
                at Xamarin.BindingTests.ProtocolTest.OnlyProtocol() in /Users/rolf/work/maccore/main/xamarin-macios/tests/bindings-test/ProtocolTest.cs:line 47

        [FAIL] ProtocolWithBaseType :   [Protocol] IP2
            Expected: 0
            But was:  1
                at Xamarin.BindingTests.ProtocolTest.ProtocolWithBaseType() in /Users/rolf/work/maccore/main/xamarin-macios/tests/bindings-test/ProtocolTest.cs:line 79

        [FAIL] ProtocolWithBaseTypeAndModel :   [Protocol] IP3
            Expected: 0
            But was:  1
                at Xamarin.BindingTests.ProtocolTest.ProtocolWithBaseTypeAndModel() in /Users/rolf/work/maccore/main/xamarin-macios/tests/bindings-test/ProtocolTest.cs:line 115