### PR TITLE
[appkit] Fix introspection tests for NSAccessibility on macOS 10.9

### DIFF
--- a/src/AppKit/NSAccessibility.cs
+++ b/src/AppKit/NSAccessibility.cs
@@ -69,13 +69,13 @@ namespace AppKit
 		High = 90
 	}
 
-#if !COREBUILD
 	[Mac (10,10)] // protocol added in 10.10
 	public partial interface INSAccessibility {}
 
 	[Mac (10,9)] // but the field/notifications are in 10.9
 	public partial class NSAccessibility
 	{
+#if !COREBUILD
 		[Mac (10,10)]
 		[DllImport (Constants.AppKitLibrary)]
 		static extern CGRect NSAccessibilityFrameInView (NSView parentView, CGRect frame);
@@ -229,6 +229,6 @@ namespace AppKit
 		{
 			return NSAccessibilitySetMayContainProtectedContent (flag);
 		}
-	}
 #endif
+	}
 }

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -23917,18 +23917,22 @@ namespace AppKit {
 		[NullAllowed, Export ("accessibilityVerticalUnitDescription")]
 		string AccessibilityVerticalUnitDescription { get; set; }
 
+		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityLayoutPointForScreenPoint:")]
 		CGPoint GetAccessibilityLayoutForScreen (CGPoint point);
 
+		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityLayoutSizeForScreenSize:")]
 		CGSize GetAccessibilityLayoutForScreen (CGSize size);
 
+		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityScreenPointForLayoutPoint:")]
 		CGPoint GetAccessibilityScreenForLayout (CGPoint point);
 
+		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityScreenSizeForLayoutSize:")]
 		CGSize GetAccessibilityScreenForLayout (CGSize size);
@@ -24123,6 +24127,7 @@ namespace AppKit {
 		[NullAllowed, Export ("accessibilityColumnHeaderUIElements", ArgumentSemantic.Copy)]
 		NSObject[] AccessibilityColumnHeaderUIElements { get; set; }
 
+		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityCellForColumn:row:")]
 		[return: NullAllowed]
@@ -24178,41 +24183,50 @@ namespace AppKit {
 		[NullAllowed, Export ("accessibilitySelectedTextRanges", ArgumentSemantic.Copy)]
 		NSValue[] AccessibilitySelectedTextRanges { get; set; }
 
+		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityAttributedStringForRange:")]
 		[return: NullAllowed]
 		NSAttributedString GetAccessibilityAttributedString (NSRange range);
 
+		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityRangeForLine:")]
 		NSRange GetAccessibilityRangeForLine (nint line);
 
+		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityStringForRange:")]
 		[return: NullAllowed]
 		string GetAccessibilityString (NSRange range);
 
+		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityRangeForPosition:")]
 		NSRange GetAccessibilityRange (CGPoint point);
 
+		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityRangeForIndex:")]
 		NSRange GetAccessibilityRange (nint index);
 
+		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityFrameForRange:")]
 		CGRect GetAccessibilityFrame (NSRange range);
 
+		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityRTFForRange:")]
 		[return: NullAllowed]
 		NSData GetAccessibilityRtf (NSRange range);
 
+		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityStyleRangeForIndex:")]
 		NSRange GetAccessibilityStyleRange (nint index);
 
+		[Mac (10,10)]
 		[Abstract]
 		[Export ("accessibilityLineForIndex:")]
 		nint GetAccessibilityLine (nint index);
@@ -24277,50 +24291,62 @@ namespace AppKit {
 		[Export ("accessibilityMinimized")]
 		bool AccessibilityMinimized { [Bind ("isAccessibilityMinimized")] get; set; }
 
+		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformCancel")]
 		bool AccessibilityPerformCancel ();
 
+		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformConfirm")]
 		bool AccessibilityPerformConfirm ();
 
+		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformDecrement")]
 		bool AccessibilityPerformDecrement ();
 
+		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformDelete")]
 		bool AccessibilityPerformDelete ();
 
+		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformIncrement")]
 		bool AccessibilityPerformIncrement ();
 
+		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformPick")]
 		bool AccessibilityPerformPick ();
 
+		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformPress")]
 		bool AccessibilityPerformPress ();
 
+		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformRaise")]
 		bool AccessibilityPerformRaise ();
 
+		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformShowAlternateUI")]
 		bool AccessibilityPerformShowAlternateUI ();
 
+		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformShowDefaultUI")]
 		bool AccessibilityPerformShowDefaultUI ();
 
+		[Mac (10, 10)]
 		[Abstract]
 		[Export ("accessibilityPerformShowMenu")]
 		bool AccessibilityPerformShowMenu ();
 
+		[Mac (10,10)]
 		[Abstract]
 		[Export ("isAccessibilitySelectorAllowed:")]
 		bool IsAccessibilitySelectorAllowed (Selector selector);

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -141,7 +141,16 @@ namespace Introspection {
 
 					// Duplicate checks, e.g. same attribute on member and type (extranous metadata)
 					if (ma.Version == ta.Version) {
-						AddErrorLine ($"[FAIL] {ma.Version} ({m}) == {ta.Version} ({t})");
+						switch (t.FullName) {
+						case "AppKit.INSAccessibility":
+							// special case for [I]NSAccessibility type (10.9) / protocol (10.10) mix up
+							// https://github.com/xamarin/xamarin-macios/issues/10009
+							// better some dupes than being inaccurate when protocol members are inlined
+							break;
+						default:
+							AddErrorLine ($"[FAIL] {ma.Version} ({m}) == {ta.Version} ({t})");
+							break;
+						}
 					}
 					// Consistency checks, e.g. member lower than type
 					// note: that's valid in some cases, like a new base type being introduced


### PR DESCRIPTION
This reverts parts of https://github.com/xamarin/xamarin-macios/pull/9993
and add a special case to the test looking for duplicate attributes
between members and the type.

Why ? Introspection fails because `bgen` inline the `NSAccessibility`
protocol (added in 10.10) into types that existed earlier. That's
normally not a problem since the type-level attribute is there.
However because of the 10.9 (type) vs 10.10 (protocol) issue that was
moved into the manual bindings (so `bgen` does not know it)

Even if built inside `COREBUILD` the issue exists since the protocol
interface does not really exists at that point (by default), so it's
the type (10.9) availability that is looked up.

In retrospect we should have created a new type, like Swift did (a
few years later), named `NSAccessibilityProtocol` for 10.10.

Fix https://github.com/xamarin/xamarin-macios/issues/10009