### PR TITLE
[tools] Localize error messages from the ExceptionSubStep linker step.

### DIFF
--- a/tools/linker/ExceptionalSubStep.cs
+++ b/tools/linker/ExceptionalSubStep.cs
@@ -126,38 +126,32 @@ namespace Xamarin.Linker {
 
 		protected virtual Exception Fail (AssemblyDefinition assembly, Exception e)
 		{
-			var message = $"{Name} failed processing `{assembly?.FullName}`.";
-			return ErrorHelper.CreateError (ErrorCode, e, message);
+			return ErrorHelper.CreateError (ErrorCode, e, Errors.MX_ExceptionalSubSteps, Name, assembly?.FullName);
 		}
 
 		protected virtual Exception Fail (TypeDefinition type, Exception e)
 		{
-			var message = $"{Name} failed processing {type?.FullName}.";
-			return ErrorHelper.CreateError (ErrorCode | 1, e, message);
+			return ErrorHelper.CreateError (ErrorCode | 1, e, Errors.MX_ExceptionalSubSteps, Name, type?.FullName);
 		}
 
 		protected virtual Exception Fail (FieldDefinition field, Exception e)
 		{
-			var message = $"{Name} failed processing `{field?.FullName}`.";
-			return ErrorHelper.CreateError (ErrorCode | 2, e, message);
+			return ErrorHelper.CreateError (ErrorCode | 2, e, Errors.MX_ExceptionalSubSteps, Name, field?.FullName);
 		}
 
 		protected virtual Exception Fail (MethodDefinition method, Exception e)
 		{
-			var message = $"{Name} failed processing `{method?.FullName}`.";
-			return ErrorHelper.CreateError (ErrorCode | 3, e, message);
+			return ErrorHelper.CreateError (ErrorCode | 3, e, Errors.MX_ExceptionalSubSteps, Name, method?.FullName);
 		}
 
 		protected virtual Exception Fail (PropertyDefinition property, Exception e)
 		{
-			var message = $"{Name} failed processing {property?.FullName}.";
-			return ErrorHelper.CreateError (ErrorCode | 4, e, message);
+			return ErrorHelper.CreateError (ErrorCode | 4, e, Errors.MX_ExceptionalSubSteps, Name, property?.FullName);
 		}
 
 		protected virtual Exception Fail (EventDefinition @event, Exception e)
 		{
-			var message = $"{Name} failed processing {@event?.FullName}.";
-			return ErrorHelper.CreateError (ErrorCode | 5, e, message);
+			return ErrorHelper.CreateError (ErrorCode | 5, e, Errors.MX_ExceptionalSubSteps, Name, @event?.FullName);
 		}
 
 		// abstracts

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -1403,6 +1403,12 @@ namespace Xamarin.Bundler {
             }
         }
         
+        internal static string MX_ExceptionalSubSteps {
+            get {
+                return ResourceManager.GetString("MX_ExceptionalSubSteps", resourceCulture);
+            }
+        }
+        
         internal static string MT2101 {
             get {
                 return ResourceManager.GetString("MT2101", resourceCulture);

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -1178,6 +1178,15 @@
 	</data>
 
 	<!-- 2020 -> 2099 is used by ExceptionalSubStep subclasses in the linker -->
+
+	<data name="MX_ExceptionalSubSteps" xml:space="preserve">
+		<value>The linker step '{0}' failed processing `{1}`.</value>
+		<comment>This is a message when processing an assembly/type/field/method/property/event fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly/type/field/method/property/event that failed processing.
+		</comment>
+	</data>
+
 	<!-- 202x: OptimizeGeneratedCodeSubStep -->
 	<!-- 203x: RemoveUserResourcesSubStep -->
 	<!-- 204x: CoreHttpMessageHandler -->

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -2768,6 +2768,14 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX_ExceptionalSubSteps">
+        <source>The linker step '{0}' failed processing `{1}`.</source>
+        <target state="new">The linker step '{0}' failed processing `{1}`.</target>
+        <note>This is a message when processing an assembly/type/field/method/property/event fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly/type/field/method/property/event that failed processing.
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -2768,6 +2768,14 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX_ExceptionalSubSteps">
+        <source>The linker step '{0}' failed processing `{1}`.</source>
+        <target state="new">The linker step '{0}' failed processing `{1}`.</target>
+        <note>This is a message when processing an assembly/type/field/method/property/event fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly/type/field/method/property/event that failed processing.
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -2768,6 +2768,14 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX_ExceptionalSubSteps">
+        <source>The linker step '{0}' failed processing `{1}`.</source>
+        <target state="new">The linker step '{0}' failed processing `{1}`.</target>
+        <note>This is a message when processing an assembly/type/field/method/property/event fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly/type/field/method/property/event that failed processing.
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -2768,6 +2768,14 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX_ExceptionalSubSteps">
+        <source>The linker step '{0}' failed processing `{1}`.</source>
+        <target state="new">The linker step '{0}' failed processing `{1}`.</target>
+        <note>This is a message when processing an assembly/type/field/method/property/event fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly/type/field/method/property/event that failed processing.
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -2768,6 +2768,14 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX_ExceptionalSubSteps">
+        <source>The linker step '{0}' failed processing `{1}`.</source>
+        <target state="new">The linker step '{0}' failed processing `{1}`.</target>
+        <note>This is a message when processing an assembly/type/field/method/property/event fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly/type/field/method/property/event that failed processing.
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -2768,6 +2768,14 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX_ExceptionalSubSteps">
+        <source>The linker step '{0}' failed processing `{1}`.</source>
+        <target state="new">The linker step '{0}' failed processing `{1}`.</target>
+        <note>This is a message when processing an assembly/type/field/method/property/event fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly/type/field/method/property/event that failed processing.
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -2768,6 +2768,14 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX_ExceptionalSubSteps">
+        <source>The linker step '{0}' failed processing `{1}`.</source>
+        <target state="new">The linker step '{0}' failed processing `{1}`.</target>
+        <note>This is a message when processing an assembly/type/field/method/property/event fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly/type/field/method/property/event that failed processing.
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -2768,6 +2768,14 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX_ExceptionalSubSteps">
+        <source>The linker step '{0}' failed processing `{1}`.</source>
+        <target state="new">The linker step '{0}' failed processing `{1}`.</target>
+        <note>This is a message when processing an assembly/type/field/method/property/event fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly/type/field/method/property/event that failed processing.
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -2768,6 +2768,14 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX_ExceptionalSubSteps">
+        <source>The linker step '{0}' failed processing `{1}`.</source>
+        <target state="new">The linker step '{0}' failed processing `{1}`.</target>
+        <note>This is a message when processing an assembly/type/field/method/property/event fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly/type/field/method/property/event that failed processing.
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -2768,6 +2768,14 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX_ExceptionalSubSteps">
+        <source>The linker step '{0}' failed processing `{1}`.</source>
+        <target state="new">The linker step '{0}' failed processing `{1}`.</target>
+        <note>This is a message when processing an assembly/type/field/method/property/event fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly/type/field/method/property/event that failed processing.
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -2768,6 +2768,14 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX_ExceptionalSubSteps">
+        <source>The linker step '{0}' failed processing `{1}`.</source>
+        <target state="new">The linker step '{0}' failed processing `{1}`.</target>
+        <note>This is a message when processing an assembly/type/field/method/property/event fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly/type/field/method/property/event that failed processing.
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -2768,6 +2768,14 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX_ExceptionalSubSteps">
+        <source>The linker step '{0}' failed processing `{1}`.</source>
+        <target state="new">The linker step '{0}' failed processing `{1}`.</target>
+        <note>This is a message when processing an assembly/type/field/method/property/event fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly/type/field/method/property/event that failed processing.
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -2768,6 +2768,14 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX_ExceptionalSubSteps">
+        <source>The linker step '{0}' failed processing `{1}`.</source>
+        <target state="new">The linker step '{0}' failed processing `{1}`.</target>
+        <note>This is a message when processing an assembly/type/field/method/property/event fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly/type/field/method/property/event that failed processing.
+		</note>
+      </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</target>


### PR DESCRIPTION
I also changed the error message slightly to hopefully make it a bit more
comprehensible when translated (since the step name won't be translated, we'll
end up with a message that mixes English with the translated string).