### PR TITLE
[msbuild] Move PathUtils.cs to tools/common so that other code can use it too.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/BundleResource.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/BundleResource.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 
 using Microsoft.Build.Framework;
 
+using Xamarin.Utils;
+
 namespace Xamarin.MacDev
 {
 	public static class BundleResource

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
@@ -11,6 +11,7 @@ using Microsoft.Build.Utilities;
 using Xamarin.MacDev.Tasks;
 using Xamarin.MacDev;
 using Xamarin.Localization.MSBuild;
+using Xamarin.Utils;
 
 namespace Xamarin.MacDev.Tasks
 {

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Xamarin.Localization.MSBuild;
+using Xamarin.Utils;
 
 namespace Xamarin.MacDev.Tasks
 {

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ZipTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ZipTaskBase.cs
@@ -4,6 +4,8 @@ using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
+using Xamarin.Utils;
+
 namespace Xamarin.MacDev.Tasks
 {
 	public abstract class ZipTaskBase : XamarinToolTask

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -39,6 +39,9 @@
     <Compile Include="..\..\tools\common\Execution.cs">
       <Link>Execution.cs</Link>
     </Compile>
+    <Compile Include="..\..\tools\common\PathUtils.cs">
+      <Link>PathUtils.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\tools\mtouch\errors.resx">

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ArchiveTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ArchiveTaskBase.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Utilities;
 
 using Xamarin.MacDev;
 using Xamarin.MacDev.Tasks;
+using Xamarin.Utils;
 
 namespace Xamarin.iOS.Tasks
 {

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/FindWatchOS1AppExtensionBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/FindWatchOS1AppExtensionBundleTaskBase.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Utilities;
 
 using Xamarin.MacDev.Tasks;
 using Xamarin.MacDev;
+using Xamarin.Utils;
 
 namespace Xamarin.iOS.Tasks
 {

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/FindWatchOS2AppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/FindWatchOS2AppBundleTaskBase.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Utilities;
 
 using Xamarin.MacDev.Tasks;
 using Xamarin.MacDev;
+using Xamarin.Utils;
 
 namespace Xamarin.iOS.Tasks
 {

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/UtilityTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/UtilityTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 
 using Xamarin.MacDev;
 using Xamarin.MacDev.Tasks;
+using Xamarin.Utils;
 
 namespace Xamarin.iOS.Tasks
 {

--- a/tools/common/PathUtils.cs
+++ b/tools/common/PathUtils.cs
@@ -1,8 +1,8 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Runtime.InteropServices;
 
-namespace Xamarin.MacDev
+namespace Xamarin.Utils
 {
 	public static class PathUtils
 	{
@@ -116,3 +116,4 @@ namespace Xamarin.MacDev
 		}
 	}
 }
+


### PR DESCRIPTION
In particular the code to resolve symlinks and relative paths is useful.