### PR TITLE
[tools] Always show nested exceptions if they're our own exceptions.

### DIFF
--- a/tools/common/ErrorHelper.tools.cs
+++ b/tools/common/ErrorHelper.tools.cs
@@ -310,8 +310,7 @@ namespace Xamarin.Bundler {
 
 				Console.Error.WriteLine (mte.ToString ());
 
-				if (Verbosity > 1)
-					ShowInner (e);
+				ShowInner (e);
 
 				if (Verbosity > 2 && !string.IsNullOrEmpty (e.StackTrace))
 					Console.Error.WriteLine (e.StackTrace);
@@ -320,8 +319,7 @@ namespace Xamarin.Bundler {
 				Console.Error.WriteLine (e.ToString ());
 			} else {
 				Console.Error.WriteLine (e.ToString ());
-				if (Verbosity > 1)
-					ShowInner (e);
+				ShowInner (e);
 				if (Verbosity > 2 && !string.IsNullOrEmpty (e.StackTrace))
 					Console.Error.WriteLine (e.StackTrace);
 			}
@@ -339,7 +337,7 @@ namespace Xamarin.Bundler {
 				Console.Error.WriteLine ("--- inner exception");
 				Console.Error.WriteLine (ie);
 				Console.Error.WriteLine ("---");
-			} else {
+			} else if (Verbosity > 0 || ie is ProductException) {
 				Console.Error.WriteLine ("\t{0}", ie.Message);
 			}
 			ShowInner (ie);


### PR DESCRIPTION
Sometimes we wrap exceptions to add more information to what's happening, but
that may end up worse if we don't print out the wrapped exceptions.

At the same time we don't want to flood the user with information if they
didn't ask for it, so only show nested exceptions if they're something we
raised ourselves.