### PR TITLE
[xharness] Give the MSBuild tests 30 more minutes to finish. Fixes #xamarin/maccore@2623.

### DIFF
--- a/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
+++ b/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
@@ -58,7 +58,7 @@ namespace Xharness.Jenkins {
 				Platform = TestPlatform.iOS,
 				TestName = "MSBuild tests",
 				Mode = "iOS (integration)",
-				Timeout = TimeSpan.FromMinutes (60),
+				Timeout = TimeSpan.FromMinutes (90),
 				Ignored = !jenkins.IncludeiOSMSBuild,
 				SupportsParallelExecution = false,
 			};


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/2326.