### PR TITLE
[jenkins] Add missing eol to pr comments.

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -106,7 +106,7 @@ else
 
 	if ./jenkins/fetch-pr-labels.sh --check=run-sample-tests; then
 		echo "The sample tests won't be triggered from public jenkins even if the 'run-sample-tests' label is set (build on internal Jenkins instead)."
-		printf "ℹ️ The sample tests won't be triggered from public jenkins even if the 'run-sample-tests' label is set (build on internal Jenkins instead)." >> "$WORKSPACE/jenkins/pr-comments.md"
+		printf "ℹ️ The sample tests won't be triggered from public jenkins even if the 'run-sample-tests' label is set (build on internal Jenkins instead).\\n" >> "$WORKSPACE/jenkins/pr-comments.md"
 	fi
 
 	if ./jenkins/fetch-pr-labels.sh --check=disable-packaged-mono; then


### PR DESCRIPTION
Example of broken pr comment: https://github.com/xamarin/xamarin-macios/pull/10020#issuecomment-720606818