### PR TITLE
[msbuild] Remove unnecessary properties in Xamarin.Mac.Common.targets.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -40,18 +40,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 		<AppBundleExtension Condition="'$(AppBundleExtension)' == ''">.app</AppBundleExtension>
 	</PropertyGroup>
-		
-	<PropertyGroup>
-		<!-- actool output caches -->
-		<_ACTool_PartialAppManifestCache>$(IntermediateOutputPath)actool\_PartialAppManifest.items</_ACTool_PartialAppManifestCache>
-		<_ACTool_BundleResourceCache>$(IntermediateOutputPath)actool\_BundleResourceWithLogicalName.items</_ACTool_BundleResourceCache>
-	</PropertyGroup>
-		
-	<PropertyGroup>
-		<!-- actool output caches -->
-		<_ACTool_PartialAppManifestCache>$(IntermediateOutputPath)actool\_PartialAppManifest.items</_ACTool_PartialAppManifestCache>
-		<_ACTool_BundleResourceCache>$(IntermediateOutputPath)actool\_BundleResourceWithLogicalName.items</_ACTool_BundleResourceCache>
-	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(_UsingXamarinSdk)' != 'true'">
 		<BuildDependsOn>


### PR DESCRIPTION
The _ACTool_PartialAppManifestCache and _ACTool_BundleResourceCache are
duplicated (merge conflict resolution failure?), and also already present in
Xamarin.Shared.targets, so just remove these definitions.