### PR TITLE
[compare-commits] Fix corruption in dotnet assemblies after API comparison.

### DIFF
--- a/tools/compare-commits.sh
+++ b/tools/compare-commits.sh
@@ -202,7 +202,7 @@ git checkout --quiet --force --detach "$BASE_HASH"
 touch "$OUTPUT_DIR/stamp"
 
 echo "${BLUE}Building src/...${CLEAR}"
-if ! make -C "$ROOT_DIR/src" BUILD_DIR="$ROOT_DIR/tools/comparison/build" PROJECT_DIR="$OUTPUT_DIR/project-files" "IOS_DESTDIR=$OUTPUT_DIR/_ios-build" "MAC_DESTDIR=$OUTPUT_DIR/_mac-build" -j8; then
+if ! make -C "$ROOT_DIR/src" BUILD_DIR="$ROOT_DIR/tools/comparison/build" PROJECT_DIR="$OUTPUT_DIR/project-files" "IOS_DESTDIR=$OUTPUT_DIR/_ios-build" "MAC_DESTDIR=$OUTPUT_DIR/_mac-build" "DOTNET_DESTDIR=$OUTPUT_DIR/_build" -j8; then
 	EC=$?
 	report_error_line "${RED}Failed to build src/${CLEAR}"
 	exit "$EC"
@@ -264,6 +264,7 @@ fi
 MODIFIED_FILES=$(find \
 	"$ROOT_DIR/_ios-build" \
 	"$ROOT_DIR/_mac-build" \
+	"$ROOT_DIR/_build" \
 	"$ROOT_DIR/src" \
 	"$ROOT_DIR/tools/apidiff" \
 	-type f \


### PR DESCRIPTION
Make sure to redirect the dotnet build output to our custom output directory
when building the previous commit so that it doesn't interfere with the normal
build output.

Also add validation for this.