### PR TITLE
Xamarin.Mac native Apple Silicon targetting support

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -779,6 +779,7 @@ MAC_TARGETS = \
 	$(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/lib/pkgconfig/mono-2.pc                          \
 	$(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/etc/mono/assemblies/System/System.config         \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/mono-sgen                            \
+	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/aarch64-darwin-mono-sgen             \
 
 $(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/lib/%: .stamp-$(MONO_BUILD_MODE) | $(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/lib
 	$(Q) $(CP) $(MONO_MAC_SDK_DESTDIR)/mac-libs/$(notdir $@) $@
@@ -796,6 +797,9 @@ $(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/etc/mono/assemblies/System/System.config: mac
 
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/mono-sgen: .stamp-$(MONO_BUILD_MODE) | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin
 	$(Q) install -m 0755 $(MONO_MAC_SDK_DESTDIR)/mac-bin/mono-sgen $@
+
+$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/aarch64-darwin-mono-sgen: .stamp-$(MONO_BUILD_MODE) | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin
+	$(Q) install -m 0755 $(MONO_MAC_SDK_DESTDIR)/mac-bin/aarch64-darwin-mono-sgen $@
 
 $(MAC_DIRECTORIES):
 	$(Q) mkdir -p $@

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -1462,5 +1462,11 @@ namespace Xamarin.Localization.MSBuild {
                 return ResourceManager.GetString("InvalidPlatform", resourceCulture);
             }
         }
+        
+        public static string E7072 {
+            get {
+                return ResourceManager.GetString("E7072", resourceCulture);
+            }
+        }
     }
 }

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1255,4 +1255,8 @@
     <data name="InvalidPlatform" xml:space="preserve">
         <value>Invalid platform: {0}</value>
     </data>
+    
+    <data name="E7072" xml:space="preserve">
+        <value>Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
@@ -1240,6 +1240,11 @@
         <target state="new">Invalid platform: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7072">
+        <source>Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</source>
+        <target state="new">Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
@@ -1240,6 +1240,11 @@
         <target state="new">Invalid platform: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7072">
+        <source>Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</source>
+        <target state="new">Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
@@ -1240,6 +1240,11 @@
         <target state="new">Invalid platform: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7072">
+        <source>Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</source>
+        <target state="new">Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
@@ -1240,6 +1240,11 @@
         <target state="new">Invalid platform: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7072">
+        <source>Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</source>
+        <target state="new">Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
@@ -1240,6 +1240,11 @@
         <target state="new">Invalid platform: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7072">
+        <source>Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</source>
+        <target state="new">Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
@@ -1240,6 +1240,11 @@
         <target state="new">Invalid platform: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7072">
+        <source>Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</source>
+        <target state="new">Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
@@ -1240,6 +1240,11 @@
         <target state="new">Invalid platform: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7072">
+        <source>Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</source>
+        <target state="new">Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
@@ -1240,6 +1240,11 @@
         <target state="new">Invalid platform: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7072">
+        <source>Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</source>
+        <target state="new">Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
@@ -1240,6 +1240,11 @@
         <target state="new">Invalid platform: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7072">
+        <source>Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</source>
+        <target state="new">Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
@@ -1240,6 +1240,11 @@
         <target state="new">Invalid platform: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7072">
+        <source>Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</source>
+        <target state="new">Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
@@ -1240,6 +1240,11 @@
         <target state="new">Invalid platform: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7072">
+        <source>Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</source>
+        <target state="new">Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
@@ -1240,6 +1240,11 @@
         <target state="new">Invalid platform: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7072">
+        <source>Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</source>
+        <target state="new">Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
@@ -1240,6 +1240,11 @@
         <target state="new">Invalid platform: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="E7072">
+        <source>Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</source>
+        <target state="new">Package product requirement file contains architectures ({0}) which mismatches with target architectures ({1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="M0001">
         <source>Tool {0} execution started with arguments: {1}
         </source>

--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -62,11 +62,17 @@ namespace Xamarin.Mac.Tasks
 			if (arch == XamMacArch.Default)
 				arch = XamMacArch.x86_64;
 
+			List <string> allSupportedArchs = new List <string> ();
 			if (arch.HasFlag (XamMacArch.i386))
-				args.AddLine ("/arch:i386");
+				allSupportedArchs.Add ("i386");
 
 			if (arch.HasFlag (XamMacArch.x86_64))
-				args.AddLine ("/arch:x86_64");
+				allSupportedArchs.Add ("x86_64");
+
+			if (arch.HasFlag (XamMacArch.ARM64))
+				allSupportedArchs.Add ("arm64");
+
+			args.AddLine ($"/abi:{string.Join (",", allSupportedArchs)}");
 
 			switch ((LinkMode ?? string.Empty).ToLower ()) {
 			case "full":

--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/XamMacArch.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/XamMacArch.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Mac.Tasks
 	{
 		Default = 0,
 		i386 = 1,
-		x86_64 = 2
+		x86_64 = 2,
+		ARM64 = 4,
 	}
 }

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -156,13 +156,14 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		</TextureAtlas>
 	</Target>
 
-	<Target Name="_CompileProductDefinition" Condition="$(CreatePackage)" DependsOnTargets="_ComputeTargetArchitectures">
+	<Target Name="_CompileProductDefinition" Condition="$(CreatePackage)" DependsOnTargets="_DetectAppManifest;_ComputeTargetArchitectures">
 		<CompileProductDefinition
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			ProductDefinition="$(ProductDefinition)"
 			OutputDirectory = "$(IntermediateOutputPath)"
-			TargetArchitectures = "$(TargetArchitectures)">
+			TargetArchitectures = "$(TargetArchitectures)"
+			AppManifest = "$(_AppManifest)">
 			<Output TaskParameter="CompiledProductDefinition" PropertyName="_CompiledProductDefinition" />
 		</CompileProductDefinition>
 	</Target>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -156,7 +156,18 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		</TextureAtlas>
 	</Target>
 
-	<Target Name="_CreateInstaller" Condition="$(CreatePackage)" DependsOnTargets="Codesign">
+	<Target Name="_CompileProductDefinition" Condition="$(CreatePackage)" DependsOnTargets="_ComputeTargetArchitectures">
+		<CompileProductDefinition
+			Condition="'$(IsMacEnabled)' == 'true'"
+			SessionId="$(BuildSessionId)"
+			ProductDefinition="$(ProductDefinition)"
+			OutputDirectory = "$(IntermediateOutputPath)"
+			TargetArchitectures = "$(TargetArchitectures)">
+			<Output TaskParameter="CompiledProductDefinition" PropertyName="_CompiledProductDefinition" />
+		</CompileProductDefinition>
+	</Target>
+
+	<Target Name="_CreateInstaller" Condition="$(CreatePackage)" DependsOnTargets="Codesign;_CompileProductDefinition">
 		<CreateInstallerPackage
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
@@ -167,7 +178,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			AppBundleDir= "$(AppBundleDir)"
 			MainAssembly= "$(TargetPath)"
 			EnablePackageSigning = "$(EnablePackageSigning)"
-			ProductDefinition = "$(ProductDefinition)"
+			ProductDefinition = "$(_CompiledProductDefinition)"
 			PackageSigningKey = "$(PackageSigningKey)"
 			PackagingExtraArgs = "$(PackagingExtraArgs)">
 		</CreateInstallerPackage>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileProductDefinitionTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileProductDefinitionTaskBase.cs
@@ -72,15 +72,13 @@ namespace Xamarin.MacDev.Tasks {
 			}
 			plist [ProductDefinitionKeys.Architectures] = archArray;
 
-			if (!plist.TryGetValue (ProductDefinitionKeys.MinimumSystemVersion, out PArray osVersionArray))
-            {
+			if (!plist.TryGetValue (ProductDefinitionKeys.MinimumSystemVersion, out PArray osVersionArray)) {
 				var minOSVersion = GetMinimumOSVersion ();
-				if (minOSVersion != null)
-				{
+				if (minOSVersion != null) {
 					osVersionArray = new PArray ();
 					osVersionArray.Add (new PString (minOSVersion));
 				}
-            }
+			}
 			if (osVersionArray != null)
 				plist [ProductDefinitionKeys.MinimumSystemVersion] = osVersionArray;
 
@@ -91,21 +89,17 @@ namespace Xamarin.MacDev.Tasks {
 		}
 
 		private string GetMinimumOSVersion ()
-        {
+		{
 			PDictionary plist;
 
-			try
-			{
+			try {
 				plist = PDictionary.FromFile (AppManifest);
-			}
-			catch (Exception ex)
-			{
+			} catch (Exception ex) {
 				Log.LogError (null, null, null, AppManifest, 0, 0, 0, 0, MSBStrings.E0010, AppManifest, ex.Message);
 				return null;
 			}
 
-			if (plist == null)
-			{
+			if (plist == null) {
 				Log.LogError (null, null, null, AppManifest, 0, 0, 0, 0, MSBStrings.E0122, AppManifest);
 				return null;
 			}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileProductDefinitionTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileProductDefinitionTaskBase.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Localization.MSBuild;
+using Xamarin.Utils;
+
+namespace Xamarin.MacDev.Tasks {
+	public abstract class CompileProductDefinitionTaskBase : XamarinTask {
+		#region Inputs
+
+		public string ProductDefinition { get; set; }
+
+		[Required]
+		public string OutputDirectory { get; set; }
+
+		[Required]
+		public string TargetArchitectures { get; set; }
+		#endregion
+
+		#region Outputs
+
+		[Output]
+		public ITaskItem CompiledProductDefinition { get; set; }
+
+		#endregion
+
+		protected TargetArchitecture architectures;
+
+		public override bool Execute ()
+		{
+			PDictionary plist;
+
+			if (File.Exists (ProductDefinition)) {
+				try {
+					plist = PDictionary.FromFile (ProductDefinition);
+				} catch (Exception ex) {
+					LogProductDefinitionError (MSBStrings.E0010, ProductDefinition, ex.Message);
+					return false;
+				}
+			} else {
+				plist = new PDictionary ();
+			}
+
+			if (!string.IsNullOrEmpty (TargetArchitectures) && !Enum.TryParse (TargetArchitectures, out architectures)) {
+				LogProductDefinitionError (MSBStrings.E0012, TargetArchitectures);
+				return false;
+			}
+
+			// productbuild can do a guess of the targeted architectures if not provided, but the guess
+			// is very simple : on Catalina and lower, it will suppose it's x86_64 (even with an arm64 slice).
+			HashSet <string> archStrings = new HashSet <string> (architectures.ToArray ().Select (a => a.ToNativeArchitecture ()));
+			if (plist.TryGetValue (ProductDefinitionKeys.Architectures, out PArray archArray)) {
+				var existingArchs = archArray.ToStringArray ();
+				if (!archStrings.SetEquals (existingArchs)) {
+					LogProductDefinitionWarning (MSBStrings.E7072, string.Join (", ", existingArchs), string.Join (", ", archStrings));
+				}
+			}
+
+			if (archArray == null) {
+				archArray = new PArray ();
+				foreach (var arch in archStrings) {
+					archArray.Add (new PString (arch));
+				}
+			}
+			plist [ProductDefinitionKeys.Architectures] = archArray;
+
+			CompiledProductDefinition = new TaskItem (Path.Combine (OutputDirectory, "Product.plist"));
+			plist.Save (CompiledProductDefinition.ItemSpec, true, false);
+
+			return !Log.HasLoggedErrors;
+		}
+
+		protected void LogProductDefinitionError (string format, params object [] args)
+		{
+			// Log an error linking to the Product.plist file
+			Log.LogError (null, null, null, ProductDefinition, 0, 0, 0, 0, format, args);
+		}
+
+		protected void LogProductDefinitionWarning (string format, params object [] args)
+		{
+			// Log a warning linking to the Product.plist file
+			Log.LogWarning (null, null, null, ProductDefinition, 0, 0, 0, 0, format, args);
+		}
+	}
+
+	public static class ProductDefinitionKeys {
+		public const string Architectures = "arch";
+	}
+}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateInstallerPackageTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateInstallerPackageTaskBase.cs
@@ -88,7 +88,7 @@ namespace Xamarin.MacDev.Tasks
 
 			if (!string.IsNullOrEmpty(ProductDefinition)) {
 				args.Add ("--product");
-				args.AddQuoted (ProductDefinition);
+				args.AddQuoted (Path.GetFullPath (ProductDefinition));
 			}
 
 			args.Add ("--component");

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileProductDefinition.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileProductDefinition.cs
@@ -1,0 +1,4 @@
+﻿namespace Xamarin.MacDev.Tasks {
+	public class CompileProductDefinition : CompileProductDefinitionTaskBase {
+	}
+}

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -107,6 +107,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.CreateAssetPackManifest" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.CreateInstallerPackage" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.CreatePkgInfo" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.CompileProductDefinition" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.Ditto" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.DSymUtil" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.EmbedProvisionProfile" AssemblyFile="$(_TaskAssemblyName)" />

--- a/opentk/Makefile.include
+++ b/opentk/Makefile.include
@@ -66,7 +66,7 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/mobile/OpenTK.dll: $(MA
 	$(Q) install -m 0755 $^ $@
 	$(Q) install -m 0644 $(<:.dll=.pdb) $(@:.dll=.pdb)
 
-$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/mobile/OpenTK.dll: $(MAC_BUILD_DIR)/mobile-64/OpenTK.dll | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/mobile
+$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/mobile/OpenTK.dll: $(MAC_BUILD_DIR)/mobile-64/OpenTK.dll | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/mobile
 	$(Q) install -m 0755 $^ $@
 	$(Q) install -m 0644 $(<:.dll=.pdb) $(@:.dll=.pdb)
 
@@ -78,7 +78,7 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/net_4_5/OpenTK.dll: $(M
 	$(Q) install -m 0755 $^ $@
 	$(Q) install -m 0644 $(<:.dll=.pdb) $(@:.dll=.pdb)
 
-$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/full/OpenTK.dll: $(MAC_BUILD_DIR)/full-64/OpenTK.dll | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/full
+$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/full/OpenTK.dll: $(MAC_BUILD_DIR)/full-64/OpenTK.dll | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/full
 	$(Q) install -m 0755 $^ $@
 	$(Q) install -m 0644 $(<:.dll=.pdb) $(@:.dll=.pdb)
 
@@ -90,9 +90,9 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/4.5/%: | $(MAC_DESTDIR)$(MAC
 
 MAC_TARGETS += \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/mobile/OpenTK.dll     \
-	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/mobile/OpenTK.dll        \
+	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/mobile/OpenTK.dll        \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/full/OpenTK.dll       \
-	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/full/OpenTK.dll          \
+	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/full/OpenTK.dll          \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/Xamarin.Mac/OpenTK.dll     \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/Xamarin.Mac/OpenTK.pdb     \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/net_4_5/OpenTK.dll       \

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -392,7 +392,7 @@ $(eval $(call LibXamarinTemplate,tvsimulator,TVSIMULATOR,_DEBUG,-debug))
 # Xamarin.Mac
 #
 
-MAC_ARCHITECTURES = x86_64
+MAC_ARCHITECTURES = x86_64 arm64
 
 CLANG_ARCH = $(addprefix -arch ,$(MAC_ARCHITECTURES))
 MAC_CLANG = DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT) $(MAC_CC) -mmacosx-version-min=$(MIN_OSX_SDK_VERSION)
@@ -401,7 +401,7 @@ MAC_SHIPPED_HEADERS = xamarin/launch.h
 
 MAC_STATIC_CFLAGS = $(MAC_CFLAGS)
 
-MAC_SOURCES = $(SHARED_SOURCES) $(SHARED_X86_64_SOURCES) launcher.m
+MAC_SOURCES = $(SHARED_SOURCES) $(SHARED_X86_64_SOURCES) $(SHARED_ARM64_SOURCES) launcher.m
 
 ALLOWED_UNDEFINED_SYMBOLS = _xamarin_enable_debug _xammac_setup
 
@@ -477,6 +477,8 @@ endef
 
 $(eval $(call ObjTemplate,x86_64,64,,,64))
 $(eval $(call ObjTemplate,x86_64,DEBUG64,-debug,-DDEBUG,64))
+$(eval $(call ObjTemplate,arm64,64,,,64))
+$(eval $(call ObjTemplate,arm64,DEBUG64,-debug,-DDEBUG,64))
 
 $(foreach arch,$(MAC_ARCHITECTURES),.libs/mac/extension-main.$(arch).o): EXTRA_DEFINES=-DEXTENSION
 
@@ -492,22 +494,22 @@ $(foreach arch,$(MAC_ARCHITECTURES),.libs/mac/extension-main.$(arch).o): EXTRA_D
 	$(Q) rm -f $@
 	$(call Q_2,LIPO,  [mac]) $(DEVICE_BIN_PATH)/lipo $^ -create -output $@
 
-.libs/mac/libxammac-debug.dylib: .libs/mac/libxammac-debug.x86_64.dylib
+.libs/mac/libxammac-debug.dylib: .libs/mac/libxammac-debug.x86_64.dylib .libs/mac/libxammac-debug.arm64.dylib
 	$(call Q_2,LIPO,  [mac]) xcrun lipo -create $^ -o $@
 
-.libs/mac/libxammac.dylib: .libs/mac/libxammac.x86_64.dylib
+.libs/mac/libxammac.dylib: .libs/mac/libxammac.x86_64.dylib .libs/mac/libxammac.arm64.dylib
 	$(call Q_2,LIPO,  [mac]) xcrun lipo -create $^ -o $@
 
-.libs/mac/libxammac-debug.a: .libs/mac/libxammac-debug.x86_64.a
+.libs/mac/libxammac-debug.a: .libs/mac/libxammac-debug.x86_64.a .libs/mac/libxammac-debug.arm64.a
 	$(call Q_2,LIPO,  [mac]) xcrun lipo -create $^ -o $@
 
-.libs/mac/libxammac.a: .libs/mac/libxammac.x86_64.a
+.libs/mac/libxammac.a: .libs/mac/libxammac.x86_64.a .libs/mac/libxammac.arm64.a
 	$(call Q_2,LIPO,  [mac]) xcrun lipo -create $^ -o $@
 
-.libs/mac/libxammac-system-debug.a: .libs/mac/libxammac-system-debug.x86_64.a
+.libs/mac/libxammac-system-debug.a: .libs/mac/libxammac-system-debug.x86_64.a .libs/mac/libxammac-system-debug.arm64.a
 	$(call Q_2,LIPO,  [mac]) xcrun lipo -create $^ -o $@
 
-.libs/mac/libxammac-system.a: .libs/mac/libxammac-system.x86_64.a
+.libs/mac/libxammac-system.a: .libs/mac/libxammac-system.x86_64.a .libs/mac/libxammac-system.arm64.a
 	$(call Q_2,LIPO,  [mac]) xcrun lipo -create $^ -o $@
 
 .libs/mac/libxammac-%.a: $(MACIOS_BINARIES_PATH)/libxammac-%.a | .libs/mac

--- a/runtime/trampolines-arm64.h
+++ b/runtime/trampolines-arm64.h
@@ -6,14 +6,14 @@ extern "C" {
 #endif
 
 struct BigDouble {
+	struct _f {
+		float f1;
+		float f2;
+	};
 	union {
 		__int128 bits;
 		long double d;
-		struct f {
-			float f1;
-			float f2;
-		};
-		struct f f;
+		_f f;
 	};
 };
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -637,8 +637,8 @@ MAC_TARGETS_DIRS += \
 	$(MAC_BUILD_DIR)/mobile/Facades \
 	$(MAC_BUILD_DIR)/full \
 	$(MAC_BUILD_DIR)/compat \
-	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/mobile    \
-	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/full      \
+	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/mobile    \
+	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/full      \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/mobile \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/full   \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/net_4_5   \
@@ -656,10 +656,10 @@ MAC_TARGETS += \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/mobile/Xamarin.Mac.pdb     \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/full/Xamarin.Mac.dll       \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/full/Xamarin.Mac.pdb       \
-	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/mobile/Xamarin.Mac.dll        \
-	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/mobile/Xamarin.Mac.pdb        \
-	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/full/Xamarin.Mac.dll          \
-	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/full/Xamarin.Mac.pdb          \
+	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/mobile/Xamarin.Mac.dll        \
+	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/mobile/Xamarin.Mac.pdb        \
+	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/full/Xamarin.Mac.dll          \
+	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/full/Xamarin.Mac.pdb          \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/Xamarin.Mac/Xamarin.Mac.dll     \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/Xamarin.Mac/Xamarin.Mac.pdb     \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/4.5/Xamarin.Mac.dll             \
@@ -676,10 +676,10 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/mobile/Xamarin.Mac.dll:
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/mobile/Xamarin.Mac.pdb: $(MAC_BUILD_DIR)/mobile-reference/Xamarin.Mac.pdb | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/mobile
 	$(Q) install -m 0644 $< $@
 
-$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/mobile/Xamarin.Mac.dll: $(MAC_BUILD_DIR)/mobile-64/Xamarin.Mac.dll | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/mobile
+$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/mobile/Xamarin.Mac.dll: $(MAC_BUILD_DIR)/mobile-64/Xamarin.Mac.dll | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/mobile
 	$(Q) install -m 0755 $< $@
 
-$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/mobile/Xamarin.Mac.pdb: $(MAC_BUILD_DIR)/mobile-64/Xamarin.Mac.pdb | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/mobile
+$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/mobile/Xamarin.Mac.pdb: $(MAC_BUILD_DIR)/mobile-64/Xamarin.Mac.pdb | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/mobile
 	$(Q) install -m 0644 $< $@
 
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/full/Xamarin.Mac.dll: $(MAC_BUILD_DIR)/full-reference/Xamarin.Mac.dll | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/full
@@ -688,10 +688,10 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/full/Xamarin.Mac.dll: $
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/full/Xamarin.Mac.pdb : $(MAC_BUILD_DIR)/full-reference/Xamarin.Mac.pdb | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/reference/full
 	$(Q) install -m 0644 $< $@
 
-$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/full/Xamarin.Mac.dll: $(MAC_BUILD_DIR)/full-64/Xamarin.Mac.dll | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/full
+$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/full/Xamarin.Mac.dll: $(MAC_BUILD_DIR)/full-64/Xamarin.Mac.dll | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/full
 	$(Q) install -m 0755 $< $@
 
-$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/full/Xamarin.Mac.pdb: $(MAC_BUILD_DIR)/full-64/Xamarin.Mac.pdb | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/full
+$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/full/Xamarin.Mac.pdb: $(MAC_BUILD_DIR)/full-64/Xamarin.Mac.pdb | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/64bits/full
 	$(Q) install -m 0644 $< $@
 
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/Xamarin.Mac/Xamarin.Mac.dll $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/Xamarin.Mac/Xamarin.Mac.pdb: | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/Xamarin.Mac

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -846,7 +846,11 @@ namespace Registrar {
 						is_stret = IntPtr.Size == 4 ? Stret.X86NeedStret (NativeReturnType, null) : Stret.X86_64NeedStret (NativeReturnType, null);
 					}
 #elif MONOMAC
-					is_stret = IntPtr.Size == 8 ? Stret.X86_64NeedStret (NativeReturnType, null) : Stret.X86NeedStret (NativeReturnType, null);
+					if (Runtime.IsARM64CallingConvention) {
+						is_stret = false;
+					} else {
+						is_stret = IntPtr.Size == 8 ? Stret.X86_64NeedStret (NativeReturnType, null) : Stret.X86NeedStret (NativeReturnType, null);
+					}
 #elif __IOS__
 					if (Runtime.Arch == Arch.DEVICE) {
 						is_stret = IntPtr.Size == 4 && Stret.ArmNeedStret (NativeReturnType, null);

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1814,7 +1814,9 @@ namespace ObjCRuntime {
 		static bool GetIsARM64CallingConvention ()
 		{
 #if MONOMAC
-			return false;
+			unsafe {
+				return NXGetLocalArchInfo ()->Name.StartsWith ("arm64");
+			}
 #elif __IOS__ || __TVOS__
 			return IntPtr.Size == 8 && Arch == Arch.DEVICE;
 #elif __WATCHOS__

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3906,7 +3906,15 @@ public partial class Generator : IMemberGatherer {
 		int index64 = dual_enum ? 1 : 0;
 
 		if (CurrentPlatform == PlatformName.MacOSX) {
+			print ("if (global::ObjCRuntime.Runtime.IsARM64CallingConvention) {");
+			indent++;
+			GenerateInvoke (false, supercall, mi, minfo, selector, args [index64], assign_to_temp, category_type, false, EnumMode.Bit64);
+			indent--;
+			print ("} else {");
+			indent++;
 			GenerateInvoke (x64_stret, supercall, mi, minfo, selector, args[index64], assign_to_temp, category_type, aligned && x64_stret, EnumMode.Bit64);
+			indent--;
+			print ("}");
 			return;
 		}
 

--- a/tests/common/ProductTests.cs
+++ b/tests/common/ProductTests.cs
@@ -112,6 +112,9 @@ namespace Xamarin.Tests
 						switch (load_command) {
 						case MachO.LoadCommands.MinMacOSX:
 							version = SdkVersions.MinOSXVersion;
+							if (slice.Architecture == MachO.Architectures.ARM64) {
+								alternate_version = new Version(11, 0, 0);
+							}
 							mono_native_compat_version = SdkVersions.MinOSXVersion;
 							mono_native_unified_version = new Version (10, 12, 0);
 							break;

--- a/tests/common/ProductTests.cs
+++ b/tests/common/ProductTests.cs
@@ -113,7 +113,7 @@ namespace Xamarin.Tests
 						case MachO.LoadCommands.MinMacOSX:
 							version = SdkVersions.MinOSXVersion;
 							if (slice.Architecture == MachO.Architectures.ARM64) {
-								alternate_version = new Version(11, 0, 0);
+								alternate_version = new Version (11, 0, 0);
 							}
 							mono_native_compat_version = SdkVersions.MinOSXVersion;
 							mono_native_unified_version = new Version (10, 12, 0);

--- a/tests/common/mac/ConsoleXM.targets
+++ b/tests/common/mac/ConsoleXM.targets
@@ -1,8 +1,8 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	
-	<Target Name="AfterBuild" Inputs="$(ProjectDir)/../../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/SDKs/Xamarin.macOS.sdk/lib/libxammac.dylib;$(ProjectDir)/../../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/x86_64/full/Xamarin.Mac.dll"
+	<Target Name="AfterBuild" Inputs="$(ProjectDir)/../../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/SDKs/Xamarin.macOS.sdk/lib/libxammac.dylib;$(ProjectDir)/../../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/64bits/full/Xamarin.Mac.dll"
 		Outputs="$(OutputPath)/Stuff/libxammac.dylib;$(OutputPath)/Stuff/Xamarin.Mac.dll">
 	    <Copy SourceFiles="$(ProjectDir)/../../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/SDKs/Xamarin.macOS.sdk/lib/libxammac.dylib" DestinationFiles="$(OutputPath)/Stuff/libxammac.dylib" />
-	    <Copy SourceFiles="$(ProjectDir)/../../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/x86_64/full/Xamarin.Mac.dll" DestinationFiles="$(OutputPath)/Stuff/Xamarin.Mac.dll" />
+	    <Copy SourceFiles="$(ProjectDir)/../../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/64bits/full/Xamarin.Mac.dll" DestinationFiles="$(OutputPath)/Stuff/Xamarin.Mac.dll" />
 	</Target>
 </Project>

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <Reference Include="mmp">
+      <Aliases>global,mmp</Aliases>
       <HintPath>..\..\_mac-build\Library\Frameworks\Xamarin.Mac.framework\Versions\git\lib\mmp\mmp.exe</HintPath>
     </Reference>
     <PackageReference Include="Mono.Cecil" Version="0.11.1" />

--- a/tests/mmptest/src/CodeStrippingTests.cs
+++ b/tests/mmptest/src/CodeStrippingTests.cs
@@ -10,7 +10,7 @@ namespace Xamarin.MMP.Tests
 {
 	public class CodeStrippingTests
 	{
-		static Func<string, bool> LipoStripConditional = s => s.Contains ("lipo") && s.Contains ("-thin");
+		static Func<string, bool> LipoStripConditional = s => s.Contains ("lipo") && s.Contains ("-extract_family");
 		static Func<string, bool> LipoStripSkipPosixAndMonoNativeConditional = s => LipoStripConditional (s) && !s.Contains ("libMonoPosixHelper.dylib") && !s.Contains ("libmono-native.dylib");
 
 		static bool DidAnyLipoStripSkipPosixAndMonoNative (BuildResult buildResult)

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/LocalizationIgnore/common-Translations.ignore
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/LocalizationIgnore/common-Translations.ignore
@@ -18,3 +18,4 @@ E7070
 E7071
 InvalidFramework
 InvalidPlatform
+E7072

--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -44,7 +44,7 @@ $(XTVOS_PCH): .stamp-check-sharpie
 	$(SHARPIE) sdk-db --xcode $(XCODE) -s appletvos$(TVOS_SDK_VERSION) -a $(XTVOS_ARCH) -exclude OSLog
 
 
-XMAC ?= $(TOP)/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/$(XMAC_ARCH)/mobile/Xamarin.Mac.dll
+XMAC ?= $(TOP)/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/64bits/mobile/Xamarin.Mac.dll
 XMAC_ARCH = x86_64
 XMAC_PCH = macosx$(OSX_SDK_VERSION)-$(XMAC_ARCH).pch
 

--- a/tests/xtro-sharpie/xtro-sharpie.csproj
+++ b/tests/xtro-sharpie/xtro-sharpie.csproj
@@ -48,7 +48,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'macOS' ">
     <StartAction>Project</StartAction>
-    <StartArguments>macosx10.15-x86_64.pch ../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/x86_64/mobile/Xamarin.Mac.dll</StartArguments>
+    <StartArguments>macosx10.15-x86_64.pch ../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/64bits/mobile/Xamarin.Mac.dll</StartArguments>
     <StartWorkingDirectory>.</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'MacCatalyst' ">

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -1070,6 +1070,7 @@ namespace Xamarin.Bundler {
 			case ApplePlatform.MacOSX:
 			case ApplePlatform.MacCatalyst:
 				validAbis.Add (Abi.x86_64);
+				validAbis.Add (Abi.ARM64);
 				break;
 			default:
 				throw ErrorHelper.CreateError (71, Errors.MX0071, Platform, ProductName);

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -1190,6 +1190,8 @@ namespace Xamarin.Bundler {
 			// Move the dSYM next to its executable
 			if (dsymFolders.Length > 0) {
 				var outputDsymDir = output + ".dSYM";
+				if (Directory.Exists (outputDsymDir))
+					Directory.Delete (outputDsymDir, true);
 				Directory.Move (dsymFolders [0], outputDsymDir);
 				RunCommand ("/usr/bin/mdimport", outputDsymDir);
 			}

--- a/tools/common/Symbols.cs
+++ b/tools/common/Symbols.cs
@@ -26,6 +26,7 @@ namespace Xamarin.Bundler
 	{
 		public SymbolType Type;
 		public bool Ignore;
+		public Abi? ValidAbis;
 
 		static string ObjectiveCPrefix {
 			get {

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -56,25 +56,36 @@ $(MMP_DIRECTORIES):
 # Partial static registrar libraries
 #
 
-GENERATE_PART_REGISTRAR = $(Q_GEN) $(LOCAL_MMP_COMMAND) --xamarin-framework-directory=$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR) -q --runregistrar:$(abspath $@) --sdkroot $(XCODE_DEVELOPER_ROOT) --sdk $(OSX_SDK_VERSION) $(abspath $<) --registrar:static --arch=x86_64 --nolink
+GENERATE_PART_REGISTRAR = $(Q_GEN) $(LOCAL_MMP_COMMAND) --xamarin-framework-directory=$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR) -q --runregistrar:$(abspath $@) --sdkroot $(XCODE_DEVELOPER_ROOT) --sdk $(OSX_SDK_VERSION) $(abspath $<) --registrar:static --nolink
 
 Xamarin.Mac.registrar.mobile.x86_64.m: $(TOP)/src/build/mac/mobile-64/Xamarin.Mac.dll $(LOCAL_MMP)
-	$(GENERATE_PART_REGISTRAR) --target-framework Xamarin.Mac,Version=v2.0,Profile=Mobile -a:$(MOBILE_BCL_DIR)/mscorlib.dll
+	$(GENERATE_PART_REGISTRAR) --arch=x86_64 --target-framework Xamarin.Mac,Version=v2.0,Profile=Mobile -a:$(MOBILE_BCL_DIR)/mscorlib.dll
 	$(Q) touch Xamarin.Mac.registrar.mobile.x86_64.m Xamarin.Mac.registrar.mobile.x86_64.h
 
+Xamarin.Mac.registrar.mobile.arm64.m: $(TOP)/src/build/mac/mobile-64/Xamarin.Mac.dll $(LOCAL_MMP)
+	$(GENERATE_PART_REGISTRAR) --arch=arm64 --target-framework Xamarin.Mac,Version=v2.0,Profile=Mobile -a:$(MOBILE_BCL_DIR)/mscorlib.dll
+	$(Q) touch Xamarin.Mac.registrar.mobile.arm64.m Xamarin.Mac.registrar.mobile.arm64.h
+
 Microsoft.macOS.registrar.x86_64.m: $(TOP)/src/build/dotnet/macos/64/Xamarin.Mac.dll $(LOCAL_MMP)
-	$(GENERATE_PART_REGISTRAR) --target-framework .NETCoreApp,Version=6.0,Profile=macos -a:$(DOTNET6_BCL_DIR)/System.Runtime.dll
+	$(GENERATE_PART_REGISTRAR) --arch=x86_64 --target-framework .NETCoreApp,Version=6.0,Profile=macos -a:$(DOTNET6_BCL_DIR)/System.Runtime.dll
 	$(Q) touch $@ $(basename $@).h
 
 Xamarin.Mac.registrar.full.x86_64.m:   $(TOP)/src/build/mac/full-64/Xamarin.Mac.dll $(LOCAL_MMP)
-	$(GENERATE_PART_REGISTRAR) --target-framework Xamarin.Mac,Version=v4.5,Profile=Full -a:$(FULL_BCL_DIR)/mscorlib.dll
+	$(GENERATE_PART_REGISTRAR) --arch=x86_64 --target-framework Xamarin.Mac,Version=v4.5,Profile=Full -a:$(FULL_BCL_DIR)/mscorlib.dll
 	$(Q) touch Xamarin.Mac.registrar.full.x86_64.m Xamarin.Mac.registrar.full.x86_64.h
 
-%.x86_64.a: %.x86_64.m
+Xamarin.Mac.registrar.full.arm64.m:   $(TOP)/src/build/mac/full-64/Xamarin.Mac.dll $(LOCAL_MMP)
+	$(GENERATE_PART_REGISTRAR) --arch=arm64 --target-framework Xamarin.Mac,Version=v4.5,Profile=Full -a:$(FULL_BCL_DIR)/mscorlib.dll
+	$(Q) touch Xamarin.Mac.registrar.full.arm64.m Xamarin.Mac.registrar.full.arm64.h
+
+Xamarin.Mac.registrar.%.x86_64.a: Xamarin.Mac.registrar.%.x86_64.m
 	$(Q_CC) $(MAC_CC) -DDEBUG -g -gdwarf-2 -x objective-c++ -std=c++14 -o $@ -c -arch x86_64 $< -Wall -Wno-unguarded-availability-new -I$(TOP)/runtime -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx
 
-Xamarin.Mac.registrar.%.a: Xamarin.Mac.registrar.%.x86_64.a
-	$(Q) $(CP) $< $@
+Xamarin.Mac.registrar.%.arm64.a: Xamarin.Mac.registrar.%.arm64.m
+	$(Q_CC) $(MAC_CC) -DDEBUG -g -gdwarf-2 -x objective-c++ -std=c++14 -o $@ -c -arch arm64 $< -Wall -Wno-unguarded-availability-new -I$(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/include -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx
+
+Xamarin.Mac.registrar.%.a: Xamarin.Mac.registrar.%.x86_64.a Xamarin.Mac.registrar.%.arm64.a
+	$(Q_LIPO) $(DEVICE_BIN_PATH)/lipo -create -output $@ $^
 
 dotnet: $(MMP_TARGETS_DOTNET)
 ifdef ENABLE_DOTNET
@@ -100,5 +111,5 @@ include ../common/Make.common
 
 # make will automatically consider files created in chained implicit rules as temporary files, and delete them afterwards
 # marking those files as .SECONDARY will prevent that deletion.
-.SECONDARY: $(foreach ext,h m a,Xamarin.Mac.registrar.mobile.x86_64.$(ext) Xamarin.Mac.registrar.full.x86_64.$(ext))
+.SECONDARY: $(foreach ext,h m a,Xamarin.Mac.registrar.mobile.x86_64.$(ext) Xamarin.Mac.registrar.mobile.arm64.$(ext) Xamarin.Mac.registrar.full.x86_64.$(ext) Xamarin.Mac.registrar.full.arm64.$(ext))
 .SECONDARY: Xamarin.Mac.registrar.mobile.a Xamarin.Mac.registrar.full.a

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -78,11 +78,11 @@ Xamarin.Mac.registrar.full.arm64.m:   $(TOP)/src/build/mac/full-64/Xamarin.Mac.d
 	$(GENERATE_PART_REGISTRAR) --arch=arm64 --target-framework Xamarin.Mac,Version=v4.5,Profile=Full -a:$(FULL_BCL_DIR)/mscorlib.dll
 	$(Q) touch Xamarin.Mac.registrar.full.arm64.m Xamarin.Mac.registrar.full.arm64.h
 
-Xamarin.Mac.registrar.%.x86_64.a: Xamarin.Mac.registrar.%.x86_64.m
+%.x86_64.a: %.x86_64.m
 	$(Q_CC) $(MAC_CC) -DDEBUG -g -gdwarf-2 -x objective-c++ -std=c++14 -o $@ -c -arch x86_64 $< -Wall -Wno-unguarded-availability-new -I$(TOP)/runtime -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx
 
-Xamarin.Mac.registrar.%.arm64.a: Xamarin.Mac.registrar.%.arm64.m
-	$(Q_CC) $(MAC_CC) -DDEBUG -g -gdwarf-2 -x objective-c++ -std=c++14 -o $@ -c -arch arm64 $< -Wall -Wno-unguarded-availability-new -I$(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/include -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx
+%.arm64.a: %.arm64.m
+	$(Q_CC) $(MAC_CC) -DDEBUG -g -gdwarf-2 -x objective-c++ -std=c++14 -o $@ -c -arch arm64 $< -Wall -Wno-unguarded-availability-new -I$(TOP)/runtime -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx
 
 Xamarin.Mac.registrar.%.a: Xamarin.Mac.registrar.%.x86_64.a Xamarin.Mac.registrar.%.arm64.a
 	$(Q_LIPO) $(DEVICE_BIN_PATH)/lipo -create -output $@ $^

--- a/tools/mmp/aot.cs
+++ b/tools/mmp/aot.cs
@@ -246,7 +246,7 @@ namespace Xamarin.Bundler {
 			});
 
 			// Lipo the result
-			if(needsLipo) {
+			if (needsLipo) {
 				Parallel.ForEach (filesToAOT, ParallelOptions, file => {
 					string [] inputs = abis.Select (abi => Path.Combine (tempAotDir, "aot", abi.AsArchString (), Path.GetFileName (file) + ".dylib")).Where (File.Exists).ToArray ();
 					string output = file + ".dylib";

--- a/tools/mmp/aot.cs
+++ b/tools/mmp/aot.cs
@@ -191,13 +191,15 @@ namespace Xamarin.Bundler {
 		}
 		
 		AOTOptions options;
+		Abi [] abis;
 		AOTCompilerType compilerType;
 		bool IsRelease;
 		bool IsModern;
 
-		public AOTCompiler (AOTOptions options, AOTCompilerType compilerType, bool isModern, bool isRelease)
+		public AOTCompiler (AOTOptions options, IEnumerable <Abi> abis, AOTCompilerType compilerType, bool isModern, bool isRelease)
 		{
 			this.options = options;
+			this.abis = abis.ToArray ();
 			this.compilerType = compilerType;
 			this.IsModern = isModern;
 			this.IsRelease = isRelease;
@@ -214,17 +216,48 @@ namespace Xamarin.Bundler {
 				throw ErrorHelper.CreateError (0099, Errors.MX0099, $"\"AOTBundle with aot: {options.CompilationType}\" ");
 
 			var monoEnv = new Dictionary<string, string> { { "MONO_PATH", files.RootDir } };
-
 			List<string> filesToAOT = GetFilesToAOT (files);
-			Parallel.ForEach (filesToAOT, ParallelOptions, file => {
-				var cmd = new List<string> ();
-				cmd.Add (options.IsHybridAOT ? "--aot=hybrid" : "--aot");
+
+			bool needsLipo = abis.Length > 1;
+			string tempAotDir = Path.GetDirectoryName (filesToAOT [0]);
+			if (needsLipo) {
+				foreach (var abi in abis) {
+					Directory.CreateDirectory (Path.Combine (tempAotDir, "aot", abi.AsArchString ()));
+				}
+			}
+
+			Parallel.ForEach (filesToAOT.SelectMany (f => abis, (file, abi) => new Tuple <string, Abi> (file, abi)), ParallelOptions, tuple => {
+				var file = tuple.Item1;
+				var abi = tuple.Item2;
+
+				var cmd = new List <string> ();
+				var aotArgs = new List <string> ();
+				aotArgs.Add ($"mtriple={abi.AsArchString ()}");
+				if (options.IsHybridAOT)
+					aotArgs.Add ("hybrid");
+				if (needsLipo)
+					aotArgs.Add ($"outfile={Path.Combine (tempAotDir, "aot", abi.AsArchString (), Path.GetFileName (file) + ".dylib")}");
+				cmd.Add ($"--aot={string.Join (",", aotArgs)}");
 				if (IsModern)
 					cmd.Add ("--runtime=mobile");
 				cmd.Add (file);
-				if (RunCommand (MonoPath, cmd, monoEnv) != 0)
+				if (RunCommand (GetMonoPath (abi), cmd, monoEnv) != 0)
 					throw ErrorHelper.CreateError (3001, Errors.MX3001, "AOT", file);
 			});
+
+			// Lipo the result
+			if(needsLipo) {
+				Parallel.ForEach (filesToAOT, ParallelOptions, file => {
+					string [] inputs = abis.Select (abi => Path.Combine (tempAotDir, "aot", abi.AsArchString (), Path.GetFileName (file) + ".dylib")).ToArray ();
+					string output = file + ".dylib";
+
+					Driver.RunLipoAndCreateDsym (Driver.App, output, inputs);
+				});
+			}
+
+			if (needsLipo) {
+				Directory.Delete (Path.Combine (tempAotDir, "aot"), true);
+			}
 
 			if (IsRelease && options.IsHybridAOT) {
 				Parallel.ForEach (filesToAOT, ParallelOptions, file => {
@@ -312,17 +345,21 @@ namespace Xamarin.Bundler {
 
 		public const string StripCommand = "/Library/Frameworks/Mono.framework/Commands/mono-cil-strip";
 
-		string MonoPath
+		string GetMonoPath (Abi abi)
 		{
-			get {
-				switch (compilerType) {
-				case AOTCompilerType.Bundled64:
+			if (compilerType == AOTCompilerType.Bundled64) {
+				switch (abi) {
+				case Abi.ARM64:
+					return Path.Combine (XamarinMacPrefix, "bin", "aarch64-darwin-mono-sgen");
+				case Abi.x86_64:
 					return Path.Combine (XamarinMacPrefix, "bin", "mono-sgen");
-				case AOTCompilerType.System64:
-					return "/Library/Frameworks/Mono.framework/Commands/mono64";
 				default:
 					throw ErrorHelper.CreateError (0099, Errors.MX0099, $"\"MonoPath with compilerType: {compilerType}\"");
 				}
+			} else if (compilerType == AOTCompilerType.System64 && abi == Abi.x86_64) {
+				return "/Library/Frameworks/Mono.framework/Commands/mono64";
+			} else {
+				throw ErrorHelper.CreateError (0099, Errors.MX0099, $"\"MonoPath with compilerType: {compilerType}\"");
 			}
 		}
 	}

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1397,7 +1397,7 @@ namespace Xamarin.Bundler {
 			List <string> archArgs = new List <string> ();
 			foreach (var abi in App.Abis) {
 				archArgs.Add ("-extract_family");
-				archArgs.Add (abi.ToString ().ToLower ());
+				archArgs.Add (abi.ToString ().ToLowerInvariant ());
 			}
 			RunLipo (App, prefix.Concat (archArgs).Concat (suffix).ToArray ());
 			if (existingArchs.Except (App.Abis).Count () > 0 && name != "MonoPosixHelper" && name != "libmono-native-unified" && name != "libmono-native-compat")

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1395,8 +1395,7 @@ namespace Xamarin.Bundler {
 			var prefix = new [] { dest };
 			var suffix = new [] { "-output", dest };
 			List <string> archArgs = new List <string> ();
-			foreach (var abi in App.Abis)
-			{
+			foreach (var abi in App.Abis) {
 				archArgs.Add ("-extract_family");
 				archArgs.Add (abi.ToString ().ToLower ());
 			}

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -831,7 +831,7 @@ namespace Xamarin.Bundler {
 
 					// Delete previous content (so we don't have any remaining dsym if we switch from having one to not having one)
 					if (Directory.Exists (abiDir))
-						Directory.Delete (abiDir);
+						Directory.Delete (abiDir, true);
 
 					var main = Path.Combine (abiDir, $"main.m");
 					BuildTarget.GenerateMain (ApplePlatform.MacOSX, abi, main, null);

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1650,7 +1650,7 @@ namespace Xamarin.Bundler {
 			switch (abi) {
 				case Abi.x86_64:
 				case Abi.ARM64:
-					return Path.Combine (Driver.GetFrameworkLibDirectory (Driver.App), arch, flavor, name + ".dll");
+					return Path.Combine (Driver.GetFrameworkLibDirectory (Driver.App), "64bits", flavor, name + ".dll");
 				default:
 					throw new ProductException (5205, true, Errors.MM5205, arch);
 			}

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -929,7 +929,7 @@ namespace Xamarin.Bundler {
 						args.Add (f);
 					}
 
-					var requiredSymbols = BuildTarget.GetRequiredSymbols ();
+					var requiredSymbols = BuildTarget.GetRequiredSymbols (target_abis: abi);
 					Driver.WriteIfDifferent (Path.Combine (App.Cache.Location, "exported-symbols-list"), string.Join ("\n", requiredSymbols.Select ((symbol) => symbol.Prefix + symbol.Name).ToArray ()));
 					switch (App.SymbolMode) {
 					case SymbolMode.Ignore:


### PR DESCRIPTION
Requires https://github.com/mono/mono/pull/20597 (and any other Apple Silicon support PR that were made previously in Mono, they haven't made their way to stable yet)

Implemented Xamarin.Mac support for targetting Apple Silicon (i.e. making apps that run natively on arm64 and x86_64). Tested with and without AOT on one of our internal apps and works on iOS/tvOS/macOS x64/macOS arm64. Compilation of the SDK was done on a x64 Mac, build of the application was done on a x64 application as well.

This is set to draft because Mono doesn't have the required changes available in the stable. However, any suggestion/proposed changes are welcome. I'm not sure how much actual interest there is in the Xamarin community for this specific support, but I think it's an important addition to Xamarin.Mac.