### PR TITLE
[tests] Update test to cope with change in Xamarin.WatchOS.dll's location.

### DIFF
--- a/tests/mtouch/SdkTest.cs
+++ b/tests/mtouch/SdkTest.cs
@@ -224,7 +224,7 @@ namespace Xamarin.Linker {
 			rv.AddRange (Directory.GetFiles (watchOSPath, "*.dll", SearchOption.TopDirectoryOnly).
 				Select ((v) => v.Substring (watchOSPath.Length)).ToArray ());
 			rv.Remove ("Xamarin.WatchOS.dll");
-			rv.Add (Path.Combine ("..", "..", "32bits", "Xamarin.WatchOS.dll"));
+			rv.Add (Path.Combine ("..", "..", "32bits", "watchOS", "Xamarin.WatchOS.dll"));
 			return rv.ToArray ();
 		}
 


### PR DESCRIPTION
Fixes this test failure:

* Xamarin.Linker.SdkTest.NoLLVMFailuresInWatchOS("../../32bits/Xamarin.WatchOS.dll"):
    AOT compilation
    Expected: 0
    But was: 1

This regresed in 87d04ac3311fa41237046fb499d84b1f3d530995.