### PR TITLE
[dotnet] Remove workaround for mono/linker#1435, which has now been fixed.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2394,7 +2394,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		static extern IntPtr class_getInstanceMethod (IntPtr cls, IntPtr sel);
 
 #if !MONOMAC // Registrar_OutExportDerivedClass is from fsharp tests
-#if !NET // The F# test library makes the linker crash (https://github.com/mono/linker/issues/1435), so exclude this test because it requires the F# test library
 		[Test]
 		public void OutOverriddenWithoutOutAttribute ()
 		{
@@ -2407,7 +2406,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				}
 			}
 		}
-#endif // !NET
 #endif
 
 		class ProtocolArgumentClass : NSObject

--- a/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
@@ -106,8 +106,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\EmbeddedResources\dotnet\iOS\EmbeddedResources.csproj" />
     <ProjectReference Include="..\..\..\..\tests\bindings-test\dotnet\iOS\bindings-test.csproj" />
-    <!-- https://github.com/mono/linker/issues/1435 -->
-    <!-- <ProjectReference Include="..\..\..\fsharplibrary\dotnet\iOS\fsharplibrary.fsproj" /> -->
+    <ProjectReference Include="..\..\..\fsharplibrary\dotnet\iOS\fsharplibrary.fsproj" />
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="..\..\CoreImage\Xam.png">


### PR DESCRIPTION
Contributes to https://github.com/xamarin/xamarin-macios/issues/8901.