### PR TITLE
[coregraphics] Update for Xcode 12.1 GM

### DIFF
--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -559,6 +559,37 @@ namespace CoreGraphics {
 				return CGColorSpaceUsesExtendedRange (handle);
 			}
 		}
+
+#if __IOS__
+		[iOS (14,1)][NoTV][NoWatch][NoMac]
+		[DllImport (Constants.CoreGraphicsLibrary)]
+		static extern bool CGColorSpaceUsesITUR_2100TF (/* CGColorSpaceRef */ IntPtr space);
+
+		[iOS (14,1)][NoTV][NoWatch][NoMac]
+		public bool UsesItur2100TF => CGColorSpaceUsesITUR_2100TF (handle);
+
+		[iOS (14,1)][NoTV][NoWatch][NoMac]
+		[DllImport (Constants.CoreGraphicsLibrary)]
+		static extern IntPtr CGColorSpaceCreateLinearized (/* CGColorSpaceRef */ IntPtr space);
+
+		[iOS (14,1)][NoTV][NoWatch][NoMac]
+		public CGColorSpace CreateLinearized () => Runtime.GetINativeObject<CGColorSpace> (CGColorSpaceCreateLinearized (handle), owns: true);
+
+		[iOS (14,1)][NoTV][NoWatch][NoMac]
+		[DllImport (Constants.CoreGraphicsLibrary)]
+		static extern IntPtr CGColorSpaceCreateExtended (/* CGColorSpaceRef */ IntPtr space);
+
+		[iOS (14,1)][NoTV][NoWatch][NoMac]
+		public CGColorSpace CreateExtended () => Runtime.GetINativeObject<CGColorSpace> (CGColorSpaceCreateExtended (handle), owns: true);
+
+		[iOS (14,1)][NoTV][NoWatch][NoMac]
+		[DllImport (Constants.CoreGraphicsLibrary)]
+		static extern IntPtr CGColorSpaceCreateExtendedLinearized (/* CGColorSpaceRef */ IntPtr space);
+
+		[iOS (14,1)][NoTV][NoWatch][NoMac]
+		public CGColorSpace CreateExtendedLinearized () => Runtime.GetINativeObject<CGColorSpace> (CGColorSpaceCreateExtendedLinearized (handle), owns: true);
+#endif
+
 #endif // !COREBUILD
 	}
 }

--- a/src/coregraphics.cs
+++ b/src/coregraphics.cs
@@ -208,10 +208,18 @@ namespace CoreGraphics {
 		[Field ("kCGColorSpaceExtendedLinearITUR_2020")]
 		NSString ExtendedLinearItur_2020 { get; }
 
+		[iOS (14,1)][NoTV][NoWatch][NoMac]
+		[Field ("kCGColorSpaceExtendedITUR_2020")]
+		NSString ExtendedItur_2020 { get; }
+
 		[Mac (10,14,3)][iOS (12,3)]
 		[TV (12,3)][Watch (5,3)]
 		[Field ("kCGColorSpaceExtendedLinearDisplayP3")]
 		NSString ExtendedLinearDisplayP3 { get; }
+
+		[iOS (14,1)][NoTV][NoWatch][NoMac]
+		[Field ("kCGColorSpaceExtendedDisplayP3")]
+		NSString ExtendedDisplayP3 { get; }
 
 		[Mac (10,14)][iOS (12,0)]
 		[TV (12,0)][Watch (5,0)]

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -214,7 +214,19 @@ partial class TestRuntime
 #elif __IOS__
 				return CheckiOSSystemVersion (14, 0);
 #elif MONOMAC
-				return CheckMacSystemVersion (11, 0, 0);
+				return CheckMacSystemVersion (10, 15, 6);
+#else
+				throw new NotImplementedException ();
+#endif
+			case 1:
+#if __WATCHOS__
+				return CheckWatchOSSystemVersion (7, 0);
+#elif __TVOS__
+				return ChecktvOSSystemVersion (14, 0);
+#elif __IOS__
+				return CheckiOSSystemVersion (14, 1);
+#elif MONOMAC
+				return CheckMacSystemVersion (10, 15, 6);
 #else
 				throw new NotImplementedException ();
 #endif

--- a/tests/monotouch-test/CoreGraphics/ColorSpaceTest.cs
+++ b/tests/monotouch-test/CoreGraphics/ColorSpaceTest.cs
@@ -398,5 +398,50 @@ namespace MonoTouchFixtures.CoreGraphics {
 			using (var cs = CGColorSpace.CreateWithName (CGColorSpaceNames.DisplayP3_Hlg))
 				Assert.True (cs.IsHdr, "DisplayP3_Hlg");
 		}
+
+#if __IOS__
+		[Test]
+		public void CGColorSpaceUsesITUR_2100TFTest ()
+		{
+			TestRuntime.AssertXcodeVersion (12, 1);
+			using (var cs = CGColorSpace.CreateWithName (CGColorSpaceNames.DisplayP3_Hlg))
+				Assert.True (cs.UsesItur2100TF, "DisplayP3_Hlg");
+			using (var cs = CGColorSpace.CreateWithName (CGColorSpaceNames.GenericRgb))
+				Assert.False (cs.UsesItur2100TF, "GenericRgb");
+		}
+
+		[Test]
+		public void CreateLinearizedTest ()
+		{
+			TestRuntime.AssertXcodeVersion (12, 1);
+			using (var cs = CGColorSpace.CreateWithName (CGColorSpaceNames.GenericRgb)) {
+				var csl = cs.CreateLinearized ();
+				Assert.NotNull (csl, "not null");
+				Assert.That ((nint) TestRuntime.CFGetRetainCount (csl.Handle), Is.EqualTo ((nint) 1));
+			}
+		}
+
+		[Test]
+		public void CreateExtendedTest ()
+		{
+			TestRuntime.AssertXcodeVersion (12, 1);
+			using (var cs = CGColorSpace.CreateWithName (CGColorSpaceNames.GenericRgb)) {
+				var csl = cs.CreateExtended ();
+				Assert.NotNull (csl, "not null");
+				Assert.That ((nint) TestRuntime.CFGetRetainCount (csl.Handle), Is.EqualTo ((nint) 1));
+			}
+		}
+
+		[Test]
+		public void CreateExtendedLinearizedTest ()
+		{
+			TestRuntime.AssertXcodeVersion (12, 1);
+			using (var cs = CGColorSpace.CreateWithName (CGColorSpaceNames.GenericRgb)) {
+				var csl = cs.CreateExtendedLinearized ();
+				Assert.NotNull (csl, "not null");
+				Assert.That ((nint) TestRuntime.CFGetRetainCount (csl.Handle), Is.EqualTo ((nint) 1));
+			}
+		}
+#endif
 	}
 }

--- a/tests/xtro-sharpie/iOS-CoreGraphics.todo
+++ b/tests/xtro-sharpie/iOS-CoreGraphics.todo
@@ -1,6 +1,0 @@
-!missing-field! kCGColorSpaceExtendedDisplayP3 not bound
-!missing-field! kCGColorSpaceExtendedITUR_2020 not bound
-!missing-pinvoke! CGColorSpaceCreateExtended is not bound
-!missing-pinvoke! CGColorSpaceCreateExtendedLinearized is not bound
-!missing-pinvoke! CGColorSpaceCreateLinearized is not bound
-!missing-pinvoke! CGColorSpaceUsesITUR_2100TF is not bound


### PR DESCRIPTION
Backport of PR#9828 (xcode12.2) with availability changes.

No need to merge it back into `xcode12.2` (it would conflict) but another
PR will be needed to change `[iOS (14,2)]` to `[iOS (14,1)]` on the new
API