### PR TITLE
[appkit] Fix NSAvailability availability information

### DIFF
--- a/src/AppKit/NSAccessibility.cs
+++ b/src/AppKit/NSAccessibility.cs
@@ -70,6 +70,10 @@ namespace AppKit
 	}
 
 #if !COREBUILD
+	[Mac (10,10)] // protocol added in 10.10
+	public partial interface INSAccessibility {}
+
+	[Mac (10,9)] // but the field/notifications are in 10.9
 	public partial class NSAccessibility
 	{
 		[Mac (10,10)]

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -23622,7 +23622,8 @@ namespace AppKit {
 	interface INSAccessibility {};
 	interface INSAccessibilityElement {};
 
-	[Mac (10,9)] // protocol added in 10.10 but the field/notifications are in 10.9
+	// 10.9 for fields/notification but 10.10 for protocol
+	// attributes added to both cases in NSAccessibility.cs
 	[Protocol]
 	interface NSAccessibility
 	{
@@ -23916,22 +23917,18 @@ namespace AppKit {
 		[NullAllowed, Export ("accessibilityVerticalUnitDescription")]
 		string AccessibilityVerticalUnitDescription { get; set; }
 
-		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityLayoutPointForScreenPoint:")]
 		CGPoint GetAccessibilityLayoutForScreen (CGPoint point);
 
-		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityLayoutSizeForScreenSize:")]
 		CGSize GetAccessibilityLayoutForScreen (CGSize size);
 
-		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityScreenPointForLayoutPoint:")]
 		CGPoint GetAccessibilityScreenForLayout (CGPoint point);
 
-		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityScreenSizeForLayoutSize:")]
 		CGSize GetAccessibilityScreenForLayout (CGSize size);
@@ -24126,7 +24123,6 @@ namespace AppKit {
 		[NullAllowed, Export ("accessibilityColumnHeaderUIElements", ArgumentSemantic.Copy)]
 		NSObject[] AccessibilityColumnHeaderUIElements { get; set; }
 
-		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityCellForColumn:row:")]
 		[return: NullAllowed]
@@ -24182,50 +24178,41 @@ namespace AppKit {
 		[NullAllowed, Export ("accessibilitySelectedTextRanges", ArgumentSemantic.Copy)]
 		NSValue[] AccessibilitySelectedTextRanges { get; set; }
 
-		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityAttributedStringForRange:")]
 		[return: NullAllowed]
 		NSAttributedString GetAccessibilityAttributedString (NSRange range);
 
-		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityRangeForLine:")]
 		NSRange GetAccessibilityRangeForLine (nint line);
 
-		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityStringForRange:")]
 		[return: NullAllowed]
 		string GetAccessibilityString (NSRange range);
 
-		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityRangeForPosition:")]
 		NSRange GetAccessibilityRange (CGPoint point);
 
-		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityRangeForIndex:")]
 		NSRange GetAccessibilityRange (nint index);
 
-		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityFrameForRange:")]
 		CGRect GetAccessibilityFrame (NSRange range);
 
-		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityRTFForRange:")]
 		[return: NullAllowed]
 		NSData GetAccessibilityRtf (NSRange range);
 
-		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityStyleRangeForIndex:")]
 		NSRange GetAccessibilityStyleRange (nint index);
 
-		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityLineForIndex:")]
 		nint GetAccessibilityLine (nint index);
@@ -24290,62 +24277,50 @@ namespace AppKit {
 		[Export ("accessibilityMinimized")]
 		bool AccessibilityMinimized { [Bind ("isAccessibilityMinimized")] get; set; }
 
-		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformCancel")]
 		bool AccessibilityPerformCancel ();
 
-		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformConfirm")]
 		bool AccessibilityPerformConfirm ();
 
-		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformDecrement")]
 		bool AccessibilityPerformDecrement ();
 
-		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformDelete")]
 		bool AccessibilityPerformDelete ();
 
-		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformIncrement")]
 		bool AccessibilityPerformIncrement ();
 
-		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformPick")]
 		bool AccessibilityPerformPick ();
 
-		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformPress")]
 		bool AccessibilityPerformPress ();
 
-		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformRaise")]
 		bool AccessibilityPerformRaise ();
 
-		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformShowAlternateUI")]
 		bool AccessibilityPerformShowAlternateUI ();
 
-		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformShowDefaultUI")]
 		bool AccessibilityPerformShowDefaultUI ();
 
-		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformShowMenu")]
 		bool AccessibilityPerformShowMenu ();
 
-		[Mac (10,10)]
 		[Abstract]
 		[Export ("isAccessibilitySelectorAllowed:")]
 		bool IsAccessibilitySelectorAllowed (Selector selector);

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -5692,7 +5692,7 @@ public partial class Generator : IMemberGatherer {
 		}
 
 		PrintXpcInterfaceAttribute (type);
-		print ("{0} interface I{1} : INativeObject, IDisposable{2}", class_visibility, TypeName, ifaces.Count () > 0 ? ", " : string.Empty);
+		print ("{0} partial interface I{1} : INativeObject, IDisposable{2}", class_visibility, TypeName, ifaces.Count () > 0 ? ", " : string.Empty);
 		indent++;
 		sb.Clear ();
 		foreach (var iface in ifaces) {


### PR DESCRIPTION
introspection failed on macOS 10.9 because some members existed
in 10.9 before the protocol itself (new in 10.10).

This is more accurate (and we can remove more [Mac] attributes)
but required to make protocol interfaces `partial` - which is a
good thing anyway.