### PR TITLE
Tags from labels using dedicated Azure DevOps token

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -38,6 +38,8 @@ variables:
 - group: XamarinCompatLab                                     # provisionator-uri setting
 - name: GitHub.Token                                          # Override the GitHub.Token setting defined in the Xamarin Release group
   value: $(github--pat--vs-mobiletools-engineering-service2)  # Use a token dedicated to critical production workflows and help avoid GitHub throttling
+- name: AzDoBuildAccess.Token
+  value: $(pat--xamarinc--build-access)
 - name: system.debug
   value: true
 - name: SigningKeychain

--- a/tools/devops/automation/scripts/VSTS.Tests.ps1
+++ b/tools/devops/automation/scripts/VSTS.Tests.ps1
@@ -12,10 +12,10 @@ Describe 'Stop-Pipeline' {
                 "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI" = "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI";
                 "SYSTEM_TEAMPROJECT" = "SYSTEM_TEAMPROJECT";
                 "BUILD_BUILDID" = "BUILD_BUILDID";
-                "SYSTEM_ACCESSTOKEN" = "SYSTEM_ACCESSTOKEN"
+                "ACCESSTOKEN" = "ACCESSTOKEN"
             }
 
-            $envVariables.GetEnumerator() | ForEach-Object { 
+            $envVariables.GetEnumerator() | ForEach-Object {
                 $key = $_.Key
                 Set-Item -Path "Env:$key" -Value $_.Value
             }
@@ -34,8 +34,8 @@ Describe 'Stop-Pipeline' {
                 if ($Uri -ne $expectedUri) {
                     return $False
                 }
-                
-                if ($Headers.Authorization -ne ("Bearer {0}" -f $envVariables["SYSTEM_ACCESSTOKEN"])) {
+
+                if ($Headers.Authorization -ne ("Bearer {0}" -f $envVariables["ACCESSTOKEN"])) {
                     return $False
                 }
 
@@ -71,10 +71,10 @@ Describe 'Stop-Pipeline' {
                 "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI" = "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI";
                 "SYSTEM_TEAMPROJECT" = "SYSTEM_TEAMPROJECT";
                 "BUILD_BUILDID" = "BUILD_BUILDID";
-                "SYSTEM_ACCESSTOKEN" = "SYSTEM_ACCESSTOKEN" 
+                "ACCESSTOKEN" = "ACCESSTOKEN"
             }
 
-            $Script:envVariables.GetEnumerator() | ForEach-Object { 
+            $Script:envVariables.GetEnumerator() | ForEach-Object {
                 $key = $_.Key
                 Set-Item -Path "Env:$key" -Value $_.Value
                 Remove-Item -Path "Env:$key"
@@ -87,7 +87,7 @@ Describe 'Stop-Pipeline' {
             }
 
             { Stop-Pipeline } | Should -Throw
-            Assert-MockCalled -CommandName Invoke-RestMethod -Times 0 -Scope It 
+            Assert-MockCalled -CommandName Invoke-RestMethod -Times 0 -Scope It
         }
     }
 }
@@ -100,10 +100,10 @@ Describe 'Set-PipelineResult' {
                 "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI" = "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI";
                 "SYSTEM_TEAMPROJECT" = "SYSTEM_TEAMPROJECT";
                 "BUILD_BUILDID" = "BUILD_BUILDID";
-                "SYSTEM_ACCESSTOKEN" = "SYSTEM_ACCESSTOKEN"
+                "ACCESSTOKEN" = "ACCESSTOKEN"
             }
 
-            $envVariables.GetEnumerator() | ForEach-Object { 
+            $envVariables.GetEnumerator() | ForEach-Object {
                 $key = $_.Key
                 Set-Item -Path "Env:$key" -Value $_.Value
             }
@@ -122,8 +122,8 @@ Describe 'Set-PipelineResult' {
                 if ($Uri -ne $expectedUri) {
                     return $False
                 }
-                
-                if ($Headers.Authorization -ne ("Bearer {0}" -f $envVariables["SYSTEM_ACCESSTOKEN"])) {
+
+                if ($Headers.Authorization -ne ("Bearer {0}" -f $envVariables["ACCESSTOKEN"])) {
                     return $False
                 }
 
@@ -159,10 +159,10 @@ Describe 'Set-PipelineResult' {
                 "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI" = "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI";
                 "SYSTEM_TEAMPROJECT" = "SYSTEM_TEAMPROJECT";
                 "BUILD_BUILDID" = "BUILD_BUILDID";
-                "SYSTEM_ACCESSTOKEN" = "SYSTEM_ACCESSTOKEN" 
+                "ACCESSTOKEN" = "ACCESSTOKEN"
             }
 
-            $Script:envVariables.GetEnumerator() | ForEach-Object { 
+            $Script:envVariables.GetEnumerator() | ForEach-Object {
                 $key = $_.Key
                 Set-Item -Path "Env:$key" -Value $_.Value
                 Remove-Item -Path "Env:$key"
@@ -175,7 +175,7 @@ Describe 'Set-PipelineResult' {
             }
 
             { Set-PipelineResult "failed" } | Should -Throw
-            Assert-MockCalled -CommandName Invoke-RestMethod -Times 0 -Scope It 
+            Assert-MockCalled -CommandName Invoke-RestMethod -Times 0 -Scope It
         }
     }
 }

--- a/tools/devops/automation/scripts/VSTS.psm1
+++ b/tools/devops/automation/scripts/VSTS.psm1
@@ -175,7 +175,6 @@ function Set-BuildTags {
     }
 }
 
-
 # export public functions, other functions are private and should not be used ouside the module.
 Export-ModuleMember -Function Stop-Pipeline
 Export-ModuleMember -Function Set-PipelineResult

--- a/tools/devops/automation/scripts/VSTS.psm1
+++ b/tools/devops/automation/scripts/VSTS.psm1
@@ -43,7 +43,7 @@ function Get-AuthHeader([string] $AccessToken)
 
     .EXAMPLE
         Stop-Pipeline
-    
+
     .NOTES
         The cmdlet depends on the following environment variables. If they are not present
         an InvalidOperationException will be thrown.
@@ -71,9 +71,7 @@ function Stop-Pipeline {
 
     $url = Get-BuildUrl
 
-    $headers = @{
-        Authorization = ("Bearer {0}" -f $Env:SYSTEM_ACCESSTOKEN)
-    }
+    $headers = Get-AuthHeader -AccessToken $Env:SYSTEM_ACCESSTOKEN
 
     $payload = @{
         status = "Cancelling"
@@ -88,7 +86,7 @@ function Stop-Pipeline {
 
     .EXAMPLE
         Set-PipelineResult  "failed"
-    
+
     .NOTES
         The cmdlet depends on the following environment variables. If they are not present
         an InvalidOperationException will be thrown.
@@ -100,7 +98,7 @@ function Stop-Pipeline {
 
         The valid values of status are:
         * "canceled" The build was canceled before starting.
-        * "failed" The build completed unsuccessfully. 
+        * "failed" The build completed unsuccessfully.
         * "none" No result
         * "partiallySucceeded" The build completed compilation successfully but had other errors.
         * "succeeded" The build completed successfully.
@@ -164,7 +162,7 @@ function Set-BuildTags {
     }
 
     # there is an api to just do one request, but it is not clear what should the body be, and we are trying and failing, ergo, use
-    # the API that sets one tag at at time. 
+    # the API that sets one tag at at time.
     # This is why people should write documentation, now I'm being  annoying with the tags
 
     $headers = Get-AuthHeader -AccessToken  $Env:SYSTEM_ACCESSTOKEN
@@ -175,12 +173,10 @@ function Set-BuildTags {
 
         Invoke-RestMethod -Uri $url -Headers $headers -Method "PUT"  -ContentType 'application/json'
     }
-
-
 }
 
 
 # export public functions, other functions are private and should not be used ouside the module.
 Export-ModuleMember -Function Stop-Pipeline
-Export-ModuleMember -Function Set-PipelineResult 
+Export-ModuleMember -Function Set-PipelineResult
 Export-ModuleMember -Function Set-BuildTags

--- a/tools/devops/automation/scripts/VSTS.psm1
+++ b/tools/devops/automation/scripts/VSTS.psm1
@@ -51,7 +51,7 @@ function Get-AuthHeader([string] $AccessToken)
         * SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: Contains the full uri of the VSTS for the team.
         * SYSTEM_TEAMPROJECT: Contains the name of the team in VSTS.
         * BUILD_BUILDID: The id of the build to cancel.
-        * SYSTEM_ACCESSTOKEN: The PAT used to be able to perform the rest call to the VSTS API.
+        * ACCESSTOKEN: The PAT used to be able to perform the rest call to the VSTS API.
 #>
 function Stop-Pipeline {
     # assert that all the env vars that are needed are present, else we do have an error
@@ -59,7 +59,7 @@ function Stop-Pipeline {
         "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI" = $Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI;
         "SYSTEM_TEAMPROJECT" = $Env:SYSTEM_TEAMPROJECT;
         "BUILD_BUILDID" = $Env:BUILD_BUILDID;
-        "SYSTEM_ACCESSTOKEN" = $Env:SYSTEM_ACCESSTOKEN
+        "ACCESSTOKEN" = $Env:ACCESSTOKEN
     }
 
     foreach ($key in $envVars.Keys) {
@@ -71,7 +71,7 @@ function Stop-Pipeline {
 
     $url = Get-BuildUrl
 
-    $headers = Get-AuthHeader -AccessToken $Env:SYSTEM_ACCESSTOKEN
+    $headers = Get-AuthHeader -AccessToken $Env:ACCESSTOKEN
 
     $payload = @{
         status = "Cancelling"
@@ -94,7 +94,7 @@ function Stop-Pipeline {
         * SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: Contains the full uri of the VSTS for the team.
         * SYSTEM_TEAMPROJECT: Contains the name of the team in VSTS.
         * BUILD_BUILDID: The id of the build to cancel.
-        * SYSTEM_ACCESSTOKEN: The PAT used to be able to perform the rest call to the VSTS API.
+        * ACCESSTOKEN: The PAT used to be able to perform the rest call to the VSTS API.
 
         The valid values of status are:
         * "canceled" The build was canceled before starting.
@@ -119,7 +119,7 @@ function Set-PipelineResult {
         "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI" = $Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI;
         "SYSTEM_TEAMPROJECT" = $Env:SYSTEM_TEAMPROJECT;
         "BUILD_BUILDID" = $Env:BUILD_BUILDID;
-        "SYSTEM_ACCESSTOKEN" = $Env:SYSTEM_ACCESSTOKEN
+        "ACCESSTOKEN" = $Env:ACCESSTOKEN
     }
 
     foreach ($key in $envVars.Keys) {
@@ -131,7 +131,7 @@ function Set-PipelineResult {
 
     $url = Get-BuildUrl
 
-    $headers = Get-AuthHeader -AccessToken  $Env:SYSTEM_ACCESSTOKEN
+    $headers = Get-AuthHeader -AccessToken  $Env:ACCESSTOKEN
 
     $payload = @{
         result = $Status
@@ -151,7 +151,7 @@ function Set-BuildTags {
         "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI" = $Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI;
         "SYSTEM_TEAMPROJECT" = $Env:SYSTEM_TEAMPROJECT;
         "BUILD_BUILDID" = $Env:BUILD_BUILDID;
-        "SYSTEM_ACCESSTOKEN" = $Env:SYSTEM_ACCESSTOKEN
+        "ACCESSTOKEN" = $Env:ACCESSTOKEN
     }
 
     foreach ($key in $envVars.Keys) {
@@ -165,7 +165,7 @@ function Set-BuildTags {
     # the API that sets one tag at at time.
     # This is why people should write documentation, now I'm being  annoying with the tags
 
-    $headers = Get-AuthHeader -AccessToken  $Env:SYSTEM_ACCESSTOKEN
+    $headers = Get-AuthHeader -AccessToken  $Env:ACCESSTOKEN
 
     foreach ($t in $Tags) {
         $url = Get-TagsRestAPIUrl -Tag $t

--- a/tools/devops/automation/templates/configure-build.yml
+++ b/tools/devops/automation/templates/configure-build.yml
@@ -76,6 +76,6 @@ steps:
   env:
     BUILD_REVISION: $(Build.SourceVersion)
     GITHUB_TOKEN: $(GitHub.Token)
-    SYSTEM_ACCESSTOKEN: $Env:SYSTEM_ACCESSTOKEN
+    SYSTEM_ACCESSTOKEN: $(DropsPAT)
   name: labels 
   displayName: 'Configure build'

--- a/tools/devops/automation/templates/configure-build.yml
+++ b/tools/devops/automation/templates/configure-build.yml
@@ -2,9 +2,7 @@
 # the tags for the build AND will set a number of configuration
 # variables to be used by the rest of the projects
 steps:
-- checkout: self          # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
-  clean: true             # Executes: git clean -ffdx && git reset --hard HEAD
-  submodules: recursive
+- checkout: none          # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
 
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/tools/devops/automation/scripts/GitHub.psm1

--- a/tools/devops/automation/templates/configure-build.yml
+++ b/tools/devops/automation/templates/configure-build.yml
@@ -76,6 +76,6 @@ steps:
   env:
     BUILD_REVISION: $(Build.SourceVersion)
     GITHUB_TOKEN: $(GitHub.Token)
-    SYSTEM_ACCESSTOKEN: $(AzDoBuildAccess.Token)
+    ACCESSTOKEN: $(AzDoBuildAccess.Token)
   name: labels
   displayName: 'Configure build'

--- a/tools/devops/automation/templates/configure-build.yml
+++ b/tools/devops/automation/templates/configure-build.yml
@@ -75,8 +75,7 @@ steps:
     Set-BuildTags -Tags $tags.ToArray()
   env:
     BUILD_REVISION: $(Build.SourceVersion)
-    CONTEXT: ${{ parameters.statusContext }}
     GITHUB_TOKEN: $(GitHub.Token)
-    SYSTEM_ACCESSTOKEN: $(DropsPAT)
+    SYSTEM_ACCESSTOKEN: $Env:SYSTEM_ACCESSTOKEN
   name: labels 
   displayName: 'Configure build'

--- a/tools/devops/automation/templates/configure-build.yml
+++ b/tools/devops/automation/templates/configure-build.yml
@@ -76,6 +76,6 @@ steps:
   env:
     BUILD_REVISION: $(Build.SourceVersion)
     GITHUB_TOKEN: $(GitHub.Token)
-    SYSTEM_ACCESSTOKEN: $(DropsPAT)
+    SYSTEM_ACCESSTOKEN: $(AzDoBuildAccess.Token)
   name: labels
   displayName: 'Configure build'

--- a/tools/devops/automation/templates/configure-build.yml
+++ b/tools/devops/automation/templates/configure-build.yml
@@ -2,7 +2,9 @@
 # the tags for the build AND will set a number of configuration
 # variables to be used by the rest of the projects
 steps:
-- checkout: none          # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
+- checkout: self          # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
+  clean: true             # Executes: git clean -ffdx && git reset --hard HEAD
+  submodules: false
 
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/tools/devops/automation/scripts/GitHub.psm1
@@ -18,7 +20,7 @@ steps:
 
     # the following list will be used to track the tags and set them in VSTS to make the monitoring person life easier
     [System.Collections.Generic.List[string]]$tags = @()
-    
+
     if ($buildReason -eq "PullRequest" -or (($buildReason -eq "Manual") -and ($buildSourceBranchName -eq "merge")) ) {
       Write-Host "Configuring build from PR."
       # This is an interesting step, we do know we are dealing with a PR, but we need the PR id to
@@ -57,7 +59,7 @@ steps:
       )
 
       foreach ($l in $labelsOfInterest) {
-        $labelPresent = 1 -eq ($prInfo.labels | Where-Object { $_.name -eq "$l"}).Count 
+        $labelPresent = 1 -eq ($prInfo.labels | Where-Object { $_.name -eq "$l"}).Count
         Write-Host "##vso[task.setvariable variable=$l;isOutput=true]$labelPresent"
       }
 
@@ -67,7 +69,7 @@ steps:
       $tags.Add("$buildSourceBranchName")
       Write-Host "##vso[task.setvariable variable=prBuild;isOutput=true]False"
     }
-    # set the tags using the cmdlet 
+    # set the tags using the cmdlet
     $tagCount = $tags.Count
     Write-Host "Found '$tagsCount' tags"
     Set-BuildTags -Tags $tags.ToArray()
@@ -75,5 +77,5 @@ steps:
     BUILD_REVISION: $(Build.SourceVersion)
     GITHUB_TOKEN: $(GitHub.Token)
     SYSTEM_ACCESSTOKEN: $(DropsPAT)
-  name: labels 
+  name: labels
   displayName: 'Configure build'

--- a/tools/devops/automation/templates/device-tests.yml
+++ b/tools/devops/automation/templates/device-tests.yml
@@ -89,7 +89,7 @@ steps:
     BUILD_REVISION: $(Build.SourceVersion)
     CONTEXT: ${{ parameters.statusContext }}
     GITHUB_TOKEN: $(GitHub.Token)
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    ACCESSTOKEN: $(System.AccessToken)
   displayName: 'Check HD Free Space'
   timeoutInMinutes: 5
   condition: succeededOrFailed() # we do not care about the previous step

--- a/tools/devops/automation/templates/governance-checks.yml
+++ b/tools/devops/automation/templates/governance-checks.yml
@@ -55,6 +55,6 @@ steps:
   env:
     BUILD_REVISION: $(Build.SourceVersion)
     GITHUB_TOKEN: $(GitHub.Token)
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    ACCESSTOKEN: $(System.AccessToken)
   displayName: "Set Github status"
   condition: succeededOrFailed()

--- a/tools/devops/automation/templates/publish-html.yml
+++ b/tools/devops/automation/templates/publish-html.yml
@@ -52,7 +52,7 @@ steps:
     XAMARIN_STORAGE_FAILED: $(XAMARIN_STORAGE_FAILED) # could not reach xamarin-storage, either the bot is not in the vpn or it finally failed
     TESTS_JOBSTATUS: $(TESTS_JOBSTATUS) # set by the runTests step
     TESTS_SUMMARY: $(TEST_SUMMARY_PATH)
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    ACCESSTOKEN: $(System.AccessToken)
   displayName: 'Add summaries'
   condition: always()
   timeoutInMinutes: 1

--- a/tools/devops/automation/templates/upload-azure.yml
+++ b/tools/devops/automation/templates/upload-azure.yml
@@ -178,6 +178,6 @@ steps:
   env:
     BUILD_REVISION: $(Build.SourceVersion)
     GITHUB_TOKEN: $(GitHub.Token)
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    ACCESSTOKEN: $(System.AccessToken)
     STORAGE_URI: $(Parameters.outputStorageUri)
   displayName: 'Set GithubStatus'


### PR DESCRIPTION
Related to https://github.com/xamarin/xamarin-macios/pull/10143

Azure DevOps does not support adding build tags to PR builds involving GitHub forks via the [AddBuildTag ](https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#addbuildtag-add-a-tag-to-the-build) command

Consequently, we need to use the [Tags](https://docs.microsoft.com/en-us/rest/api/azure/devops/build/tags?view=azure-devops-rest-6.0) REST API.  Furthermore, we need to use our own Azure DevOps PAT since the System.AccessToken will not work.

This change incorporates a dedicated Azure DevOps PAT based on a service account where the PAT value is obtained from KeyVault.  Replaces the "hard coded" DropsPAT previously used to unblock the tags-related REST API calls.