### PR TITLE
[tests][intro] Detect cases where [Unavailable] is mis-used

### DIFF
--- a/src/WatchKit/iOS/WKAccessibility.cs
+++ b/src/WatchKit/iOS/WKAccessibility.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 using ObjCRuntime;
 
 namespace WatchKit {
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
+
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKAccessibilityImageRegion.cs
+++ b/src/WatchKit/iOS/WKAccessibilityImageRegion.cs
@@ -8,7 +8,6 @@ using ObjCRuntime;
 
 namespace WatchKit {
 	[Register ("WKAccessibilityImageRegion", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKErrorCode.cs
+++ b/src/WatchKit/iOS/WKErrorCode.cs
@@ -6,7 +6,6 @@ using Foundation;
 using ObjCRuntime;
 
 namespace WatchKit {
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKInterfaceButton.cs
+++ b/src/WatchKit/iOS/WKInterfaceButton.cs
@@ -7,7 +7,6 @@ using ObjCRuntime;
 
 namespace WatchKit {
 	[Register ("WKInterfaceButton", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKInterfaceController.cs
+++ b/src/WatchKit/iOS/WKInterfaceController.cs
@@ -10,7 +10,6 @@ using UIKit;
 
 namespace WatchKit {
 	[Register ("WKInterfaceController", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKInterfaceDate.cs
+++ b/src/WatchKit/iOS/WKInterfaceDate.cs
@@ -7,7 +7,6 @@ using ObjCRuntime;
 
 namespace WatchKit {
 	[Register ("WKInterfaceDate", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKInterfaceDevice.cs
+++ b/src/WatchKit/iOS/WKInterfaceDevice.cs
@@ -10,7 +10,6 @@ using UIKit;
 
 namespace WatchKit {
 	[Register ("WKInterfaceDevice", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKInterfaceGroup.cs
+++ b/src/WatchKit/iOS/WKInterfaceGroup.cs
@@ -7,7 +7,6 @@ using ObjCRuntime;
 
 namespace WatchKit {
 	[Register ("WKInterfaceGroup", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKInterfaceImage.cs
+++ b/src/WatchKit/iOS/WKInterfaceImage.cs
@@ -7,7 +7,6 @@ using ObjCRuntime;
 
 namespace WatchKit {
 	[Register ("WKInterfaceImage", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKInterfaceLabel.cs
+++ b/src/WatchKit/iOS/WKInterfaceLabel.cs
@@ -7,7 +7,6 @@ using ObjCRuntime;
 
 namespace WatchKit {
 	[Register ("WKInterfaceLabel", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKInterfaceMap.cs
+++ b/src/WatchKit/iOS/WKInterfaceMap.cs
@@ -8,7 +8,6 @@ using ObjCRuntime;
 
 namespace WatchKit {
 	[Register ("WKInterfaceMap", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKInterfaceObject.cs
+++ b/src/WatchKit/iOS/WKInterfaceObject.cs
@@ -9,7 +9,6 @@ using UIKit;
 
 namespace WatchKit {
 	[Register ("WKInterfaceObject", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKInterfaceSeparator.cs
+++ b/src/WatchKit/iOS/WKInterfaceSeparator.cs
@@ -7,7 +7,6 @@ using ObjCRuntime;
 
 namespace WatchKit {
 	[Register ("WKInterfaceSeparator", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKInterfaceSlider.cs
+++ b/src/WatchKit/iOS/WKInterfaceSlider.cs
@@ -7,7 +7,6 @@ using ObjCRuntime;
 
 namespace WatchKit {
 	[Register ("WKInterfaceSlider", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKInterfaceSwitch.cs
+++ b/src/WatchKit/iOS/WKInterfaceSwitch.cs
@@ -7,7 +7,6 @@ using ObjCRuntime;
 
 namespace WatchKit {
 	[Register ("WKInterfaceSwitch", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKInterfaceTable.cs
+++ b/src/WatchKit/iOS/WKInterfaceTable.cs
@@ -7,7 +7,6 @@ using ObjCRuntime;
 
 namespace WatchKit {
 	[Register ("WKInterfaceTable", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKInterfaceTimer.cs
+++ b/src/WatchKit/iOS/WKInterfaceTimer.cs
@@ -7,7 +7,6 @@ using ObjCRuntime;
 
 namespace WatchKit {
 	[Register ("WKInterfaceTimer", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKMenuItemIcon.cs
+++ b/src/WatchKit/iOS/WKMenuItemIcon.cs
@@ -5,7 +5,6 @@ using System.ComponentModel;
 using ObjCRuntime;
 
 namespace WatchKit {
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKTextInputMode.cs
+++ b/src/WatchKit/iOS/WKTextInputMode.cs
@@ -5,7 +5,6 @@ using System.ComponentModel;
 using ObjCRuntime;
 
 namespace WatchKit {
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKUserNotificationInterfaceController.cs
+++ b/src/WatchKit/iOS/WKUserNotificationInterfaceController.cs
@@ -7,7 +7,6 @@ using ObjCRuntime;
 
 namespace WatchKit {
 	[Register ("WKUserNotificationInterfaceController", SkipRegistration = true)]
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/WatchKit/iOS/WKUserNotificationInterfaceType.cs
+++ b/src/WatchKit/iOS/WKUserNotificationInterfaceType.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 using ObjCRuntime;
 
 namespace WatchKit {
-	[Introduced (PlatformName.iOS, 8,2, PlatformArchitecture.All)]
+
 	[Unavailable (PlatformName.iOS, PlatformArchitecture.All)]
 	[Obsolete (Constants.WatchKitRemoved)]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/watchkit.cs
+++ b/src/watchkit.cs
@@ -26,7 +26,6 @@ using System;
 using System.ComponentModel;
 
 namespace WatchKit {
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[BaseType (typeof (NSObject))]
 	[Abstract] // <quote>To use this class, subclass it</quote> 
@@ -51,28 +50,23 @@ namespace WatchKit {
 		[Export ("didDeactivate")]
 		void DidDeactivate ();
 
-#if WATCH
 		[Export ("didAppear")]
 		void DidAppear ();
 
 		[Export ("willDisappear")]
 		void WillDisappear ();
-#endif
 
 		[Export ("table:didSelectRowAtIndex:")]
 		void DidSelectRow (WKInterfaceTable table, nint rowIndex);
 
-		[Deprecated (PlatformName.iOS, 10,0, message: "Use 'UNUserNotificationCenterDelegate' instead.")]
 		[Deprecated (PlatformName.WatchOS, 3,0, message: "Use 'UNUserNotificationCenterDelegate' instead.")]
 		[Export ("handleActionWithIdentifier:forRemoteNotification:")]
 		void HandleRemoteNotificationAction ([NullAllowed] string identifier, NSDictionary remoteNotification);
 
-		[Deprecated (PlatformName.iOS, 10,0, message: "Use 'UNUserNotificationCenterDelegate' instead.")]
 		[Deprecated (PlatformName.WatchOS, 3,0, message: "Use 'UNUserNotificationCenterDelegate' instead.")]
 		[Export ("handleActionWithIdentifier:forLocalNotification:")]
 		void HandleLocalNotificationAction ([NullAllowed] string identifier, UILocalNotification localNotification);
 
-		[iOS (10,0)]
 		[NoWatch]
 		[Export ("handleActionWithIdentifier:forNotification:")]
 		void HandleAction ([NullAllowed] string identifier, UNNotification notification);
@@ -156,7 +150,7 @@ namespace WatchKit {
 		// This NSDictionary is OK, it is arbitrary and user specific
 		void UpdateUserActivity (string type, [NullAllowed] NSDictionary userInfo, [NullAllowed] NSUrl webpageURL);
 
-		[Watch (5,0)][ NoiOS]
+		[Watch (5,0)]
 		[Export ("updateUserActivity:")]
 		void UpdateUserActivity (NSUserActivity userActivity);
 
@@ -168,7 +162,6 @@ namespace WatchKit {
 		[Async]
 		void PresentTextInputController ([NullAllowed] string [] suggestions, WKTextInputMode inputMode, Action<NSArray> completion);
 
-		[iOS (9,0)]
 		[Export ("presentTextInputControllerWithSuggestionsForLanguage:allowedInputMode:completion:")]
 		[Async]
 		void PresentTextInputController ([NullAllowed] Func<NSString, NSArray> suggestionsHandler, WKTextInputMode inputMode, Action<NSArray> completion);
@@ -181,7 +174,7 @@ namespace WatchKit {
 		[Static, Export ("reloadRootControllersWithNames:contexts:")]
 		void ReloadRootControllers (string [] names, [NullAllowed] NSObject [] contexts);
 
-		[Watch (4,0)][NoiOS]
+		[Watch (4,0)]
 		[Static]
 		[Export ("reloadRootPageControllersWithNames:contexts:orientation:pageIndex:")]
 		void ReloadRootPageControllers (string[] names, [NullAllowed] NSObject[] contexts, WKPageOrientation orientation, nint pageIndex);
@@ -192,7 +185,6 @@ namespace WatchKit {
 		NSString ErrorDomain { get; }
 #endif
 
-#if WATCH
 		[Export ("dismissMediaPlayerController")]
 		void DismissMediaPlayerController ();
 
@@ -235,46 +227,45 @@ namespace WatchKit {
 		[Export ("pickerDidSettle:")]
 		void PickerDidSettle (WKInterfacePicker picker);
 
-		[NoiOS]
+#if WATCH
 		[Export ("presentMediaPlayerControllerWithURL:options:completion:")]
 		[Async (ResultType = typeof (WKPresentMediaPlayerResult))]
 		void PresentMediaPlayerController (NSUrl url, [NullAllowed] NSDictionary options, Action<bool, double, NSError> completion);
 #endif
 
-		[Watch (3,0)][NoiOS]
+		[Watch (3,0)]
 		[Export ("crownSequencer", ArgumentSemantic.Strong)]
 		WKCrownSequencer CrownSequencer { get; }
 
-		[Watch (4,0)][NoiOS]
+		[Watch (4,0)]
 		[Export ("scrollToObject:atScrollPosition:animated:")]
 		void ScrollTo (WKInterfaceObject @object, WKInterfaceScrollPosition scrollPosition, bool animated);
 
-		[Watch (4,0)][NoiOS]
+		[Watch (4,0)]
 		[Export ("interfaceDidScrollToTop")]
 		void InterfaceDidScrollToTop ();
 
-		[Watch (4,0)][NoiOS]
+		[Watch (4,0)]
 		[Export ("interfaceOffsetDidScrollToTop")]
 		void InterfaceOffsetDidScrollToTop ();
 
-		[Watch (4,0)][NoiOS]
+		[Watch (4,0)]
 		[Export ("interfaceOffsetDidScrollToBottom")]
 		void InterfaceOffsetDidScrollToBottom ();
 
-		[Watch (5,0), NoiOS]
+		[Watch (5,0)]
 		[Export ("contentSafeAreaInsets")]
 		UIEdgeInsets ContentSafeAreaInsets { get; }
 
-		[Watch (5,0), NoiOS]
+		[Watch (5,0)]
 		[Export ("systemMinimumLayoutMargins")]
 		NSDirectionalEdgeInsets SystemMinimumLayoutMargins { get; }
 
-		[Watch (5,0), NoiOS]
+		[Watch (5,0)]
 		[Export ("tableScrollingHapticFeedbackEnabled")]
 		bool TableScrollingHapticFeedbackEnabled { [Bind ("isTableScrollingHapticFeedbackEnabled")] get; set; }
 	}
 
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[BaseType (typeof (WKInterfaceController))]
 	[DisableDefaultCtor] // DesignatedInitializer below
@@ -284,48 +275,44 @@ namespace WatchKit {
 		[Export ("init")]
 		IntPtr Constructor ();
 
-		[Deprecated (PlatformName.iOS, 10,0, message: "Use 'DidReceiveNotification' instead.")]
 		[Deprecated (PlatformName.WatchOS, 3,0, message: "Use 'DidReceiveNotification' instead.")]
 		[Export ("didReceiveRemoteNotification:withCompletion:")]
 		void DidReceiveRemoteNotification (NSDictionary remoteNotification, Action<WKUserNotificationInterfaceType> completionHandler);
 
-		[Deprecated (PlatformName.iOS, 10,0, message: "Use 'DidReceiveNotification' instead.")]
 		[Deprecated (PlatformName.WatchOS, 3,0, message: "Use 'DidReceiveNotification' instead.")]
 		[Export ("didReceiveLocalNotification:withCompletion:")]
 		void DidReceiveLocalNotification (UILocalNotification localNotification, Action<WKUserNotificationInterfaceType> completionHandler);
 
 		[Deprecated (PlatformName.WatchOS, 5,0, message: "Use 'DidReceiveNotification(UNNotification)' instead.")]
-		[Watch (3,0)][iOS (10,0)]
+		[Watch (3,0)]
 		[Export ("didReceiveNotification:withCompletion:")]
 		void DidReceiveNotification (UNNotification notification, Action<WKUserNotificationInterfaceType> completionHandler);
 
-		[NoiOS]
 		[Deprecated (PlatformName.WatchOS, 3,0, message: "Use overload accepting an 'UNNotification' parameter.")]
 		[Export ("suggestionsForResponseToActionWithIdentifier:forRemoteNotification:inputLanguage:")]
 		string[] GetSuggestionsForResponseToAction (string identifier, NSDictionary remoteNotification, string inputLanguage);
 
-		[NoiOS]
 		[Deprecated (PlatformName.WatchOS, 3,0, message: "Use overload accepting an 'UNNotification' parameter.")]
 		[Export ("suggestionsForResponseToActionWithIdentifier:forLocalNotification:inputLanguage:")]
 		string[] GetSuggestionsForResponseToAction (string identifier, UILocalNotification localNotification, string inputLanguage);
 
-		[Watch (3,0)][NoiOS]
+		[Watch (3,0)]
 		[Export ("suggestionsForResponseToActionWithIdentifier:forNotification:inputLanguage:")]
 		string[] GetSuggestionsForResponseToAction (string identifier, UNNotification notification, string inputLanguage);
 
-		[Watch (5,0)][NoiOS]
+		[Watch (5,0)]
 		[Export ("notificationActions", ArgumentSemantic.Copy)]
 		UNNotificationAction[] NotificationActions { get; set; }
 
-		[Watch (5,0)][NoiOS]
+		[Watch (5,0)]
 		[Export ("didReceiveNotification:")]
 		void DidReceiveNotification (UNNotification notification);
 
-		[Watch (5,0)][NoiOS]
+		[Watch (5,0)]
 		[Export ("performNotificationDefaultAction")]
 		void PerformNotificationDefaultAction ();
 
-		[Watch (5,0)][NoiOS]
+		[Watch (5,0)]
 		[Export ("performDismissAction")]
 		void PerformDismissAction ();
 
@@ -336,7 +323,6 @@ namespace WatchKit {
 
 	}
 	
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -357,38 +343,29 @@ namespace WatchKit {
 		[Export ("setHeight:")]
 		void SetHeight (nfloat height);
 
-		[Watch (2,1), NoiOS]
+		[Watch (2,1)]
 		[Export ("setSemanticContentAttribute:")]
 		void SetSemanticContentAttribute (WKInterfaceSemanticContentAttribute semanticContentAttribute);
 
-#if WATCH
-		[NoiOS]
 		[Export ("setHorizontalAlignment:")]
 		void SetHorizontalAlignment (WKInterfaceObjectHorizontalAlignment horizontalAlignment);
 
-		[NoiOS]
 		[Export ("setVerticalAlignment:")]
 		void SetVerticalAlignment (WKInterfaceObjectVerticalAlignment verticalAlignment);
-#endif
 
-		[NoiOS]
 		[Export ("setRelativeWidth:withAdjustment:")]
 		void SetRelativeWidth (nfloat width, nfloat adjustment);
 
-		[NoiOS]
 		[Export ("setRelativeHeight:withAdjustment:")]
 		void SetRelativeHeight (nfloat height, nfloat adjustment);
 
-		[NoiOS]
 		[Export ("sizeToFitWidth")]
 		void SizeToFitWidth ();
 
-		[NoiOS]
 		[Export ("sizeToFitHeight")]
 		void SizeToFitHeight ();
 	}
 
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[Category]
 	[BaseType (typeof (WKInterfaceObject))]
@@ -414,18 +391,17 @@ namespace WatchKit {
 		[Export ("setAccessibilityIdentifier:")]
 		void SetAccessibilityIdentifier ([NullAllowed] string accessibilityIdentifier);
 
-		[Watch (2,0)][NoiOS]
+		[Watch (2,0)]
 		[Notification]
 		[Field ("WKAccessibilityVoiceOverStatusChanged")]
 		NSString VoiceOverStatusChanged { get; }
 
-		[Watch (4,0)][NoiOS]
+		[Watch (4,0)]
 		[Notification]
 		[Field ("WKAccessibilityReduceMotionStatusDidChangeNotification")]
 		NSString ReduceMotionStatusDidChangeNotification { get; }
 	}
 
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // does not make sense to create, it should only be used thru the singleton
@@ -464,81 +440,80 @@ namespace WatchKit {
 		[Export ("removeAllCachedImages")]
 		void RemoveAllCachedImages ();
 
-		[iOS (9,0), Watch (2,0)]
+		[Watch (2,0)]
 		[Export ("systemVersion")]
 		string SystemVersion { get; }
 
-		[iOS (9,0), Watch (2,0)]
+		[Watch (2,0)]
 		[Export ("name")]
 		string Name { get; }
 
-		[iOS (9,0), Watch (2,0)]
+		[Watch (2,0)]
 		[Export ("model")]
 		string Model { get; }
 
-		[iOS (9,0), Watch (2,0)]
+		[Watch (2,0)]
 		[Export ("localizedModel")]
 		string LocalizedModel { get; }
 
-		[iOS (9,0)][Watch (2,0)]
+		[Watch (2,0)]
 		[Export ("systemName")]
 		string SystemName { get; }
 
-		[Watch (3,0)][NoiOS]
+		[Watch (3,0)]
 		[Export ("waterResistanceRating")]
 		WKWaterResistanceRating WaterResistanceRating { get; }
 
-		[Watch (2,0), NoiOS]
+		[Watch (2,0)]
 		[Export ("playHaptic:")]
 		void PlayHaptic (WKHapticType type);
 
-		[Watch (2,1), NoiOS]
+		[Watch (2,1)]
 		[Export ("layoutDirection")]
 		WKInterfaceLayoutDirection LayoutDirection { get; }
 
-		[Watch (2,1), NoiOS]
+		[Watch (2,1)]
 		[Static]
 		[Export ("interfaceLayoutDirectionForSemanticContentAttribute:")]
 		WKInterfaceLayoutDirection GetInterfaceLayoutDirection (WKInterfaceSemanticContentAttribute semanticContentAttribute);
 
-		[Watch (3,0)][NoiOS]
+		[Watch (3,0)]
 		[Export ("wristLocation")]
 		WKInterfaceDeviceWristLocation WristLocation { get; }
 
-		[Watch (3,0)][NoiOS]
+		[Watch (3,0)]
 		[Export ("crownOrientation")]
 		WKInterfaceDeviceCrownOrientation CrownOrientation { get; }
 
-		[Watch (4,0)][NoiOS]
+		[Watch (4,0)]
 		[Export ("batteryMonitoringEnabled")]
 		bool BatteryMonitoringEnabled { [Bind ("isBatteryMonitoringEnabled")] get; set; }
 
-		[Watch (4,0)][NoiOS]
+		[Watch (4,0)]
 		[Export ("batteryLevel")]
 		float BatteryLevel { get; }
 
-		[Watch (4,0)][NoiOS]
+		[Watch (4,0)]
 		[Export ("batteryState")]
 		WKInterfaceDeviceBatteryState BatteryState { get; }
 
-		[Watch (6,0)][NoiOS]
+		[Watch (6,0)]
 		[Export ("supportsAudioStreaming")]
 		bool SupportsAudioStreaming { get; }
 
-		[Watch (6,2), NoiOS]
+		[Watch (6,2)]
 		[NullAllowed, Export ("identifierForVendor", ArgumentSemantic.Strong)]
 		NSUuid IdentifierForVendor { get; }
 
-		[Watch (6,1)][NoiOS]
+		[Watch (6,1)]
 		[Export ("enableWaterLock")]
 		void EnableWaterLock ();
 
-		[Watch (6,1)][NoiOS]
+		[Watch (6,1)]
 		[Export ("isWaterLockEnabled")]
 		bool IsWaterLockEnabled { get; }
 	}
 
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[DisableDefaultCtor] // Do not subclass or create instances of this class yourself. -> Handle is nil if init is called
 	[BaseType (typeof (WKInterfaceObject))]
@@ -565,7 +540,6 @@ namespace WatchKit {
 		void SetEnabled (bool enabled);
 	}
 
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[BaseType (typeof (WKInterfaceObject))]
 	[DisableDefaultCtor] // Do not subclass or create instances of this class yourself. -> Handle is nil if init is called
@@ -585,12 +559,10 @@ namespace WatchKit {
 		[Export ("setCornerRadius:")]
 		void SetCornerRadius (nfloat cornerRadius);
 
-		[NoiOS]
 		[Export ("setContentInset:")]
 		void SetContentInset (UIEdgeInsets contentInset);
 	}
 
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[BaseType (typeof (WKInterfaceObject))]
 	[DisableDefaultCtor] // Do not subclass or create instances of this class yourself. -> Handle is nil if init is called
@@ -608,7 +580,6 @@ namespace WatchKit {
 		void SetTintColor ([NullAllowed] UIColor color);
 	}
 
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[DisableDefaultCtor] // Do not subclass or create instances of this class yourself. -> Handle is nil if init is called
 	[BaseType (typeof (WKInterfaceObject))]
@@ -624,7 +595,6 @@ namespace WatchKit {
 		void SetText ([NullAllowed] NSAttributedString attributedText);
 	}
 
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[DisableDefaultCtor] // Do not subclass or create instances of this class yourself. -> Handle is nil if init is called
 	[BaseType (typeof (WKInterfaceObject))]
@@ -639,7 +609,6 @@ namespace WatchKit {
 		void SetCalendar ([NullAllowed] NSCalendar calendar);
 	}
 
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[DisableDefaultCtor] // Do not subclass or create instances of this class yourself. -> Handle is nil if init is called
 	[BaseType (typeof (WKInterfaceObject))]
@@ -658,7 +627,6 @@ namespace WatchKit {
 		void Stop ();
 	}
 
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[DisableDefaultCtor] // Do not subclass or create instances of this class yourself. -> Handle is nil if init is called
 	[BaseType (typeof (WKInterfaceObject))]
@@ -685,20 +653,19 @@ namespace WatchKit {
 		[Export ("scrollToRowAtIndex:")]
 		void ScrollToRow (nint index);
 
-		[Watch (3,0)][NoiOS]
+		[Watch (3,0)]
 		[Export ("performSegueForRow:")]
 		void PerformSegue (nint row);
 
-		[Watch (5,1), NoiOS]
+		[Watch (5,1)]
 		[Export ("curvesAtTop")]
 		bool CurvesAtTop { get; set; }
 
-		[Watch (5,1), NoiOS]
+		[Watch (5,1)]
 		[Export ("curvesAtBottom")]
 		bool CurvesAtBottom { get; set; }
 	}
 
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[DisableDefaultCtor] // Do not subclass or create instances of this class yourself. -> Handle is nil if init is called
 	[BaseType (typeof (WKInterfaceObject))]
@@ -741,7 +708,6 @@ namespace WatchKit {
 		void SetUserTrackingMode (WKInterfaceMapUserTrackingMode mode, bool animated);
 	}
 
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[DisableDefaultCtor] // Do not subclass or create instances of this class yourself. -> Handle is nil if init is called
 	[BaseType (typeof (WKInterfaceObject))]
@@ -750,7 +716,6 @@ namespace WatchKit {
 		void SetColor ([NullAllowed] UIColor color);
 	}
 	
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[DisableDefaultCtor] // Do not subclass or create instances of this class yourself. -> Handle is nil if init is called
 	[BaseType (typeof (WKInterfaceObject))]
@@ -768,7 +733,6 @@ namespace WatchKit {
 		void SetNumberOfSteps (nint numberOfSteps);
 	}
 
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[DisableDefaultCtor] // Do not subclass or create instances of this class yourself. -> Handle is nil if init is called
 	[BaseType (typeof (WKInterfaceObject))]
@@ -790,7 +754,6 @@ namespace WatchKit {
 		void SetTitle ([NullAllowed] NSAttributedString attributedTitle);
 	}
 
-	[iOS (8,2)]
 	[Unavailable (PlatformName.iOS)]
 	[BaseType (typeof (NSObject))]
 	interface WKAccessibilityImageRegion {
@@ -804,21 +767,18 @@ namespace WatchKit {
 
 	interface IWKImageAnimatable {}
 
-	[iOS (9,0)]
 	[Unavailable (PlatformName.iOS)]
 	[Protocol]
 	interface WKImageAnimatable {
-		[iOS (8,2)]
+
 		[Abstract]
 		[Export ("startAnimating")]
 		void StartAnimating ();
 
-		[iOS (8,2)]
 		[Abstract]
 		[Export ("startAnimatingWithImagesInRange:duration:repeatCount:")]
 		void StartAnimating (NSRange imageRange, double duration, nint repeatCount);
 
-		[iOS (8,2)]
 		[Abstract]
 		[Export ("stopAnimating")]
 		void StopAnimating ();
@@ -954,17 +914,17 @@ namespace WatchKit {
 		void SetCurrentTime (double time);
 #endif
 
-		[Watch (2,0), NoiOS]
+		[Watch (2,0)]
 		[Notification]
 		[Field ("WKAudioFilePlayerItemTimeJumpedNotification")]
 		NSString TimeJumpedNotification { get; }
 
-		[Watch (2,0), NoiOS]
+		[Watch (2,0)]
 		[Notification]
 		[Field ("WKAudioFilePlayerItemDidPlayToEndTimeNotification")]
 		NSString DidPlayToEndTimeNotification { get; }
 
-		[Watch (2,0), NoiOS]
+		[Watch (2,0)]
 		[Notification]
 		[Field ("WKAudioFilePlayerItemFailedToPlayToEndTimeNotification")]
 		NSString FailedToPlayToEndTimeNotification { get; }
@@ -1037,23 +997,23 @@ namespace WatchKit {
 		[Export ("globalTintColor")]
 		UIColor GlobalTintColor { get; }
 
-		[Watch (7, 0), NoiOS]
+		[Watch (7, 0)]
 		[Notification, Field ("WKApplicationDidFinishLaunchingNotification")]
 		NSString DidFinishLaunchingNotification { get; }
 
-		[Watch (7, 0), NoiOS]
+		[Watch (7, 0)]
 		[Notification, Field ("WKApplicationDidBecomeActiveNotification")]
 		NSString DidBecomeActiveNotification { get; }
 
-		[Watch (7, 0), NoiOS]
+		[Watch (7, 0)]
 		[Notification, Field ("WKApplicationWillResignActiveNotification")]
 		NSString WillResignActiveNotification { get; }
 
-		[Watch (7, 0), NoiOS]
+		[Watch (7, 0)]
 		[Notification, Field ("WKApplicationWillEnterForegroundNotification")]
 		NSString WillEnterForegroundNotification { get; }
 
-		[Watch (7, 0), NoiOS]
+		[Watch (7, 0)]
 		[Notification, Field ("WKApplicationDidEnterBackgroundNotification")]
 		NSString DidEnterBackgroundNotification { get; }
 	}


### PR DESCRIPTION
For each platform the presence of `[Unavailable]` should mean there are
no other availability (introduced, deprecated or obsoleted) attributes
on the same member.

Also check if the type is unavailable. In that case no member should,
for that platform, have other availability attributes.

Also fix failures - all in WatchKit which was removed from iOS.