### PR TITLE
[tests] Set DEVELOPER_DIR when calling xcrun manually.

### DIFF
--- a/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
@@ -184,7 +184,7 @@
     <CustomMetalSmeltingInput Include="..\..\Resources\fragmentShader.metal" />
   </ItemGroup>
 
-  <Target Name="CustomMetalSmelting" Inputs="@(CustomMetalSmeltingInput)" Outputs="$(_AppBundlePath)\fragmentShader.metallib" Condition="'$(_SdkIsSimulator)' != 'true'" DependsOnTargets="_GenerateBundleName">
+  <Target Name="CustomMetalSmelting" Inputs="@(CustomMetalSmeltingInput)" Outputs="$(_AppBundlePath)\fragmentShader.metallib" Condition="'$(_SdkIsSimulator)' != 'true'" DependsOnTargets="_GenerateBundleName;_DetectSdkLocations">
     <PropertyGroup>
         <_SmeltingSdk Condition="'$(_PlatformName)' == 'iOS'">iphoneos</_SmeltingSdk>
         <_SmeltingSdk Condition="'$(_PlatformName)' == 'tvOS'">appletvos</_SmeltingSdk>
@@ -192,8 +192,8 @@
         <_SmeltingMinOS Condition="'$(_PlatformName)' == 'tvOS'">-mtvos-version-min=11.0</_SmeltingMinOS>
     </PropertyGroup>
     <MakeDir Directories="$(IntermediateOutputPath);$(AppBundleDir)" />
-    <Exec Command="xcrun -sdk $(_SmeltingSdk) metal -c @(CustomMetalSmeltingInput) -o $(IntermediateOutputPath)\fragmentShader.air $(_SmeltingMinOS)" />
-    <Exec Command="xcrun -sdk $(_SmeltingSdk) metallib $(IntermediateOutputPath)\fragmentShader.air -o $(AppBundleDir)\fragmentShader.metallib" />
+    <Exec Command="xcrun -sdk $(_SmeltingSdk) metal -c @(CustomMetalSmeltingInput) -o $(IntermediateOutputPath)\fragmentShader.air $(_SmeltingMinOS)" EnvironmentVariables="DEVELOPER_DIR=$(_SdkDevPath)" />
+    <Exec Command="xcrun -sdk $(_SmeltingSdk) metallib $(IntermediateOutputPath)\fragmentShader.air -o $(AppBundleDir)\fragmentShader.metallib" EnvironmentVariables="DEVELOPER_DIR=$(_SdkDevPath)" />
   </Target>
 
   <Target Name="BeforeBuild" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)" DependsOnTargets="CustomMetalSmelting" >

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -374,7 +374,7 @@
     <GeneratedTestOutput Include="..\..\tests\test-libraries\RegistrarTest.generated.cs" />
     <CustomMetalSmeltingInput Include="Resources\fragmentShader.metal" />
   </ItemGroup>
-  <Target Name="CustomMetalSmelting" Inputs="@(CustomMetalSmeltingInput)" Outputs="$(_AppBundlePath)\fragmentShader.metallib" Condition="'$(Platform)' != 'iPhoneSimulator' And '$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" DependsOnTargets="_GenerateBundleName">
+  <Target Name="CustomMetalSmelting" Inputs="@(CustomMetalSmeltingInput)" Outputs="$(_AppBundlePath)\fragmentShader.metallib" Condition="'$(Platform)' != 'iPhoneSimulator' And '$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" DependsOnTargets="_GenerateBundleName;_DetectSdkLocations">
     <PropertyGroup>
         <_SmeltingSdk Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">iphoneos</_SmeltingSdk>
         <_SmeltingSdk Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.TVOS'">appletvos</_SmeltingSdk>
@@ -382,8 +382,8 @@
         <_SmeltingMinOS Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.TVOS'">-mtvos-version-min=11.0</_SmeltingMinOS>
     </PropertyGroup>
     <MakeDir Directories="$(IntermediateOutputPath);$(AppBundleDir)" />
-    <Exec Command="xcrun -sdk $(_SmeltingSdk) metal -c @(CustomMetalSmeltingInput) -o $(IntermediateOutputPath)\fragmentShader.air $(_SmeltingMinOS)" />
-    <Exec Command="xcrun -sdk $(_SmeltingSdk) metallib $(IntermediateOutputPath)\fragmentShader.air -o $(AppBundleDir)\fragmentShader.metallib" />
+    <Exec Command="xcrun -sdk $(_SmeltingSdk) metal -c @(CustomMetalSmeltingInput) -o $(IntermediateOutputPath)\fragmentShader.air $(_SmeltingMinOS)" EnvironmentVariables="DEVELOPER_DIR=$(_SdkDevPath)" />
+    <Exec Command="xcrun -sdk $(_SmeltingSdk) metallib $(IntermediateOutputPath)\fragmentShader.air -o $(AppBundleDir)\fragmentShader.metallib" EnvironmentVariables="DEVELOPER_DIR=$(_SdkDevPath)" />
   </Target>
   <Target Name="BeforeBuild" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)" DependsOnTargets="CustomMetalSmelting" >
     <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -262,10 +262,10 @@
     <GeneratedTestOutput Include="..\..\tests\test-libraries\RegistrarTest.generated.cs" />
     <CustomMetalSmeltingInput Include="..\monotouch-test\Resources\fragmentShader.metal" />
   </ItemGroup>
-  <Target Name="CustomMetalSmelting" Inputs="@(CustomMetalSmeltingInput)" Outputs="$(_AppBundlePath)\Contents\Resources\fragmentShader.metallib" DependsOnTargets="_GenerateBundleName">
+  <Target Name="CustomMetalSmelting" Inputs="@(CustomMetalSmeltingInput)" Outputs="$(_AppBundlePath)\Contents\Resources\fragmentShader.metallib" DependsOnTargets="_GenerateBundleName;_DetectSdkLocations">
     <MakeDir Directories="$(IntermediateOutputPath)\Contents\Resources;$(AppBundleDir)\Contents\Resources" />
-    <Exec Command="xcrun -sdk macosx metal -c @(CustomMetalSmeltingInput) -o $(IntermediateOutputPath)\Contents\Resources\fragmentShader.air -mmacos-version-min=10.13" />
-    <Exec Command="xcrun -sdk macosx metallib $(IntermediateOutputPath)\Contents\Resources\fragmentShader.air -o $(AppBundleDir)\Contents\Resources\fragmentShader.metallib" />
+    <Exec Command="xcrun -sdk macosx metal -c @(CustomMetalSmeltingInput) -o $(IntermediateOutputPath)\Contents\Resources\fragmentShader.air -mmacos-version-min=10.13" EnvironmentVariables="DEVELOPER_DIR=$(_SdkDevPath)"/>
+    <Exec Command="xcrun -sdk macosx metallib $(IntermediateOutputPath)\Contents\Resources\fragmentShader.air -o $(AppBundleDir)\Contents\Resources\fragmentShader.metallib" EnvironmentVariables="DEVELOPER_DIR=$(_SdkDevPath)" />
   </Target>
   <Target Name="BeforeBuild" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)" DependsOnTargets="CustomMetalSmelting">
     <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />


### PR DESCRIPTION
This fixes build problems that may occur when the various versions of Xcode
(system Xcode, VSMac Xcode, '/Applications/Xcode.app' symlink) don't agree on
which Xcode is THE Xcode:

    CustomMetalSmelting:
      Creating directory "bin/iPhone/Debug-unified/monotouchtest.app".
      xcrun -sdk iphoneos metal -c Resources/fragmentShader.metal -o obj/iPhone/Debug-unified//fragmentShader.air -mios-version-min=11.0
      2020-10-14 09:09:03.985 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for IDEWatchSupportUI.ideplugin (com.apple.dt.IDEWatchSupportUI) not present
      2020-10-14 09:09:03.985 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for IDEWatchSupportCore.ideplugin (com.apple.dt.IDEWatchSupportCore) not present
      2020-10-14 09:09:03.985 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for IBCocoaTouchBuildSupport.ideplugin (com.apple.dt.IDE.IBCocoaTouchBuildSupport) not present
      2020-10-14 09:09:03.985 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for GPUDebuggerOSXSupport.ideplugin (com.apple.dt.gpu.GPUDebuggerOSXSupport) not present
      2020-10-14 09:09:03.985 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for IDEOSXSupportCore.ideplugin (com.apple.dt.IDE.IDEOSXSupportCore) not present
      2020-10-14 09:09:03.985 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for IDEOSXSupportUI.ideplugin (com.apple.dt.IDE.IDEOSXSupportUI) not present
      2020-10-14 09:09:03.985 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for IBAppleTVBuildSupport.ideplugin (com.apple.dt.IDE.IBAppleTVBuildSupport) not present
      2020-10-14 09:09:03.985 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for IDEInterfaceBuilderAppleTVIntegration.ideplugin (com.apple.dt.IDE.IDEInterfaceBuilderAppleTVIntegration) not present
      2020-10-14 09:09:03.985 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for IDEInterfaceBuilderWatchKitIntegration.ideplugin (com.apple.dt.IDE.IDEInterfaceBuilderWatchKitIntegration) not present
      2020-10-14 09:09:03.986 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for IDEInterfaceBuilderWatchKitBuildSupport.ideplugin (com.apple.dt.IDE.IDEInterfaceBuilderWatchKitBuildSupport) not present
      2020-10-14 09:09:03.986 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for GPUDebuggertvOSSupport.ideplugin (com.apple.dt.gpu.GPUDebuggertvOSSupport) not present
      2020-10-14 09:09:03.986 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for IDEAppleTVSupportUI.ideplugin (com.apple.dt.IDEAppleTVSupportUI) not present
      2020-10-14 09:09:03.986 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for IDEAppleTVSupportCore.ideplugin (com.apple.dt.IDEAppleTVSupportCore) not present
      2020-10-14 09:09:03.986 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for DVTAppleTVSupportCore.dvtplugin (com.apple.dt.DVTAppleTVSupportCore) not present
      2020-10-14 09:09:03.986 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for GPUDebuggeriOSSupport.ideplugin (com.apple.dt.gpu.GPUDebuggeriOSSupport) not present
      2020-10-14 09:09:03.986 xcodebuild[59510:1676867] [MT] DVTPlugInManager: Required plug-in compatibility UUID C80A9C11-3902-4885-944E-A035869BA910 for IDEiOSPlatformSupportCore.ideplugin (com.apple.dt.IDEiOSPlatformSupportCore) not present
      2020-10-14 09:09:04.081 xcodebuild[59510:1676867] [MT] DVTPlatform: Required content for platform watchOS is missing.
      Domain: DVTFoundationErrorDomain
      Code: 4
      Recovery Suggestion: Please reinstall Xcode.
      --
      No Xcode.DVTFoundation.ExtendedPlatformInfo extension found for platform with identifier com.apple.platform.watchos
      Domain: DVTExtendedPlatformInfoErrorDomain
      Code: 2
      --
    xcodebuild : error : Initialization failed. [[...]/xamarin-macios/tests/monotouch-test/monotouch-test.csproj]
      	Reason: Required content for platform watchOS is missing.
    xcrun : error : sh -c '/Applications/Xcode_11.7.0.app/Contents/Developer/usr/bin/xcodebuild -sdk iphoneos -find metal 2> /dev/null' failed with exit code 17920: (null) (errno=No such file or directory) [[...]/xamarin-macios/tests/monotouch-test/monotouch-test.csproj]
    xcrun : error : unable to find utility "metal", not a developer tool or in PATH [[...]/xamarin-macios/tests/monotouch-test/monotouch-test.csproj]
    [...]/xamarin-macios/tests/monotouch-test/monotouch-test.csproj(385,5): error MSB3073: The command "xcrun -sdk iphoneos metal -c Resources/fragmentShader.metal -o obj/iPhone/Debug-unified//fragmentShader.air -mios-version-min=11.0" exited with code 72.