### PR TITLE
[tests] Re-enable MediaAccessibility/ImageCaptioningTest.cs` `SetCaption` test

### DIFF
--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -67,15 +67,6 @@ namespace MonoTouchFixtures.MediaAccessibility {
 		[Test]
 		public void SetCaption ()
 		{
-#if __MACOS__
-			// looks like Apple broke something inside Xcode 12.2 Beta 2 in both sim and device
-			// NSInvalidArgumentException Reason: -[__NSCFType _getValue:forType:]: unrecognized selector sent to instance
-			// when calling MAImageCaptioning.SetCaption
-			// Seems to be fixed for iOS now but not for macOS
-			if (TestRuntime.CheckExactXcodeVersion (12, 2, beta: 3))
-				Assert.Ignore ("Broken in Xcode 12.2 Beta 3");
-#endif
-
 			TestRuntime.AssertXcodeVersion (11, 0);
 			Assert.Throws<ArgumentNullException> (() => MAImageCaptioning.SetCaption (null, "xamarin", out _));
 			// note: calling on a remote URL crash the process - not that it should work but...


### PR DESCRIPTION
This works fine with Xcode 12.3 beta 1 on 10.15.7 (Intel) and 11.0

ref: https://github.com/xamarin/xamarin-macios/issues/10165