### PR TITLE
[dotnet] Implement AOT compilation.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -281,14 +281,23 @@
 		<ReadItemsFromFile File="$(_LinkerItemsDirectory)/_RegistrarFile.items" Condition="Exists('$(_LinkerItemsDirectory)/_RegistrarFile.items')">
 			<Output TaskParameter="Items" ItemName="_RegistrarFile" />
 		</ReadItemsFromFile>
+
+		<ItemGroup>
+			<_AssembliesToAOT Include="@(ResolvedFileToPublish)" Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe' " />
+		</ItemGroup>
 	</Target>
 
 	<!-- Native code -->
 
 	<Target Name="_ComputeFrameworkVariables" DependsOnTargets="ResolveRuntimePackAssets">
+		<PropertyGroup>
+			<_MonoNugetPackageId Condition="'$(_PlatformName)' != 'macOS'">Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)</_MonoNugetPackageId>
+			<_MonoNugetPackageId Condition="'$(_PlatformName)' == 'macOS'">Microsoft.NETCore.App.Runtime.Mono.$(RuntimeIdentifier)</_MonoNugetPackageId>
+		</PropertyGroup>
 		<ItemGroup>
 			<!-- Look in the ResolvedFrameworkReference for our Microsoft.* package. This should only find a single package. -->
 			<_XamarinFrameworkReference Include="@(ResolvedFrameworkReference)" Condition="'%(ResolvedFrameworkReference.Identity)' == 'Microsoft.$(_PlatformName)'" />
+			<_MonoFrameworkReference Include="@(ResolvedFrameworkReference)" Condition="'%(ResolvedFrameworkReference.RuntimePackName)' == '$(_MonoNugetPackageId)'" />
 		</ItemGroup>
 		<PropertyGroup>
 			<_XamarinSdkRuntimePackDirectory>%(_XamarinFrameworkReference.RuntimePackPath)</_XamarinSdkRuntimePackDirectory>
@@ -299,6 +308,8 @@
 			<_XamarinRefAssemblyPath>$(_XamarinRefAssemblyDirectory)$(_PlatformAssemblyName).dll</_XamarinRefAssemblyPath>
 
 			<_LibPartialStaticRegistrar>$(_XamarinNativeLibraryDirectory)/Microsoft.$(_PlatformName).registrar.a</_LibPartialStaticRegistrar>
+
+			<_MonoRuntimePackPath>%(_MonoFrameworkReference.RuntimePackPath)/runtimes/$(RuntimeIdentifier)/</_MonoRuntimePackPath>
 		</PropertyGroup>
 	</Target>
 
@@ -313,6 +324,12 @@
 		<PropertyGroup>
 			<_IntermediateNativeLibraryDir>$(IntermediateOutputPath)nativelibraries/</_IntermediateNativeLibraryDir>
 			<_NativeExecutableName>$(_AppBundleName)</_NativeExecutableName>
+			<_NativeExecutablePublishDir Condition="'$(_PlatformName)' != 'macOS'">$(MSBuildProjectDirectory)$(_AppBundlePath)\</_NativeExecutablePublishDir>
+			<_NativeExecutablePublishDir Condition="'$(_PlatformName)' == 'macOS'">$(MSBuildProjectDirectory)$(_AppBundlePath)\Contents\MacOS\</_NativeExecutablePublishDir>
+
+			<_AOTCompiler>$(_MonoRuntimePackPath)native/cross/mono-aot-cross</_AOTCompiler>
+			<_AOTInputDirectory>$(_IntermediateNativeLibraryDir)aot-input/</_AOTInputDirectory>
+			<_AOTOutputDirectory>$(_IntermediateNativeLibraryDir)aot-output/</_AOTOutputDirectory>
 
 			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == '' And ('$(ComputedPlatform)' != 'iPhone' Or '$(_PlatformName)' == 'macOS')">dylib</_LibMonoLinkMode>
 			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == ''">static</_LibMonoLinkMode>
@@ -326,8 +343,6 @@
 			<_LibXamarinName Condition="'$(_LibXamarinName)' == '' And '$(_BundlerDebug)' == 'true'">libxamarin-debug.$(_LibXamarinExtension)</_LibXamarinName>
 			<_LibXamarinName Condition="'$(_LibXamarinName)' == '' And '$(_BundlerDebug)' != 'true'">libxamarin.$(_LibXamarinExtension)</_LibXamarinName>
 
-			<_MonoNugetPackageId Condition="'$(_PlatformName)' != 'macOS'">Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)</_MonoNugetPackageId>
-			<_MonoNugetPackageId Condition="'$(_PlatformName)' == 'macOS'">Microsoft.NETCore.App.Runtime.Mono.$(RuntimeIdentifier)</_MonoNugetPackageId>
 		</PropertyGroup>
 
 		<ItemGroup>
@@ -345,6 +360,53 @@
 			<_MonoLibraryFix Include="@(_MonoLibrary)" Condition="'%(_MonoLibrary.Extension)' == '.dylib'">
 				<TargetPath>$(_IntermediateNativeLibraryDir)%(Filename)%(Extension)</TargetPath>
 			</_MonoLibraryFix>
+		</ItemGroup>
+	</Target>
+
+	<!-- App bundle creation tasks -->
+	<Target Name="_AOTCompile"
+			Condition="'$(_SdkIsSimulator)' != 'true' And '$(_PlatformName)' != 'macOS'"
+			DependsOnTargets="_ComputeVariables"
+			Inputs="@(_AssembliesToAOT)"
+			Outputs="@(_AssembliesToAOT -> '$(_AOTOutputDirectory)%(Filename)%(Extension).o')">
+
+		<AOTCompile
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			Assemblies="@(_AssembliesToAOT)"
+			AOTCompilerPath="$(_AOTCompiler)"
+			InputDirectory="$(_AOTInputDirectory)"
+			MinimumOSVersion="$(_MinimumOSVersion)"
+			OutputDirectory="$(_AOTOutputDirectory)"
+			SdkDevPath="$(_SdkDevPath)"
+			TargetArchitectures="$(TargetArchitectures)"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+		>
+			<Output TaskParameter="AssemblyFiles" ItemName="_AOTAssemblyFiles" />
+			<Output TaskParameter="AOTData" ItemName="_AOTData" />
+		</AOTCompile>
+
+		<CompileNativeCode
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			CompileInfo="@(_AOTAssemblyFiles)"
+			MinimumOSVersion="$(_MinimumOSVersion)"
+			SdkDevPath="$(_SdkDevPath)"
+			SdkIsSimulator="$(_SdkIsSimulator)"
+			SdkRoot="$(_SdkRoot)"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+		>
+			<Output TaskParameter="ObjectFiles" ItemName="_AOTObjectFiles" />
+		</CompileNativeCode>
+
+		<ItemGroup>
+			<!-- Add the AOT-compiled output to the main executable -->
+			<_XamarinMainLibraries Include="@(_AOTObjectFiles)" />
+
+			<!-- copy the aotdata files to the .app -->
+			<ResolvedFileToPublish Include="$(_AOTOutputDirectory)%(_AssembliesToAOT.Filename).aotdata.arm64" >
+				<RelativePath>$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_NativeExecutablePublishDir)))\%(_AssembliesToAOT.Filename).aotdata.arm64</RelativePath>
+			</ResolvedFileToPublish>
 		</ItemGroup>
 	</Target>
 
@@ -377,7 +439,7 @@
 	</Target>
 
 	<Target Name="_CompileNativeExecutable"
-		DependsOnTargets="_DetectSdkLocations;_ComputeTargetArchitectures;_GenerateBundleName;_GetMinimumOSVersion;_ComputeNativeExecutableInputs"
+		DependsOnTargets="_DetectSdkLocations;_ComputeTargetArchitectures;_GenerateBundleName;_GetMinimumOSVersion;_ComputeNativeExecutableInputs;_AOTCompile;"
 		Inputs="@(_CompileNativeExecutableFile)"
 		Outputs="@(_CompileNativeExecutableFile -> '%(OutputFile)')"
 		>
@@ -449,8 +511,6 @@
 		>
 
 		<PropertyGroup>
-			<_NativeExecutablePublishDir Condition="'$(_PlatformName)' != 'macOS'">$(MSBuildProjectDirectory)$(_AppBundlePath)\</_NativeExecutablePublishDir>
-			<_NativeExecutablePublishDir Condition="'$(_PlatformName)' == 'macOS'">$(MSBuildProjectDirectory)$(_AppBundlePath)\Contents\MacOS\</_NativeExecutablePublishDir>
 			<_DylibRPath Condition="'$(_PlatformName)' != 'macOS'">@executable_path</_DylibRPath>
 			<_DylibRPath Condition="'$(_PlatformName)' == 'macOS'">@executable_path/../$(_CustomBundleName)/</_DylibRPath>
 		</PropertyGroup>
@@ -461,6 +521,13 @@
 			<_XamarinMainLibraries Include="@(_MonoLibrary)" />
 			<!-- The frameworks we need to link with (both weakly and normally) -->
 			<_NativeExecutableFrameworks Include="@(_LinkerFrameworks)" />
+
+			<!-- CFNetwork is required by xamarin_start_wwan -->
+			<_NativeExecutableFrameworks Include="CFNetwork" Condition="'$(_PlatformName)' == 'iOS'" />
+
+			<!-- Mono requires zlib and iconv -->
+			<_MainLinkerFlags Include="-lz" />
+			<_MainLinkerFlags Include="-liconv" />
 		</ItemGroup>
 
 		<LinkNativeCode
@@ -468,7 +535,7 @@
 			DylibRPath="$(_DylibRPath)"
 			EntitlementsInExecutable="$(_CompiledEntitlements)"
 			Frameworks="@(_NativeExecutableFrameworks);@(_BindingLibraryFrameworks)"
-			LinkerFlags="@(_BindingLibraryLinkerFlags)"
+			LinkerFlags="@(_BindingLibraryLinkerFlags);@(_MainLinkerFlags)"
 			LinkWithLibraries="@(_XamarinMainLibraries);@(_BindingLibraryLinkWith);@(_MainLinkWith)"
 			MinimumOSVersion="$(_MinimumOSVersion)"
 			ObjectFiles="@(_NativeExecutableObjectFiles)"

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/AOTCompileTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/AOTCompileTaskBase.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Localization.MSBuild;
+using Xamarin.Utils;
+
+namespace Xamarin.MacDev.Tasks {
+	public abstract class AOTCompileTaskBase : XamarinTask {
+		[Required]
+		public string AOTCompilerPath { get; set; }
+
+		[Required]
+		public ITaskItem [] Assemblies { get; set; }
+
+		[Required]
+		public string InputDirectory { get; set; }
+
+		[Required]
+		public string MinimumOSVersion { get; set; }
+
+		[Required]
+		public string OutputDirectory { get; set; }
+
+		[Required]
+		public string SdkDevPath { get; set; }
+
+		[Required]
+		public string TargetArchitectures { get; set; }
+
+		TargetArchitecture architectures;
+
+#region Output
+		[Output]
+		public ITaskItem[] AssemblyFiles { get; set; }
+
+		[Output]
+		public ITaskItem[] AOTData { get; set; }
+#endregion
+
+		public override bool Execute ()
+		{
+			if (!Enum.TryParse (TargetArchitectures, out architectures)) {
+				Log.LogError (12, null, MSBStrings.E0012, TargetArchitectures);
+				return false;
+			}
+
+			var inputs = new List<string> (Assemblies.Length);
+			for (var i = 0; i < Assemblies.Length; i++) {
+				inputs.Add (Path.GetFullPath (Assemblies [i].ItemSpec));
+			}
+
+			// All the assemblies to AOT must be in the same directory
+			var assemblyDirectories = inputs.Select (v => Path.GetDirectoryName (Path.GetFullPath (v))).Distinct ().ToArray ();
+			if (assemblyDirectories.Length > 1) {
+				// The assemblies are not in the same directory, so copy them somewhere else (to InputDirectory)
+				Directory.CreateDirectory (InputDirectory);
+				for (var i = 0; i < inputs.Count; i++) {
+					var newInput = Path.Combine (InputDirectory, Path.GetFileName (inputs [i]));
+					File.Copy (inputs [i], newInput, true);
+					inputs [i] = newInput;
+				}
+			} else {
+				// The assemblies are all in the same directory, we can just use that as input.
+				InputDirectory = assemblyDirectories [0];
+			}
+
+			Directory.CreateDirectory (OutputDirectory);
+
+			var aotAssemblyFiles = new List<ITaskItem> ();
+			var aotDataFiles = new List<ITaskItem> ();
+			var processes = new Task<Execution> [Assemblies.Length];
+			var objectFiles = new List<ITaskItem> ();
+
+			var environment = new Dictionary<string, string> {
+				{ "MONO_PATH", Path.GetFullPath (InputDirectory) },
+			};
+
+			foreach (var arch in architectures.ToArray ()) {
+				for (var i = 0; i < Assemblies.Length; i++) {
+					var asm = Assemblies [i];
+					var input = inputs [i];
+					var abi = arch.ToNativeArchitecture ();
+					var aotData = Path.Combine (OutputDirectory, Path.GetFileNameWithoutExtension (input) + ".aotdata." + abi);
+					var aotAssembly = Path.Combine (OutputDirectory, Path.GetFileName (input) + ".s");
+
+					var aotAssemblyItem = new TaskItem (aotAssembly);
+					aotAssemblyItem.SetMetadata ("Arguments", "-Xlinker -rpath -Xlinker @executable_path/ -Qunused-arguments -x assembler -D DEBUG");
+					aotAssemblyItem.SetMetadata ("Arch", abi);
+					aotAssemblyFiles.Add (aotAssemblyItem);
+					aotDataFiles.Add (new TaskItem (aotData));
+
+					var aotArg = new StringBuilder ();
+					aotArg.Append ($"--aot=mtriple={abi}-{PlatformName.ToLowerInvariant ()},");
+					aotArg.Append ($"data-outfile={aotData},");
+					aotArg.Append ($"static,asmonly,direct-icalls,full,dwarfdebug,no-direct-calls,");
+					aotArg.Append ($"soft-debug,");
+					aotArg.Append ($"outfile={aotAssembly}");
+
+					var arguments = new List<string> ();
+					arguments.Add (aotArg.ToString ());
+					arguments.Add ("--debug");
+					arguments.Add ("-O=gsharedvt");
+					arguments.Add ("-O=-float32");
+					arguments.Add (input);
+
+					processes [i] = ExecuteAsync (AOTCompilerPath, arguments, environment: environment, sdkDevPath: SdkDevPath, showErrorIfFailure: false /* we show our own error below */)
+						.ContinueWith ((v) => {
+							if (v.Result.ExitCode != 0)
+								Log.LogError ("Failed to AOT compile {0}, the AOT compiler exited with code {1}", Path.GetFileName (input), v.Result.ExitCode);
+
+							return System.Threading.Tasks.Task.FromResult<Execution> (v.Result);
+						}).Unwrap ();
+				}
+			}
+
+			System.Threading.Tasks.Task.WaitAll (processes);
+
+			AOTData = aotDataFiles.ToArray ();
+			AssemblyFiles = aotAssemblyFiles.ToArray ();
+
+			return !Log.HasLoggedErrors;
+
+		}
+	}
+}
+

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/LinkNativeCodeTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/LinkNativeCodeTaskBase.cs
@@ -77,6 +77,7 @@ namespace Xamarin.MacDev.Tasks {
 					var libExtension = Path.GetExtension (lib).ToLowerInvariant ();
 					switch (libExtension) {
 					case ".a":
+					case ".o":
 						var forceLoad = string.Equals (libSpec.GetMetadata ("ForceLoad"), "true", StringComparison.OrdinalIgnoreCase);
 						if (forceLoad)
 							arguments.Add ("-force_load");

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompile.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompile.cs
@@ -1,0 +1,5 @@
+namespace Xamarin.MacDev.Tasks {
+	public class AOTCompile : AOTCompileTaskBase {
+	}
+}
+

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -98,6 +98,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<!-- Tasks shared between Xamarin.iOS and Xamarin.Mac -->
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.ArTool" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.AOTCompile" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.Codesign" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.CollectBundleResources" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.ComputeBundleResourceOutputPaths" AssemblyFile="$(_TaskAssemblyName)" />


### PR DESCRIPTION
* Add an AOTCompile task that runs the AOT compiler for a given set of input assemblies.
  This task will eventually be deprecated by an equivalent task provided by Mono,
  but this works for now.

* Add an _AOTCompile target that takes care of running the AOT compiler and compile
  the result into object files.