### PR TITLE
[dotnet-linker] Add a CollectUnmarkedMembersStep that will keep linked away types around for the static registrar.

### DIFF
--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -60,8 +60,6 @@ namespace Xharness.Jenkins {
 
 				switch (test.TestName) {
 				case "monotouch-test":
-					if (test.TestProject.IsDotNetProject)
-						ignore = true;
 					if (supports_dynamic_registrar_on_device)
 						yield return new TestData { Variation = "Debug (dynamic registrar)", MTouchExtraArgs = "--registrar:dynamic", Debug = true, Profiling = false, Ignored = ignore };
 					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, Defines = "OPTIMIZEALL", Ignored = ignore };

--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -60,6 +60,8 @@ namespace Xharness.Jenkins {
 
 				switch (test.TestName) {
 				case "monotouch-test":
+					if (test.TestProject.IsDotNetProject)
+						ignore = true;
 					if (supports_dynamic_registrar_on_device)
 						yield return new TestData { Variation = "Debug (dynamic registrar)", MTouchExtraArgs = "--registrar:dynamic", Debug = true, Profiling = false, Ignored = ignore };
 					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, Defines = "OPTIMIZEALL", Ignored = ignore };
@@ -91,8 +93,6 @@ namespace Xharness.Jenkins {
 			case "iPhoneSimulator":
 				switch (test.TestName) {
 				case "monotouch-test":
-					if (test.TestProject.IsDotNetProject)
-						ignore = true;
 					// The default is to run monotouch-test with the dynamic registrar (in the simulator), so that's already covered
 					yield return new TestData { Variation = "Debug (LinkSdk)", Debug = true, Profiling = false, LinkMode = "LinkSdk", Ignored = ignore };
 					yield return new TestData { Variation = "Debug (static registrar)", MTouchExtraArgs = "--registrar:static", Debug = true, Profiling = false, Undefines = "DYNAMIC_REGISTRAR", Ignored = ignore };

--- a/tools/dotnet-linker/SetupStep.cs
+++ b/tools/dotnet-linker/SetupStep.cs
@@ -77,6 +77,7 @@ namespace Xamarin {
 				prelink_substeps.Add (new OptimizeGeneratedCodeSubStep ());
 				prelink_substeps.Add (new MarkNSObjects ());
 				prelink_substeps.Add (new PreserveSmartEnumConversionsSubStep ());
+				prelink_substeps.Add (new CollectUnmarkedMembersSubStep ());
 
 				post_sweep_substeps.Add (new RemoveAttributesStep ());
 			}

--- a/tools/dotnet-linker/Steps/CollectUnmarkedMembers.cs
+++ b/tools/dotnet-linker/Steps/CollectUnmarkedMembers.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+using Mono.Cecil;
+using Mono.Linker.Steps;
+
+namespace Xamarin.Linker {
+	// The static registrar may need access to information that has been linked away,
+	// in particular types and interfaces, so we need to store those somewhere
+	// so that the static registrar can access them.
+	public class CollectUnmarkedMembersSubStep : ConfigurationAwareSubStep {
+		Dictionary<TypeDefinition, List<TypeDefinition>> ProtocolImplementations => Configuration.DerivedLinkContext.ProtocolImplementations;
+
+		public override SubStepTargets Targets {
+			get {
+				return SubStepTargets.Type;
+			}
+		}
+
+		public override void ProcessType (TypeDefinition type)
+		{
+			if (!Annotations.IsMarked (type))
+				LinkContext.AddLinkedAwayType (type);
+
+			if (type.HasInterfaces) {
+				foreach (var iface in type.Interfaces) {
+					if (Annotations.IsMarked (iface))
+						continue;
+
+					// This interface might be removed, so save it
+					if (!ProtocolImplementations.TryGetValue (type, out var list))
+						ProtocolImplementations [type] = list = new List<TypeDefinition> ();
+					list.Add (iface.InterfaceType.Resolve ());
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
The static registrar may need access to types that have been linked away, so
store unmarked types so that the static registrar can access them later.

This also makes all the monotouch-test variations green, so enable them all.

Fixes this monotouch-test when all optimizations are enabled:

    MonoTouchFixtures.ObjCRuntime.RegistrarTest
        [FAIL] TestProtocolRegistration :   UIApplicationDelegate/17669
            Expected: True
            But was:  False
                at MonoTouchFixtures.ObjCRuntime.RegistrarTest.TestProtocolRegistration() in xamarin-macios/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs:line 1350