### PR TITLE
[Actions] Add the backport action

### DIFF
--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -1,0 +1,23 @@
+name: Backport Trigger
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  launchBackportBuild:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '@vs-mobiletools-engineering-service2 backport')
+
+    steps:
+      - uses: xamarin/backport-bot-action@v1.0
+        with:
+          pull_request_url: ${{ github.event.issue.pull_request.url }}
+          comment_body: ${{ github.event.comment.body }}
+          comment_author: ${{ github.actor }}
+          github_repository: ${{ github.repository }}
+          ado_organization: ${{ secrets.ADO_PROJECTCOLLECTION }}
+          ado_project: ${{ secrets.ADO_PROJECT }}
+          backport_pipeline_id: ${{ secrets.BACKPORT_PIPELINEID }}
+          ado_build_pat: ${{ secrets.ADO_BUILDPAT }}
+          github_account_pat: ${{ secrets.SERVICEACCOUNT_PAT }}

--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   launchBackportBuild:
     runs-on: ubuntu-latest
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '@vs-mobiletools-engineering-service2 backport')
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/sudo backport')
 
     steps:
       - uses: xamarin/backport-bot-action@v1.0


### PR DESCRIPTION
As part of the effort to move away from jenkins, the @monojenkins bot will be retired. This adds an action to be used that does the same job.

New action can be executed via '@vs-mobiletools-engineering-service2 backport $TARGET_BRANCH'