### PR TITLE
[dotnet-linker] Improve error reporting by consolidating it in the LinkerConfiguration class.

### DIFF
--- a/src/ObjCRuntime/ErrorHelper.cs
+++ b/src/ObjCRuntime/ErrorHelper.cs
@@ -37,7 +37,15 @@ namespace ObjCRuntime {
 			return new ProductException (code, false, innerException, message, args);
 		}
 
-		static void CollectExceptions (Exception ex, List<Exception> exceptions)
+		internal static IList<Exception> CollectExceptions (IEnumerable<Exception> exceptions)
+		{
+			var rv = new List<Exception> ();
+			foreach (var ex in exceptions)
+				CollectExceptions (ex, rv);
+			return rv;
+		}
+
+		internal static void CollectExceptions (Exception ex, List<Exception> exceptions)
 		{
 			AggregateException ae = ex as AggregateException;
 

--- a/tools/common/ErrorHelper.tools.cs
+++ b/tools/common/ErrorHelper.tools.cs
@@ -272,11 +272,8 @@ namespace Xamarin.Bundler {
 
 		public static void Show (IEnumerable<Exception> list)
 		{
-			List<Exception> exceptions = new List<Exception> ();
+			var exceptions = CollectExceptions (list);
 			bool error = false;
-
-			foreach (var e in list)
-				CollectExceptions (e, exceptions);
 
 			foreach (var ex in exceptions)
 				error |= ShowInternal (ex);

--- a/tools/dotnet-linker/Steps/ConfigurationAwareStep.cs
+++ b/tools/dotnet-linker/Steps/ConfigurationAwareStep.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Linker {
 
 		protected void Report (Exception exception)
 		{
-			ErrorHelper.Show (exception);
+			Configuration.Report (exception);
 		}
 
 		protected void Report (List<Exception> exceptions)

--- a/tools/dotnet-linker/Steps/ConfigurationAwareSubStep.cs
+++ b/tools/dotnet-linker/Steps/ConfigurationAwareSubStep.cs
@@ -7,14 +7,12 @@ namespace Xamarin.Linker {
 	public abstract class ConfigurationAwareSubStep : ExceptionalSubStep {
 		protected override void Report (Exception exception)
 		{
-			ErrorHelper.Show (exception);
+			Configuration.Report (exception);
 		}
 
 		protected void Report (List<Exception> exceptions)
 		{
-			// Maybe there's a better way to show errors that integrates with the linker?
-			// We can't just throw an exception or exit here, since there might be only warnings in the list of exceptions.
-			ErrorHelper.Show (exceptions);
+			Configuration.Report (exceptions);
 		}
 	}
 }


### PR DESCRIPTION
* Continue using our own error handling logic, and print our problems to stderr.
* Also use the linker's messaging facilities to report a more generic error,
  in case stderr doesn't show up for some reason.