### PR TITLE
[Maccore] Bump maccore to remove old not needed code.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := f490737c8e3a7ecedb6005bfc8cc9792fe046931
+NEEDED_MACCORE_VERSION := 6c3fe624a98287d37d9230da21fe720008fa530e
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
The maccore lib dependency was a problem for governance checks. Also
removes the roslyn analyzer code.

Commits:

* [Deps] Remove Ionic.Zip. Is not needed and gives governance issues. (#8c98216) https://github.com/xamarin/maccore/commit/8c98216efd070686d1bcb86afa2684463b62fc4e
* Remove roslyn-analyzers files (#2149) https://github.com/xamarin/maccore/commit/8c98216efd070686d1bcb86afa2684463b62fc4e

Full diff: https://github.com/xamarin/maccore/compare/f490737c8e3a7ecedb6005bfc8cc9792fe046931..6c3fe624a98287d37d9230da21fe720008fa530e