### PR TITLE
[dotnet-linker] Improve error reporting

### DIFF
--- a/tools/dotnet-linker/Steps/ConfigurationAwareStep.cs
+++ b/tools/dotnet-linker/Steps/ConfigurationAwareStep.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Linker {
 
 		protected void Report (Exception exception)
 		{
-			Configuration.Report (exception);
+			LinkerConfiguration.Report (Context, exception);
 		}
 
 		protected void Report (List<Exception> exceptions)

--- a/tools/dotnet-linker/Steps/ConfigurationAwareSubStep.cs
+++ b/tools/dotnet-linker/Steps/ConfigurationAwareSubStep.cs
@@ -7,12 +7,12 @@ namespace Xamarin.Linker {
 	public abstract class ConfigurationAwareSubStep : ExceptionalSubStep {
 		protected override void Report (Exception exception)
 		{
-			Configuration.Report (exception);
+			LinkerConfiguration.Report (Context, exception);
 		}
 
 		protected void Report (List<Exception> exceptions)
 		{
-			Configuration.Report (exceptions);
+			LinkerConfiguration.Report (Context, exceptions);
 		}
 	}
 }


### PR DESCRIPTION
Improve error reporting in dotnet-linker by not requiring an instance of a LinkerConfiguration
to report errors. This is accomplished by making the LinkerConfiguration.Report method
a static method.

Otherwise reporting errors before we've successfully created a LinkerConfiguration
turns out to be troublesome (we end up throwing another exception, usually a NullReferenceException,
which is just confusing).