### PR TITLE
[tests] Fix macOS 11 intro/apitest

### DIFF
--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -2125,6 +2125,9 @@ namespace GameKit {
 		GKAchievement Achievement { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // the native 'init' method returned nil.
+#endif
 	[NoWatch]
 	[Mac (10,9)]
 	[BaseType (

--- a/tests/apitest/src/DelegateAndDataSourceTest.cs
+++ b/tests/apitest/src/DelegateAndDataSourceTest.cs
@@ -126,6 +126,10 @@ namespace Xamarin.Mac.Tests
 			case "AVCaptureView":
 				// Deallocating a AVCaptureView makes it trigger a permission dialog, which we don't want, so just skip this type.
 				return true;
+			case "GKGameCenterViewController": // the native 'init' method returned nil.
+				if (PlatformHelper.CheckSystemVersion (11, 0))
+					return true;
+				break;
 			}
 
 			switch (t.Namespace) {

--- a/tests/introspection/Mac/MacApiCtorInitTest.cs
+++ b/tests/introspection/Mac/MacApiCtorInitTest.cs
@@ -198,6 +198,8 @@ namespace Introspection {
 				return true;
 			case "AVFoundation.AVAudioRecorder": // Stopped working in macOS 10.15.2
 				return TestRuntime.CheckXcodeVersion (11, 2);
+			case "GameKit.GKGameCenterViewController": // the native 'init' method returned nil.
+				return TestRuntime.CheckXcodeVersion (11, 2);
 
 			}
 
@@ -226,6 +228,10 @@ namespace Introspection {
 				break;
 			case "QTKit":
 				if (Mac.CheckSystemVersion (10, 15)) // QTKit is gone in 10.15
+					return true;
+				break;
+			case "ModelIO": // Looks like it is broken in macOS beta 9
+				if (Mac.CheckSystemVersion (11, 0)) // Causes error on test: turning unknown type for VtValue with unregistered C++ type bool
 					return true;
 				break;
 			}
@@ -299,6 +305,11 @@ namespace Introspection {
 			case "AVFoundation.AVMutableMediaSelection":
 			case "CoreLocation.CLBeacon":
 			case "GameKit.GKTurnBasedMatch":
+				break;
+			// crash with xcode 12.2 Beta 2 (and GM in iOS)
+			case "CoreSpotlight.CSLocalizedString":
+				if (TestRuntime.CheckXcodeVersion (12, 0))
+					return;
 				break;
 			default:
 				base.CheckToString (obj);


### PR DESCRIPTION
* 'GKGameCenterViewController' init throws on macOS 11 and makes sense
  to remove the DefaultCtor since it has other init methods that
  should be used instead. Added XAMCORE_4_0 removal.

* 'ModelIO' seems to be broken in macOS 11.0, if you touch several
  types you end up getting some C++ errors

* 'CoreSpotlight.CSLocalizedString' crashes in Xcode 12.0 GM and now
  in Xcode 12.2 Beta 2 on macOS.

Added issues to check for future betas/GM here https://github.com/xamarin/xamarin-macios/issues/9744