### PR TITLE
Ensure the pip virtualenv command is on the PATH

### DIFF
--- a/tools/devops/automation/templates/build-packages.yml
+++ b/tools/devops/automation/templates/build-packages.yml
@@ -184,9 +184,9 @@ steps:
   condition: and(succeeded(), eq(variables['configuration.SignPkgs'], 'True'), eq(variables['configuration.IsPr'], 'True'))
 
   # Ensure virtualenv is on the PATH
-  - template: set-path/v1.yml@templates
-    parameters:
-      prependToPath: '/Users/builder/Library/Python/2.7/bin'
+- template: set-path/v1.yml@templates
+  parameters:
+    prependToPath: '/Users/builder/Library/Python/2.7/bin'
 
 - bash: |
     VIRTUAL_ENV_PATH=$(Build.SourcesDirectory)/venv

--- a/tools/devops/automation/templates/build-packages.yml
+++ b/tools/devops/automation/templates/build-packages.yml
@@ -183,8 +183,12 @@ steps:
   displayName: 'Signing PR Build'
   condition: and(succeeded(), eq(variables['configuration.SignPkgs'], 'True'), eq(variables['configuration.IsPr'], 'True'))
 
+  # Ensure virtualenv is on the PATH
+  - template: set-path/v1.yml@templates
+    parameters:
+      prependToPath: '/Users/builder/Library/Python/2.7/bin'
+
 - bash: |
-    export PATH="$PATH:/Users/builder/Library/Python/2.7/bin"  # UNDONE: Temporary fix until virtualenv is included in the image along with the PATH setting
     VIRTUAL_ENV_PATH=$(Build.SourcesDirectory)/venv
     pip install virtualenv
     virtualenv "$VIRTUAL_ENV_PATH" --system-site-packages

--- a/tools/devops/automation/templates/build-packages.yml
+++ b/tools/devops/automation/templates/build-packages.yml
@@ -186,7 +186,7 @@ steps:
   # Ensure virtualenv is on the PATH
 - template: set-path/v1.yml@templates
   parameters:
-    prependToPath: '/Users/builder/Library/Python/2.7/bin'
+    prependToPath: '/Users/builder/Library/Python/2.7/bin:/usr/local/bin/virtualenv'
 
 - bash: |
     VIRTUAL_ENV_PATH=$(Build.SourcesDirectory)/venv

--- a/tools/devops/automation/templates/build-packages.yml
+++ b/tools/devops/automation/templates/build-packages.yml
@@ -186,7 +186,7 @@ steps:
   # Ensure virtualenv is on the PATH
 - template: set-path/v1.yml@templates
   parameters:
-    prependToPath: '/Users/builder/Library/Python/2.7/bin:/usr/local/bin/virtualenv'
+    prependToPath: '/Users/builder/Library/Python/2.7/bin'
 
 - bash: |
     VIRTUAL_ENV_PATH=$(Build.SourcesDirectory)/venv


### PR DESCRIPTION
Related work item: VS #[1250035](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1250035)

Utilize the `set-path` yaml template to ensure `virtualenv` is on the path for the duration of the build.  