### PR TITLE
[bgen] Avoid a NullReferenceException when reporting multiple attributes on a type. Fixes #10310.

### DIFF
--- a/src/generator-attribute-manager.cs
+++ b/src/generator-attribute-manager.cs
@@ -466,6 +466,8 @@ public class AttributeManager
 		if (provider is ParameterInfo) {
 			var pi = (ParameterInfo) provider;
 			name = $"the method {pi.Member.DeclaringType.FullName}.{pi.Member.Name}'s parameter #{pi.Position} ({pi.Name})";
+		} else if (provider is Type type) {
+			name = $"the type {type.FullName}";
 		} else if (provider is MemberInfo) {
 			var mi = (MemberInfo) provider;
 			name = $"the member {mi.DeclaringType.FullName}.{mi.Name}";

--- a/tests/generator/ErrorTests.cs
+++ b/tests/generator/ErrorTests.cs
@@ -204,6 +204,16 @@ namespace GeneratorTests
 		}
 
 		[Test]
+		public void BI1059 ()
+		{
+			var bgen = new BGenTool ();
+			bgen.Profile = Profile.iOS;
+			bgen.CreateTemporaryBinding (File.ReadAllText (Path.Combine (Configuration.SourceRoot, "tests", "generator", "bi1059.cs")));
+			bgen.AssertExecuteError ("build");
+			bgen.AssertError (1059, "Found 2 Foundation.PreserveAttribute attributes on the member the type BI1059. At most one was expected.");
+		}
+
+		[Test]
 		public void BI1060 ()
 		{
 			var bgen = new BGenTool ();

--- a/tests/generator/bi1059.cs
+++ b/tests/generator/bi1059.cs
@@ -1,0 +1,6 @@
+using Foundation;
+
+[Protocol]
+[Preserve (AllMembers = true)]
+[Preserve (AllMembers = true)]
+partial interface BI1059 {}


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/10310.