### PR TITLE
[src] Improve the generate-frameworks.csharp script.

### DIFF
--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -49,7 +49,8 @@ DOTNET_TARGETS_DIRS += \
 
 $(BUILD_DIR)/generator-frameworks.g.cs: frameworks.sources Makefile.generator generate-frameworks.csharp
 	@mkdir -p $(dir $@)
-	@./generate-frameworks.csharp $@ '$(IOS_FRAMEWORKS)' '$(MAC_FRAMEWORKS)' '$(WATCHOS_FRAMEWORKS)' '$(TVOS_FRAMEWORKS)'
+	$(Q) ./generate-frameworks.csharp $@.tmp '$(IOS_FRAMEWORKS)' '$(MAC_FRAMEWORKS)' '$(WATCHOS_FRAMEWORKS)' '$(TVOS_FRAMEWORKS)'
+	$(Q) mv $@.tmp $@
 
 $(DOTNET_BUILD_DIR)/Xamarin.Apple.BindingAttributes.dll: generator-attributes.cs Makefile.generator | $(DOTNET_BUILD_DIR)
 	$(Q_DOTNET_BUILD) $(SYSTEM_CSC) $(DOTNET_FLAGS) -out:$@ $<

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -49,7 +49,7 @@ DOTNET_TARGETS_DIRS += \
 
 $(BUILD_DIR)/generator-frameworks.g.cs: frameworks.sources Makefile.generator generate-frameworks.csharp
 	@mkdir -p $(dir $@)
-	@./generate-frameworks.csharp '$(IOS_FRAMEWORKS)' '$(MAC_FRAMEWORKS)' '$(WATCHOS_FRAMEWORKS)' '$(TVOS_FRAMEWORKS)' > $@
+	@./generate-frameworks.csharp $@ '$(IOS_FRAMEWORKS)' '$(MAC_FRAMEWORKS)' '$(WATCHOS_FRAMEWORKS)' '$(TVOS_FRAMEWORKS)'
 
 $(DOTNET_BUILD_DIR)/Xamarin.Apple.BindingAttributes.dll: generator-attributes.cs Makefile.generator | $(DOTNET_BUILD_DIR)
 	$(Q_DOTNET_BUILD) $(SYSTEM_CSC) $(DOTNET_FLAGS) -out:$@ $<

--- a/src/generate-frameworks.csharp
+++ b/src/generate-frameworks.csharp
@@ -1,17 +1,21 @@
-#!/usr/bin/env /Library/Frameworks/Mono.framework/Commands/csharp
+#!/usr/bin/env /Library/Frameworks/Mono.framework/Commands/csharp -s
 
 try {
 	var args = Environment.GetCommandLineArgs ();
-	if (args.Length != 6 /* 2 default + 4 real */) {
-		Console.WriteLine ($"Need 4 arguments, got {args.Length - 2} arguments");
+	var defaultArgumentCount = 3;
+	var actualArgumentCount = 4;
+	if (args.Length != defaultArgumentCount + actualArgumentCount) {
+		Console.WriteLine ($"Need {actualArgumentCount} arguments, got {args.Length - defaultArgumentCount} arguments");
 		Environment.Exit (1);
 		return;
 	}
 
-	var iosframeworks = args [2].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-	var macosframeworks = args [3].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-	var watchosframeworks = args [4].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-	var tvosframeworks = args [5].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+	args = args.Skip (3).ToArray ();
+
+	var iosframeworks = args [0].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+	var macosframeworks = args [1].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+	var watchosframeworks = args [2].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+	var tvosframeworks = args [3].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 	var allframeworks = new string [] [] { iosframeworks, macosframeworks, watchosframeworks, tvosframeworks };
 	var names = new string [] { "iosframeworks", "macosframeworks", "watchosframeworks", "tvosframeworks" };
 

--- a/src/generate-frameworks.csharp
+++ b/src/generate-frameworks.csharp
@@ -1,41 +1,46 @@
 #!/usr/bin/env /Library/Frameworks/Mono.framework/Commands/csharp
 
-var args = Environment.GetCommandLineArgs ();
-if (args.Length != 6 /* 2 default + 4 real */) {
-	Console.WriteLine ($"Need 4 arguments, got {args.Length - 2} arguments");
+try {
+	var args = Environment.GetCommandLineArgs ();
+	if (args.Length != 6 /* 2 default + 4 real */) {
+		Console.WriteLine ($"Need 4 arguments, got {args.Length - 2} arguments");
+		Environment.Exit (1);
+		return;
+	}
+
+	var iosframeworks = args [2].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+	var macosframeworks = args [3].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+	var watchosframeworks = args [4].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+	var tvosframeworks = args [5].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+	var allframeworks = new string [] [] { iosframeworks, macosframeworks, watchosframeworks, tvosframeworks };
+	var names = new string [] { "iosframeworks", "macosframeworks", "watchosframeworks", "tvosframeworks" };
+
+	var all = new HashSet<string> ();
+	foreach (var fws in allframeworks)
+		foreach (var fw in fws)
+			all.Add (fw)
+
+	Console.WriteLine ("using System.Collections.Generic;");
+	Console.WriteLine ();
+	Console.WriteLine ("partial class Frameworks {");
+
+	for (int i = 0; i < names.Length; i++) {
+		var name = names [i];
+		var frameworks = allframeworks [i];
+		Console.Write ($"\treadonly HashSet<string> {name} = new HashSet<string> {{\"");
+		Console.Write (string.Join ("\", \"", frameworks));
+		Console.WriteLine ("\"};");
+	}
+
+	var allArray = all.ToArray ();
+	Array.Sort (allArray);
+	foreach (var fw in allArray)
+		Console.WriteLine ($"\tbool? _{fw.Replace (".", "")};");
+	foreach (var fw in allArray)
+		Console.WriteLine ($"\tpublic bool Have{fw} {{ get {{ if (!_{fw}.HasValue) _{fw} = GetValue (\"{fw}\"); return _{fw}.Value; }} }}");
+	Console.WriteLine ("}");
+	Environment.Exit (0);
+} catch (Exception e) {
+	Console.WriteLine ("Failed: {0}", e);
 	Environment.Exit (1);
-	return;
 }
-
-var iosframeworks = args [2].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-var macosframeworks = args [3].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-var watchosframeworks = args [4].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-var tvosframeworks = args [5].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-var allframeworks = new string [] [] { iosframeworks, macosframeworks, watchosframeworks, tvosframeworks };
-var names = new string [] { "iosframeworks", "macosframeworks", "watchosframeworks", "tvosframeworks" };
-
-var all = new HashSet<string> ();
-foreach (var fws in allframeworks)
-	foreach (var fw in fws)
-		all.Add (fw)
-
-Console.WriteLine ("using System.Collections.Generic;");
-Console.WriteLine ();
-Console.WriteLine ("partial class Frameworks {");
-
-for (int i = 0; i < names.Length; i++) {
-	var name = names [i];
-	var frameworks = allframeworks [i];
-	Console.Write ($"\treadonly HashSet<string> {name} = new HashSet<string> {{\"");
-	Console.Write (string.Join ("\", \"", frameworks));
-	Console.WriteLine ("\"};");
-}
-
-var allArray = all.ToArray ();
-Array.Sort (allArray);
-foreach (var fw in allArray)
-	Console.WriteLine ($"\tbool? _{fw.Replace (".", "")};");
-foreach (var fw in allArray)
-	Console.WriteLine ($"\tpublic bool Have{fw} {{ get {{ if (!_{fw}.HasValue) _{fw} = GetValue (\"{fw}\"); return _{fw}.Value; }} }}");
-Console.WriteLine ("}");
-Environment.Exit (0);

--- a/src/generate-frameworks.csharp
+++ b/src/generate-frameworks.csharp
@@ -1,9 +1,12 @@
 #!/usr/bin/env /Library/Frameworks/Mono.framework/Commands/csharp -s
 
+using System.IO;
+using System.Text;
+
 try {
 	var args = Environment.GetCommandLineArgs ();
 	var defaultArgumentCount = 3;
-	var actualArgumentCount = 4;
+	var actualArgumentCount = 5;
 	if (args.Length != defaultArgumentCount + actualArgumentCount) {
 		Console.WriteLine ($"Need {actualArgumentCount} arguments, got {args.Length - defaultArgumentCount} arguments");
 		Environment.Exit (1);
@@ -11,6 +14,10 @@ try {
 	}
 
 	args = args.Skip (3).ToArray ();
+
+	var csharpOutput = args [0];
+
+	args = args.Skip (1).ToArray ();
 
 	var iosframeworks = args [0].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 	var macosframeworks = args [1].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
@@ -22,27 +29,31 @@ try {
 	var all = new HashSet<string> ();
 	foreach (var fws in allframeworks)
 		foreach (var fw in fws)
-			all.Add (fw)
+			all.Add (fw);
 
-	Console.WriteLine ("using System.Collections.Generic;");
-	Console.WriteLine ();
-	Console.WriteLine ("partial class Frameworks {");
+	var sb = new StringBuilder ();
+	sb.AppendLine ("using System.Collections.Generic;");
+	sb.AppendLine ();
+	sb.AppendLine ("partial class Frameworks {");
 
 	for (int i = 0; i < names.Length; i++) {
 		var name = names [i];
 		var frameworks = allframeworks [i];
-		Console.Write ($"\treadonly HashSet<string> {name} = new HashSet<string> {{\"");
-		Console.Write (string.Join ("\", \"", frameworks));
-		Console.WriteLine ("\"};");
+		sb.Append ($"\treadonly HashSet<string> {name} = new HashSet<string> {{\"");
+		sb.Append (string.Join ("\", \"", frameworks));
+		sb.AppendLine ("\"};");
 	}
 
 	var allArray = all.ToArray ();
 	Array.Sort (allArray);
 	foreach (var fw in allArray)
-		Console.WriteLine ($"\tbool? _{fw.Replace (".", "")};");
+		sb.AppendLine ($"\tbool? _{fw.Replace (".", "")};");
 	foreach (var fw in allArray)
-		Console.WriteLine ($"\tpublic bool Have{fw} {{ get {{ if (!_{fw}.HasValue) _{fw} = GetValue (\"{fw}\"); return _{fw}.Value; }} }}");
-	Console.WriteLine ("}");
+		sb.AppendLine ($"\tpublic bool Have{fw} {{ get {{ if (!_{fw}.HasValue) _{fw} = GetValue (\"{fw}\"); return _{fw}.Value; }} }}");
+	sb.AppendLine ("}");
+
+	File.WriteAllText (csharpOutput, sb.ToString ());
+
 	Environment.Exit (0);
 } catch (Exception e) {
 	Console.WriteLine ("Failed: {0}", e);


### PR DESCRIPTION
* Add exception handling to avoid ignoring any failures.
* Pass -s to csharp and improve argument handling a bit.
* Pass the output path as the first argument, this way standard output can
  have diagnostic output.
* Use temporary files to avoid rebuilding issues if there are any failures.


This PR might be best viewed by ignoring whitespace.