### PR TITLE
[draft][generator] Support for generic classes in our block trampolines

### DIFF
--- a/src/Foundation/Additions.cs
+++ b/src/Foundation/Additions.cs
@@ -1,5 +1,21 @@
 // Copyright 2014 Xamarin Inc. All rights reserved.
 
+using System.Drawing;
+using System.Diagnostics;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+using System.Diagnostics.CodeAnalysis;
+using UIKit;
+
+using Foundation;
+using CoreMotion;
+using ObjCRuntime;
+using AVFoundation;
+using FileProvider;
+using CoreFoundation;
+
+
 #if !MONOMAC && !WATCH
 
 using System;
@@ -25,3 +41,29 @@ namespace Foundation {
 }
 
 #endif // !MONOMAC && !WATCH
+
+namespace ObjCRuntime {
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	static partial class TrampolinesTest   {
+
+		[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
+		[UserDelegateType (typeof (Func<NSOrderedCollectionChange<INativeObject>, NSOrderedCollectionChange<INativeObject>>))]
+		internal delegate IntPtr DFuncArity2V0Test<ObjectType>  (IntPtr block, IntPtr arg) where ObjectType : INativeObject;
+
+		//
+		// This class bridges native block invocations that call into C#
+		//
+		static internal class SDFuncArity2V0Test<ObjectType> where ObjectType : INativeObject {
+			static internal readonly DFuncArity2V0Test<ObjectType> Handler = Invoke;
+
+			[MonoPInvokeCallback (typeof (DFuncArity2V0Test<INativeObject>))]
+			static unsafe IntPtr Invoke (IntPtr block, IntPtr arg) {
+				var descriptor = (BlockLiteral *) block;
+				var del = (Func<NSOrderedCollectionChange<ObjectType>, NSOrderedCollectionChange<ObjectType>>) (descriptor->Target);
+				global::Foundation.NSOrderedCollectionChange<ObjectType> retval = del ( Runtime.GetNSObject<global::Foundation.NSOrderedCollectionChange<ObjectType>> (arg));
+				return retval != null ? retval.Handle : IntPtr.Zero;
+			}
+		} /* class SDFuncArity2V0 */
+	}
+}

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -16032,6 +16032,93 @@ namespace Foundation
 		InferMoves = (1uL << 2),
 	}
 
+	// audit-objc-generics: @interface NSOrderedCollectionDifference<ObjectType> : NSObject <NSFastEnumeration>
+[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+[BaseType (typeof(NSObject))]
+interface NSOrderedCollectionDifference<ObjectType> : INSFastEnumeration
+where ObjectType : INativeObject
+{
+	// -(instancetype _Nonnull)initWithChanges:(NSArray<NSOrderedCollectionChange<ObjectType> *> * _Nonnull)changes;
+	[Export ("initWithChanges:")]
+	IntPtr Constructor (NSOrderedCollectionChange<ObjectType>[] changes);
+
+	// -(instancetype _Nonnull)initWithInsertIndexes:(NSIndexSet * _Nonnull)inserts insertedObjects:(NSArray<ObjectType> * _Nullable)insertedObjects removeIndexes:(NSIndexSet * _Nonnull)removes removedObjects:(NSArray<ObjectType> * _Nullable)removedObjects additionalChanges:(NSArray<NSOrderedCollectionChange<ObjectType> *> * _Nonnull)changes __attribute__((objc_designated_initializer));
+	[Export ("initWithInsertIndexes:insertedObjects:removeIndexes:removedObjects:additionalChanges:")]
+	[DesignatedInitializer]
+	IntPtr Constructor (NSIndexSet inserts, [NullAllowed] NSObject[] insertedObjects, NSIndexSet removes, [NullAllowed] NSObject[] removedObjects, NSOrderedCollectionChange<ObjectType>[] changes);
+
+	// -(instancetype _Nonnull)initWithInsertIndexes:(NSIndexSet * _Nonnull)inserts insertedObjects:(NSArray<ObjectType> * _Nullable)insertedObjects removeIndexes:(NSIndexSet * _Nonnull)removes removedObjects:(NSArray<ObjectType> * _Nullable)removedObjects;
+	[Export ("initWithInsertIndexes:insertedObjects:removeIndexes:removedObjects:")]
+	IntPtr Constructor (NSIndexSet inserts, [NullAllowed] NSObject[] insertedObjects, NSIndexSet removes, [NullAllowed] NSObject[] removedObjects);
+
+	// @property (readonly, strong) NSArray<NSOrderedCollectionChange<ObjectType> *> * _Nonnull insertions __attribute__((availability(macos, introduced=10.15))) __attribute__((availability(ios, introduced=13.0))) __attribute__((availability(watchos, introduced=6.0))) __attribute__((availability(tvos, introduced=13.0)));
+	[Watch (6, 0), TV (13, 0), Mac (10, 15), iOS (13, 0)]
+	[Export ("insertions", ArgumentSemantic.Strong)]
+	NSOrderedCollectionChange<ObjectType>[] Insertions { get; }
+
+	// @property (readonly, strong) NSArray<NSOrderedCollectionChange<ObjectType> *> * _Nonnull removals __attribute__((availability(macos, introduced=10.15))) __attribute__((availability(ios, introduced=13.0))) __attribute__((availability(watchos, introduced=6.0))) __attribute__((availability(tvos, introduced=13.0)));
+	[Watch (6, 0), TV (13, 0), Mac (10, 15), iOS (13, 0)]
+	[Export ("removals", ArgumentSemantic.Strong)]
+	NSOrderedCollectionChange<ObjectType>[] Removals { get; }
+
+	// @property (readonly, assign) BOOL hasChanges;
+	[Export ("hasChanges")]
+	bool HasChanges { get; }
+
+	// -(NSOrderedCollectionDifference<id> * _Nonnull)differenceByTransformingChangesWithBlock:(NSOrderedCollectionChange<id> * _Nonnull (^ _Nonnull)(NSOrderedCollectionChange<ObjectType> * _Nonnull))block;
+	[Export ("differenceByTransformingChangesWithBlock:")]
+	NSOrderedCollectionDifference<ObjectType> DifferenceByTransformingChangesWithBlock (Func<NSOrderedCollectionChange<ObjectType>, NSOrderedCollectionChange<ObjectType>> block);
+
+	// -(instancetype _Nonnull)inverseDifference __attribute__((availability(macos, introduced=10.15))) __attribute__((availability(ios, introduced=13.0))) __attribute__((availability(watchos, introduced=6.0))) __attribute__((availability(tvos, introduced=13.0)));
+	[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+	[Export ("inverseDifference")]
+	NSOrderedCollectionDifference<ObjectType> InverseDifference ();
+}
+
+// audit-objc-generics: @interface NSOrderedCollectionChange<ObjectType> : NSObject
+[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+[BaseType (typeof(NSObject))]
+[DisableDefaultCtor]
+interface NSOrderedCollectionChange<ObjectType>
+where ObjectType : INativeObject
+{
+	// +(NSOrderedCollectionChange<ObjectType> * _Nonnull)changeWithObject:(ObjectType _Nullable)anObject type:(NSCollectionChangeType)type index:(NSUInteger)index;
+	[Static]
+	[Export ("changeWithObject:type:index:")]
+	NSOrderedCollectionChange<ObjectType> ChangeWithObject ([NullAllowed] NSObject anObject, NSCollectionChangeType type, nuint index);
+
+	// +(NSOrderedCollectionChange<ObjectType> * _Nonnull)changeWithObject:(ObjectType _Nullable)anObject type:(NSCollectionChangeType)type index:(NSUInteger)index associatedIndex:(NSUInteger)associatedIndex;
+	[Static]
+	[Export ("changeWithObject:type:index:associatedIndex:")]
+	NSOrderedCollectionChange<ObjectType> ChangeWithObject ([NullAllowed] NSObject anObject, NSCollectionChangeType type, nuint index, nuint associatedIndex);
+
+	// @property (readonly, strong) ObjectType _Nullable object;
+	[NullAllowed, Export ("object", ArgumentSemantic.Strong)]
+	NSObject Object { get; }
+
+	// @property (readonly) NSCollectionChangeType changeType;
+	[Export ("changeType")]
+	NSCollectionChangeType ChangeType { get; }
+
+	// @property (readonly) NSUInteger index;
+	[Export ("index")]
+	nuint Index { get; }
+
+	// @property (readonly) NSUInteger associatedIndex;
+	[Export ("associatedIndex")]
+	nuint AssociatedIndex { get; }
+
+	// -(instancetype _Nonnull)initWithObject:(ObjectType _Nullable)anObject type:(NSCollectionChangeType)type index:(NSUInteger)index;
+	[Export ("initWithObject:type:index:")]
+	IntPtr Constructor ([NullAllowed] NSObject anObject, NSCollectionChangeType type, nuint index);
+
+	// -(instancetype _Nonnull)initWithObject:(ObjectType _Nullable)anObject type:(NSCollectionChangeType)type index:(NSUInteger)index associatedIndex:(NSUInteger)associatedIndex __attribute__((objc_designated_initializer));
+	[Export ("initWithObject:type:index:associatedIndex:")]
+	[DesignatedInitializer]
+	IntPtr Constructor ([NullAllowed] NSObject anObject, NSCollectionChangeType type, nuint index, nuint associatedIndex);
+}
+
+
 	[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 	[BaseType (typeof (NSDimension))]
 	[DisableDefaultCtor] // NSGenericException Reason: -init should never be called on NSUnit!

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1609,7 +1609,9 @@ public partial class Generator : IMemberGatherer {
 	{
 		if (trampolines.ContainsKey (t)){
 			return trampolines [t];
-		} 
+		}
+		if (t.GetMethod("Invoke").ReturnType.ToString().Contains("`1"))
+			Console.WriteLine ();
 
 		var mi = t.GetMethod ("Invoke");
 		var pars = new StringBuilder ();
@@ -1779,7 +1781,14 @@ public partial class Generator : IMemberGatherer {
 		}
 
 		var rt = mi.ReturnType;
+		//invoke.AppendFormat (" Runtime.GetNSObject<{1}> ({0})", safe_name, RenderType (pi.ParameterType));
+
 		var rts = IsNativeEnum (rt) ? "var" : rt.ToString ();
+		///// Debugging code
+		if (rts.Contains ("`1"))
+			//Console.WriteLine ();
+			rts = RenderType(rt);
+		///// End debugging code
 		var trampoline_name = MakeTrampolineName (t);
 		var ti = new TrampolineInfo (userDelegate: FormatType (null, t),
 					     delegateName: "D" + trampoline_name,
@@ -2609,6 +2618,10 @@ public partial class Generator : IMemberGatherer {
 			} else {
 				if (ti.Convert.Length > 0)
 					print (ti.Convert);
+				///////// Debugging code
+				if (ti.DelegateReturnType.Contains ("`1"))
+					Console.WriteLine ();
+				///////// End debugging code
 				print ("{0} retval = del ({1});", ti.DelegateReturnType, ti.Invoke);
 				if (ti.PostConvert.Length > 0)
 					print (ti.PostConvert);

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -22280,8 +22280,8 @@ namespace UIKit {
 		NSDiffableDataSourceSectionSnapshot<ItemIdentifierType> FinalSnapshot { get; }
 
 		// TODO: Enable when Foundation return type is bound
-		// [Export ("difference")]
-		// NSOrderedCollectionDifference<ItemIdentifierType> Difference { get; }
+		[Export ("difference")]
+		NSOrderedCollectionDifference<ItemIdentifierType> Difference { get; }
 	}
 
 	[NoWatch, TV (14,0), iOS (14,0)]
@@ -22297,8 +22297,8 @@ namespace UIKit {
 		NSDiffableDataSourceSnapshot <SectionIdentifierType, ItemIdentifierType> FinalSnapshot { get; }
 
 		// TODO: Enable when Foundation return type is bound
-		// [Export ("difference")]
-		// NSOrderedCollectionDifference <ItemIdentifierType> Difference { get; }
+		[Export ("difference")]
+		NSOrderedCollectionDifference <ItemIdentifierType> Difference { get; }
 
 		[Export ("sectionTransactions")]
 		NSDiffableDataSourceSectionTransaction<SectionIdentifierType, ItemIdentifierType> [] SectionTransactions { get; }


### PR DESCRIPTION
https://github.com/xamarin/xamarin-macios/issues/8993

With the changes in this PR, building should result in the following errors:

```
build/ios/native/ObjCRuntime/Trampolines.g.cs(85,56): error CS0246: The type or namespace name 'ObjectType' could not be found (are you missing a using directive or an assembly reference?)
build/ios/native/ObjCRuntime/Trampolines.g.cs(85,95): error CS0246: The type or namespace name 'ObjectType' could not be found (are you missing a using directive or an assembly reference?)
build/ios/native/ObjCRuntime/Trampolines.g.cs(94,83): error CS0246: The type or namespace name 'ObjectType' could not be found (are you missing a using directive or an assembly reference?)
build/ios/native/ObjCRuntime/Trampolines.g.cs(94,37): error CS0246: The type or namespace name 'ObjectType' could not be found (are you missing a using directive or an assembly reference?)
build/ios/native/ObjCRuntime/Trampolines.g.cs(56,61): error CS0246: The type or namespace name 'ObjectType' could not be found (are you missing a using directive or an assembly reference?)
build/ios/native/ObjCRuntime/Trampolines.g.cs(56,100): error CS0246: The type or namespace name 'ObjectType' could not be found (are you missing a using directive or an assembly reference?)
make: *** [build/ios/native-64/Xamarin.iOS.dll] Error 1
```

Additions.cs and Trampolines.g.cs contain similar code. The chunk added to Additions.cs is what we _want_ the generator to produce. Trampolines.g.cs contains what the generator produces right now with the small change that I've made.

```
➜  src git:(trampolines_work) ✗ make
GEN      bgen.exe
GEN      [ios] generated_sources


CSC      [ios/64 bit] Xamarin.iOS.dll
build/ios/native/ObjCRuntime/Trampolines.g.cs(69,41): error CS1002: ; expected
build/ios/native/ObjCRuntime/Trampolines.g.cs(69,41): error CS1056: Unexpected character '`'
build/ios/native/ObjCRuntime/Trampolines.g.cs(69,56): error CS1002: ; expected
make: *** [build/ios/native-64/Xamarin.iOS.dll] Error 1
```

If you comment out the generator changes you should see the following error:

```
➜  src git:(trampolines_work) ✗ make
GEN      bgen.exe
GEN      [ios] generated_sources


CSC      [ios/64 bit] Xamarin.iOS.dll
build/ios/native/ObjCRuntime/Trampolines.g.cs(69,41): error CS1002: ; expected
build/ios/native/ObjCRuntime/Trampolines.g.cs(69,41): error CS1056: Unexpected character '`'
build/ios/native/ObjCRuntime/Trampolines.g.cs(69,56): error CS1002: ; expected
make: *** [build/ios/native-64/Xamarin.iOS.dll] Error 1
```

And the generated code will look like this:

```
		[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
		[UserDelegateType (typeof (Func<NSOrderedCollectionChange<ObjectType>, NSOrderedCollectionChange<ObjectType>>))]
		internal delegate IntPtr DFuncArity2V0 (IntPtr block, IntPtr arg);
		
		//
		// This class bridges native block invocations that call into C#
		//
		static internal class SDFuncArity2V0 {
			static internal readonly DFuncArity2V0 Handler = Invoke;
			
			[MonoPInvokeCallback (typeof (DFuncArity2V0))]
			static unsafe IntPtr Invoke (IntPtr block, IntPtr arg) {
				var descriptor = (BlockLiteral *) block;
				var del = (Func<NSOrderedCollectionChange<ObjectType>, NSOrderedCollectionChange<ObjectType>>) (descriptor->Target);
				Foundation.NSOrderedCollectionChange`1[ObjectType] retval = del ( Runtime.GetNSObject<global::Foundation.NSOrderedCollectionChange<ObjectType>> (arg));
				return retval != null ? retval.Handle : IntPtr.Zero;
			}
		} /* class SDFuncArity2V0 */
```

`Foundation.NSOrderedCollectionChange`1[ObjectType]` is how reflection shows generics. Calling `RenderType` in the generator expands it to `global::Foundation.NSOrderedCollectionChange<ObjectType>`, which is what we want.

Next steps 
- Figuring out how to get the generator to output the trampoline code in Additions.cs
- Possible bonus: updating sharpie to handle this case better (as-is, manual modifications have to be made to the bindings) cc @dalexsoto 

Other notes:
`INativeObject` is used instead of `NSObject`. To verify, try out the following line of Swift in Xcode:

```
let test = NSOrderedCollectionChange.init(object: CGColor.init(gray: 1.0, alpha: 1.0)/*Int.init()*/, type: NSCollectionChangeType.insert, index: 0);
```