### PR TITLE
[mmp] Fix link path for Stripper.cs

### DIFF
--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -453,7 +453,7 @@
       <Link>tools\common\Driver.execution.cs</Link>
     </Compile>
     <Compile Include="..\mtouch\Stripper.cs">
-      <Link>external\tools\mtouch\Stripper.cs</Link>
+      <Link>tools\mtouch\Stripper.cs</Link>
     </Compile>
     <Compile Include="..\common\AssemblyBuildTarget.cs">
       <Link>tools\common\AssemblyBuildTarget.cs</Link>


### PR DESCRIPTION
This makes the file show up in the right place (together with other files from
the tools/mtouch directory) in the solution explorer in VSMac.