### PR TITLE
[mpscore] Update for Xcode 12.1 GM

### DIFF
--- a/src/MetalPerformanceShaders/MPSDefs.cs
+++ b/src/MetalPerformanceShaders/MPSDefs.cs
@@ -62,10 +62,14 @@ namespace MetalPerformanceShaders {
 		Int8 = SignedBit | 8,
 		Int16 = SignedBit | 16,
 		Int32 = SignedBit | 32,
+		[iOS (14,1)][NoTV][NoMac]
+		Int64 = SignedBit | 64,
 
 		UInt8 = 8,
 		UInt16 = 16,
 		UInt32 = 32,
+		[iOS (14,1)][NoTV][NoMac]
+		UInt64 = 64,
 
 		[iOS (11,0), TV (11,0)]
 		NormalizedBit = 0x40000000,


### PR DESCRIPTION
The new enum members are available in all platforms in Xcode 12.2.

Another PR will change the `[iOS (14,2)]` to `[iOS (14,1)]` in the
`xcode12.2` branch.