### PR TITLE
[dotnet] Don't try to update the location of the dynamic libraries when we didn't fix them.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -422,7 +422,7 @@
 		/>
 
 		<!-- Update our item groups -->
-		<ItemGroup>
+		<ItemGroup Condition="'$(IsMacEnabled)' == 'true'">
 			<_MonoLibraryFixed Include="@(_MonoLibrary -> '$(_IntermediateNativeLibraryDir)%(Filename)%(Extension)')" />
 			<ResolvedFileToPublish Remove="@(_MonoLibrary)" />
 			<ResolvedFileToPublish Include="@(_MonoLibraryFixed)" />


### PR DESCRIPTION
We're already not running part of the _UpdateDynamicLibraryId task when in
offline mode, so exclude the rest as well.

Fixes these build errors in offline mode:

    C:\Program Files\dotnet\sdk\5.0.100-rc.2.20480.7\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Publish.targets(237,5): error MSB3030: Could not copy the file "obj\Debug\net5.0-ios\ios-x64\nativelibraries/libSystem.Net.Security.Native.dylib" because it was not found. [C:\code\net6-samples\HelloiOS\HelloiOS.csproj]
    C:\Program Files\dotnet\sdk\5.0.100-rc.2.20480.7\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Publish.targets(237,5): error MSB3030: Could not copy the file "obj\Debug\net5.0-ios\ios-x64\nativelibraries/libSystem.IO.Compression.Native.dylib" because it was not found. [C:\code\net6-samples\HelloiOS\HelloiOS.csproj]
    C:\Program Files\dotnet\sdk\5.0.100-rc.2.20480.7\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Publish.targets(237,5): error MSB3030: Could not copy the file "obj\Debug\net5.0-ios\ios-x64\nativelibraries/libSystem.Security.Cryptography.Native.Apple.dylib" because it was not found. [C:\code\net6-samples\HelloiOS\HelloiOS.csproj]
    C:\Program Files\dotnet\sdk\5.0.100-rc.2.20480.7\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Publish.targets(237,5): error MSB3030: Could not copy the file "obj\Debug\net5.0-ios\ios-x64\nativelibraries/libmonosgen-2.0.dylib" because it was not found. [C:\code\net6-samples\HelloiOS\HelloiOS.csproj]
    C:\Program Files\dotnet\sdk\5.0.100-rc.2.20480.7\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Publish.targets(237,5): error MSB3030: Could not copy the file "obj\Debug\net5.0-ios\ios-x64\nativelibraries/libSystem.Native.dylib" because it was not found. [C:\code\net6-samples\HelloiOS\HelloiOS.csproj]