### PR TITLE
[compare-commits] Fix building the previous commit for Xamarin.MacCatalyst. Fixes #10222.

### DIFF
--- a/tools/compare-commits.sh
+++ b/tools/compare-commits.sh
@@ -180,7 +180,7 @@ mkdir -p "$OUTPUT_DIR/project-files"
 ln -s git "$OUTPUT_DIR/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current"
 ln -s git "$OUTPUT_DIR/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current"
 
-for dir in 2.1 Xamarin.iOS Xamarin.TVOS Xamarin.WatchOS; do
+for dir in 2.1 Xamarin.iOS Xamarin.TVOS Xamarin.WatchOS Xamarin.MacCatalyst; do
 	$CP -R "$ROOT_DIR/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/$dir" "$OUTPUT_DIR/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono"
 done
 


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/10222.