### PR TITLE
[fileprovider] Update for Xcode 12.2 beta 3

### DIFF
--- a/src/fileprovider.cs
+++ b/src/fileprovider.cs
@@ -522,10 +522,6 @@ namespace FileProvider {
 		NSDictionary GetUserInfo ();
 
 		[NoiOS]
-		[Export ("excludedFromSync")]
-		bool ExcludedFromSync { [Bind ("isExcludedFromSync")] get; }
-
-		[NoiOS]
 		[Export ("fileSystemFlags")]
 		NSFileProviderFileSystemFlags FileSystemFlags { get; }
 

--- a/tests/xtro-sharpie/macOS-FileProvider.todo
+++ b/tests/xtro-sharpie/macOS-FileProvider.todo
@@ -1,1 +1,0 @@
-!extra-protocol-member! unexpected selector NSFileProviderItem::isExcludedFromSync found


### PR DESCRIPTION
note: this is not a breaking change (even if it looks like one, even in
API diff) since there is a `[NoMac]` in `d16-8-xm` that was removed (and
never released for XM) in `xcode12`.