### PR TITLE
Add support for binding projects in Mac Catalyst. Fixes #10286.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.MacCatalyst.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.MacCatalyst.ObjCBinding.CSharp.targets
@@ -1,0 +1,35 @@
+<!--
+***********************************************************************************************
+Xamarin.MacCatalyst.ObjCBinding.CSharp.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+This file imports the version- and platform-specific targets for the project importing
+this file. This file also defines targets to produce an error if the specified targets
+file does not exist, but the project is built anyway (command-line or IDE build).
+
+Copyright (C) 2015-2016 Xamarin Inc. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
+			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
+
+	<PropertyGroup>
+		<!-- Version/fx properties -->
+		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.MacCatalyst</TargetFrameworkIdentifier>
+		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<AssetTargetFallback>xamarinios10;$(AssetTargetFallback)</AssetTargetFallback>
+	</PropertyGroup>
+
+	<Import Project="..\iOS\Xamarin.iOS.ObjCBinding.CSharp.targets"/>
+
+	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
+			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
+</Project>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -652,6 +652,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CreateDebugConfiguration" Condition="'$(_BundlerDebug)' == 'true' And '$(IsWatchApp)' == 'false'"
 		DependsOnTargets="_CopyResourcesToBundle;_DetectDebugNetworkConfiguration"
 		Outputs="$(_AppResourcesPath)MonoTouchDebugConfiguration.txt" >
+		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_AppResourcesPath)" />
 		<CreateDebugConfiguration
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -83,7 +83,7 @@ EXTRA_DEPENDENCIES = libtest.h $(GENERATED_FILES) rename.h
 COMMON_DYLIB_ARGS=-g -dynamiclib -gdwarf-2 -fms-extensions libframework.m -o $$@ -Wall -framework Foundation -lz
 .libs/$(1)/libtest.x86.dylib: ARCH=i386
 $$(foreach arch,$(3),.libs/$(1)/libtest.$$(arch).dylib): libframework.m | .libs/$(1)
-	$$(call Q_2,CC,    [$(1)]) $$(XCODE_CC) $$(COMMON_DYLIB_ARGS) -arch $$(if $$(ARCH),i386,$$(subst libtest.,,$$(basename $$(notdir $$@)))) $(5) -isysroot $(XCODE_DEVELOPER_ROOT)/Platforms/$(4).platform/Developer/SDKs/$(4)$$($(6)_SDK_VERSION).sdk
+	$$(call Q_2,CC,    [$(1)]) $$(XCODE_CC) $$(COMMON_DYLIB_ARGS) -arch $$(if $$(ARCH),i386,$$(subst libtest.,,$$(basename $$(notdir $$@)))) $(5)
 	$$(Q) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool -id @rpath/XTest.framework/XTest $$@
 
 .libs/$(1)/libtest.dylib: $$(foreach arch,$(3),.libs/$(1)/libtest.$$(arch).dylib)
@@ -117,21 +117,24 @@ endef
 # 4: platform name
 # 5: min version
 # 6: os
-$(eval $(call Template,iphonesimulator,IOSSIMULATOR,x86 x86_64,iPhoneSimulator,-mios-simulator-version-min=8.0,IOS))
-$(eval $(call Template,iphoneos,IPHONEOS,armv7 armv7s arm64,iPhoneOS,-miphoneos-version-min=8.0,IOS))
+$(eval $(call Template,iphonesimulator,IOSSIMULATOR,x86 x86_64,iPhoneSimulator,-mios-simulator-version-min=8.0 -isysroot $(SIMULATOR_SDK)))
+$(eval $(call Template,iphoneos,IPHONEOS,armv7 armv7s arm64,iPhoneOS,-miphoneos-version-min=8.0 -isysroot $(DEVICE_SDK)))
 ifdef INCLUDE_TVOS
-$(eval $(call Template,tvsimulator,TVSIMULATOR,x86_64,AppleTVSimulator,-mtvos-simulator-version-min=9.0,TVOS))
-$(eval $(call Template,tvos,TVOS,arm64,AppleTVOS,-mtvos-version-min=9.0 -fembed-bitcode,TVOS))
+$(eval $(call Template,tvsimulator,TVSIMULATOR,x86_64,AppleTVSimulator,-mtvos-simulator-version-min=9.0 -isysroot $(SIMULATORTV_SDK)))
+$(eval $(call Template,tvos,TVOS,arm64,AppleTVOS,-mtvos-version-min=9.0 -fembed-bitcode -isysroot $(DEVICETV_SDK)))
 endif
 ifdef INCLUDE_WATCH
-$(eval $(call Template,watchsimulator,WATCHSIMULATOR,x86 x86_64,WatchSimulator,-mwatchos-simulator-version-min=2.0,WATCHOS))
-$(eval $(call Template,watchos,WATCHOS,armv7k arm64_32,WatchOS,-mwatchos-version-min=2.0 -fembed-bitcode,WATCHOS))
+$(eval $(call Template,watchsimulator,WATCHSIMULATOR,x86 x86_64,WatchSimulator,-mwatchos-simulator-version-min=2.0 -isysroot $(SIMULATORWATCH_SDK)))
+$(eval $(call Template,watchos,WATCHOS,armv7k arm64_32,WatchOS,-mwatchos-version-min=2.0 -fembed-bitcode -isysroot $(DEVICEWATCH_SDK)))
 endif
 ifdef INCLUDE_MAC
-$(eval $(call Template,macos,MACOS,x86_64,MacOSX,-mmacosx-version-min=$(MIN_OSX_VERSION_FOR_MAC),MACOS,x86_64))
+$(eval $(call Template,macos,MACOS,x86_64,MacOSX,-mmacosx-version-min=$(MIN_OSX_VERSION_FOR_MAC) -isysroot $(XCODE_DEVELOPER_ROOT)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(OSX_SDK_VERSION).sdk))
+endif
+ifdef INCLUDE_MACCATALYST
+$(eval $(call Template,maccatalyst,MACCATALYST,x86_64,MacCatalyst,$(MACCATALYST_COMMON_CFLAGS)))
 endif
 
-.libs/ios-fat .libs/tvos-fat .libs/watchos-fat:
+.libs/ios-fat .libs/tvos-fat .libs/watchos-fat .libs/maccatalyst-fat:
 	$(Q) mkdir -p $@
 
 define LibTemplate
@@ -151,6 +154,8 @@ $(eval $(call LibTemplate,arm64+x86_64,.libs/tvos/libtest.arm64.o,.libs/tvsimula
 
 $(eval $(call LibTemplate,armv7k+x86,.libs/watchos/libtest.armv7k.o,.libs/watchsimulator/libtest.x86.o,watchos-fat,WATCHOS))
 
+$(eval $(call LibTemplate,x86_64,.libs/maccatalyst/libtest.x86_64.o,,maccatalyst-fat,MACCATALYST))
+
 define FatFrameworkTemplate
 .libs/$(1)/XStaticObjectTest.framework/XStaticObjectTest: .libs/$(2)/XStaticObjectTest.framework/XStaticObjectTest .libs/$(3)/XStaticObjectTest.framework/XStaticObjectTest | .libs/$(1)
 	$(Q) mkdir -p $$(dir $$@)
@@ -166,8 +171,10 @@ define FatFrameworkTemplate
 
 .libs/$(1)/XTest.framework/Info.plist: .libs/$(2)/XTest.framework/Info.plist .libs/$(3)/XTest.framework/Info.plist
 	$(Q) mkdir -p $$(dir $$@)
+ifneq ($(2),$(3))
 	@# Check if the Info.plists are identical
 	$(Q) diff $$^
+endif
 	@# Copy one of them
 	$(Q) $(CP) $$< $$@
 
@@ -190,10 +197,14 @@ endef
 $(eval $(call FatFrameworkTemplate,ios-fat,iphoneos,iphonesimulator))
 $(eval $(call FatFrameworkTemplate,tvos-fat,tvos,tvsimulator))
 $(eval $(call FatFrameworkTemplate,watchos-fat,watchos,watchsimulator))
+$(eval $(call FatFrameworkTemplate,maccatalyst-fat,maccatalyst,maccatalyst))
 
 XCPLATFORMS=iphoneos iphonesimulator tvos tvsimulator watchos watchsimulator
 ifdef INCLUDE_MAC
 XCPLATFORMS+= macos
+endif
+ifdef INCLUDE_MACCATALYST
+XCPLATFORMS+= maccatalyst
 endif
 
 XTEST_XCFRAMEWORKS += $(foreach platform,$(XCPLATFORMS),.libs/$(platform)/XTest.framework)

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -148,6 +148,22 @@ namespace Xamarin.Bundler {
 			}
 		}
 
+		public string FrameworksDirectory {
+			get {
+				switch (Platform) {
+				case ApplePlatform.iOS:
+				case ApplePlatform.TVOS:
+				case ApplePlatform.WatchOS:
+					return Path.Combine (AppDirectory, "Frameworks");
+				case ApplePlatform.MacOSX:
+				case ApplePlatform.MacCatalyst:
+					return Path.Combine (AppDirectory, "Contents", "Frameworks");
+				default:
+					throw ErrorHelper.CreateError (71, Errors.MX0071, Platform, ProductName);
+				}
+			}
+		}
+
 		// How Mono should be embedded into the app.
 		public AssemblyBuildTarget LibMonoLinkMode {
 			get {

--- a/tools/common/CompilerFlags.cs
+++ b/tools/common/CompilerFlags.cs
@@ -301,7 +301,19 @@ namespace Xamarin.Utils
 				args.Add ("-Xlinker");
 				args.Add ("-rpath");
 				args.Add ("-Xlinker");
-				args.Add ("@executable_path/Frameworks");
+				switch (Application.Platform) {
+				case ApplePlatform.iOS:
+				case ApplePlatform.TVOS:
+				case ApplePlatform.WatchOS:
+					args.Add ("@executable_path/Frameworks");
+					break;
+				case ApplePlatform.MacCatalyst:
+				case ApplePlatform.MacOSX:
+					args.Add ("@executable_path/../Frameworks");
+					break;
+				default:
+					throw ErrorHelper.CreateError (71, Errors.MX0071, Application.Platform, Application.ProductName);
+				}
 				if (Application.IsExtension) {
 					args.Add ("-Xlinker");
 					args.Add ("-rpath");

--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -948,7 +948,8 @@ namespace Xamarin.Bundler {
 						throw ErrorHelper.CreateError (65, Errors.MT0065_A, DeploymentTarget, string.Join (", ", Frameworks.ToArray ()));
 					break;
 				case ApplePlatform.TVOS:
-					// All versions of tvOS support extensions
+				case ApplePlatform.MacCatalyst:
+					// All versions of tvOS and Mac Catalyst support extensions
 					break;
 				default:
 					throw ErrorHelper.CreateError (71, Errors.MX0071, Platform, "Xamarin.iOS");

--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -1203,7 +1203,7 @@ namespace Xamarin.Bundler {
 				BundleFileInfo info;
 				if (!Path.GetFileName (fw).EndsWith (".framework", StringComparison.Ordinal))
 					continue;
-				var key = $"Frameworks/{Path.GetFileName (fw)}";
+				var key = Path.GetFileName (fw);
 				if (!bundle_files.TryGetValue (key, out info))
 					bundle_files [key] = info = new BundleFileInfo ();
 				info.Sources.Add (fw);
@@ -1231,7 +1231,6 @@ namespace Xamarin.Bundler {
 			foreach (var kvp in bundle_files) {
 				var name = kvp.Key;
 				var info = kvp.Value;
-				var targetPath = Path.Combine (ContentDirectory, name);
 				var files = info.Sources;
 				var isFramework = Directory.Exists (files.First ());
 
@@ -1242,6 +1241,7 @@ namespace Xamarin.Bundler {
 					throw ErrorHelper.CreateError (99, Errors.MX0099, $"'can't process a mix of dylibs and frameworks: {string.Join(", ", files)}'");
 
 				if (isFramework) {
+					var targetPath = Path.Combine (FrameworksDirectory, name);
 					// This is a framework
 					if (files.Count > 1) {
 						// If we have multiple frameworks, check if they're identical, and remove any duplicates
@@ -1291,6 +1291,7 @@ namespace Xamarin.Bundler {
 						}
 					}
 				} else {
+					var targetPath = Path.Combine (ContentDirectory, name);
 					var targetDirectory = Path.GetDirectoryName (targetPath);
 					if (!IsUptodate (files, new string [] { targetPath })) {
 						Directory.CreateDirectory (targetDirectory);


### PR DESCRIPTION
* Build our native test libraries for Mac Catalyst.
* Add the required MSBuild targets file for Mac Catalyst binding projects to work
* Fix up a few things in mtouch and msbuild logic.

This makes the framework-test and interdependent-binding-projects tests green.

Fixes https://github.com/xamarin/xamarin-macios/issues/10286.
Partial fix for https://github.com/xamarin/xamarin-macios/issues/10217.