### PR TITLE
[msbuild] Add a TargetArchitectures argument to the LinkNativeCode task.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -465,6 +465,7 @@
 			SdkDevPath="$(_SdkDevPath)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			SdkRoot="$(_SdkRoot)"
+			TargetArchitectures="$(TargetArchitectures)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 		/>
 

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -1354,5 +1354,11 @@ namespace Xamarin.Localization.MSBuild {
                 return ResourceManager.GetString("E7069", resourceCulture);
             }
         }
+        
+        public static string E7070 {
+            get {
+                return ResourceManager.GetString("E7070", resourceCulture);
+            }
+        }
     }
 }

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1174,4 +1174,8 @@
     <data name="E7069" xml:space="preserve">
         <value>Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+.</value>
     </data>
+    
+    <data name="E7070" xml:space="preserve">
+        <value>Invalid architecture ({0}): can't link more than one architecture at a time.</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
@@ -1145,6 +1145,11 @@
         <target state="new">Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+.</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7070">
+        <source>Invalid architecture ({0}): can't link more than one architecture at a time.</source>
+        <target state="new">Invalid architecture ({0}): can't link more than one architecture at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
@@ -1145,6 +1145,11 @@
         <target state="new">Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+.</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7070">
+        <source>Invalid architecture ({0}): can't link more than one architecture at a time.</source>
+        <target state="new">Invalid architecture ({0}): can't link more than one architecture at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
@@ -1145,6 +1145,11 @@
         <target state="new">Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+.</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7070">
+        <source>Invalid architecture ({0}): can't link more than one architecture at a time.</source>
+        <target state="new">Invalid architecture ({0}): can't link more than one architecture at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
@@ -1145,6 +1145,11 @@
         <target state="new">Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+.</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7070">
+        <source>Invalid architecture ({0}): can't link more than one architecture at a time.</source>
+        <target state="new">Invalid architecture ({0}): can't link more than one architecture at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
@@ -1145,6 +1145,11 @@
         <target state="new">Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+.</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7070">
+        <source>Invalid architecture ({0}): can't link more than one architecture at a time.</source>
+        <target state="new">Invalid architecture ({0}): can't link more than one architecture at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
@@ -1145,6 +1145,11 @@
         <target state="new">Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+.</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7070">
+        <source>Invalid architecture ({0}): can't link more than one architecture at a time.</source>
+        <target state="new">Invalid architecture ({0}): can't link more than one architecture at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
@@ -1145,6 +1145,11 @@
         <target state="new">Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+.</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7070">
+        <source>Invalid architecture ({0}): can't link more than one architecture at a time.</source>
+        <target state="new">Invalid architecture ({0}): can't link more than one architecture at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
@@ -1145,6 +1145,11 @@
         <target state="new">Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+.</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7070">
+        <source>Invalid architecture ({0}): can't link more than one architecture at a time.</source>
+        <target state="new">Invalid architecture ({0}): can't link more than one architecture at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
@@ -1145,6 +1145,11 @@
         <target state="new">Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+.</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7070">
+        <source>Invalid architecture ({0}): can't link more than one architecture at a time.</source>
+        <target state="new">Invalid architecture ({0}): can't link more than one architecture at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
@@ -1145,6 +1145,11 @@
         <target state="new">Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+.</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7070">
+        <source>Invalid architecture ({0}): can't link more than one architecture at a time.</source>
+        <target state="new">Invalid architecture ({0}): can't link more than one architecture at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
@@ -1145,6 +1145,11 @@
         <target state="new">Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+.</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7070">
+        <source>Invalid architecture ({0}): can't link more than one architecture at a time.</source>
+        <target state="new">Invalid architecture ({0}): can't link more than one architecture at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
@@ -1145,6 +1145,11 @@
         <target state="new">Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+.</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7070">
+        <source>Invalid architecture ({0}): can't link more than one architecture at a time.</source>
+        <target state="new">Invalid architecture ({0}): can't link more than one architecture at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
@@ -1145,6 +1145,11 @@
         <target state="new">Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+.</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7070">
+        <source>Invalid architecture ({0}): can't link more than one architecture at a time.</source>
+        <target state="new">Invalid architecture ({0}): can't link more than one architecture at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/TargetArchitecture.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/TargetArchitecture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Xamarin.MacDev.Tasks {
 	[Flags]
@@ -17,5 +18,49 @@ namespace Xamarin.MacDev.Tasks {
 
 		// Note: needed for backwards compatability
 		ARMv6_ARMv7 = ARMv6 | ARMv7,
+	}
+
+	public static class TargetArchitectureExtensions {
+		public static IList<TargetArchitecture> ToArray (this TargetArchitecture self)
+		{
+			if (self == TargetArchitecture.Default)
+				return Array.Empty<TargetArchitecture> ();
+
+			var rv = new List<TargetArchitecture> ();
+
+			var simpleValues = new List<TargetArchitecture> ((TargetArchitecture []) Enum.GetValues (typeof (TargetArchitecture)));
+			simpleValues.Remove (TargetArchitecture.Default);
+			simpleValues.Remove (TargetArchitecture.ARMv6_ARMv7);
+
+			foreach (var arch in simpleValues) {
+				if ((self & arch) == arch)
+					rv.Add (arch);
+			}
+
+			return rv;
+		}
+
+		public static string ToNativeArchitecture (this TargetArchitecture self)
+		{
+			switch (self) {
+			case TargetArchitecture.i386:
+			case TargetArchitecture.x86_64:
+				return self.ToString ();
+			case TargetArchitecture.ARMv6:
+				return "armv6";
+			case TargetArchitecture.ARMv7:
+				return "armv7";
+			case TargetArchitecture.ARMv7s:
+				return "armv7s";
+			case TargetArchitecture.ARMv7k:
+				return "armv7k";
+			case TargetArchitecture.ARM64:
+				return "arm64";
+			case TargetArchitecture.ARM64_32:
+				return "arm64_32";
+			default:
+				throw new ArgumentOutOfRangeException (nameof (self), $"The value '{self}' does not represent a single architecture.");
+			}
+		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/LinkNativeCodeTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/LinkNativeCodeTaskBase.cs
@@ -4,6 +4,8 @@ using System.IO;
 
 using Microsoft.Build.Framework;
 
+using Xamarin.Localization.MSBuild;
+
 namespace Xamarin.MacDev.Tasks {
 	public abstract class LinkNativeCodeTaskBase : XamarinTask {
 
@@ -36,13 +38,33 @@ namespace Xamarin.MacDev.Tasks {
 		public ITaskItem[] Frameworks { get; set; }
 
 		public string DylibRPath { get; set; }
+
+		[Required]
+		public string TargetArchitectures { get; set; }
+
+		TargetArchitecture architectures;
 #endregion
 
 		public override bool Execute ()
 		{
+			if (!Enum.TryParse (TargetArchitectures, out architectures)) {
+				Log.LogError (12, null, MSBStrings.E0012, TargetArchitectures);
+				return false;
+			}
+
+			var abis = architectures.ToArray ();
+			if (abis.Count != 1) {
+				Log.LogError (7070, null, MSBStrings.E7070, /* Invalid architecture ({0}): can't link more than one architecture at a time. */ TargetArchitectures);
+				return false;
+			}
+			var abi = abis [0].ToNativeArchitecture ();
+
 			var arguments = new List<string> ();
 			arguments.Add ("clang");
 
+			arguments.Add ("-arch");
+			arguments.Add (abi);
+			
 			arguments.Add (PlatformFrameworkHelper.GetMinimumVersionArgument (TargetFrameworkMoniker, SdkIsSimulator, MinimumOSVersion));
 
 			arguments.Add ("-isysroot");


### PR DESCRIPTION
The native linker defaults to the execution architecture, which works fine for
64-bit iOS Simulator (because we target x86_64 and run on x86_64), but it
doesn't work for any other architecture, so make sure to pass the architecture
to the native linker.

Also make sure we only get one architecture, because the native linker doesn't support
building fat libraries (we'll have to add support for manually lipoing the result).