### PR TITLE
[xcode12.1] Add ikvm-fork as a submodule instead of using the sources embedded in the mono archive. (#9776) (#9783)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,7 @@
     path = external/Xamarin.MacDev
     url = ../../xamarin/Xamarin.MacDev
     branch = xcode12
+[submodule "external/ikvm-fork"]
+    path = external/ikvm-fork
+    url = ../../mono/ikvm-fork
+    branch = master

--- a/Make.config
+++ b/Make.config
@@ -274,6 +274,7 @@ XAMARIN_MACDEV_PATH=$(TOP)/external/Xamarin.MacDev
 GUI_UNIT_PATH=$(TOP)/external/guiunit
 MACCORE_PATH=$(TOP)/../maccore
 MACIOS_BINARIES_PATH=$(TOP)/external/macios-binaries
+IKVM_PATH=$(TOP)/external/ikvm-fork
 
 MONO_PREFIX ?= /Library/Frameworks/Mono.framework/Versions/Current
 SYSTEM_MCS=$(MONO_PREFIX)/bin/mcs

--- a/mk/versions.mk
+++ b/mk/versions.mk
@@ -69,6 +69,7 @@ $(eval $(call CheckSubmoduleTemplate,opentk,OPENTK))
 $(eval $(call CheckSubmoduleTemplate,Xamarin.MacDev,XAMARIN_MACDEV))
 $(eval $(call CheckSubmoduleTemplate,guiunit,GUI_UNIT))
 $(eval $(call CheckSubmoduleTemplate,macios-binaries,MACIOS_BINARIES))
+$(eval $(call CheckSubmoduleTemplate,ikvm-fork,IKVM))
 
 include $(TOP)/mk/xamarin.mk
 

--- a/src/bgen/bgen.csproj
+++ b/src/bgen/bgen.csproj
@@ -19,277 +19,278 @@
     <BuildsDir>$(RepositoryPath)/builds</BuildsDir>
     <BuildDir Condition="'$(BUILD_DIR)' != ''">$(BUILD_DIR)\</BuildDir>
     <BuildDir Condition="'$(BUILD_DIR)' == ''">..\build\</BuildDir>
+    <IkvmSourcePath>$(RepositoryPath)\external\ikvm-fork\</IkvmSourcePath>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="$(RepositoryPath)\docs\website\generator-errors.md">
       <Link>generator-errors.md</Link>
     </None>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Impl\ITypeOwner.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Impl\ITypeOwner.cs">
       <Link>ikvm\ITypeOwner.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Impl\SymbolSupport.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Impl\SymbolSupport.cs">
       <Link>ikvm\SymbolSupport.cs</Link>
     </Compile>
     <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\mcs\class\Mono.Security\Mono.Security.Cryptography\CryptoConvert.cs">
       <Link>ikvm\CryptoConvert.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\AmbiguousMatchException.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\AmbiguousMatchException.cs">
       <Link>ikvm\AmbiguousMatchException.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Assembly.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Assembly.cs">
       <Link>ikvm\Assembly.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\AssemblyName.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\AssemblyName.cs">
       <Link>ikvm\AssemblyName.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\BadImageFormatException.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\BadImageFormatException.cs">
       <Link>ikvm\BadImageFormatException.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Binder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Binder.cs">
       <Link>ikvm\Binder.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\ConstructorInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\ConstructorInfo.cs">
       <Link>ikvm\ConstructorInfo.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\CustomAttributeData.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\CustomAttributeData.cs">
       <Link>ikvm\CustomAttributeData.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\CustomAttributeNamedArgument.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\CustomAttributeNamedArgument.cs">
       <Link>ikvm\CustomAttributeNamedArgument.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\CustomAttributeTypedArgument.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\CustomAttributeTypedArgument.cs">
       <Link>ikvm\CustomAttributeTypedArgument.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\CustomModifiers.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\CustomModifiers.cs">
       <Link>ikvm\CustomModifiers.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Enums.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Enums.cs">
       <Link>ikvm\Enums.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\EventInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\EventInfo.cs">
       <Link>ikvm\EventInfo.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\ExceptionHandlingClause.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\ExceptionHandlingClause.cs">
       <Link>ikvm\ExceptionHandlingClause.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\FieldInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\FieldInfo.cs">
       <Link>ikvm\FieldInfo.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\FieldSignature.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\FieldSignature.cs">
       <Link>ikvm\FieldSignature.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Fusion.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Fusion.cs">
       <Link>ikvm\Fusion.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\GenericWrappers.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\GenericWrappers.cs">
       <Link>ikvm\GenericWrappers.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\InterfaceMapping.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\InterfaceMapping.cs">
       <Link>ikvm\InterfaceMapping.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\LocalVariableInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\LocalVariableInfo.cs">
       <Link>ikvm\LocalVariableInfo.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\ManifestResourceInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\ManifestResourceInfo.cs">
       <Link>ikvm\ManifestResourceInfo.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\MarshalSpec.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\MarshalSpec.cs">
       <Link>ikvm\MarshalSpec.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\MemberInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\MemberInfo.cs">
       <Link>ikvm\MemberInfo.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\MethodBase.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\MethodBase.cs">
       <Link>ikvm\MethodBase.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\MethodBody.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\MethodBody.cs">
       <Link>ikvm\MethodBody.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\MethodImplMap.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\MethodImplMap.cs">
       <Link>ikvm\MethodImplMap.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\MethodInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\MethodInfo.cs">
       <Link>ikvm\MethodInfo.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\MethodSignature.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\MethodSignature.cs">
       <Link>ikvm\MethodSignature.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Missing.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Missing.cs">
       <Link>ikvm\Missing.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Module.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Module.cs">
       <Link>ikvm\Module.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\ParameterInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\ParameterInfo.cs">
       <Link>ikvm\ParameterInfo.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\ParameterModifier.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\ParameterModifier.cs">
       <Link>ikvm\ParameterModifier.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Projection.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Projection.cs">
       <Link>ikvm\Projection.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\PropertyInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\PropertyInfo.cs">
       <Link>ikvm\PropertyInfo.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\PropertySignature.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\PropertySignature.cs">
       <Link>ikvm\PropertySignature.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Signature.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Signature.cs">
       <Link>ikvm\Signature.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\StandAloneMethodSig.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\StandAloneMethodSig.cs">
       <Link>ikvm\StandAloneMethodSig.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\StrongNameKeyPair.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\StrongNameKeyPair.cs">
       <Link>ikvm\StrongNameKeyPair.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Type.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Type.cs">
       <Link>ikvm\Type.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\TypeInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\TypeInfo.cs">
       <Link>ikvm\TypeInfo.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\TypeNameParser.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\TypeNameParser.cs">
       <Link>ikvm\TypeNameParser.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Universe.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Universe.cs">
       <Link>ikvm\Universe.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Util.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Util.cs">
       <Link>ikvm\Util.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\coreclr.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\coreclr.cs">
       <Link>ikvm\coreclr.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\AssemblyBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\AssemblyBuilder.cs">
       <Link>ikvm\AssemblyBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\ConstructorBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\ConstructorBuilder.cs">
       <Link>ikvm\ConstructorBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\CustomAttributeBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\CustomAttributeBuilder.cs">
       <Link>ikvm\CustomAttributeBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\CustomModifiersBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\CustomModifiersBuilder.cs">
       <Link>ikvm\CustomModifiersBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\EnumBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\EnumBuilder.cs">
       <Link>ikvm\EnumBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\Enums.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\Enums.cs">
       <Link>ikvm\Enums.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\EventBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\EventBuilder.cs">
       <Link>ikvm\EventBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\ExceptionHandler.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\ExceptionHandler.cs">
       <Link>ikvm\ExceptionHandler.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\FieldBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\FieldBuilder.cs">
       <Link>ikvm\FieldBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\ILGenerator.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\ILGenerator.cs">
       <Link>ikvm\ILGenerator.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\MethodBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\MethodBuilder.cs">
       <Link>ikvm\MethodBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\ModuleBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\ModuleBuilder.cs">
       <Link>ikvm\ModuleBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\OpCode.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\OpCode.cs">
       <Link>ikvm\OpCode.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\OpCodes.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\OpCodes.cs">
       <Link>ikvm\OpCodes.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\ParameterBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\ParameterBuilder.cs">
       <Link>ikvm\ParameterBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\PropertyBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\PropertyBuilder.cs">
       <Link>ikvm\PropertyBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\SignatureHelper.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\SignatureHelper.cs">
       <Link>ikvm\SignatureHelper.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\Tokens.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\Tokens.cs">
       <Link>ikvm\Tokens.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\TypeBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\TypeBuilder.cs">
       <Link>ikvm\TypeBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Metadata\CliHeader.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Metadata\CliHeader.cs">
       <Link>ikvm\CliHeader.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Metadata\MetadataRW.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Metadata\MetadataRW.cs">
       <Link>ikvm\MetadataRW.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Metadata\Tables.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Metadata\Tables.cs">
       <Link>ikvm\Tables.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\AssemblyReader.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\AssemblyReader.cs">
       <Link>ikvm\AssemblyReader.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\Authenticode.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\Authenticode.cs">
       <Link>ikvm\Authenticode.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\ByteReader.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\ByteReader.cs">
       <Link>ikvm\ByteReader.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\EventInfoImpl.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\EventInfoImpl.cs">
       <Link>ikvm\EventInfoImpl.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\Field.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\Field.cs">
       <Link>ikvm\Field.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\GenericTypeParameter.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\GenericTypeParameter.cs">
       <Link>ikvm\GenericTypeParameter.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\MetadataReader.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\MetadataReader.cs">
       <Link>ikvm\MetadataReader.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\Method.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\Method.cs">
       <Link>ikvm\Method.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\ModuleReader.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\ModuleReader.cs">
       <Link>ikvm\ModuleReader.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\PEReader.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\PEReader.cs">
       <Link>ikvm\PEReader.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\PropertyInfoImpl.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\PropertyInfoImpl.cs">
       <Link>ikvm\PropertyInfoImpl.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\ResourceModule.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\ResourceModule.cs">
       <Link>ikvm\ResourceModule.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\TypeDefImpl.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\TypeDefImpl.cs">
       <Link>ikvm\TypeDefImpl.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\ByteBuffer.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\ByteBuffer.cs">
       <Link>ikvm\ByteBuffer.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\Heaps.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\Heaps.cs">
       <Link>ikvm\Heaps.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\MetadataWriter.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\MetadataWriter.cs">
       <Link>ikvm\MetadataWriter.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\ModuleWriter.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\ModuleWriter.cs">
       <Link>ikvm\ModuleWriter.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\PEWriter.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\PEWriter.cs">
       <Link>ikvm\PEWriter.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\ResourceSection.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\ResourceSection.cs">
       <Link>ikvm\ResourceSection.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\TextSection.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\TextSection.cs">
       <Link>ikvm\TextSection.cs</Link>
     </Compile>
-    <Compile Include="$(BuildsDir)\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\VersionInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\VersionInfo.cs">
       <Link>ikvm\VersionInfo.cs</Link>
     </Compile>
     <Compile Include="$(RepositoryPath)\src\btouch.cs" />

--- a/src/generator.csproj
+++ b/src/generator.csproj
@@ -11,6 +11,7 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <BuildDir Condition="'$(BUILD_DIR)' != ''">$(BUILD_DIR)\</BuildDir>
     <BuildDir Condition="'$(BUILD_DIR)' == ''">build\</BuildDir>
+    <IkvmSourcePath>..\external\ikvm-fork\</IkvmSourcePath>
     <LangVersion>latest</LangVersion>
     <NoWarn>8601,8618</NoWarn>
   </PropertyGroup>
@@ -86,271 +87,271 @@
     <None Include="..\docs\website\generator-errors.md">
       <Link>generator-errors.md</Link>
     </None>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Impl\ITypeOwner.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Impl\ITypeOwner.cs">
       <Link>ikvm\ITypeOwner.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Impl\SymbolSupport.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Impl\SymbolSupport.cs">
       <Link>ikvm\SymbolSupport.cs</Link>
     </Compile>
     <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\mcs\class\Mono.Security\Mono.Security.Cryptography\CryptoConvert.cs">
       <Link>ikvm\CryptoConvert.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\AmbiguousMatchException.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\AmbiguousMatchException.cs">
       <Link>ikvm\AmbiguousMatchException.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Assembly.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Assembly.cs">
       <Link>ikvm\Assembly.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\AssemblyName.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\AssemblyName.cs">
       <Link>ikvm\AssemblyName.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\BadImageFormatException.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\BadImageFormatException.cs">
       <Link>ikvm\BadImageFormatException.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Binder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Binder.cs">
       <Link>ikvm\Binder.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\ConstructorInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\ConstructorInfo.cs">
       <Link>ikvm\ConstructorInfo.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\CustomAttributeData.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\CustomAttributeData.cs">
       <Link>ikvm\CustomAttributeData.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\CustomAttributeNamedArgument.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\CustomAttributeNamedArgument.cs">
       <Link>ikvm\CustomAttributeNamedArgument.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\CustomAttributeTypedArgument.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\CustomAttributeTypedArgument.cs">
       <Link>ikvm\CustomAttributeTypedArgument.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\CustomModifiers.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\CustomModifiers.cs">
       <Link>ikvm\CustomModifiers.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Enums.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Enums.cs">
       <Link>ikvm\Enums.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\EventInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\EventInfo.cs">
       <Link>ikvm\EventInfo.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\ExceptionHandlingClause.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\ExceptionHandlingClause.cs">
       <Link>ikvm\ExceptionHandlingClause.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\FieldInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\FieldInfo.cs">
       <Link>ikvm\FieldInfo.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\FieldSignature.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\FieldSignature.cs">
       <Link>ikvm\FieldSignature.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Fusion.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Fusion.cs">
       <Link>ikvm\Fusion.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\GenericWrappers.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\GenericWrappers.cs">
       <Link>ikvm\GenericWrappers.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\InterfaceMapping.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\InterfaceMapping.cs">
       <Link>ikvm\InterfaceMapping.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\LocalVariableInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\LocalVariableInfo.cs">
       <Link>ikvm\LocalVariableInfo.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\ManifestResourceInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\ManifestResourceInfo.cs">
       <Link>ikvm\ManifestResourceInfo.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\MarshalSpec.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\MarshalSpec.cs">
       <Link>ikvm\MarshalSpec.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\MemberInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\MemberInfo.cs">
       <Link>ikvm\MemberInfo.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\MethodBase.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\MethodBase.cs">
       <Link>ikvm\MethodBase.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\MethodBody.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\MethodBody.cs">
       <Link>ikvm\MethodBody.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\MethodImplMap.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\MethodImplMap.cs">
       <Link>ikvm\MethodImplMap.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\MethodInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\MethodInfo.cs">
       <Link>ikvm\MethodInfo.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\MethodSignature.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\MethodSignature.cs">
       <Link>ikvm\MethodSignature.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Missing.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Missing.cs">
       <Link>ikvm\Missing.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Module.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Module.cs">
       <Link>ikvm\Module.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\ParameterInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\ParameterInfo.cs">
       <Link>ikvm\ParameterInfo.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\ParameterModifier.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\ParameterModifier.cs">
       <Link>ikvm\ParameterModifier.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Projection.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Projection.cs">
       <Link>ikvm\Projection.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\PropertyInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\PropertyInfo.cs">
       <Link>ikvm\PropertyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\PropertySignature.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\PropertySignature.cs">
       <Link>ikvm\PropertySignature.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Signature.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Signature.cs">
       <Link>ikvm\Signature.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\StandAloneMethodSig.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\StandAloneMethodSig.cs">
       <Link>ikvm\StandAloneMethodSig.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\StrongNameKeyPair.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\StrongNameKeyPair.cs">
       <Link>ikvm\StrongNameKeyPair.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Type.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Type.cs">
       <Link>ikvm\Type.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\TypeInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\TypeInfo.cs">
       <Link>ikvm\TypeInfo.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\TypeNameParser.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\TypeNameParser.cs">
       <Link>ikvm\TypeNameParser.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Universe.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Universe.cs">
       <Link>ikvm\Universe.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Util.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Util.cs">
       <Link>ikvm\Util.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\coreclr.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\coreclr.cs">
       <Link>ikvm\coreclr.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\AssemblyBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\AssemblyBuilder.cs">
       <Link>ikvm\AssemblyBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\ConstructorBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\ConstructorBuilder.cs">
       <Link>ikvm\ConstructorBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\CustomAttributeBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\CustomAttributeBuilder.cs">
       <Link>ikvm\CustomAttributeBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\CustomModifiersBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\CustomModifiersBuilder.cs">
       <Link>ikvm\CustomModifiersBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\EnumBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\EnumBuilder.cs">
       <Link>ikvm\EnumBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\Enums.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\Enums.cs">
       <Link>ikvm\Enums.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\EventBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\EventBuilder.cs">
       <Link>ikvm\EventBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\ExceptionHandler.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\ExceptionHandler.cs">
       <Link>ikvm\ExceptionHandler.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\FieldBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\FieldBuilder.cs">
       <Link>ikvm\FieldBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\ILGenerator.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\ILGenerator.cs">
       <Link>ikvm\ILGenerator.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\MethodBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\MethodBuilder.cs">
       <Link>ikvm\MethodBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\ModuleBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\ModuleBuilder.cs">
       <Link>ikvm\ModuleBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\OpCode.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\OpCode.cs">
       <Link>ikvm\OpCode.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\OpCodes.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\OpCodes.cs">
       <Link>ikvm\OpCodes.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\ParameterBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\ParameterBuilder.cs">
       <Link>ikvm\ParameterBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\PropertyBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\PropertyBuilder.cs">
       <Link>ikvm\PropertyBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\SignatureHelper.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\SignatureHelper.cs">
       <Link>ikvm\SignatureHelper.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\Tokens.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\Tokens.cs">
       <Link>ikvm\Tokens.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Emit\TypeBuilder.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Emit\TypeBuilder.cs">
       <Link>ikvm\TypeBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Metadata\CliHeader.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Metadata\CliHeader.cs">
       <Link>ikvm\CliHeader.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Metadata\MetadataRW.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Metadata\MetadataRW.cs">
       <Link>ikvm\MetadataRW.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Metadata\Tables.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Metadata\Tables.cs">
       <Link>ikvm\Tables.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\AssemblyReader.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\AssemblyReader.cs">
       <Link>ikvm\AssemblyReader.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\Authenticode.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\Authenticode.cs">
       <Link>ikvm\Authenticode.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\ByteReader.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\ByteReader.cs">
       <Link>ikvm\ByteReader.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\EventInfoImpl.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\EventInfoImpl.cs">
       <Link>ikvm\EventInfoImpl.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\Field.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\Field.cs">
       <Link>ikvm\Field.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\GenericTypeParameter.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\GenericTypeParameter.cs">
       <Link>ikvm\GenericTypeParameter.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\MetadataReader.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\MetadataReader.cs">
       <Link>ikvm\MetadataReader.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\Method.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\Method.cs">
       <Link>ikvm\Method.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\ModuleReader.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\ModuleReader.cs">
       <Link>ikvm\ModuleReader.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\PEReader.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\PEReader.cs">
       <Link>ikvm\PEReader.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\PropertyInfoImpl.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\PropertyInfoImpl.cs">
       <Link>ikvm\PropertyInfoImpl.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\ResourceModule.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\ResourceModule.cs">
       <Link>ikvm\ResourceModule.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Reader\TypeDefImpl.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Reader\TypeDefImpl.cs">
       <Link>ikvm\TypeDefImpl.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\ByteBuffer.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\ByteBuffer.cs">
       <Link>ikvm\ByteBuffer.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\Heaps.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\Heaps.cs">
       <Link>ikvm\Heaps.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\MetadataWriter.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\MetadataWriter.cs">
       <Link>ikvm\MetadataWriter.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\ModuleWriter.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\ModuleWriter.cs">
       <Link>ikvm\ModuleWriter.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\PEWriter.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\PEWriter.cs">
       <Link>ikvm\PEWriter.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\ResourceSection.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\ResourceSection.cs">
       <Link>ikvm\ResourceSection.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\TextSection.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\TextSection.cs">
       <Link>ikvm\TextSection.cs</Link>
     </Compile>
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\external\ikvm\reflect\Writer\VersionInfo.cs">
+    <Compile Include="$(IkvmSourcePath)reflect\Writer\VersionInfo.cs">
       <Link>ikvm\VersionInfo.cs</Link>
     </Compile>
     <Compile Include="..\src\btouch.cs" />


### PR DESCRIPTION
There are two reasons for this:

* It grants us more independence from the mono archive for .NET 6.
* We need a bugfix in ikvm, but we can't necessarily bump mono.

Co-authored-by: Rolf Bjarne Kvinge <rolf@xamarin.com>