### PR TITLE
[dotnet] Remove workaround for F# projects

### DIFF
--- a/tests/fsharplibrary/dotnet/shared.targets
+++ b/tests/fsharplibrary/dotnet/shared.targets
@@ -7,9 +7,6 @@
 		<FSharpLibraryDirectory>$(RootTestsDirectory)\fsharplibrary</FSharpLibraryDirectory>
 
 		<AssemblyOriginatorKeyFile>$(RootTestsDirectory)\..\product.snk</AssemblyOriginatorKeyFile>
-
-		<!-- Work around https://github.com/dotnet/sdk/issues/12954 -->
-		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Contributes to #8901. Issue dotnet/sdk#12954 was marked as fixed, the dotnet version was recently bumped to one that should contain the fix.