### PR TITLE
[d16-8] [VSTS] If we fail dumping the env, continue.

### DIFF
--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -66,6 +66,7 @@ steps:
     Get-ChildItem env:
   displayName: 'Dump Environment'
   timeoutInMinutes: 1
+  continueOnError: true
 
 # Uses the powershell cmdlet to remove known directories that are not needed and use space.
 # we might hit issue https://github.com/PowerShell/PowerShell/issues/9246, so we always do exit 0


### PR DESCRIPTION
This step is not working on certain bots, there are several examples at https://dev.azure.com/devdiv/DevDiv/_build?definitionId=13122&_a=summary

Backport of #10193.

/cc @mandel-macaque 