### PR TITLE
[tests] Fix ignoring dotnet tests when certain platforms have been disabled.

### DIFF
--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -799,6 +799,49 @@ namespace Xamarin.Tests
 				throw new NotImplementedException (platform.ToString ());
 			}
 		}
+
+		// Calls Assert.Ignore if the given platform isn't included in the current build.
+		public static void IgnoreIfIgnoredPlatform (ApplePlatform platform)
+		{
+			switch (platform) {
+			case ApplePlatform.iOS:
+				if (!include_ios)
+					Assert.Ignore ("iOS is not included in this build");
+				break;
+			case ApplePlatform.TVOS:
+				if (!include_tvos)
+					Assert.Ignore ("tvOS is not included in this build");
+				break;
+			case ApplePlatform.WatchOS:
+				if (!include_watchos)
+					Assert.Ignore ("watchOS is not included in this build");
+				break;
+			case ApplePlatform.MacOSX:
+				if (!include_mac)
+					Assert.Ignore ("macOS is not included in this build");
+				break;
+			default:
+				throw new ArgumentOutOfRangeException ($"Unknown platform: {platform}");
+			}
+		}
+
+		// Calls Assert.Ignore if the given platform isn't included in the current build.
+		public static void IgnoreIfIgnoredPlatform (string platform)
+		{
+			switch (platform.ToLower ()) {
+			case "ios":
+			case "tvos":
+			case "watchos":
+			case "macosx":
+				IgnoreIfIgnoredPlatform ((ApplePlatform) Enum.Parse (typeof (ApplePlatform), platform, true));
+				break;
+			case "macos":
+				IgnoreIfIgnoredPlatform (ApplePlatform.MacOSX);
+				break;
+			default:
+				throw new ArgumentOutOfRangeException ($"Unknown platform: {platform}");
+			}
+		}
 	}
 }
 

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -50,6 +50,7 @@ namespace Xamarin.Tests {
 		{
 			var platform = ApplePlatform.iOS;
 			var project_path = GetProjectPath ("MySingleView");
+			Configuration.IgnoreIfIgnoredPlatform (platform);
 			Clean (project_path);
 			var result = DotNet.AssertBuild (project_path, verbosity);
 			AssertThatLinkerExecuted (result);
@@ -59,10 +60,9 @@ namespace Xamarin.Tests {
 		[Test]
 		public void BuildMyCocoaApp ()
 		{
-			if (!Configuration.include_mac)
-				Assert.Ignore ("Ignore until Xamarin.Mac is re-enabled. Issue: https://github.com/xamarin/xamarin-macios/issues/9680");
 			var platform = ApplePlatform.MacOSX;
 			var project_path = GetProjectPath ("MyCocoaApp");
+			Configuration.IgnoreIfIgnoredPlatform (platform);
 			Clean (project_path);
 			var result = DotNet.AssertBuild (project_path, verbosity);
 			AssertThatLinkerExecuted (result);
@@ -74,6 +74,7 @@ namespace Xamarin.Tests {
 		{
 			var platform = ApplePlatform.TVOS;
 			var project_path = GetProjectPath ("MyTVApp");
+			Configuration.IgnoreIfIgnoredPlatform (platform);
 			Clean (project_path);
 			var result = DotNet.AssertBuild (project_path, verbosity);
 			AssertThatLinkerExecuted (result);
@@ -83,6 +84,7 @@ namespace Xamarin.Tests {
 		[Test]
 		public void BuildMyWatchApp ()
 		{
+			Configuration.IgnoreIfIgnoredPlatform (ApplePlatform.WatchOS);
 			var project_path = GetProjectPath ("MyWatchApp");
 			Clean (project_path);
 			var result = DotNet.AssertBuildFailure (project_path, verbosity);
@@ -95,8 +97,7 @@ namespace Xamarin.Tests {
 		[TestCase ("macOS")]
 		public void BuildMyClassLibrary (string platform)
 		{
-			if (platform == "macOS" && !Configuration.include_mac)
-				Assert.Ignore ("Ignore until Xamarin.Mac is re-enabled. Issue: https://github.com/xamarin/xamarin-macios/issues/9680");
+			Configuration.IgnoreIfIgnoredPlatform (platform);
 			var project_path = GetProjectPath ("MyClassLibrary", platform);
 			Clean (project_path);
 			var result = DotNet.AssertBuild (project_path, verbosity);
@@ -109,8 +110,7 @@ namespace Xamarin.Tests {
 		[TestCase ("macOS")]
 		public void BuildEmbeddedResourcesTest (string platform)
 		{
-			if (!Configuration.include_mac)
-				Assert.Ignore ("Ignore until Xamarin.Mac is re-enabled. Issue: https://github.com/xamarin/xamarin-macios/issues/9680");
+			Configuration.IgnoreIfIgnoredPlatform (platform);
 			var assemblyName = "EmbeddedResources";
 			var dotnet_bindings_dir = Path.Combine (Configuration.SourceRoot, "tests", assemblyName, "dotnet");
 			var project_dir = Path.Combine (dotnet_bindings_dir, platform);
@@ -143,8 +143,7 @@ namespace Xamarin.Tests {
 		[TestCase ("macOS")]
 		public void BuildFSharpLibraryTest (string platform)
 		{
-			if (!Configuration.include_mac)
-				Assert.Ignore ("Ignore until Xamarin.Mac is re-enabled. Issue: https://github.com/xamarin/xamarin-macios/issues/9680");
+			Configuration.IgnoreIfIgnoredPlatform (platform);
 			var assemblyName = "fsharplibrary";
 			var dotnet_bindings_dir = Path.Combine (Configuration.SourceRoot, "tests", assemblyName, "dotnet");
 			var project_dir = Path.Combine (dotnet_bindings_dir, platform);
@@ -171,8 +170,7 @@ namespace Xamarin.Tests {
 		[TestCase ("macOS")]
 		public void BuildBindingsTest (string platform)
 		{
-			if (!Configuration.include_mac)
-				Assert.Ignore ("Ignore until Xamarin.Mac is re-enabled. Issue: https://github.com/xamarin/xamarin-macios/issues/9680");
+			Configuration.IgnoreIfIgnoredPlatform (platform);
 			var assemblyName = "bindings-test";
 			var dotnet_bindings_dir = Path.Combine (Configuration.SourceRoot, "tests", assemblyName, "dotnet");
 			var project_dir = Path.Combine (dotnet_bindings_dir, platform);
@@ -202,8 +200,7 @@ namespace Xamarin.Tests {
 		[TestCase ("macOS")]
 		public void BuildBindingsTest2 (string platform)
 		{
-			if (!Configuration.include_mac)
-				Assert.Ignore ("Ignore until Xamarin.Mac is re-enabled. Issue: https://github.com/xamarin/xamarin-macios/issues/9680");
+			Configuration.IgnoreIfIgnoredPlatform (platform);
 			var assemblyName = "bindings-test2";
 			var dotnet_bindings_dir = Path.Combine (Configuration.SourceRoot, "tests", assemblyName, "dotnet");
 			var project_dir = Path.Combine (dotnet_bindings_dir, platform);
@@ -233,8 +230,7 @@ namespace Xamarin.Tests {
 		[TestCase ("macOS", "xammac")]
 		public void BuildBundledResources (string platform, string prefix)
 		{
-			if (!Configuration.include_mac)
-				Assert.Ignore ("Ignore until Xamarin.Mac is re-enabled. Issue: https://github.com/xamarin/xamarin-macios/issues/9680");
+			Configuration.IgnoreIfIgnoredPlatform (platform);
 			var assemblyName = "BundledResources";
 			var dotnet_bindings_dir = Path.Combine (Configuration.SourceRoot, "tests", assemblyName, "dotnet");
 			var project_dir = Path.Combine (dotnet_bindings_dir, platform);
@@ -267,6 +263,7 @@ namespace Xamarin.Tests {
 		// [TestCase ("macOS")] // No macOS Touch.Client project for .NET yet
 		public void BuildInterdependentBindingProjects (string platform)
 		{
+			Configuration.IgnoreIfIgnoredPlatform (platform);
 			var assemblyName = "interdependent-binding-projects";
 			var dotnet_bindings_dir = Path.Combine (Configuration.SourceRoot, "tests", assemblyName, "dotnet");
 			var project_dir = Path.Combine (dotnet_bindings_dir, platform);


### PR DESCRIPTION
Fixes an issue where some of the non-macOS dotnet tests where ignored because
the logic to disable the macOS ones were incorrect.