### PR TITLE
[maccore] Bump maccore to get CredScan fixes

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := d1f2dfa9a9189a77c7b6acc1f00c4a45ada6b2d4
+NEEDED_MACCORE_VERSION := 6a86f16e0f8bf5cad707eb9bb145a40596a7f438
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@6a86f16e0f [CredScan] Avoid scanning src/cfnetwork.cs due to false positives (#2323)

Diff: https://github.com/xamarin/maccore/compare/d1f2dfa9a9189a77c7b6acc1f00c4a45ada6b2d4..6a86f16e0f8bf5cad707eb9bb145a40596a7f438