### PR TITLE
[xcode12.2][intro] check for duplicate or inconsistent availability attributes (#9825)

### DIFF
--- a/src/AVFoundation/AVAssetDownloadStorageManagementPolicy.cs
+++ b/src/AVFoundation/AVAssetDownloadStorageManagementPolicy.cs
@@ -8,8 +8,6 @@ using ObjCRuntime;
 namespace AVFoundation {
 	public partial class AVAssetDownloadStorageManagementPolicy {
 
-		[iOS (11,0)]
-		[NoTV][NoMac][NoWatch]
 		public virtual AVAssetDownloadedAssetEvictionPriority Priority {
 			get { return AVAssetDownloadedAssetEvictionPriorityExtensions.GetValue (_Priority); }
 			set { throw new NotImplementedException (); }
@@ -18,8 +16,6 @@ namespace AVFoundation {
 
 	public partial class AVMutableAssetDownloadStorageManagementPolicy {
 		
-		[iOS (11,0)]
-		[NoTV][NoMac][NoWatch]
 		public override AVAssetDownloadedAssetEvictionPriority Priority {
 			get { return AVAssetDownloadedAssetEvictionPriorityExtensions.GetValue (_Priority); }
 			set { _Priority = value.GetConstant (); }

--- a/src/AVFoundation/AVCaptureDeviceDiscoverySession.cs
+++ b/src/AVFoundation/AVCaptureDeviceDiscoverySession.cs
@@ -14,7 +14,7 @@ using ObjCRuntime;
 namespace AVFoundation {
 #if IOS
 	public partial class AVCaptureDeviceDiscoverySession {
-		[iOS (10,0)]
+
 		public static AVCaptureDeviceDiscoverySession Create (AVCaptureDeviceType [] deviceTypes, string mediaType, AVCaptureDevicePosition position)
 		{
 			var arr = new NSMutableArray ();

--- a/src/AVFoundation/AVContentKeyResponse.cs
+++ b/src/AVFoundation/AVContentKeyResponse.cs
@@ -25,7 +25,7 @@ namespace AVFoundation {
 
 		public static AVContentKeyResponse Create (NSData fairPlayStreamingKeyResponseData) => Create (fairPlayStreamingKeyResponseData, AVContentKeyResponseDataType.FairPlayStreamingKeyResponseData);
 			
-		[TV (10,2), Mac (10,12,4), iOS (10,3), NoWatch]
+		[NoWatch]
 		public static AVContentKeyResponse Create (NSData data, AVContentKeyResponseDataType dataType = AVContentKeyResponseDataType.FairPlayStreamingKeyResponseData) {
 			switch (dataType) {
 			case AVContentKeyResponseDataType.AuthorizationTokenData:

--- a/src/AVFoundation/AVPlayerViewController.cs
+++ b/src/AVFoundation/AVPlayerViewController.cs
@@ -16,7 +16,6 @@ namespace AVKit {
 		// the resulting syntax does not look good in user code so we provide a better looking API
 		// https://trello.com/c/iQpXOxCd/227-category-and-static-methods-selectors
 		// note: we cannot reuse the same method name - as it would break compilation of existing apps
-		[iOS (8,0)]
 		static public void PrepareForPrerollAds ()
 		{
 			(null as AVPlayerViewController).PreparePrerollAds ();

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -3057,7 +3057,6 @@ namespace AppKit {
 		FullWidth,
 		Inset,
 		SourceList,
-		[Mac (11,0)]
 		Plain,
 	}
 

--- a/src/CloudKit/CKCompat.cs
+++ b/src/CloudKit/CKCompat.cs
@@ -16,7 +16,7 @@ namespace CloudKit {
 
 #if !XAMCORE_4_0
 	public partial class CKQueryNotification {
-		[iOS (8, 0), Mac (10, 10)]
+
 		[Obsolete ("Empty stub (not public API). Use 'DatabaseScope' instead.")]
 		public virtual bool IsPublicDatabase { get; }
 	}
@@ -46,33 +46,27 @@ namespace CloudKit {
 
 	public partial class CKContainer {
 #if __IOS__ || MONOMAC
-		[iOS (8, 0), Mac (10, 10)]
 		[Obsolete ("Always throw a 'NotSupportedException' (not a public API). Use 'DiscoverAllIdentities' instead.")]
 		public virtual void DiscoverAllContactUserInfos (Action<CKDiscoveredUserInfo[], NSError> completionHandler) 
 			=> throw new NotSupportedException ();
 
-		[iOS (8, 0), Mac (10, 10)]
 		[Obsolete ("Always throw a 'NotSupportedException' (not a public API). Use 'DiscoverAllIdentities' instead.")]
 		public virtual Task<CKDiscoveredUserInfo[]> DiscoverAllContactUserInfosAsync ()
 			=> Task.FromException<CKDiscoveredUserInfo[]> (new NotSupportedException ());
 #endif
 
-		[iOS (8, 0), Mac (10, 10)]
 		[Obsolete ("Always throw a 'NotSupportedException' (not a public API). Use 'DiscoverUserIdentityWithEmailAddress' instead.")]
 		public virtual void DiscoverUserInfo (string email, Action<CKDiscoveredUserInfo, NSError> completionHandler)
 			=> throw new NotSupportedException ();
 
-		[iOS (8, 0), Mac (10, 10)]
 		[Obsolete ("Always throw a 'NotSupportedException' (not a public API). Use 'DiscoverUserIdentityWithEmailAddress' instead.")]
 		public virtual Task<CKDiscoveredUserInfo> DiscoverUserInfoAsync (string email)
 			=> Task.FromException<CKDiscoveredUserInfo> (new NotSupportedException ());
 
-		[iOS (8, 0), Mac (10, 10)]
 		[Obsolete ("Always throw a 'NotSupportedException' (not a public API). Use 'DiscoverUserIdentity' instead.")]
 		public virtual void DiscoverUserInfo (CKRecordID userRecordId, Action<CKDiscoveredUserInfo, NSError> completionHandler)
 			=> throw new NotSupportedException ();
 
-		[iOS (8, 0), Mac (10, 10)]
 		[Obsolete ("Always throw a 'NotSupportedException' (not a public API). Use 'DiscoverUserIdentity' instead.")]
 		public virtual Task<CKDiscoveredUserInfo> DiscoverUserInfoAsync (CKRecordID userRecordId)
 			=> Task.FromException<CKDiscoveredUserInfo> (new NotSupportedException ());

--- a/src/CloudKit/Enums.cs
+++ b/src/CloudKit/Enums.cs
@@ -104,7 +104,7 @@ namespace CloudKit
 		Query = 1,
 		RecordZone = 2,
 		ReadNotification = 3,
-		[iOS (10,0), TV (10,0), Mac (10,12), Watch (3,0)] Database = 4,
+		[iOS (10,0), TV (10,0), Mac (10,12)] Database = 4,
 	}
 
 	// NSInteger -> CKNotification.h
@@ -127,7 +127,7 @@ namespace CloudKit
 	public enum CKRecordZoneCapabilities : ulong {
 		FetchChanges = 1 << 0,
 		Atomic = 1 << 1,
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12)] Sharing = 1 << 2,
+		[iOS (10,0), TV (10,0), Mac (10,12)] Sharing = 1 << 2,
 	}
 
 	// NSUInteger -> CKReference.h

--- a/src/CoreGraphics/CGColorConversionInfo.cs
+++ b/src/CoreGraphics/CGColorConversionInfo.cs
@@ -116,11 +116,9 @@ namespace CoreGraphics {
 				throw new Exception ("Failed to create CGColorConverter");
 		}
 
-		[iOS (10,0)][Mac (10,12)]
 		[DllImport(Constants.CoreGraphicsLibrary)]
 		extern static IntPtr CGColorConversionInfoCreate (/* cg_nullable CGColorSpaceRef */ IntPtr src, /* cg_nullable CGColorSpaceRef */ IntPtr dst);
 
-		[iOS (10,0)][Mac (10,12)]
 		public CGColorConversionInfo (CGColorSpace source, CGColorSpace destination)
 		{
 			// API accept null arguments but returns null, which we can't use

--- a/src/CoreML/MLDictionaryFeatureProvider.cs
+++ b/src/CoreML/MLDictionaryFeatureProvider.cs
@@ -14,7 +14,6 @@ using ObjCRuntime;
 namespace CoreML {
 	public partial class MLDictionaryFeatureProvider {
 
-		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		public MLFeatureValue this [string featureName] {
 			get { return GetFeatureValue (featureName); }
 		}

--- a/src/CoreML/MLMultiArray.cs
+++ b/src/CoreML/MLMultiArray.cs
@@ -27,58 +27,49 @@ namespace CoreML {
 			return NSArray.ArrayFromHandle<nint> (handle, (v) => Messaging.nint_objc_msgSend (v, Selector.GetHandle ("integerValue")));
 		}
 
-		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		public MLMultiArray (nint [] shape, MLMultiArrayDataType dataType, out NSError error)
 			: this (ConvertArray (shape), dataType, out error)
 		{
 		}
 
-		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		public MLMultiArray (IntPtr dataPointer, nint [] shape, MLMultiArrayDataType dataType, nint [] strides, Action<IntPtr> deallocator, out NSError error)
 			: this (dataPointer, ConvertArray (shape), dataType, ConvertArray (strides), deallocator, out error)
 		{
 		}
 
-		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		public NSNumber this [nint idx] {
 			get { return GetObject (idx); }
 			set { SetObject (value, idx); }
 		}
 
-		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		public NSNumber this [params nint[] indices] {
 			get { return GetObject (indices); }
 			set { SetObject (value, indices); }
 		}
 
-		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		public NSNumber this [NSNumber [] key] {
 			get { return GetObject (key); }
 			set { SetObject (value, key); }
 		}
 
-		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		public NSNumber GetObject (params nint[] indices)
 		{
 			using (var arr = NSArray.FromNSObjects<nint> (NSNumber.FromNInt, indices))
 				return GetObject (arr.GetHandle ());
 		}
 
-		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		public void SetObject (NSNumber obj, params nint[] indices)
 		{
 			using (var arr = NSArray.FromNSObjects<nint> (NSNumber.FromNInt, indices))
 				SetObject (obj, arr.GetHandle ());
 		}
 
-		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		public nint[] Shape {
 			get {
 				return ConvertArray (_Shape);
 			}
 		}
 
-		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		public nint[] Strides {
 			get {
 				return ConvertArray (_Strides);

--- a/src/CoreMedia/CMSync.cs
+++ b/src/CoreMedia/CMSync.cs
@@ -361,11 +361,11 @@ namespace CoreMedia {
 			return CMTimebaseSetTimerToFireImmediately (Handle, timer.Handle);
 		}
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static CMTimebaseError CMTimebaseSetMasterTimebase (/* CMTimebaseRef* */ IntPtr timebase, /* CMTimebaseRef* */ IntPtr newMasterTimebase);
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		public CMTimebaseError SetMasterTimebase (CMTimebase newMasterTimebase)
 		{
 			if (newMasterTimebase == null)
@@ -374,11 +374,11 @@ namespace CoreMedia {
 			return CMTimebaseSetMasterTimebase (Handle, newMasterTimebase.Handle);
 		}
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static CMTimebaseError CMTimebaseSetMasterClock (/* CMTimebaseRef* */ IntPtr timebase, /* CMClockRef* */ IntPtr newMasterClock);
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		public CMTimebaseError SetMasterClock (CMClock newMasterClock)
 		{
 			if (newMasterClock == null)

--- a/src/CoreVideo/CVImageBuffer.cs
+++ b/src/CoreVideo/CVImageBuffer.cs
@@ -125,40 +125,40 @@ namespace CoreVideo {
 #endif
 
 		[DllImport (Constants.CoreVideoLibrary)]
-		[iOS (11, 0), Mac (10, 13), TV (11, 0), Watch (4, 0)]
+		[iOS (11, 0), Mac (10, 13), TV (11, 0)]
 		extern static int CVYCbCrMatrixGetIntegerCodePointForString (IntPtr yCbCrMatrixString);
 
-		[iOS (11, 0), Mac (10, 13), TV (11, 0), Watch (4, 0)]
+		[iOS (11, 0), Mac (10, 13), TV (11, 0)]
 		public static int GetCodePoint (CVImageBufferYCbCrMatrix yCbCrMatrix)
 		{
 			return CVYCbCrMatrixGetIntegerCodePointForString (yCbCrMatrix.GetConstant ().Handle);
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
-		[iOS (11, 0), Mac (10, 13), TV (11, 0), Watch (4, 0)]
+		[iOS (11, 0), Mac (10, 13), TV (11, 0)]
 		extern static int CVColorPrimariesGetIntegerCodePointForString (IntPtr colorPrimariesString);
 
-		[iOS (11, 0), Mac (10, 13), TV (11, 0), Watch (4, 0)]
+		[iOS (11, 0), Mac (10, 13), TV (11, 0)]
 		public static int GetCodePoint (CVImageBufferColorPrimaries color)
 		{
 			return CVColorPrimariesGetIntegerCodePointForString (color.GetConstant ().Handle);
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
-		[iOS (11, 0), Mac (10, 13), TV (11, 0), Watch (4, 0)]
+		[iOS (11, 0), Mac (10, 13), TV (11, 0)]
 		extern static int CVTransferFunctionGetIntegerCodePointForString (IntPtr colorPrimariesString);
 
-		[iOS (11, 0), Mac (10, 13), TV (11, 0), Watch (4, 0)]
+		[iOS (11, 0), Mac (10, 13), TV (11, 0)]
 		public static int GetCodePoint (CVImageBufferTransferFunction function)
 		{
 			return CVTransferFunctionGetIntegerCodePointForString (function.GetConstant ().Handle);
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
-		[iOS (11, 0), Mac (10, 13), TV (11, 0), Watch (4, 0)]
+		[iOS (11, 0), Mac (10, 13), TV (11, 0)]
 		extern static IntPtr CVYCbCrMatrixGetStringForIntegerCodePoint (int yCbCrMatrixCodePoint);
 
-		[iOS (11, 0), Mac (10, 13), TV (11, 0), Watch (4, 0)]
+		[iOS (11, 0), Mac (10, 13), TV (11, 0)]
 		public static CVImageBufferYCbCrMatrix GetYCbCrMatrixOption (int yCbCrMatrixCodePoint)
 		{
 			var ret = Runtime.GetNSObject<NSString> (CVYCbCrMatrixGetStringForIntegerCodePoint (yCbCrMatrixCodePoint));
@@ -166,10 +166,10 @@ namespace CoreVideo {
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
-		[iOS (11, 0), Mac (10, 13), TV (11, 0), Watch (4, 0)]
+		[iOS (11, 0), Mac (10, 13), TV (11, 0)]
 		extern static IntPtr CVColorPrimariesGetStringForIntegerCodePoint (int colorPrimariesCodePoint);
 
-		[iOS (11, 0), Mac (10, 13), TV (11, 0), Watch (4, 0)]
+		[iOS (11, 0), Mac (10, 13), TV (11, 0)]
 		public static CVImageBufferColorPrimaries GetColorPrimariesOption (int colorPrimariesCodePoint)
 		{
 			var ret = Runtime.GetNSObject<NSString> (CVColorPrimariesGetStringForIntegerCodePoint (colorPrimariesCodePoint));
@@ -177,10 +177,10 @@ namespace CoreVideo {
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
-		[iOS (11, 0), Mac (10, 13), TV (11, 0), Watch (4, 0)]
+		[iOS (11, 0), Mac (10, 13), TV (11, 0)]
 		extern static IntPtr CVTransferFunctionGetStringForIntegerCodePoint (int transferFunctionCodePoint);
 
-		[iOS (11, 0), Mac (10, 13), TV (11, 0), Watch (4, 0)]
+		[iOS (11, 0), Mac (10, 13), TV (11, 0)]
 		public static CVImageBufferTransferFunction GetTransferFunctionOption (int transferFunctionCodePoint)
 		{
 			var ret = Runtime.GetNSObject<NSString> (CVTransferFunctionGetStringForIntegerCodePoint (transferFunctionCodePoint));

--- a/src/GLKit/Defs.cs
+++ b/src/GLKit/Defs.cs
@@ -134,11 +134,9 @@ namespace GLKit {
 		public bool Normalized;
 
 #if !COREBUILD
-		[iOS (9,0)][Mac (10,11)]
 		[DllImport (Constants.GLKitLibrary, EntryPoint = "GLKVertexAttributeParametersFromModelIO")]
 		extern static GLKVertexAttributeParameters FromVertexFormat_ (nuint vertexFormat);
 
-		[iOS (9,0)][Mac (10,11)]
 		public static GLKVertexAttributeParameters FromVertexFormat (MDLVertexFormat vertexFormat)
 		{
 			return FromVertexFormat_ ((nuint) (ulong) vertexFormat);

--- a/src/GameController/GCMicroGamepadSnapshot.cs
+++ b/src/GameController/GCMicroGamepadSnapshot.cs
@@ -91,10 +91,8 @@ namespace GameController {
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 		[DllImport (Constants.GameControllerLibrary)]
-		[Mac (10, 12)]
 		static extern bool GCMicroGamepadSnapShotDataV100FromNSData (out GCMicroGamepadSnapShotDataV100 snapshotData, /* NSData */ IntPtr data);
 
-		[Mac (10, 12)]
 		[Deprecated (PlatformName.iOS, 12, 2, message: "Use 'TryGetSnapshotData (NSData, out GCMicroGamepadSnapshotData)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 14, 4, message: "Use 'TryGetSnapshotData (NSData, out GCMicroGamepadSnapshotData)' instead.")]
 		[Deprecated (PlatformName.TvOS, 12, 2, message: "Use 'TryGetSnapshotData (NSData, out GCMicroGamepadSnapshotData)' instead.")]

--- a/src/HomeKit/HMActionSet.cs
+++ b/src/HomeKit/HMActionSet.cs
@@ -7,7 +7,6 @@ namespace HomeKit {
 	partial class HMActionSet {
 
 		[iOS (9,0)]
-		[TV (10,0)]
 		public HMActionSetType ActionSetType {
 			get {
 				var s = _ActionSetType;

--- a/src/HomeKit/HMCharacteristic.cs
+++ b/src/HomeKit/HMCharacteristic.cs
@@ -4,8 +4,6 @@ using Foundation;
 
 namespace HomeKit {
 
-	[iOS (8,0)]
-	[TV (10,0)]
 	partial class HMCharacteristic 
 	{
 		public bool SupportsEventNotification {
@@ -39,7 +37,6 @@ namespace HomeKit {
 		}
 
 		[iOS (9,3)][Watch (2,2)]
-		[TV (10,0)]
 		public bool Hidden {
 			get {
 				foreach (var p in Properties) {

--- a/src/HomeKit/HMEnums.cs
+++ b/src/HomeKit/HMEnums.cs
@@ -573,7 +573,7 @@ namespace HomeKit {
 		[Field ("HMCharacteristicTypeHumidifierThreshold")]
 		HumidifierThreshold,
 
-		[iOS (9,0), Watch (2,0), TV (10,0)]
+		[iOS (9,0)]
 		[Field ("HMCharacteristicTypeSecuritySystemAlarmType")]
 		SecuritySystemAlarmType,
 

--- a/src/HomeKit/HMHome.cs
+++ b/src/HomeKit/HMHome.cs
@@ -89,7 +89,6 @@ namespace HomeKit {
 #if (WATCH || TVOS)
 		[Obsolete ("This API is not available on this platform.")]
 #endif
-		[Introduced (PlatformName.iOS, 8,0, PlatformArchitecture.All, message: "This API in now prohibited on iOS. Use 'ManageUsers' instead.")]
 		[Obsoleted (PlatformName.iOS, 9,0, PlatformArchitecture.All, message: "This API in now prohibited on iOS. Use 'ManageUsers' instead.")]
 		public virtual void RemoveUser (HMUser user, Action<NSError> completion) {
 			throw new NotSupportedException ();
@@ -100,7 +99,6 @@ namespace HomeKit {
 #if (WATCH || TVOS)
 		[Obsolete ("This API is not available on this platform.")]
 #endif
-		[Introduced (PlatformName.iOS, 8,0, PlatformArchitecture.All, message: "This API in now prohibited on iOS. Use 'ManageUsers' instead.")]
 		[Obsoleted (PlatformName.iOS, 9,0, PlatformArchitecture.All, message: "This API in now prohibited on iOS. Use 'ManageUsers' instead.")]
 		public virtual Task RemoveUserAsync (HMUser user) {
 			throw new NotSupportedException ();

--- a/src/IOSurface/IOSurface.cs
+++ b/src/IOSurface/IOSurface.cs
@@ -33,9 +33,6 @@ namespace IOSurface {
 
 		// kern_return_t
 		// See bug #59201 [iOS (10,0)]
-		[iOS (11, 0)]
-		[Mac (10, 12)]
-		[TV (11, 0)]
 		public int Lock (IOSurfaceLockOptions options, ref int seed)
 		{
 			unsafe {
@@ -47,9 +44,6 @@ namespace IOSurface {
 
 		// kern_return_t
 		// See bug #59201 [iOS (10,0)]
-		[iOS (11, 0)]
-		[Mac (10, 12)]
-		[TV (11, 0)]
 		public int Lock (IOSurfaceLockOptions options)
 		{
 			return _Lock (options, IntPtr.Zero);
@@ -57,9 +51,6 @@ namespace IOSurface {
 		
 		// kern_return_t
 		// See bug #59201 [iOS (10,0)]
-		[iOS (11, 0)]
-		[Mac (10, 12)]
-		[TV (11, 0)]
 		public int Unlock (IOSurfaceLockOptions options, ref int seed)
 		{
 			unsafe {
@@ -71,9 +62,6 @@ namespace IOSurface {
 
 		// kern_return_t
 		// See bug #59201 [iOS (10,0)]
-		[iOS (11, 0)]
-		[Mac (10, 12)]
-		[TV (11, 0)]
 		public int Unlock (IOSurfaceLockOptions options)
 		{
 			return _Unlock (options, IntPtr.Zero);
@@ -81,8 +69,6 @@ namespace IOSurface {
 
 #if !MONOMAC
 		// kern_return_t
-		[iOS (11, 0)]
-		[TV (11, 0)]
 		public int SetPurgeable (IOSurfacePurgeabilityState newState, ref IOSurfacePurgeabilityState oldState)
 		{
 			unsafe {
@@ -92,8 +78,6 @@ namespace IOSurface {
 			}
 		}
 
-		[iOS (11, 0)]
-		[TV (11, 0)]
 		public int SetPurgeable (IOSurfacePurgeabilityState newState)
 		{
 			return _SetPurgeable (newState, IntPtr.Zero);

--- a/src/Metal/MTLDevice.cs
+++ b/src/Metal/MTLDevice.cs
@@ -47,11 +47,11 @@ namespace Metal {
 		}
 
 #if MONOMAC
-		[Mac (10,11), NoiOS, NoWatch, NoTV]
+		[NoiOS, NoWatch, NoTV]
 		[DllImport (Constants.MetalLibrary)]
 		unsafe static extern IntPtr MTLCopyAllDevices ();
 
-		[Mac (10,11), NoiOS, NoWatch, NoTV]
+		[NoiOS, NoWatch, NoTV]
 		public static IMTLDevice [] GetAllDevices ()
 		{
 			var rv = MTLCopyAllDevices ();

--- a/src/Metal/MTLEnums.cs
+++ b/src/Metal/MTLEnums.cs
@@ -410,7 +410,7 @@ namespace Metal {
 		[iOS (9,0)]
 		Depth32Float_Stencil8 = 260,
 	
-		[NoWatch, iOS (9,0), TV (9,0), Mac (10,11)]
+		[NoWatch, iOS (9,0), TV (9,0)]
 		X32_Stencil8 = 261,
 
 		[Mac (10,12)][NoiOS][NoTV]

--- a/src/Metal/MTLRasterizationRateLayerDescriptor.cs
+++ b/src/Metal/MTLRasterizationRateLayerDescriptor.cs
@@ -9,8 +9,8 @@ using ObjCRuntime;
 namespace Metal {
 	public partial class MTLRasterizationRateLayerDescriptor
 	{
-/*  Selectors reported as not working by instrospection: https://github.com/xamarin/maccore/issues/1976
-		[NoMac, NoTV, iOS (13,0)]
+/*  Selectors reported as not working by introspection: https://github.com/xamarin/maccore/issues/1976
+		[NoMac]
 		public double[] HorizontalSampleStorage { 
 			get {
 				var width = (int)SampleCount.Width;
@@ -20,7 +20,7 @@ namespace Metal {
 			}
 		}
 
-		[NoMac, NoTV, iOS (13,0)]
+		[NoMac]
 		public double[] VerticalSampleStorage {
 			get {
 				var height = (int)SampleCount.Height;
@@ -30,7 +30,7 @@ namespace Metal {
 			}
 		}
 */
-		[NoMac, NoTV, iOS (13,0)]
+		[NoMac]
 		static public MTLRasterizationRateLayerDescriptor Create (MTLSize sampleCount, float[] horizontal, float[] vertical)
 		{
 			if (horizontal == null)

--- a/src/ModelIO/MDLNoiseTexture.cs
+++ b/src/ModelIO/MDLNoiseTexture.cs
@@ -11,7 +11,7 @@ namespace ModelIO {
 	}
 
 	public partial class MDLNoiseTexture {
-		[iOS (9,0), Mac (10,11)]
+
 		public MDLNoiseTexture (float input, string name, Vector2i textureDimensions, MDLTextureChannelEncoding channelEncoding) : this (input, name, textureDimensions, channelEncoding, MDLNoiseTextureType.Vector)
 		{
 		}

--- a/src/Network/NWAdvertiseDescriptor.cs
+++ b/src/Network/NWAdvertiseDescriptor.cs
@@ -65,15 +65,15 @@ namespace Network {
 			get => nw_advertise_descriptor_get_no_auto_rename (GetCheckedHandle ());
 		}
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
 		static extern OS_nw_txt_record nw_advertise_descriptor_copy_txt_record_object (OS_nw_advertise_descriptor advertise_descriptor);
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
 		static extern void nw_advertise_descriptor_set_txt_record_object (OS_nw_advertise_descriptor advertise_descriptor, OS_nw_txt_record txt_record);
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		public NWTxtRecord TxtRecord {
 			get => new NWTxtRecord (nw_advertise_descriptor_copy_txt_record_object (GetCheckedHandle ()), owns: true); 
 			set => nw_advertise_descriptor_set_txt_record_object (GetCheckedHandle (), value.GetHandle ()); 

--- a/src/Network/NWConnection.cs
+++ b/src/Network/NWConnection.cs
@@ -574,7 +574,7 @@ namespace Network {
 			BlockLiteral.SimpleCall (method, (arg)=> nw_connection_batch (GetCheckedHandle (), arg));
 		}
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_connection_access_establishment_report (IntPtr connection, IntPtr queue, ref BlockLiteral access_block);
 
@@ -592,7 +592,7 @@ namespace Network {
 			}
 		}
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void GetEstablishmentReport (DispatchQueue queue, Action<NWEstablishmentReport> handler)
 		{

--- a/src/Network/NWEndpoint.cs
+++ b/src/Network/NWEndpoint.cs
@@ -116,11 +116,11 @@ namespace Network {
 
 		public string? BonjourServiceDomain => Marshal.PtrToStringAnsi (nw_endpoint_get_bonjour_service_domain (GetCheckedHandle ()));
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
 		static extern OS_nw_endpoint nw_endpoint_create_url (string url);
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		public static NWEndpoint? Create (string url)
 		{
 			if (url == null)
@@ -131,11 +131,11 @@ namespace Network {
 			return new NWEndpoint (handle, owns: true);
 		}
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr nw_endpoint_get_url (OS_nw_endpoint endpoint);
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		public string? Url => Marshal.PtrToStringAnsi (nw_endpoint_get_url (GetCheckedHandle ()));
 	}
 }

--- a/src/Network/NWListener.cs
+++ b/src/Network/NWListener.cs
@@ -243,15 +243,15 @@ namespace Network {
 			nw_listener_set_advertise_descriptor (GetCheckedHandle (), descriptor.GetHandle ());
 		}
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
 		static extern uint nw_listener_get_new_connection_limit (IntPtr listener);
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
 		static extern void nw_listener_set_new_connection_limit (IntPtr listener, uint new_connection_limit);
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		public uint ConnectionLimit {
 			get => nw_listener_get_new_connection_limit (GetCheckedHandle ());
 			set => nw_listener_set_new_connection_limit (GetCheckedHandle (), value);

--- a/src/Network/NWParameters.cs
+++ b/src/Network/NWParameters.cs
@@ -484,16 +484,16 @@ namespace Network {
 			set => nw_parameters_set_include_peer_to_peer (GetCheckedHandle (), value);
 		}
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool nw_parameters_get_prohibit_constrained (IntPtr parameters);
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
 		static extern void nw_parameters_set_prohibit_constrained (IntPtr parameters, bool prohibit_constrained);
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		public bool ProhibitConstrained {
 			get => nw_parameters_get_prohibit_constrained (GetCheckedHandle ());
 			set => nw_parameters_set_prohibit_constrained (GetCheckedHandle (), value);

--- a/src/Network/NWPath.cs
+++ b/src/Network/NWPath.cs
@@ -134,14 +134,14 @@ namespace Network {
 			}
 		}
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
 		static extern bool nw_path_is_constrained (IntPtr path);
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		public bool IsConstrained => nw_path_is_constrained (GetCheckedHandle ());
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
 		static extern void nw_path_enumerate_gateways (IntPtr path, ref BlockLiteral enumerate_block);
 
@@ -158,7 +158,7 @@ namespace Network {
 			}
 		}
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void EnumerateGateways (Action<NWEndpoint> callback)
 		{

--- a/src/Network/NWProtocolDefinition.cs
+++ b/src/Network/NWProtocolDefinition.cs
@@ -78,20 +78,20 @@ namespace Network {
 
 		public static NWProtocolDefinition CreateTlsDefinition () => new NWProtocolDefinition (nw_protocol_copy_tls_definition (), owns: true);
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
 		static extern OS_nw_protocol_definition nw_protocol_copy_ws_definition ();
 
 #if !XAMCORE_4_0
 		[Obsolete ("Use 'CreateWebSocketDefinition' method instead.")]
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		public static NWProtocolDefinition WebSocketDefinition => new NWProtocolDefinition (nw_protocol_copy_ws_definition (), owns: true);
 #endif
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		public static NWProtocolDefinition CreateWebSocketDefinition () => new NWProtocolDefinition (nw_protocol_copy_ws_definition (), owns: true);
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[Watch (6,0), TV (13,0), Mac (10,15)]
 		[DllImport (Constants.NetworkLibrary)]
 		static extern unsafe OS_nw_protocol_definition nw_framer_create_definition (string identifier, NWFramerCreateFlags flags, ref BlockLiteral start_handler);
 		delegate NWFramerStartResult nw_framer_create_definition_t (IntPtr block, IntPtr framer);
@@ -109,7 +109,7 @@ namespace Network {
 			return NWFramerStartResult.Unknown;
 		}
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static NWProtocolDefinition CreateFramerDefinition (string identifier, NWFramerCreateFlags flags, Func<NWFramer, NWFramerStartResult> startCallback)
 		{

--- a/src/Network/NWProtocolIPOptions.cs
+++ b/src/Network/NWProtocolIPOptions.cs
@@ -54,7 +54,6 @@ namespace Network {
 		public void SetCalculateReceiveTime (bool shouldCalculateReceiveTime)
 			=> nw_ip_options_set_calculate_receive_time (GetCheckedHandle (), shouldCalculateReceiveTime);
 
-		[TV (13,0), Mac (10,15), iOS (13,0)]
 		public void SetIPLocalAddressPreference (NWIPLocalAddressPreference localAddressPreference)
 			=> nw_ip_options_set_local_address_preference (GetCheckedHandle (), localAddressPreference);
 	}

--- a/src/Network/NWProtocolMetadata.cs
+++ b/src/Network/NWProtocolMetadata.cs
@@ -212,18 +212,18 @@ namespace Network {
 		}
 #endif
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern bool nw_protocol_metadata_is_framer_message (OS_nw_protocol_metadata metadata);
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		public bool IsFramerMessage => nw_protocol_metadata_is_framer_message (GetCheckedHandle ());
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern bool nw_protocol_metadata_is_ws (OS_nw_protocol_metadata metadata);
 
-		[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		public bool IsWebSocket => nw_protocol_metadata_is_ws (GetCheckedHandle ());
 	}
 }

--- a/src/Network/NWProtocolOptions.cs
+++ b/src/Network/NWProtocolOptions.cs
@@ -107,12 +107,12 @@ namespace Network {
 		}
 
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern void nw_ip_options_set_local_address_preference (IntPtr options, NWIPLocalAddressPreference preference);
 
 		[Obsolete ("Use the 'NWProtocolIPOptions' class instead.")]
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		public NWIPLocalAddressPreference IPLocalAddressPreference {
 			set => nw_ip_options_set_local_address_preference (GetCheckedHandle (), value);
 		}

--- a/src/SceneKit/SCNSkinner.cs
+++ b/src/SceneKit/SCNSkinner.cs
@@ -51,13 +51,11 @@ namespace SceneKit {
 		}
 
 		[Mac (10, 10)]
-		[iOS (8, 0)]
 		public SCNMatrix4 [] BoneInverseBindTransforms {
 			get { return FromNSArray (_BoneInverseBindTransforms); }
 		}
 
 		[Mac (10, 10)]
-		[iOS (8, 0)]
 		public static SCNSkinner Create (SCNGeometry baseGeometry,
 			SCNNode [] bones, SCNMatrix4 [] boneInverseBindTransforms,
 			SCNGeometrySource boneWeights, SCNGeometrySource boneIndices)

--- a/src/Security/SecSharedCredential.cs
+++ b/src/Security/SecSharedCredential.cs
@@ -12,9 +12,6 @@ namespace Security {
 
 	public static partial class SecSharedCredential {
 
-		[iOS (8,0)]
-		[Mac (11,0)]
-		[Introduced (PlatformName.MacCatalyst, 14,0)]
 		[DllImport (Constants.SecurityLibrary)]
 		extern static void SecAddSharedWebCredential (IntPtr /* CFStringRef */ fqdn, IntPtr /* CFStringRef */ account, IntPtr /* CFStringRef */ password,
 			IntPtr /* void (^completionHandler)( CFErrorRef error) ) */ completionHandler);
@@ -36,7 +33,6 @@ namespace Security {
 			} 
 		} 
 
-		[iOS (8,0)]
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static void AddSharedWebCredential (string domainName, string account, string password, Action<NSError> handler)
 		{
@@ -67,8 +63,6 @@ namespace Security {
 			}
 		}
 
-		[iOS (8,0)]
-		[Mac (11,0)]
 		[Deprecated (PlatformName.iOS, 14,0)]
 		[Deprecated (PlatformName.MacOSX, 11,0)]
 		[DllImport (Constants.SecurityLibrary)]
@@ -102,8 +96,6 @@ namespace Security {
 		}
 #endif
 
-		[iOS (8,0)]
-		[Mac (11,0)]
 		[Deprecated (PlatformName.iOS, 14,0, message: "Use 'ASAuthorizationPasswordRequest' instead.")]
 		[Deprecated (PlatformName.MacOSX, 11,0, message: "Use 'ASAuthorizationPasswordRequest' instead.")]
 		[BindingImpl (BindingImplOptions.Optimizable)]
@@ -143,14 +135,9 @@ namespace Security {
 			}
 		}
 
-		[iOS (8,0)]
-		[Mac (11,0)]
 		[DllImport (Constants.SecurityLibrary)]
 		extern static IntPtr /* CFStringRef */ SecCreateSharedWebCredentialPassword ();
 
-		[iOS (8,0)]
-		[Mac (11,0)]
-		[Introduced (PlatformName.MacCatalyst, 14,0)]
 		public static string CreateSharedWebCredentialPassword ()
 		{
 			var handle = SecCreateSharedWebCredentialPassword ();

--- a/src/SensorKit/SRSensor.cs
+++ b/src/SensorKit/SRSensor.cs
@@ -8,8 +8,6 @@ namespace SensorKit {
 
 	public partial class SRSensorExtensions {
 
-		[NoWatch, NoTV, NoMac]
-		[iOS (14,0)]
 		public static SRSensor GetSensorForDeletionRecords (this SRSensor self)
 		{
 			var constant = self.GetConstant ();

--- a/src/StoreKit/NativeMethods.cs
+++ b/src/StoreKit/NativeMethods.cs
@@ -5,7 +5,7 @@ using ObjCRuntime;
 namespace StoreKit {
 
 	partial class SKReceiptRefreshRequest {
-		[Watch (6, 2), iOS (7,1), Mac (10,14)]
+		[iOS (7,1), Mac (10,14)]
 		[DllImport (Constants.StoreKitLibrary, EntryPoint = "SKTerminateForInvalidReceipt")]
 		static extern public void TerminateForInvalidReceipt ();
 	}

--- a/src/StoreKit/SKCloudServiceSetupOptions.cs
+++ b/src/StoreKit/SKCloudServiceSetupOptions.cs
@@ -8,7 +8,6 @@ namespace StoreKit {
 
 	partial class SKCloudServiceSetupOptions {
 
-		[iOS (10,1)]
 		public virtual SKCloudServiceSetupAction? Action {
 			get {
 				return (SKCloudServiceSetupAction?) (SKCloudServiceSetupActionExtensions.GetValue (_Action));

--- a/src/UIKit/UICellAccessory.cs
+++ b/src/UIKit/UICellAccessory.cs
@@ -19,11 +19,9 @@ namespace UIKit {
 
 	public partial class UICellAccessory {
 
-		[TV (14,0), iOS (14,0)]
 		[DllImport (Constants.UIKitLibrary)]
 		static extern IntPtr UICellAccessoryPositionBeforeAccessoryOfClass (IntPtr accessoryCls);
 
-		[TV (14,0), iOS (14,0)]
 		[return: DelegateProxy (typeof (SDUICellAccessoryPosition))]
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static UICellAccessoryPosition GetPositionBeforeAccessory (Class accessoryClass)
@@ -34,16 +32,13 @@ namespace UIKit {
 			return NIDUICellAccessoryPosition.Create (ret)!;
 		}
 		
-		[TV (14,0), iOS (14,0)]
 		[return: DelegateProxy (typeof (SDUICellAccessoryPosition))]
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static UICellAccessoryPosition GetPositionBeforeAccessory (Type accessoryType) => GetPositionBeforeAccessory (new Class (accessoryType));
 
-		[TV (14,0), iOS (14,0)]
 		[DllImport (Constants.UIKitLibrary)]
 		static extern IntPtr UICellAccessoryPositionAfterAccessoryOfClass (IntPtr accessoryCls);
 
-		[TV (14,0), iOS (14,0)]
 		[return: DelegateProxy (typeof (SDUICellAccessoryPosition))]
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static UICellAccessoryPosition GetPositionAfterAccessory (Class accessoryClass)
@@ -54,7 +49,6 @@ namespace UIKit {
 			return NIDUICellAccessoryPosition.Create (ret)!;
 		}
 
-		[TV (14,0), iOS (14,0)]
 		[return: DelegateProxy (typeof (SDUICellAccessoryPosition))]
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static UICellAccessoryPosition GetPositionAfterAccessory (Type accessoryType) => GetPositionAfterAccessory (new Class (accessoryType));

--- a/src/UIKit/UIEnums.cs
+++ b/src/UIKit/UIEnums.cs
@@ -2461,6 +2461,10 @@ namespace UIKit {
 
 		[Field ("UIWindowSceneSessionRoleExternalDisplay")]
 		ExternalDisplay,
+
+		[NoTV][NoWatch]
+		[Field ("CPTemplateApplicationSceneSessionRoleApplication", "CarPlay")]
+		CarTemplateApplication,
 	}
 
 	[iOS (13,0), TV (13,0), NoWatch]

--- a/src/UIKit/UIVibrancyEffect.cs
+++ b/src/UIKit/UIVibrancyEffect.cs
@@ -17,7 +17,6 @@ namespace UIKit {
 		// the resulting syntax does not look good in user code so we provide a better looking API
 		// https://trello.com/c/iQpXOxCd/227-category-and-static-methods-selectors
 		// note: we cannot reuse the same method name - as it would break compilation of existing apps
-		[iOS (8,0)]
 		[Deprecated (PlatformName.iOS, 10,0, message: "Use 'CreatePrimaryVibrancyEffectForNotificationCenter' instead.")]
 		static public UIVibrancyEffect CreateForNotificationCenter ()
 		{

--- a/src/VideoToolbox/VTCompressionSession.cs
+++ b/src/VideoToolbox/VTCompressionSession.cs
@@ -198,11 +198,11 @@ namespace VideoToolbox {
 			return null;
 		}
 
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		[DllImport (Constants.VideoToolboxLibrary)]
 		extern static VTStatus VTCompressionSessionPrepareToEncodeFrames (IntPtr handle);
 
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		public VTStatus PrepareToEncodeFrames ()
 		{
 			if (Handle == IntPtr.Zero)
@@ -300,11 +300,11 @@ namespace VideoToolbox {
 			return VTCompressionSessionCompleteFrames (Handle, completeUntilPresentationTimeStamp);
 		}
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		[DllImport (Constants.VideoToolboxLibrary)]
 		extern static VTStatus VTCompressionSessionBeginPass (IntPtr session, VTCompressionSessionOptionFlags flags, IntPtr reserved);
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		public VTStatus BeginPass (VTCompressionSessionOptionFlags flags)
 		{
 			if (Handle == IntPtr.Zero)
@@ -312,15 +312,15 @@ namespace VideoToolbox {
 			return VTCompressionSessionBeginPass (Handle, flags, IntPtr.Zero);
 		}
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		[DllImport (Constants.VideoToolboxLibrary)]
 		extern static VTStatus VTCompressionSessionEndPass (IntPtr session, out byte furtherPassesRequestedOut, IntPtr reserved);
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		[DllImport (Constants.VideoToolboxLibrary)]
 		extern static VTStatus VTCompressionSessionEndPass (IntPtr session, IntPtr ptrByte, IntPtr reserved);
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		public VTStatus EndPass (out bool furtherPassesRequested)
 		{
 			if (Handle == IntPtr.Zero)
@@ -341,14 +341,14 @@ namespace VideoToolbox {
 			return VTCompressionSessionEndPass (Handle, IntPtr.Zero, IntPtr.Zero);
 		}
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		[DllImport (Constants.VideoToolboxLibrary)]
 		extern static VTStatus VTCompressionSessionGetTimeRangesForNextPass (
 			/* VTCompressionSessionRef */ IntPtr session, 
 			/* CMItemCount* */ out int itemCount, 
 			/* const CMTimeRange** */ out IntPtr target);
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		public VTStatus GetTimeRangesForNextPass (out CMTimeRange [] timeRanges)
 		{
 			if (Handle == IntPtr.Zero)

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -367,7 +367,6 @@ namespace AppKit {
 		[Export ("initWithAppearanceNamed:bundle:")]
 		IntPtr Constructor (string name, [NullAllowed] NSBundle bundle);
 
-		[Mac (10,9)]
 		[Export ("name")]
 		string Name { get; }
 
@@ -392,7 +391,6 @@ namespace AppKit {
 		[Static, Export ("appearanceNamed:")]
 		NSAppearance GetAppearance (NSString name);
 
-		[Mac (10,9)]
 		[Field ("NSAppearanceNameAqua")]
 		NSString NameAqua { get; }
 
@@ -400,7 +398,7 @@ namespace AppKit {
 		[Field ("NSAppearanceNameDarkAqua")]
 		NSString NameDarkAqua { get; }
 
-		[Availability (Introduced = Platform.Mac_10_9, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Field ("NSAppearanceNameLightContent")]
 		NSString NameLightContent { get; }
 
@@ -7322,7 +7320,6 @@ namespace AppKit {
 		[Export ("mergeCellsInHorizontalRange:verticalRange:")]
 		void MergeCells (NSRange hRange, NSRange vRange);
 
-		[Mac (10, 12)]
 		[Field ("NSGridViewSizeForContent")]
 		nfloat SizeForContent { get; }
 	}
@@ -14782,7 +14779,7 @@ namespace AppKit {
 		[Export ("spacing")]
 		nfloat Spacing { get; set; }
 
-		[Availability (Introduced = Platform.Mac_10_9, Deprecated = Platform.Mac_10_11, Message = "Set Distribution to NSStackViewDistribution.EqualSpacing instead.")]
+		[Availability (Deprecated = Platform.Mac_10_11, Message = "Set Distribution to NSStackViewDistribution.EqualSpacing instead.")]
 		[Export ("hasEqualSpacing")]
 		bool HasEqualSpacing { get; set; }
 
@@ -23625,7 +23622,7 @@ namespace AppKit {
 	interface INSAccessibility {};
 	interface INSAccessibilityElement {};
 
-	[Mac (10,10)]
+	[Mac (10,9)] // protocol added in 10.10 but the field/notifications are in 10.9
 	[Protocol]
 	interface NSAccessibility
 	{

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -24437,7 +24437,6 @@ namespace AppKit {
 		[Field ("NSAccessibilityCreatedNotification")]
 		NSString CreatedNotification { get; }
 
-		[Mac (10, 9)]
 		[Notification]
 		[Field ("NSAccessibilityLayoutChangedNotification")]
 		NSString LayoutChangedNotification { get; }

--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -1612,7 +1612,6 @@ namespace ARKit {
 	[DisableDefaultCtor]
 	interface AREnvironmentProbeAnchor {
 		// Inlined from 'ARAnchorCopying' protocol (we can't have constructors in interfaces)
-		[iOS (12,0)]
 		[Export ("initWithAnchor:")]
 		IntPtr Constructor (ARAnchor anchor);
 
@@ -1686,7 +1685,6 @@ namespace ARKit {
 		[return: NullAllowed]
 		ARReferenceObject Merge (ARReferenceObject @object, [NullAllowed] out NSError error);
 
-		[iOS (12,0)]
 		[Field ("ARReferenceObjectArchiveExtension")]
 		NSString ArchiveExtension { get; }
 	}
@@ -1697,7 +1695,6 @@ namespace ARKit {
 	[DisableDefaultCtor]
 	interface ARObjectAnchor {
 		// Inlined from 'ARAnchorCopying' protocol (we can't have constructors in interfaces)
-		[iOS (12,0)]
 		[Export ("initWithAnchor:")]
 		IntPtr Constructor (ARAnchor anchor);
 
@@ -2240,7 +2237,6 @@ namespace ARKit {
 	[BaseType (typeof (ARAnchor))]
 	interface ARGeoAnchor : ARTrackable {
 		// Inlined from 'ARAnchorCopying' protocol (we can't have constructors in interfaces)
-		[iOS (14,0)]
 		[Export ("initWithAnchor:")]
 		IntPtr Constructor (ARAnchor anchor);
 

--- a/src/audiounit.cs
+++ b/src/audiounit.cs
@@ -248,11 +248,9 @@ namespace AudioUnit {
 		[Export ("shouldChangeToFormat:forBus:")]
 		bool ShouldChangeToFormat (AVAudioFormat format, AUAudioUnitBus bus);
 
-		[Mac (10,11)][iOS (7,0)]
 		[Notification, Field ("kAudioComponentRegistrationsChangedNotification")]
 		NSString AudioComponentRegistrationsChangedNotification { get; }
 
-		[Mac (10,11)][iOS (7,0)]
 		[Notification, Field ("kAudioComponentInstanceInvalidationNotification")]
 		NSString AudioComponentInstanceInvalidationNotification { get; }
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -1232,7 +1232,7 @@ namespace AVFoundation {
 		[Export ("isEqual:"), Internal]
 		bool IsEqual (NSObject obj);
 		
-		[iOS (10,0), TV (10,0), Watch (3,0), Mac (10,12)]
+		[iOS (10,0), TV (10,0), Mac (10,12)]
 		[NullAllowed, Export ("magicCookie", ArgumentSemantic.Retain)]
 		NSData MagicCookie { get; set; }
 	}
@@ -1985,7 +1985,7 @@ namespace AVFoundation {
 		bool SetCategory (string category, AVAudioSessionCategoryOptions options, out NSError outError);
 		
 		[NoMac]
-		[iOS (10,0), TV (10,0), Watch (3,0)]
+		[iOS (10,0), TV (10,0)]
 		[Export ("setCategory:mode:options:error:")]
 		bool SetCategory (string category, string mode, AVAudioSessionCategoryOptions options, out NSError outError);
 
@@ -2471,7 +2471,7 @@ namespace AVFoundation {
 		[Export ("UID")]
 		string UID { get;  }
 
-		[iOS (10, 0), TV (10,0), Watch (3,0)]
+		[iOS (10, 0), TV (10,0)]
 		[Export ("hasHardwareVoiceCallProcessing")]
 		bool HasHardwareVoiceCallProcessing { get; }
 
@@ -3077,11 +3077,11 @@ namespace AVFoundation {
 		[Export ("overallDurationHint")]
 		CMTime OverallDurationHint { get; }
 
-		[iOS (11, 0), TV (11, 0), Mac (10, 13), Watch (6,0)]
+		[iOS (11, 0), TV (11, 0), Mac (10, 13)]
 		[Export ("allMediaSelections")]
 		AVMediaSelection[] AllMediaSelections { get; }
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[Export ("minimumTimeOffsetFromLive")]
 		CMTime MinimumTimeOffsetFromLive { get; }
 	}
@@ -3365,7 +3365,6 @@ namespace AVFoundation {
 		[Export ("flushFromSourceTime:completionHandler:")]
 		void Flush (CMTime time, Action<bool> completionHandler);
 
-		[TV (11,0), Mac (10,13), iOS (11,0)]
 		[Notification (typeof (AudioRendererWasFlushedAutomaticallyEventArgs))]
 		[Field ("AVSampleBufferAudioRendererWasFlushedAutomaticallyNotification")]
 		NSString AudioRendererWasFlushedAutomaticallyNotification { get; }
@@ -7382,7 +7381,7 @@ namespace AVFoundation {
 		[Export ("insertMediaTimeRange:intoTimeRange:")]
 		bool InsertMediaTimeRange (CMTimeRange mediaTimeRange, CMTimeRange trackTimeRange);
 
-		[Watch (6,0), NoTV, iOS (13,0), Mac (10,13)]
+		[Mac (10,13)]
 		[Export ("replaceFormatDescription:withFormatDescription:")]
 		void ReplaceFormatDescription (CMFormatDescription formatDescription, CMFormatDescription newFormatDescription);
 	}
@@ -10065,7 +10064,7 @@ namespace AVFoundation {
 		[Field ("AVCaptureDeviceTypeBuiltInTelephotoCamera")]
 		BuiltInTelephotoCamera,
 
-		[iOS (10, 0), NoMac]
+		[NoMac]
 		[Deprecated (PlatformName.iOS, 10, 2, message: "Use 'BuiltInDualCamera' instead.")]
 		[Field ("AVCaptureDeviceTypeBuiltInDuoCamera")]
 		BuiltInDuoCamera,
@@ -10579,7 +10578,7 @@ namespace AVFoundation {
 		[Field ("AVCaptureISOCurrent")]
 		float ISOCurrent { get; } /* float, not CGFloat */
 
-		[iOS (8,0), Watch (6,0), NoMac]
+		[iOS (8,0), NoMac]
 		[Field ("AVCaptureLensPositionCurrent")]
 		float LensPositionCurrent { get; } /* float, not CGFloat */
 
@@ -11060,12 +11059,12 @@ namespace AVFoundation {
 		[Export ("initWithPreferredLanguages:preferredMediaCharacteristics:")]
 		IntPtr Constructor ([NullAllowed] string [] preferredLanguages, [NullAllowed] NSString [] preferredMediaCharacteristics);
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[Export ("initWithPrincipalMediaCharacteristics:preferredLanguages:preferredMediaCharacteristics:")]
 		IntPtr Constructor ([NullAllowed] [BindAs (typeof (AVMediaCharacteristics []))]NSString[] principalMediaCharacteristics, [NullAllowed] [BindAs (typeof (AVMediaCharacteristics []))] NSString[] preferredLanguages, [NullAllowed] string[] preferredMediaCharacteristics);
 
 		[BindAs (typeof (AVMediaCharacteristics []))]
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[NullAllowed, Export ("principalMediaCharacteristics")]
 		NSString[] PrincipalMediaCharacteristics { get; }
 	}
@@ -11479,24 +11478,24 @@ namespace AVFoundation {
 		NSString _VideoApertureMode { get; set; }
 
 		[Notification]
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[Field ("AVPlayerItemRecommendedTimeOffsetFromLiveDidChangeNotification")]
 		NSString RecommendedTimeOffsetFromLiveDidChangeNotification { get; }
 
 		[Notification]
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[Field ("AVPlayerItemMediaSelectionDidChangeNotification")]
 		NSString MediaSelectionDidChangeNotification { get; }
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[Export ("configuredTimeOffsetFromLive", ArgumentSemantic.Assign)]
 		CMTime ConfiguredTimeOffsetFromLive { get; set; }
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[Export ("recommendedTimeOffsetFromLive")]
 		CMTime RecommendedTimeOffsetFromLive { get; }
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[Export ("automaticallyPreservesTimeOffsetFromLive")]
 		bool AutomaticallyPreservesTimeOffsetFromLive { get; set; }
 
@@ -11988,11 +11987,11 @@ namespace AVFoundation {
 		[Export ("observedBitrate")]
 		double ObservedBitrate { get; }
 
-		[iOS (8,0), TV (9,0), Watch (6,0), Mac (10,10)]
+		[iOS (8,0), TV (9,0), Mac (10,10)]
 		[Export ("indicatedBitrate")]
 		double IndicatedBitrate { get; }
 
-		[iOS (10, 0), TV (10,0), Watch (6,0), Mac (10, 12)]
+		[iOS (10, 0), TV (10,0), Mac (10, 12)]
 		[Export ("indicatedAverageBitrate")]
 		double IndicatedAverageBitrate { get; }
 
@@ -12330,7 +12329,7 @@ namespace AVFoundation {
 		[Field ("AVSampleRateConverterAlgorithm_Mastering"), Internal]
 		NSString AVSampleRateConverterAlgorithm_Mastering { get; }
 		
-		[iOS (10, 0), TV (10,0), Watch (3,0), Mac (10,12)]
+		[iOS (10, 0), TV (10,0), Mac (10,12)]
 		[Field ("AVSampleRateConverterAlgorithm_MinimumPhase")]
 		NSString AVSampleRateConverterAlgorithm_MinimumPhase { get; }
 
@@ -12392,12 +12391,12 @@ namespace AVFoundation {
 		[Export ("timebase", ArgumentSemantic.Retain)]
 		CMTimebase Timebase { get; }
 
-		[iOS (8, 0), Mac (10,10)]
+		[Mac (10,10)]
 		[Field ("AVSampleBufferDisplayLayerFailedToDecodeNotification")]
 		[Notification]
 		NSString FailedToDecodeNotification { get; }
 
-		[iOS (8, 0), Mac (10,10)]
+		[Mac (10,10)]
 		[Field ("AVSampleBufferDisplayLayerFailedToDecodeNotificationErrorKey")]
 		NSString FailedToDecodeNotificationErrorKey { get; }
 
@@ -12473,7 +12472,7 @@ namespace AVFoundation {
 		[Field ("AVSpeechSynthesisVoiceIdentifierAlex")]
 		NSString IdentifierAlex { get; }
 
-		[iOS (10, 0), TV (10,0), Watch (3,0), Mac (10,15)]
+		[iOS (10, 0), TV (10,0), Mac (10,15)]
 		[Field ("AVSpeechSynthesisIPANotationAttribute")]
 		NSString IpaNotationAttribute { get; }
 
@@ -12683,7 +12682,7 @@ namespace AVFoundation {
 		[Export ("URLAsset")]
 		AVUrlAsset UrlAsset { get; }
 
-		[Availability (Introduced = Platform.iOS_9_0, Deprecated = Platform.iOS_10_0)]
+		[Availability (Deprecated = Platform.iOS_10_0)]
 		[Export ("destinationURL")]
 		NSUrl DestinationUrl { get; }
 
@@ -12756,7 +12755,7 @@ namespace AVFoundation {
 		[Export ("sessionWithConfiguration:assetDownloadDelegate:delegateQueue:")]
 		AVAssetDownloadUrlSession CreateSession (NSUrlSessionConfiguration configuration, [NullAllowed] IAVAssetDownloadDelegate @delegate, [NullAllowed] NSOperationQueue delegateQueue);
 
-		[Availability (Introduced = Platform.iOS_9_0, Deprecated = Platform.iOS_10_0, Message="Please use 'GetAssetDownloadTask (AVUrlAsset, string, NSData, NSDictionary<NSString, NSObject>)'.")]
+		[Availability (Deprecated = Platform.iOS_10_0, Message="Please use 'GetAssetDownloadTask (AVUrlAsset, string, NSData, NSDictionary<NSString, NSObject>)'.")]
 		[Export ("assetDownloadTaskWithURLAsset:destinationURL:options:")]
 		[return: NullAllowed]
 		AVAssetDownloadTask GetAssetDownloadTask (AVUrlAsset urlAsset, NSUrl destinationUrl, [NullAllowed] NSDictionary options);
@@ -13120,7 +13119,7 @@ namespace AVFoundation {
 
 		[Export ("audioComponentDescription")]
 		AudioComponentDescription AudioComponentDescription { get; }
-		[iOS (9,0), Mac (10,10)]
+
 		[Field ("AVAudioUnitComponentTagsDidChangeNotification")]
 		[Notification]
 		NSString TagsDidChangeNotification { get; }
@@ -13466,7 +13465,7 @@ namespace AVFoundation {
 		[Export ("respondByRequestingPersistableContentKeyRequestAndReturnError:")]
 		bool RespondByRequestingPersistableContentKeyRequest ([NullAllowed] out NSError error);
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[Field ("AVContentKeyRequestRequiresValidationDataInSecureTokenKey")]
 		NSString RequiresValidationDataInSecureTokenKey { get; }
 	}
@@ -13516,7 +13515,6 @@ namespace AVFoundation {
 	[BaseType (typeof(NSObject))]
 	interface AVRouteDetector {
 		[Notification]
-		[TV (11, 0), NoWatch, Mac (10, 13), iOS (11, 0)]
 		[Field ("AVRouteDetectorMultipleRoutesDetectedDidChangeNotification")]
 		NSString MultipleRoutesDetectedDidChange { get; }
 
@@ -13611,36 +13609,31 @@ namespace AVFoundation {
 		// From @interface AVCapturePhotoBracketedCapture (AVCapturePhoto)
 
 #if !MONOMAC
-		[iOS (11, 0)]
 		[NullAllowed, Export ("bracketSettings")]
 		AVCaptureBracketedStillImageSettings BracketSettings { get; }
 #endif
 
-		[iOS (11, 0), NoMac]
+		[NoMac]
 		[Export ("lensStabilizationStatus")]
 		AVCaptureLensStabilizationStatus LensStabilizationStatus { get; }
 
-		[iOS (11, 0), NoMac]
+		[NoMac]
 		[Export ("sequenceCount")]
 		nint SequenceCount { get; }
 
 		// @interface AVCapturePhotoConversions (AVCapturePhoto)
-		[iOS (11, 0)]
 		[NullAllowed, Export ("fileDataRepresentation")]
 		NSData FileDataRepresentation { get; }
 
-		[iOS (11,0), NoMac]
+		[NoMac]
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Use 'GetFileDataRepresentation' instead.")]
 		[Export ("fileDataRepresentationWithReplacementMetadata:replacementEmbeddedThumbnailPhotoFormat:replacementEmbeddedThumbnailPixelBuffer:replacementDepthData:")]
 		[return: NullAllowed]
 		NSData GetFileDataRepresentation ([NullAllowed] NSDictionary<NSString, NSObject> replacementMetadata, [NullAllowed] NSDictionary<NSString, NSObject> replacementEmbeddedThumbnailPhotoFormat, [NullAllowed] CVPixelBuffer replacementEmbeddedThumbnailPixelBuffer, [NullAllowed] AVDepthData replacementDepthData);
 
-
-		[iOS (11, 0)]
 		[NullAllowed, Export ("CGImageRepresentation")]
 		CGImage CGImageRepresentation { get; }
 
-		[iOS (11, 0)]
 		[NullAllowed, Export ("previewCGImageRepresentation")]
 		CGImage PreviewCGImageRepresentation { get; }
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -3892,27 +3892,27 @@ namespace AVFoundation {
 		[Field ("AVAssetResourceLoadingRequestStreamingContentKeyRequestRequiresPersistentKey")]
 		NSString StreamingContentKeyRequestRequiresPersistentKey { get; }
 
-		[iOS (7,0), Mac (10, 9)]
+		[iOS (7,0)]
 		[Export ("isCancelled")]
 		bool IsCancelled { get; }
 
-		[iOS (7,0), Mac (10, 9)]
+		[iOS (7,0)]
 		[Export ("contentInformationRequest"), NullAllowed]
 		AVAssetResourceLoadingContentInformationRequest ContentInformationRequest { get; }
 
-		[iOS (7,0), Mac (10, 9)]
+		[iOS (7,0)]
 		[Export ("dataRequest"), NullAllowed]
 		AVAssetResourceLoadingDataRequest DataRequest { get; }
 
-		[iOS (7,0), Mac (10, 9)]
+		[iOS (7,0)]
 		[Export ("response", ArgumentSemantic.Copy), NullAllowed]
 		NSUrlResponse Response { get; set; }
 
-		[iOS (7,0), Mac (10, 9)]
+		[iOS (7,0)]
 		[Export ("redirect", ArgumentSemantic.Copy), NullAllowed]
 		NSUrlRequest Redirect { get; set; }
 
-		[iOS (7,0), Mac (10, 9)]
+		[iOS (7,0)]
 		[Export ("finishLoading")]
 		void FinishLoading ();
 		
@@ -6728,7 +6728,7 @@ namespace AVFoundation {
 		CMTime Time{ get;}
 
 #if !XAMCORE_4_0
-		[Field ("AVMetadataObjectTypeFace"), Mac (10,10)]
+		[Field ("AVMetadataObjectTypeFace")]
 		NSString TypeFace { get; }
 
 		[NoTV, iOS (7,0), Mac (10,15)]
@@ -7422,22 +7422,20 @@ namespace AVFoundation {
 	interface AVFragmentedMovieTrack
 	{
 #if !XAMCORE_4_0
-		[Mac (10, 10), NoiOS, NoWatch]
+		[NoiOS, NoWatch]
 		[Field ("AVFragmentedMovieTrackTimeRangeDidChangeNotification")]
 		NSString ATimeRangeDidChangeNotification { get; }
 #endif
 
-		[Mac (10, 10)]
 		[Field ("AVFragmentedMovieTrackTimeRangeDidChangeNotification")]
 		[Notification]
 		NSString TimeRangeDidChangeNotification { get; }
 
-		[Mac (10, 10)]
 		[Notification]
 		[Field ("AVFragmentedMovieTrackSegmentsDidChangeNotification")]
 		NSString SegmentsDidChangeNotification { get; }
 
-		[Mac (10, 10), NoiOS, NoWatch]
+		[NoiOS, NoWatch]
 		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use either 'AVFragmentedMovieTrackTimeRangeDidChangeNotification' or 'AVFragmentedMovieTrackSegmentsDidChangeNotification' instead. In either case, you can assume that the sender's 'TotalSampleDataLength' has changed.")]
 		[Field ("AVFragmentedMovieTrackTotalSampleDataLengthDidChangeNotification")]
 		NSString TotalSampleDataLengthDidChangeNotification { get; }
@@ -12391,12 +12389,10 @@ namespace AVFoundation {
 		[Export ("timebase", ArgumentSemantic.Retain)]
 		CMTimebase Timebase { get; }
 
-		[Mac (10,10)]
 		[Field ("AVSampleBufferDisplayLayerFailedToDecodeNotification")]
 		[Notification]
 		NSString FailedToDecodeNotification { get; }
 
-		[Mac (10,10)]
 		[Field ("AVSampleBufferDisplayLayerFailedToDecodeNotificationErrorKey")]
 		NSString FailedToDecodeNotificationErrorKey { get; }
 
@@ -12472,15 +12468,15 @@ namespace AVFoundation {
 		[Field ("AVSpeechSynthesisVoiceIdentifierAlex")]
 		NSString IdentifierAlex { get; }
 
-		[iOS (10, 0), TV (10,0), Mac (10,15)]
+		[iOS (10, 0), TV (10,0)]
 		[Field ("AVSpeechSynthesisIPANotationAttribute")]
 		NSString IpaNotationAttribute { get; }
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[Watch (6,0), TV (13,0), iOS (13,0)]
 		[Export ("gender")]
 		AVSpeechSynthesisVoiceGender Gender { get; }
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[Watch (6,0), TV (13,0), iOS (13,0)]
 		[Export ("audioFileSettings")]
 		NSDictionary<NSString, NSObject> AudioFileSettings { get; }
 	}

--- a/src/avkit.cs
+++ b/src/avkit.cs
@@ -444,32 +444,26 @@ namespace AVKit {
 		[Export ("updatesNowPlayingInfoCenter")]
 		bool UpdatesNowPlayingInfoCenter { get; set; }
 
-		[Mac (10,9)]
 		[NullAllowed]
 		[Export ("actionPopUpButtonMenu")]
 		NSMenu ActionPopUpButtonMenu { get; set; }
 
-		[Mac (10,9)] // No async
+		// No async
 		[Export ("beginTrimmingWithCompletionHandler:")]
 		void BeginTrimming ([NullAllowed] Action<AVPlayerViewTrimResult> handler);
 
-		[Mac (10,9)]
 		[Export ("canBeginTrimming")]
 		bool CanBeginTrimming { get; }
 
-		[Mac (10,9)]
 		[Export ("flashChapterNumber:chapterTitle:")]
 		void FlashChapter (nuint chapterNumber, [NullAllowed] string chapterTitle);
 
-		[Mac (10,9)]
 		[Export ("showsFrameSteppingButtons")]
 		bool ShowsFrameSteppingButtons { get; set; }
 
-		[Mac (10,9)]
 		[Export ("showsFullScreenToggleButton")]
 		bool ShowsFullScreenToggleButton { get; set; }
 
-		[Mac (10,9)]
 		[Export ("showsSharingServiceButton")]
 		bool ShowsSharingServiceButton { get; set; }
 		

--- a/src/avkit.cs
+++ b/src/avkit.cs
@@ -98,11 +98,11 @@ namespace AVKit {
 		[Export ("pictureInPictureButtonStopImageCompatibleWithTraitCollection:")]
 		UIImage CreateStopButton ([NullAllowed] UITraitCollection traitCollection);
 
-		[TV (14, 0), NoWatch, Mac (11, 0), iOS (14, 0)]
+		[NoWatch, Mac (11, 0), iOS (14, 0)]
 		[Export ("requiresLinearPlayback")]
 		bool RequiresLinearPlayback { get; set; }
 
-		[TV (14, 0), NoWatch, NoMac, NoiOS]
+		[NoWatch, NoMac, NoiOS]
 		[Export ("canStopPictureInPicture")]
 		bool CanStopPictureInPicture { get; }
 	}

--- a/src/carplay.cs
+++ b/src/carplay.cs
@@ -609,7 +609,6 @@ namespace CarPlay {
 	[BaseType (typeof (NSObject))]
 	interface CPManeuver : NSCopying, NSSecureCoding {
 
-		[Introduced (PlatformName.iOS, 12,0)]
 		[Deprecated (PlatformName.iOS, 13,0, message: "Use 'CPManeuver.SymbolImage' instead.")]
 		[NullAllowed, Export ("symbolSet", ArgumentSemantic.Strong)]
 		CPImageSet SymbolSet { get; set; }

--- a/src/carplay.cs
+++ b/src/carplay.cs
@@ -1134,7 +1134,6 @@ namespace CarPlay {
 		[Export ("carWindow", ArgumentSemantic.Strong)]
 		CPWindow CarWindow { get; }
 
-		[iOS (13, 0)]
 		[Field ("CPTemplateApplicationSceneSessionRoleApplication")]
 		NSString SessionRoleApplication { get; }
 	}

--- a/src/classkit.cs
+++ b/src/classkit.cs
@@ -273,37 +273,37 @@ namespace ClassKit {
 		void ResignActive ();
 
 		[Introduced (PlatformName.MacCatalyst, 14, 0)]
-		[NoWatch, NoTV, Mac (11,0), iOS (14, 0)]
+		[iOS (14, 0)]
 		[Export ("assignable")]
 		bool Assignable { [Bind ("isAssignable")] get; set; }
 
 		[Introduced (PlatformName.MacCatalyst, 14, 0)]
-		[NoWatch, NoTV, Mac (11,0), iOS (14, 0)]
+		[iOS (14, 0)]
 		[Export ("suggestedAge", ArgumentSemantic.Assign)]
 		NSRange SuggestedAge { get; set; }
 
 		[Introduced (PlatformName.MacCatalyst, 14, 0)]
-		[NoWatch, NoTV, Mac (11,0), iOS (14, 0)]
+		[iOS (14, 0)]
 		[Export ("suggestedCompletionTime", ArgumentSemantic.Assign)]
 		NSRange SuggestedCompletionTime { get; set; }
 
 		[Introduced (PlatformName.MacCatalyst, 14, 0)]
-		[NoWatch, NoTV, Mac (11,0), iOS (14, 0)]
+		[iOS (14, 0)]
 		[Export ("progressReportingCapabilities", ArgumentSemantic.Copy)]
 		NSSet<CLSProgressReportingCapability> ProgressReportingCapabilities { get; }
 
 		[Introduced (PlatformName.MacCatalyst, 14, 0)]
-		[NoWatch, NoTV, Mac (11,0), iOS (14, 0)]
+		[iOS (14, 0)]
 		[Export ("setType:")]
 		void SetType (CLSContextType type);
 
 		[Introduced (PlatformName.MacCatalyst, 14, 0)]
-		[NoWatch, NoTV, Mac (11,0), iOS (14, 0)]
+		[iOS (14, 0)]
 		[Export ("addProgressReportingCapabilities:")]
 		void AddProgressReportingCapabilities (NSSet<CLSProgressReportingCapability> capabilities);
 
 		[Introduced (PlatformName.MacCatalyst, 14, 0)]
-		[NoWatch, NoTV, Mac (11,0), iOS (14, 0)]
+		[iOS (14, 0)]
 		[Export ("resetProgressReportingCapabilities")]
 		void ResetProgressReportingCapabilities ();
 

--- a/src/cloudkit.cs
+++ b/src/cloudkit.cs
@@ -199,8 +199,6 @@ namespace CloudKit {
 	interface CKContainer {
 
 		[NoWatch]
-		[iOS (8, 0)]
-		[Mac (10, 10)]
 		[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'CurrentUserDefaultName' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'CurrentUserDefaultName' instead.")]
 		[Field ("CKOwnerDefaultName")]
@@ -433,16 +431,12 @@ namespace CloudKit {
 		[Export ("userRecordID", ArgumentSemantic.Copy)]
 		CKRecordID UserRecordId { get; }
 
-		[iOS (8, 0)]
-		[Mac (10, 10)]
 		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'DisplayContact.GivenName'.")]
 		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'DisplayContact.GivenName'.")]
 		[NullAllowed]
 		[Export ("firstName", ArgumentSemantic.Copy)]
 		string FirstName { get; }
 
-		[iOS (8, 0)]
-		[Mac (10, 10)]
 		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'DisplayContact.FamilyName'.")]
 		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'DisplayContact.FamilyName'.")]
 		[NullAllowed]
@@ -1101,7 +1095,7 @@ namespace CloudKit {
 		[NullAllowed, Export ("recordID", ArgumentSemantic.Copy)]
 		CKRecordID RecordId { get; }
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12)]
+		[iOS (10,0), TV (10,0), Mac (10,12)]
 		[Export ("databaseScope", ArgumentSemantic.Assign)]
 		CKDatabaseScope DatabaseScope { get; }
 	}
@@ -1116,7 +1110,7 @@ namespace CloudKit {
 		[Export ("recordZoneID", ArgumentSemantic.Copy)]
 		CKRecordZoneID RecordZoneId { get; }
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12)]
+		[iOS (10,0), TV (10,0), Mac (10,12)]
 		[Export ("databaseScope", ArgumentSemantic.Assign)]
 		CKDatabaseScope DatabaseScope { get; }
 	}
@@ -1613,7 +1607,7 @@ namespace CloudKit {
 		[Export ("predicate", ArgumentSemantic.Copy)]
 		NSPredicate Predicate { get; }
 
-		[TV (10,0), Watch (6,0)]
+		[TV (10,0)]
 		[NullAllowed]
 		[Export ("notificationInfo", ArgumentSemantic.Copy)]
 		CKNotificationInfo NotificationInfo { get; set; }
@@ -1665,7 +1659,6 @@ namespace CloudKit {
 		[Export ("desiredKeys", ArgumentSemantic.Copy)]
 		string [] DesiredKeys { get; set; }
 
-		[TV (10, 0)]
 		[Export ("shouldBadge", ArgumentSemantic.UnsafeUnretained)]
 		bool ShouldBadge { get; set; }
 

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -451,7 +451,7 @@ namespace CoreBluetooth {
 		[Override]
 		CBDescriptor [] Descriptors { get; set; }
 
-		[iOS (7,0), Export ("subscribedCentrals"), Mac (10,9)]
+		[iOS (7,0), Export ("subscribedCentrals")]
 		CBCentral [] SubscribedCentrals { get; }
 	}
 
@@ -841,7 +841,6 @@ namespace CoreBluetooth {
 	[BaseType (typeof (CBManager), Delegates=new[] { "WeakDelegate" }, Events=new[] { typeof (CBPeripheralManagerDelegate) })]
 	interface CBPeripheralManager {
 
-		[Mac (10,9)] 
 		[Export ("init")]
 		IntPtr Constructor ();
 
@@ -854,7 +853,7 @@ namespace CoreBluetooth {
 		[NoTV]
 		[NoWatch]
 		[DesignatedInitializer]
-		[iOS (7,0),Mac (10,9)]
+		[iOS (7,0)]
 		[Export ("initWithDelegate:queue:options:")]
 		[PostGet ("WeakDelegate")]
 		IntPtr Constructor ([Protocolize] CBPeripheralManagerDelegate peripheralDelegate, [NullAllowed] DispatchQueue queue, [NullAllowed] NSDictionary options);
@@ -1006,19 +1005,16 @@ namespace CoreBluetooth {
 	[Watch (4,0)][iOS (11,0)][TV (11,0)][Mac (10,13)]
 	[BaseType (typeof (NSObject), Name = "CBL2CAPChannel")]
 	interface CBL2CapChannel {
-		[Mac (10,13)]
+
 		[Export ("peer")]
 		CBPeer Peer { get; }
 
-		[Mac (10,13)]
 		[Export ("inputStream")]
 		NSInputStream InputStream { get; }
 
-		[Mac (10,13)]
 		[Export ("outputStream")]
 		NSOutputStream OutputStream { get; }
 
-		[Mac (10,13)]
 		[Export ("PSM")]
 		/* uint16_t */ ushort Psm { get; }
 	}

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -2696,11 +2696,9 @@ namespace CoreData
 		NSError Error { get; }
 
 		[Notification]
-		[Watch (7, 0), TV (14, 0), Mac (11, 0), iOS (14, 0)]
 		[Field ("NSPersistentCloudKitContainerEventChangedNotification")]
 		NSString ChangedNotification { get; }
 
-		[Watch (7, 0), TV (14, 0), Mac (11, 0), iOS (14, 0)]
 		[Field ("NSPersistentCloudKitContainerEventUserInfoKey")]
 		NSString UserInfoKey { get; }
 	}

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -2245,7 +2245,7 @@ namespace CoreImage {
 		[Export ("setROISelector:")]
 		void SetRegionOfInterestSelector (Selector aMethod);
 #endif
-		[iOS (8,0), Mac (10,11)]
+		[Mac (10,11)]
 		[Export ("applyWithExtent:roiCallback:arguments:")]
 		CIImage ApplyWithExtent (CGRect extent, CIKernelRoiCallback callback, [NullAllowed] NSObject [] args);
 	}
@@ -2301,7 +2301,6 @@ namespace CoreImage {
 		CIImageAccumulator FromRectangle (CGRect rect, int ciImageFormat);
 #endif
 
-		[iOS (9,0)]
 		[Static]
 		[Export ("imageAccumulatorWithExtent:format:colorSpace:")]
 		CIImageAccumulator FromRectangle (CGRect extent, CIFormat format, CGColorSpace colorSpace);

--- a/src/coremedia.cs
+++ b/src/coremedia.cs
@@ -169,11 +169,11 @@ namespace CoreMedia {
 		[Field ("kCMSampleBufferAttachmentKey_CameraIntrinsicMatrix")]
 		NSString CameraIntrinsicMatrixKey { get; }
 
-		[iOS (13,0), Mac (10,15), TV (13,0), Watch (6,0)]
+		[iOS (13,0), Mac (10,15), TV (13,0)]
 		[Field ("kCMSampleAttachmentKey_AudioIndependentSampleDecoderRefreshCount")]
 		NSString AudioIndependentSampleDecoderRefreshCountKey { get; }
 
-		[Mac (10,10), Watch (6,0)]
+		[Mac (10,10)]
 		[Field ("kCMSampleBufferAttachmentKey_ForceKeyFrame")]
 		NSString ForceKeyFrameKey { get; }
 	}
@@ -208,10 +208,10 @@ namespace CoreMedia {
 		[iOS (11,0), Mac (10,13), TV (11,0)]
 		NSData CameraIntrinsicMatrix { get; set; }
 
-		[iOS (13,0), Mac (10,15), TV (13,0), Watch (6,0)]
+		[iOS (13,0), Mac (10,15), TV (13,0)]
 		nint AudioIndependentSampleDecoderRefreshCount { get; set; }
 
-		[Mac (10,10), Watch (6,0)]
+		[Mac (10,10)]
 		bool ForceKeyFrame { get; set; }
 	}
 

--- a/src/corespotlight.cs
+++ b/src/corespotlight.cs
@@ -1011,36 +1011,36 @@ namespace CoreSpotlight {
 
 		// CSSearchableItemAttributeSet_CSGeneral
 
-		[iOS (11,0), NoTV, Mac (10, 11)]
+		[iOS (11,0), NoTV]
 		[NullAllowed, Export ("userCreated", ArgumentSemantic.Strong)]
 		[Internal] // We would like to use [BindAs (typeof (bool?))]
 		NSNumber _IsUserCreated { [Bind ("isUserCreated")] get; set; }
 
-		[iOS (11, 0), NoTV, Mac (10, 11)]
+		[iOS (11, 0), NoTV]
 		[NullAllowed, Export ("userOwned", ArgumentSemantic.Strong)]
 		[Internal] // We would like to use[BindAs (typeof (bool?))]
 		NSNumber _IsUserOwned { [Bind ("isUserOwned")] get; set; }
 
-		[iOS (11, 0), NoTV, Mac (10, 11)]
+		[iOS (11, 0), NoTV]
 		[NullAllowed, Export ("userCurated", ArgumentSemantic.Strong)]
 		[Internal] // We would like to use [BindAs (typeof (bool?))]
 		NSNumber _IsUserCurated { [Bind ("isUserCurated")] get; set; }
 
-		[iOS (11, 0), NoTV, Mac (10, 11)]
+		[iOS (11, 0), NoTV]
 		[NullAllowed, Export ("rankingHint", ArgumentSemantic.Strong)]
 		NSNumber RankingHint { get; set; }
 
 		// CSSearchableItemAttributeSet_CSItemProvider
 
-		[iOS (11, 0), NoTV, Mac (10, 11)]
+		[iOS (11, 0), NoTV]
 		[NullAllowed, Export ("providerDataTypeIdentifiers", ArgumentSemantic.Copy)]
 		string[] ProviderDataTypeIdentifiers { get; set; }
 
-		[iOS (11, 0), NoTV, Mac (10, 11)]
+		[iOS (11, 0), NoTV]
 		[NullAllowed, Export ("providerFileTypeIdentifiers", ArgumentSemantic.Copy)]
 		string[] ProviderFileTypeIdentifiers { get; set; }
 
-		[iOS (11, 0), NoTV, Mac (10, 11)]
+		[iOS (11, 0), NoTV]
 		[NullAllowed, Export ("providerInPlaceFileTypeIdentifiers", ArgumentSemantic.Copy)]
 		string[] ProviderInPlaceFileTypeIdentifiers { get; set; }
 	}

--- a/src/externalaccessory.cs
+++ b/src/externalaccessory.cs
@@ -213,7 +213,6 @@ namespace ExternalAccessory {
 
 #if !MONOMAC
 		[NoTV]
-		[iOS (8,0)]
 		[Export ("configureAccessory:withConfigurationUIOnViewController:")]
 		void ConfigureAccessory (EAWiFiUnconfiguredAccessory accessory, UIViewController viewController);
 #endif

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -11971,37 +11971,37 @@ namespace Foundation
 		[Export ("old")]
 		bool Old { [Bind ("isOld")] get; }
 #endif
-		[iOS (7,0), Field ("NSProgressKindFile")]
+		[Field ("NSProgressKindFile")]
 		NSString KindFile { get; }
 	
-		[iOS (7,0), Field ("NSProgressEstimatedTimeRemainingKey")]
+		[Field ("NSProgressEstimatedTimeRemainingKey")]
 		NSString EstimatedTimeRemainingKey { get; }
 	
-		[iOS (7,0), Field ("NSProgressThroughputKey")]
+		[Field ("NSProgressThroughputKey")]
 		NSString ThroughputKey { get; }
 	
-		[iOS (7,0), Field ("NSProgressFileOperationKindKey")]
+		[Field ("NSProgressFileOperationKindKey")]
 		NSString FileOperationKindKey { get; }
 	
-		[iOS (7,0), Field ("NSProgressFileOperationKindDownloading")]
+		[Field ("NSProgressFileOperationKindDownloading")]
 		NSString FileOperationKindDownloading { get; }
 	
-		[iOS (7,0), Field ("NSProgressFileOperationKindDecompressingAfterDownloading")]
+		[Field ("NSProgressFileOperationKindDecompressingAfterDownloading")]
 		NSString FileOperationKindDecompressingAfterDownloading { get; }
 	
-		[iOS (7,0), Field ("NSProgressFileOperationKindReceiving")]
+		[Field ("NSProgressFileOperationKindReceiving")]
 		NSString FileOperationKindReceiving { get; }
 	
-		[iOS (7,0), Field ("NSProgressFileOperationKindCopying")]
+		[Field ("NSProgressFileOperationKindCopying")]
 		NSString FileOperationKindCopying { get; }
 	
-		[iOS (7,0), Field ("NSProgressFileURLKey")]
+		[Field ("NSProgressFileURLKey")]
 		NSString FileURLKey { get; }
 	
-		[iOS (7,0), Field ("NSProgressFileTotalCountKey")]
+		[Field ("NSProgressFileTotalCountKey")]
 		NSString FileTotalCountKey { get; }
 	
-		[iOS (7,0), Field ("NSProgressFileCompletedCountKey")]
+		[Field ("NSProgressFileCompletedCountKey")]
 		NSString FileCompletedCountKey { get; }
 
 #if MONOMAC

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -10071,15 +10071,12 @@ namespace Foundation
 		NSString ErrorDomain { get; }
 
 #if MONOMAC
-		[Mac (10,10)]
 		[Export ("sourceFrame")]
 		CGRect SourceFrame { get; }
 
-		[Mac (10,10)]
 		[Export ("containerFrame")]
 		CGRect ContainerFrame { get; }
 
-		[Mac (10,10)]
 		[Export ("preferredPresentationSize")]
 		CGSize PreferredPresentationSize { get; }
 

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -2329,7 +2329,7 @@ namespace GameKit {
 		[Export ("data")]
 		NSData Data { get; }
 
-		[iOS (8,0)][Mac (10,10)]
+		[iOS (8,0)]
 		[Export ("replyDate")]
 		NSDate ReplyDate { get; }
 	}

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -831,7 +831,6 @@ namespace GameKit {
 		[NullAllowed] // by default this property is null
 		[Export ("authenticateHandler", ArgumentSemantic.Copy)]
 #if WATCH
-		[Watch (3,0)]
 		Action<NSError> AuthenticateHandler { get; set; }
 #elif !MONOMAC
 		Action<UIViewController, NSError> AuthenticateHandler { get; set; }

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -108,13 +108,13 @@ namespace HealthKit {
 
 		[NoWatch]
 		[Obsolete ("Use the overload that takes HKAnchoredObjectResultHandler2 instead")]
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
 		[Export ("initWithType:predicate:anchor:limit:completionHandler:")]
 		IntPtr Constructor (HKSampleType type, [NullAllowed] NSPredicate predicate, nuint anchor, nuint limit, HKAnchoredObjectResultHandler completion);
 
 		[NoWatch]
 		[Sealed]
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
 		[Export ("initWithType:predicate:anchor:limit:completionHandler:")]
 		IntPtr Constructor (HKSampleType type, [NullAllowed] NSPredicate predicate, nuint anchor, nuint limit, HKAnchoredObjectResultHandler2 completion);
 
@@ -546,13 +546,11 @@ namespace HealthKit {
 		void AddSamples (HKSample [] samples, HKWorkout workout, HKStoreSampleAddedCallback callback);
 
 		[NoiOS]
-		[Watch (2,0)]
 		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use 'HKWorkoutSession.Start' instead.")]
 		[Export ("startWorkoutSession:")]
 		void StartWorkoutSession (HKWorkoutSession workoutSession);
 
 		[NoiOS]
-		[Watch (2,0)]
 		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use 'HKWorkoutSession.End' instead.")]
 		[Export ("endWorkoutSession:")]
 		void EndWorkoutSession (HKWorkoutSession workoutSession);
@@ -964,7 +962,7 @@ namespace HealthKit {
 		[Export ("UUID", ArgumentSemantic.Strong)]
 		NSUuid Uuid { get; }
 
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
 		[Export ("source", ArgumentSemantic.Strong)]
 		HKSource Source { get; }
 
@@ -1236,7 +1234,6 @@ namespace HealthKit {
 
 		[Deprecated (PlatformName.WatchOS, 2,2, message: "Use 'ObjectType' property.")]
 		[Deprecated (PlatformName.iOS, 9,3, message: "Use 'ObjectType' property.")]
-		[Watch (2,0)]
 		[NullAllowed, Export ("sampleType", ArgumentSemantic.Strong)]
 		HKSampleType SampleType { get; }
 

--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -99,7 +99,7 @@ namespace HomeKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
 		[Export ("identifier", ArgumentSemantic.Copy)]
 		NSUuid Identifier { get; }
 
@@ -123,7 +123,7 @@ namespace HomeKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
 		[Export ("identifiersForBridgedAccessories", ArgumentSemantic.Copy)]
 		NSUuid [] IdentifiersForBridgedAccessories { get; }
 
@@ -720,13 +720,13 @@ namespace HomeKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
 		[Export ("users")]
 		HMUser [] Users { get; }
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0, Message = "Use 'ManageUsers' instead.")]
+		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'ManageUsers' instead.")]
 		[Async]
 		[Export ("addUserWithCompletionHandler:")]
 		void AddUser (Action<HMUser,NSError> completion);

--- a/src/iad.cs
+++ b/src/iad.cs
@@ -231,7 +231,7 @@ namespace iAd {
 		[Export ("sharedClient")]
 		ADClient SharedClient { get; }
 
-		[Availability (Introduced = Platform.iOS_7_1, Deprecated = Platform.iOS_9_0, Message = "Replaced by 'RequestAttributionDetails'.")]
+		[Availability (Deprecated = Platform.iOS_9_0, Message = "Replaced by 'RequestAttributionDetails'.")]
 		[Export ("determineAppInstallationAttributionWithCompletionHandler:")]
 		void DetermineAppInstallationAttribution (AttributedToiAdCompletionHandler completionHandler);
 

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -444,7 +444,7 @@ namespace Intents {
 	[Mac (11,0), NoTV]
 	[Native]
 	public enum INPersonSuggestionType : long {
-		[iOS (12,0), Mac (10,14), Watch (5,0)]
+		[iOS (12,0), Watch (5,0)]
 		None = 0,
 		SocialProfile = 1,
 		InstantMessageAddress,

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -3709,7 +3709,7 @@ namespace Intents {
 		[Export ("imageNamed:")]
 		INImage FromName (string name);
 
-		[Watch (7,0), TV (14,0), NoMac, iOS (14,0)]
+		[Watch (7,0), NoMac, iOS (14,0)]
 		[Static]
 		[Export ("systemImageNamed:")]
 		INImage FromSystem (string systemImageName);
@@ -4390,13 +4390,9 @@ namespace Intents {
 		[NullAllowed, Export ("customIdentifier")]
 		string CustomIdentifier { get; }
 
-		[iOS (10, 0)]
-		[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
 		[NullAllowed, Export ("relationship"), Protected]
 		NSString WeakRelationship { get; }
 
-		[iOS (10, 0)]
-		[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
 		[Wrap ("INPersonRelationshipExtensions.GetValue (WeakRelationship)")]
 		INPersonRelationship Relationship { get; }
 

--- a/src/javascriptcore.cs
+++ b/src/javascriptcore.cs
@@ -77,11 +77,10 @@ namespace JavaScriptCore {
 		#endregion
 
 		/* C API Bridging functions */
-		[Mac (10,9), iOS (7,0)]
+
 		[Static, Export ("contextWithJSGlobalContextRef:")]
 		JSContext FromJSGlobalContextRef (IntPtr nativeJsGlobalContextRef);
 
-		[Mac (10,9), iOS (7,0)]
 		[Export ("JSGlobalContextRef")]
 		IntPtr JSGlobalContextRefPtr { get; }
 	}
@@ -295,7 +294,6 @@ namespace JavaScriptCore {
 
 		#endregion
 
-		[Mac (10,9), iOS (7,0)]
 		[Static, Export ("valueWithJSValueRef:inContext:")]
 		JSValue FromJSJSValueRef (IntPtr nativeJsValueRefvalue, JSContext context);
 

--- a/src/localauthentication.cs
+++ b/src/localauthentication.cs
@@ -30,7 +30,7 @@ namespace LocalAuthentication {
 		string LocalizedFallbackTitle { get; set; }
 
 #if !XAMCORE_4_0
-		[iOS (8,3), Mac (10,10)]
+		[iOS (8,3)]
 		[Field ("LAErrorDomain")]
 		NSString ErrorDomain { get; }
 #endif

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -1225,7 +1225,7 @@ namespace MapKit {
 	interface MKLocalSearchRequest : NSCopying {
 
 		[DesignatedInitializer]
-		[TV (9,2)][NoWatch][iOS (9,3)][Mac (10,11,4)]
+		[NoWatch][iOS (9,3)][Mac (10,11,4)]
 		[Export ("initWithCompletion:")]
 		IntPtr Constructor (MKLocalSearchCompletion completion);
 
@@ -2171,7 +2171,6 @@ namespace MapKit {
 	[DisableDefaultCtor]
 	interface MKLocalPointsOfInterestRequest : NSCopying
 	{
-		[TV (14, 0), NoWatch, Mac (11, 0), iOS (14, 0)]
 		[Field ("MKPointsOfInterestRequestMaxRadius")]
 		double RequestMaxRadius { get; }
 

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -619,7 +619,7 @@ namespace MapKit {
 //		void _HandleSelectionAtPoint (CGPoint locationInView);
 
 		[NoTV]
-		[Mac(10,9), iOS(9,0)]
+		[iOS(9,0)]
 		[Export ("showsCompass")]
 		bool ShowsCompass { get; set; }
 

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -1755,7 +1755,7 @@ namespace MediaPlayer {
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface MPRemoteCommandCenter {
-		[Mac (10,12,2)]
+
 		[Static]
 		[Export ("sharedCommandCenter")]
 		MPRemoteCommandCenter Shared { get; }

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -60,7 +60,7 @@ namespace MediaPlayer {
 		[Field ("MPMediaEntityPropertyPersistentID")]
 		NSString PropertyPersistentID { get; }
 
-		[NoiOS, NoMac, Watch (5,0)]
+		[NoiOS, NoMac]
 		[Export ("persistentID")]
 		ulong PersistentID { get; }
 
@@ -1443,7 +1443,6 @@ namespace MediaPlayer {
 		[iOS (11,0)]
 		[TV (11,0)]
 		[Mac (10,13)]
-		[Watch (5,0)]
 		[Field ("MPNowPlayingInfoPropertyServiceIdentifier")]
 		NSString PropertyServiceIdentifier { get; }
 
@@ -1650,7 +1649,7 @@ namespace MediaPlayer {
 		[Export ("contentLimitsEnforced")]
 		bool ContentLimitsEnforced { get; }
 
-		[Availability (Introduced = Platform.iOS_8_4, Deprecated = Platform.iOS_9_0, Message = "Replaced by 'ContentLimitsEnforced'.")]
+		[Availability (Deprecated = Platform.iOS_9_0, Message = "Replaced by 'ContentLimitsEnforced'.")]
 		[Export ("contentLimitsEnabled")]
 		bool ContentLimitsEnabled { get; }
 

--- a/src/messages.cs
+++ b/src/messages.cs
@@ -65,7 +65,6 @@ namespace Messages {
 	[Protocol]
 	interface MSMessagesAppTranscriptPresentation
 	{
-		[iOS (11,0)]
 		[Abstract]
 		[Export ("contentSizeThatFits:")]
 		CGSize GetContentSizeThatFits (CGSize size);

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -2054,7 +2054,7 @@ namespace Metal {
 		MTLPixelFormat StencilAttachmentPixelFormat { get; set; }
 		
 		[iOS (12,0)]
-		[NoTV, NoWatch, Mac (10,11)]
+		[NoTV, NoWatch]
 		[Export ("inputPrimitiveTopology", ArgumentSemantic.Assign)]
 		MTLPrimitiveTopologyClass InputPrimitiveTopology { get; set; }
 		
@@ -2107,7 +2107,7 @@ namespace Metal {
 		[Export ("maxVertexAmplificationCount")]
 		nuint MaxVertexAmplificationCount { get; set; }
 
-		[Mac (11, 0), iOS (14, 0), TV (14,0)]
+		[iOS (14, 0), TV (14,0)]
 		[NullAllowed, Export ("binaryArchives", ArgumentSemantic.Copy)]
 		IMTLBinaryArchive[] BinaryArchives { get; set; }
 
@@ -2525,7 +2525,7 @@ namespace Metal {
 		[Export ("fastMathEnabled")]
 		bool FastMathEnabled { get; set; }
 
-		[iOS (9,0)][Mac (10,11)]
+		[iOS (9,0)]
 		[Export ("languageVersion", ArgumentSemantic.Assign)]
 		MTLLanguageVersion LanguageVersion { get; set; }
 
@@ -3358,7 +3358,6 @@ namespace Metal {
 		MTLRenderPassDescriptor CreateRenderPassDescriptor ();
 		
 		[iOS (12,0)]
-		[Mac (10,11)]
 		[NoTV]
 		[Export ("renderTargetArrayLength")]
 		nuint RenderTargetArrayLength { get; set; }
@@ -4575,20 +4574,16 @@ namespace Metal {
 	[BaseType (typeof (NSObject))]
 	interface MTLCounterSampleBufferDescriptor : NSCopying
 	{
-		[Mac (10, 15)]
 		[NullAllowed]
 		[Export ("counterSet", ArgumentSemantic.Retain)]
 		IMTLCounterSet CounterSet { get; set; }
 
-		[Mac (10, 15)]
 		[Export ("label")]
 		string Label { get; set; }
 
-		[Mac (10, 15)]
 		[Export ("storageMode", ArgumentSemantic.Assign)]
 		MTLStorageMode StorageMode { get; set; }
 
-		[Mac (10, 15)]
 		[Export ("sampleCount")]
 		nuint SampleCount { get; set; }
 	}

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -2107,7 +2107,7 @@ namespace Metal {
 		[Export ("maxVertexAmplificationCount")]
 		nuint MaxVertexAmplificationCount { get; set; }
 
-		[iOS (14, 0), TV (14,0)]
+		[Mac (11, 0), iOS (14, 0), TV (14,0)]
 		[NullAllowed, Export ("binaryArchives", ArgumentSemantic.Copy)]
 		IMTLBinaryArchive[] BinaryArchives { get; set; }
 
@@ -4107,7 +4107,7 @@ namespace Metal {
 		[Export ("reset")]
 		void Reset ();
 
-		[Mac (11, 0), iOS (14,0)]
+		[iOS (14,0)]
 		[NullAllowed, Export ("binaryArchives", ArgumentSemantic.Copy)]
 		IMTLBinaryArchive[] BinaryArchives { get; set; }
 	}
@@ -4178,7 +4178,7 @@ namespace Metal {
 #if XAMCORE_4_0 
 		[Abstract]
 #endif
-		[iOS (13,0), TV (13,0), Mac (10,14)]
+		[iOS (13,0), TV (13,0)]
 		[Export ("setRenderPipelineState:")]
 		void SetRenderPipelineState (IMTLRenderPipelineState pipelineState);
 

--- a/src/metalperformanceshaders.cs
+++ b/src/metalperformanceshaders.cs
@@ -51,7 +51,7 @@ namespace MetalPerformanceShaders {
 		IntPtr Constructor (IMTLDevice device);
 
 		// inlining ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -61,7 +61,7 @@ namespace MetalPerformanceShaders {
 	[BaseType (typeof (MPSUnaryImageKernel))]
 	[DisableDefaultCtor]
 	interface MPSImageBox {
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -95,7 +95,7 @@ namespace MetalPerformanceShaders {
 	[BaseType (typeof (MPSUnaryImageKernel))]
 	[DisableDefaultCtor]
 	interface MPSImageGaussianBlur {
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -136,7 +136,7 @@ namespace MetalPerformanceShaders {
 	[BaseType (typeof (MPSUnaryImageKernel))]
 	[DisableDefaultCtor]
 	interface MPSImagePyramid {
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -170,7 +170,7 @@ namespace MetalPerformanceShaders {
 		IntPtr InitWithDevice (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, /* float* */ IntPtr kernelWeights);
 
 		// inlining ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -279,7 +279,7 @@ namespace MetalPerformanceShaders {
 		IntPtr Constructor (IMTLDevice device);
 
 		// inlining ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -295,7 +295,7 @@ namespace MetalPerformanceShaders {
 		IntPtr Constructor (IMTLDevice device);
 
 		// inlining ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -336,7 +336,7 @@ namespace MetalPerformanceShaders {
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device);
 
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -346,7 +346,7 @@ namespace MetalPerformanceShaders {
 	[BaseType (typeof (MPSKernel))]
 	[DisableDefaultCtor]
 	interface MPSBinaryImageKernel {
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -417,7 +417,7 @@ namespace MetalPerformanceShaders {
 		[Export ("minKernelDiameter")]
 		nuint MinKernelDiameter { get; }
 
-		[TV (11, 0), Mac (10, 13), iOS (11, 0)]
+		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -439,7 +439,7 @@ namespace MetalPerformanceShaders {
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
 
-		[TV (11, 0), Mac (10, 13), iOS (11, 0)]
+		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -1874,7 +1874,7 @@ namespace MetalPerformanceShaders {
 		IntPtr InitWithDevice (IMTLDevice device, MPSAlphaType srcAlpha, MPSAlphaType destAlpha, [NullAllowed] /* nfloat* */ IntPtr backgroundColor, [NullAllowed] CGColorConversionInfo conversionInfo);
 
 		// inlining ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -2011,7 +2011,7 @@ namespace MetalPerformanceShaders {
 	[BaseType (typeof (MPSKernel))]
 	[DisableDefaultCtor]
 	interface MPSMatrixMultiplication {
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithDevice:resultRows:resultColumns:interiorColumns:")]
 		IntPtr Constructor (IMTLDevice device, nuint resultRows, nuint resultColumns, nuint interiorColumns);
 

--- a/src/metalperformanceshaders.cs
+++ b/src/metalperformanceshaders.cs
@@ -115,7 +115,7 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor]
 	interface MPSImageSobel {
 		// inlining .ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -489,7 +489,7 @@ namespace MetalPerformanceShaders {
 		// inlining ctor from base class -> done in manual bindings (wrt float* argument)
 
 		// inlining ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -508,7 +508,7 @@ namespace MetalPerformanceShaders {
 		IntPtr Constructor (IMTLDevice device);
 
 		// inlining ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -537,7 +537,7 @@ namespace MetalPerformanceShaders {
 		IntPtr _Transform { get; }
 
 		// inlining ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -564,7 +564,7 @@ namespace MetalPerformanceShaders {
 		IntPtr _Transform { get; }
 
 		// inlining ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -588,7 +588,7 @@ namespace MetalPerformanceShaders {
 		IntPtr _Transform { get; }
 
 		// inlining ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -612,7 +612,7 @@ namespace MetalPerformanceShaders {
 		IntPtr _Transform { get; }
 
 		// inlining ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -636,7 +636,7 @@ namespace MetalPerformanceShaders {
 		IntPtr _Transform { get; }
 
 		// inlining ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -684,7 +684,7 @@ namespace MetalPerformanceShaders {
 		IntPtr Constructor (IMTLDevice device);
 
 		// inlining ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -807,7 +807,7 @@ namespace MetalPerformanceShaders {
 		[Export ("appendBatchBarrier")]
 		bool AppendBatchBarrier { get; }
 
-		[TV (11,0), Mac (10,13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("destinationImageDescriptorForSourceImages:sourceStates:")]
 		MPSImageDescriptor GetDestinationImageDescriptor (NSArray<MPSImage> sourceImages, [NullAllowed] NSArray<MPSState> sourceStates);
 
@@ -847,7 +847,7 @@ namespace MetalPerformanceShaders {
 		IntPtr Constructor (IMTLDevice device);
 
 		// inlining ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[DesignatedInitializer]
 		[Export ("initWithCoder:device:")]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
@@ -868,7 +868,7 @@ namespace MetalPerformanceShaders {
 		[Export ("c")]
 		float C { get; }
 
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[NullAllowed, Export ("data", ArgumentSemantic.Retain)]
 		NSData Data { get; }
 
@@ -1245,12 +1245,12 @@ namespace MetalPerformanceShaders {
 		// [Export ("initWithDevice:")] marked as NS_UNAVAILABLE - Use initWithDevice:convolutionDescriptor:kernelWeights:biasTerms instead
 
 		// inlining ctor from base class
-		[TV (11,0), Mac (10, 13), iOS (11,0)]
+		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
 
-		[TV (11, 0), Mac (10, 13), iOS (11, 0)]
+		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithDevice:weights:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device, IMPSCnnConvolutionDataSource weights);
@@ -1286,7 +1286,7 @@ namespace MetalPerformanceShaders {
 
 		// [Export ("initWithDevice:")] marked as NS_UNAVAILABLE - Use initWithDevice:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY: instead
 
-		[TV (11, 0), Mac (10, 13), iOS (11, 0)]
+		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);

--- a/src/metalperformanceshaders.cs
+++ b/src/metalperformanceshaders.cs
@@ -1908,9 +1908,7 @@ namespace MetalPerformanceShaders {
 		MPSMatrixDescriptor Create (nuint rows, nuint columns, nuint rowBytes, MPSDataType dataType);
 
 		[Static]
-		[Introduced (PlatformName.iOS, 10, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0)]
-		[Introduced (PlatformName.TvOS, 10, 0)]
 		[Deprecated (PlatformName.TvOS, 11, 0)]
 		[Unavailable (PlatformName.MacCatalyst)]
 		[Export ("rowBytesFromColumns:dataType:")]
@@ -7251,7 +7249,6 @@ namespace MetalPerformanceShaders {
 		[Export ("reloadWeightsAndBiasesFromDataSource")]
 		void ReloadWeightsAndBiasesFromDataSource ();
 
-		[TV (11,3), Mac (10,13,4), iOS (11,3)]
 		[Export ("reloadWeightsAndBiasesWithCommandBuffer:state:")]
 		void ReloadWeightsAndBiases (IMTLCommandBuffer commandBuffer, MPSCnnConvolutionWeightsAndBiasesState state);
 	}
@@ -7964,7 +7961,6 @@ namespace MetalPerformanceShaders {
 		[NullAllowed, Export ("data", ArgumentSemantic.Retain)]
 		NSData Data { get; }
 
-		[TV (11, 0), Mac (10, 13), iOS (11, 0)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);

--- a/src/metrickit.cs
+++ b/src/metrickit.cs
@@ -58,7 +58,7 @@ namespace MetricKit {
 		NSMeasurement<NSUnitDuration> CumulativeGpuTime { get; }
 	}
 
-	// NSUnit is added as a parent to ensure that the intermediate tmp dll can be comppiled
+	// NSUnit is added as a parent to ensure that the intermediate tmp dll can be compiled
 	// since at this stage the compiler does not know about the inheritance of NSDimension.
 	[NoWatch, NoTV, NoMac, iOS (13,0)]
 	[BaseType (typeof(NSDimension))]
@@ -74,7 +74,7 @@ namespace MetricKit {
 		MXUnitSignalBars Bars { get; }
 	}
 
-	// NSUnit is added as a parent to ensure that the intermediate tmp dll can be comppiled
+	// NSUnit is added as a parent to ensure that the intermediate tmp dll can be compiled
 	// since at this stage the compiler does not know about the inheritance of NSDimension.
 	[NoWatch, NoTV, NoMac, iOS (13,0)]
 	[BaseType (typeof(NSDimension))]

--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -237,7 +237,6 @@ namespace ModelIO {
 		[Export ("animations", ArgumentSemantic.Retain)]
 		IMDLObjectContainerComponent Animations { get; set; }
 
-		[iOS (9,0), Mac(10,11)]
 		[Static]
 		[Export ("assetWithSCNScene:")]
 		MDLAsset FromScene (SCNScene scene);
@@ -402,7 +401,6 @@ namespace ModelIO {
 			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")] set;
 		}
 
-		[iOS (9,0), Mac(10,11)]
 		[Static]
 		[Export ("cameraWithSCNCamera:")]
 		MDLCamera FromSceneCamera (SCNCamera sceneCamera);
@@ -475,7 +473,6 @@ namespace ModelIO {
 		// No documentation to confirm but this should be a constant (hence NSString).
 		NSString ColorSpace { get; set; }
 
-		[iOS (9,0), Mac(10,11)]
 		[Static]
 		[Export ("lightWithSCNLight:")]
 		MDLLight FromSceneLight (SCNLight sceneLight);
@@ -574,7 +571,6 @@ namespace ModelIO {
 		[Export ("materialFace", ArgumentSemantic.Assign)]
 		MDLMaterialFace MaterialFace { get; set; }
 
-		[iOS (9,0), Mac(10,11)]
 		[Static]
 		[Export ("materialWithSCNMaterial:")]
 		MDLMaterial FromSceneMaterial (SCNMaterial material);
@@ -1010,7 +1006,6 @@ namespace ModelIO {
 		[Export ("generateLightMapVertexColorsWithLightsToConsider:objectsToConsider:vertexAttributeNamed:")]
 		bool GenerateLightMapVertexColors (MDLLight [] lightsToConsider, MDLObject [] objectsToConsider, string vertexAttributeName);
 
-		[iOS (9,0), Mac(10,11)]
 		[Static]
 		[Export ("meshWithSCNGeometry:")]
 		MDLMesh FromGeometry (SCNGeometry geometry);
@@ -1246,7 +1241,6 @@ namespace ModelIO {
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		MDLAxisAlignedBoundingBox GetBoundingBox (double atTime);
 
-		[iOS (9,0), Mac(10,11)]
 		[Static]
 		[Export ("objectWithSCNNode:")]
 		MDLObject FromNode (SCNNode node);

--- a/src/multipeerconnectivity.cs
+++ b/src/multipeerconnectivity.cs
@@ -229,16 +229,13 @@ namespace MultipeerConnectivity {
 	partial interface MCNearbyServiceBrowserDelegate {
 
 		[Abstract]
-		[Mac (10,9)]
 		[Export ("browser:foundPeer:withDiscoveryInfo:")]
 		void FoundPeer (MCNearbyServiceBrowser browser, MCPeerID peerID, [NullAllowed] NSDictionary info);
 
 		[Abstract]
-		[Mac (10,9)]
 		[Export ("browser:lostPeer:")]
 		void LostPeer (MCNearbyServiceBrowser browser, MCPeerID peerID);
 
-		[Mac (10,9)]
 		[Export ("browser:didNotStartBrowsingForPeers:")]
 		void DidNotStartBrowsingForPeers (MCNearbyServiceBrowser browser, NSError error);
 	}

--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -488,7 +488,7 @@ namespace NetworkExtension {
 		[NullAllowed, Export ("sourceAppAuditToken")]
 		NSData SourceAppAuditToken { get; }
 
-		[Mac (10, 15), iOS (13, 1)]
+		[iOS (13, 1)]
 		[Export ("identifier")]
 		NSUuid Identifier { get; }
 	}

--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -492,7 +492,7 @@ namespace PassKit {
 		[NullAllowed, Export ("billingContact", ArgumentSemantic.Strong)]
 		PKContact BillingContact { get; set; }
 
-		[Watch (3,0)][iOS (10,0)]
+		[iOS (10,0)]
 		[Static]
 		[Export ("availableNetworks")]
 		NSString[] AvailableNetworks { get; }
@@ -910,12 +910,10 @@ namespace PassKit {
 		NSString CartesBancaires { get; }
 
 		[iOS (9,2)]
-		[Watch (2,2)]
 		[Field ("PKPaymentNetworkChinaUnionPay")]
 		NSString ChinaUnionPay { get; }
 
 		[iOS (9,2)]
-		[Watch (2,2)]
 		[Field ("PKPaymentNetworkInterac")]
 		NSString Interac { get; }
 

--- a/src/photos.cs
+++ b/src/photos.cs
@@ -1290,7 +1290,7 @@ namespace Photos
 		void PrepareLivePhotoForPlayback (CGSize targetSize, [NullAllowed] NSDictionary<NSString, NSObject> options, Action<PHLivePhoto, NSError> handler);
 
 		// the API existed earlier but the key needed to create the strong dictionary did not work
-		[iOS (11,0)][TV (11,0)][Mac (10,12)]
+		[iOS (11,0)][TV (11,0)]
 		[Async]
 		[Wrap ("_PrepareLivePhotoForPlayback (targetSize, options.GetDictionary (), handler)")]
 		void PrepareLivePhotoForPlayback (CGSize targetSize, [NullAllowed] PHLivePhotoEditingOption options, Action<PHLivePhoto, NSError> handler);
@@ -1308,7 +1308,7 @@ namespace Photos
 		void SaveLivePhoto (PHContentEditingOutput output, [NullAllowed] NSDictionary<NSString, NSObject> options, Action<bool, NSError> handler);
 
 		// the API existed earlier but the key needed to create the strong dictionary did not work
-		[iOS (11,0)][TV (11,0)][Mac (10,12)]
+		[iOS (11,0)][TV (11,0)]
 		[Async]
 		[Wrap ("_SaveLivePhoto (output, options.GetDictionary (), handler)")]
 		void SaveLivePhoto (PHContentEditingOutput output, [NullAllowed] PHLivePhotoEditingOption options, Action<bool, NSError> handler);

--- a/src/replaykit.cs
+++ b/src/replaykit.cs
@@ -37,7 +37,7 @@ namespace ReplayKit {
 		[Export ("previewControllerDelegate", ArgumentSemantic.Weak)][NullAllowed]
 		IRPPreviewViewControllerDelegate PreviewControllerDelegate { get; set; }
 
-		[TV (10, 0), NoiOS]
+		[NoiOS]
 		[NoMac]
 		[Export ("mode", ArgumentSemantic.Assign)]
 		RPPreviewViewControllerMode Mode { get; set; }

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -200,11 +200,9 @@ namespace SceneKit {
 		void ResumeAnimation (NSString key);
 
 		[Abstract]
-		[Watch (3, 0)]
 		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'SCNAnimationPlayer.Paused' instead.")]
 		[TV (9, 0)]
 		[Deprecated (PlatformName.TvOS, 11, 0,   message: "Use 'SCNAnimationPlayer.Paused' instead.")]
-		[iOS (8, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0,    message: "Use 'SCNAnimationPlayer.Paused' instead.")]
 		[Mac (10, 9)]
 		[Deprecated (PlatformName.MacOSX, 10, 13,message: "Use 'SCNAnimationPlayer.Paused' instead.")]
@@ -397,15 +395,15 @@ namespace SceneKit {
 		[Static, Export ("camera")]
 		SCNCamera Create ();
 
-		[iOS (8,0)][Mac (10,9)]
+		[Mac (10,9)]
 		[Export ("projectionTransform")]
 		SCNMatrix4 ProjectionTransform { get; [Mac (10,9)] set; }
 
-		[iOS (8,0)][Mac (10,9)]
+		[Mac (10,9)]
 		[Export ("automaticallyAdjustsZRange")]
 		bool AutomaticallyAdjustsZRange { get; set; }
 		
-		[iOS (8,0)][Mac (10,9)]
+		[Mac (10,9)]
 		[Export ("orthographicScale")]
 		double OrthographicScale { get; set; }
 
@@ -413,7 +411,7 @@ namespace SceneKit {
 		[Deprecated (PlatformName.iOS,    11, 0,  message: "Use 'FocusDistance' instead.")]
 		[Deprecated (PlatformName.TvOS,   11, 0,  message: "Use 'FocusDistance' instead.")]
 		[Deprecated (PlatformName.WatchOS, 4, 0,  message: "Use 'FocusDistance' instead.")]
-		[iOS (8,0)][Mac (10,9)]
+		[Mac (10,9)]
 		[Export ("focalDistance")]
 		nfloat FocalDistance { get; set; }
 
@@ -421,7 +419,7 @@ namespace SceneKit {
 		[Deprecated (PlatformName.iOS,    11, 0,  message: "Use 'FocusDistance' instead.")]
 		[Deprecated (PlatformName.TvOS,   11, 0,  message: "Use 'FocusDistance' instead.")]
 		[Deprecated (PlatformName.WatchOS, 4, 0,  message: "Use 'FocusDistance' instead.")]
-		[iOS (8,0)][Mac (10,9)]
+		[Mac (10,9)]
 		[Export ("focalSize")]
 		nfloat FocalSize { get; set; }
 
@@ -429,7 +427,7 @@ namespace SceneKit {
 		[Deprecated (PlatformName.iOS,    11, 0,  message: "Use 'FStop' instead.")]
 		[Deprecated (PlatformName.TvOS,   11, 0,  message: "Use 'FStop' instead.")]
 		[Deprecated (PlatformName.WatchOS, 4, 0,  message: "Use 'FStop' instead.")]
-		[iOS (8,0)][Mac (10,9)]
+		[Mac (10,9)]
 		[Export ("focalBlurRadius")]
 		nfloat FocalBlurRadius { get; set; }
 
@@ -437,7 +435,7 @@ namespace SceneKit {
 		[Deprecated (PlatformName.iOS,    11, 0,  message: "Use 'FStop' instead with FStop = SensorHeight / Aperture.")]
 		[Deprecated (PlatformName.TvOS,   11, 0,  message: "Use 'FStop' instead with FStop = SensorHeight / Aperture.")]
 		[Deprecated (PlatformName.WatchOS, 4, 0,  message: "Use 'FStop' instead with FStop = SensorHeight / Aperture.")]
-		[iOS (8,0)][Mac (10,9)]
+		[Mac (10,9)]
 		[Export ("aperture")]
 		nfloat Aperture { get; set; }
 
@@ -521,7 +519,7 @@ namespace SceneKit {
 		[Export ("colorGrading")]
 		SCNMaterialProperty ColorGrading { get; }
 
-		[iOS (8,0)][Mac (10,10)]
+		[Mac (10,10)]
 		[Export ("categoryBitMask")]
 		nuint CategoryBitMask { get; set; }
 
@@ -1130,7 +1128,7 @@ namespace SceneKit {
 		[Field ("SCNHitTestRootNodeKey")]
 		NSString RootNodeKey { get; }
 
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		[Field ("SCNHitTestIgnoreHiddenNodesKey")]
 		NSString IgnoreHiddenNodesKey { get; }
 
@@ -1320,7 +1318,7 @@ namespace SceneKit {
 		[Export ("zFar")]
 		nfloat ZFar { get; set; }
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		[Export ("categoryBitMask")]
 		nuint CategoryBitMask { get; set; }
 
@@ -2644,15 +2642,14 @@ namespace SceneKit {
 
 		
 
-		[Mac (10,9), iOS (8,0)]
 		[Field ("SCNSceneExportDestinationURL")]
 		NSString ExportDestinationUrl { get; }
 
-		[Mac (10,10), iOS (8,0)] // More 32-bit brokenness - 17710842
+		[Mac (10,10)] // More 32-bit brokenness - 17710842
 		[Export ("physicsWorld")]
 		SCNPhysicsWorld PhysicsWorld { get; }
 
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		[Export ("background")]
 		SCNMaterialProperty Background { get; }
 
@@ -2660,42 +2657,41 @@ namespace SceneKit {
 		[Export ("lightingEnvironment")]
 		SCNMaterialProperty LightingEnvironment { get; }
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		[Export ("fogStartDistance")]
 		nfloat FogStartDistance { get; set; }
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		[Export ("fogEndDistance")]
 		nfloat FogEndDistance { get; set; }
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		[Export ("fogDensityExponent")]
 		nfloat FogDensityExponent { get; set; }
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		[Export ("fogColor", ArgumentSemantic.Retain)]
 		NSObject FogColor { get; set; }
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		[Export ("paused")]
 		bool Paused { [Bind ("isPaused")] get; set; }
 
-		[Mac (10,9), iOS (8,0)]
 		[Static, Export ("sceneNamed:")]
 		SCNScene FromFile (string name);
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		[Static, Export ("sceneNamed:inDirectory:options:")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		SCNScene FromFile (string name, [NullAllowed] string directory, [NullAllowed] NSDictionary options);
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		[Static, Wrap ("FromFile (name, directory, options.GetDictionary ())")]
 		SCNScene FromFile (string name, string directory, SCNSceneLoadingOptions options);
 
 		// Keeping here the same name WriteToUrl for iOS and friends because it is how it was bound
 		// initialy for macOS and having it named diferently would hurt shared code
-		[TV (10, 0), NoWatch, Mac (10, 9), iOS (10, 0)]
+		[TV (10, 0), NoWatch, iOS (10, 0)]
 		[Export ("writeToURL:options:delegate:progressHandler:")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		bool WriteToUrl (NSUrl url,
@@ -2703,7 +2699,7 @@ namespace SceneKit {
 			[NullAllowed] ISCNSceneExportDelegate aDelegate,
 			[NullAllowed] SCNSceneExportProgressHandler exportProgressHandler);
 
-		[TV (10, 0), NoWatch, Mac (10, 9), iOS (10, 0)]
+		[TV (10, 0), NoWatch, iOS (10, 0)]
 		[Wrap ("WriteToUrl (url, options.GetDictionary (), handler, exportProgressHandler)")]
 		bool WriteToUrl (NSUrl url, SCNSceneLoadingOptions options, ISCNSceneExportDelegate handler, SCNSceneExportProgressHandler exportProgressHandler);
 
@@ -2736,7 +2732,7 @@ namespace SceneKit {
 		[Field ("SCNSceneFrameRateAttributeKey")]
 		NSString FrameRateAttributeKey { get; }
 
-		[iOS (8,0)][Mac (10,10)]
+		[Mac (10,10)]
 		[Field ("SCNSceneUpAxisAttributeKey")]
 		NSString UpAxisAttributeKey { get; }
 
@@ -2875,34 +2871,34 @@ namespace SceneKit {
 		NSString UseSafeModeKey	 { get; }
 
 		[Mac(10,10)]
-		[iOS (8,0)] // header said NA and docs says "Available in iOS 8.0 through iOS 8.2." but it's back on iOS11
+		// header said NA and docs says "Available in iOS 8.0 through iOS 8.2." but it's back on iOS11
 		[TV (11,0), Watch (4,0)]
 		[Field ("SCNSceneSourceConvertUnitsToMetersKey")]
 		NSString ConvertUnitsToMetersKey { get; }
 
 		[Mac(10,10)]
-		[iOS (8,0)] // header said NA and docs says "Available in iOS 8.0 through iOS 8.2." but it's back on iOS11
+		// header said NA and docs says "Available in iOS 8.0 through iOS 8.2." but it's back on iOS11
 		[TV (11,0), Watch (4,0)]
 		[Field ("SCNSceneSourceConvertToYUpKey")]
 		NSString ConvertToYUpKey { get; }
 
-		[Mac(10,10), iOS(8,0)]
+		[Mac(10,10)]
 		[Field ("SCNSceneSourceAnimationImportPolicyKey")]
 		NSString AnimationImportPolicyKey { get; }
 		
-		[Mac(10,10), iOS(8,0)]
+		[Mac(10,10)]
 		[Field ("SCNSceneSourceAnimationImportPolicyPlay")]
 		NSString AnimationImportPolicyPlay { get; }
 		
-		[Mac(10,10), iOS(8,0)]
+		[Mac(10,10)]
 		[Field ("SCNSceneSourceAnimationImportPolicyPlayRepeatedly")]
 		NSString AnimationImportPolicyPlayRepeatedly { get; }
 		
-		[Mac(10,10), iOS(8,0)]
+		[Mac(10,10)]
 		[Field ("SCNSceneSourceAnimationImportPolicyDoNotPlay")]
 		NSString AnimationImportPolicyDoNotPlay { get; }
 		
-		[Mac(10,10), iOS(8,0)]
+		[Mac(10,10)]
 		[Field ("SCNSceneSourceAnimationImportPolicyPlayUsingSceneTimeBase")]
 		NSString AnimationImportPolicyPlayUsingSceneTimeBase { get; }
 
@@ -3472,7 +3468,7 @@ namespace SceneKit {
 		[Export ("stop:")]
 		void Stop ([NullAllowed] NSObject sender);
 
-		[iOS (8,0)][Mac (10,10)]
+		[Mac (10,10)]
 		[Export ("snapshot")]
 		NSImage Snapshot ();
 
@@ -3480,7 +3476,7 @@ namespace SceneKit {
 		[Export ("preferredFramesPerSecond")]
 		nint PreferredFramesPerSecond { get; set; }
 
-		[iOS (8,0)][Mac (10,10)]
+		[Mac (10,10)]
 		[Export ("antialiasingMode")]
 		SCNAntialiasingMode AntialiasingMode { get; set; }
 
@@ -3628,7 +3624,7 @@ namespace SceneKit {
 		[Export ("influenceFactor")]
 		nfloat InfluenceFactor { get; set; }
 
-		[Mac (10, 10), iOS (8,0)]
+		[Mac (10, 10)]
 		[TV (11,0)][Watch (4,0)]
 		[Export ("enabled")]
 		bool Enabled { [Bind ("isEnabled")] get; set; }

--- a/src/security.cs
+++ b/src/security.cs
@@ -59,7 +59,7 @@ namespace Security {
 		[Field ("kSecPolicyAppleRevocation")]
 		NSString AppleRevocation { get; }
 
-		[iOS (7,0)][Mac (10,9)]
+		[Mac (10,9)]
 		[Field ("kSecPolicyApplePassbookSigning")]
 		NSString ApplePassbookSigning { get; }
 
@@ -84,7 +84,7 @@ namespace Security {
 		[Field ("kSecPolicyRevocationFlags")]
 		NSString RevocationFlags { get; }
 
-		[iOS (7,0)][Mac (10,9)]
+		[Mac (10,9)]
 		[Field ("kSecPolicyTeamIdentifier")]
 		NSString TeamIdentifier { get; }
 	}

--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -3251,22 +3251,19 @@ namespace SpriteKit {
 
 #if !WATCH
 		// Static Category from GameplayKit
-		[iOS (10,0), TV (10,0), NoWatch, Mac (10,12)]
+		[NoWatch]
 		[Static]
 		[Export ("tileMapNodesWithTileSet:columns:rows:tileSize:fromNoiseMap:tileTypeNoiseMapThresholds:")]
 		SKTileMapNode[] FromTileSet (SKTileSet tileSet, nuint columns, nuint rows, CGSize tileSize, GKNoiseMap noiseMap, NSNumber[] thresholds);
 #endif
 
-		[iOS (9,0), Mac (10,11)]
 		[Export ("attributeValues", ArgumentSemantic.Copy)]
 		NSDictionary<NSString, SKAttributeValue> AttributeValues { get; set; }
 
-		[iOS (9,0), Mac(10,11)]
 		[Export ("valueForAttributeNamed:")]
 		[return: NullAllowed]
 		SKAttributeValue GetValue (string key);
 
-		[iOS (9,0), Mac(10,11)]
 		[Export ("setValue:forAttributeNamed:")]
 		void SetValue (SKAttributeValue value, string key);
 	}

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -15455,12 +15455,10 @@ namespace UIKit {
 	[iOS (8,0)]
 	partial interface UITraitEnvironment {
 		[Abstract]
-		[iOS (8,0)]
 		[Export ("traitCollection")]
 		UITraitCollection TraitCollection { get; }
 
 		[Abstract]
-		[iOS (8,0)]
 		[Export ("traitCollectionDidChange:")]
 		void TraitCollectionDidChange ([NullAllowed] UITraitCollection previousTraitCollection);
 	}
@@ -19753,7 +19751,7 @@ namespace UIKit {
 	interface UIUserActivityRestoring
 	{
 		[Abstract]
-		[iOS (8,0), TV(12,0)]
+		[TV(12,0)]
 		[Export ("restoreUserActivityState:")]
 		void RestoreUserActivityState (NSUserActivity activity);
 	}
@@ -21234,7 +21232,6 @@ namespace UIKit {
 	[BaseType (typeof (NSObject))]
 	interface UITextFormattingCoordinatorDelegate {
 
-		[iOS (13,0)]
 		[Abstract]
 		[Export ("updateTextAttributesWithConversionHandler:")]
 		void UpdateTextAttributes (UITextAttributesConversionHandler conversionHandler);

--- a/src/usernotifications.cs
+++ b/src/usernotifications.cs
@@ -594,11 +594,11 @@ namespace UserNotifications {
 		[Export ("showPreviewsSetting")]
 		UNShowPreviewsSetting ShowPreviewsSetting { get; }
 
-		[Watch (5, 0), NoTV, Mac (10, 14), iOS (12, 0)]
+		[Watch (5, 0), NoTV, iOS (12, 0)]
 		[Export ("criticalAlertSetting")]
 		UNNotificationSetting CriticalAlertSetting { get; }
 
-		[Watch (5, 0), NoTV, Mac (10, 14), iOS (12, 0)]
+		[Watch (5, 0), NoTV, iOS (12, 0)]
 		[Export ("providesAppNotificationSettings")]
 		bool ProvidesAppNotificationSettings { get; }
 

--- a/src/vision.cs
+++ b/src/vision.cs
@@ -3185,26 +3185,21 @@ namespace Vision {
 		// ('Revision', 'WeakSupportedRevisions', 'SupportedRevisions', 'DefaultRevision' and 'CurrentRevision')
 		// into subclasses so the correct class_ptr is used for the static members and the right enum type is also used.
 
-		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("revision")]
 		VNGenerateOpticalFlowRequestRevision Revision { get; set; }
 
-		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Static]
 		[Export ("supportedRevisions", ArgumentSemantic.Copy)]
 		NSIndexSet WeakSupportedRevisions { get; }
 
-		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Static]
 		[Wrap ("GetSupportedVersions<VNGenerateOpticalFlowRequestRevision> (WeakSupportedRevisions)")]
 		VNGenerateOpticalFlowRequestRevision [] SupportedRevisions { get; }
 
-		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Static]
 		[Export ("defaultRevision")]
 		VNGenerateOpticalFlowRequestRevision DefaultRevision { get; }
 
-		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Static]
 		[Export ("currentRevision")]
 		VNGenerateOpticalFlowRequestRevision CurrentRevision { get; }

--- a/src/wkwebkit.cs
+++ b/src/wkwebkit.cs
@@ -859,11 +859,11 @@ namespace WebKit
 		[Export ("allowsInlineMediaPlayback")]
 		bool AllowsInlineMediaPlayback { get; set; }
 
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0, Message = "Use 'RequiresUserActionForMediaPlayback' or 'MediaTypesRequiringUserActionForPlayback' instead.")]
+		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'RequiresUserActionForMediaPlayback' or 'MediaTypesRequiringUserActionForPlayback' instead.")]
 		[Export ("mediaPlaybackRequiresUserAction")]
 		bool MediaPlaybackRequiresUserAction { get; set; }
 
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0, Message = "Use 'AllowsAirPlayForMediaPlayback' instead.")]
+		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AllowsAirPlayForMediaPlayback' instead.")]
 		[Export ("mediaPlaybackAllowsAirPlay")]
 		bool MediaPlaybackAllowsAirPlay { get; set; }
 

--- a/src/xkit.cs
+++ b/src/xkit.cs
@@ -900,7 +900,6 @@ namespace UIKit {
 		[Export ("typesetterBehavior")]
 		NSTypesetterBehavior TypesetterBehavior { get; set; }
 
-		[iOS (7,0)]
 		[Export ("allowsNonContiguousLayout")]
 		bool AllowsNonContiguousLayout { get; set; }
 

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -63,6 +63,62 @@ namespace Introspection {
 #endif
 		}
 
+		bool FoundInProtocols (MemberInfo m, Type t)
+		{
+			var method = m.ToString ();
+			foreach (var intf in t.GetInterfaces ()) {
+				var p = Assembly.GetType (intf.FullName);
+				if (p != null) {
+					// here we want inherited members so we don't have to hunt inherited interfaces recursively
+					foreach (var pm in p.GetMembers ()) {
+						if (pm.ToString () != method)
+							continue;
+						return true;
+					}
+					foreach (var ca in p.GetCustomAttributes<Foundation.ProtocolMemberAttribute> ()) {
+						// TODO check signature in [ProtocolMember]
+						if (ca.IsProperty) {
+							if (m.Name == "get_" + ca.Name)
+								return true;
+							if (m.Name == "set_" + ca.Name)
+								return true;
+						}
+						if (m.Name == ca.Name)
+							return true;
+					}
+				}
+				p = Assembly.GetType (intf.Namespace + "." + intf.Name.Substring (1));
+				if (p != null) {
+					// here we want inherited members so we don't have to hunt inherited interfaces recursively
+					foreach (var pm in p.GetMembers ()) {
+						if (pm.ToString () != method)
+							continue;
+						return true;
+					}
+				}
+				p = Assembly.GetType (intf.Namespace + "." + intf.Name.Substring (1) + "_Extensions");
+				if (p != null) {
+					// here we want inherited members so we don't have to hunt inherited interfaces recursively
+					foreach (var pm in p.GetMembers ()) {
+						// map extension method to original @optional
+						if (m.Name != pm.Name)
+							continue;
+						var parameters = (pm as MethodInfo).GetParameters ();
+						if (parameters.Length == 0)
+							continue;
+						var pattern = "(" + parameters [0].ParameterType.FullName;
+						if (parameters.Length > 1)
+							pattern += ", ";
+						var s = pm.ToString ().Replace (pattern, "(");
+						if (s != method)
+							continue;
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
 		[Test]
 		public void Introduced ()
 		{
@@ -72,22 +128,41 @@ namespace Introspection {
 				if (LogProgress)
 					Console.WriteLine ($"T: {t}");
 				var ta = CheckAvailability (t);
-				foreach (var m in t.GetMembers ()) {
+				foreach (var m in t.GetMembers (BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public)) {
 					if (LogProgress)
 						Console.WriteLine ($"M: {m}");
 					var ma = CheckAvailability (m);
 					if (ta == null || ma == null)
 						continue;
+
+					// need to skip members that are copied to satisfy interfaces (protocol members)
+					if (FoundInProtocols (m, t))
+						continue;
+
 					// Duplicate checks, e.g. same attribute on member and type (extranous metadata)
 					if (ma.Version == ta.Version) {
-// about 4000
-//						AddErrorLine ($"[FAIL] {ma.Version} (Member) == {ta.Version} (Type) on '{m}'.");
+						AddErrorLine ($"[FAIL] {ma.Version} ({m}) == {ta.Version} ({t})");
 					}
 					// Consistency checks, e.g. member lower than type
 					// note: that's valid in some cases, like a new base type being introduced
 					if (ma.Version < ta.Version) {
-// about 8000
-//						AddErrorLine ($"[FAIL] {ma.Version} (Member) < {ta.Version} (Type) on '{m}'.");
+						switch (t.FullName) {
+						case "CoreBluetooth.CBPeer":
+							switch (m.ToString ()) {
+							// type added later and existing property was moved
+							case "Foundation.NSUuid get_Identifier()":
+							case "Foundation.NSUuid Identifier":
+								continue;
+							}
+							break;
+						case "MetricKit.MXUnitAveragePixelLuminance":
+						case "MetricKit.MXUnitSignalBars":
+							// design bug wrt generics leading to redefinition of some members in subclasses
+							if (m.ToString () == "System.String Symbol")
+								continue;
+							break;
+						}
+						AddErrorLine ($"[FAIL] {ma.Version} ({m}) < {ta.Version} ({t})");
 					}
 				}
 			}


### PR DESCRIPTION
This can easily happen when existing type(s) or framework are added to a
platform. E.g.

```csharp
[Watch (6,0)][iOS (9,0)] interface AVFoo {
   [Watch (6,0)][iOS (13,0)]
   void NewMember ();
}
```

Here we have duplicate attributes and, while not confusing, it does mean
extra (and non required) metadata into the platform assemblies.

```csharp
[Watch (6,0)][iOS (9,0)] interface AVFoo {
   [Watch (5,0)][iOS (13,0)]
   void NewMember ();
}
```

Here we declare a member as available when the type is not. I'm not sure
how the IDE will react - but this should be audited since one of them is
wrong (whatever the IDE behaviour is).

Fix https://github.com/xamarin/xamarin-macios/issues/6856

Backport of https://github.com/xamarin/xamarin-macios/pull/9825