### PR TITLE
[Harness] Fix device tests by ensuring that the lambdas are correctly chained.

### DIFF
--- a/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
+++ b/tests/xharness/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
@@ -7,7 +7,7 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners {
 	public interface ISimpleListener {
 		Task CompletionTask { get; }
-		Task ConnectedTask { get; }
+		Task<bool> ConnectedTask { get; }
 		int Port { get; }
 		ILog TestLog { get; }
 
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners {
 		protected abstract void Start ();
 		protected abstract void Stop ();
 
-		public Task ConnectedTask => connected.Task;
+		public Task<bool> ConnectedTask => connected.Task;
 		public int Port { get; protected set; }
 		public abstract void Initialize ();
 

--- a/tests/xharness/Xharness.Tests/Tests/AppRunnerTests.cs
+++ b/tests/xharness/Xharness.Tests/Tests/AppRunnerTests.cs
@@ -319,7 +319,7 @@ namespace Xharness.Tests {
 			// Mock finding simulators
 			simulators
 				.Setup (x => x.LoadDevices (It.IsAny<ILog> (), false, false, false))
-				.Returns (Task.CompletedTask);
+				.Returns (Task<bool>.CompletedTask);
 
 			string simulatorLogPath = Path.Combine (Path.GetTempPath (), "simulator-logs");
 
@@ -333,7 +333,7 @@ namespace Xharness.Tests {
 				.Setup (x => x.Create (It.IsAny<string> (), "TestLog", It.IsAny<bool> ()))
 				.Returns (listenerLogFile.Object);
 
-			simpleListener.SetupGet (x => x.ConnectedTask).Returns (Task.CompletedTask);
+			simpleListener.SetupGet (x => x.ConnectedTask).Returns (Task.FromResult (true));
 
 			var captureLog = new Mock<ICaptureLog> ();
 			captureLog.SetupGet (x => x.FullPath).Returns (simulatorLogPath);
@@ -424,7 +424,7 @@ namespace Xharness.Tests {
 				.Setup (x => x.Create (It.Is<string> (s => s.StartsWith ("test-sim64-")), "TestLog", It.IsAny<bool?> ()))
 				.Returns (listenerLogFile);
 
-			simpleListener.SetupGet (x => x.ConnectedTask).Returns (Task.CompletedTask);
+			simpleListener.SetupGet (x => x.ConnectedTask).Returns (Task.FromResult (true));
 
 			var captureLog = new Mock<ICaptureLog> ();
 			captureLog.SetupGet (x => x.FullPath).Returns (simulatorLogPath);
@@ -531,7 +531,7 @@ namespace Xharness.Tests {
 				.Setup (x => x.Create (It.IsAny<string> (), "TestLog", It.IsAny<bool> ()))
 				.Returns (listenerLogFile.Object);
 
-			simpleListener.SetupGet (x => x.ConnectedTask).Returns (Task.CompletedTask);
+			simpleListener.SetupGet (x => x.ConnectedTask).Returns (Task.FromResult (true));
 
 			// Act
 			var appRunner = new AppRunner (processManager.Object,
@@ -585,7 +585,7 @@ namespace Xharness.Tests {
 				.Setup (x => x.Create (It.Is<string> (s => s.StartsWith ("device-Test iPad-")), "Device log", It.IsAny<bool?> ()))
 				.Returns (deviceSystemLog.Object);
 
-			simpleListener.SetupGet (x => x.ConnectedTask).Returns (Task.CompletedTask);
+			simpleListener.SetupGet (x => x.ConnectedTask).Returns (Task.FromResult (true));
 
 			var deviceLogCapturer = new Mock<IDeviceLogCapturer> ();
 
@@ -693,7 +693,7 @@ namespace Xharness.Tests {
 				.Setup (x => x.Create (It.Is<string> (s => s.StartsWith ("device-Test iPad-")), "Device log", It.IsAny<bool?> ()))
 				.Returns (deviceSystemLog.Object);
 
-			simpleListener.SetupGet (x => x.ConnectedTask).Returns (Task.CompletedTask);
+			simpleListener.SetupGet (x => x.ConnectedTask).Returns (Task.FromResult (true));
 
 			var deviceLogCapturer = new Mock<IDeviceLogCapturer> ();
 


### PR DESCRIPTION
The launch continuation was not being used correctly since it was using
a Task<bool> on a Task. That is possible because class Task<T> : Task
but was giving runtime issues.

The problem with this case is that, since the launch callback was not
called, although the test were executed, it would set the test as a
timeout, waiting for 3 mins on a users machine, 15 on CI.

With the change, the launch callback is always executed
allowing the results to be reported correctly.

This means that tests do not longer wait for the timeout (15 mins) and the CI should have enough time to execute all tests. Also fixes those cases in which we got correct results AND the test was set as a timeout.

fixes https://github.com/xamarin/maccore/issues/2316
fixes https://github.com/xamarin/maccore/issues/2185