### PR TITLE
[tests] Use the FSharp.Core NuGet for Mac Catalyst.

### DIFF
--- a/tests/fsharp/fsharp.fsproj
+++ b/tests/fsharp/fsharp.fsproj
@@ -150,7 +150,8 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core" />
+    <Reference Include="FSharp.Core" Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.MacCatalyst'" />
+    <PackageReference Include="FSharp.Core" Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.MacCatalyst'" Version="5.0.0" />
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/fsharplibrary/fsharplibrary.fsproj
+++ b/tests/fsharplibrary/fsharplibrary.fsproj
@@ -41,7 +41,8 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core" />
+    <Reference Include="FSharp.Core" Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.MacCatalyst'" />
+    <PackageReference Include="FSharp.Core" Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.MacCatalyst'" Version="5.0.0" />
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
We're not shipping F# assemblies for Mac Catalyst, so just use the ones from
NuGet instead.

This is a partial fix for https://github.com/xamarin/xamarin-macios/issues/10217.