### PR TITLE
[xharness] Bring back special processing of GuiUnit for Xamarin.Mac test projects.

### DIFF
--- a/tests/xharness/Targets/MacTarget.cs
+++ b/tests/xharness/Targets/MacTarget.cs
@@ -132,6 +132,28 @@ namespace Xharness.Targets
 					break;
 				}
 				break;
+			case "GuiUnit_NET_4_5.csproj":
+				switch (Flavor) {
+				case MacFlavors.Full:
+				case MacFlavors.System:
+					fixed_include = include;
+					return true;
+				case MacFlavors.Modern:
+					fixed_include = Path.Combine (Path.GetDirectoryName (include), "GuiUnit_xammac_mobile" + Path.GetExtension (include));
+					return true;
+				}
+				break;
+			case "GuiUnit_xammac_mobile.csproj":
+				switch (Flavor) {
+				case MacFlavors.Full:
+				case MacFlavors.System:
+					fixed_include = Path.Combine (Path.GetDirectoryName (include), "GuiUnit_NET_4_5" + Path.GetExtension (include));
+					return true;
+				case MacFlavors.Modern:
+					fixed_include = include;
+					return true;
+				}
+				break;
 			}
 
 			return base.FixProjectReference (include, subdir, suffix, out fixed_include);


### PR DESCRIPTION
This code isn't necessary in main, because we've removed any GuiUnit usage,
but in d16-8 we're still using GuiUnit, which means we still need to process
GuiUnit project references correctly.

This fixes numerous build failures when building Xamarin.Mac tests (in
particular when building Xamarin.Mac tests for older macOS versions).