### PR TITLE
[metrickit] Add missing `MXMetricManager.MakeLogHandle` API

### DIFF
--- a/src/CoreFoundation/OSLog.cs
+++ b/src/CoreFoundation/OSLog.cs
@@ -68,7 +68,7 @@ namespace CoreFoundation {
 		[DllImport ("__Internal")]
 		extern static void xamarin_os_log (IntPtr logHandle, OSLogLevel level, string message);
 
-		OSLog (IntPtr handle, bool owns)
+		internal OSLog (IntPtr handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/MetricKit/MXMetricManager.cs
+++ b/src/MetricKit/MXMetricManager.cs
@@ -1,0 +1,19 @@
+#if IOS
+using System;
+
+using CoreFoundation;
+using Foundation;
+using ObjCRuntime;
+
+namespace MetricKit {
+
+	public partial class MXMetricManager {
+
+		public static OSLog MakeLogHandle (NSString category)
+		{
+			var ptr = _MakeLogHandle (category);
+			return new OSLog (ptr, owns: true);
+		}
+	}
+}
+#endif

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1122,6 +1122,7 @@ METALPERFORMANCESHADERS_SOURCES = \
 METRICKIT_SOURCES = \
 	MetricKit/MXMetaData.cs \
 	MetricKit/MXMetric.cs \
+	MetricKit/MXMetricManager.cs \
 	MetricKit/MXMetricPayload.cs \
 
 # MLCompute

--- a/src/metrickit.cs
+++ b/src/metrickit.cs
@@ -405,6 +405,11 @@ namespace MetricKit {
 		[iOS (14,0)]
 		[Export ("pastDiagnosticPayloads", ArgumentSemantic.Strong)]
 		MXDiagnosticPayload[] PastDiagnosticPayloads { get; }
+
+		[Static]
+		[Internal]
+		[Export ("makeLogHandleWithCategory:")]
+		IntPtr /* os_log_t */ _MakeLogHandle (NSString category);
 	}
 
 	interface IMXMetricManagerSubscriber { }

--- a/tests/monotouch-test/MetricKit/MetricManagerTest.cs
+++ b/tests/monotouch-test/MetricKit/MetricManagerTest.cs
@@ -1,0 +1,34 @@
+﻿#if __IOS__
+
+using System;
+
+using CoreFoundation;
+using Foundation;
+using MetricKit;
+using ObjCRuntime;
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.MetricKit {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class MetricManagerTest {
+
+		[SetUp]
+		public void SetUp ()
+		{
+			TestRuntime.AssertXcodeVersion (11, 0);
+		}
+
+		[Test]
+		public void MakeLogHandle ()
+		{
+			using (var ns = new NSString ("xamarin"))
+			using (var lh = MXMetricManager.MakeLogHandle (ns)) {
+				Assert.That (lh.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
+			}
+		}
+	}
+}
+
+#endif

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -286,6 +286,7 @@
     <Folder Include="BackgroundTasks\" />
     <Folder Include="WebKit\" />
     <Folder Include="NearbyInteraction\" />
+    <Folder Include="MetricKit\" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="AudioToolbox\1.caf" />

--- a/tests/xtro-sharpie/iOS-MetricKit.ignore
+++ b/tests/xtro-sharpie/iOS-MetricKit.ignore
@@ -1,2 +1,0 @@
-# os_log_create and friends are not bound.
-!missing-selector! +MXMetricManager::makeLogHandleWithCategory: not bound


### PR DESCRIPTION
and add unit test since it's _partially_ a manual binding as it
returns an non-ObjC type.

Fixes https://github.com/xamarin/xamarin-macios/issues/10004