### PR TITLE
Trigger updates to get PR trigger to fire 

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test +
+# UNDONE: Trigger test ++
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -63,15 +63,6 @@ pr:
     - d16-*
 
 stages:
-- stage: configure
-  displayName: 'Configure'
-  jobs:
-  - job: pipeline_configuration
-    pool:
-      vmImage: ubuntu-latest
-
-    steps:
-    - template: templates/configure-build.yml
 
 - stage: governance_checks
   displayName: 'Governance Checks'

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test: xamarin-macios: Enable WebHook #1
+# UNDONE: Trigger test: xamarin-macios: Enable WebHook #2
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test: xamarin-macios: Enable WebHook #2
+# UNDONE: Trigger test: xamarin-macios: Enable WebHook #4
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test: PR WebHook
+# UNDONE: Trigger test: PR WebHook & vsmobiletoolsengineeringsvc2
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test: mjbond-msft account
+# UNDONE: Trigger test: PR WebHook
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test ++
+# UNDONE: Trigger test +++
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test +++
+# UNDONE: Trigger test ++++
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test: xamarin-macios.trigger.test: xamarinhq
+# UNDONE: Trigger test: xamarin-macios: service connection: xamarin (after changing service connections for https://dev.azure.com/xamarin internal & public macios-related pipelines)
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,6 +53,7 @@ variables:
 
 trigger: none
 
+# UNDONE: Trigger test
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test
+# UNDONE: Trigger test +
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test: vsmobiletoolsengineeringsv2 account
+# UNDONE: Trigger test: mjbond-msft account
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test +++++++
+# UNDONE: Trigger test ++++++++
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test: PR WebHook & vsmobiletoolsengineeringsvc2
+# UNDONE: Trigger test: xamarin-macios.trigger.test: xamarinhq
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test: Disable PR related xamarin-macios webhooks
+# UNDONE: Trigger test: vsmobiletoolsengineeringsv2 account
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test +++++
+# UNDONE: Trigger test ++++++
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test: xamarin-macios: Enable WebHook #6
+# UNDONE: Trigger test: xamarin-macios: Enable WebHook #8 and #9
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test ++++++
+# UNDONE: Trigger test +++++++
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test: xamarin-macios: service connection: xamarin (after changing service connections for https://dev.azure.com/xamarin internal & public macios-related pipelines)
+# UNDONE: Trigger test: xamarin-macios: Enable WebHook #1
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test: xamarin-macios: Enable WebHook #5
+# UNDONE: Trigger test: xamarin-macios: Enable WebHook #6
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test: xamarin-macios: Enable WebHook #4
+# UNDONE: Trigger test: xamarin-macios: Enable WebHook #5
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test ++++
+# UNDONE: Trigger test +++++
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -57,11 +57,20 @@ pr:
   autoCancel: true
   branches:
     include:
+    - yaml-pipeline
     - main
     - d16-*
-    - yaml-pipeline                                           # UNDONE: Enable triggering of YAML pipeline changes - remove prior to merging the YAML pipeline build to main
 
 stages:
+- stage: configure
+  displayName: 'Configure'
+  jobs:
+  - job: pipeline_configuration
+    pool:
+      vmImage: ubuntu-latest
+
+    steps:
+    - template: templates/configure-build.yml
 
 - stage: governance_checks
   displayName: 'Governance Checks'

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test: xamarin-macios: Enable WebHook #8 and #9
+# UNDONE: Trigger test: xamarin-macios: Enable WebHooks #11, 13 and 14
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -53,7 +53,7 @@ variables:
 
 trigger: none
 
-# UNDONE: Trigger test ++++++++
+# UNDONE: Trigger test: Disable PR related xamarin-macios webhooks
 pr:
   autoCancel: true
   branches:


### PR DESCRIPTION
Morale of the story is that Azure DevOps pipeline PR triggers will only fire for public GitHub repos on forks when the "Require a team member's comment before building a pull request" option is selected
https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=13760&view=Tab_Triggers