### PR TITLE
[monotouch-test] Don't assert any specific value for the ReusedConnec…

### DIFF
--- a/tests/monotouch-test/Foundation/UrlSessionTaskTransactionMetricsTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTaskTransactionMetricsTest.cs
@@ -58,7 +58,7 @@ namespace MonoTouchFixtures.Foundation {
 					Assert.Null (sttm.ResponseEndDate, "ResponseEndDate");
 					Assert.Null (sttm.ResponseStartDate, "ResponseStartDate");
 				}
-				Assert.AreEqual (TestRuntime.CheckXcodeVersion (12,0), sttm.ReusedConnection, "ReusedConnection");
+				Assert.That (sttm.ReusedConnection, Is.EqualTo (true).Or.EqualTo (false), "ReusedConnection");
 				Assert.Null (sttm.SecureConnectionEndDate, "SecureConnectionEndDate");
 				Assert.Null (sttm.SecureConnectionStartDate, "SecureConnectionStartDate");
 			}


### PR DESCRIPTION
…tion value in UrlSessionTaskTransactionMetricsTest. Fixes #xamarin/maccore@2281. (#9660)

Fixes https://github.com/xamarin/maccore/issues/2281.
