### PR TITLE
[tests][monotouch-tests] ModelIO tests can't be executed on old Mac

### DIFF
--- a/tests/monotouch-test/ModelIO/MDLAnimatedValueTypesTests.cs
+++ b/tests/monotouch-test/ModelIO/MDLAnimatedValueTypesTests.cs
@@ -38,9 +38,8 @@ namespace MonoTouchFixtures.ModelIO {
 			// ModelIO seems to be broken in Xcode 12.2 Beta 3 so disabling for now.
 			if (TestRuntime.CheckExactXcodeVersion (12, 2, beta: 3))
 				Assert.Inconclusive ("ModelIO is not working in Xcode 12.2 Beta 3");
-#else
-			TestRuntime.AssertXcodeVersion (9, 0);
 #endif
+			TestRuntime.AssertXcodeVersion (9, 0);
 		}
 
 		[Test]


### PR DESCRIPTION
even if broken/ignored on 12.2 beta 3 the original condition, to check
for Xcode 9, remains required.