### PR TITLE
[tests][cecil] Check that error-based enum values don't have availability attributes

### DIFF
--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -207,30 +207,19 @@ namespace AVFoundation {
 		AirPlayControllerRequiresInternet = -11856,
 		AirPlayReceiverRequiresInternet = -11857,
 
-		[iOS (9,0), Mac (10,11)]
 		VideoCompositorFailed = -11858,
 
 #if !MONOMAC
-		[iOS (9,0)]
 		RecordingAlreadyInProgress = -11859,
 #endif
-		[NoWatch, iOS (10,0), TV (10,0), Mac (10,12)]
 		UnsupportedOutputSettings = -11861,
-		[NoWatch, iOS (10,0), TV (10,0), Mac (10,12)]
 		OperationNotAllowed = -11862,
-		[NoWatch, iOS (11,0), TV (11,0), Mac (10,13)]
 		ContentIsUnavailable = -11863,
-		[NoWatch, iOS (11,0), TV (11,0), Mac (10,13)]
 		FormatUnsupported = -11864,
-		[NoWatch, iOS (11,0), TV (11,0), Mac (10,13)]
 		MalformedDepth = -11865,
-		[NoWatch, iOS (11,0), TV (11,0), Mac (10,13)]
 		ContentNotUpdated = -11866,
-		[NoWatch, iOS (11,0), TV (11,0), Mac (10,13)]
 		NoLongerPlayable = -11867,
-		[NoWatch, iOS (11,0), TV (11,0), Mac (10,13)]
 		NoCompatibleAlternatesForExternalDisplay = -11868,
-		[NoWatch, iOS (11,2), TV (11,2), Mac (10,13,2)]
 		NoSourceTrack = -11869,
 	}
 

--- a/src/AudioToolbox/AudioServices.cs
+++ b/src/AudioToolbox/AudioServices.cs
@@ -41,7 +41,6 @@ namespace AudioToolbox {
 		BadSpecifierSizeError = 0x21737063,		// '!spc'
 		SystemSoundUnspecifiedError = -1500,
 		SystemSoundClientTimedOutError = -1501,
-		[iOS (10,0), Mac (10,12)]
 		SystemSoundExceededMaximumDurationError = -1502,
 	}
 

--- a/src/CloudKit/Enums.cs
+++ b/src/CloudKit/Enums.cs
@@ -75,13 +75,13 @@ namespace CloudKit
 		ZoneNotFound = 26,
 		LimitExceeded  = 27,
 		UserDeletedZone = 28,
-		[iOS (10,0), TV (10,0), Mac (10,12)] TooManyParticipants = 29,
-		[iOS (10,0), TV (10,0), Mac (10,12)] AlreadyShared = 30,
-		[iOS (10,0), TV (10,0), Mac (10,12)] ReferenceViolation = 31,
-		[iOS (10,0), TV (10,0), Mac (10,12)] ManagedAccountRestricted = 32,
-		[iOS (10,0), TV (10,0), Mac (10,12)] ParticipantMayNeedVerification = 33,
-		[iOS (11,0), TV (11,0), Mac (10,13), Watch (4,0)] ResponseLost = 34,
-		[iOS (11,3), TV (11,3), Mac (10,13), Watch (4,3)] AssetNotAvailable = 35,
+		TooManyParticipants = 29,
+		AlreadyShared = 30,
+		ReferenceViolation = 31,
+		ManagedAccountRestricted = 32,
+		ParticipantMayNeedVerification = 33,
+		ResponseLost = 34,
+		AssetNotAvailable = 35,
 	}
 
 	// NSInteger -> CKModifyRecordsOperation.h

--- a/src/CoreBluetooth/Enums.cs
+++ b/src/CoreBluetooth/Enums.cs
@@ -109,13 +109,9 @@ namespace CoreBluetooth {
 		PeripheralDisconnected,
 		UUIDNotAllowed,
 		AlreadyAdvertising,
-		[iOS (7,1)][Mac (10,13)]
 		ConnectionFailed,
-		[iOS (9,0)][Mac (10,13)]
 		ConnectionLimitReached,
-		[iOS (11,0)][TV (11,0)][Mac (10,13)]
 		UnknownDevice,
-		[iOS (12,0)][TV (12,0)][Mac (10,14)][Watch (5,0)]
 		OperationNotSupported,
 		PeerRemovedPairingInformation,
 		EncryptionTimedOut,

--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -350,7 +350,6 @@ namespace Foundation  {
 
 		CoderReadCorruptError = 4864,
 		CoderValueNotFoundError = 4865,
-		[Mac (10,13), iOS (11,0), Watch (4,0), TV (11,0)]
 		CoderInvalidValueError = 4866,
 		CoderErrorMinimum = 4864,
 		CoderErrorMaximum = 4991,
@@ -362,30 +361,18 @@ namespace Foundation  {
 		BundleOnDemandResourceExceededMaximumSizeError = 4993,
 		BundleOnDemandResourceInvalidTagError = 4994,
 
-		[Mac (10,12)][iOS (10,0)][NoTV][NoWatch]
 		CloudSharingNetworkFailureError = 5120,
-		[Mac (10,12)][iOS (10,0)][NoTV][NoWatch]
 		CloudSharingQuotaExceededError = 5121,
-		[Mac (10,12)][iOS (10,0)][NoTV][NoWatch]
 		CloudSharingTooManyParticipantsError = 5122,
-		[Mac (10,12)][iOS (10,0)][NoTV][NoWatch]
 		CloudSharingConflictError = 5123,
-		[Mac (10,12)][iOS (10,0)][NoTV][NoWatch]
 		CloudSharingNoPermissionError = 5124,
-		[Mac (10,12)][iOS (10,0)][NoTV][NoWatch]
 		CloudSharingOtherError = 5375,
-		[Mac (10,12)][iOS (10,0)][NoTV][NoWatch]
 		CloudSharingErrorMinimum = 5120,
-		[Mac (10,12)][iOS (10,0)][NoTV][NoWatch]
 		CloudSharingErrorMaximum = 5375,
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		CompressionFailedError = 5376,
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		DecompressionFailedError = 5377,
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		CompressionErrorMinimum = 5376,
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		CompressionErrorMaximum = 5503,
 	}
 	

--- a/src/HomeKit/HMEnums.cs
+++ b/src/HomeKit/HMEnums.cs
@@ -8,7 +8,6 @@ namespace HomeKit {
 	[TV (10,0)]
 	[Native]
 	public enum HMError : long {
-		[Watch (4,2), TV (11,2), iOS (11,2)]
 		UnexpectedError                         = -1,
 		AlreadyExists                           = 1,
 		NotFound                                = 2,

--- a/src/MediaPlayer/MediaPlayer.cs
+++ b/src/MediaPlayer/MediaPlayer.cs
@@ -311,7 +311,6 @@ namespace MediaPlayer {
 		NetworkConnectionFailed,
 		NotFound,
 		NotSupported,
-		[iOS (10,1)]
 		Cancelled,
 		RequestTimedOut,
 	}

--- a/src/Metal/MTLEnums.cs
+++ b/src/Metal/MTLEnums.cs
@@ -76,9 +76,7 @@ namespace Metal {
 		NotPermitted = 7,
 		OutOfMemory = 8,
 		InvalidResource = 9,
-		[iOS (10,0), TV (10,0), NoWatch, NoMac]
 		Memoryless = 10,
-		[Mac (10,13), NoiOS, NoTV, NoWatch]
 		DeviceRemoved = 11,
 	}
 
@@ -387,9 +385,7 @@ namespace Metal {
 		Internal,
 		CompileFailure,
 		CompileWarning,
-		[iOS (10,0), TV (10,0), NoWatch, Mac (10,12)]
 		FunctionNotFound,
-		[iOS (10,0), TV (10,0), NoWatch, Mac (10,12)]
 		FileNotFound,
 	}
 

--- a/src/PassKit/PKEnums.cs
+++ b/src/PassKit/PKEnums.cs
@@ -27,7 +27,6 @@ namespace PassKit {
 		InvalidData = 1,
 		UnsupportedVersion,
 		InvalidSignature,
-		[iOS (8,0)]
 		NotEntitled
 	}
 

--- a/src/callkit.cs
+++ b/src/callkit.cs
@@ -74,7 +74,6 @@ namespace CallKit {
 		MaximumEntriesExceeded = 5,
 		ExtensionDisabled = 6,
 		CurrentlyLoading = 7,
-		[iOS (11,0)]
 		UnexpectedIncrementalRemoval = 8,
 	}
 

--- a/src/coreml.cs
+++ b/src/coreml.cs
@@ -49,7 +49,6 @@ namespace CoreML {
 		Generic = 0,
 		FeatureType = 1,
 		IO = 3,
-		[Watch (4,2), TV (11,2), Mac (10,13,2), iOS (11,2)]
 		CustomLayer = 4,
 		CustomModel = 5,
 		Update = 6,

--- a/src/fileprovider.cs
+++ b/src/fileprovider.cs
@@ -175,19 +175,12 @@ namespace FileProvider {
 		InsufficientQuota = -1003,
 		ServerUnreachable = -1004,
 		NoSuchItem = -1005,
-		[NoiOS]
 		VersionOutOfDate = -1006,
-		[NoiOS]
 		DirectoryNotEmpty = -1007,
-		[NoiOS]
 		ProviderNotFound = -2001,
-		[NoiOS]
 		ProviderTranslocated = -2002,
-		[NoiOS]
 		OlderExtensionVersionRunning = -2003,
-		[NoiOS]
 		NewerExtensionVersionFound = -2004,
-		[NoiOS]
 		CannotSynchronize = -2005,
 	}
 

--- a/tests/cecil-tests/EnumTest.cs
+++ b/tests/cecil-tests/EnumTest.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using Mono.Cecil;
+
+#nullable enable
+
+namespace Cecil.Tests {
+
+	[TestFixture]
+	public class EnumTest {
+
+		[TestCaseSource (typeof (Helper), "PlatformAssemblies")]
+		// https://github.com/xamarin/xamarin-macios/issues/9724
+		public void NoAvailabilityOnError (string assemblyPath)
+		{
+			var assembly = Helper.GetAssembly (assemblyPath);
+			if (assembly == null) {
+				Assert.Ignore ("{assemblyPath} could not be found (might be disabled in build)");
+				return; // just to help nullability
+			}
+			HashSet<string> found = new HashSet<string> ();
+			foreach (var type in assembly.MainModule.Types)
+				NoAvailabilityOnError (type, found);
+
+			Assert.That (found, Is.Empty, string.Join (", ", found));
+		}
+
+		bool IsErrorEnum (TypeDefinition type)
+		{
+			if (!type.IsEnum)
+				return false;
+
+			if (type.Name.EndsWith ("Error", StringComparison.Ordinal))
+				return true;
+			if (type.Name.EndsWith ("ErrorCode", StringComparison.Ordinal))
+				return true;
+
+			if (!type.HasCustomAttributes)
+				return false;
+			foreach (var ca in type.CustomAttributes) {
+				if (ca.AttributeType.Name == "ErrorDomainAttribute")
+					return true;
+			}
+			return false;
+		}
+
+		void NoAvailabilityOnError (TypeDefinition type, ISet<string> found)
+		{
+			if (type.HasNestedTypes) {
+				foreach (var nt in type.NestedTypes)
+					NoAvailabilityOnError (nt, found);
+			}
+
+			if (!IsErrorEnum (type))
+				return;
+
+			foreach (var f in type.Fields) {
+				if (!f.HasCustomAttributes)
+					continue;
+				foreach (var ca in f.CustomAttributes) {
+					switch (ca.AttributeType.Name) {
+					case "ObsoleteAttribute":
+						// this is fine
+						break;
+					case "IntroducedAttribute":
+					case "UnavailableAttribute":
+					case "iOSAttribute":
+					case "MacAttribute":
+					case "TVAttribute":
+					case "WatchAttribute":
+					case "NoiOSAttribute":
+					case "NoMacAttribute":
+					case "NoTVAttribute":
+					case "NoWatchAttribute":
+						found.Add ($"{type.FullName}.{f.Name}");
+						break;
+					default:
+						break;
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
and fixes the ones that have some.

From https://github.com/xamarin/xamarin-macios/issues/9724

We do not _normally_ add availability attributes on enums **members** that represent error codes. In part because it's a lot of metadata and, foremost, because it's not really helpful to write code. E.g.

```csharp
var err = Call.Api (1);
switch (err) {
case NSError.Bad:
case NSError.Wrong:
   Console.WriteLine ($"API failed: {err});
   break;
case NSError.Ok:
   break;
default:
   Console.WriteLine ($"Unknown error code {err}");
   break;
}
```

Adding version checks inside this would be complicated (source wise) and not really helpful since
* API can return undefined error code (and the error logic should work);
* Availability information is not 100% accurate;

As such we default to not add them - but we some time forgot about it. An intro rule could easily ensure we don't add them needlessly.