### PR TITLE
[msbuild] Refactor how we figure out which native libraries to sign for Xamarin.Mac

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -443,12 +443,6 @@ namespace Xamarin.Localization.MSBuild {
             }
         }
         
-        public static string E0088 {
-            get {
-                return ResourceManager.GetString("E0088", resourceCulture);
-            }
-        }
-        
         public static string E0089 {
             get {
                 return ResourceManager.GetString("E0089", resourceCulture);

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -374,10 +374,7 @@
     
     <!-- E0087: not used anymore -->
     
-    <data name="E0088" xml:space="preserve">
-        <value>Could not get native libraries: {0}
-        </value>
-    </data>
+    <!-- E0088: not used anymore -->
         
     <data name="E0089" xml:space="preserve">
         <value>Unrecognized platform: {0}

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
@@ -291,13 +291,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0088">
-        <source>Could not get native libraries: {0}
-        </source>
-        <target state="new">Could not get native libraries: {0}
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0089">
         <source>Unrecognized platform: {0}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
@@ -291,13 +291,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0088">
-        <source>Could not get native libraries: {0}
-        </source>
-        <target state="new">Could not get native libraries: {0}
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0089">
         <source>Unrecognized platform: {0}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
@@ -291,13 +291,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0088">
-        <source>Could not get native libraries: {0}
-        </source>
-        <target state="new">Could not get native libraries: {0}
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0089">
         <source>Unrecognized platform: {0}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
@@ -291,13 +291,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0088">
-        <source>Could not get native libraries: {0}
-        </source>
-        <target state="new">Could not get native libraries: {0}
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0089">
         <source>Unrecognized platform: {0}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
@@ -291,13 +291,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0088">
-        <source>Could not get native libraries: {0}
-        </source>
-        <target state="new">Could not get native libraries: {0}
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0089">
         <source>Unrecognized platform: {0}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
@@ -291,13 +291,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0088">
-        <source>Could not get native libraries: {0}
-        </source>
-        <target state="new">Could not get native libraries: {0}
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0089">
         <source>Unrecognized platform: {0}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
@@ -291,13 +291,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0088">
-        <source>Could not get native libraries: {0}
-        </source>
-        <target state="new">Could not get native libraries: {0}
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0089">
         <source>Unrecognized platform: {0}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
@@ -291,13 +291,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0088">
-        <source>Could not get native libraries: {0}
-        </source>
-        <target state="new">Could not get native libraries: {0}
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0089">
         <source>Unrecognized platform: {0}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
@@ -291,13 +291,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0088">
-        <source>Could not get native libraries: {0}
-        </source>
-        <target state="new">Could not get native libraries: {0}
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0089">
         <source>Unrecognized platform: {0}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
@@ -291,13 +291,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0088">
-        <source>Could not get native libraries: {0}
-        </source>
-        <target state="new">Could not get native libraries: {0}
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0089">
         <source>Unrecognized platform: {0}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
@@ -291,13 +291,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0088">
-        <source>Could not get native libraries: {0}
-        </source>
-        <target state="new">Could not get native libraries: {0}
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0089">
         <source>Unrecognized platform: {0}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
@@ -291,13 +291,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0088">
-        <source>Could not get native libraries: {0}
-        </source>
-        <target state="new">Could not get native libraries: {0}
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0089">
         <source>Unrecognized platform: {0}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
@@ -291,13 +291,6 @@
         </target>
         <note></note>
       </trans-unit>
-      <trans-unit id="E0088">
-        <source>Could not get native libraries: {0}
-        </source>
-        <target state="new">Could not get native libraries: {0}
-        </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="E0089">
         <source>Unrecognized platform: {0}
         </source>

--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -38,9 +38,6 @@ namespace Xamarin.Mac.Tasks
 		[Required]
 		public string CustomBundleName { get; set; }
 
-		[Output]
-		public ITaskItem[] NativeLibraries { get; set; }
-
 		protected override bool ValidateParameters ()
 		{
 			XamMacArch arch;
@@ -118,22 +115,6 @@ namespace Xamarin.Mac.Tasks
 		{
 			if (!base.Execute ())
 				return false;
-
-			var monoBundleDir = Path.Combine (AppBundleDir, "Contents", CustomBundleName);
-
-			try {
-				var nativeLibrariesPath = Directory.EnumerateFiles (monoBundleDir, "*.dylib", SearchOption.AllDirectories);
-				var nativeLibraryItems = new List<ITaskItem> ();
-
-				foreach (var nativeLibrary in nativeLibrariesPath) {
-					nativeLibraryItems.Add (new TaskItem (nativeLibrary));
-				}
-
-				NativeLibraries = nativeLibraryItems.ToArray ();
-			} catch (Exception ex) {
-				Log.LogError (null, null, null, AppBundleDir, 0, 0, 0, 0, MSBStrings.E0088, ex.Message);
-				return false;
-			}
 
 			return !Log.HasLoggedErrors;
 		}

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -123,6 +123,12 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CodesignNativeLibraries" Condition="'$(_RequireCodeSigning)'" DependsOnTargets="_DetectSigningIdentity">
+
+		<ItemGroup>
+			<_CodesignNativeLibrary Include="$(_AppContentsPath)\**\*.dylib" />
+			<_CodesignNativeLibrary Include="$(_AppResourcesPath)\**\*.metallib" />
+		</ItemGroup>
+
 		<Codesign
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(CodesignExe)"
@@ -130,7 +136,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			Condition="'@(_NativeLibrary)' != '' And '$(IsMacEnabled)' == 'true'"
 			CodesignAllocate="$(_CodesignAllocate)"
 			Keychain="$(CodesignKeychain)"
-			Resources="@(_NativeLibrary)"
+			Resources="@(_CodesignNativeLibrary)"
 			SigningKey="$(_CodeSigningKey)"
 			ExtraArgs="$(CodesignExtraArgs)"
 			IsAppExtension="$(IsAppExtension)"
@@ -231,10 +237,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			SdkRoot="$(_SdkRoot)"
 			OutputLibrary="$(_AppBundlePath)Contents\Resources\default.metallib">
 		</MetalLib>
-
-		<CreateItem Include="$(_AppBundlePath)Contents\Resources\default.metallib">
-			<Output TaskParameter="Include" ItemName="_NativeLibrary" />
-		</CreateItem>
 	</Target>
 
 	<Target Name="_CompileTextureAtlases" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_CoreCompileTextureAtlases" />
@@ -274,10 +276,11 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		</CreateInstallerPackage>
 	</Target>
 
-	<Target Name="_GenerateBundleName">
+	<Target Name="_GenerateBundleName" DependsOnTargets="_ParseBundlerArguments">
 		<PropertyGroup>
 			<AppBundleDir>$(OutputPath)$(_AppBundleName)$(AppBundleExtension)</AppBundleDir>
 			<_AppBundlePath>$(AppBundleDir)\</_AppBundlePath>
+			<_AppContentsPath>$(_AppBundlePath)Contents\$(_CustomBundleName)\</_AppContentsPath>
 			<_AppResourcesPath>$(_AppBundlePath)Contents\Resources\</_AppResourcesPath>
 		</PropertyGroup>
 	</Target>
@@ -352,7 +355,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			StandardOutputImportance="High"
 			XamarinSdkRoot="$(_XamarinSdkRoot)"
 			>
-			<Output TaskParameter="NativeLibraries" ItemName="_NativeLibrary" />
 		</Mmp>
 	</Target>
 


### PR DESCRIPTION
Refactor how we figure out which native libraries to sign for Xamarin.Mac to align it with how it's done for Xamarin.iOS.

* The MmpTask searched (and returned) and *.dylib files in the
  Contents/MonoBundle directory; replace this with MSBuild item group
  globbing. This also makes an error code unused, so remove that as well.
* The _TemperMetal task returned the compiled *.metallib file; replace this
  with MSBuild item group globbing.