### PR TITLE
[msbuild] Include all the *.targets and *.props files from the Xamarin.Shared directory in the XI and XM tasks projects.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -17,10 +17,10 @@
     <None Include="*.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="../Xamarin.Shared/Xamarin.Shared.targets">
+    <None Include="../Xamarin.Shared/*.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="../Xamarin.Shared/Xamarin.Shared.props">
+    <None Include="../Xamarin.Shared/*.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
@@ -25,10 +25,10 @@
     <None Include="*.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="../Xamarin.Shared/Xamarin.Shared.targets">
+    <None Include="../Xamarin.Shared/*.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="../Xamarin.Shared/Xamarin.Shared.props">
+    <None Include="../Xamarin.Shared/*.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
This way these files end up copied to the output directory, and from there
they're included in msbuild.zip which our Windows support needs.