### PR TITLE
[VSTS] Remove the UI prompt ASAP.

### DIFF
--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -35,6 +35,12 @@ steps:
 - checkout: maccore
   persistCredentials: true  # hugely important, else there are some scripts that check a single file from maccore that will fail
 
+- bash: |
+    security set-key-partition-list -S apple-tool:,apple: -s -k $(OSX_KEYCHAIN_PASS) login.keychain
+  displayName: 'Remove security UI-prompt (http://stackoverflow.com/a/40039594/183422)'
+  condition: succeededOrFailed() # we do not care about the previous process cleanup
+  continueOnError: true
+
 - bash: cd $(System.DefaultWorkingDirectory)/xamarin-macios/ && git clean -xdf
   displayName: 'Clean workspace'
 
@@ -194,11 +200,6 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/device-tests/scripts/System.psm1
     Clear-XamarinProcesses 
   displayName: 'Process cleanup'
-
-- bash: |
-    security set-key-partition-list -S apple-tool:,apple: -s -k $(OSX_KEYCHAIN_PASS) login.keychain
-  displayName: 'Remove security UI-prompt (http://stackoverflow.com/a/40039594/183422)'
-  condition: succeededOrFailed() # we do not care about the previous process cleanup
 
 # Increase mlaunch verbosity. Will step on the old setting present.
 - pwsh : |


### PR DESCRIPTION
Using provisionator could result in the UI prompt being shown which will
make the pipeline hang until there is human interaction.

Move the step to be one of the first ones to ensure provisionator does
not get stuck.