### PR TITLE
[msbuild] Archive the user frameworks .dSYM when available

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ArchiveTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ArchiveTaskBase.cs
@@ -173,6 +173,16 @@ namespace Xamarin.iOS.Tasks
 					Ditto (DSYMDir, destDir);
 				}
 
+				// for each user framework that is bundled inside the app we must also archive their dSYMs, if available
+				foreach (var fx in Directory.GetDirectories (Path.Combine (AppBundleDir.ItemSpec, "Frameworks"), "*.framework")) {
+					var dsym = Path.GetFileName (fx) + ".dSYM";
+					var fq_dsym = Path.Combine (AppBundleDir.ItemSpec, "..", dsym);
+					if (Directory.Exists (fq_dsym)) {
+						var destDir = Path.Combine (archiveDir, "dSYMs", dsym);
+						Ditto (fq_dsym, destDir);
+					}
+				}
+
 				// Archive the mSYMs...
 				if (Directory.Exists (MSYMDir)) {
 					var destDir = Path.Combine (archiveDir, "mSYMs", Path.GetFileName (MSYMDir));


### PR DESCRIPTION
This also includes dSYM inside xcframeworks, e.g.

```
...
├── dSYMs
│   ├── Universal.framework.dSYM
│   │   └── Contents
│   │       ├── Info.plist
│   │       └── Resources
│   │           └── DWARF
│   │               └── Universal
│   └── xcf_ios.app.dSYM
│       └── Contents
│           ├── Info.plist
│           └── Resources
│               └── DWARF
│                   └── xcf_ios
...
```
from https://github.com/spouliot/xcframework/tree/main/xamarin/xcf-ios

versus
```
...
└── dSYMs
    ├── Universal.framework.dSYM
    │   └── Contents
    │       ├── Info.plist
    │       └── Resources
    │           └── DWARF
    │               └── Universal
    └── xcf-ios.app.dSYM
        └── Contents
            ├── Info.plist
            └── Resources
                └── DWARF
                    └── xcf-ios
...
```
from the similar ObjC sample https://github.com/spouliot/xcframework/tree/main/objc/xcf-ios