### PR TITLE
[dotnet] Prevent linking out code referenced by P/Invoke

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -314,9 +314,13 @@
 		<ReadItemsFromFile File="$(_LinkerItemsDirectory)/_RegistrarFile.items" Condition="Exists('$(_LinkerItemsDirectory)/_RegistrarFile.items')">
 			<Output TaskParameter="Items" ItemName="_RegistrarFile" />
 		</ReadItemsFromFile>
-		<!-- Load _RegistrarFile -->
+		<!-- Load _ReferencesFile -->
 		<ReadItemsFromFile File="$(_LinkerItemsDirectory)/_ReferencesFile.items" Condition="Exists('$(_LinkerItemsDirectory)/_ReferencesFile.items')">
 			<Output TaskParameter="Items" ItemName="_ReferencesFile" />
+		</ReadItemsFromFile>
+		<!-- Load _ReferencesLinkerFlags -->
+		<ReadItemsFromFile File="$(_LinkerItemsDirectory)/_ReferencesLinkerFlags.items" Condition="Exists('$(_LinkerItemsDirectory)/_ReferencesLinkerFlags.items')">
+			<Output TaskParameter="Items" ItemName="_ReferencesLinkerFlags" />
 		</ReadItemsFromFile>
 
 		<ItemGroup>
@@ -577,7 +581,7 @@
 			DylibRPath="$(_DylibRPath)"
 			EntitlementsInExecutable="$(_CompiledEntitlements)"
 			Frameworks="@(_NativeExecutableFrameworks);@(_BindingLibraryFrameworks)"
-			LinkerFlags="@(_BindingLibraryLinkerFlags);@(_MainLinkerFlags)"
+			LinkerFlags="@(_BindingLibraryLinkerFlags);@(_ReferencesLinkerFlags);@(_MainLinkerFlags)"
 			LinkWithLibraries="@(_XamarinMainLibraries);@(_BindingLibraryLinkWith);@(_MainLinkWith)"
 			MinimumOSVersion="$(_MinimumOSVersion)"
 			ObjectFiles="@(_NativeExecutableObjectFiles)"

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -314,6 +314,10 @@
 		<ReadItemsFromFile File="$(_LinkerItemsDirectory)/_RegistrarFile.items" Condition="Exists('$(_LinkerItemsDirectory)/_RegistrarFile.items')">
 			<Output TaskParameter="Items" ItemName="_RegistrarFile" />
 		</ReadItemsFromFile>
+		<!-- Load _RegistrarFile -->
+		<ReadItemsFromFile File="$(_LinkerItemsDirectory)/_ReferencesFile.items" Condition="Exists('$(_LinkerItemsDirectory)/_ReferencesFile.items')">
+			<Output TaskParameter="Items" ItemName="_ReferencesFile" />
+		</ReadItemsFromFile>
 
 		<ItemGroup>
 			<_AssembliesToAOT Include="@(ResolvedFileToPublish)" Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe' " />
@@ -465,6 +469,9 @@
 				<OutputFile>$(_IntermediateNativeLibraryDir)%(Filename).o</OutputFile>
 			</_CompileNativeExecutableFile>
 			<_CompileNativeExecutableFile Include="@(_RegistrarFile)">
+				<OutputFile>$(_IntermediateNativeLibraryDir)%(Filename).o</OutputFile>
+			</_CompileNativeExecutableFile>
+			<_CompileNativeExecutableFile Include="@(_ReferencesFile)">
 				<OutputFile>$(_IntermediateNativeLibraryDir)%(Filename).o</OutputFile>
 			</_CompileNativeExecutableFile>
 			<_XamarinMainIncludeDirectory Include="$(_XamarinIncludeDirectory)" />

--- a/tools/dotnet-linker/SetupStep.cs
+++ b/tools/dotnet-linker/SetupStep.cs
@@ -89,6 +89,7 @@ namespace Xamarin {
 			Steps.Add (new ExtractBindingLibrariesStep ());
 			Steps.Add (new RegistrarStep ());
 			Steps.Add (new GenerateMainStep ());
+			Steps.Add (new GenerateReferencesStep ());
 			Steps.Add (new GatherFrameworksStep ());
 
 			Configuration.Write ();

--- a/tools/dotnet-linker/SetupStep.cs
+++ b/tools/dotnet-linker/SetupStep.cs
@@ -85,6 +85,7 @@ namespace Xamarin {
 				post_sweep_substeps.Add (new RemoveAttributesStep ());
 			}
 
+			Steps.Add (new ListExportedSymbols (null));
 			Steps.Add (new LoadNonSkippedAssembliesStep ());
 			Steps.Add (new ExtractBindingLibrariesStep ());
 			Steps.Add (new RegistrarStep ());

--- a/tools/dotnet-linker/Steps/GenerateReferencesStep.cs
+++ b/tools/dotnet-linker/Steps/GenerateReferencesStep.cs
@@ -38,7 +38,7 @@ namespace Xamarin {
 			var hasSymbols = false;
 			if (assembly.MainModule.HasModuleReferences) {
 				hasSymbols = true;
-			} else if (assembly.MainModule.HasTypeReference (Namespaces.Foundation + ".FieldAttribute")) {
+			} else if (assembly.MainModule.HasTypeReference ("Foundation.FieldAttribute")) {
 				hasSymbols = true;
 			}
 			if (!hasSymbols)

--- a/tools/dotnet-linker/Steps/GenerateReferencesStep.cs
+++ b/tools/dotnet-linker/Steps/GenerateReferencesStep.cs
@@ -35,12 +35,7 @@ namespace Xamarin {
 			if (!assembly.MainModule.HasTypes)
 				return;
 
-			var hasSymbols = false;
-			if (assembly.MainModule.HasModuleReferences) {
-				hasSymbols = true;
-			} else if (assembly.MainModule.HasTypeReference ("Foundation.FieldAttribute")) {
-				hasSymbols = true;
-			}
+			var hasSymbols = assembly.MainModule.HasModuleReferences || assembly.MainModule.HasTypeReference ("Foundation.FieldAttribute");
 			if (!hasSymbols)
 				return;
 

--- a/tools/dotnet-linker/Steps/GenerateReferencesStep.cs
+++ b/tools/dotnet-linker/Steps/GenerateReferencesStep.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+using Mono.Cecil;
+
+using Xamarin.Bundler;
+using Xamarin.Linker;
+
+namespace Xamarin {
+
+	public class GenerateReferencesStep : ConfigurationAwareStep {
+		private Symbols required_symbols = new Symbols ();
+		
+		protected override string Name { get; } = "Generate References";
+		protected override int ErrorCode { get; } = 2320;
+
+		protected override void TryEndProcess ()
+		{
+			base.TryEndProcess ();
+
+			var items = new List<MSBuildItem> ();
+			var file = Path.Combine (Configuration.CacheDirectory, $"references.mm");
+			if (Configuration.Target.GenerateReferencingSource (file, required_symbols) != null) {
+				var item = new MSBuildItem { Include = file };
+				items.Add (item);
+			}
+			Configuration.WriteOutputForMSBuild ("_ReferencesFile", items);
+		}
+
+		protected override void TryProcessAssembly (AssemblyDefinition assembly)
+		{
+			base.TryProcessAssembly (assembly);
+
+			if (!assembly.MainModule.HasTypes)
+				return;
+
+			var hasSymbols = false;
+			if (assembly.MainModule.HasModuleReferences) {
+				hasSymbols = true;
+			} else if (assembly.MainModule.HasTypeReference (Namespaces.Foundation + ".FieldAttribute")) {
+				hasSymbols = true;
+			}
+			if (!hasSymbols)
+				return;
+
+			foreach (var type in assembly.MainModule.Types)
+				ProcessType (type);
+		}
+
+		void ProcessType (TypeDefinition type)
+		{
+			if (type.HasNestedTypes) {
+				foreach (var nested in type.NestedTypes)
+					ProcessType (nested);
+			}
+
+			if (type.HasMethods) {
+				foreach (var method in type.Methods)
+					ProcessMethod (method);
+			}
+		}
+
+		void ProcessMethod (MethodDefinition method)
+		{
+			if (method.IsPInvokeImpl && method.HasPInvokeInfo && method.PInvokeInfo != null) {
+				var pinfo = method.PInvokeInfo;
+				if (pinfo.Module.Name == "__Internal") {
+					required_symbols.AddFunction (pinfo.EntryPoint).AddMember (method);
+				}
+			}
+		}
+	}
+}

--- a/tools/dotnet-linker/Steps/GenerateReferencesStep.cs
+++ b/tools/dotnet-linker/Steps/GenerateReferencesStep.cs
@@ -34,7 +34,6 @@ namespace Xamarin {
 				Configuration.WriteOutputForMSBuild ("_ReferencesFile", items);
 				break;
 			case SymbolMode.Linker:
-			case SymbolMode.Default:
 				foreach (var symbol in required_symbols) {
 					var item = new MSBuildItem { Include = "-u" + symbol.Prefix + symbol.Name };
 					items.Add (item);

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -146,6 +146,9 @@
     <Compile Include="..\linker\MonoTouch.Tuner\Extensions.cs">
       <Link>external\tools\linker\MonoTouch.Tuner\Extensions.cs</Link>
     </Compile>
+    <Compile Include="..\linker\MonoTouch.Tuner\ListExportedSymbols.cs">
+      <Link>external\tools\linker\MonoTouch.Tuner\ListExportedSymbols.cs</Link>
+    </Compile>
     <Compile Include="..\linker\MonoTouch.Tuner\PreserveSmartEnumConversionsSubStep.cs">
       <Link>external\tools\linker\MonoTouch.Tuner\PreserveSmartEnumConversionsSubStep.cs</Link>
     </Compile>

--- a/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
+++ b/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
@@ -10,18 +10,26 @@ using Xamarin.Bundler;
 using Xamarin.Linker;
 using Xamarin.Tuner;
 
-namespace MonoTouch.Tuner
+namespace Xamarin.Linker.Steps
 {
 	public class ListExportedSymbols : BaseStep
 	{
 		PInvokeWrapperGenerator state;
 		bool skip_sdk_assemblies;
 
+#if NET
+		public DerivedLinkContext DerivedLinkContext {
+			get {
+				return LinkerConfiguration.GetInstance (Context).DerivedLinkContext;
+			}
+		}
+#else
 		public DerivedLinkContext DerivedLinkContext {
 			get {
 				return (DerivedLinkContext) Context;
 			}
 		}
+#endif
 
 		internal ListExportedSymbols (PInvokeWrapperGenerator state, bool skip_sdk_assemblies = false)
 		{
@@ -36,8 +44,10 @@ namespace MonoTouch.Tuner
 			if (Annotations.GetAction (assembly) == AssemblyAction.Delete)
 				return;
 
+#if !NET
 			if (skip_sdk_assemblies && Profile.IsSdkAssembly (assembly))
 				return;
+#endif
 
 			if (!assembly.MainModule.HasTypes)
 				return;

--- a/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
+++ b/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
@@ -9,6 +9,7 @@ using Mono.Tuner;
 using Xamarin.Bundler;
 using Xamarin.Linker;
 using Xamarin.Tuner;
+using Xamarin.Utils;
 
 namespace Xamarin.Linker.Steps
 {
@@ -122,8 +123,14 @@ namespace Xamarin.Linker.Steps
 				case "__Internal":
 					DerivedLinkContext.RequiredSymbols.AddFunction (pinfo.EntryPoint).AddMember (method);
 					break;
-				case "System.Native":
+
 				case "System.Net.Security.Native":
+#if NET
+					if (DerivedLinkContext.App.Platform == ApplePlatform.TVOS)
+						break; // tvOS does not ship with System.Net.Security.Native due to https://github.com/dotnet/runtime/issues/45535
+					goto case "System.Native";
+#endif
+				case "System.Native":
 				case "System.Security.Cryptography.Native.Apple":
 					DerivedLinkContext.RequireMonoNative = true;
 					DerivedLinkContext.RequiredSymbols.AddFunction (pinfo.EntryPoint).AddMember (method);

--- a/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
+++ b/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
@@ -17,19 +17,15 @@ namespace Xamarin.Linker.Steps
 		PInvokeWrapperGenerator state;
 		bool skip_sdk_assemblies;
 
+		public DerivedLinkContext DerivedLinkContext {
+			get {
 #if NET
-		public DerivedLinkContext DerivedLinkContext {
-			get {
 				return LinkerConfiguration.GetInstance (Context).DerivedLinkContext;
-			}
-		}
 #else
-		public DerivedLinkContext DerivedLinkContext {
-			get {
 				return (DerivedLinkContext) Context;
+#endif
 			}
 		}
-#endif
 
 		internal ListExportedSymbols (PInvokeWrapperGenerator state, bool skip_sdk_assemblies = false)
 		{


### PR DESCRIPTION
Fixes running the following code:

```csharp
	var ciFilter = CIFilter.FromName ("CIColorMatrix");
	var result = (CIImage)ciFilter.ValueForKey (new NSString ("outputImage"));
```

which resulted into call to `xamarin_IntPtr_objc_msgSend_IntPtr` which was linked out from the native code.

This adds a step to dotnet-linker that mimics what mmp/mtouch was doing. Depending on symbol mode setting it either generates: a) references.m file that contains code referencing all the P/Invoked symbols to prevent the native linker from linking them out, or b) `-u<symbol>` linker flags that mark the symbols to be preserved.