### PR TITLE
[dotnet] Avoid double registration of static registrar

### DIFF
--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -558,8 +558,10 @@ namespace Xamarin.Bundler {
 		{
 			sw.WriteLine ("#define MONOMAC 1");
 			sw.WriteLine ("#include <xamarin/xamarin.h>");
+#if !NET
 			if (App.Registrar == RegistrarMode.PartialStatic)
 				sw.WriteLine ("extern \"C\" void xamarin_create_classes_Xamarin_Mac ();");
+#endif
 			sw.WriteLine ();
 			sw.WriteLine ();
 			sw.WriteLine ();
@@ -585,11 +587,12 @@ namespace Xamarin.Bundler {
 				sw.WriteLine ("\txamarin_disable_omit_fp = true;");
 			sw.WriteLine ();
 
-
+#if !NET
 			if (App.Registrar == RegistrarMode.Static)
 				sw.WriteLine ("\txamarin_create_classes ();");
 			else if (App.Registrar == RegistrarMode.PartialStatic)
 				sw.WriteLine ("\txamarin_create_classes_Xamarin_Mac ();");
+#endif
 
 			if (App.EnableDebug)
 				sw.WriteLine ("\txamarin_debug_mode = TRUE;");


### PR DESCRIPTION
The method `xamarin_create_classes_Xamarin_Mac` was called twice which resulted in corruption of the type map. The first call was made from the generated `xammac_setup` method. The second call was made through registration method added in the RegistrarStep of dotnet-linker. This PR removes the first call for consistency with iOS and other platforms.