### PR TITLE
Allowing Default Constructor in AVRouteDetector. Fixes #10139

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -13530,7 +13530,6 @@ namespace AVFoundation {
 	}
 
 	[TV (11,0), NoWatch, Mac (10,13), iOS (11,0)]
-	[DisableDefaultCtor]
 	[BaseType (typeof(NSObject))]
 	interface AVRouteDetector {
 		[Notification]


### PR DESCRIPTION
Customer created issue about not being able to use the default constructor in AVRoute Detector in this [issue](https://github.com/xamarin/xamarin-macios/issues/10139). 

After discussing with Alex and Manuel, we saw in Xcode that the default constructor does not cause any errors and we were able to use properties of that instance as well. 

Therefore, we are enabling the default constructor.

fixes: #10139