### PR TITLE
[dotnet] Don't link the main executable with any dylibs on macOS.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -551,7 +551,9 @@
 		<ItemGroup>
 			<_XamarinMainLibraries Include="$(_XamarinNativeLibraryDirectory)/$(_LibXamarinName)" />
 			<!-- Link with the libraries shipped with the mono runtime pack -->
-			<_XamarinMainLibraries Include="@(_MonoLibrary)" />
+			<_XamarinMainLibraries Include="@(_MonoLibrary)" Condition="'$(_PlatformName)' != 'macOS'" />
+			<!-- But don't link with any dylibs on macOS, because they might have library initializers which may fail - instead delay any failures until whatever feature they provide is needed -->
+			<_XamarinMainLibraries Include="@(_MonoLibrary)" Condition="'$(_PlatformName)' == 'macOS' And ('%(_MonoLibrary.Extension)' == '.a' Or '%(_MonoLibrary.Filename)' == 'libcoreclr')" />
 			<!-- The frameworks we need to link with (both weakly and normally) -->
 			<_NativeExecutableFrameworks Include="@(_LinkerFrameworks)" />
 


### PR DESCRIPTION
Don't link the main executable with any dylib (except libcoreclr) on macOS,
because that may end up running library initializers in those dylibs, and they
may abort if something goes wrong.

This way we delay any failures until those dylibs are actually needed.

In particular, libSystem.Security.Cryptography.Native.OpenSsl.dylib will abort
in its library initializer if it can't find the native libssl.dylib it wants:
https://github.com/dotnet/runtime/blob/1d9e50cb4735df46d3de0cee5791e97295eaf588/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c#L122-L126
and my system doesn't have any of the libssl.dylib versions that code wants.