### PR TITLE
[tools] Renumber RemoveRejectedTypesStep's error code base to match other ExceptionalSubStep subclasses.

### DIFF
--- a/tools/linker/RemoveRejectedTypesStep.cs
+++ b/tools/linker/RemoveRejectedTypesStep.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Linker {
 		}
 
 		protected override string Name { get; } = "Removing Rejected Type";
-		protected override int ErrorCode { get; } = 2660;
+		protected override int ErrorCode { get; } = 2220;
 
 		public List<(string originalFullName, string replacementTypeName)> TypeReferencesToBeRemoved = new List<(string,string)> () {
 			// order is important for nested types (that's why tuples are used instead of a Dictionary)

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -1177,7 +1177,15 @@
 		</value>
 	</data>
 
-	<!-- 2020 -> 2099 is used by the linker -->
+	<!-- 2020 -> 2099 is used by ExceptionalSubStep subclasses in the linker -->
+	<!-- 202x: OptimizeGeneratedCodeSubStep -->
+	<!-- 203x: RemoveUserResourcesSubStep -->
+	<!-- 204x: CoreHttpMessageHandler -->
+	<!-- 205x: RemoveCode -->
+	<!-- 206x: SealerSubStep -->
+	<!-- 207x: MetadataReducerSubStep -->
+	<!-- 208x: MarkNSObjects -->
+	<!-- 209x: InlinerSubStep -->
 
 	<data name="MT2101" xml:space="preserve">
 		<value>Can't resolve the reference '{0}', referenced from the method '{1}' in '{2}'.
@@ -1274,6 +1282,11 @@
 		</value>
 	</data>
 
+	<!-- 2200 -> 2299 is used by/reserved for ExceptionalSubStep subclasses in the linker -->
+	<!-- 220x: PreserveSmartEnumConversionsSubStep -->
+	<!-- 221x: RemoveBitcodeIncompatibleCodeStep -->
+	<!-- 222x: RemoveRejectedTypesStep -->
+	
 	<data name="MX3001" xml:space="preserve">
 		<value>Could not {0} the assembly '{1}'
 		</value>


### PR DESCRIPTION
Also document which numbers each subclass uses in Errors.resx. This makes it
much easier to figure out the next number to use.