### PR TITLE
[tests][monotouch] Fix recent CGColorSpace tests not to fail on macOS 10.15.x

### DIFF
--- a/tests/monotouch-test/CoreGraphics/ColorSpaceTest.cs
+++ b/tests/monotouch-test/CoreGraphics/ColorSpaceTest.cs
@@ -402,7 +402,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 		[Test]
 		public void CGColorSpaceUsesITUR_2100TFTest ()
 		{
-			TestRuntime.AssertXcodeVersion (12, 1);
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			using (var cs = CGColorSpace.CreateWithName (CGColorSpaceNames.DisplayP3_Hlg))
 				Assert.True (cs.UsesItur2100TF, "DisplayP3_Hlg");
 			using (var cs = CGColorSpace.CreateWithName (CGColorSpaceNames.GenericRgb))
@@ -412,7 +412,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 		[Test]
 		public void CreateLinearizedTest ()
 		{
-			TestRuntime.AssertXcodeVersion (12, 1);
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			using (var cs = CGColorSpace.CreateWithName (CGColorSpaceNames.GenericRgb)) {
 				var csl = cs.CreateLinearized ();
 				Assert.NotNull (csl, "not null");
@@ -423,7 +423,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 		[Test]
 		public void CreateExtendedTest ()
 		{
-			TestRuntime.AssertXcodeVersion (12, 1);
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			using (var cs = CGColorSpace.CreateWithName (CGColorSpaceNames.GenericRgb)) {
 				var csl = cs.CreateExtended ();
 				Assert.NotNull (csl, "not null");
@@ -434,7 +434,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 		[Test]
 		public void CreateExtendedLinearizedTest ()
 		{
-			TestRuntime.AssertXcodeVersion (12, 1);
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
 			using (var cs = CGColorSpace.CreateWithName (CGColorSpaceNames.GenericRgb)) {
 				var csl = cs.CreateExtendedLinearized ();
 				Assert.NotNull (csl, "not null");


### PR DESCRIPTION
```
CreateExtendedTest: System.EntryPointNotFoundException : CGColorSpaceCreateExtended assembly:<unknown assembly> type:<unknown type> member:(null)
```

The API was added in iOS 14.0 (Xcode 12.0) but macOS 11.0 (Xcode 12.2)
and it does not exists on my Mac (10.15.7) even if I don't recall seeing
fail on the bots.