### PR TITLE
[dotnet] Don't try to include any results from the AOT compiler unless we're on a Mac.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -399,7 +399,7 @@
 			<Output TaskParameter="ObjectFiles" ItemName="_AOTObjectFiles" />
 		</CompileNativeCode>
 
-		<ItemGroup>
+		<ItemGroup Condition="'$(IsMacEnabled)' == 'true'">
 			<!-- Add the AOT-compiled output to the main executable -->
 			<_XamarinMainLibraries Include="@(_AOTObjectFiles)" />
 

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -320,10 +320,13 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
-		[TestCase ("ios-x64")]
-		[TestCase ("ios-arm64")]
-		public void IsNotMacBuild (string runtimeIdentifier)
+		[TestCase ("ios-x64", false)]
+		[TestCase ("ios-arm64", true)]
+		public void IsNotMacBuild (string runtimeIdentifier, bool isDeviceBuild)
 		{
+			if (isDeviceBuild)
+				Configuration.AssertDeviceAvailable ();
+
 			var platform = ApplePlatform.iOS;
 			var project_path = GetProjectPath ("MySingleView");
 			Configuration.IgnoreIfIgnoredPlatform (platform);

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -324,19 +324,6 @@ namespace Xamarin.Tests {
 		[TestCase ("ios-arm64")]
 		public void IsNotMacBuild (string runtimeIdentifier)
 		{
-			ExecutionHelper.Execute ("nuget", new [] { "list", "-Source", "local-dotnet-feed", "-Prerelease" }, out var output);
-			// Undo nuget's wrapping: https://github.com/NuGet/Home/issues/10198
-			var lines = output.ToString ().Split ('\n').ToList ();
-			for (var i = lines.Count - 2; i >= 0; i--) {
-				if (lines [i].Length == 79) {
-					lines [i] += lines [i + 1];
-					lines.RemoveAt (i + 1);
-				}					
-			}
-			Console.Error.WriteLine ($"'nuget list -Source local-dotnet-feed -Prerelease' output:\n{string.Join ("\n", lines)}");
-			ExecutionHelper.Execute ("ls", new [] { "-la", "../../../../../../_build/nuget-feed" }, out output);
-			Console.Error.WriteLine (output);
-
 			var platform = ApplePlatform.iOS;
 			var project_path = GetProjectPath ("MySingleView");
 			Configuration.IgnoreIfIgnoredPlatform (platform);

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -324,6 +324,19 @@ namespace Xamarin.Tests {
 		[TestCase ("ios-arm64")]
 		public void IsNotMacBuild (string runtimeIdentifier)
 		{
+			ExecutionHelper.Execute ("nuget", new [] { "list", "-Source", "local-dotnet-feed", "-Prerelease" }, out var output);
+			// Undo nuget's wrapping: https://github.com/NuGet/Home/issues/10198
+			var lines = output.ToString ().Split ('\n').ToList ();
+			for (var i = lines.Count - 2; i >= 0; i--) {
+				if (lines [i].Length == 79) {
+					lines [i] += lines [i + 1];
+					lines.RemoveAt (i + 1);
+				}					
+			}
+			Console.Error.WriteLine ($"'nuget list -Source local-dotnet-feed -Prerelease' output:\n{string.Join ("\n", lines)}");
+			ExecutionHelper.Execute ("ls", new [] { "-la", "../../../../../../_build/nuget-feed" }, out output);
+			Console.Error.WriteLine (output);
+
 			var platform = ApplePlatform.iOS;
 			var project_path = GetProjectPath ("MySingleView");
 			Configuration.IgnoreIfIgnoredPlatform (platform);


### PR DESCRIPTION
Because the AOT compiler won't execute unless we're on a Mac.

Also add a test.