### PR TITLE
[Tools] Remove compilation warning CS0105

### DIFF
--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using Mono.Cecil;
 
 using Xamarin.Bundler;
-using Xamarin.Utils;
 using Registrar;
 #endif
 


### PR DESCRIPTION
For reviewers, expand the github diff, you will see that the namespace was added outside the #if, ergo is not needed and gives the warning.