### PR TITLE
[d16-8] [monotouch] Fix ARSkeletonTest failure

### DIFF
--- a/tests/monotouch-test/ARKit/ARSkeletonTest.cs
+++ b/tests/monotouch-test/ARKit/ARSkeletonTest.cs
@@ -12,6 +12,13 @@ namespace monotouchtest.ARKit {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class ARSkeletonTest {
+
+		[SetUp]
+		public void Setup ()
+		{
+			TestRuntime.AssertXcodeVersion (12, 0);
+		}
+
 		[Test]
 		public void UnknownPointTest ()
 		{


### PR DESCRIPTION
Just in time for fall! 💀 👻 🎃 

Validated failure + fix locally.

Should be backported to:

- [ ] d16-8
- [ ] xcode12.2

Example of failure on pre-Xcode12 device:

`[FAIL] UnknownPointTest : System.EntryPointNotFoundException : ARSkeletonJointNameForRecognizedPointKey : at ARKit.ARSkeleton.CreateJointName (Foundation.NSString recognizedPointKey) [0x00014] in /Library/Frameworks/Xamarin.iOS.framework/Versions/14.0.0.202/src/Xamarin.iOS/ARKit/ARSkeleton.cs:20`

- [PR comment](https://github.com/xamarin/xamarin-macios/pull/9847#commitcomment-43190716)
- [HTML test results](http://xamarin-storage/jenkins/xamarin-macios/xcode12-xharness/cb8f89b78e4ce34cecdcab5a470acc287dbdd166/4139086/device-tests/jenkins-results/tests/index.html)

Backport of #9922.

/cc @whitneyschmidt 