### PR TITLE
[Security] Fix the underlying integral type for SslCipherSuite for Mac Catalyst.

### DIFF
--- a/src/Security/SecureTransport.cs
+++ b/src/Security/SecureTransport.cs
@@ -275,7 +275,7 @@ namespace Security {
 	[Deprecated (PlatformName.iOS, 13,0, message: "Use 'TlsCipherSuite' instead.")]
 	[Deprecated (PlatformName.TvOS, 13,0, message: "Use 'TlsCipherSuite' instead.")]
 	[Deprecated (PlatformName.WatchOS, 6,0, message: "Use 'TlsCipherSuite' instead.")]
-#if MONOMAC
+#if MONOMAC || __MACCATALYST__
 	public enum SslCipherSuite : uint {
 #else
 	public enum SslCipherSuite : ushort {


### PR DESCRIPTION
This difference manifested as a memory corruption (because we were passing an array of the enum to native code, and the array was half the size it should be, so native code write into random memory).
