### PR TITLE
[xcode12.2] [Tests] Fix a test that crashes on devices due to possible bonjour services present.

### DIFF
--- a/tests/monotouch-test/Network/NWBrowserTest.cs
+++ b/tests/monotouch-test/Network/NWBrowserTest.cs
@@ -73,6 +73,8 @@ namespace MonoTouchFixtures.Network {
 		[Test]
 		public void TestStateChangesHandler ()
 		{
+			if (Runtime.Arch == Arch.DEVICE)
+				Assert.Ignore ("This test makes connection assumptions and can crash the device tests.");
 			// In the test we are doing the following:
 			//
 			// 1. Start a browser. At this point, we have no listeners (unless someone is exposing it in the lab)


### PR DESCRIPTION


Backport of #9867.

/cc @mandel-macaque 