### PR TITLE
[msbuild] Remove the old `--rsrc` argument when using `ditto`

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ArchiveTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ArchiveTaskBase.cs
@@ -3,9 +3,7 @@ using System.IO;
 using System.Diagnostics;
 
 using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 
-using Xamarin.MacDev;
 using System.Globalization;
 
 namespace Xamarin.MacDev.Tasks
@@ -87,8 +85,6 @@ namespace Xamarin.MacDev.Tasks
 		protected static int Ditto (string source, string destination)
 		{
 			var args = new CommandLineArgumentBuilder ();
-
-			args.Add ("-rsrc");
 
 			args.AddQuoted (source);
 			args.AddQuoted (destination);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
@@ -2,7 +2,6 @@
 using System.IO;
 
 using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 
 namespace Xamarin.MacDev.Tasks
 {
@@ -36,8 +35,6 @@ namespace Xamarin.MacDev.Tasks
 		protected override string GenerateCommandLineCommands ()
 		{
 			var args = new CommandLineArgumentBuilder ();
-
-			args.Add ("-rsrc");
 
 			args.AddQuoted (Source.ItemSpec);
 			args.AddQuoted (Destination.ItemSpec);


### PR DESCRIPTION
`--rsrc` has been the default since macOS 10.4