### PR TITLE
[Xcode12.2] Bring some changes preset in d16-7 that are missing in xcode12.2.

### DIFF
--- a/src/MetalPerformanceShaders/MPSStateBatch.cs
+++ b/src/MetalPerformanceShaders/MPSStateBatch.cs
@@ -44,11 +44,13 @@ namespace MetalPerformanceShaders {
 			MPSStateBatchSynchronize (stateBatch.Handle, commandBuffer.Handle);
 		}
 
+		[Introduced (PlatformName.MacCatalyst, 13, 0)]
 		[iOS (12,0), TV (12,0), Mac (10,14)]
 		[DllImport (Constants.MetalPerformanceShadersLibrary)]
 		static extern nuint MPSStateBatchResourceSize (IntPtr batch);
 
 		// Using 'NSArray<MPSState>' instead of `MPSState[]` because array 'Handle' matters.
+		[Introduced (PlatformName.MacCatalyst, 13, 0)]
 		[iOS (12,0), TV (12,0), Mac (10,14)]
 		public static nuint GetResourceSize (NSArray<MPSState> stateBatch)
 		{

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -13752,7 +13752,7 @@ namespace AVFoundation {
 		CMFormatDescription ReplacementFormatDescription { get; }
 	}
 
-	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler (bool isSilence, AudioTimeStamp timestamp, uint frameCunt, ref AudioBuffers outputData);
+	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler (bool isSilence, AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
 
 	[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 	[BaseType (typeof(AVAudioNode))]


### PR DESCRIPTION
Some fixes were not back-ported from main to xcode12, this changes were present in d16-7 and have been released, this means that we have at least 2 regressions:

1. NSUrlSessionHandler fix
2. Audiotools typo.
3. MetalPerformantShaders missing availability in catalyst.

Related PR: https://github.com/xamarin/xamarin-macios/pull/9762