### PR TITLE
[tests][xcode12.2] Fix xammac tests

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -236,7 +236,7 @@ partial class TestRuntime
 			/*
 			 * I could be parsing the string but docs says it is not suitable for parsing and this is ugly enough so
 			 * an apology in advance (I'm very sorry =]) to my future self or whoever is dealing with this if it broke
-			 * but there are no better at this time. That said this is good enough for the current use case.
+			 * but there are no better solutions at this time. That said this is good enough for the current use case.
 			 * Example: Version 10.16 (Build 20A5395g)
 			 *
 			 * The above statement also applies to 'CheckExactmacOSSystemVersion' =S

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -181,7 +181,7 @@ partial class TestRuntime
 			Xcode = new { Major = 12, Minor = 2, Beta = 3 },
 			iOS = new { Major = 14, Minor = 2, Build = "18B5072" },
 			tvOS = new { Major = 14, Minor = 2, Build = "18K5047" },
-			macOS = new { Major = 11, Minor = 0, Build = "?" },
+			macOS = new { Major = 11, Minor = 0, Build = "20A5395" },
 			watchOS = new { Major = 7, Minor = 1, Build = "18R5572" },
 		};
 
@@ -219,6 +219,20 @@ partial class TestRuntime
 			var actual = GetiOSBuildVersion ();
 			Console.WriteLine (actual);
 			return actual.StartsWith (v.tvOS.Build, StringComparison.Ordinal);
+#elif __MACOS__
+			if (!CheckExactmacOSSystemVersion (v.macOS.Major, v.macOS.Minor))
+				return false;
+			if (v.macOS.Build == "?")
+				throw new NotImplementedException ($"Build number for macOS {v.macOS.Major}.{v.macOS.Minor} beta {beta}.");
+			/*
+			 * I could be parsing the string but docs says it is not suitable for parsing and this is ugly enough so
+			 * an apology in advace (I'm very sorry =]) to my future self or whoever is dealing with this if it broke
+			 * but there are no better at this time. That said this is good enough for the current use case.
+			 * Example: Version 10.16 (Build 20A5395g)
+			 *
+			 * The above statement also applies to 'CheckExactmacOSSystemVersion' =S
+			 */
+			return NSProcessInfo.ProcessInfo.OperatingSystemVersionString.Contains (v.macOS.Build, StringComparison.Ordinal);
 #else
 			throw new NotImplementedException ();
 #endif
@@ -712,6 +726,19 @@ partial class TestRuntime
 		return version.Major == major && version.Minor == minor;
 #else
 		throw new Exception ("Can't get tvOS System version on other platforms.");
+#endif
+	}
+
+	static bool CheckExactmacOSSystemVersion (int major, int minor, int build = 0)
+	{
+#if __MACOS__
+		var v = NSProcessInfo.ProcessInfo.OperatingSystemVersion;
+		var currentVersion = new Version ((int) v.Major, (int) v.Minor, (int) v.PatchVersion);
+		if (currentVersion == new Version (10, 16, 0))
+			currentVersion = new Version (11, 0, 0);
+		return currentVersion == new Version (major, minor, build);
+#else
+		throw new Exception ("Can't get macOS System version on other platforms.");
 #endif
 	}
 

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -226,7 +226,7 @@ partial class TestRuntime
 				throw new NotImplementedException ($"Build number for macOS {v.macOS.Major}.{v.macOS.Minor} beta {beta}.");
 			/*
 			 * I could be parsing the string but docs says it is not suitable for parsing and this is ugly enough so
-			 * an apology in advace (I'm very sorry =]) to my future self or whoever is dealing with this if it broke
+			 * an apology in advance (I'm very sorry =]) to my future self or whoever is dealing with this if it broke
 			 * but there are no better at this time. That said this is good enough for the current use case.
 			 * Example: Version 10.16 (Build 20A5395g)
 			 *

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -43,6 +43,15 @@ partial class TestRuntime
 
 	public const string BuildVersion_iOS9_GM = "13A340";
 
+	// Xcode 12.0 removed macOS 11.0 SDK and moved it up to Xcode 12.2
+	// we use this constant to make up for that difference when using
+	// AssertXcodeVersion and CheckXcodeVersion
+#if __MACOS__
+	public const int MinorXcode12APIMismatch = 2;
+#else
+	public const int MinorXcode12APIMismatch = 0;
+#endif
+
 	public static string GetiOSBuildVersion ()
 	{
 #if __WATCHOS__

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -118,6 +118,12 @@ namespace Introspection {
 			case "CKSubscription":
 			case "MPSCnnConvolutionState":
 				return true;
+			case "AVSpeechSynthesisVoice": // Calling description crashes the test
+#if __WATCHOS__
+				return TestRuntime.CheckXcodeVersion (12, 2); // CheckExactXcodeVersion is not implemented in watchOS yet but will be covered by iOS parrot below
+#else
+				return TestRuntime.CheckExactXcodeVersion (12, 2, beta: 3);
+#endif
 			}
 
 			switch (type.Namespace) {

--- a/tests/introspection/iOS/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOS/iOSApiCtorInitTest.cs
@@ -229,12 +229,6 @@ namespace Introspection {
 				// MPSPredicate.mm:102: failed assertion `[MPSPredicate initWithBuffer:offset:] device: Apple A8 GPU does not support predication.'
 				return ((Runtime.Arch == Arch.DEVICE) && (UIScreen.MainScreen.NativeBounds.Width <= 1920));
 #endif
-			case "AVSpeechSynthesisVoice": // Calling description crashes the test
-#if __WATCHOS__
-				return TestRuntime.CheckXcodeVersion (12, 2); // CheckExactXcodeVersion is not implemented in watchOS yet but will be covered by iOS parrot below
-#else
-				return TestRuntime.CheckExactXcodeVersion (12, 2, beta: 3);
-#endif
 			default:
 				return base.Skip (type);
 			}

--- a/tests/monotouch-test/AudioUnit/AudioUnitTest.cs
+++ b/tests/monotouch-test/AudioUnit/AudioUnitTest.cs
@@ -53,7 +53,11 @@ namespace MonoTouchFixtures.AudioUnit
 		[Test]
 		public void CopyIconTest ()
 		{ 
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			AudioComponentDescription cd = new AudioComponentDescription () {
 				ComponentType = AudioComponentType.Output,
 #if MONOMAC

--- a/tests/monotouch-test/AudioUnit/AudioUnitTest.cs
+++ b/tests/monotouch-test/AudioUnit/AudioUnitTest.cs
@@ -53,11 +53,7 @@ namespace MonoTouchFixtures.AudioUnit
 		[Test]
 		public void CopyIconTest ()
 		{ 
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			AudioComponentDescription cd = new AudioComponentDescription () {
 				ComponentType = AudioComponentType.Output,
 #if MONOMAC

--- a/tests/monotouch-test/CoreGraphics/ColorTest.cs
+++ b/tests/monotouch-test/CoreGraphics/ColorTest.cs
@@ -101,7 +101,11 @@ namespace MonoTouchFixtures.CoreGraphics {
 		[Test]
 		public void GetAXName ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			using (var c = new CGColor (CGConstantColor.Black)) {
 				Assert.IsNotNull (c.AXName, "AXName");
 			}

--- a/tests/monotouch-test/CoreGraphics/ColorTest.cs
+++ b/tests/monotouch-test/CoreGraphics/ColorTest.cs
@@ -101,11 +101,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 		[Test]
 		public void GetAXName ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			using (var c = new CGColor (CGConstantColor.Black)) {
 				Assert.IsNotNull (c.AXName, "AXName");
 			}

--- a/tests/monotouch-test/CoreText/FontManagerTest.cs
+++ b/tests/monotouch-test/CoreText/FontManagerTest.cs
@@ -61,7 +61,10 @@ namespace MonoTouchFixtures.CoreText {
 				// Assert.IsNotNull (err, "err 3");
 				err = CTFontManager.UnregisterFontsForUrl (url, CTFontManagerScope.Process);
 #if MONOMAC
-				Assert.IsNull (err, "err 4");
+				if (TestRuntime.CheckXcodeVersion (12,2))
+					Assert.IsNotNull (err, "err 4");
+				else
+					Assert.IsNull (err, "err 4");
 #else
 				Assert.IsNotNull (err, "err 4");
 #endif
@@ -155,7 +158,12 @@ namespace MonoTouchFixtures.CoreText {
 				// Assert.IsNotNull (err [0], "err 3[0]");
 				err = CTFontManager.UnregisterFontsForUrl (new [] { url }, CTFontManagerScope.Process);
 #if MONOMAC
-				Assert.IsNull (err, "err 4");
+				if (TestRuntime.CheckXcodeVersion (12, 2)) {
+					Assert.IsNotNull (err, "err 4");
+					Assert.AreEqual (1, err.Length, "err 4 l");
+					Assert.IsNotNull (err [0], "err 4[0]");
+				} else
+					Assert.IsNull (err, "err 4");
 #else
 				Assert.IsNotNull (err, "err 4");
 				Assert.AreEqual (1, err.Length, "err 4 l");

--- a/tests/monotouch-test/GameKit/LeaderboardViewControllerTest.cs
+++ b/tests/monotouch-test/GameKit/LeaderboardViewControllerTest.cs
@@ -33,7 +33,7 @@ namespace MonoTouchFixtures.GameKit {
 		{
 #if MONOMAC
 			// For some reason the init method is not allowed on Xcode 12.2 Beta 3 anymore
-			// but was a llowed before that said this class got deprecated in 10.10 so it may now be
+			// but was allowed before that said this class got deprecated in 10.10 so it may now be
 			// a permanent change.
 			if (TestRuntime.CheckExactXcodeVersion (12, 2, beta: 3))
 				Assert.Inconclusive ("'LeaderboardViewControllerTest' the native 'init' method returned nil.");

--- a/tests/monotouch-test/GameKit/LeaderboardViewControllerTest.cs
+++ b/tests/monotouch-test/GameKit/LeaderboardViewControllerTest.cs
@@ -31,6 +31,13 @@ namespace MonoTouchFixtures.GameKit {
 		[Test]
 		public void DefaultCtor ()
 		{
+#if MONOMAC
+			// For some reason the init method is not allowed on Xcode 12.2 Beta 3 anymore
+			// but was a llowed before that said this class got deprecated in 10.10 so it may now be
+			// a permanent change.
+			if (TestRuntime.CheckExactXcodeVersion (12, 2, beta: 3))
+				Assert.Inconclusive ("'LeaderboardViewControllerTest' the native 'init' method returned nil.");
+#endif
 			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
 			using (var vc = new GKLeaderboardViewController ()) {
 				Assert.Null (vc.Category, "Category");

--- a/tests/monotouch-test/MLCompute/MLEnumsTest.cs
+++ b/tests/monotouch-test/MLCompute/MLEnumsTest.cs
@@ -16,10 +16,8 @@ namespace MonoTouchFixtures.MLCompute {
 		[SetUp]
 		public void SetUp ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
+#if !MONOMAC
 			if (Runtime.Arch == Arch.SIMULATOR)
 				Assert.Ignore ("https://github.com/xamarin/maccore/issues/2271");
 #endif

--- a/tests/monotouch-test/MLCompute/MLEnumsTest.cs
+++ b/tests/monotouch-test/MLCompute/MLEnumsTest.cs
@@ -16,8 +16,10 @@ namespace MonoTouchFixtures.MLCompute {
 		[SetUp]
 		public void SetUp ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
-#if !MONOMAC
 			if (Runtime.Arch == Arch.SIMULATOR)
 				Assert.Ignore ("https://github.com/xamarin/maccore/issues/2271");
 #endif

--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -130,7 +130,7 @@ namespace MonoTouchFixtures.MediaAccessibility {
 				Assert.Null (e, "rw / set / no error"); // weird, it can't be saved back to the file metadata
 
 				var s = MAImageCaptioning.GetCaption (rw_url, out e);
-					if (TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
+				if (TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
 					Assert.AreEqual ("xamarin", s, "rw / roundtrip"); // :)
 				} else {
 					Assert.Null (s, "rw / roundtrip"); // :(

--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -67,12 +67,13 @@ namespace MonoTouchFixtures.MediaAccessibility {
 		[Test]
 		public void SetCaption ()
 		{
-#if !__MACOS__
+#if __MACOS__
 			// looks like Apple broke something inside Xcode 12.2 Beta 2 in both sim and device
 			// NSInvalidArgumentException Reason: -[__NSCFType _getValue:forType:]: unrecognized selector sent to instance
 			// when calling MAImageCaptioning.SetCaption
-			if (TestRuntime.CheckExactXcodeVersion (12, 2, 2))
-				Assert.Ignore ("Broken in Xcode 12.2 Beta 2");
+			// Seems to be fixed for iOS now but not for macOS
+			if (TestRuntime.CheckExactXcodeVersion (12, 2, beta: 3))
+				Assert.Ignore ("Broken in Xcode 12.2 Beta 3");
 #endif
 
 			TestRuntime.AssertXcodeVersion (11, 0);
@@ -103,7 +104,11 @@ namespace MonoTouchFixtures.MediaAccessibility {
 					Assert.Null (e, "ro / set / no error"); // weird, it can't be saved back to the file metadata
 
 					var s = MAImageCaptioning.GetCaption (url, out e);
+#if __MACOS__
+					if (TestRuntime.CheckXcodeVersion (12, 2)) {
+#else
 					if (TestRuntime.CheckXcodeVersion (12, 0)) {
+#endif
 						Assert.AreEqual ("xamarin", s, "ro / roundtrip");
 					} else {
 						Assert.Null (s, "ro / roundtrip"); // not very surprising since Set can't save it
@@ -112,7 +117,11 @@ namespace MonoTouchFixtures.MediaAccessibility {
 
 					Assert.True (MAImageCaptioning.SetCaption (url, "xamarin", out e), "Set 2");
 					s = MAImageCaptioning.GetCaption (url, out e);
+#if __MACOS__
+					if (TestRuntime.CheckXcodeVersion (12, 2)) {
+#else
 					if (TestRuntime.CheckXcodeVersion (12, 0)) {
+#endif
 						Assert.AreEqual ("xamarin", s, "ro / back to original");
 					} else {
 						Assert.Null (s, "ro / back to original");
@@ -129,7 +138,11 @@ namespace MonoTouchFixtures.MediaAccessibility {
 				Assert.Null (e, "rw / set / no error"); // weird, it can't be saved back to the file metadata
 
 				var s = MAImageCaptioning.GetCaption (rw_url, out e);
-				if (TestRuntime.CheckXcodeVersion (12, 0)) {
+#if __MACOS__
+					if (TestRuntime.CheckXcodeVersion (12, 2)) {
+#else
+					if (TestRuntime.CheckXcodeVersion (12, 0)) {
+#endif
 					Assert.AreEqual ("xamarin", s, "rw / roundtrip"); // :)
 				} else {
 					Assert.Null (s, "rw / roundtrip"); // :(
@@ -138,7 +151,11 @@ namespace MonoTouchFixtures.MediaAccessibility {
 
 				Assert.True (MAImageCaptioning.SetCaption (rw_url, "xamarin", out e), "Set 2");
 				s = MAImageCaptioning.GetCaption (rw_url, out e);
-				if (TestRuntime.CheckXcodeVersion (12, 0)) {
+#if __MACOS__
+					if (TestRuntime.CheckXcodeVersion (12, 2)) {
+#else
+					if (TestRuntime.CheckXcodeVersion (12, 0)) {
+#endif
 					Assert.AreEqual ("xamarin", s, "rw / back to original");
 				} else {
 					Assert.Null (s, "rw / back to original");

--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -104,11 +104,7 @@ namespace MonoTouchFixtures.MediaAccessibility {
 					Assert.Null (e, "ro / set / no error"); // weird, it can't be saved back to the file metadata
 
 					var s = MAImageCaptioning.GetCaption (url, out e);
-#if __MACOS__
-					if (TestRuntime.CheckXcodeVersion (12, 2)) {
-#else
-					if (TestRuntime.CheckXcodeVersion (12, 0)) {
-#endif
+					if (TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
 						Assert.AreEqual ("xamarin", s, "ro / roundtrip");
 					} else {
 						Assert.Null (s, "ro / roundtrip"); // not very surprising since Set can't save it
@@ -117,11 +113,7 @@ namespace MonoTouchFixtures.MediaAccessibility {
 
 					Assert.True (MAImageCaptioning.SetCaption (url, "xamarin", out e), "Set 2");
 					s = MAImageCaptioning.GetCaption (url, out e);
-#if __MACOS__
-					if (TestRuntime.CheckXcodeVersion (12, 2)) {
-#else
-					if (TestRuntime.CheckXcodeVersion (12, 0)) {
-#endif
+					if (TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
 						Assert.AreEqual ("xamarin", s, "ro / back to original");
 					} else {
 						Assert.Null (s, "ro / back to original");
@@ -138,11 +130,7 @@ namespace MonoTouchFixtures.MediaAccessibility {
 				Assert.Null (e, "rw / set / no error"); // weird, it can't be saved back to the file metadata
 
 				var s = MAImageCaptioning.GetCaption (rw_url, out e);
-#if __MACOS__
-					if (TestRuntime.CheckXcodeVersion (12, 2)) {
-#else
-					if (TestRuntime.CheckXcodeVersion (12, 0)) {
-#endif
+					if (TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
 					Assert.AreEqual ("xamarin", s, "rw / roundtrip"); // :)
 				} else {
 					Assert.Null (s, "rw / roundtrip"); // :(
@@ -151,11 +139,7 @@ namespace MonoTouchFixtures.MediaAccessibility {
 
 				Assert.True (MAImageCaptioning.SetCaption (rw_url, "xamarin", out e), "Set 2");
 				s = MAImageCaptioning.GetCaption (rw_url, out e);
-#if __MACOS__
-					if (TestRuntime.CheckXcodeVersion (12, 2)) {
-#else
-					if (TestRuntime.CheckXcodeVersion (12, 0)) {
-#endif
+				if (TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
 					Assert.AreEqual ("xamarin", s, "rw / back to original");
 				} else {
 					Assert.Null (s, "rw / back to original");

--- a/tests/monotouch-test/Metal/MTLBlitPassDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLBlitPassDescriptorTest.cs
@@ -16,7 +16,11 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 		}
 
 		[Test]

--- a/tests/monotouch-test/Metal/MTLBlitPassDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLBlitPassDescriptorTest.cs
@@ -14,14 +14,7 @@ namespace MonoTouchFixtures.Metal {
 	public class MTLBlitPassDescriptorTest { 
 
 		[SetUp]
-		public void SetUp ()
-		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
-		}
+		public void Setup () => TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 
 		[Test]
 		public void TestSampleBufferAttachments ()

--- a/tests/monotouch-test/Metal/MTLBlitPassDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLBlitPassDescriptorTest.cs
@@ -14,7 +14,10 @@ namespace MonoTouchFixtures.Metal {
 	public class MTLBlitPassDescriptorTest { 
 
 		[SetUp]
-		public void Setup () => TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
+		public void SetUp ()
+		{
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
+		}
 
 		[Test]
 		public void TestSampleBufferAttachments ()

--- a/tests/monotouch-test/Metal/MTLBlitPassSampleBufferAttachmentDescriptorArrayTest.cs
+++ b/tests/monotouch-test/Metal/MTLBlitPassSampleBufferAttachmentDescriptorArrayTest.cs
@@ -16,7 +16,11 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			array = new MTLBlitPassSampleBufferAttachmentDescriptorArray ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLBlitPassSampleBufferAttachmentDescriptorArrayTest.cs
+++ b/tests/monotouch-test/Metal/MTLBlitPassSampleBufferAttachmentDescriptorArrayTest.cs
@@ -16,11 +16,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			array = new MTLBlitPassSampleBufferAttachmentDescriptorArray ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLBlitPassSampleBufferAttachmentDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLBlitPassSampleBufferAttachmentDescriptorTest.cs
@@ -17,11 +17,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			descriptor = new MTLBlitPassSampleBufferAttachmentDescriptor ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLBlitPassSampleBufferAttachmentDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLBlitPassSampleBufferAttachmentDescriptorTest.cs
@@ -17,7 +17,11 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			descriptor = new MTLBlitPassSampleBufferAttachmentDescriptor ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLComputePassDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLComputePassDescriptorTest.cs
@@ -16,11 +16,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			descriptor = MTLComputePassDescriptor.Create ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLComputePassDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLComputePassDescriptorTest.cs
@@ -16,7 +16,11 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			descriptor = MTLComputePassDescriptor.Create ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLComputePassSampleBufferAttachmentDescriptorArrayTest.cs
+++ b/tests/monotouch-test/Metal/MTLComputePassSampleBufferAttachmentDescriptorArrayTest.cs
@@ -16,7 +16,11 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif 
 			array = new MTLComputePassSampleBufferAttachmentDescriptorArray ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLComputePassSampleBufferAttachmentDescriptorArrayTest.cs
+++ b/tests/monotouch-test/Metal/MTLComputePassSampleBufferAttachmentDescriptorArrayTest.cs
@@ -16,11 +16,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif 
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			array = new MTLComputePassSampleBufferAttachmentDescriptorArray ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLComputePassSampleBufferAttachmentDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLComputePassSampleBufferAttachmentDescriptorTest.cs
@@ -16,11 +16,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{ 
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			descriptor = new MTLComputePassSampleBufferAttachmentDescriptor ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLComputePassSampleBufferAttachmentDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLComputePassSampleBufferAttachmentDescriptorTest.cs
@@ -16,7 +16,11 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{ 
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			descriptor = new MTLComputePassSampleBufferAttachmentDescriptor ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLIntersectionFunctionTableDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLIntersectionFunctionTableDescriptorTest.cs
@@ -13,14 +13,7 @@ namespace MonoTouchFixtures.Metal {
 	public class MTLIntersectionFunctionTableDescriptorTest {
 
 		[SetUp]
-		public void SetUp ()
-		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
-		}
+		public void Setup () => TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 
 		[Test]
 		public void FunctionCountTest ()

--- a/tests/monotouch-test/Metal/MTLIntersectionFunctionTableDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLIntersectionFunctionTableDescriptorTest.cs
@@ -13,7 +13,10 @@ namespace MonoTouchFixtures.Metal {
 	public class MTLIntersectionFunctionTableDescriptorTest {
 
 		[SetUp]
-		public void Setup () => TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
+		public void SetUp ()
+		{
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
+		}
 
 		[Test]
 		public void FunctionCountTest ()

--- a/tests/monotouch-test/Metal/MTLIntersectionFunctionTableDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLIntersectionFunctionTableDescriptorTest.cs
@@ -15,7 +15,11 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 		}
 
 		[Test]

--- a/tests/monotouch-test/Metal/MTLLinkedFunctionsTest.cs
+++ b/tests/monotouch-test/Metal/MTLLinkedFunctionsTest.cs
@@ -16,11 +16,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			functions = MTLLinkedFunctions.Create ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLLinkedFunctionsTest.cs
+++ b/tests/monotouch-test/Metal/MTLLinkedFunctionsTest.cs
@@ -16,7 +16,11 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			functions = MTLLinkedFunctions.Create ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLRenderPassSampleBufferAttachmentDescriptorArrayTest.cs
+++ b/tests/monotouch-test/Metal/MTLRenderPassSampleBufferAttachmentDescriptorArrayTest.cs
@@ -16,7 +16,11 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			array = new MTLRenderPassSampleBufferAttachmentDescriptorArray ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLRenderPassSampleBufferAttachmentDescriptorArrayTest.cs
+++ b/tests/monotouch-test/Metal/MTLRenderPassSampleBufferAttachmentDescriptorArrayTest.cs
@@ -16,11 +16,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			array = new MTLRenderPassSampleBufferAttachmentDescriptorArray ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLRenderPassSampleBufferAttachmentDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLRenderPassSampleBufferAttachmentDescriptorTest.cs
@@ -16,7 +16,11 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			descriptor = new MTLRenderPassSampleBufferAttachmentDescriptor ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLRenderPassSampleBufferAttachmentDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLRenderPassSampleBufferAttachmentDescriptorTest.cs
@@ -16,11 +16,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			descriptor = new MTLRenderPassSampleBufferAttachmentDescriptor ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLResourceStatePassDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLResourceStatePassDescriptorTest.cs
@@ -16,7 +16,11 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			descriptor = MTLResourceStatePassDescriptor.Create ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLResourceStatePassDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLResourceStatePassDescriptorTest.cs
@@ -16,11 +16,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			descriptor = MTLResourceStatePassDescriptor.Create ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLResourceStatePassSampleBufferAttachmentDescriptorArrayTest.cs
+++ b/tests/monotouch-test/Metal/MTLResourceStatePassSampleBufferAttachmentDescriptorArrayTest.cs
@@ -16,7 +16,11 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			array = new MTLResourceStatePassSampleBufferAttachmentDescriptorArray ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLResourceStatePassSampleBufferAttachmentDescriptorArrayTest.cs
+++ b/tests/monotouch-test/Metal/MTLResourceStatePassSampleBufferAttachmentDescriptorArrayTest.cs
@@ -16,11 +16,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			array = new MTLResourceStatePassSampleBufferAttachmentDescriptorArray ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLResourceStatePassSampleBufferAttachmentDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLResourceStatePassSampleBufferAttachmentDescriptorTest.cs
@@ -17,11 +17,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			descriptor = new MTLResourceStatePassSampleBufferAttachmentDescriptor ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLResourceStatePassSampleBufferAttachmentDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLResourceStatePassSampleBufferAttachmentDescriptorTest.cs
@@ -17,7 +17,11 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			descriptor = new MTLResourceStatePassSampleBufferAttachmentDescriptor ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLTileRenderPipelineDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLTileRenderPipelineDescriptorTest.cs
@@ -17,11 +17,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			descriptor = new MTLTileRenderPipelineDescriptor ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLTileRenderPipelineDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLTileRenderPipelineDescriptorTest.cs
@@ -17,7 +17,11 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			descriptor = new MTLTileRenderPipelineDescriptor ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLVisibleFunctionTableDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLVisibleFunctionTableDescriptorTest.cs
@@ -17,7 +17,11 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			descriptor = MTLVisibleFunctionTableDescriptor.Create ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLVisibleFunctionTableDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLVisibleFunctionTableDescriptorTest.cs
@@ -17,11 +17,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			descriptor = MTLVisibleFunctionTableDescriptor.Create ();
 		}
 

--- a/tests/monotouch-test/ModelIO/MDLAnimatedValueTypesTests.cs
+++ b/tests/monotouch-test/ModelIO/MDLAnimatedValueTypesTests.cs
@@ -34,7 +34,13 @@ namespace MonoTouchFixtures.ModelIO {
 		[TestFixtureSetUp]
 		public void Setup ()
 		{
+#if MONOMAC
+			// ModelIO seems to be broken in Xcode 12.2 Beta 3 so disabling for now.
+			if (TestRuntime.CheckExactXcodeVersion (12, 2, beta: 3))
+				Assert.Inconclusive ("ModelIO is not working in Xcode 12.2 Beta 3");
+#else
 			TestRuntime.AssertXcodeVersion (9, 0);
+#endif
 		}
 
 		[Test]

--- a/tests/monotouch-test/NaturalLanguage/NLTaggerTest.cs
+++ b/tests/monotouch-test/NaturalLanguage/NLTaggerTest.cs
@@ -66,11 +66,7 @@ namespace MonoTouchFixtures.NaturalLanguage {
 		[Test]
 		public void GetTagHypotheses ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			using (var tagger = new NLTagger (NLTagScheme.LexicalClass) { String = Text }) {
 				var dict = tagger.GetTagHypotheses (0, NLTokenUnit.Sentence, NLTagScheme.LexicalClass, nuint.MaxValue);
 				Assert.That (dict.Count, Is.EqualTo (1), "Count");
@@ -82,11 +78,7 @@ namespace MonoTouchFixtures.NaturalLanguage {
 		[Test]
 		public void GetTagHypotheses_Range ()
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			using (var tagger = new NLTagger (NLTagScheme.LexicalClass) { String = Text }) {
 				var dict = tagger.GetTagHypotheses (0, NLTokenUnit.Sentence, NLTagScheme.LexicalClass, nuint.MaxValue, out NSRange range);
 				Assert.That (dict.Count, Is.EqualTo (1), "Count");

--- a/tests/monotouch-test/NaturalLanguage/NLTaggerTest.cs
+++ b/tests/monotouch-test/NaturalLanguage/NLTaggerTest.cs
@@ -66,7 +66,11 @@ namespace MonoTouchFixtures.NaturalLanguage {
 		[Test]
 		public void GetTagHypotheses ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			using (var tagger = new NLTagger (NLTagScheme.LexicalClass) { String = Text }) {
 				var dict = tagger.GetTagHypotheses (0, NLTokenUnit.Sentence, NLTagScheme.LexicalClass, nuint.MaxValue);
 				Assert.That (dict.Count, Is.EqualTo (1), "Count");
@@ -78,7 +82,11 @@ namespace MonoTouchFixtures.NaturalLanguage {
 		[Test]
 		public void GetTagHypotheses_Range ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			using (var tagger = new NLTagger (NLTagScheme.LexicalClass) { String = Text }) {
 				var dict = tagger.GetTagHypotheses (0, NLTokenUnit.Sentence, NLTagScheme.LexicalClass, nuint.MaxValue, out NSRange range);
 				Assert.That (dict.Count, Is.EqualTo (1), "Count");

--- a/tests/monotouch-test/Network/NWConnectionGroupTest.cs
+++ b/tests/monotouch-test/Network/NWConnectionGroupTest.cs
@@ -26,7 +26,11 @@ namespace MonoTouchFixtures.Network {
 		[SetUp]
 		public void SetUp ()
 		{ 
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			endpoint = NWEndpoint.Create ("224.0.0.251", "5353");
 			parameters = NWParameters.CreateUdp ();
 			descriptor = new NWMulticastGroup (endpoint);

--- a/tests/monotouch-test/Network/NWConnectionGroupTest.cs
+++ b/tests/monotouch-test/Network/NWConnectionGroupTest.cs
@@ -26,11 +26,7 @@ namespace MonoTouchFixtures.Network {
 		[SetUp]
 		public void SetUp ()
 		{ 
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			endpoint = NWEndpoint.Create ("224.0.0.251", "5353");
 			parameters = NWParameters.CreateUdp ();
 			descriptor = new NWMulticastGroup (endpoint);

--- a/tests/monotouch-test/Network/NWMulticastGroupTest.cs
+++ b/tests/monotouch-test/Network/NWMulticastGroupTest.cs
@@ -21,7 +21,11 @@ namespace MonoTouchFixtures.Network {
 		[SetUp]
 		public void SetUp ()
 		{ 
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			endpoint = NWEndpoint.Create ("224.0.0.251", "5353");
 			descriptor = new NWMulticastGroup (endpoint);
 		}

--- a/tests/monotouch-test/Network/NWMulticastGroupTest.cs
+++ b/tests/monotouch-test/Network/NWMulticastGroupTest.cs
@@ -21,11 +21,7 @@ namespace MonoTouchFixtures.Network {
 		[SetUp]
 		public void SetUp ()
 		{ 
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			endpoint = NWEndpoint.Create ("224.0.0.251", "5353");
 			descriptor = new NWMulticastGroup (endpoint);
 		}

--- a/tests/monotouch-test/Security/TrustTest.cs
+++ b/tests/monotouch-test/Security/TrustTest.cs
@@ -295,7 +295,11 @@ namespace MonoTouchFixtures.Security {
 			using (SecKey pkey = trust.GetPublicKey ()) {
 				Assert.That (CFGetRetainCount (pkey.Handle), Is.GreaterThanOrEqualTo ((nint) 1), "RetainCount(pkey)");
 			}
+#if __MACOS__
+			if (TestRuntime.CheckXcodeVersion (12,2)) {
+#else
 			if (TestRuntime.CheckXcodeVersion (12,0)) {
+#endif
 				using (SecKey key = trust.GetKey ()) {
 					Assert.That (key.BlockSize, Is.EqualTo (128), "BlockSize");
 					Assert.That (CFGetRetainCount (key.Handle), Is.GreaterThanOrEqualTo ((nint) 1), "RetainCount(key)");
@@ -390,10 +394,8 @@ namespace MonoTouchFixtures.Security {
 				// old certificate (built in our tests) was not quite up to spec and it eventually became important
 				Assert.False (trust.Evaluate (out var error), "Evaluate");
 				Assert.NotNull (error, "error");
-				if (TestRuntime.CheckXcodeVersion (12, 2))
-					Assert.That (error.LocalizedDescription, Is.EqualTo ("“mail.google.com” certificate is using a broken signature algorithm"), "desc");
-				else
-					Assert.That (error.LocalizedDescription, Is.EqualTo ("“mail.google.com” certificate is not standards compliant"), "desc");
+				// We have different error messages that all contain mail.google.com and some different text.
+				Assert.That (error.LocalizedDescription, Is.StringContaining ("mail.google.com"), "LocalizedDescription");
 			} else if (TestRuntime.CheckXcodeVersion (11, 0)) {
 				Assert.False (trust.Evaluate (out var error), "Evaluate");
 				Assert.NotNull (error, "error");

--- a/tests/monotouch-test/Security/TrustTest.cs
+++ b/tests/monotouch-test/Security/TrustTest.cs
@@ -295,11 +295,7 @@ namespace MonoTouchFixtures.Security {
 			using (SecKey pkey = trust.GetPublicKey ()) {
 				Assert.That (CFGetRetainCount (pkey.Handle), Is.GreaterThanOrEqualTo ((nint) 1), "RetainCount(pkey)");
 			}
-#if __MACOS__
-			if (TestRuntime.CheckXcodeVersion (12,2)) {
-#else
-			if (TestRuntime.CheckXcodeVersion (12,0)) {
-#endif
+			if (TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
 				using (SecKey key = trust.GetKey ()) {
 					Assert.That (key.BlockSize, Is.EqualTo (128), "BlockSize");
 					Assert.That (CFGetRetainCount (key.Handle), Is.GreaterThanOrEqualTo ((nint) 1), "RetainCount(key)");

--- a/tests/monotouch-test/UniformTypeIdentifiers/TypeTest.cs
+++ b/tests/monotouch-test/UniformTypeIdentifiers/TypeTest.cs
@@ -11,7 +11,10 @@ namespace MonoTouchFixtures.UniformTypeIdentifiers {
 	public class UTTypeTests {
 
 		[SetUp]
-		public void Setup () => TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
+		public void SetUp ()
+		{
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
+		}
 
 		[Test]
 		public void Archive ()

--- a/tests/monotouch-test/UniformTypeIdentifiers/TypeTest.cs
+++ b/tests/monotouch-test/UniformTypeIdentifiers/TypeTest.cs
@@ -11,14 +11,7 @@ namespace MonoTouchFixtures.UniformTypeIdentifiers {
 	public class UTTypeTests {
 
 		[SetUp]
-		public void Setup ()
-		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
-		}
+		public void Setup () => TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 
 		[Test]
 		public void Archive ()

--- a/tests/monotouch-test/UniformTypeIdentifiers/TypeTest.cs
+++ b/tests/monotouch-test/UniformTypeIdentifiers/TypeTest.cs
@@ -13,7 +13,11 @@ namespace MonoTouchFixtures.UniformTypeIdentifiers {
 		[SetUp]
 		public void Setup ()
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 		}
 
 		[Test]

--- a/tests/monotouch-test/VideoToolbox/VTUtilitiesTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTUtilitiesTests.cs
@@ -120,7 +120,11 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[TestCase (CMVideoCodecType.Hevc)]
 		public void TestRegisterSupplementalVideoDecoder (CMVideoCodecType codec)
 		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
 			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
 			// ensure that the call does not crash, we do not have anyother thing to test since there is 
 			// no way to know if it was a success
 			VTUtilities.RegisterSupplementalVideoDecoder (codec);

--- a/tests/monotouch-test/VideoToolbox/VTUtilitiesTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTUtilitiesTests.cs
@@ -120,11 +120,7 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[TestCase (CMVideoCodecType.Hevc)]
 		public void TestRegisterSupplementalVideoDecoder (CMVideoCodecType codec)
 		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			// ensure that the call does not crash, we do not have anyother thing to test since there is 
 			// no way to know if it was a success
 			VTUtilities.RegisterSupplementalVideoDecoder (codec);

--- a/tests/monotouch-test/Vision/VNCircleTests.cs
+++ b/tests/monotouch-test/Vision/VNCircleTests.cs
@@ -25,7 +25,14 @@ namespace MonoTouchFixtures.Vision {
 	public class VNCircleTests {
 
 		[SetUp]
-		public void Setup () => TestRuntime.AssertXcodeVersion (12, 0);
+		public void Setup ()
+		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
+			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
+		}
 
 		[Test]
 		public void CreateUsingRadiusTest ()

--- a/tests/monotouch-test/Vision/VNCircleTests.cs
+++ b/tests/monotouch-test/Vision/VNCircleTests.cs
@@ -25,14 +25,7 @@ namespace MonoTouchFixtures.Vision {
 	public class VNCircleTests {
 
 		[SetUp]
-		public void Setup ()
-		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
-		}
+		public void Setup () => TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 
 		[Test]
 		public void CreateUsingRadiusTest ()

--- a/tests/monotouch-test/Vision/VNGeometryUtilsTests.cs
+++ b/tests/monotouch-test/Vision/VNGeometryUtilsTests.cs
@@ -26,14 +26,7 @@ namespace MonoTouchFixtures.Vision {
 	public class VNGeometryUtilsTests {
 
 		[SetUp]
-		public void Setup ()
-		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
-		}
+		public void Setup () => TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 
 		[Test]
 		public void CreateBoundingCircleTest ()

--- a/tests/monotouch-test/Vision/VNGeometryUtilsTests.cs
+++ b/tests/monotouch-test/Vision/VNGeometryUtilsTests.cs
@@ -26,7 +26,14 @@ namespace MonoTouchFixtures.Vision {
 	public class VNGeometryUtilsTests {
 
 		[SetUp]
-		public void Setup () => TestRuntime.AssertXcodeVersion (12, 0);
+		public void Setup ()
+		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
+			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
+		}
 
 		[Test]
 		public void CreateBoundingCircleTest ()

--- a/tests/monotouch-test/Vision/VNRequestTests.cs
+++ b/tests/monotouch-test/Vision/VNRequestTests.cs
@@ -136,11 +136,7 @@ namespace MonoTouchFixtures.Vision {
 				Assert.That (faceObservation.BoundingBox, Is.EqualTo (rect));
 
 				var recognizedObjectObservation = VNRecognizedObjectObservation.FromBoundingBox (VNRecognizedObjectObservationRequestRevision.Unspecified, rect);
-#if __MACOS__
-				if (TestRuntime.CheckXcodeVersion (11, 0) && !TestRuntime.CheckXcodeVersion (12, 2)) {
-#else
-				if (TestRuntime.CheckXcodeVersion (11, 0) && !TestRuntime.CheckXcodeVersion (12, 0)) {
-#endif
+				if (TestRuntime.CheckXcodeVersion (11, 0) && !TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
 					Assert.IsNull (recognizedObjectObservation, "recognizedObjectObservation is not null");
 				} else {
 					Assert.NotNull (recognizedObjectObservation, "recognizedObjectObservation is null");
@@ -171,11 +167,7 @@ namespace MonoTouchFixtures.Vision {
 				Assert.That (faceObservation.BoundingBox, Is.EqualTo (rect));
 
 				var recognizedObjectObservation = VNRecognizedObjectObservation.FromBoundingBox ((VNRecognizedObjectObservationRequestRevision) 5000, rect);
-#if __MACOS__
-				if (TestRuntime.CheckXcodeVersion (11, 0) && !TestRuntime.CheckXcodeVersion (12, 2)) {
-#else
-				if (TestRuntime.CheckXcodeVersion (11, 0) && !TestRuntime.CheckXcodeVersion (12, 0)) {
-#endif
+				if (TestRuntime.CheckXcodeVersion (11, 0) && !TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
 					Assert.IsNull (recognizedObjectObservation, "randomRevision recognizedObjectObservation is null");
 				} else {
 					Assert.NotNull (recognizedObjectObservation, "randomRevision recognizedObjectObservation is null");
@@ -211,11 +203,7 @@ namespace MonoTouchFixtures.Vision {
 				Assert.That (faceObservation.BoundingBox, Is.EqualTo (rect));
 
 				var recognizedObjectObservation = VNRecognizedObjectObservation.FromBoundingBox (VNRecognizedObjectObservationRequestRevision.Two, rect);
-#if __MACOS__
-				if (TestRuntime.CheckXcodeVersion (11, 0) && !TestRuntime.CheckXcodeVersion (12, 2)) {
-#else
-				if (TestRuntime.CheckXcodeVersion (11, 0) && !TestRuntime.CheckXcodeVersion (12, 0)) {
-#endif
+				if (TestRuntime.CheckXcodeVersion (11, 0) && !TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
 					Assert.Null (recognizedObjectObservation, "recognizedObjectObservation is null");
 				} else {
 					Assert.NotNull (recognizedObjectObservation, "recognizedObjectObservation is null");

--- a/tests/monotouch-test/Vision/VNRequestTests.cs
+++ b/tests/monotouch-test/Vision/VNRequestTests.cs
@@ -136,8 +136,12 @@ namespace MonoTouchFixtures.Vision {
 				Assert.That (faceObservation.BoundingBox, Is.EqualTo (rect));
 
 				var recognizedObjectObservation = VNRecognizedObjectObservation.FromBoundingBox (VNRecognizedObjectObservationRequestRevision.Unspecified, rect);
+#if __MACOS__
+				if (TestRuntime.CheckXcodeVersion (11, 0) && !TestRuntime.CheckXcodeVersion (12, 2)) {
+#else
 				if (TestRuntime.CheckXcodeVersion (11, 0) && !TestRuntime.CheckXcodeVersion (12, 0)) {
-					Assert.IsNull (recognizedObjectObservation, "recognizedObjectObservation is null");
+#endif
+					Assert.IsNull (recognizedObjectObservation, "recognizedObjectObservation is not null");
 				} else {
 					Assert.NotNull (recognizedObjectObservation, "recognizedObjectObservation is null");
 					Assert.That (recognizedObjectObservation.BoundingBox, Is.EqualTo (rect));
@@ -167,7 +171,11 @@ namespace MonoTouchFixtures.Vision {
 				Assert.That (faceObservation.BoundingBox, Is.EqualTo (rect));
 
 				var recognizedObjectObservation = VNRecognizedObjectObservation.FromBoundingBox ((VNRecognizedObjectObservationRequestRevision) 5000, rect);
+#if __MACOS__
+				if (TestRuntime.CheckXcodeVersion (11, 0) && !TestRuntime.CheckXcodeVersion (12, 2)) {
+#else
 				if (TestRuntime.CheckXcodeVersion (11, 0) && !TestRuntime.CheckXcodeVersion (12, 0)) {
+#endif
 					Assert.IsNull (recognizedObjectObservation, "randomRevision recognizedObjectObservation is null");
 				} else {
 					Assert.NotNull (recognizedObjectObservation, "randomRevision recognizedObjectObservation is null");
@@ -203,7 +211,11 @@ namespace MonoTouchFixtures.Vision {
 				Assert.That (faceObservation.BoundingBox, Is.EqualTo (rect));
 
 				var recognizedObjectObservation = VNRecognizedObjectObservation.FromBoundingBox (VNRecognizedObjectObservationRequestRevision.Two, rect);
+#if __MACOS__
+				if (TestRuntime.CheckXcodeVersion (11, 0) && !TestRuntime.CheckXcodeVersion (12, 2)) {
+#else
 				if (TestRuntime.CheckXcodeVersion (11, 0) && !TestRuntime.CheckXcodeVersion (12, 0)) {
+#endif
 					Assert.Null (recognizedObjectObservation, "recognizedObjectObservation is null");
 				} else {
 					Assert.NotNull (recognizedObjectObservation, "recognizedObjectObservation is null");

--- a/tests/monotouch-test/Vision/VNVectorTests.cs
+++ b/tests/monotouch-test/Vision/VNVectorTests.cs
@@ -25,7 +25,14 @@ namespace MonoTouchFixtures.Vision {
 	public class VNVectorTests {
 
 		[SetUp]
-		public void Setup () => TestRuntime.AssertXcodeVersion (12, 0);
+		public void Setup ()
+		{
+#if __MACOS__
+			TestRuntime.AssertXcodeVersion (12, 2);
+#else
+			TestRuntime.AssertXcodeVersion (12, 0);
+#endif
+		}
 
 		[Test]
 		public void VNVectorCreateTest ()

--- a/tests/monotouch-test/Vision/VNVectorTests.cs
+++ b/tests/monotouch-test/Vision/VNVectorTests.cs
@@ -25,14 +25,7 @@ namespace MonoTouchFixtures.Vision {
 	public class VNVectorTests {
 
 		[SetUp]
-		public void Setup ()
-		{
-#if __MACOS__
-			TestRuntime.AssertXcodeVersion (12, 2);
-#else
-			TestRuntime.AssertXcodeVersion (12, 0);
-#endif
-		}
+		public void Setup () => TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 
 		[Test]
 		public void VNVectorCreateTest ()


### PR DESCRIPTION
xammac tests began to fail because Xcode 12.0 includes macOS 10.15 SDK so our tests needed to be adjusted for asking Xcode 12.2 when running in the Xamarin.Mac context also added an implementation for `CheckExactXcodeVersion` for macOS which is somewhat dangerous (?) because Apple docs says `OperatingSystemVersionString` is not appropriate for parsing but ¯\\(◉‿◉)/¯ this helps us to add some 🦜 tests for future betas.