### PR TITLE
[dotnet] Improve context-ful linker errors by including the underlying exception message in the output.

### DIFF
--- a/tools/dotnet-linker/Steps/ConfigurationAwareStep.cs
+++ b/tools/dotnet-linker/Steps/ConfigurationAwareStep.cs
@@ -68,18 +68,17 @@ namespace Xamarin.Linker {
 
 		protected virtual Exception Fail (AssemblyDefinition assembly, Exception e)
 		{
-			/* Re-use MX_ExceptionalSubSteps here, it works just fine */
-			return ErrorHelper.CreateError (ErrorCode, e, Errors.MX_ExceptionalSubSteps, Name, assembly?.FullName);
+			return ErrorHelper.CreateError (ErrorCode, e, Errors.MX_ConfigurationAwareStepWithAssembly, Name, assembly?.FullName, e.Message);
 		}
 
 		protected virtual Exception Fail (Exception e)
 		{
-			return ErrorHelper.CreateError (ErrorCode | 1, e, Errors.MX_ConfigurationAwareStep, Name);
+			return ErrorHelper.CreateError (ErrorCode | 1, e, Errors.MX_ConfigurationAwareStep, Name, e.Message);
 		}
 
 		protected virtual Exception FailEnd (Exception e)
 		{
-			return ErrorHelper.CreateError (ErrorCode | 2, e, Errors.MX_ConfigurationAwareStep, Name);
+			return ErrorHelper.CreateError (ErrorCode | 2, e, Errors.MX_ConfigurationAwareStep, Name, e.Message);
 		}
 
 		// abstracts

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -1529,6 +1529,12 @@ namespace Xamarin.Bundler {
             }
         }
         
+        internal static string MX_ConfigurationAwareStepWithAssembly {
+            get {
+                return ResourceManager.GetString("MX_ConfigurationAwareStepWithAssembly", resourceCulture);
+            }
+        }
+        
         internal static string MX3001 {
             get {
                 return ResourceManager.GetString("MX3001", resourceCulture);
@@ -2296,7 +2302,7 @@ namespace Xamarin.Bundler {
                 return ResourceManager.GetString("MX5222", resourceCulture);
             }
         }
-
+        
         internal static string MX5223 {
             get {
                 return ResourceManager.GetString("MX5223", resourceCulture);

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -1301,9 +1301,19 @@
 	<!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
 
 	<data name="MX_ConfigurationAwareStep" xml:space="preserve">
-		<value>The linker step '{0}' failed during processing.</value>
+		<value>The linker step '{0}' failed during processing: {1}</value>
 		<comment>This is a message when processing fails in the linker.
 			{0} - The name of the step that fails.
+			{1} - A string describing what failed.
+		</comment>
+	</data>
+
+	<data name="MX_ConfigurationAwareStepWithAssembly" xml:space="preserve">
+		<value>The linker step '{0}' failed while processing {1}: {2}</value>
+		<comment>This is a message when processing an assembly fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly that failed processing.
+			{1} - A string describing what failed
 		</comment>
 	</data>
 

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -2769,10 +2769,20 @@
         <note></note>
       </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
-        <source>The linker step '{0}' failed during processing.</source>
-        <target state="new">The linker step '{0}' failed during processing.</target>
+        <source>The linker step '{0}' failed during processing: {1}</source>
+        <target state="new">The linker step '{0}' failed during processing: {1}</target>
         <note>This is a message when processing fails in the linker.
 			{0} - The name of the step that fails.
+			{1} - A string describing what failed.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX_ConfigurationAwareStepWithAssembly">
+        <source>The linker step '{0}' failed while processing {1}: {2}</source>
+        <target state="new">The linker step '{0}' failed while processing {1}: {2}</target>
+        <note>This is a message when processing an assembly fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly that failed processing.
+			{1} - A string describing what failed
 		</note>
       </trans-unit>
       <trans-unit id="MX_ExceptionalSubSteps">

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -2769,10 +2769,20 @@
         <note></note>
       </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
-        <source>The linker step '{0}' failed during processing.</source>
-        <target state="new">The linker step '{0}' failed during processing.</target>
+        <source>The linker step '{0}' failed during processing: {1}</source>
+        <target state="new">The linker step '{0}' failed during processing: {1}</target>
         <note>This is a message when processing fails in the linker.
 			{0} - The name of the step that fails.
+			{1} - A string describing what failed.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX_ConfigurationAwareStepWithAssembly">
+        <source>The linker step '{0}' failed while processing {1}: {2}</source>
+        <target state="new">The linker step '{0}' failed while processing {1}: {2}</target>
+        <note>This is a message when processing an assembly fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly that failed processing.
+			{1} - A string describing what failed
 		</note>
       </trans-unit>
       <trans-unit id="MX_ExceptionalSubSteps">

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -2769,10 +2769,20 @@
         <note></note>
       </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
-        <source>The linker step '{0}' failed during processing.</source>
-        <target state="new">The linker step '{0}' failed during processing.</target>
+        <source>The linker step '{0}' failed during processing: {1}</source>
+        <target state="new">The linker step '{0}' failed during processing: {1}</target>
         <note>This is a message when processing fails in the linker.
 			{0} - The name of the step that fails.
+			{1} - A string describing what failed.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX_ConfigurationAwareStepWithAssembly">
+        <source>The linker step '{0}' failed while processing {1}: {2}</source>
+        <target state="new">The linker step '{0}' failed while processing {1}: {2}</target>
+        <note>This is a message when processing an assembly fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly that failed processing.
+			{1} - A string describing what failed
 		</note>
       </trans-unit>
       <trans-unit id="MX_ExceptionalSubSteps">

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -2769,10 +2769,20 @@
         <note></note>
       </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
-        <source>The linker step '{0}' failed during processing.</source>
-        <target state="new">The linker step '{0}' failed during processing.</target>
+        <source>The linker step '{0}' failed during processing: {1}</source>
+        <target state="new">The linker step '{0}' failed during processing: {1}</target>
         <note>This is a message when processing fails in the linker.
 			{0} - The name of the step that fails.
+			{1} - A string describing what failed.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX_ConfigurationAwareStepWithAssembly">
+        <source>The linker step '{0}' failed while processing {1}: {2}</source>
+        <target state="new">The linker step '{0}' failed while processing {1}: {2}</target>
+        <note>This is a message when processing an assembly fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly that failed processing.
+			{1} - A string describing what failed
 		</note>
       </trans-unit>
       <trans-unit id="MX_ExceptionalSubSteps">

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -2769,10 +2769,20 @@
         <note></note>
       </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
-        <source>The linker step '{0}' failed during processing.</source>
-        <target state="new">The linker step '{0}' failed during processing.</target>
+        <source>The linker step '{0}' failed during processing: {1}</source>
+        <target state="new">The linker step '{0}' failed during processing: {1}</target>
         <note>This is a message when processing fails in the linker.
 			{0} - The name of the step that fails.
+			{1} - A string describing what failed.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX_ConfigurationAwareStepWithAssembly">
+        <source>The linker step '{0}' failed while processing {1}: {2}</source>
+        <target state="new">The linker step '{0}' failed while processing {1}: {2}</target>
+        <note>This is a message when processing an assembly fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly that failed processing.
+			{1} - A string describing what failed
 		</note>
       </trans-unit>
       <trans-unit id="MX_ExceptionalSubSteps">

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -2769,10 +2769,20 @@
         <note></note>
       </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
-        <source>The linker step '{0}' failed during processing.</source>
-        <target state="new">The linker step '{0}' failed during processing.</target>
+        <source>The linker step '{0}' failed during processing: {1}</source>
+        <target state="new">The linker step '{0}' failed during processing: {1}</target>
         <note>This is a message when processing fails in the linker.
 			{0} - The name of the step that fails.
+			{1} - A string describing what failed.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX_ConfigurationAwareStepWithAssembly">
+        <source>The linker step '{0}' failed while processing {1}: {2}</source>
+        <target state="new">The linker step '{0}' failed while processing {1}: {2}</target>
+        <note>This is a message when processing an assembly fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly that failed processing.
+			{1} - A string describing what failed
 		</note>
       </trans-unit>
       <trans-unit id="MX_ExceptionalSubSteps">

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -2769,10 +2769,20 @@
         <note></note>
       </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
-        <source>The linker step '{0}' failed during processing.</source>
-        <target state="new">The linker step '{0}' failed during processing.</target>
+        <source>The linker step '{0}' failed during processing: {1}</source>
+        <target state="new">The linker step '{0}' failed during processing: {1}</target>
         <note>This is a message when processing fails in the linker.
 			{0} - The name of the step that fails.
+			{1} - A string describing what failed.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX_ConfigurationAwareStepWithAssembly">
+        <source>The linker step '{0}' failed while processing {1}: {2}</source>
+        <target state="new">The linker step '{0}' failed while processing {1}: {2}</target>
+        <note>This is a message when processing an assembly fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly that failed processing.
+			{1} - A string describing what failed
 		</note>
       </trans-unit>
       <trans-unit id="MX_ExceptionalSubSteps">

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -2769,10 +2769,20 @@
         <note></note>
       </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
-        <source>The linker step '{0}' failed during processing.</source>
-        <target state="new">The linker step '{0}' failed during processing.</target>
+        <source>The linker step '{0}' failed during processing: {1}</source>
+        <target state="new">The linker step '{0}' failed during processing: {1}</target>
         <note>This is a message when processing fails in the linker.
 			{0} - The name of the step that fails.
+			{1} - A string describing what failed.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX_ConfigurationAwareStepWithAssembly">
+        <source>The linker step '{0}' failed while processing {1}: {2}</source>
+        <target state="new">The linker step '{0}' failed while processing {1}: {2}</target>
+        <note>This is a message when processing an assembly fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly that failed processing.
+			{1} - A string describing what failed
 		</note>
       </trans-unit>
       <trans-unit id="MX_ExceptionalSubSteps">

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -2769,10 +2769,20 @@
         <note></note>
       </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
-        <source>The linker step '{0}' failed during processing.</source>
-        <target state="new">The linker step '{0}' failed during processing.</target>
+        <source>The linker step '{0}' failed during processing: {1}</source>
+        <target state="new">The linker step '{0}' failed during processing: {1}</target>
         <note>This is a message when processing fails in the linker.
 			{0} - The name of the step that fails.
+			{1} - A string describing what failed.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX_ConfigurationAwareStepWithAssembly">
+        <source>The linker step '{0}' failed while processing {1}: {2}</source>
+        <target state="new">The linker step '{0}' failed while processing {1}: {2}</target>
+        <note>This is a message when processing an assembly fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly that failed processing.
+			{1} - A string describing what failed
 		</note>
       </trans-unit>
       <trans-unit id="MX_ExceptionalSubSteps">

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -2769,10 +2769,20 @@
         <note></note>
       </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
-        <source>The linker step '{0}' failed during processing.</source>
-        <target state="new">The linker step '{0}' failed during processing.</target>
+        <source>The linker step '{0}' failed during processing: {1}</source>
+        <target state="new">The linker step '{0}' failed during processing: {1}</target>
         <note>This is a message when processing fails in the linker.
 			{0} - The name of the step that fails.
+			{1} - A string describing what failed.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX_ConfigurationAwareStepWithAssembly">
+        <source>The linker step '{0}' failed while processing {1}: {2}</source>
+        <target state="new">The linker step '{0}' failed while processing {1}: {2}</target>
+        <note>This is a message when processing an assembly fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly that failed processing.
+			{1} - A string describing what failed
 		</note>
       </trans-unit>
       <trans-unit id="MX_ExceptionalSubSteps">

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -2769,10 +2769,20 @@
         <note></note>
       </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
-        <source>The linker step '{0}' failed during processing.</source>
-        <target state="new">The linker step '{0}' failed during processing.</target>
+        <source>The linker step '{0}' failed during processing: {1}</source>
+        <target state="new">The linker step '{0}' failed during processing: {1}</target>
         <note>This is a message when processing fails in the linker.
 			{0} - The name of the step that fails.
+			{1} - A string describing what failed.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX_ConfigurationAwareStepWithAssembly">
+        <source>The linker step '{0}' failed while processing {1}: {2}</source>
+        <target state="new">The linker step '{0}' failed while processing {1}: {2}</target>
+        <note>This is a message when processing an assembly fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly that failed processing.
+			{1} - A string describing what failed
 		</note>
       </trans-unit>
       <trans-unit id="MX_ExceptionalSubSteps">

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -2769,10 +2769,20 @@
         <note></note>
       </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
-        <source>The linker step '{0}' failed during processing.</source>
-        <target state="new">The linker step '{0}' failed during processing.</target>
+        <source>The linker step '{0}' failed during processing: {1}</source>
+        <target state="new">The linker step '{0}' failed during processing: {1}</target>
         <note>This is a message when processing fails in the linker.
 			{0} - The name of the step that fails.
+			{1} - A string describing what failed.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX_ConfigurationAwareStepWithAssembly">
+        <source>The linker step '{0}' failed while processing {1}: {2}</source>
+        <target state="new">The linker step '{0}' failed while processing {1}: {2}</target>
+        <note>This is a message when processing an assembly fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly that failed processing.
+			{1} - A string describing what failed
 		</note>
       </trans-unit>
       <trans-unit id="MX_ExceptionalSubSteps">

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -2769,10 +2769,20 @@
         <note></note>
       </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
-        <source>The linker step '{0}' failed during processing.</source>
-        <target state="new">The linker step '{0}' failed during processing.</target>
+        <source>The linker step '{0}' failed during processing: {1}</source>
+        <target state="new">The linker step '{0}' failed during processing: {1}</target>
         <note>This is a message when processing fails in the linker.
 			{0} - The name of the step that fails.
+			{1} - A string describing what failed.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX_ConfigurationAwareStepWithAssembly">
+        <source>The linker step '{0}' failed while processing {1}: {2}</source>
+        <target state="new">The linker step '{0}' failed while processing {1}: {2}</target>
+        <note>This is a message when processing an assembly fails in the linker.
+			{0} - The name of the step that fails.
+			{1} - The name of the assembly that failed processing.
+			{1} - A string describing what failed
 		</note>
       </trans-unit>
       <trans-unit id="MX_ExceptionalSubSteps">


### PR DESCRIPTION
Because just this is kind of useless:

    error MT2301: The linker step 'Setup' failed during processing.

now it will say:

    error MT2301: The linker step 'Setup' failed during processing: <hopefully something useful here>