### PR TITLE
[msbuild] Use the existing user framework dSYM when available

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
@@ -73,8 +73,10 @@ namespace Xamarin.MacDev.Tasks
 
 		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
 		{
-			// TODO: do proper parsing of error messages and such
-			Log.LogMessage (messageImportance, "{0}", singleLine);
+			if (singleLine.StartsWith ("warning:", StringComparison.Ordinal))
+				Log.LogWarning (singleLine);
+			else
+				Log.LogMessage (messageImportance, singleLine);
 		}
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -524,34 +524,61 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</Touch>
 	</Target>
 
-	<Target Name="_GenerateFrameworkDebugSymbols" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_CompileToNative;_ParseBundlerArguments;_CollectFrameworks"
+	<Target Name="_CopyUserFrameworkDebugSymbols" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_CompileToNative;_ParseBundlerArguments;"
+		Inputs="%(_FrameworkNativeReference.Name)"
+		Outputs="$(AppBundleDir)\..\%(_FrameworkNativeReference.Filename).framework.dSYM\Contents\Info.plist"
+		>
+
+		<PropertyGroup>
+			<_Source>%(_FrameworkNativeReference.Name)\..\dSYMs\%(_FrameworkNativeReference.Filename).framework.dSYM\</_Source>
+			<_Destination>$(AppBundleDir)\..\%(_FrameworkNativeReference.Filename).framework.dSYM</_Destination>
+		</PropertyGroup>
+
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_Destination)" />
+
+		<!-- if available copy the provided user frameworks .dSYM -->
+		<Ditto
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true' And Exists ('$(_Source)')"
+			Source="$(_Source)"
+			Destination="$(_Destination)"
+		>
+		</Ditto>
+	</Target>
+
+	<Target Name="_GenerateFrameworkDebugSymbols" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_CopyUserFrameworkDebugSymbols;_CollectFrameworks"
 		Inputs="%(_Frameworks.Identity)"
 		Outputs="$(AppBundleDir)\..\%(_Frameworks.Filename).framework.dSYM\Contents\Info.plist"
 		>
 
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(AppBundleDir)\..\%(_Frameworks.Filename).framework.dSYM" />
+		<PropertyGroup>
+			<_Destination>$(AppBundleDir)\..\%(_Frameworks.Filename).framework.dSYM</_Destination>
+		</PropertyGroup>
 
-		<!-- run dsymutil on embedded frameworks -->
-		<DSymUtil
-			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true' And '$(_NoDSymUtil)' == 'false'"
-			AppBundleDir="$(AppBundleDir)"
-			Architectures=""
-			DSymDir="$(AppBundleDir)\..\%(_Frameworks.Filename).framework.dSYM"
-			Executable="%(_Frameworks.Identity)"
-			ToolExe="$(DSymUtilExe)"
-			ToolPath="$(DSymUtilPath)">
-		</DSymUtil>
+		<!-- if the user framework does not provide it's own dSYM then we try to build one -->
+		<ItemGroup Condition="'$(IsMacEnabled)' == 'true' And !Exists (_Destination)">
+			<!-- run dsymutil on embedded frameworks -->
+			<DSymUtil
+				SessionId="$(BuildSessionId)"
+				Condition="'$(_NoDSymUtil)' == 'false'"
+				AppBundleDir="$(AppBundleDir)"
+				Architectures=""
+				DSymDir="$(_Destination)"
+				Executable="%(_Frameworks.Identity)"
+				ToolExe="$(DSymUtilExe)"
+				ToolPath="$(DSymUtilPath)">
+			</DSymUtil>
 
-		<!-- strip embedded frameworks -->
-		<SymbolStrip
-			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true' And '$(_NoSymbolStrip)' == 'false'"
-			Executable="%(_Frameworks.Identity)"
-			IsFramework="true"
-			SymbolFile=""
-		>
-		</SymbolStrip>
+			<!-- strip embedded frameworks -->
+			<SymbolStrip
+				SessionId="$(BuildSessionId)"
+				Condition="'$(_NoSymbolStrip)' == 'false'"
+				Executable="%(_Frameworks.Identity)"
+				IsFramework="true"
+				SymbolFile=""
+			>
+			</SymbolStrip>
+		</ItemGroup>
 
 		<!-- _GenerateDebugSymbols will run spotlight to index the dSYMs -->
 	</Target>


### PR DESCRIPTION
User frameworks comes in different "shapes"

* You can roll your own (like ours are) and they are likely to be similar
  to dynamic libraries. Of interest is the fact that the native binary
  will include debugging symbols. On which our tools will, at a later
  point, run `dsymutil` to create a `dSYM` and `strip` the binary.

* You can create them with a tool, like Xcode, and the build's output
  will give you a `dSYM` and a stripped (no debug information) binary.

Now we can't process the later like the former. Because if we execute
`dsymutil` on the **stripped** framework we'll get an _empty_ (no symbol)
`.dSYM`. The tool will issue a warning like:

> warning: no debug symbols in executable (-arch arm64)

which is easy to miss since it's informational (now promoted to a proper
msbuild warning).

The result is that the archive will have our new, but _empty_ .dSYM,
which won't be of any help to symbolicate crashes later.

It's also quite inefficient since
* we run `dsymutil` way too often (to produce nothing useful)
* we run `strip` on the, already stripped, framework binary

The solution is to check if the user framework comes with a `.dSYM`.
If it does then this is the one we should bundle in the archive and we
can skip the `dsymutil` and `strip` steps.

If it does not have one (dSYM) then the current logic is the best we can
do, i.e. assume there might be debug information inside the binary,
extract it (`dsymutil`) and remove it (`strip`) from shipping code.