### PR TITLE
[dotnet] Don't run the linker nor install_name_tool when running in offline mode on Windows.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -86,7 +86,7 @@
 	
 	<PropertyGroup>
 		<!-- We must run the linker for executable projects and app extension projects. We must set PublishTrimmed before importing Microsoft.NET.Sdk, because it'll be evaluated there. -->
-		<PublishTrimmed Condition="'$(PublishTrimmed)' == '' And ($(_ProjectType.EndsWith ('ExecutableProject')) Or $(_ProjectType.EndsWith ('AppExtensionProject')))">true</PublishTrimmed>
+		<PublishTrimmed Condition="'$(PublishTrimmed)' == '' And ($(_ProjectType.EndsWith ('ExecutableProject')) Or $(_ProjectType.EndsWith ('AppExtensionProject'))) And '$(IsMacEnabled)' == 'true'">true</PublishTrimmed>
 
 		<!-- App extensions are self-contained, even though their OutputType=Library -->
 		<SelfContained Condition="'$(SelfContained)' == '' And $(_ProjectType.EndsWith ('AppExtensionProject'))">true</SelfContained>
@@ -404,8 +404,16 @@
 		</PropertyGroup>
 
 		<!-- install_name_tool modifies the file in-place, so copy it first to a temporary directory before we fix it -->
-		<Copy SourceFiles="%(_MonoLibrary.FullPath)" DestinationFolder="$(_IntermediateNativeLibraryDir)" />
-		<Exec Command="xcrun install_name_tool -id $(_ExecutablePathPrefix)%(_MonoLibrary.Filename)%(_MonoLibrary.Extension) $(_IntermediateNativeLibraryDir)%(_MonoLibrary.Filename)%(_MonoLibrary.Extension)" EnvironmentVariables="DEVELOPER_DIR=$(_SdkDevPath)" />
+		<Copy
+			Condition="'$(IsMacEnabled)' == 'true'"
+			SourceFiles="%(_MonoLibrary.FullPath)"
+			DestinationFolder="$(_IntermediateNativeLibraryDir)"
+		/>
+		<Exec
+			Condition="'$(IsMacEnabled)' == 'true'"
+			Command="xcrun install_name_tool -id $(_ExecutablePathPrefix)%(_MonoLibrary.Filename)%(_MonoLibrary.Extension) $(_IntermediateNativeLibraryDir)%(_MonoLibrary.Filename)%(_MonoLibrary.Extension)"
+			EnvironmentVariables="DEVELOPER_DIR=$(_SdkDevPath)"
+		/>
 
 		<!-- Update our item groups -->
 		<ItemGroup>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -85,9 +85,6 @@
 	</ItemGroup>
 	
 	<PropertyGroup>
-		<!-- We must run the linker for executable projects and app extension projects. We must set PublishTrimmed before importing Microsoft.NET.Sdk, because it'll be evaluated there. -->
-		<PublishTrimmed Condition="'$(PublishTrimmed)' == '' And ($(_ProjectType.EndsWith ('ExecutableProject')) Or $(_ProjectType.EndsWith ('AppExtensionProject'))) And '$(IsMacEnabled)' == 'true'">true</PublishTrimmed>
-
 		<!-- App extensions are self-contained, even though their OutputType=Library -->
 		<SelfContained Condition="'$(SelfContained)' == '' And $(_ProjectType.EndsWith ('AppExtensionProject'))">true</SelfContained>
 
@@ -596,4 +593,9 @@
 	<Import Project="$(_TargetsDirectory)Xamarin.Mac.$(_ProjectLanguage).targets"                  Condition="'$(_ProjectType)' == 'macOSExecutableProject' Or '$(_ProjectType)' == 'macOSClassLibrary' " />
 	<Import Project="$(_TargetsDirectory)Xamarin.Mac.AppExtension.$(_ProjectLanguage).targets"     Condition="'$(_ProjectType)' == 'macOSAppExtensionProject' " />
 	<Import Project="$(_TargetsDirectory)Xamarin.Mac.ObjCBinding.$(_ProjectLanguage).targets"      Condition="'$(_ProjectType)' == 'macOSBindingProject' " />
+
+	<PropertyGroup>
+		<!-- PublishTrimmed depends on IsMacEnabled, which is defined in the Xamarin.iOS/Xamarin.Mac targets files we import just above here -->
+		<PublishTrimmed Condition="'$(PublishTrimmed)' == '' And ($(_ProjectType.EndsWith ('ExecutableProject')) Or $(_ProjectType.EndsWith ('AppExtensionProject'))) And '$(IsMacEnabled)' == 'true'">true</PublishTrimmed>
+	</PropertyGroup>
 </Project>


### PR DESCRIPTION
When running in offline mode on Windows, we only want to compile the C# code
(to make sure it compiles). We do this by adding an '$(IsMacEnabled)' == 'true'
checks to code that we don't want to run in offline mode.

The linker fails like this, and the easiest fix is to just disable it:

    > dotnet build .\HelloiOS\HelloiOS.csproj -p:IsMacEnabled=false
    Microsoft (R) Build Engine version 16.8.0-preview-20475-05+aed5e7ed0 for .NET
    Copyright (C) Microsoft Corporation. All rights reserved.
      Determining projects to restore...
      Restored C:\src\net5-samples\HelloiOS\HelloiOS.csproj (in 6.28 sec).
      You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
      HelloiOS -> C:\src\net5-samples\HelloiOS\bin\Debug\net5.0-ios\ios-x64\HelloiOS.dll
    ILLink : error IL1012: IL Linker has encountered an unexpected error. Please report the issue at https://github.com/mono/linker/issues [C:\src\net5-samples\HelloiOS\HelloiOS.csproj]
      Fatal error in IL Linker
      Unhandled exception. System.DllNotFoundException: Unable to load DLL '/usr/lib/libSystem.dylib' or one of its dependencies: The specified module could not be found. (0x8007007E)
         at Xamarin.Bundler.Target.realpath(String path, IntPtr zero)
         at Xamarin.Bundler.Target.GetRealPath(String path)
         at Cache.set_Location(String value)
         at Xamarin.Linker.LinkerConfiguration..ctor(String linker_file)
         at Xamarin.Linker.LinkerConfiguration.GetInstance(LinkContext context)
         at Xamarin.Linker.ConfigurationAwareStep.get_Configuration()
         at Xamarin.SetupStep.Process()
         at Mono.Linker.Steps.BaseStep.Process(LinkContext context)
         at Mono.Linker.Pipeline.ProcessStep(LinkContext context, IStep step)
         at Mono.Linker.Pipeline.Process(LinkContext context)
         at Mono.Linker.Driver.Run(ILogger customLogger)
         at Mono.Linker.Driver.Main(String[] args)

And disables install_name_tool too:

    > dotnet build .\HelloiOS\HelloiOS.csproj -p:IsMacEnabled=false -p:PublishTrimmed=false
    Xamarin.Shared.Sdk.targets(391,3): error MSB3073: The command "xcrun install_name_tool -id @executable_path/libSystem.IO.Compression.Native.dylib obj\Debug\net5.0-ios\ios-x64\nativelibraries/libSystem.IO.Compression.Native.dylib" exited with code 9009.