### PR TITLE
Re-enable provisioning steps

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -62,7 +62,8 @@ stages:
     displayName: 'Build packages'
     timeoutInMinutes: 1000
     pool:
-      name: VSEng-Xamarin-RedmondMacCatalinaBuildPool-iOS-Untrusted
+      # name: VSEng-Xamarin-RedmondMacCatalinaBuildPool-iOS-Untrusted  # UNDONE: Test
+      name: VSEng-Xamarin-RedmondMacCatalinaBuildPool-VSForMac-Test
       demands:
       - Agent.OS -equals Darwin
       - Agent.OSVersion -equals 10.15

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -14,7 +14,7 @@ resources:
   - repository: templates
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/dev/bond/keychain                      # UNDONE: Change back to main once keychain diagnostics change has been merged (or not)
+    ref: refs/heads/main
     endpoint: xamarin
 
   - repository: maccore
@@ -43,7 +43,7 @@ variables:
 - name: SigningKeychain
   value: "builder.keychain"
 - name: OSX_KEYCHAIN_PASS                                     # UNDONE: Override the OSX_KEYCHAIN_PASS to use same password as used by the iOS mac pool machines
-  value: $(ios-pool-keychain-password)
+  value: $(pass--lab--mac--builder--keychain)
 
 trigger: none
 
@@ -62,8 +62,7 @@ stages:
     displayName: 'Build packages'
     timeoutInMinutes: 1000
     pool:
-      # name: VSEng-Xamarin-RedmondMacCatalinaBuildPool-iOS-Untrusted  # UNDONE: Test
-      name: VSEng-Xamarin-RedmondMacCatalinaBuildPool-VSForMac-Test
+      name: VSEng-Xamarin-RedmondMacCatalinaBuildPool-iOS-Untrusted
       demands:
       - Agent.OS -equals Darwin
       - Agent.OSVersion -equals 10.15

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,6 +53,7 @@ pr:
     include:
     - main
     - d16-*
+    - yaml-pipeline                                           # UNDONE: Enable triggering of YAML pipeline changes - remove prior to merging the YAML pipeline build to main
 
 stages:
 - stage: build_packages

--- a/tools/devops/automation/templates/build-packages.yml
+++ b/tools/devops/automation/templates/build-packages.yml
@@ -231,6 +231,10 @@ steps:
     GitHubToken: $(GitHub.Token)
     ArtifactDirectory: $(Build.SourcesDirectory)/package-internal
 
+- template: uninstall-certificates/v1.yml@templates
+  parameters:
+    HostedMacKeychainPassword: $(OSX_KEYCHAIN_PASS)
+
 # upload each of the pkgs into the pipeline artifacts
 - task: PublishPipelineArtifact@1
   displayName: 'Publish Build Artifacts'

--- a/tools/devops/automation/templates/build-packages.yml
+++ b/tools/devops/automation/templates/build-packages.yml
@@ -187,7 +187,7 @@ steps:
     DeveloperIdInstaller: $(developer-id-installer)
     IphoneDeveloper: $(iphone-developer)
     MacDeveloper: $(mac-developer)
-    HostedMacKeychainPassword: $(AzDO-OnPrem-KeychainPass)
+    HostedMacKeychainPassword: $(OSX_KEYCHAIN_PASS)
 
 # HACK HACK: brew remove python2, but the script uses python2, this is a dirty workaround
 - bash: |

--- a/tools/devops/automation/templates/build-packages.yml
+++ b/tools/devops/automation/templates/build-packages.yml
@@ -224,6 +224,7 @@ steps:
   name: notarize
   displayName: 'Signing Release Build'
   condition: and(succeeded(), eq(variables['configuration.SignPkgs'], 'True'), eq(variables['configuration.IsPr'], 'False'))
+  enabled: false                # UNDONE: TEST: Disabled -- avoid cost of signing, which should not impact key chains
   timeoutInMinutes: 90
 
 - template: generate-workspace-info.yml@templates

--- a/tools/devops/automation/templates/build-packages.yml
+++ b/tools/devops/automation/templates/build-packages.yml
@@ -176,11 +176,10 @@ steps:
   displayName: 'Signing PR Build'
   condition: and(succeeded(), eq(variables['configuration.SignPkgs'], 'True'), eq(variables['configuration.IsPr'], 'True'))
 
-# HACK HACK: We shold not need to do this, the install of the certs template should be smart enough
-- bash: |
-    security delete-keychain builder.keychain
-  displayName: 'Remove builder keychain'
-  continueOnError: true
+# UNDONE: This step can be removed once the agents have been sanitized
+- template: uninstall-certificates/v1.yml@templates
+  parameters:
+    HostedMacKeychainPassword: $(OSX_KEYCHAIN_PASS)
 
 - template: install-certificates.yml@templates
   parameters:
@@ -224,7 +223,6 @@ steps:
   name: notarize
   displayName: 'Signing Release Build'
   condition: and(succeeded(), eq(variables['configuration.SignPkgs'], 'True'), eq(variables['configuration.IsPr'], 'False'))
-  enabled: false                # UNDONE: TEST: Disabled -- avoid cost of signing, which should not impact key chains
   timeoutInMinutes: 90
 
 - template: generate-workspace-info.yml@templates

--- a/tools/devops/automation/templates/build-packages.yml
+++ b/tools/devops/automation/templates/build-packages.yml
@@ -29,7 +29,6 @@ steps:
   inputs:
     provisioning_script: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/provision-brew-packages.csx
     provisioning_extra_args: '-vvvv'
-  enabled: false
   timeoutInMinutes: 30
 
 - bash: |
@@ -37,28 +36,17 @@ steps:
   displayName: 'Generate provisionator files.'
 
 - task: xamops.azdevex.provisionator-task.provisionator@1
-  displayName: 'Provision Xcode'
+  displayName: 'Provision Products & Frameworks'
   inputs:
     provisioning_script: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/build-provisioning.csx
     provisioning_extra_args: '-vvvv'
-  enabled: false
   timeoutInMinutes: 250
-
-# Disabled
-- task: xamops.azdevex.provisionator-task.provisionator@1
-  displayName: 'Provision Objective Sharpie'
-  inputs:
-    provisioning_script: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/provision-objective-sharpie.csx
-    provisioning_extra_args: '-vvvv'
-  enabled: false
-  timeoutInMinutes: 30
 
 - task: xamops.azdevex.provisionator-task.provisionator@1
   displayName: 'Provision .NET Core'
   inputs:
     provisioning_script: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/provision-dotnetcore.csx
     provisioning_extra_args: '-vvvv'
-  enabled: false
   timeoutInMinutes: 30
 
 - powershell: |


### PR DESCRIPTION
The Keychain issue affecting provisioning steps has been fixed in the `install-certificates` template.  Reenable the affected provisioning steps.