### PR TITLE
[tests] Rewrite ValidateAppBundleTaskTests to not create a task in-process.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1062,7 +1062,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			$(_AppBundlePath)..\%(_ResolvedAppExtensionReferences.FileName)%(_ResolvedAppExtensionReferences.Extension).dSYM" />
 	</Target>
 
-	<Target Name="_ValidateAppBundle" Condition="'$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_DetectSdkLocations;_ComputeTargetFrameworkMoniker">
+	<Target Name="_ValidateAppBundle" Condition="'$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_DetectSdkLocations;_ComputeTargetFrameworkMoniker;_GenerateBundleName">
 		<ValidateAppBundleTask
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/ExtensionTestBase.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/ExtensionTestBase.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 
+using Microsoft.Build.Evaluation;
+
 namespace Xamarin.iOS.Tasks
 {
 	public class ExtensionTestBase : TestBase {
@@ -15,7 +17,7 @@ namespace Xamarin.iOS.Tasks
 			Platform = platform;
 		}
 
-		public void BuildExtension (string hostAppName, string extensionName, string platform, string config, int expectedErrorCount = 0, System.Action<ProjectPaths> additionalAsserts = null)
+		public Project BuildExtension (string hostAppName, string extensionName, string platform, string config, int expectedErrorCount = 0, System.Action<ProjectPaths> additionalAsserts = null)
 		{
 			var bundlePath = platform;
 			var mtouchPaths = SetupProjectPaths (hostAppName, "../", true, bundlePath, config);
@@ -34,7 +36,7 @@ namespace Xamarin.iOS.Tasks
 			RunTarget (proj, "Build", expectedErrorCount);
 
 			if (expectedErrorCount > 0)
-				return;
+				return proj;
 
 			Assert.IsTrue (Directory.Exists (AppBundlePath), "{1} App Bundle does not exist: {0} ", AppBundlePath, bundlePath);
 
@@ -65,6 +67,8 @@ namespace Xamarin.iOS.Tasks
 
 			if (additionalAsserts != null)
 				additionalAsserts (mtouchPaths);
+
+			return proj;
 		}
 
 		public void SetupPaths (string appName, string platform) 

--- a/tests/msbuild/Xamarin.MacDev.Tests/TestHelpers/TestBase.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/TestHelpers/TestBase.cs
@@ -317,13 +317,6 @@ namespace Xamarin.iOS.Tasks
 		{
 		}
 
-		public T CreateTask<T> () where T : Task, new()
-		{
-			var t = new T ();
-			t.BuildEngine = Engine;
-			return t;
-		}
-
 		/// <summary>
 		/// Executes the task and log its error messages.</summary>
 		/// <remarks>


### PR DESCRIPTION
This is a step towards making Xamarin.MacDev.Tests run tests out-of-process.

It requires adding '_GenerateBundleName' as a dependency for the
'_ValidateAppBundle' target, because we're invoking the '_ValidateAppBundle'
directly, and we can't depend on any other targets executing
'_GenerateBundleName', because there are no other executed targets.