### PR TITLE
[VSTS] Add branchname in the nugets.

### DIFF
--- a/tools/devops/automation/templates/build-packages.yml
+++ b/tools/devops/automation/templates/build-packages.yml
@@ -248,6 +248,8 @@ steps:
   displayName: 'Build Nugets'
   condition: and(succeeded(), eq(variables['configuration.BuildNugets'], 'True'))
   timeoutInMinutes: 180
+  env:
+    BRANCH_NAME: $(Build.SourceBranchName) # expected by make since it used to be set by jenkins
 
 - bash:  $(Build.SourcesDirectory)/xamarin-macios/tools/devops/automation/productsign.sh
   env:


### PR DESCRIPTION
If the env is not set, we have names such as
'Microsoft.watchOS.Runtime.watchos-x86.7.1.100-ci.HEAD.165+sha.14522b296.nupkg'