### PR TITLE
[tests] Set MSBuildEnableWorkloadResolver=true when running the .NET tests.

### DIFF
--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -58,6 +58,9 @@ namespace Xamarin.Tests {
 				var env = new Dictionary<string, string> ();
 				env ["MSBuildSDKsPath"] = null;
 				env ["MSBUILD_EXE_PATH"] = null;
+				// This is a temporary variable to enable the .NET workload resolver, because it's opt-in for now.
+				// Ref: https://github.com/dotnet/sdk/issues/13849
+				env ["MSBuildEnableWorkloadResolver"] = "true";
 				var output = new StringBuilder ();
 				var rv = ExecutionHelper.Execute (Executable, args, env, output, output, workingDirectory: Path.GetDirectoryName (project), timeout: TimeSpan.FromMinutes (10));
 				if (assert_success && rv != 0) {


### PR DESCRIPTION
This works fine when executed from xharness, because
MSBuildEnableWorkloadResolver is set by xharness, but without this the dotnet
tests fail when executed from the IDE.