### PR TITLE
[generator] Fix potential warnings/errors when `[Sealed]` is used on types. Fix #9065

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -457,11 +457,12 @@ public class MemberInformation
 	public readonly Type category_extension_type;
 	internal readonly WrapPropMemberInformation wpmi;
 	public readonly bool is_abstract, is_protected, is_internal, is_unified_internal, is_override, is_new, is_sealed, is_static, is_thread_static, is_autorelease, is_wrapper, is_forced;
-	public readonly bool is_type_sealed, ignore_category_static_warnings, is_basewrapper_protocol_method;
+	public readonly bool ignore_category_static_warnings, is_basewrapper_protocol_method;
 	public readonly bool has_inner_wrap_attribute;
 	public readonly Generator.ThreadCheck threadCheck;
 	public bool is_unsafe, is_virtual_method, is_export, is_category_extension, is_variadic, is_interface_impl, is_extension_method, is_appearance, is_model, is_ctor;
 	public bool is_return_release;
+	public bool is_type_sealed;
 	public bool protocolize;
 	public string selector, wrap_method, is_forced_owns;
 	public bool is_bindAs => Generator.HasBindAsAttribute (mi);
@@ -637,7 +638,7 @@ public class MemberInformation
 			mods += "static ";
 		} else if (is_abstract) {
 			mods += "abstract ";
-		} else if (is_virtual_method) {
+		} else if (is_virtual_method && !is_type_sealed) {
 			mods += is_override ? "override " : "virtual ";
 		}
 
@@ -6561,7 +6562,10 @@ public partial class Generator : IMemberGatherer {
 					}
 					GeneratedCode (sw, 2);
 					sw.WriteLine ("\t\t[EditorBrowsable (EditorBrowsableState.Advanced)]");
-					sw.WriteLine ("\t\tprotected internal {0} (IntPtr handle) : base (handle)", TypeName);
+					sw.Write ($"\t\t");
+					if (!is_sealed)
+						sw.Write ("protected ");
+					sw.WriteLine ($"internal {TypeName} (IntPtr handle) : base (handle)");
 					sw.WriteLine ("\t\t{");
 					if (is_direct_binding_value != null)
 						sw.WriteLine ("\t\t\tIsDirectBinding = {0};", is_direct_binding_value);
@@ -6584,6 +6588,8 @@ public partial class Generator : IMemberGatherer {
 					appearance_selectors.Add (mi);
 				
 				var minfo = new MemberInformation (this, this, mi, type, is_category_class ? bta.BaseType : null, is_model: is_model);
+				// the type above is not the the we're generating, e.g. it would be `NSCopying` for `Copy(NSZone?)`
+				minfo.is_type_sealed = is_sealed;
 
 				if (type == mi.DeclaringType || type.IsSubclassOf (mi.DeclaringType)) {
 					// not an injected protocol method.

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -629,6 +629,9 @@ namespace GeneratorTests
 			BuildFile (Profile.iOS, "tests/diamond-protocol.cs");
 		}
 
+		[Test]
+		public void GHIssue9065_Sealed () => BuildFile (Profile.iOS, nowarnings: true, "ghissue9065.cs");
+
 		BGenTool BuildFile (Profile profile, params string [] filenames)
 		{
 			return BuildFile (profile, true, false, filenames);

--- a/tests/generator/ghissue9065.cs
+++ b/tests/generator/ghissue9065.cs
@@ -1,0 +1,13 @@
+using Foundation;
+using ObjCRuntime;
+
+namespace GHIssue9065 {
+
+	[Sealed]
+	[BaseType (typeof (NSObject))]
+	interface Widget : INSCopying {
+		[Export ("doSomething:atIndex:")]
+		[Static]
+		void DoSomething (NSObject obj, int index);
+	}
+}


### PR DESCRIPTION
Fix build warnings
```
build/mac/mobile/ReplayKit/RPScreenRecorder.g.cs(113,22): warning CS0628: 'RPScreenRecorder.RPScreenRecorder(IntPtr)': new protected member declared in sealed class
build/mac/full/ReplayKit/RPScreenRecorder.g.cs(113,22): warning CS0628: 'RPScreenRecorder.RPScreenRecorder(IntPtr)': new protected member declared in sealed class
```
which still happens even if we disable XM in `main` :|

Added generator test based on Whitney's test case from github issue

ref: https://github.com/xamarin/xamarin-macios/issues/9065