### PR TITLE
[tests] Make sure there are no simulators lurking around when we start running the .NET unit tests.

### DIFF
--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -362,5 +362,36 @@ namespace Xamarin.Tests {
 					return true;
 				});
 		}
+
+		// This is copied from the KillEverything method in xharness/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorDevice.cs and modified to work here.
+		[OneTimeSetUp]
+		public void KillEverything ()
+		{
+			ExecutionHelper.Execute ("launchctl", new [] { "remove", "com.apple.CoreSimulator.CoreSimulatorService" }, timeout: TimeSpan.FromSeconds (10));
+
+			var to_kill = new string [] { "iPhone Simulator", "iOS Simulator", "Simulator", "Simulator (Watch)", "com.apple.CoreSimulator.CoreSimulatorService", "ibtoold" };
+
+			var args = new List<string> ();
+			args.Add ("-9");
+			args.AddRange (to_kill);
+			ExecutionHelper.Execute ("killall", args, timeout: TimeSpan.FromSeconds (10));
+
+			var dirsToBeDeleted = new [] {
+				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), "Library", "Saved Application State", "com.apple.watchsimulator.savedState"),
+				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), "Library", "Saved Application State", "com.apple.iphonesimulator.savedState"),
+			};
+
+			foreach (var dir in dirsToBeDeleted) {
+				try {
+					if (Directory.Exists (dir))
+						Directory.Delete (dir, true);
+				} catch (Exception e) {
+					Console.WriteLine ("Could not delete the directory '{0}': {1}", dir, e.Message);
+				}
+			}
+
+			// https://github.com/xamarin/xamarin-macios/issues/10012
+			ExecutionHelper.Execute ("xcrun", new [] { "simctl", "list" });
+		}
 	}
 }


### PR DESCRIPTION
It seems actool can fail in interesting ways if there are other types of simulators running from earlier tests:

* com.apple.actool.errors
   * Failed to find newest available Simulator runtime, no available runtime found from:
        watchOS 7.0 (7.0 - 18R382) - com.apple.CoreSimulator.SimRuntime.watchOS-7-0 (unavailable, failed to open liblaunch_sim.dylib) ==> not available: Error Domain=com.apple.CoreSimulator.SimError Code=401 "The watchOS 7.0 simulator runtime is not available." UserInfo={NSLocalizedDescription=The watchOS 7.0 simulator runtime is not available., NSUnderlyingError=0x7ff2160359b0 {Error Domain=NSPOSIXErrorDomain Code=53 "Software caused connection abort" UserInfo={NSLocalizedFailureReason=XPC error talking to SimLaunchHostService: <error: 0x7fff958b89a0> { count = 1, transaction: 0, voucher = 0x0, contents =
        	"XPCErrorDescription" => <string: 0x7fff958b8b08> { length = 18, contents = "Connection invalid" }
        }}}, NSLocalizedRecoverySuggestion=Unable to open liblaunch_sim.dylib.  Try reinstalling Xcode or the simulator runtime., NSLocalizedFailureReason=failed to open liblaunch_sim.dylib}

        tvOS 14.0 (14.0 - 18J383) - com.apple.CoreSimulator.SimRuntime.tvOS-14-0 (unavailable, failed to open liblaunch_sim.dylib) ==> not available: Error Domain=com.apple.CoreSimulator.SimError Code=401 "The tvOS 14.0 simulator runtime is not available." UserInfo={NSLocalizedDescription=The tvOS 14.0 simulator runtime is not available., NSUnderlyingError=0x7ff216332580 {Error Domain=NSPOSIXErrorDomain Code=53 "Software caused connection abort" UserInfo={NSLocalizedFailureReason=XPC error talking to SimLaunchHostService: <error: 0x7fff958b89a0> { count = 1, transaction: 0, voucher = 0x0, contents =
        	"XPCErrorDescription" => <string: 0x7fff958b8b08> { length = 18, contents = "Connection invalid" }
        }}}, NSLocalizedRecoverySuggestion=Unable to open liblaunch_sim.dylib.  Try reinstalling Xcode or the simulator runtime., NSLocalizedFailureReason=failed to open liblaunch_sim.dylib},

        iOS 14.1 (14.1 - 18A8394) - com.apple.CoreSimulator.SimRuntime.iOS-14-1 (unavailable, failed to open liblaunch_sim.dylib) ==> not available: Error Domain=com.apple.CoreSimulator.SimError Code=401 "The iOS 14.1 simulator runtime is not available." UserInfo={NSLocalizedDescription=The iOS 14.1 simulator runtime is not available., NSUnderlyingError=0x7ff21a607c80 {Error Domain=NSPOSIXErrorDomain Code=53 "Software caused connection abort" UserInfo={NSLocalizedFailureReason=XPC error talking to SimLaunchHostService: <error: 0x7fff958b89a0> { count = 1, transaction: 0, voucher = 0x0, contents =
        	"XPCErrorDescription" => <string: 0x7fff958b8b08> { length = 18, contents = "Connection invalid" }
        }}}, NSLocalizedRecoverySuggestion=Unable to open liblaunch_sim.dylib.  Try reinstalling Xcode or the simulator runtime., NSLocalizedFailureReason=failed to open liblaunch_sim.dylib},
    ] when matching for <IBCocoaTouchPlatformToolDescription: 0x7ff216274910> System content for IBAppleTVFramework-fourteenAndLater <IBScaleFactorDeviceTypeDescription: 0x7ff21622c520> scaleFactor=1x, renderMode.identifier=(null), idiom=<IBAppleTVIdiom: 0x7ff219f898b0> runtime=<IBCocoaTouchTargetRuntime: 0x7ff216257050>

Ref: https://github.com/xamarin/xamarin-macios/issues/10012