### PR TITLE
[mlaunch] Adjust build logic to ship mlaunch with the .NET nugets when we're building mlaunch as well.

### DIFF
--- a/tools/mlaunch/Makefile
+++ b/tools/mlaunch/Makefile
@@ -14,19 +14,28 @@ endif
 DOTNET_PLATFORMS_MOBILE=$(filter-out macOS,$(DOTNET_PLATFORMS))
 
 ifdef ENABLE_MLAUNCH
-all-local install-local clean-local::
-	$(MAKE) -C $(MACCORE_PATH)/tools/mlaunch $@
+build-and-install:
+	$(MAKE) -C $(MACCORE_PATH)/tools/mlaunch all -j8
+	$(MAKE) -C $(MACCORE_PATH)/tools/mlaunch install -j8
 else
-all-local install-local::
+build-and-install:
 	$(Q) $(CP) -R $(MACIOS_BINARIES_PATH)/mlaunch/bin/mlaunch $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin
 	$(Q) $(CP) -R $(MACIOS_BINARIES_PATH)/mlaunch/lib/mlaunch $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib
-ifdef ENABLE_DOTNET
-all-local install-local::
-	$(Q) for platform in $(DOTNET_PLATFORMS_MOBILE); do \
-		$(CP) -R $(MACIOS_BINARIES_PATH)/mlaunch/bin/mlaunch $(DOTNET_DESTDIR)/Microsoft.$$platform.Sdk/tools/bin; \
-		$(CP) -R $(MACIOS_BINARIES_PATH)/mlaunch/lib/mlaunch $(DOTNET_DESTDIR)/Microsoft.$$platform.Sdk/tools/lib; \
-	done
 endif
+
+all-local:: build-and-install
+
+ifdef ENABLE_MLAUNCH
+clean-local::
+	$(MAKE) -C $(MACCORE_PATH)/tools/mlaunch $@
+endif
+
+ifdef ENABLE_DOTNET
+all-local:: build-and-install
+	$(Q) for platform in $(DOTNET_PLATFORMS_MOBILE); do \
+		$(CP) -R $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch $(DOTNET_DESTDIR)/Microsoft.$$platform.Sdk/tools/bin; \
+		$(CP) -R $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mlaunch $(DOTNET_DESTDIR)/Microsoft.$$platform.Sdk/tools/lib; \
+	done
 endif
 
 ifdef ENABLE_XAMARIN


### PR DESCRIPTION
The original implementation only worked when we used mlaunch from the
macios-binaries repository.