### PR TITLE
[VSTS] Ensure that we have a reasonable timeout. Will unblock device tests.

### DIFF
--- a/tools/devops/device-tests/templates/device-tests.yml
+++ b/tools/devops/device-tests/templates/device-tests.yml
@@ -136,6 +136,7 @@ steps:
   displayName: 'Add provisioning profiles'
   env:
     LOGIN_KEYCHAIN_PASSWORD: $(OSX_KEYCHAIN_PASS)
+  timeoutInMinutes: 30
 
 # Executed ONLY when the profisioning profiles step failed. At this point, we do know that 
 # we cannot run the tests, therefore:


### PR DESCRIPTION
Some bots are not configure correctly and block, that means we wait for ever. Just wait for 30 mins max.