### PR TITLE
[msbuild] Treat 'ResolvedCompileFileDefinitions' as a list of reference assemblies as well. Fixes #9266.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -751,6 +751,8 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<!-- This is exactly what "Microsoft.NuGet.Build.Tasks"'s 'ResolveNuGetPackageAssets' target is doing -->
 			<!-- Effectively 'ResolveNuGetPackageAssets' computes the NuGet packages using their json asset file, adds the full assemblies to 'ReferenceCopyLocalPaths' and outputs the resolved references via '_ReferencesFromNuGetPackages' -->
 			<ReferencePath Remove="@(_ReferencesFromNuGetPackages)" />
+			<!-- It seems newer version of the .NET SDK uses the 'ResolvedCompileFileDefinitions' property instead of '_ReferencesFromNuGetPackages' -->
+			<ReferencePath Remove="@(ResolvedCompileFileDefinitions)" />
 			<_BundlerReferencePath Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll'" />
 			<_CompileToNativeInput Include="$(TargetDir)$(TargetFileName);@(_BundlerReferencePath)" />
 			<_CompileToNativeInput Condition="'@(_ResolvedAppExtensionReferences)' != ''" Include="%(_ResolvedAppExtensionReferences.Identity)\..\bundler.stamp" />


### PR DESCRIPTION
The build logic will put reference assemblies in
'ResolvedCompileFileDefinitions' instead of '_ReferencesFromNuGetPackages'
when using the new-style packageref format, so we need to handle
'ResolvedCompileFileDefinitions' the same way we handle
'_ReferencesFromNuGetPackages'.

I was unfortunately not able to create a unit test for this scenario, because
xibuild sets MSBUILD_EXE_PATH to make msbuild look in our local build files,
and then the restore fails with:

> Issue9266.csproj : error MSB4236: The SDK 'Msbuild.Sdk.Extras/2.1.2' specified could not be found.

If I don't use "Msbuild.Sdk.Extras" in the test, then it doesn't hit the
broken path this PR is fixing. If I change xibuild to not set
MSBUILD_EXE_PATH, we're not testing our local bits anymore, but the system
Xamarin.Mac.

Fixes https://github.com/xamarin/xamarin-macios/issues/9266.