### PR TITLE
[xcode12.2] Bump maccore. Fixes #9961.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 5e97cc52a4dd7d4c2ed98fdfb0ba4e6d57c600ad
+NEEDED_MACCORE_VERSION := 0e3a80dd61bd8d24a302c961a2afa92499013df1
 NEEDED_MACCORE_BRANCH := xcode12
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@0e3a80dd61 [Xamarin.Hosting] Apps without Info.plists aren't watch apps. (#2329)

Diff: https://github.com/xamarin/maccore/compare/5e97cc52a4dd7d4c2ed98fdfb0ba4e6d57c600ad..0e3a80dd61bd8d24a302c961a2afa92499013df1

Fixes: https://github.com/xamarin/xamarin-macios/issues/9961