### PR TITLE
[dotnet] Add app extension targets to our list of stuff to do during the build.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -147,6 +147,8 @@
 			_CopyResourcesToBundle;
 			_CompileEntitlements;
 			_CompileAppManifest;
+			_ResolveAppExtensionReferences;
+			_ExtendAppExtensionReferences;
 			_ComputeLinkerArguments;
 			ComputeFilesToPublish;
 			_LoadLinkerOutput;
@@ -154,6 +156,7 @@
 			_LinkNativeExecutable;
 			_ComputePublishLocation;
 			CopyFilesToPublishDirectory;
+			_CopyAppExtensionsToBundle;
 		</CreateAppBundleDependsOn>
 	</PropertyGroup>
 

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -116,8 +116,6 @@ namespace Xamarin.Tests {
 					var components = v.Split ('/');
 					if (components.Any (v => v.EndsWith (".framework", StringComparison.Ordinal))) {
 						return false; // TODO
-					} else if (components.Any (v => v.EndsWith (".appex", StringComparison.Ordinal))) {
-						return false; // TODO
 					} else if (components.Any (v => v.EndsWith (".mlmodelc", StringComparison.Ordinal))) {
 						return false; // TODO
 					}

--- a/tests/common/TestProjects/MyActionExtension/MyActionExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyActionExtension/MyActionExtension.dotnet.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-ios</TargetFramework>
+    <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyDocumentPickerExtension/MyDocumentPickerExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyDocumentPickerExtension/MyDocumentPickerExtension.dotnet.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-ios</TargetFramework>
+    <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyExtensionWithPackageReference/MyExtensionWithPackageReference.dotnet.csproj
+++ b/tests/common/TestProjects/MyExtensionWithPackageReference/MyExtensionWithPackageReference.dotnet.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-ios</TargetFramework>
+    <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
   </PropertyGroup>
 

--- a/tests/common/TestProjects/MyKeyboardExtension/MyKeyboardExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyKeyboardExtension/MyKeyboardExtension.dotnet.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-ios</TargetFramework>
+    <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyPhotoEditingExtension/MyPhotoEditingExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyPhotoEditingExtension/MyPhotoEditingExtension.dotnet.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-ios</TargetFramework>
+    <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyShareExtension/MyShareExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyShareExtension/MyShareExtension.dotnet.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-ios</TargetFramework>
+    <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyTVServicesExtension/MyTVServicesExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyTVServicesExtension/MyTVServicesExtension.dotnet.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-tvos</TargetFramework>
+    <RuntimeIdentifier>tvos-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyTodayExtension/MyTodayExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyTodayExtension/MyTodayExtension.dotnet.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-ios</TargetFramework>
+    <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyWatchApp2/MyWatchApp2.dotnet.csproj
+++ b/tests/common/TestProjects/MyWatchApp2/MyWatchApp2.dotnet.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-watchos</TargetFramework>
+    <RuntimeIdentifier>watchos-x86</RuntimeIdentifier>
     <IsWatchOSApp>true</IsWatchOSApp>
   </PropertyGroup>
 

--- a/tests/common/TestProjects/MyWatchKit2Extension/MyWatchKit2Extension.dotnet.csproj
+++ b/tests/common/TestProjects/MyWatchKit2Extension/MyWatchKit2Extension.dotnet.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-watchos</TargetFramework>
+    <RuntimeIdentifier>watchos-x86</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
   </PropertyGroup>
 

--- a/tests/common/TestProjects/MyWatchKit2IntentsExtension/MyWatchKit2IntentsExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyWatchKit2IntentsExtension/MyWatchKit2IntentsExtension.dotnet.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-watchos</TargetFramework>
+    <RuntimeIdentifier>watchos-x86</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyiOSFrameworkBinding/MyiOSFrameworkBinding.dotnet.csproj
+++ b/tests/common/TestProjects/MyiOSFrameworkBinding/MyiOSFrameworkBinding.dotnet.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-ios</TargetFramework>
+    <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <IsBindingProject>true</IsBindingProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>


### PR DESCRIPTION
That makes app extensions buid in dotnet.

This required adding a RuntimeIdentifier property to all the extension test
projects.