### PR TITLE
[mmp] Fix the build.

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -332,7 +332,7 @@ namespace Xamarin.Bundler {
 					}
 				} else {
 					// Write the cache data as the last step, so there is no half-done/incomplete (but yet detected as valid) cache.
-					App.Cache.ValidateCache ();
+					App.Cache.ValidateCache (App);
 				}
 			}
 


### PR DESCRIPTION
This broke in 59bc3c16abc2162dc3984671f7ff76df92895e3d, and wasn't caught because the Xamarin.Mac build is disabled.