### PR TITLE
[dotnet] Set default runtime feature switches.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -112,6 +112,17 @@
 
 		<!-- On the other hand, we want the linker to link away debug support in the actual code unless we're building for Debug -->
 		<DebuggerSupport Condition="'$(DebuggerSupport)' == ''">$(_BundlerDebug)</DebuggerSupport>
+
+		<!--
+			Other runtime libraries feature switches defaults
+			Available feature switches: https://github.com/dotnet/runtime/blob/master/docs/workflow/trimming/feature-switches.md
+		-->
+		<EnableUnsafeBinaryFormatterSerialization Condition="'$(EnableUnsafeBinaryFormatterSerialization)' == ''">false</EnableUnsafeBinaryFormatterSerialization>
+		<EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
+		<EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
+		<HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
+		<StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
+		<UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
Set all current feature switches, except for InvariantGlobalization, to
defaults which trim the features.

Ref: https://github.com/dotnet/runtime/blob/master/docs/workflow/trimming/feature-switches.md
Ref: https://github.com/xamarin/xamarin-android/pull/5337

This drops the hello world app size from 28.6 MB to 23.5 MB. Full report:
https://gist.github.com/rolfbjarne/71cc18b49446862f1d42aa29526b0ac6