### PR TITLE
[msbuild] Always create debug symbols when building native code.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileNativeCodeTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileNativeCodeTaskBase.cs
@@ -46,6 +46,7 @@ namespace Xamarin.MacDev.Tasks {
 				var arguments = new List<string> ();
 
 				arguments.Add ("clang");
+				arguments.Add ("-g");
 
 				arguments.Add (PlatformFrameworkHelper.GetMinimumVersionArgument (TargetFrameworkMoniker, SdkIsSimulator, MinimumOSVersion));
 


### PR DESCRIPTION
There's no reason not to, since we strip the executables later when needed.