### PR TITLE
[xcode12.2][tests][cecil] Check for absence of `[NoX]` (Unavailable) in platform assemblies. Fix #4835

### DIFF
--- a/src/AVFoundation/AVTypes.cs
+++ b/src/AVFoundation/AVTypes.cs
@@ -256,7 +256,12 @@ namespace AVFoundation {
 	}
 #endif
 
+#if MONOMAC || !XAMCORE_4_0
+
 	[Mac (10, 10), NoiOS, NoWatch, NoTV]
+#if !MONOMAC
+	[Obsolete ("This API is not available on this platform.")]
+#endif
 	[StructLayout (LayoutKind.Sequential)]
 	public struct AVSampleCursorSyncInfo {
 		[MarshalAs (UnmanagedType.I1)]
@@ -270,6 +275,9 @@ namespace AVFoundation {
 	}
 
 	[Mac (10, 10), NoiOS, NoWatch, NoTV]
+#if !MONOMAC
+	[Obsolete ("This API is not available on this platform.")]
+#endif
 	[StructLayout (LayoutKind.Sequential)]
 	public struct AVSampleCursorDependencyInfo {
 		[MarshalAs (UnmanagedType.I1)]
@@ -292,6 +300,9 @@ namespace AVFoundation {
 	}
 
 	[Mac (10, 10), NoiOS, NoWatch, NoTV]
+#if !MONOMAC
+	[Obsolete ("This API is not available on this platform.")]
+#endif
 	[StructLayout (LayoutKind.Sequential)]
 	public struct AVSampleCursorStorageRange {
 		public long Offset;
@@ -299,6 +310,9 @@ namespace AVFoundation {
 	}
 
 	[Mac (10, 10), NoiOS, NoWatch, NoTV]
+#if !MONOMAC
+	[Obsolete ("This API is not available on this platform.")]
+#endif
 	[StructLayout (LayoutKind.Sequential)]
 	public struct AVSampleCursorChunkInfo {
 		public long SampleCount;
@@ -312,6 +326,7 @@ namespace AVFoundation {
 		[MarshalAs (UnmanagedType.I1)]
 		public bool HasUniformFormatDescriptions;
 	}
+#endif
 
 #if MONOMAC
 

--- a/src/AudioUnit/AudioComponent.cs
+++ b/src/AudioUnit/AudioComponent.cs
@@ -48,8 +48,14 @@ namespace AudioUnit
 {
 
 #if !COREBUILD
+
+#if (!WATCH && !TVOS) || ((WATCH || TVOS) && !XAMCORE_4_0)
+
 	// keys are not constants and had to be found in AudioToolbox.framework/Headers/AudioComponent.h
 	[NoWatch, NoTV, Mac (10,13), iOS (11,0)]
+#if ((WATCH || TVOS) && !XAMCORE_4_0)
+	[Obsolete ("This API is not available on this platform.")]
+#endif
 	public partial class ResourceUsageInfo : DictionaryContainer {
 		static NSString userClientK = new NSString ("iokit.user-client");
 		static NSString globalNameK = new NSString ("mach-lookup.global-name");
@@ -111,6 +117,9 @@ namespace AudioUnit
 
 	// keys are not constants and had to be found in AudioToolbox.framework/Headers/AudioComponent.h
 	[NoWatch, NoTV, Mac (10,13), iOS (11,0)]
+#if ((WATCH || TVOS) && !XAMCORE_4_0)
+	[Obsolete ("This API is not available on this platform.")]
+#endif
 	public partial class AudioComponentInfo : DictionaryContainer {
 		static NSString typeK = new NSString ("type");
 		static NSString subtypeK = new NSString ("subtype");
@@ -213,8 +222,9 @@ namespace AudioUnit
 			}
 		}
 	}
-
 #endif
+
+#endif // !COREBUILD
 
 
 	public class AudioComponent : INativeObject {

--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -1388,7 +1388,6 @@ namespace CoreMidi {
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static MidiEntityRef MIDIDeviceGetEntity (MidiDeviceRef handle, nint item);
 
-		[NoiOS]
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static int MIDIDeviceAddEntity (MidiDeviceRef device, /* CFString */ IntPtr name, bool embedded, nuint numSourceEndpoints, nuint numDestinationEndpoints, MidiEntityRef newEntity);
 
@@ -1402,7 +1401,6 @@ namespace CoreMidi {
 			return new MidiEntity (h);
 		}
 
-		[NoiOS]
 		public int Add (string name, bool embedded, nuint numSourceEndpoints, nuint numDestinationEndpoints, MidiEntity newEntity)
 		{
 			if (handle == MidiObject.InvalidRef)

--- a/src/CoreVideo/CVImageBuffer.cs
+++ b/src/CoreVideo/CVImageBuffer.cs
@@ -101,6 +101,9 @@ namespace CoreVideo {
 #elif !XAMCORE_3_0
 		[Deprecated (PlatformName.MacOSX, 10, 4)]
 		[Unavailable (PlatformName.iOS)]
+#if IOS
+		[Obsolete ("This API is not available on this platform.")]
+#endif
 		public CGColorSpace ColorSpace {
 			get {
 				return null;

--- a/src/GameKit/GKCompat.cs
+++ b/src/GameKit/GKCompat.cs
@@ -29,6 +29,7 @@ namespace GameKit {
 
 #if WATCH && !XAMCORE_4_0
 	[Unavailable (PlatformName.WatchOS)]
+	[Obsolete ("This API is not available on this platform.")]
 	public static class GKGameSessionErrorCodeExtensions {
 		[Obsolete ("Always returns null.")]
 		public static NSString GetDomain (this GKGameSessionErrorCode self) => null;

--- a/src/HomeKit/HMHome.cs
+++ b/src/HomeKit/HMHome.cs
@@ -82,8 +82,13 @@ namespace HomeKit {
 			return GetServices (arr.ToArray ());
 		}
 
+#if !XAMCORE_4_0
+
 		[NoTV]
 		[NoWatch]
+#if (WATCH || TVOS)
+		[Obsolete ("This API is not available on this platform.")]
+#endif
 		[Introduced (PlatformName.iOS, 8,0, PlatformArchitecture.All, message: "This API in now prohibited on iOS. Use 'ManageUsers' instead.")]
 		[Obsoleted (PlatformName.iOS, 9,0, PlatformArchitecture.All, message: "This API in now prohibited on iOS. Use 'ManageUsers' instead.")]
 		public virtual void RemoveUser (HMUser user, Action<NSError> completion) {
@@ -92,10 +97,14 @@ namespace HomeKit {
 
 		[NoTV]
 		[NoWatch]
+#if (WATCH || TVOS)
+		[Obsolete ("This API is not available on this platform.")]
+#endif
 		[Introduced (PlatformName.iOS, 8,0, PlatformArchitecture.All, message: "This API in now prohibited on iOS. Use 'ManageUsers' instead.")]
 		[Obsoleted (PlatformName.iOS, 9,0, PlatformArchitecture.All, message: "This API in now prohibited on iOS. Use 'ManageUsers' instead.")]
 		public virtual Task RemoveUserAsync (HMUser user) {
 			throw new NotSupportedException ();
 		}
+#endif
 	}
 }

--- a/src/MapKit/MKFeatureDisplayPriority.cs
+++ b/src/MapKit/MKFeatureDisplayPriority.cs
@@ -3,11 +3,17 @@ using ObjCRuntime;
 
 namespace MapKit {
 
+#if !WATCH || (WATCH && !XAMCORE_4_0)
+
 	// .net does not allow float-based enumerations
 	[TV (11,0)][NoWatch][iOS (11,0)][Mac (10,13)]
+#if WATCH && !XAMCORE_4_0
+	[Obsolete ("This API is not available on this platform.")]
+#endif
 	public static class MKFeatureDisplayPriority {
 		public const float Required = 1000f;
 		public const float DefaultHigh = 750f;
 		public const float DefaultLow = 250f;
 	}
+#endif
 }

--- a/src/Metal/Defs.cs
+++ b/src/Metal/Defs.cs
@@ -386,8 +386,12 @@ namespace Metal {
 	}
 #endif
 
+#if !TVOS || !XAMCORE_4_0
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[Mac (11,0), iOS (14,0), NoTV]
+#if TVOS && !XAMCORE_4_0
+	[Obsolete ("This API is not available on this platform.")]
+#endif
 	[StructLayout (LayoutKind.Sequential)]
 	public struct MTLAccelerationStructureSizes
 	{
@@ -397,5 +401,5 @@ namespace Metal {
 
 		public nuint RefitScratchBufferSize;
 	}
-
+#endif
 }

--- a/tests/cecil-tests/Test.cs
+++ b/tests/cecil-tests/Test.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 
 using NUnit.Framework;
 
@@ -19,7 +21,7 @@ namespace Cecil.Tests {
 			var assembly = Helper.GetAssembly (assemblyPath);
 			if (assembly == null)
 				Assert.Ignore ("{assemblyPath} could not be found (might be disabled in build)");
-			// look inside all .cctor (static constructor) insde `assemblyName`
+			// look inside all .cctor (static constructor) inside `assemblyName`
 			foreach (var m in Helper.FilterMethods (assembly!, (m) => m.IsStatic && m.IsConstructor)) {
 				foreach (var ins in m.Body.Instructions) {
 					if (ins.OpCode != OpCodes.Stsfld)
@@ -85,6 +87,110 @@ namespace Cecil.Tests {
 				else
 					return; // single case, no point in iterating anymore
 			}
+		}
+
+		// from PlatformAvailability2.cs / keep in sync
+		public enum PlatformName : byte {
+			None,
+			MacOSX,
+			iOS,
+			WatchOS,
+			TvOS,
+			MacCatalyst,
+		}
+
+		[TestCaseSource (typeof (Helper), "PlatformAssemblies")]
+		// ref: https://github.com/xamarin/xamarin-macios/issues/4835
+		public void Unavailable (string assemblyPath)
+		{
+			var assembly = Helper.GetAssembly (assemblyPath);
+			if (assembly == null) {
+				Assert.Ignore ("{assemblyPath} could not be found (might be disabled in build)");
+				return; // just to help nullability
+			}
+
+			var platform = PlatformName.None;
+			switch (assembly.Name.Name) {
+			case "Xamarin.Mac":
+				platform = PlatformName.MacOSX;
+				break;
+			case "Xamarin.iOS":
+				platform = PlatformName.iOS;
+				break;
+			case "Xamarin.WatchOS":
+				platform = PlatformName.WatchOS;
+				break;
+			case "Xamarin.TVOS":
+				platform = PlatformName.TvOS;
+				break;
+			}
+			Assert.That (platform, Is.Not.EqualTo (PlatformName.None), "None");
+
+			Assert.False (IsUnavailable (assembly, platform), "Assembly");
+			Assert.False (IsUnavailable (assembly.MainModule, platform), "MainModule");
+			foreach (var type in assembly.MainModule.Types)
+				Unavailable (type, platform);
+		}
+
+		void Unavailable (TypeDefinition type, PlatformName platform)
+		{
+			Assert.False (IsUnavailable (type, platform), type.FullName);
+			if (type.HasNestedTypes) {
+				foreach (var nt in type.NestedTypes)
+					Unavailable (nt, platform);
+			}
+			if (type.HasEvents) {
+				foreach (var @event in type.Events)
+					Assert.False (IsUnavailable (@event, platform), @event.FullName);
+			}
+			// Enum members are generated with `[No*` by design
+			// as they ease code sharing and don't risk exposing private symbols
+			if (!type.IsEnum && type.HasFields) {
+				foreach (var field in type.Fields)
+					Assert.False (IsUnavailable (field, platform), field.FullName);
+			}
+			if (type.HasMethods) {
+				foreach (var method in type.Methods)
+					Assert.False (IsUnavailable (method, platform), method.FullName);
+			}
+			if (type.HasProperties) {
+				foreach (var property in type.Properties)
+					Assert.False (IsUnavailable (property, platform), property.FullName);
+			}
+		}
+
+		// UnavailableAttribute and it's subclasses
+		// NoMacAttribute (1), NoiOSAttribute (2), NoWatchAttribute (3), NoTVAttribute (4)
+		// MacCatalyst (5) does not have an attribute right now (but [Unavailable] is possible on the PlatformName)
+		bool IsUnavailable (ICustomAttributeProvider cap, PlatformName platform)
+		{
+			if (!cap.HasCustomAttributes)
+				return false;
+
+			var unavailable = false;
+			foreach (var ca in cap.CustomAttributes) {
+				switch (ca.AttributeType.FullName) {
+				case "ObjCRuntime.UnavailableAttribute":
+					unavailable = platform == (PlatformName) (byte) ca.ConstructorArguments [0].Value;
+					break;
+				case "ObjCRuntime.NoMacAttribute":
+					unavailable = platform == PlatformName.MacOSX;
+					break;
+				case "ObjCRuntime.NoiOSAttribute":
+					unavailable = platform == PlatformName.iOS;
+					break;
+				case "ObjCRuntime.NoWatchAttribute":
+					unavailable = platform == PlatformName.WatchOS;
+					break;
+				case "ObjCRuntime.NoTVAttribute":
+					unavailable = platform == PlatformName.TvOS;
+					break;
+				case "System.ObsoleteAttribute":
+					// we have to live with past mistakes, don't report errors on [Obsolete] members
+					return false;
+				}
+			}
+			return unavailable;
 		}
 	}
 }


### PR DESCRIPTION
It's way too easy to forget that attributes like `[NoiOS]` means the code
is not generated (for bindings) on that platform but that they will be
compiled for _manual_ bindings (not run thru the generator).

This can expose types (and API) that are not usable on some platforms.
This new test checks that the `[No*]` and `[Unavailable]` attributes
are not in their respective platform assemblies.

For compatibility (existing mistakes) we ignore the check on API that
are decorated with `[Obsolete]` attributes.

Changes in the bindings are fix such mistakes - mostly adding the
`[Obsolete]` attribute.

Fix https://github.com/xamarin/xamarin-macios/issues/4835

backport of https://github.com/xamarin/xamarin-macios/pull/9686