### PR TITLE
[d16-8] [msbuild] Fix setting the IsXcode8 variable.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSdkLocationCoreTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSdkLocationCoreTaskBase.cs
@@ -130,6 +130,9 @@ namespace Xamarin.MacDev.Tasks {
 			if (EnsureAppleSdkRoot ())
 				EnsureSdkPath ();
 			EnsureXamarinSdkRoot ();
+
+			IsXcode8 = AppleSdkSettings.XcodeVersion.Major >= 8;
+
 			return !Log.HasLoggedErrors;
 		}
 


### PR DESCRIPTION
This got accidentially dropped here: https://github.com/xamarin/xamarin-macios/commit/95d71c8ee19bca9edfc1120a4fc5a9710c3a3223#diff-f677cd73ddfb82ecd3c565024fe0029cL68

Backport of #9723.

/cc @rolfbjarne 