### PR TITLE
[msbuild] Pass -F <dir> -framework <framework> for user frameworks.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/LinkNativeCodeTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/LinkNativeCodeTaskBase.cs
@@ -86,8 +86,15 @@ namespace Xamarin.MacDev.Tasks {
 			if (Frameworks != null) {
 				foreach (var fw in Frameworks) {
 					var is_weak = fw.GetMetadata ("IsWeak") == "true";
+					var framework = fw.ItemSpec;
+					if (framework.EndsWith (".framework", StringComparison.Ordinal)) {
+						// user framework, we need to pass -F to the linker so that the linker finds the user framework.
+						arguments.Add ("-F");
+						arguments.Add (Path.GetDirectoryName (Path.GetFullPath (framework)));
+						framework = Path.GetFileNameWithoutExtension (framework);
+					}
 					arguments.Add (is_weak ? "-weak_framework" : "-framework");
-					arguments.Add (fw.ItemSpec);
+					arguments.Add (framework);
 				}
 			}
 

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/DotnetTest.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/DotnetTest.cs
@@ -37,7 +37,7 @@ namespace Xamarin.iOS.Tasks {
 		[TestCase ("MyAppWithPackageReference")]
 		[TestCase ("MyCoreMLApp")]
 		[TestCase ("MyIBToolLinkTest")]
-		// [TestCase ("MyiOSAppWithBinding")] // TODO: .NET version fails to compile due to a bug wrt to how we pass frameworks to the linker.
+		[TestCase ("MyiOSAppWithBinding")]
 		// [TestCase ("MyLinkedAssets")] // TODO: Requires fat apps, which has not been implemented yet
 		[TestCase ("MyMasterDetailApp")]
 		[TestCase ("MyMetalGame")]


### PR DESCRIPTION
This fixes a build failure in the MyiOSAppWithBinding test.