### PR TITLE
[xcode12.2][tests][xtro] Check for deprecated p/invokes (C API)

### DIFF
--- a/src/AddressBook/ABMultiValue.cs
+++ b/src/AddressBook/ABMultiValue.cs
@@ -40,6 +40,7 @@ using ObjCRuntime;
 
 namespace AddressBook {
 
+	[Deprecated (PlatformName.iOS, 9,0)]
 	static class ABMultiValue {
 		public const uint Mask = (1 << 8);
 

--- a/src/AppKit/NSGraphics.cs
+++ b/src/AppKit/NSGraphics.cs
@@ -202,11 +202,11 @@ namespace AppKit {
 		public extern static void DrawWindowBackground (CGRect aRect);
 		
 		[DllImport (Constants.AppKitLibrary, EntryPoint="NSDisableScreenUpdates")]
-		[Deprecated (PlatformName.MacOSX, 10, 14, message : "Not usually necessary, 'NSAnimationContext.RunAnimation' can be used instead and not suffer from performance issues.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Not usually necessary, 'NSAnimationContext.RunAnimation' can be used instead and not suffer from performance issues.")]
 		public extern static void DisableScreenUpdates ();
 		
 		[DllImport (Constants.AppKitLibrary, EntryPoint="NSEnableScreenUpdates")]
-		[Deprecated (PlatformName.MacOSX, 10, 14, message : "Not usually necessary, 'NSAnimationContext.RunAnimation' can be used instead and not suffer from performance issues.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Not usually necessary, 'NSAnimationContext.RunAnimation' can be used instead and not suffer from performance issues.")]
 		public extern static void EnableScreenUpdates ();
 		
 	}

--- a/src/AppKit/NSWorkspace.cs
+++ b/src/AppKit/NSWorkspace.cs
@@ -44,9 +44,6 @@ namespace AppKit {
 		[DllImport (Constants.FoundationLibrary)]
 		extern static IntPtr NSFileTypeForHFSTypeCode (uint /* OSType = int32_t */ hfsFileTypeCode);
 
-		[DllImport (Constants.FoundationLibrary)]
-		extern static int UTGetOSTypeFromString (IntPtr str);
-
 		private static IntPtr GetNSFileType (uint fourCcTypeCode)
 		{
 			return NSFileTypeForHFSTypeCode (fourCcTypeCode);

--- a/src/AudioUnit/AUGraph.cs
+++ b/src/AudioUnit/AUGraph.cs
@@ -56,6 +56,7 @@ namespace AudioUnit
 		InvalidElement				= -10877,		
 	}
 
+	[Deprecated (PlatformName.iOS, 14,0, message: "Use 'AVAudioEngine' instead.")]
 	public class AUGraph : INativeObject, IDisposable
 	{
 		readonly GCHandle gcHandle;

--- a/src/AudioUnit/AUGraph.cs
+++ b/src/AudioUnit/AUGraph.cs
@@ -57,6 +57,7 @@ namespace AudioUnit
 	}
 
 	[Deprecated (PlatformName.iOS, 14,0, message: "Use 'AVAudioEngine' instead.")]
+	[Deprecated (PlatformName.MacOSX, 11,0, message: "Use 'AVAudioEngine' instead.")]
 	public class AUGraph : INativeObject, IDisposable
 	{
 		readonly GCHandle gcHandle;

--- a/src/AudioUnit/AudioComponent.cs
+++ b/src/AudioUnit/AudioComponent.cs
@@ -352,20 +352,24 @@ namespace AudioUnit
 
 #if !MONOMAC
 		[iOS (7,0)]
+		[Deprecated (PlatformName.iOS, 14,0)]
 		[DllImport(Constants.AudioUnitLibrary)]
 		static extern IntPtr AudioComponentGetIcon (IntPtr comp, float /* float */ desiredPointSize);
 
 		[iOS (7,0)]
+		[Deprecated (PlatformName.iOS, 14,0, message: "Use 'CopyIcon' instead.")]
 		public UIKit.UIImage GetIcon (float desiredPointSize)
 		{
 			return new UIKit.UIImage (AudioComponentGetIcon (handle, desiredPointSize));
 		}
 
 		[iOS (7,0)]
+		[Deprecated (PlatformName.iOS, 13,0)]
 		[DllImport(Constants.AudioUnitLibrary)]
 		static extern double AudioComponentGetLastActiveTime (IntPtr comp);
 
 		[iOS (7,0)]
+		[Deprecated (PlatformName.iOS, 13,0, message: "Use 'AudioUnit' instead.")]
 		public double LastActiveTime {
 			get {
 				return AudioComponentGetLastActiveTime (handle);

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -772,10 +772,12 @@ namespace AudioUnit
 
 #if !MONOMAC
 		[iOS (7,0)]
+		[Deprecated (PlatformName.iOS, 13,0)]
 		[DllImport (Constants.AudioUnitLibrary)]
 		static extern AudioComponentStatus AudioOutputUnitPublish (AudioComponentDescription inDesc, IntPtr /* CFStringRef */ inName, uint /* UInt32 */ inVersion, IntPtr /* AudioUnit */ inOutputUnit);
 
 		[iOS (7,0)]
+		[Deprecated (PlatformName.iOS, 13,0, message: "Use 'AudioUnit' instead.")]
 		public AudioComponentStatus AudioOutputUnitPublish (AudioComponentDescription description, string name, uint version = 1)
 		{
 
@@ -788,10 +790,12 @@ namespace AudioUnit
 		}
 
 		[iOS (7,0)]
+		[Deprecated (PlatformName.iOS, 13,0)]
 		[DllImport (Constants.AudioUnitLibrary)]
 		static extern IntPtr AudioOutputUnitGetHostIcon (IntPtr /* AudioUnit */ au, float /* float */ desiredPointSize);
 
 		[iOS (7,0)]
+		[Deprecated (PlatformName.iOS, 13,0, message: "Use 'AudioUnit' instead.")]
 		public UIKit.UIImage GetHostIcon (float desiredPointSize)
 		{
 			return new UIKit.UIImage (AudioOutputUnitGetHostIcon (handle, desiredPointSize));

--- a/src/CoreFoundation/CFStream.cs
+++ b/src/CoreFoundation/CFStream.cs
@@ -243,8 +243,8 @@ namespace CoreFoundation {
 		internal extern static /* CFReadStreamRef __nonnull */ IntPtr CFReadStreamCreateForHTTPRequest (
 			/* CFAllocatorRef __nullable */ IntPtr alloc, /* CFHTTPMessageRef __nonnull */ IntPtr request);
 
-		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'NSUrlSession'.")]
-		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'NSUrlSession'.")]
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'NSUrlSession' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'NSUrlSession' instead.")]
 		public static CFHTTPStream CreateForHTTPRequest (CFHTTPMessage request)
 		{
 			if (request == null)
@@ -255,11 +255,15 @@ namespace CoreFoundation {
 		}
 
 		// CFHTTPStream.h in CFNetwork.framework (not CoreFoundation)
+		[Deprecated (PlatformName.iOS, 9,0)]
+		[Deprecated (PlatformName.MacOSX, 10,11)]
 		[DllImport (Constants.CFNetworkLibrary)]
 		internal extern static /* CFReadStreamRef __nonnull */ IntPtr CFReadStreamCreateForStreamedHTTPRequest (
 			/* CFAllocatorRef __nullable */ IntPtr alloc, /* CFHTTPMessageRef __nonnull */ IntPtr requestHeaders,
 			/* CFReadStreamRef __nonnull */ IntPtr requestBody);
 
+		[Deprecated (PlatformName.iOS, 9,0, message : "Use 'NSUrlSession' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10,11, message : "Use 'NSUrlSession' instead.")]
 		public static CFHTTPStream CreateForStreamedHTTPRequest (CFHTTPMessage request, CFReadStream body)
 		{
 			if (request == null)

--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -530,6 +530,8 @@ namespace CoreFoundation {
 		[DllImport (Constants.libcLibrary)]
 		extern static void dispatch_after (/* dispath_time_t */ ulong time, IntPtr queue, IntPtr block);
 
+		[Deprecated (PlatformName.iOS, 6,0)]
+		[Deprecated (PlatformName.MacOSX, 10,9)]
 		[DllImport (Constants.libcLibrary)]
 		extern static IntPtr dispatch_get_current_queue ();
 

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -901,6 +901,8 @@ namespace CoreGraphics {
 			CGContextSetFontSize (handle, size);
 		}
 
+		[Deprecated (PlatformName.iOS, 7,0)]
+		[Deprecated (PlatformName.MacOSX, 10,9)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSelectFont (/* CGContextRef */ IntPtr c,
 			/* const char* __nullable */ string name, /* CGFloat */ nfloat size, CGTextEncoding textEncoding);
@@ -926,6 +928,8 @@ namespace CoreGraphics {
 			CGContextShowGlyphsAtPositions (handle, glyphs, positions, count);
 		}
 
+		[Deprecated (PlatformName.iOS, 7,0)]
+		[Deprecated (PlatformName.MacOSX, 10,9)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowText (/* CGContextRef */ IntPtr c, /* const char* __nullable */ string s, /* size_t */ nint length);
 
@@ -947,6 +951,8 @@ namespace CoreGraphics {
 			CGContextShowText (handle, str, str == null ? 0 : str.Length);
 		}
 
+		[Deprecated (PlatformName.iOS, 7,0)]
+		[Deprecated (PlatformName.MacOSX, 10,9)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowText (/* CGContextRef */ IntPtr c, /* const char* __nullable */ byte[] bytes, /* size_t */ nint length);
 
@@ -968,6 +974,8 @@ namespace CoreGraphics {
 			CGContextShowText (handle, bytes, bytes == null ? 0 : bytes.Length);
 		}
 
+		[Deprecated (PlatformName.iOS, 7,0)]
+		[Deprecated (PlatformName.MacOSX, 10,9)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowTextAtPoint (/* CGContextRef __nullable */ IntPtr c, /* CGFloat */ nfloat x, 
 			/* CGFloat */ nfloat y, /* const char* __nullable */ string str, /* size_t */ nint length);
@@ -986,6 +994,8 @@ namespace CoreGraphics {
 			CGContextShowTextAtPoint (handle, x, y, str, str == null ? 0 : str.Length);
 		}
 
+		[Deprecated (PlatformName.iOS, 7,0)]
+		[Deprecated (PlatformName.MacOSX, 10,9)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowTextAtPoint (/* CGContextRef */ IntPtr c, /* CGFloat */ nfloat x, /* CGFloat */ nfloat y, /* const char* */ byte[] bytes, /* size_t */ nint length);
 
@@ -999,6 +1009,8 @@ namespace CoreGraphics {
 			CGContextShowTextAtPoint (handle, x, y, bytes, bytes == null ? 0 : bytes.Length);
 		}
 
+		[Deprecated (PlatformName.iOS, 7,0)]
+		[Deprecated (PlatformName.MacOSX, 10,9)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowGlyphs (/* CGContextRef __nullable */ IntPtr c,
 			/* const CGGlyph * __nullable */ ushort [] glyphs, /* size_t */ nint count);
@@ -1021,6 +1033,8 @@ namespace CoreGraphics {
 			CGContextShowGlyphs (handle, glyphs, count);
 		}
 		
+		[Deprecated (PlatformName.iOS, 7,0)]
+		[Deprecated (PlatformName.MacOSX, 10,9)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowGlyphsAtPoint (/* CGContextRef */ IntPtr context, /* CGFloat */ nfloat x,
 			/* CGFloat */ nfloat y, /* const CGGlyph * __nullable */ ushort [] glyphs, /* size_t */ nint count);
@@ -1043,6 +1057,8 @@ namespace CoreGraphics {
 			CGContextShowGlyphsAtPoint (handle, x, y, glyphs, glyphs == null ? 0 : glyphs.Length);
 		}
 
+		[Deprecated (PlatformName.iOS, 7,0)]
+		[Deprecated (PlatformName.MacOSX, 10,9)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowGlyphsWithAdvances (/* CGContextRef __nullable */ IntPtr c,
 			/* const CGGlyph * __nullable */ ushort [] glyphs,

--- a/src/CoreMedia/CMSync.cs
+++ b/src/CoreMedia/CMSync.cs
@@ -205,6 +205,8 @@ namespace CoreMedia {
 		}
 
 #if !WATCH
+		[Deprecated (PlatformName.iOS, 9,0)]
+		[Deprecated (PlatformName.MacOSX, 10,11)]
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMTimebaseRef */ IntPtr CMTimebaseGetMasterTimebase (/* CMTimebaseRef */ IntPtr timebase);
 
@@ -219,6 +221,8 @@ namespace CoreMedia {
 			return new CMTimebase (ptr, false);			
 		}
 
+		[Deprecated (PlatformName.iOS, 9,0)]
+		[Deprecated (PlatformName.MacOSX, 10,11)]
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMClockRef */ IntPtr CMTimebaseGetMasterClock (/* CMTimebaseRef */ IntPtr timebase);
 
@@ -233,6 +237,8 @@ namespace CoreMedia {
 			return new CMClock (ptr, false);
 		}
 
+		[Deprecated (PlatformName.iOS, 9,0)]
+		[Deprecated (PlatformName.MacOSX, 10,11)]
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMClockOrTimebaseRef */ IntPtr CMTimebaseGetMaster (/* CMTimebaseRef */ IntPtr timebase);
 
@@ -247,6 +253,8 @@ namespace CoreMedia {
 			return new CMClockOrTimebase (ptr, false);
 		}
 
+		[Deprecated (PlatformName.iOS, 9,0)]
+		[Deprecated (PlatformName.MacOSX, 10,11)]
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMClockRef */ IntPtr CMTimebaseGetUltimateMasterClock (/* CMTimebaseRef */ IntPtr timebase);
 

--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -508,6 +508,7 @@ namespace CoreMidi {
 		extern static int /* OSStatus = SInt32 */ MIDIClientDispose (MidiObjectRef handle);
 
 		[Deprecated (PlatformName.iOS, 14,0)]
+		[Deprecated (PlatformName.MacOSX, 11,0)]
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static int /* OSStatus = SInt32 */ MIDISourceCreate (MidiObjectRef handle, IntPtr name, out MidiObjectRef endpoint);
 			
@@ -545,6 +546,7 @@ namespace CoreMidi {
 		}
 
 		[Deprecated (PlatformName.iOS, 14,0)]
+		[Deprecated (PlatformName.MacOSX, 11,0)]
 		public MidiEndpoint CreateVirtualSource (string name, out MidiError statusCode)
 		{
 			using (var nsstr = new NSString (name)){
@@ -560,6 +562,7 @@ namespace CoreMidi {
 		}
 
 		[Deprecated (PlatformName.iOS, 14,0)]
+		[Deprecated (PlatformName.MacOSX, 11,0)]
 		public MidiEndpoint CreateVirtualDestination (string name, out MidiError status)
 		{
 			var m = new MidiEndpoint (this, name, out status);
@@ -873,6 +876,7 @@ namespace CoreMidi {
 	public class MidiPort : MidiObject {
 #if !COREBUILD
 		[Deprecated (PlatformName.iOS, 14,0)]
+		[Deprecated (PlatformName.MacOSX, 11,0)]
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static int /* OSStatus = SInt32 */ MIDIInputPortCreate (MidiClientRef client, IntPtr /* CFStringRef */ portName, MidiReadProc readProc, IntPtr context, out MidiPortRef midiPort);
 
@@ -971,10 +975,12 @@ namespace CoreMidi {
 		}
 
 		[Deprecated (PlatformName.iOS, 14,0)]
+		[Deprecated (PlatformName.MacOSX, 11,0)]
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static MidiError /* OSStatus = SInt32 */ MIDISend (MidiPortRef port, MidiEndpointRef endpoint, IntPtr packets);
 
 		[Deprecated (PlatformName.iOS, 14,0)]
+		[Deprecated (PlatformName.MacOSX, 11,0)]
 		public MidiError Send (MidiEndpoint endpoint, MidiPacket [] packets)
 		{
 			if (endpoint == null)
@@ -1395,6 +1401,7 @@ namespace CoreMidi {
 		extern static MidiEntityRef MIDIDeviceGetEntity (MidiDeviceRef handle, nint item);
 
 		[Deprecated (PlatformName.iOS, 14,0)]
+		[Deprecated (PlatformName.MacOSX, 11,0)]
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static int MIDIDeviceAddEntity (MidiDeviceRef device, /* CFString */ IntPtr name, bool embedded, nuint numSourceEndpoints, nuint numDestinationEndpoints, MidiEntityRef newEntity);
 
@@ -1907,6 +1914,7 @@ namespace CoreMidi {
 		extern static int /* OSStatus = SInt32 */ MIDIEndpointDispose (MidiEndpointRef handle);
 		
 		[Deprecated (PlatformName.iOS, 14,0)]
+		[Deprecated (PlatformName.MacOSX, 11,0)]
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static MidiError /* OSStatus = SInt32 */ MIDIDestinationCreate (MidiClientRef client, IntPtr /* CFStringRef */ name, MidiReadProc readProc, IntPtr context, out MidiEndpointRef midiEndpoint);
 
@@ -1915,6 +1923,7 @@ namespace CoreMidi {
 
 		[DllImport (Constants.CoreMidiLibrary)]
 		[Deprecated (PlatformName.iOS, 14,0)]
+		[Deprecated (PlatformName.MacOSX, 11,0)]
 		extern static MidiError /* OSStatus = SInt32 */ MIDIReceived (MidiEndpointRef handle, IntPtr /* MIDIPacketList* */ packetList);
 		
 		[DllImport (Constants.CoreMidiLibrary)]
@@ -2004,6 +2013,7 @@ namespace CoreMidi {
 		}
 
 		[Deprecated (PlatformName.iOS, 14,0)]
+		[Deprecated (PlatformName.MacOSX, 11,0)]
 		public MidiError Received (MidiPacket [] packets)
 		{
 			if (packets == null)

--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -507,6 +507,7 @@ namespace CoreMidi {
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static int /* OSStatus = SInt32 */ MIDIClientDispose (MidiObjectRef handle);
 
+		[Deprecated (PlatformName.iOS, 14,0)]
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static int /* OSStatus = SInt32 */ MIDISourceCreate (MidiObjectRef handle, IntPtr name, out MidiObjectRef endpoint);
 			
@@ -543,6 +544,7 @@ namespace CoreMidi {
 			return Name;
 		}
 
+		[Deprecated (PlatformName.iOS, 14,0)]
 		public MidiEndpoint CreateVirtualSource (string name, out MidiError statusCode)
 		{
 			using (var nsstr = new NSString (name)){
@@ -557,6 +559,7 @@ namespace CoreMidi {
 			}			
 		}
 
+		[Deprecated (PlatformName.iOS, 14,0)]
 		public MidiEndpoint CreateVirtualDestination (string name, out MidiError status)
 		{
 			var m = new MidiEndpoint (this, name, out status);
@@ -869,6 +872,7 @@ namespace CoreMidi {
 	
 	public class MidiPort : MidiObject {
 #if !COREBUILD
+		[Deprecated (PlatformName.iOS, 14,0)]
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static int /* OSStatus = SInt32 */ MIDIInputPortCreate (MidiClientRef client, IntPtr /* CFStringRef */ portName, MidiReadProc readProc, IntPtr context, out MidiPortRef midiPort);
 
@@ -966,9 +970,11 @@ namespace CoreMidi {
 			return (input ? "[input:" : "[output:") + Client + ":" + PortName + "]";
 		}
 
+		[Deprecated (PlatformName.iOS, 14,0)]
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static MidiError /* OSStatus = SInt32 */ MIDISend (MidiPortRef port, MidiEndpointRef endpoint, IntPtr packets);
 
+		[Deprecated (PlatformName.iOS, 14,0)]
 		public MidiError Send (MidiEndpoint endpoint, MidiPacket [] packets)
 		{
 			if (endpoint == null)
@@ -1388,6 +1394,7 @@ namespace CoreMidi {
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static MidiEntityRef MIDIDeviceGetEntity (MidiDeviceRef handle, nint item);
 
+		[Deprecated (PlatformName.iOS, 14,0)]
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static int MIDIDeviceAddEntity (MidiDeviceRef device, /* CFString */ IntPtr name, bool embedded, nuint numSourceEndpoints, nuint numDestinationEndpoints, MidiEntityRef newEntity);
 
@@ -1401,6 +1408,7 @@ namespace CoreMidi {
 			return new MidiEntity (h);
 		}
 
+		[Deprecated (PlatformName.iOS, 14,0)]
 		public int Add (string name, bool embedded, nuint numSourceEndpoints, nuint numDestinationEndpoints, MidiEntity newEntity)
 		{
 			if (handle == MidiObject.InvalidRef)
@@ -1898,6 +1906,7 @@ namespace CoreMidi {
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static int /* OSStatus = SInt32 */ MIDIEndpointDispose (MidiEndpointRef handle);
 		
+		[Deprecated (PlatformName.iOS, 14,0)]
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static MidiError /* OSStatus = SInt32 */ MIDIDestinationCreate (MidiClientRef client, IntPtr /* CFStringRef */ name, MidiReadProc readProc, IntPtr context, out MidiEndpointRef midiEndpoint);
 
@@ -1905,6 +1914,7 @@ namespace CoreMidi {
 		extern static int /* OSStatus = SInt32 */ MIDIFlushOutput (MidiEndpointRef handle);
 
 		[DllImport (Constants.CoreMidiLibrary)]
+		[Deprecated (PlatformName.iOS, 14,0)]
 		extern static MidiError /* OSStatus = SInt32 */ MIDIReceived (MidiEndpointRef handle, IntPtr /* MIDIPacketList* */ packetList);
 		
 		[DllImport (Constants.CoreMidiLibrary)]
@@ -1993,6 +2003,7 @@ namespace CoreMidi {
 			MIDIFlushOutput (handle);
 		}
 
+		[Deprecated (PlatformName.iOS, 14,0)]
 		public MidiError Received (MidiPacket [] packets)
 		{
 			if (packets == null)

--- a/src/CoreServices/LaunchServices.cs
+++ b/src/CoreServices/LaunchServices.cs
@@ -256,9 +256,11 @@ namespace CoreServices
 			);
 		}
 
+		[Deprecated (PlatformName.MacOSX, 10,15)]
 		[DllImport (Constants.CoreServicesLibrary)]
 		static extern IntPtr LSCopyAllHandlersForURLScheme (IntPtr inUrlScheme);
 
+		[Deprecated (PlatformName.MacOSX, 10,15, message: "Use 'GetApplicationUrlsForUrl' instead.")]
 		public static string [] GetAllHandlersForUrlScheme (string urlScheme)
 		{
 			if (urlScheme == null)
@@ -269,9 +271,11 @@ namespace CoreServices
 			);
 		}
 
+		[Deprecated (PlatformName.MacOSX, 10,15)]
 		[DllImport (Constants.CoreServicesLibrary)]
 		static extern IntPtr LSCopyDefaultHandlerForURLScheme (IntPtr inUrlScheme);
 
+		[Deprecated (PlatformName.MacOSX, 10,15, message: "Use 'GetDefaultApplicationUrlForUrl' instead.")]
 		public static string GetDefaultHandlerForUrlScheme (string urlScheme)
 		{
 			if (urlScheme == null)

--- a/src/CoreText/CTFontManager.cs
+++ b/src/CoreText/CTFontManager.cs
@@ -132,6 +132,10 @@ namespace CoreText {
 			}
 		}
 
+		[Deprecated (PlatformName.MacOSX, 10,15)]
+		[Deprecated (PlatformName.iOS, 13,0)]
+		[Deprecated (PlatformName.WatchOS, 6,0)]
+		[Deprecated (PlatformName.TvOS, 13,0)]
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern bool CTFontManagerRegisterFontsForURLs(IntPtr arrayRef, CTFontManagerScope scope, ref IntPtr error_array);
 
@@ -207,6 +211,10 @@ namespace CoreText {
 			}
 		}
 
+		[Deprecated (PlatformName.MacOSX, 10,15)]
+		[Deprecated (PlatformName.iOS, 13,0)]
+		[Deprecated (PlatformName.WatchOS, 6,0)]
+		[Deprecated (PlatformName.TvOS, 13,0)]
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern bool CTFontManagerUnregisterFontsForURLs(IntPtr arrayRef, CTFontManagerScope scope, ref IntPtr error_array);
 

--- a/src/ObjCRuntime/PlatformAvailability.cs
+++ b/src/ObjCRuntime/PlatformAvailability.cs
@@ -288,6 +288,7 @@ namespace ObjCRuntime
 		const int sys2 = 1937339186;
 
 		// Deprecated in OSX 10.8 - but no good alternative is (yet) available
+		[Deprecated (PlatformName.MacOSX, 10, 8)]
 		[DllImport ("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
 		static extern int Gestalt (int selector, out int result);
 

--- a/src/Security/Authorization.cs
+++ b/src/Security/Authorization.cs
@@ -100,6 +100,7 @@ namespace Security {
 		[DllImport (Constants.SecurityLibrary)]
 		extern static int /* OSStatus = int */ AuthorizationCreate (AuthorizationItemSet *rights, AuthorizationItemSet *environment, AuthorizationFlags flags, out IntPtr auth);
 
+		[Deprecated (PlatformName.MacOSX, 10,7)]
 		[DllImport (Constants.SecurityLibrary)]
 		extern static int /* OSStatus = int */ AuthorizationExecuteWithPrivileges (IntPtr handle, string pathToTool, AuthorizationFlags flags, string [] args, IntPtr FILEPtr);
 
@@ -111,6 +112,7 @@ namespace Security {
 			this.handle = handle;
 		}
 
+		[Deprecated (PlatformName.MacOSX, 10,7)]
 		public int ExecuteWithPrivileges (string pathToTool, AuthorizationFlags flags, string [] args)
 		{
 			return AuthorizationExecuteWithPrivileges (handle, pathToTool, flags, args, IntPtr.Zero);

--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -269,6 +269,9 @@ namespace Security {
 #else
 		[iOS (10,3)]
 		[TV (10,3)]
+		[Deprecated (PlatformName.iOS, 12,0)]
+		[Deprecated (PlatformName.TvOS, 12,0)]
+		[Deprecated (PlatformName.WatchOS, 5,0)]
 		[DllImport (Constants.SecurityLibrary)]
 		static extern /* __nullable SecKeyRef */ IntPtr SecCertificateCopyPublicKey (IntPtr /* SecCertificateRef */ certificate);
 
@@ -368,9 +371,14 @@ namespace Security {
 
 #if MONOMAC
 		[DllImport (Constants.SecurityLibrary)]
+		[Deprecated (PlatformName.MacOSX, 10,13)]
 		static extern /* __nullable CFDataRef */ IntPtr SecCertificateCopySerialNumber (IntPtr /* SecCertificateRef */ certificate, IntPtr /* CFErrorRef * */ error);
 #else
 		[iOS (10,3)]
+		[Deprecated (PlatformName.iOS, 11,0)]
+		[Deprecated (PlatformName.MacOSX, 10,13)]
+		[Deprecated (PlatformName.WatchOS, 4,0)]
+		[Deprecated (PlatformName.TvOS, 11,0)]
 		[DllImport (Constants.SecurityLibrary)]
 		static extern /* __nullable CFDataRef */ IntPtr SecCertificateCopySerialNumber (IntPtr /* SecCertificateRef */ certificate);
 #endif

--- a/src/Security/SecProtocolMetadata.cs
+++ b/src/Security/SecProtocolMetadata.cs
@@ -65,8 +65,16 @@ namespace Security {
 		public TlsCipherSuite NegotiatedTlsCipherSuite => sec_protocol_metadata_get_negotiated_tls_ciphersuite (GetCheckedHandle ());
 
 		[DllImport (Constants.SecurityLibrary)]
+		[Deprecated (PlatformName.iOS, 13,0)]
+		[Deprecated (PlatformName.TvOS, 13,0)]
+		[Deprecated (PlatformName.WatchOS, 6,0)]
+		[Deprecated (PlatformName.MacOSX, 10,15)]
 		extern static SslCipherSuite sec_protocol_metadata_get_negotiated_ciphersuite (IntPtr handle);
 
+		[Deprecated (PlatformName.iOS, 13,0, message: "Use 'NegotiatedTlsCipherSuite' instead.")]
+		[Deprecated (PlatformName.TvOS, 13,0, message: "Use 'NegotiatedTlsCipherSuite' instead.")]
+		[Deprecated (PlatformName.WatchOS, 6,0, message: "Use 'NegotiatedTlsCipherSuite' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10,15, message: "Use 'NegotiatedTlsCipherSuite' instead.")]
 		public SslCipherSuite NegotiatedCipherSuite => sec_protocol_metadata_get_negotiated_ciphersuite (GetCheckedHandle ());
 
 		[DllImport (Constants.SecurityLibrary)]

--- a/src/Security/SecSharedCredential.cs
+++ b/src/Security/SecSharedCredential.cs
@@ -69,7 +69,8 @@ namespace Security {
 
 		[iOS (8,0)]
 		[Mac (11,0)]
-		[Introduced (PlatformName.MacCatalyst, 14,0)]
+		[Deprecated (PlatformName.iOS, 14,0)]
+		[Deprecated (PlatformName.MacOSX, 11,0)]
 		[DllImport (Constants.SecurityLibrary)]
 		extern static void SecRequestSharedWebCredential ( IntPtr /* CFStringRef */ fqdn, IntPtr /* CFStringRef */ account,
 			IntPtr /* void (^completionHandler)( CFArrayRef credentials, CFErrorRef error) */ completionHandler);
@@ -103,10 +104,8 @@ namespace Security {
 
 		[iOS (8,0)]
 		[Mac (11,0)]
-		[Introduced (PlatformName.MacCatalyst, 14,0)]
 		[Deprecated (PlatformName.iOS, 14,0, message: "Use 'ASAuthorizationPasswordRequest' instead.")]
 		[Deprecated (PlatformName.MacOSX, 11,0, message: "Use 'ASAuthorizationPasswordRequest' instead.")]
-		[Deprecated (PlatformName.MacCatalyst, 14,0, message: "Use 'ASAuthorizationPasswordRequest' instead.")]
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static void RequestSharedWebCredential (string domainName, string account, Action<SecSharedCredentialInfo[], NSError> handler)
 		{
@@ -146,7 +145,6 @@ namespace Security {
 
 		[iOS (8,0)]
 		[Mac (11,0)]
-		[Introduced (PlatformName.MacCatalyst, 14,0)]
 		[DllImport (Constants.SecurityLibrary)]
 		extern static IntPtr /* CFStringRef */ SecCreateSharedWebCredentialPassword ();
 

--- a/src/Security/Trust.cs
+++ b/src/Security/Trust.cs
@@ -125,6 +125,10 @@ namespace Security {
 				throw new ArgumentException (result.ToString ());
 		}
 
+		[Deprecated (PlatformName.iOS, 12,1)]
+		[Deprecated (PlatformName.TvOS, 12,1)]
+		[Deprecated (PlatformName.WatchOS, 5,1)]
+		[Deprecated (PlatformName.MacOSX, 10,14,1)]
 		[DllImport (Constants.SecurityLibrary)]
 		extern static SecStatusCode /* OSStatus */ SecTrustEvaluate (IntPtr /* SecTrustRef */ trust, out /* SecTrustResultType */ SecTrustResult result);
 
@@ -169,6 +173,10 @@ namespace Security {
 			}
 		}
 
+		[Deprecated (PlatformName.iOS, 14,0)]
+		[Deprecated (PlatformName.MacOSX, 11,0)]
+		[Deprecated (PlatformName.TvOS, 14,0)]
+		[Deprecated (PlatformName.WatchOS, 7,0)]
 		[DllImport (Constants.SecurityLibrary)]
 		extern static IntPtr /* SecKeyRef */ SecTrustCopyPublicKey (IntPtr /* SecTrustRef */ trust);
 

--- a/src/SystemConfiguration/CaptiveNetwork.cs
+++ b/src/SystemConfiguration/CaptiveNetwork.cs
@@ -60,10 +60,12 @@ namespace SystemConfiguration {
 		
 #if !MONOMAC
 
+		[Deprecated (PlatformName.iOS, 14,0)]
 		[DllImport (Constants.SystemConfigurationLibrary)]
 		extern static IntPtr /* CFDictionaryRef __nullable */  CNCopyCurrentNetworkInfo (
 			/* CFStringRef __nonnull */ IntPtr interfaceName);
 
+		[Deprecated (PlatformName.iOS, 14,0)]
 		static public StatusCode TryCopyCurrentNetworkInfo (string interfaceName, out NSDictionary currentNetworkInfo)
 		{
 			using (var nss = new NSString (interfaceName)) {
@@ -99,12 +101,15 @@ namespace SystemConfiguration {
 			return StatusCode.OK;
 		}
 
+		[Deprecated (PlatformName.iOS, 9,0)]
 		[DllImport (Constants.SystemConfigurationLibrary)]
 		extern static bool CNMarkPortalOffline (IntPtr /* CFStringRef __nonnull */ interfaceName);
 
+		[Deprecated (PlatformName.iOS, 9,0)]
 		[DllImport (Constants.SystemConfigurationLibrary)]
 		extern static bool CNMarkPortalOnline (IntPtr /* CFStringRef __nonnull */ interfaceName);
 
+		[Deprecated (PlatformName.iOS, 9,0)]
 		static public bool MarkPortalOnline (string iface)
 		{
 			using (var nss = new NSString (iface)) {
@@ -112,6 +117,7 @@ namespace SystemConfiguration {
 			}
 		}
 
+		[Deprecated (PlatformName.iOS, 9,0)]
 		static public bool MarkPortalOffline (string iface)
 		{
 			using (var nss = new NSString (iface)) {
@@ -119,9 +125,11 @@ namespace SystemConfiguration {
 			}
 		}
 
+		[Deprecated (PlatformName.iOS, 9,0)]
 		[DllImport (Constants.SystemConfigurationLibrary)]
 		extern static bool CNSetSupportedSSIDs (IntPtr /* CFArrayRef __nonnull */ ssidArray);
 
+		[Deprecated (PlatformName.iOS, 9,0)]
 		static public bool SetSupportedSSIDs (string [] ssids)
 		{
 			using (var arr = NSArray.FromStrings (ssids)) {

--- a/src/TVServices/TVEnums.cs
+++ b/src/TVServices/TVEnums.cs
@@ -39,10 +39,12 @@ namespace TVServices {
 
 	static public class TVContentItemImageShapeExtensions {
 
+		[Deprecated (PlatformName.TvOS, 13,0)]
 		[DllImport (Constants.TVServicesLibrary)]
 		static extern CGSize TVTopShelfImageSizeForShape (/* TVContentItemImageShape */ nint shape,
 			/* TVTopShelfContentStyle */ nint style);
 
+		[Deprecated (PlatformName.TvOS, 13,0, message: "Use 'TVTopShelfSectionedContent.GetImageSize' or 'TVTopShelfInsetContent.ImageSize' instead.")]
 		static public CGSize GetSize (this TVContentItemImageShape self, TVTopShelfContentStyle style)
 		{
 			return TVTopShelfImageSizeForShape ((nint) (int) self, (nint) (int) style);


### PR DESCRIPTION
We already had support for ObjC API but nothing reported missing
availability attributes for p/invokes, used in manual bindings

backport of https://github.com/xamarin/xamarin-macios/pull/9700
with additional fixes for Xamarin.Mac.dll