### PR TITLE
[tests] Make the baseline sample test pass the correct environment variables.

### DIFF
--- a/tests/sampletester/SampleTester.cs
+++ b/tests/sampletester/SampleTester.cs
@@ -116,6 +116,30 @@ namespace Samples {
 			return info;
 		}
 
+		public static Dictionary<string, string> GetEnvironmentVariables (TestPlatform platform)
+		{
+			var environment_variables = new Dictionary<string, string> ();
+			environment_variables ["MD_APPLE_SDK_ROOT"] = Path.GetDirectoryName (Path.GetDirectoryName (Configuration.XcodeLocation));
+			switch (platform) {
+			case TestPlatform.iOS:
+			case TestPlatform.tvOS:
+			case TestPlatform.watchOS:
+				environment_variables ["MD_MTOUCH_SDK_ROOT"] = Path.Combine (Configuration.IOS_DESTDIR, "Library", "Frameworks", "Xamarin.iOS.framework", "Versions", "Current");
+				environment_variables ["TargetFrameworkFallbackSearchPaths"] = Path.Combine (Configuration.IOS_DESTDIR, "Library", "Frameworks", "Mono.framework", "External", "xbuild-frameworks");
+				environment_variables ["MSBuildExtensionsPathFallbackPathsOverride"] = Path.Combine (Configuration.IOS_DESTDIR, "Library", "Frameworks", "Mono.framework", "External", "xbuild");
+				break;
+			case TestPlatform.macOS:
+				environment_variables ["TargetFrameworkFallbackSearchPaths"] = Path.Combine (Configuration.MAC_DESTDIR, "Library", "Frameworks", "Mono.framework", "External", "xbuild-frameworks");
+				environment_variables ["MSBuildExtensionsPathFallbackPathsOverride"] = Path.Combine (Configuration.MAC_DESTDIR, "Library", "Frameworks", "Mono.framework", "External", "xbuild");
+				environment_variables ["XamarinMacFrameworkRoot"] = Path.Combine (Configuration.MAC_DESTDIR, "Library", "Frameworks", "Xamarin.Mac.framework", "Versions", "Current");
+				environment_variables ["XAMMAC_FRAMEWORK_PATH"] = Path.Combine (Configuration.MAC_DESTDIR, "Library", "Frameworks", "Xamarin.Mac.framework", "Versions", "Current");
+				break;
+			default:
+				throw new NotImplementedException (platform.ToString ());
+			}
+			return environment_variables;
+		}
+
 		[Test]
 		public void BuildSample ([ValueSource ("GetSampleData")] SampleTestData sampleTestData)
 		{
@@ -140,26 +164,6 @@ namespace Samples {
 				case TestPlatform.macOS:
 					if (!Configuration.include_mac)
 						Assert.Ignore ("macOS support has been disabled");
-					break;
-				default:
-					throw new NotImplementedException (sampleTestData.Platform.ToString ());
-				}
-
-				var environment_variables = new Dictionary<string, string> ();
-				environment_variables ["MD_APPLE_SDK_ROOT"] = Path.GetDirectoryName (Path.GetDirectoryName (Configuration.XcodeLocation));
-				switch (data.Project.Platform) {
-				case TestPlatform.iOS:
-				case TestPlatform.tvOS:
-				case TestPlatform.watchOS:
-					environment_variables ["MD_MTOUCH_SDK_ROOT"] = Path.Combine (Configuration.IOS_DESTDIR, "Library", "Frameworks", "Xamarin.iOS.framework", "Versions", "Current");
-					environment_variables ["TargetFrameworkFallbackSearchPaths"] = Path.Combine (Configuration.IOS_DESTDIR, "Library", "Frameworks", "Mono.framework", "External", "xbuild-frameworks");
-					environment_variables ["MSBuildExtensionsPathFallbackPathsOverride"] = Path.Combine (Configuration.IOS_DESTDIR, "Library", "Frameworks", "Mono.framework", "External", "xbuild");
-					break;
-				case TestPlatform.macOS:
-					environment_variables ["TargetFrameworkFallbackSearchPaths"] = Path.Combine (Configuration.MAC_DESTDIR, "Library", "Frameworks", "Mono.framework", "External", "xbuild-frameworks");
-					environment_variables ["MSBuildExtensionsPathFallbackPathsOverride"] = Path.Combine (Configuration.MAC_DESTDIR, "Library", "Frameworks", "Mono.framework", "External", "xbuild");
-					environment_variables ["XamarinMacFrameworkRoot"] = Path.Combine (Configuration.MAC_DESTDIR, "Library", "Frameworks", "Xamarin.Mac.framework", "Versions", "Current");
-					environment_variables ["XAMMAC_FRAMEWORK_PATH"] = Path.Combine (Configuration.MAC_DESTDIR, "Library", "Frameworks", "Xamarin.Mac.framework", "Versions", "Current");
 					break;
 				default:
 					throw new NotImplementedException (sampleTestData.Platform.ToString ());
@@ -195,7 +199,7 @@ namespace Samples {
 					File.WriteAllLines (sln_path, filtered_sln);
 				}
 
-				ProcessHelper.BuildSolution (file_to_build, sampleTestData.Platform, sampleTestData.Configuration, environment_variables, sampleTestData.Timeout, target, data.CodesignKey);
+				ProcessHelper.BuildSolution (file_to_build, sampleTestData.Platform, sampleTestData.Configuration, GetEnvironmentVariables (data.Project.Platform), sampleTestData.Timeout, target, data.CodesignKey);
 				Console.WriteLine ("✅ {0} succeeded.", TestContext.CurrentContext.Test.FullName);
 			} catch (Exception e) {
 				Console.WriteLine ("❌ {0} failed: {1}", TestContext.CurrentContext.Test.FullName, e.Message);
@@ -308,7 +312,7 @@ namespace Samples {
 		{
 			var sln = Path.Combine (Configuration.SourceRoot, "tests", "sampletester", "BaselineTest", "BaselineTest.sln");
 			GitHub.CleanRepository (Path.GetDirectoryName (sln));
-			ProcessHelper.BuildSolution (sln, "iPhone", "Debug", new Dictionary<string, string> (), SampleTester.DefaultTimeout);
+			ProcessHelper.BuildSolution (sln, "iPhone", "Debug", SampleTester.GetEnvironmentVariables (TestPlatform.iOS), SampleTester.DefaultTimeout);
 		}
 
 	}


### PR DESCRIPTION
This makes it so that we use the configured Xcode, and not the default (/Applications/Xcode.app), which may be a symlink, which doesn't work with Xcode 12:

    Tool /Applications/Xcode.app/Contents/Developer/usr/bin/ibtool execution started with arguments: --errors --warnings --notices --output-format xml1 --minimum-deployment-target 8.0 --target-device iphone --target-device ipad --auto-activate-custom-fonts --sdk /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.2.sdk --compilation-directory /Users/runner/work/1/s/xamarin-macios/tests/sampletester/BaselineTest/obj/iPhone/Debug/ibtool /Users/runner/work/1/s/xamarin-macios/tests/sampletester/BaselineTest/LaunchScreen.storyboard
             (TaskId:13)
    Tool /Applications/Xcode.app/Contents/Developer/usr/bin/ibtool execution finished (exit code = 134).
             (TaskId:13)
    LaunchScreen.storyboard : error : 2020-10-22 17:47:39.854 ibtoold[5120:92020] [MT] DVTAssertions: Warning in /Library/Caches/com.apple.xbs/Sources/DVTFrameworks/DVTFrameworks-17515.1/DVTFoundation/PlugInArchitecture/DataModel/DVTPlugIn.m:232 [/Users/runner/work/1/s/xamarin-macios/tests/sampletester/BaselineTest/BaselineTest.csproj]
    LaunchScreen.storyboard : error : Details:  Requested but did not find required plug-in with identifier com.apple.rc.RCIDESupportCore [/Users/runner/work/1/s/xamarin-macios/tests/sampletester/BaselineTest/BaselineTest.csproj]
    LaunchScreen.storyboard : error : Object:   <DVTPlugIn: 0x7fe30d129560> [/Users/runner/work/1/s/xamarin-macios/tests/sampletester/BaselineTest/BaselineTest.csproj]
    LaunchScreen.storyboard : error : Method:   -awakeWithPropertyList: [/Users/runner/work/1/s/xamarin-macios/tests/sampletester/BaselineTest/BaselineTest.csproj]
    LaunchScreen.storyboard : error : Thread:   <NSThread: 0x7fe30780acc0>{number = 1, name = main} [/Users/runner/work/1/s/xamarin-macios/tests/sampletester/BaselineTest/BaselineTest.csproj]
    LaunchScreen.storyboard : error : Please file a bug at https://feedbackassistant.apple.com with this warning message and any useful information you can provide. [/Users/runner/work/1/s/xamarin-macios/tests/sampletester/BaselineTest/BaselineTest.csproj]
    LaunchScreen.storyboard : error : 2020-10-22 17:47:39.863 ibtoold[5120:92020] Requested but did not find extension point with identifier Xcode.InterfaceBuilderBuildSupport.PlatformDefinition for extension Xcode.IBCocoaTouchBuildSupport.PlatformDefinition.MacCatalyst of plug-in com.apple.dt.IDE.IBCocoaBuildSupport [/Users/runner/work/1/s/xamarin-macios/tests/sampletester/BaselineTest/BaselineTest.csproj]
    LaunchScreen.storyboard : error : 2020-10-22 17:47:39.863 ibtoold[5120:92020] Requested but did not find extension point with identifier Xcode.InterfaceBuilderBuildSupport.PlatformDefinition for extension Xcode.IBCocoaBuildSupport.PlatformDefinition.Cocoa of plug-in com.apple.dt.IDE.IBCocoaBuildSupport [/Users/runner/work/1/s/xamarin-macios/tests/sampletester/BaselineTest/BaselineTest.csproj]
    LaunchScreen.storyboard : error : 2020-10-22 17:47:39.880 ibtoold[5120:92020] Requested but did not find extension point with identifier Xcode.InterfaceBuilderBuildSupport.PlatformDefinition for extension Xcode.IBCocoaTouchBuildSupport.PlatformDefinition.CocoaTouch of plug-in com.apple.dt.IDE.IBCocoaTouchBuildSupport [/Users/runner/work/1/s/xamarin-macios/tests/sampletester/BaselineTest/BaselineTest.csproj]
    LaunchScreen.storyboard : error : 2020-10-22 17:47:39.880 ibtoold[5120:92020] Requested but did not find extension point with identifier Xcode.InterfaceBuilderBuildSupport.PlatformDefinition for extension Xcode.IBAppleTVBuildSupport.PlatformDefinition.AppleTV of plug-in com.apple.dt.IDE.IBAppleTVBuildSupport [/Users/runner/work/1/s/xamarin-macios/tests/sampletester/BaselineTest/BaselineTest.csproj]
    LaunchScreen.storyboard : error : 2020-10-22 17:47:39.883 ibtoold[5120:92020] Requested but did not find extension point with identifier Xcode.InterfaceBuilderBuildSupport.PlatformDefinition for extension Xcode.IDEInterfaceBuilder.PlatformDefinition.WatchOS of plug-in com.apple.dt.IDE.IDEInterfaceBuilderWatchKitBuildSupport [/Users/runner/work/1/s/xamarin-macios/tests/sampletester/BaselineTest/BaselineTest.csproj]
    LaunchScreen.storyboard : error : 2020-10-22 17:47:39.979 ibtoold[5120:92020] [MT] DVTAssertions: ASSERTION FAILURE in /Library/Caches/com.apple.xbs/Sources/IDEInterfaceBuilder/IDEInterfaceBuilder-17506/InterfaceBuilderKit/Utilities/IBScopedSingletonRegistry.m:45 [/Users/runner/work/1/s/xamarin-macios/tests/sampletester/BaselineTest/BaselineTest.csproj]