### PR TITLE
[tests] Use MyiOSFrameworkBinding as a binding test project instead of bindings-test

### DIFF
--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/BindingProject.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/BindingProject.cs
@@ -17,12 +17,12 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void BuildTest ()
 		{
-			var mtouchPaths = SetupProjectPaths ("bindings-test", projectPath: Path.Combine (Configuration.RootPath, "tests", "bindings-test", "iOS"), includePlatform: false, config: "Any CPU/Debug-unified");
+			var mtouchPaths = SetupProjectPaths ("MyiOSFrameworkBinding", includePlatform: false);
 
 			var proj = SetupProject (Engine, mtouchPaths.ProjectCSProjPath);
 
 			AppBundlePath = mtouchPaths.AppBundlePath;
-			var dllPath = Path.Combine(mtouchPaths.ProjectBinPath, "bindings-test.dll");
+			var dllPath = Path.Combine (mtouchPaths.ProjectBinPath, "MyiOSFrameworkBinding.dll");
 
 			Engine.ProjectCollection.SetGlobalProperty ("Platform", Platform);
 


### PR DESCRIPTION
MyiOSFrameworkBinding is in our normal collection of test projects (in
tests/common/TestProjects), which means it doesn't need a lot of special
casing to make it work.