### PR TITLE
Generate default compilation includes for pdf image assets.

### DIFF
--- a/dotnet/DefaultCompilationIncludes.md
+++ b/dotnet/DefaultCompilationIncludes.md
@@ -29,9 +29,9 @@ subdirectory are included by default (as `InterfaceDefinition` items).
 
 ## Asset catalogs
 
-All \*.jpg, \*.png and \*.json files inside asset catalogs (\*.xcassets) in
-the project directory or any subdirectory are included by default (as
-`ImageAsset` items).
+All \*.pdf, \*.jpg, \*.png and \*.json files inside asset catalogs
+(\*.xcassets) in the project directory or any subdirectory are included by
+default (as `ImageAsset` items).
 
 ## Binding projects
 

--- a/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
+++ b/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
@@ -33,7 +33,7 @@
 
 	<!-- Default Asset Catalog file inclusion -->
 	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == '@PLATFORM@' And '$(_EnableDefaultXamarinItems)' == 'true' ">
-		<ImageAsset Include="**\*.xcassets\**\*.png;**\*.xcassets\*\*.jpg;**\*.xcassets\**\*.json">
+		<ImageAsset Include="**\*.xcassets\**\*.png;**\*.xcassets\*\*.jpg;**\*.xcassets\**\*.pdf;**\*.xcassets\**\*.json">
 			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
 			<Visible>false</Visible>
 			<IsDefaultItem>true</IsDefaultItem>


### PR DESCRIPTION
iOS and macOS have support to generate image assets for various
resolutions from vector based PDF files. These files should be included by
default for SDK-Style projects.