### PR TITLE
[msbuild] Only execute DetectDebugNetworkConfigurationTask for debug builds

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectDebugNetworkConfigurationTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectDebugNetworkConfigurationTaskBase.cs
@@ -38,11 +38,10 @@ namespace Xamarin.iOS.Tasks
 
 		public override bool Execute ()
 		{
-			var ips = new List<string> ();
-
 			if (SdkIsSimulator) {
-				ips.Add (IPAddress.Loopback.ToString ());
+				DebugIPAddresses = IPAddress.Loopback.ToString ();
 			} else if (DebugOverWiFi) {
+				var ips = new List<string> ();
 				string [] hosts = null;
 
 				if (!string.IsNullOrEmpty (DebuggerHosts))
@@ -83,9 +82,9 @@ namespace Xamarin.iOS.Tasks
 					Log.LogError (7002, null, MSBStrings.E7002);
 					return false;
 				}
-			}
 
-			DebugIPAddresses = string.Join (";", ips.ToArray ());
+				DebugIPAddresses = string.Join (";", ips);
+			}
 
 			Log.LogTaskProperty ("DebugIPAddresses", DebugIPAddresses);
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -913,7 +913,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</EmbedMobileProvision>
 	</Target>
 
-	<Target Name="_DetectDebugNetworkConfiguration">
+	<Target Name="_DetectDebugNetworkConfiguration" Condition="'$(_BundlerDebug)' == 'true'">
 		<DetectDebugNetworkConfiguration
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"


### PR DESCRIPTION
Not that it was very slow but it did make to the top 10 of the
archive build I was debugging.

Also reduce allocations in the task itself, for when it's needed.