### PR TITLE
[msbuild] Stop allowing a watch family for iOS apps.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
@@ -315,7 +315,6 @@ namespace Xamarin.iOS.Tasks
 				validFamilies = new AppleDeviceFamily[] {
 					AppleDeviceFamily.IPhone,
 					AppleDeviceFamily.IPad,
-					AppleDeviceFamily.Watch
 				};
 				break;
 			case ApplePlatform.WatchOS:


### PR DESCRIPTION
A Watch family is no longer valid for an iOS app because we don't support
watchOS 1 anymore.