### PR TITLE
Exclude yaml-pipeline branch from building

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -454,9 +454,18 @@ timestamps {
                             currentStage = "${STAGE_NAME}"
                             echo ("Building on ${env.NODE_NAME}")
                             sh ("env | sort") // Print out environment for debug purposes
+
+                            branchName = env.BRANCH_NAME
+                            echo ("Branch name: ${branchName}")
+
+                            if (branchName == 'yaml-pipeline') {
+                                echo ("Build skipped for the ${branchName} branch as a separate Azure DevOps build provides coverage for these changes")
+                                return
+                            }
+
                             scmVars = checkout scm
                             isPr = (env.CHANGE_ID && !env.CHANGE_ID.empty ? true : false)
-                            branchName = env.BRANCH_NAME
+
                             if (isPr) {
                                 gitHash = sh (script: "git log -1 --pretty=%H refs/remotes/origin/${env.BRANCH_NAME}", returnStdout: true).trim ()
                             } else {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -457,7 +457,6 @@ timestamps {
 
                             branchName = env.BRANCH_NAME
                             echo ("Branch name: ${branchName}")
-
                             if (branchName == 'yaml-pipeline') {
                                 echo ("Build skipped for the ${branchName} branch as a separate Azure DevOps build provides coverage for these changes")
                                 return
@@ -465,7 +464,6 @@ timestamps {
 
                             scmVars = checkout scm
                             isPr = (env.CHANGE_ID && !env.CHANGE_ID.empty ? true : false)
-
                             if (isPr) {
                                 gitHash = sh (script: "git log -1 --pretty=%H refs/remotes/origin/${env.BRANCH_NAME}", returnStdout: true).trim ()
                             } else {


### PR DESCRIPTION
We need a branch directly in the repo and not as a fork to build & validate a new yaml build & test pipeline being developed. The branch effectively serves as the main branch for the yaml pipeline development effort with forked branches feeding into it. This change effectively prevents builds of the `yaml-pipeline` branch on Jenkins; though builds for the branch will trigger there, but they will immediately exit.