### PR TITLE
Bump to .NET 5.0.100-rc.2.20459.1

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -442,9 +442,9 @@ DOTNET_FEED_DIR ?= $(DOTNET_DESTDIR)/nuget-feed
 # We're using preview versions, and there will probably be many of them, so install locally (into builds/downloads) if there's no system version to
 # avoid consuming a lot of disk space (since they're never automatically deleted). The system-dependencies.sh script will install locally as long
 # as there's a TARBALL url.
-DOTNET5_VERSION=5.0.100-rc.2.20459.1
-DOTNET5_URL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-rc.2.20459.1/dotnet-sdk-5.0.100-rc.2.20459.1-osx-x64.pkg
-DOTNET5_TARBALL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-rc.2.20459.1/dotnet-sdk-5.0.100-rc.2.20459.1-osx-x64.tar.gz
+DOTNET5_VERSION=5.0.100-rc.2.20480.7
+DOTNET5_URL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-rc.2.20480.7/dotnet-sdk-5.0.100-rc.2.20480.7-osx-x64.pkg
+DOTNET5_TARBALL=https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.100-rc.2.20480.7/dotnet-sdk-5.0.100-rc.2.20480.7-osx-x64.tar.gz
 # Use the system dotnet executable if the dotnet version we need is installed, otherwise use the local version.
 ifneq ($(wildcard /usr/local/share/dotnet/sdk/$(DOTNET5_VERSION)),)
 DOTNET5=$(DOTNET)

--- a/dotnet/generate-target-platforms.csharp
+++ b/dotnet/generate-target-platforms.csharp
@@ -31,11 +31,11 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ("\t<ItemGroup>");
 
 	foreach (XmlNode n in nodes)
-		writer.WriteLine ($"\t\t<{platform}SdkSupportedTargetPlatform Include=\"{n.InnerText}\" />");
+		writer.WriteLine ($"\t\t<{platform}SdkSupportedTargetPlatformVersion Include=\"{n.InnerText}\" />");
 
 	writer.WriteLine ("\t</ItemGroup>");
 	writer.WriteLine ("\t<ItemGroup>");
-	writer.WriteLine ($"\t\t<SdkSupportedTargetPlatform Condition=\"'$(TargetPlatformIdentifier)' == '{platform}'\" Include=\"@({platform}SdkSupportedTargetPlatform)\" />");
+	writer.WriteLine ($"\t\t<SdkSupportedTargetPlatformVersion Condition=\"'$(TargetPlatformIdentifier)' == '{platform}'\" Include=\"@({platform}SdkSupportedTargetPlatformVersion)\" />");
 	writer.WriteLine ("\t</ItemGroup>");
 	writer.WriteLine ("</Project>");
 }


### PR DESCRIPTION
@(SdkSupportedTargetPlatform) was renamed to
@(SdkSupportedTargetPlatformVersion), so match that and update our own
variable names as well.