### PR TITLE
[Maccore] Bump maccore to fix governance issues.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 6c3fe624a98287d37d9230da21fe720008fa530e
+NEEDED_MACCORE_VERSION := 5133d2cea1c52fb783f64ab2ba97c760cf33f5f4
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
All governance issues have been fixed.

Commits:

* Remove roslyn-analyzers files (#2149) https://github.com/xamarin/maccore/commit/6c3fe624a98287d37d9230da21fe720008fa530e
* [Governance] Add ignores for the test profiles in maccore. (#2337) https://github.com/xamarin/maccore/commit/5133d2cea1c52fb783f64ab2ba97c760cf33f5f4

Full diff: https://github.com/xamarin/maccore/compare/8c98216efd070686d1bcb86afa2684463b62fc4e..5133d2cea1c52fb783f64ab2ba97c760cf33f5f4