### PR TITLE
[macos] Handle symlinks in user frameworks

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -354,6 +354,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			ProjectGuid="$(ProjectGuid)"
 			ProjectTypeGuids="$(ProjectTypeGuids)"
 			OutputPath="$(OutputPath)"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			>
 			<Output TaskParameter="ArchiveDir" PropertyName="ArchiveDir" />
 		</Archive>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -9,6 +9,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.Collections.Generic;
 using Xamarin.Localization.MSBuild;
+using Xamarin.Utils;
 
 namespace Xamarin.MacDev.Tasks
 {
@@ -230,7 +231,10 @@ namespace Xamarin.MacDev.Tasks
 			} else if (File.Exists (item.ItemSpec)) {
 				codesignedFiles.Add (item);
 
-				var dirName = Path.GetDirectoryName (item.ItemSpec);
+				// on macOS apps {item.ItemSpec} can be a symlink to `Versions/Current/{item.ItemSpec}`
+				// and `Current` also a symlink to `A`... and `_CodeSignature` will be found there
+				var path = PathUtils.ResolveSymbolicLinks (item.ItemSpec);
+				var dirName = Path.GetDirectoryName (path);
 
 				if (Path.GetExtension (dirName) == ".framework")
 					codesignedFiles.AddRange (Directory.EnumerateFiles (Path.Combine (dirName, CodeSignatureDirName)).Select (x => new TaskItem (x)));

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1364,6 +1364,10 @@ namespace Xamarin.Bundler {
 				return;
 
 			var arch = App.Abi.AsString ();
+			// macOS frameworks often uses symlinks and we do not
+			// want to replace the symlink with the thin binary
+			// while leaving the fat binary inside the framework
+			dest = GetRealPath (dest);
 			RunLipo (App, new [] { dest, "-thin", arch, "-output", dest });
 			if (name != "MonoPosixHelper" && name != "libmono-native-unified" && name != "libmono-native-compat")
 				ErrorHelper.Warning (2108, Errors.MM2108, name, arch);


### PR DESCRIPTION
User frameworks for macOS often uses symlinks (as Xcode creates them
this way).

This cause problem cause the symlink is on the binary and we expected
the `_CodeSignature` directory to by side-by-side with the binary. This
was missing and cause exceptions when codesigning such frameworks.

A second problem happened because `mmp` use `lipo -thin` to remove
non-required architectures. However when a framework has symlinks, like:

```
├── Frameworks
│   └── Universal.framework
│       ├── Resources -> Versions/Current/Resources
│       ├── Universal -> Versions/Current/Universal
│       └── Versions
│           ├── A
│           │   ├── Resources
│           │   │   └── Info.plist
│           │   ├── Universal
│           │   └── _CodeSignature
│           │       └── CodeResources
│           └── Current -> A
```

then this actually replaced the (very small) symlink with a thin version
of the framework. Which means the original one was still _fat_ and the
whole app was now larger than the original version.

Sample used: https://github.com/spouliot/xcframework/tree/main/xamarin/xcf-mac