### PR TITLE
[msbuild] Add SceneKit assets to our items included by default.

### DIFF
--- a/dotnet/DefaultCompilationIncludes.md
+++ b/dotnet/DefaultCompilationIncludes.md
@@ -17,6 +17,11 @@ the platform-specific variables `EnableDefaultiOSItems=false`,
 All \*.plist files in the root directory are included by default (as `None`
 items).
 
+## SceneKit Assets
+
+All \*.scnassets directories anywhere in the project directory or any
+subdirectory are included by default (as `SceneKitAsset` items).
+
 ## Binding projects
 
 Default compilation includes is turned off for binding projects, because

--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -25,6 +25,13 @@
     </None>
   </ItemGroup>
 
+  <!-- Default SceneKit assets inclusion -->
+  <ItemGroup Condition="'$(_EnableDefaultXamarinItems)' == 'true' ">
+    <SceneKitAsset Include="**\*.scnassets\*">
+      <IsDefaultItem>true</IsDefaultItem>
+    </SceneKitAsset>
+  </ItemGroup>
+
   <!-- Architecture -->
   <!-- If the old-style variables are set, use those -->
   <PropertyGroup Condition=" '$(TargetArchitectures)' == '' ">

--- a/msbuild/Xamarin.MacDev.Tasks.Core/BundleResource.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/BundleResource.cs
@@ -77,7 +77,8 @@ namespace Xamarin.MacDev
 				}
 			}
 
-			var definingProjectFullPath = item.GetMetadata ("DefiningProjectFullPath");
+			var isDefaultItem = item.GetMetadata ("IsDefaultItem") == "true";
+			var definingProjectFullPath = item.GetMetadata (isDefaultItem ? "MSBuildProjectFullPath" : "DefiningProjectFullPath");
 			var path = item.GetMetadata ("FullPath");
 			string baseDir;
 

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/DotnetTest.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/DotnetTest.cs
@@ -54,8 +54,8 @@ namespace Xamarin.iOS.Tasks {
 		[TestCase ("MyXamarinFormsApp")]
 		public void CompareBuilds (string project, int expectedErrorCount = 0)
 		{
-			var net461 = GetTestDirectory ("net461");
-			var dotnet = GetTestDirectory ("dotnet");
+			var net461 = GetTestDirectory ("net461-" + ProjectConfiguration, ExecutionMode.MSBuild);
+			var dotnet = GetTestDirectory ("dotnet-" + ProjectConfiguration, ExecutionMode.DotNet);
 
 			Configuration.FixupTestFiles (dotnet, "dotnet");
 			Configuration.CopyDotNetSupportingFiles (dotnet);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
@@ -39,7 +39,7 @@ namespace Xamarin.iOS.Tasks
 			public static string ResolveReferences = "ResolveReferences";
 		}
 
-		protected static string GetTestDirectory (string mode = null)
+		protected static string GetTestDirectory (string mode = null, ExecutionMode? executionMode = null)
 		{
 			var assembly_path = Assembly.GetExecutingAssembly ().Location;
 			if (string.IsNullOrEmpty (mode)) {
@@ -54,7 +54,7 @@ namespace Xamarin.iOS.Tasks
 			var testSourceDirectory = Path.Combine (Configuration.RootPath, "msbuild", "tests");
 			var rv = Configuration.CloneTestDirectory (testSourceDirectory, mode);
 
-			if (mode == "dotnet")
+			if (executionMode == ExecutionMode.DotNet)
 				Configuration.CopyDotNetSupportingFiles (rv);
 
 			return rv;

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -119,7 +119,6 @@ namespace Xamarin.Tests {
 					switch (dirext) {
 					case ".storyboardc": // TODO
 					case ".atlasc": // TODO
-					case ".scnassets": // TODO
 						return false;
 					}
 


### PR DESCRIPTION
There's a minor wrinkle here: we need to calculate the virtual path of the
SceneKit items (relative to the project), but for items included by default
their defining project is not the user's project, but our
Xamarin.Shared.Sdk.DefaultItems.targets file.

The solution is to add metadata for items included by default
('IsDefaultItem'), and if that's found when we calculate the virtual path, use
the executable project to calculate the virtual path, instead of the project
that defined the SceneKit items.