### PR TITLE
Bind CarTemplateApplication as part of UIWindowSceneSessionRole enum

### DIFF
--- a/src/UIKit/UIEnums.cs
+++ b/src/UIKit/UIEnums.cs
@@ -2462,7 +2462,8 @@ namespace UIKit {
 		[Field ("UIWindowSceneSessionRoleExternalDisplay")]
 		ExternalDisplay,
 
-		[Field ("CPTemplateApplicationSceneSessionRoleApplication")]
+		[iOS (13,0)][NoTV][NoWatch]
+		[Field ("CPTemplateApplicationSceneSessionRoleApplication", "CarPlay")]
 		CarTemplateApplication,
 	}
 

--- a/src/UIKit/UIEnums.cs
+++ b/src/UIKit/UIEnums.cs
@@ -2461,6 +2461,9 @@ namespace UIKit {
 
 		[Field ("UIWindowSceneSessionRoleExternalDisplay")]
 		ExternalDisplay,
+
+		[Field ("CPTemplateApplicationSceneSessionRoleApplication")]
+		CarTemplateApplication,
 	}
 
 	[iOS (13,0), TV (13,0), NoWatch]

--- a/src/carplay.cs
+++ b/src/carplay.cs
@@ -1136,6 +1136,7 @@ namespace CarPlay {
 
 		[iOS (13, 0)]
 		[Field ("CPTemplateApplicationSceneSessionRoleApplication")]
+		[Advice ("Use `UIWindowSceneSessionRole.CarTemplateApplication` instead.")]
 		NSString SessionRoleApplication { get; }
 	}
 

--- a/src/carplay.cs
+++ b/src/carplay.cs
@@ -1136,7 +1136,7 @@ namespace CarPlay {
 
 #if !XAMCORE_4_0
 		[Field ("CPTemplateApplicationSceneSessionRoleApplication")]
-		[Advice ("Use `UIWindowSceneSessionRole.CarTemplateApplication` instead.")]
+		[Advice ("Use 'UIWindowSceneSessionRole.CarTemplateApplication' instead.")]
 		NSString SessionRoleApplication { get; }
 #endif
 	}

--- a/src/carplay.cs
+++ b/src/carplay.cs
@@ -1134,10 +1134,11 @@ namespace CarPlay {
 		[Export ("carWindow", ArgumentSemantic.Strong)]
 		CPWindow CarWindow { get; }
 
-		[iOS (13, 0)]
+#if !XAMCORE_4_0
 		[Field ("CPTemplateApplicationSceneSessionRoleApplication")]
 		[Advice ("Use `UIWindowSceneSessionRole.CarTemplateApplication` instead.")]
 		NSString SessionRoleApplication { get; }
+#endif
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (12,0)]


### PR DESCRIPTION
- https://github.com/xamarin/xamarin-macios/issues/9749
- See https://developer.apple.com/documentation/uikit/uiscenesessionrole?language=objc to see that Apple groups them together despite the name 

I did not test it in a full CarPlay app but this:
```
            return UISceneConfiguration.Create ("Default Configuration", UIWindowSceneSessionRole.CarTemplateApplication);

```

doesn't crash in Sim.