### PR TITLE
[src] Any type forwarders in iOS' Xamarin.iOS.dll must appear in the Mac Catalyst facade as well.

### DIFF
--- a/src/generate-type-forwarders/Program.cs
+++ b/src/generate-type-forwarders/Program.cs
@@ -22,6 +22,11 @@ namespace GenerateTypeForwarders {
 			var sb = new StringBuilder ();
 
 			sb.AppendLine ("using System.Runtime.CompilerServices;");
+
+			foreach (var exportedType in from.MainModule.ExportedTypes) {
+				sb.AppendLine ($"[assembly: TypeForwardedToAttribute (typeof ({exportedType.Namespace}.{exportedType.Name}))]");
+			}
+
 			foreach (var type in from.MainModule.Types) {
 				if (type.IsNotPublic)
 					continue;


### PR DESCRIPTION
This shows up in a Xamarin.Forms app, which has a reference to
System.Drawing.RectangleF in Xamarin.iOS.dll, which is a type forwarder to
System.Drawing.Common.dll. That type forwarder must also exist in the
Xamarin.iOS.dll Facadate that Mac Catalyst uses.