### PR TITLE
[msbuild] Use localized error strings instead of constants for a few errors.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
@@ -327,7 +327,7 @@ namespace Xamarin.MacDev.Tasks
 				platform = MobileProvisionPlatform.MacOS;
 				break;
 			default:
-				Log.LogError ("Unknown SDK platform: {0}", SdkPlatform);
+				Log.LogError (MSBStrings.E0048, SdkPlatform);
 				return false;
 			}
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
@@ -427,7 +427,7 @@ namespace Xamarin.MacDev.Tasks
 				platform = MobileProvisionPlatform.MacOS;
 				break;
 			default:
-				Log.LogError ("Unknown SDK platform: {0}", SdkPlatform);
+				Log.LogError (MSBStrings.E0048, SdkPlatform);
 				return false;
 			}
 


### PR DESCRIPTION
Seems like this got past the localization work somehow.