### PR TITLE
[dotnet] Add support for 'dotnet build -t:run'.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -481,14 +481,7 @@
 		<_MlaunchPath Condition="'$(_MlaunchPath)' == ''">$(_XamarinSdkRootDirectory)tools\bin\mlaunch</_MlaunchPath>
 	</PropertyGroup>
 
-	<Target Name="_PrepareRunMac" DependsOnTargets="_GenerateBundleName" Condition="'$(_PlatformName)' == 'macOS'">
-		<PropertyGroup Condition="'$(_PlatformName)' == 'macOS'">
-			<RunCommand>open</RunCommand>
-			<RunArguments>-a "$(_AppBundlePath)"</RunArguments>
-		</PropertyGroup>
-	</Target>
-
-	<Target Name="_InstallMobile" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName" Condition="'$(_PlatformName)' != 'macOS' And '$(_SdkIsSimulator)' == 'false'">
+	<Target Name="_InstallMobile" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName" Condition="'$(_SdkIsSimulator)' == 'false'">
 		<GetMlaunchArguments
 			SessionId="$(BuildSessionId)"
 			AppBundlePath="$(_AppBundlePath)"
@@ -507,7 +500,7 @@
 		<Exec Command="$(_MlaunchPath) $(_MlaunchInstallArguments)" />
 	</Target>
 
-	<Target Name="_PrepareRunMobile" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_InstallMobile" Condition="'$(_PlatformName)' != 'macOS'">
+	<Target Name="_PrepareRunMobile" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_InstallMobile" >
 		<PropertyGroup>
 			<!-- capture output by default -->
 			<_MlaunchCaptureOutput Condition="'$(_MlaunchCaptureOutput)' == ''">true</_MlaunchCaptureOutput>
@@ -540,7 +533,8 @@
 		</PropertyGroup>
 	</Target>
 
-	<Target Name="_PrepareRun" DependsOnTargets="_PrepareRunMac;_PrepareRunMobile" BeforeTargets="Run" />
+	<!-- This is only needed for mobile platforms, RunCommand and RunArguments are defined for macOS in Microsoft.macOS.Sdk.targets. -->
+	<Target Name="_PrepareRun" DependsOnTargets="_PrepareRunMobile" BeforeTargets="Run" Condition="'$(_PlatformName)' != 'macOS'" />
 
 	<!-- Import existing targets -->
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -475,6 +475,73 @@
 		</ItemGroup>
 	</Target>
 
+	<!-- Install & Run -->
+
+	<PropertyGroup>
+		<_MlaunchPath Condition="'$(_MlaunchPath)' == ''">$(_XamarinSdkRootDirectory)tools\bin\mlaunch</_MlaunchPath>
+	</PropertyGroup>
+
+	<Target Name="_PrepareRunMac" DependsOnTargets="_GenerateBundleName" Condition="'$(_PlatformName)' == 'macOS'">
+		<PropertyGroup Condition="'$(_PlatformName)' == 'macOS'">
+			<RunCommand>open</RunCommand>
+			<RunArguments>-a "$(_AppBundlePath)"</RunArguments>
+		</PropertyGroup>
+	</Target>
+
+	<Target Name="_InstallMobile" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName" Condition="'$(_PlatformName)' != 'macOS' And '$(_SdkIsSimulator)' == 'false'">
+		<GetMlaunchArguments
+			SessionId="$(BuildSessionId)"
+			AppBundlePath="$(_AppBundlePath)"
+			AppManifestPath="$(_AppBundlePath)$(_AppBundleManifestRelativePath)Info.plist"
+			DeviceName="$(_DeviceName)"
+			InstallApp="$(_AppBundlePath)"
+			MlaunchPath="$(_MlaunchPath)"
+			SdkDevPath="$(_SdkDevPath)"
+			SdkIsSimulator="$(_SdkIsSimulator)"
+			SdkVersion="$(_SdkVersion)"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+		>
+			<Output TaskParameter="MlaunchArguments" PropertyName="_MlaunchInstallArguments" />
+		</GetMlaunchArguments>
+
+		<Exec Command="$(_MlaunchPath) $(_MlaunchInstallArguments)" />
+	</Target>
+
+	<Target Name="_PrepareRunMobile" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_InstallMobile" Condition="'$(_PlatformName)' != 'macOS'">
+		<PropertyGroup>
+			<!-- capture output by default -->
+			<_MlaunchCaptureOutput Condition="'$(_MlaunchCaptureOutput)' == ''">true</_MlaunchCaptureOutput>
+			<!-- wait for exit by default -->
+			<_MlaunchWaitForExit Condition="'$(_MlaunchWaitForExit)' == ''">true</_MlaunchWaitForExit>
+			<!-- don't set standard output/error path, mlaunch will by default write to stdout/stderr -->
+		</PropertyGroup>
+		<GetMlaunchArguments
+			SessionId="$(BuildSessionId)"
+			AppBundlePath="$(_AppBundlePath)"
+			AppManifestPath="$(_AppBundlePath)$(_AppBundleManifestRelativePath)Info.plist"
+			CaptureOutput="$(_MlaunchCaptureOutput)"
+			DeviceName="$(_DeviceName)"
+			LaunchApp="$(_AppBundlePath)"
+			MlaunchPath="$(_MlaunchPath)"
+			SdkIsSimulator="$(_SdkIsSimulator)"
+			SdkDevPath="$(_SdkDevPath)"
+			SdkVersion="$(_SdkVersion)"
+			StandardErrorPath="$(_MlaunchStandardErrorPath)"
+			StandardOutputPath="$(_MlaunchStandardOutputPath)"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+			WaitForExit="$(_MlaunchWaitForExit)"
+		>
+			<Output TaskParameter="MlaunchArguments" PropertyName="_MlaunchRunArguments" />
+		</GetMlaunchArguments>
+
+		<PropertyGroup>
+			<RunCommand>$(_MlaunchPath)</RunCommand>
+			<RunArguments>$(_MlaunchRunArguments)</RunArguments>
+		</PropertyGroup>
+	</Target>
+
+	<Target Name="_PrepareRun" DependsOnTargets="_PrepareRunMac;_PrepareRunMobile" BeforeTargets="Run" />
+
 	<!-- Import existing targets -->
 
 	<PropertyGroup>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
@@ -97,7 +97,7 @@ namespace Xamarin.MacDev.Tasks {
 				{  "DEVELOPER_DIR", sdkDevPath },
 			};
 			Log.LogMessage (MessageImportance.Low, $"Executing '{fileName} {StringUtils.FormatArguments (arguments)}'");
-			var rv = await Execution.RunAsync ("xcrun", arguments, environment: environment, mergeOutput: true);
+			var rv = await Execution.RunAsync (fileName, arguments, environment: environment, mergeOutput: true);
 			if (rv.ExitCode != 0) {
 				Log.LogMessage (MessageImportance.Normal, rv.StandardOutput.ToString ());
 				Log.LogError ($"Executing '{fileName} {StringUtils.FormatArguments (arguments)}' failed with exit code {rv.ExitCode}. Please review build log for more information.");

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -61,6 +61,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.GetDirectories" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.GetFiles" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.GetFullPath" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.GetMlaunchArguments" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.IBTool" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.Metal" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.MetalLib" AssemblyFile="$(_TaskAssemblyName)" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/GetMlaunchArgumentsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/GetMlaunchArgumentsTaskBase.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Xml;
+
+using Microsoft.Build.Framework;
+
+using Xamarin.MacDev;
+using Xamarin.MacDev.Tasks;
+using Xamarin.Utils;
+
+namespace Xamarin.iOS.Tasks {
+	public abstract class GetMlaunchArgumentsTaskBase : XamarinTask {
+
+		[Required]
+		public bool SdkIsSimulator { get; set; }
+
+		[Required]
+		public string SdkVersion { get; set; }
+
+		[Required]
+		public string AppBundlePath { get; set; }
+
+		[Required]
+		public string AppManifestPath { get; set; }
+
+		[Required]
+		public string SdkDevPath { get; set; }
+
+		public string DeviceName { get; set; }
+		public string LaunchApp { get; set; }
+		public string InstallApp { get; set; }
+		public bool CaptureOutput { get; set; } // Set to true to capture output. If StandardOutput|ErrorPath is not set, write to the current terminal's stdout/stderr (requires WaitForExit)
+		public string StandardOutputPath { get; set; } // Set to a path to capture output there
+		public string StandardErrorPath { get; set; } // Set to a path to capture output there
+		public bool WaitForExit { get; set; } // Required for capturing stdout/stderr output
+
+		[Required]
+		public string MlaunchPath { get; set; }
+
+		[Output]
+		public string MlaunchArguments { get; set; }
+
+		public IPhoneDeviceType DeviceType {
+			get {
+				switch (Platform) {
+				case ApplePlatform.iOS:
+				case ApplePlatform.TVOS:
+				case ApplePlatform.WatchOS:
+					var plist = PDictionary.FromFile (AppManifestPath);
+					return plist.GetUIDeviceFamily ();
+				default:
+					throw new InvalidOperationException ($"Invalid platform: {Platform}");
+				}
+			}
+		}
+
+		List<string> GetDeviceTypes ()
+		{
+			var tmpfile = Path.GetTempFileName ();
+			try {
+				var output = new StringBuilder ();
+				var result = ExecuteAsync (MlaunchPath, new string [] { "--listsim", tmpfile }, SdkDevPath).Result;
+				if (result.ExitCode != 0)
+					return null;
+
+				// Which product family are we looking for?
+				string productFamily;
+				switch (DeviceType) {
+				case IPhoneDeviceType.IPhone:
+				case IPhoneDeviceType.IPad:
+				case IPhoneDeviceType.TV:
+				case IPhoneDeviceType.Watch:
+					productFamily = DeviceType.ToString ();
+					break;
+				case IPhoneDeviceType.IPhoneAndIPad:
+					productFamily = "IPad";
+					break;
+				default:
+					throw new InvalidOperationException ($"Invalid device type: {DeviceType}");
+				}
+
+				// Load mlaunch's output
+				var xml = new XmlDocument ();
+				xml.Load (tmpfile);
+				// Get the device types for the product family we're looking for
+				var nodes = xml.SelectNodes ($"/MTouch/Simulator/SupportedDeviceTypes/SimDeviceType[ProductFamilyId='{productFamily}']").Cast<XmlNode> ();
+				// Create a list of them all
+				var deviceTypes = new List<(long Min, long Max, string Identifier)> ();
+				foreach (var node in nodes) {
+					var minRuntimeVersionValue = node.SelectSingleNode ("MinRuntimeVersion").InnerText;
+					var maxRuntimeVersionValue = node.SelectSingleNode ("MaxRuntimeVersion").InnerText;
+					var identifier = node.SelectSingleNode ("Identifier").InnerText;
+					if (!long.TryParse (minRuntimeVersionValue, out var minRuntimeVersion))
+						continue;
+					if (!long.TryParse (maxRuntimeVersionValue, out var maxRuntimeVersion))
+						continue;
+					deviceTypes.Add ((minRuntimeVersion, maxRuntimeVersion, identifier));
+				}
+				// Sort by minRuntimeVersion, this is a rudimentary way of sorting so that the last device is at the end.
+				deviceTypes.Sort ((a, b) => a.Min.CompareTo (b.Min));
+				// Return the sorted list
+				return deviceTypes.Select (v => v.Identifier).ToList ();
+			} finally {
+				File.Delete (tmpfile);
+			}
+		}
+
+		protected string GenerateCommandLineCommands ()
+		{
+			var sb = new CommandLineArgumentBuilder ();
+
+			if (!string.IsNullOrEmpty (LaunchApp)) {
+				sb.Add (SdkIsSimulator ? "--launchsim" : "--launchdev");
+				sb.AddQuoted (LaunchApp);
+			}
+
+			if (!string.IsNullOrEmpty (InstallApp)) {
+				sb.Add (SdkIsSimulator ? "--installsim" : "--installdev");
+				sb.AddQuoted (InstallApp);
+			}
+
+			if (SdkIsSimulator && string.IsNullOrEmpty (DeviceName)) {
+				var simruntime = $"com.apple.CoreSimulator.SimRuntime.{PlatformName}-{SdkVersion.Replace ('.', '-')}";
+				var simdevicetypes = GetDeviceTypes ();
+				string simdevicetype;
+
+				if (simdevicetypes?.Count > 0) {
+					// Use the latest device type we can find. This seems to be what Xcode does by default.
+					simdevicetype = simdevicetypes.Last ();
+				} else {
+					// We couldn't find any device types, so pick one.
+					switch (Platform) {
+					case ApplePlatform.iOS:
+						// Don't try to launch an iPad-only app on an iPhone
+						if (DeviceType == IPhoneDeviceType.IPad) {
+							simdevicetype = "com.apple.CoreSimulator.SimDeviceType.iPad--7th-generation-";
+						} else {
+							simdevicetype = "com.apple.CoreSimulator.SimDeviceType.iPhone-11";
+						}
+						break;
+					case ApplePlatform.TVOS:
+						simdevicetype = "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-1080p";
+						break;
+					case ApplePlatform.WatchOS:
+						simdevicetype = "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-5-40mm";
+						break;
+					default:
+						throw new InvalidOperationException ($"Invalid platform: {Platform}");
+					}
+				}
+				DeviceName = $":v2:runtime={simruntime},devicetype={simdevicetype}";
+			}
+
+			if (!string.IsNullOrEmpty (DeviceName)) {
+				if (SdkIsSimulator) {
+					sb.Add ("--device");
+				} else {
+					sb.Add ("--devname");
+				}
+				sb.AddQuoted (DeviceName);
+			}
+
+			if (CaptureOutput && string.IsNullOrEmpty (StandardOutputPath))
+				StandardOutputPath = GetTerminalName (1);
+
+			if (CaptureOutput && string.IsNullOrEmpty (StandardErrorPath))
+				StandardErrorPath = GetTerminalName (2);
+
+			if (!string.IsNullOrEmpty (StandardOutputPath)) {
+				sb.Add ("--stdout");
+				sb.AddQuoted (StandardOutputPath);
+			}
+
+			if (!string.IsNullOrEmpty (StandardErrorPath)) {
+				sb.Add ("--stderr");
+				sb.AddQuoted (StandardErrorPath);
+			}
+
+			if (WaitForExit)
+				sb.Add ("--wait-for-exit");
+
+			return sb.ToString ();
+		}
+
+		static string GetTerminalName (int fd)
+		{
+			if (isatty (fd) != 1)
+				return null;
+
+			return Marshal.PtrToStringAuto (ttyname (fd));
+		}
+
+		public override bool Execute ()
+		{
+			MlaunchArguments = GenerateCommandLineCommands ();
+			return !Log.HasLoggedErrors;
+		}
+
+		[DllImport ("/usr/lib/libc.dylib")]
+		extern static IntPtr ttyname (int filedes);
+
+		[DllImport ("/usr/lib/libc.dylib")]
+		extern static int isatty (int fd);
+	}
+}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
@@ -32,4 +32,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\tools\common\StringUtils.cs">
+      <Link>StringUtils.cs</Link>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/GetMlaunchArguments.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/GetMlaunchArguments.cs
@@ -1,0 +1,4 @@
+namespace Xamarin.iOS.Tasks {
+	public class GetMlaunchArguments : GetMlaunchArgumentsTaskBase {
+	}
+}

--- a/tools/mlaunch/Makefile
+++ b/tools/mlaunch/Makefile
@@ -11,6 +11,8 @@ ENABLE_MLAUNCH=1
 endif
 endif
 
+DOTNET_PLATFORMS_MOBILE=$(filter-out macOS,$(DOTNET_PLATFORMS))
+
 ifdef ENABLE_MLAUNCH
 all-local install-local clean-local::
 	$(MAKE) -C $(MACCORE_PATH)/tools/mlaunch $@
@@ -18,6 +20,13 @@ else
 all-local install-local::
 	$(Q) $(CP) -R $(MACIOS_BINARIES_PATH)/mlaunch/bin/mlaunch $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin
 	$(Q) $(CP) -R $(MACIOS_BINARIES_PATH)/mlaunch/lib/mlaunch $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib
+ifdef ENABLE_DOTNET
+all-local install-local::
+	$(Q) for platform in $(DOTNET_PLATFORMS_MOBILE); do \
+		$(CP) -R $(MACIOS_BINARIES_PATH)/mlaunch/bin/mlaunch $(DOTNET_DESTDIR)/Microsoft.$$platform.Sdk/tools/bin; \
+		$(CP) -R $(MACIOS_BINARIES_PATH)/mlaunch/lib/mlaunch $(DOTNET_DESTDIR)/Microsoft.$$platform.Sdk/tools/lib; \
+	done
+endif
 endif
 
 ifdef ENABLE_XAMARIN


### PR DESCRIPTION
* Ship mlaunch in the iOS, tvOS and watchOS NuGets. It should probably go into
  a separate NuGet (to avoid shipping the same mlaunch executable in three different
  packages), but that can be done at a later stage.

* Add a GetMlaunchArguments task that computes the mlaunch arguments to install
  or launch an app in either the simulator or on device.

* Implement the MSBuild logic to make the Run target (provided by .NET) launch
  mlaunch (for iOS, tvOS and watchOS) or the built app (for macOS). This is done
  by setting the RunCommand and RunArguments properties (which the Run target uses)
  to the correct values.

Ideally I'd would make 'dotnet run' work too, but that runs into a different problem which
I haven't figured out yet:

    A fatal error was encountered. The library 'libhostpolicy.dylib' required to execute the application was not found in '/Users/rolf/work/maccore/onedotnet/xamarin-macios/tests/dotnet/MySingleView/bin/Debug/net5.0-ios/ios-x64/'.
    Failed to run as a self-contained app.
      - The application was run as a self-contained app because '/Users/rolf/work/maccore/onedotnet/xamarin-macios/tests/dotnet/MySingleView/bin/Debug/net5.0-ios/ios-x64/MySingleView.runtimeconfig.json' did not specify a framework.
      - If this should be a framework-dependent app, specify the appropriate framework in '/Users/rolf/work/maccore/onedotnet/xamarin-macios/tests/dotnet/MySingleView/bin/Debug/net5.0-ios/ios-x64/MySingleView.runtimeconfig.json'.

That's for a different pull request though.

Ref https://github.com/xamarin/net6-samples/issues/35.