### PR TITLE
[tests][intro] ConstantsCheck should only be executed on latest OS

### DIFF
--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -1033,7 +1033,11 @@ namespace Introspection
 			// unless the latest OS is used there's likely to be missing ones
 			// so we run this test only on the latest supported (matching SDK) OS
 			var sdk = new Version (Constants.SdkVersion);
+#if MONOMAC
 			if (!PlatformHelper.CheckSystemVersion (sdk.Major, sdk.Minor))
+#else
+			if (!UIDevice.CurrentDevice.CheckSystemVersion (sdk.Major, sdk.Minor))
+#endif
 				Assert.Ignore ($"Constants only verified using the latest OS version ({sdk.Major}.{sdk.Minor})");
 
 			var c = typeof (Constants);

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -1035,6 +1035,8 @@ namespace Introspection
 			var sdk = new Version (Constants.SdkVersion);
 #if MONOMAC
 			if (!PlatformHelper.CheckSystemVersion (sdk.Major, sdk.Minor))
+#elif __WATCHOS__
+			if (!WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (sdk.Major, sdk.Minor))
 #else
 			if (!UIDevice.CurrentDevice.CheckSystemVersion (sdk.Major, sdk.Minor))
 #endif

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -1029,6 +1029,13 @@ namespace Introspection
 		[Test]
 		public void ConstantsCheck ()
 		{
+			// The constants are file paths for frameworks / dylibs
+			// unless the latest OS is used there's likely to be missing ones
+			// so we run this test only on the latest supported (matching SDK) OS
+			var sdk = new Version (Constants.SdkVersion);
+			if (!PlatformHelper.CheckSystemVersion (sdk.Major, sdk.Minor))
+				Assert.Ignore ($"Constants only verified using the latest OS version ({sdk.Major}.{sdk.Minor})");
+
 			var c = typeof (Constants);
 			foreach (var fi in c.GetFields ()) {
 				if (!fi.IsPublic)


### PR DESCRIPTION
since the files, mapped by the constants, might not be present in earlier
versions of the OS. We can only be sure, of their presence, on the
current/supported SDK version

Fix intro running on iOS 10.3 (64 bits)

```
Introspection.iOSApiTypoTest
    [PASS] AttributeTypoTest
    [FAIL] ConstantsCheck :   NetworkLibrary
  Expected: True
  But was:  False
 :   at Introspection.ApiTypoTest.ConstantsCheck () [0x00168] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/introspection/ApiTypoTest.cs:1088
```