### PR TITLE
[tests] Fix assert in DetectAppManifest_LibraryProject.

### DIFF
--- a/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/TargetTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/TargetTests.cs
@@ -627,7 +627,7 @@ namespace Xamarin.iOS.Tasks
 		public void DetectAppManifest_LibraryProject ()
 		{
 			RunTargetOnInstance (LibraryProjectInstance, TargetName.DetectAppManifest);
-			Assert.That (LibraryProjectInstance.GetPropertyValue ("_AppManifest"), Is.Not.Null.Or.Empty, "#1");
+			Assert.That (LibraryProjectInstance.GetPropertyValue ("_AppManifest"), Is.Null.Or.Empty, "#1");
 		}
 	}
 }


### PR DESCRIPTION
"Is.Not.Null.Or.Empty" is equal to "(value != null) || (value.Length == 0)", which
is the same as "value != null", i.e. "Is.Not.Null", which was clearly not the intention
of this code.

The fact is that the _AppManifest value is not set for library projects, so the correct
assert is to verify that the value is null or empty.