### PR TITLE
[MetricKit] Don't use deprecated API to check system version.

### DIFF
--- a/src/MetricKit/MXMetaData.cs
+++ b/src/MetricKit/MXMetaData.cs
@@ -11,7 +11,7 @@ namespace MetricKit {
 
 		public virtual NSDictionary DictionaryRepresentation {
 			get {
-				if (PlatformHelper.CheckSystemVersion (14,0))
+				if (UIDevice.CurrentDevice.CheckSystemVersion (14,0))
 					return _DictionaryRepresentation14;
 				else
 					return _DictionaryRepresentation13;

--- a/src/MetricKit/MXMetric.cs
+++ b/src/MetricKit/MXMetric.cs
@@ -11,7 +11,7 @@ namespace MetricKit {
 
 		public virtual NSDictionary DictionaryRepresentation {
 			get {
-				if (PlatformHelper.CheckSystemVersion (14,0))
+				if (UIDevice.CurrentDevice.CheckSystemVersion (14,0))
 					return _DictionaryRepresentation14;
 				else
 					return _DictionaryRepresentation13;

--- a/src/MetricKit/MXMetricPayload.cs
+++ b/src/MetricKit/MXMetricPayload.cs
@@ -11,7 +11,7 @@ namespace MetricKit {
 
 		public virtual NSDictionary DictionaryRepresentation {
 			get {
-				if (PlatformHelper.CheckSystemVersion (14,0))
+				if (UIDevice.CurrentDevice.CheckSystemVersion (14,0))
 					return _DictionaryRepresentation14;
 				else
 					return _DictionaryRepresentation13;


### PR DESCRIPTION
It won't work on platforms that don't have these deprecated API (Mac Catalyst).