### PR TITLE
[dotnet] Fix install name for libxamarin[-debug].dylib on macOS

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -543,9 +543,12 @@ $(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/%: .libs/$(3)
 endef
 
 # Copy libxammac* to libxamarin* for macOS for now. Eventually we might rename libxammac to libxamarin, which would make it possible to remove this hack.
-.libs/mac/libxamarin%: .libs/mac/libxammac%
+.libs/mac/libxamarin%.a: .libs/mac/libxammac%.a
 	$(Q)$(CP) $< $@
 
+.libs/mac/libxamarin%.dylib: .libs/mac/libxammac%.dylib
+	$(Q)$(CP) $< $@
+	$(Q) install_name_tool -id @rpath/$(@F) $@
 
 $(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call DotNetLibTemplate,$(platform),$(rid)))))
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -543,10 +543,10 @@ $(DOTNET_DESTDIR)/Microsoft.$(1).Runtime.$(2)/runtimes/$(2)/native/%: .libs/$(3)
 endef
 
 # Copy libxammac* to libxamarin* for macOS for now. Eventually we might rename libxammac to libxamarin, which would make it possible to remove this hack.
-.libs/mac/libxamarin%.a: .libs/mac/libxammac%.a
+.libs/mac/libxamarin%a: .libs/mac/libxammac%a
 	$(Q)$(CP) $< $@
 
-.libs/mac/libxamarin%.dylib: .libs/mac/libxammac%.dylib
+.libs/mac/libxamarin%dylib: .libs/mac/libxammac%dylib
 	$(Q)$(CP) $< $@
 	$(Q) install_name_tool -id @rpath/$(@F) $@
 

--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -294,12 +294,13 @@ update_environment (xamarin_initialize_data *data)
 	NSString *monobundle_dir;
 
 	if (data->launch_mode == XamarinLaunchModeEmbedded) {
-		monobundle_dir = [data->app_dir stringByAppendingPathComponent: @"Versions/Current/MonoBundle"];
+		monobundle_dir = [data->app_dir stringByAppendingPathComponent: @"Versions/Current"];
 		res_dir = [data->app_dir stringByAppendingPathComponent: @"Versions/Current/Resources"];
 	} else {
-		monobundle_dir = [data->app_dir stringByAppendingPathComponent: @"Contents/MonoBundle"];
+		monobundle_dir = [data->app_dir stringByAppendingPathComponent: @"Contents"];
 		res_dir = [data->app_dir stringByAppendingPathComponent: @"Contents/Resources"];
 	}
+	monobundle_dir = [monobundle_dir stringByAppendingPathComponent: xamarin_custom_bundle_name == NULL ? @"MonoBundle" : xamarin_custom_bundle_name];
 
 #ifdef DYNAMIC_MONO_RUNTIME
 	NSString *bin_dir = [data->app_dir stringByAppendingPathComponent: @"Contents/MacOS"];
@@ -314,10 +315,11 @@ update_environment (xamarin_initialize_data *data)
 	push_env ("PKG_CONFIG_PATH", [res_dir stringByAppendingPathComponent: @"/lib/pkgconfig"]);
 	push_env ("PKG_CONFIG_PATH", [res_dir stringByAppendingPathComponent: @"/share/pkgconfig"]);
 	
-	
 	push_env ("MONO_GAC_PREFIX", res_dir);
 	push_env ("PATH", bin_dir);
-	
+
+	push_env ("MONO_PATH", monobundle_dir);
+
 	data->requires_relaunch = true;
 #else
 	// disable /dev/shm since Apple refuse applications that uses it in the Mac App Store

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1381,6 +1381,9 @@ xamarin_get_bundle_path ()
 	NSString *bundle_path;
 	char *result;
 
+	if (main_bundle == NULL)
+		xamarin_assertion_message ("Could not find the main bundle in the app ([NSBundle mainBundle] returned nil)");
+
 #if MONOMAC
 	if (xamarin_launch_mode == XamarinLaunchModeEmbedded) {
 		bundle_path = [[[NSBundle bundleForClass: [XamarinAssociatedObject class]] bundlePath] stringByAppendingPathComponent: @"Versions/Current"];
@@ -1391,9 +1394,6 @@ xamarin_get_bundle_path ()
 #else
 	bundle_path = [main_bundle bundlePath];
 #endif
-
-	if (main_bundle == NULL)
-		xamarin_assertion_message ("Could not find the main bundle in the app ([NSBundle mainBundle] returned nil)");
 
 	result = mono_path_resolve_symlinks ([bundle_path UTF8String]);
 

--- a/runtime/xamarin/main.h
+++ b/runtime/xamarin/main.h
@@ -60,6 +60,9 @@ extern char *xamarin_entry_assembly_path;
 extern bool xamarin_init_mono_debug;
 extern int xamarin_log_level;
 extern const char *xamarin_executable_name;
+#if MONOMAC
+extern NSString *xamarin_custom_bundle_name;
+#endif
 extern const char *xamarin_arch_name;
 extern bool xamarin_is_gc_coop;
 extern enum MarshalObjectiveCExceptionMode xamarin_marshal_objectivec_exception_mode;


### PR DESCRIPTION
Contributes to #9800:

- Fix install name for libxamarin[-debug].dylib on macOS
- Make sure the bundle path is passed to the child process on relaunch