### PR TITLE
[tests] Simplify temp file management in the msbuild tests.

### DIFF
--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
@@ -33,7 +33,7 @@ namespace Xamarin.iOS.Tasks
 			Task = CreateTask<CompileAppManifest> ();
 
 			Task.AppBundleName = appBundleName;
-			Task.AppManifestBundleDirectory = "AppBundlePath";
+			Task.AppManifestBundleDirectory = Path.Combine (Cache.CreateTemporaryDirectory (), "AppBundlePath");
 			Task.AssemblyName = assemblyName;
 			Task.AppManifest = CreateTempFile ("foo.plist");
 			Task.BundleIdentifier = bundleIdentifier;
@@ -59,9 +59,6 @@ namespace Xamarin.iOS.Tasks
 		public override void Teardown ()
 		{
 			base.Teardown ();
-
-			if (Directory.Exists ("AppBundlePath"))
-				Directory.Delete ("AppBundlePath", true);
 		}
 
 		#region General tests

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/MTouchTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/MTouchTaskTests.cs
@@ -54,6 +54,8 @@ namespace Xamarin.iOS.Tasks
 		{
 			base.Setup ();
 
+			var tmpdir = Cache.CreateTemporaryDirectory ();
+
 			Task = CreateTask<CustomMTouchTask> ();
 			Task.ToolExe = "/path/to/mtouch";
 
@@ -63,10 +65,10 @@ namespace Xamarin.iOS.Tasks
 			Task.IntermediateOutputPath = Path.Combine ("obj", "mtouch-cache");
 			Task.MainAssembly = new TaskItem ("Main.exe");
 			Task.References = new [] { new TaskItem ("a.dll"), new TaskItem ("b with spaces.dll"), new TaskItem ("c\"quoted\".dll") };
-			Task.ResponseFilePath = Path.Combine (Path.GetTempPath (), "response-file.rsp");
+			Task.ResponseFilePath = Path.Combine (tmpdir, "response-file.rsp");
 			Task.SdkRoot = "/path/to/sdkroot";
 			Task.SdkVersion = "6.1";
-			Task.SymbolsList = Path.Combine (Path.GetTempPath (), "mtouch-symbol-list");
+			Task.SymbolsList = Path.Combine (tmpdir, "mtouch-symbol-list");
 			Task.TargetFrameworkMoniker = "Xamarin.iOS,v1.0";
 		}
 
@@ -211,7 +213,7 @@ namespace Xamarin.iOS.Tasks
 			using (var sdk = new TempSdk()) {
 				Task.TargetFrameworkMoniker = "MonoTouch,v1.0";
 
-				var expectedPath = Path.GetTempFileName ();
+				var expectedPath = Path.Combine (Cache.CreateTemporaryDirectory (), "tmpfile");
 
 				Task.References = new[] { new TaskItem (expectedPath, new Dictionary<string, string> { { "FrameworkFile", "true" } }) };
 
@@ -302,8 +304,7 @@ namespace Xamarin.iOS.Tasks
 
 			public TempSdk ()
 			{
-				SdkDir = Path.Combine (Path.GetTempPath (), Guid.NewGuid ().ToString ());
-				Directory.CreateDirectory (SdkDir);
+				SdkDir = Cache.CreateTemporaryDirectory ();
 				Directory.CreateDirectory (Path.Combine (SdkDir, "bin"));
 				File.WriteAllText (Path.Combine (SdkDir, "Version"), "1.0.0.0"); // Fake Version file so that MonoTouchSdk detects this as a real Sdk location.
 				File.WriteAllText (Path.Combine (SdkDir, "bin", "mtouch"), "echo \"fake mtouch\""); // Fake mtouch binary so that MonoTouchSdk detects this as a real Sdk location.
@@ -318,7 +319,6 @@ namespace Xamarin.iOS.Tasks
 			public void Dispose ()
 			{
 				IPhoneSdks.MonoTouch = sdk;
-				Directory.Delete (SdkDir, true);
 			}
 		}
 	}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/PropertyListEditorTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/PropertyListEditorTaskTests.cs
@@ -65,7 +65,7 @@ namespace Xamarin.iOS.Tasks
 		static void TestExecuteTask (PDictionary input, PropertyListEditorAction action, string entry, string type, string value, PObject expected)
 		{
 			var task = new PropertyListEditor {
-				PropertyList = Path.GetTempFileName (),
+				PropertyList = Path.Combine (Cache.CreateTemporaryDirectory (), "propertyList.plist"),
 				BuildEngine = new TestEngine (),
 				Action = action.ToString (),
 				Entry = entry,
@@ -74,22 +74,18 @@ namespace Xamarin.iOS.Tasks
 			};
 			input.Save (task.PropertyList);
 
-			try {
-				if (expected == null) {
-					Assert.IsFalse (task.Execute (), "Task was expected to fail.");
-					return;
-				}
-
-				Assert.IsTrue (task.Execute (), "Task was expected to execute successfully.");
-
-				var output = PObject.FromFile (task.PropertyList);
-
-				Assert.AreEqual (expected.Type, output.Type, "Task produced the incorrect plist output.");
-
-				CheckValue (output, expected);
-			} finally {
-				File.Delete (task.PropertyList);
+			if (expected == null) {
+				Assert.IsFalse (task.Execute (), "Task was expected to fail.");
+				return;
 			}
+
+			Assert.IsTrue (task.Execute (), "Task was expected to execute successfully.");
+
+			var output = PObject.FromFile (task.PropertyList);
+
+			Assert.AreEqual (expected.Type, output.Type, "Task produced the incorrect plist output.");
+
+			CheckValue (output, expected);
 		}
 
 		[Test]
@@ -318,15 +314,11 @@ namespace Xamarin.iOS.Tasks
 			var merge = (PDictionary) expected.Clone ();
 			merge.Remove ("CFBundleIdentifier");
 
-			var tmp = Path.GetTempFileName ();
+			var tmp = Path.Combine (Cache.CreateTemporaryDirectory (), "tmpfile");
 
 			merge.Save (tmp);
 
-			try {
-				TestExecuteTask (plist, PropertyListEditorAction.Merge, null, null, tmp, expected);
-			} finally {
-				File.Delete (tmp);
-			}
+			TestExecuteTask (plist, PropertyListEditorAction.Merge, null, null, tmp, expected);
 		}
 
 		[Test]
@@ -351,15 +343,11 @@ namespace Xamarin.iOS.Tasks
 			array0.RemoveAt (3);
 			array0.RemoveAt (2);
 
-			var tmp = Path.GetTempFileName ();
+			var tmp = Path.Combine (Cache.CreateTemporaryDirectory (), "tmpfile");
 
 			array1.Save (tmp);
 
-			try {
-				TestExecuteTask (plist, PropertyListEditorAction.Merge, ":CFArrayItems", null, tmp, expected);
-			} finally {
-				File.Delete (tmp);
-			}
+			TestExecuteTask (plist, PropertyListEditorAction.Merge, ":CFArrayItems", null, tmp, expected);
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/TestBase.cs
@@ -129,10 +129,6 @@ namespace Xamarin.iOS.Tasks
 		public string MonoTouchProjectCSProjPath;
 		public string AppBundlePath;
 
-		public string TempDir {
-			get; set;
-		}
-
 		public ProjectPaths SetupProjectPaths (string projectName, string csprojName, string baseDir = "../", bool includePlatform = true, string platform = "iPhoneSimulator", string config = "Debug", string projectPath = null, bool is_dotnet = false)
 		{
 			var testsBase = GetTestDirectory ();
@@ -248,10 +244,6 @@ namespace Xamarin.iOS.Tasks
 			var paths = SetupProjectPaths ("MySingleView");
 			MonoTouchProjectPath = paths.ProjectPath;
 
-			TempDir = Path.Combine (Path.GetDirectoryName (Assembly.GetExecutingAssembly ().Location), "ScratchDir");
-			SafeDelete (TempDir);
-			Directory.CreateDirectory (TempDir);
-
 			// Ensure the bin and obj directories are cleared
 			SafeDelete (Path.Combine (MonoTouchProjectPath, "bin"));
 			SafeDelete (Path.Combine (MonoTouchProjectPath, "obj"));
@@ -323,7 +315,6 @@ namespace Xamarin.iOS.Tasks
 		[TearDown]
 		public virtual void Teardown ()
 		{
-			SafeDelete (TempDir);
 		}
 
 		public T CreateTask<T> () where T : Task, new()
@@ -353,10 +344,7 @@ namespace Xamarin.iOS.Tasks
 
 		protected string CreateTempFile (string path)
 		{
-			path = Path.Combine (TempDir, path);
-			Directory.CreateDirectory (Path.GetDirectoryName (path));
-			using (new FileStream (path, FileMode.CreateNew)) {}
-			return path;
+			return Path.Combine (Cache.CreateTemporaryDirectory (), path);
 		}
 
 		protected DateTime GetLastModified (string file)
@@ -386,7 +374,7 @@ namespace Xamarin.iOS.Tasks
 			else
 				plist [key] = value;
 
-			var modifiedPListPath = Path.Combine (TempDir, "modified.plist");
+			var modifiedPListPath = Path.Combine (Cache.CreateTemporaryDirectory (), "modified.plist");
 			plist.Save (modifiedPListPath);
 			return modifiedPListPath;
 		}

--- a/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/TargetTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/TargetTests.cs
@@ -596,7 +596,7 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void DetectAppManifest_ExecutableProject_LinkedPList ()
 		{
-			string linkedPlist = CreateTempFile (Path.Combine (TempDir, "Linked.plist"));
+			string linkedPlist = CreateTempFile ("Linked.plist");
 
 			RemoveItemsByName (MonoTouchProject, "None");
 			MonoTouchProjectInstance = MonoTouchProject.CreateProjectInstance ();
@@ -611,7 +611,7 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void DetectAppManifest_ExecutableProject_LogicalNamePList ()
 		{
-			string logicalPlist = CreateTempFile (Path.Combine (TempDir, "Logical.plist"));
+			string logicalPlist = CreateTempFile ("Logical.plist");
 
 			RemoveItemsByName (MonoTouchProject, "None");
 			MonoTouchProjectInstance = MonoTouchProject.CreateProjectInstance ();

--- a/tests/msbuild/Xamarin.MacDev.Tests/TestHelpers/TestBase.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/TestHelpers/TestBase.cs
@@ -129,10 +129,6 @@ namespace Xamarin.iOS.Tasks
 		public string MonoTouchProjectCSProjPath;
 		public string AppBundlePath;
 
-		public string TempDir {
-			get; set;
-		}
-
 		public ProjectPaths SetupProjectPaths (string projectName, string csprojName, string baseDir = "../", bool includePlatform = true, string platform = "iPhoneSimulator", string config = "Debug", string projectPath = null, bool is_dotnet = false)
 		{
 			var testsBase = GetTestDirectory ();
@@ -248,10 +244,6 @@ namespace Xamarin.iOS.Tasks
 			var paths = SetupProjectPaths ("MySingleView");
 			MonoTouchProjectPath = paths.ProjectPath;
 
-			TempDir = Path.Combine (Path.GetDirectoryName (Assembly.GetExecutingAssembly ().Location), "ScratchDir");
-			SafeDelete (TempDir);
-			Directory.CreateDirectory (TempDir);
-
 			// Ensure the bin and obj directories are cleared
 			SafeDelete (Path.Combine (MonoTouchProjectPath, "bin"));
 			SafeDelete (Path.Combine (MonoTouchProjectPath, "obj"));
@@ -323,7 +315,6 @@ namespace Xamarin.iOS.Tasks
 		[TearDown]
 		public virtual void Teardown ()
 		{
-			SafeDelete (TempDir);
 		}
 
 		public T CreateTask<T> () where T : Task, new()
@@ -353,8 +344,7 @@ namespace Xamarin.iOS.Tasks
 
 		protected string CreateTempFile (string path)
 		{
-			path = Path.Combine (TempDir, path);
-			Directory.CreateDirectory (Path.GetDirectoryName (path));
+			path = Path.Combine (Cache.CreateTemporaryDirectory (), path);
 			using (new FileStream (path, FileMode.CreateNew)) {}
 			return path;
 		}
@@ -386,7 +376,7 @@ namespace Xamarin.iOS.Tasks
 			else
 				plist [key] = value;
 
-			var modifiedPListPath = Path.Combine (TempDir, "modified.plist");
+			var modifiedPListPath = CreateTempFile ("modified.plist");
 			plist.Save (modifiedPListPath);
 			return modifiedPListPath;
 		}


### PR DESCRIPTION
* Use Cache.CreateTemporaryDirectory everywhere.
* Stop manually deleting temporary files/directories, they'll be deleted automatically.

It might be easier to review this by ignoring whitespace, since some code changed indentation.