### PR TITLE
[Foundation] Break out of the delegate when we have canceled a task. Fixes #9132

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -553,7 +553,7 @@ namespace Foundation {
 						//                        we did not find the data.
 						if (inflight.CancellationToken.IsCancellationRequested) {
 							task?.Cancel ();
-							// return null so that we break out of any deleate method.
+							// return null so that we break out of any delegate method.
 							return null;
 						}
 						return inflight;

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -546,7 +546,7 @@ namespace Foundation {
 						// cancel the task it means that we are not interested in any of the delegate methods:
 						// 
 						// DidReceiveResponse     We might have received a response, but either the user cancelled or a 
-						//                        timeout did, if that is the case, we do not care about the respose.
+						//                        timeout did, if that is the case, we do not care about the response.
 						// DidReceiveData         Of buffer has a partial response ergo garbage and there is not real 
 						//                        reason we would like to add more data.
 						// DidCompleteWithError - We are not changing a behaviour compared to the case in which 

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -542,9 +542,20 @@ namespace Foundation {
 
 				lock (sessionHandler.inflightRequestsLock)
 					if (sessionHandler.inflightRequests.TryGetValue (task, out inflight)) {
-						// ensure that we did not cancel the request, if we did, do cancel the task
-						if (inflight.CancellationToken.IsCancellationRequested)
+						// ensure that we did not cancel the request, if we did, do cancel the task, if we 
+						// cancel the task it means that we are not interested in any of the delegate methods:
+						// 
+						// DidReceiveResponse     We might have received a response, but either the user cancelled or a 
+						//                        timeout did, if that is the case, we do not care about the respose.
+						// DidReceiveData         Of buffer has a partial response ergo garbage and there is not real 
+						//                        reason we would like to add more data.
+						// DidCompleteWithError - We are not changing a behaviour compared to the case in which 
+						//                        we did not find the data.
+						if (inflight.CancellationToken.IsCancellationRequested) {
 							task?.Cancel ();
+							// return null so that we break out of any deleate method.
+							return null;
+						}
 						return inflight;
 					}
 


### PR DESCRIPTION
This is an interesting issue that happens in the following scenario:

1. A request is performed that will take some extra time to get a
   response or an error.
2. The request is cancelled BEFORE the delegate methods
   DidReceiveResponse, DidReceiveData or DidCompleteWithError and
   called. Yet we have not yet fully canceled the native request. It
   does take some time to do so, that is why we have a
   'NSURLSessionTaskStateCanceling' and not 'NSURLSessionTaskStateCancelled'

The issue happens because the GetInflightData checks if the task has
been canceled. In that method we have the following:

```csharp
if (inflight.CancellationToken.IsCancellationRequested)
  task?.Cancel ();
return inflight;
```

The call of the Cancel method in the NSData task has as ripple effect which
is the execution of the following callback:

```csharp
cancellationToken.Register (() => {
  RemoveInflightData (dataTask);
  tcs.TrySetCanceled ();
});
```

Which calls:

```csharp
void RemoveInflightData (NSUrlSessionTask task, bool cancel = true)
{
      lock (inflightRequestsLock) {
              if (inflightRequests.TryGetValue (task, out var data)) {
                      if (cancel)
                              data.CancellationTokenSource.Cancel ();
                      data.Dispose ();
                      inflightRequests.Remove (task);
              }
              // do we need to be notified? If we have not inflightData, we do not
              if (inflightRequests.Count == 0)
                      RemoveNotification ();
      }

      if (cancel)
              task?.Cancel ();

      task?.Dispose ();
}
```

The above call does call Dispose and Dipose in the inflight data does:
```csharp
if (disposing) {
    if (CancellationTokenSource != null) {
            CancellationTokenSource.Dispose ();
            CancellationTokenSource = null;
    }
}
```

If we follow these set of events for example in the
DidRecieveResponse:
```csharp
[Preserve (Conditional = true)]
public override void DidReceiveResponse (NSUrlSession session, NSUrlSessionDataTask dataTask, NSUrlResponse response, Action<NSUrlSessionResponseDisposition> completionHandler)
{
    var inflight = GetInflightData (dataTask);

    if (inflight == null)
            return;

    try {
            var urlResponse = (NSHttpUrlResponse)response;
            var status = (int)urlResponse.StatusCode;

            var content = new NSUrlSessionDataTaskStreamContent (inflight.Stream, () => {
                    if (!inflight.Completed) {
                            dataTask.Cancel ();
                    }

                    inflight.Disposed = true;
                    inflight.Stream.TrySetException (new ObjectDisposedException ("The content stream was disposed."));

                    sessionHandler.RemoveInflightData (dataTask);
            }, inflight.CancellationTokenSource.Token);
```
If can happen that, when we get the delegate call to the method, the
request has been cancelled. That means that we are in the precise state
in which we do not longer care about the response BUT we did get a
infligh data reference.. that HAS BEEN DISPOSED!!! this later gives a NRE
in several places.

The correct way is to return null from the GetInflighData method if we
have been cancelled, this makes sense because if we cancelled we do not
care about the execution of any of the methods that required the data
since it has been disposed!

fixes #9132