### PR TITLE
Revert "[introspection] Adapt to .NET 5's vision of how ConstructorInfo.ToString () should behave."

### DIFF
--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -329,13 +329,6 @@ namespace Introspection {
 		{
 			var cstr = ctor.ToString ();
 
-#if NET
-			// .NET 5 has an unusual take on how a ConstructorInfo should be converted to a string
-			// See also: https://github.com/dotnet/runtime/issues/36688
-			if (cstr.StartsWith (".ctorVoid ", StringComparison.Ordinal))
-				cstr = "Void .ctor" + cstr.Substring (".ctorVoid ".Length);
-#endif
-
 			switch (type.Name) {
 			case "MKTileOverlayRenderer":
 				// NSInvalidArgumentEception Expected a MKTileOverlay


### PR DESCRIPTION
This reverts commit f69ed9a25ef1f4c6695917dfe4b6d6ceca484b43.

This is now fixed in .NET.