### PR TITLE
[Xcode12][ARKit] Fix ARFrameSemantics and ARErrorCode

### DIFF
--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -61,7 +61,11 @@ namespace ARKit {
 		SensorUnavailable = 101,
 		SensorFailed = 102,
 		CameraUnauthorized = 103,
+		MicrophoneUnauthorized = 104,
+		LocationUnauthorized = 105,
 		WorldTrackingFailed = 200,
+		GeoTrackingNotAvailableAtLocation = 201,
+		GeoTrackingFailed = 202,
 		InvalidReferenceImage = 300,
 		InvalidReferenceObject = 301,
 		InvalidWorldMap = 302,
@@ -74,6 +78,7 @@ namespace ARKit {
 		InsufficientFeatures = 400,
 		ObjectMergeFailed = 401,
 		FileIOFailed = 500,
+		RequestFailed = 501,
 	}
 
 	[iOS (11,0)]
@@ -196,7 +201,9 @@ namespace ARKit {
 		PersonSegmentationWithDepth = (1 << 1) | (1 << 0),
 		BodyDetection = 1 << 2,
 		[iOS (14,0)]
-		SceneDepth = (1 << 4),
+		SceneDepth = (1 << 3),
+		[iOS (14,0)]
+		SmoothedSceneDepth = (1 << 4),
 	}
 
 	[iOS (13,0)]


### PR DESCRIPTION
Partial backport of #9691

This fixes incorrect enum value for ARFrameSemantics.SceneDepth and add some missing values to ARErrorCode