### PR TITLE
[versions-check.csharp] Improve this script a bit

### DIFF
--- a/versions-check.csharp
+++ b/versions-check.csharp
@@ -1,4 +1,4 @@
-#!/usr/bin/env /Library/Frameworks/Mono.framework/Commands/csharp
+#!/usr/bin/env /Library/Frameworks/Mono.framework/Commands/csharp -s
 
 // this script is to make sure our versions.plist files are not out of date with our min/max supported OS versions.
 
@@ -7,74 +7,83 @@
 using System.IO;
 using System.Xml;
 
-var args = Environment.GetCommandLineArgs ();
-if (args.Length != 13 /* 2 default + 9 real */) {
-	// first arg is "/Library/Frameworks/Mono.framework/Versions/4.8.0/lib/mono/4.5/csharp.exe"
-	// second arg the script itself
-	// then comes the ones we care about
-	Console.WriteLine ("Need 11 arguments, got {0}", args.Length - 2);
-	Environment.Exit (1);
-	return;
-}
-
-var plistPath = args [2];
-var iOSMin = args [3];
-var iOSMax = args [4];
-var tvOSMin = args [5];
-var tvOSMax = args [6];
-var watchOSMin = args [7];
-var watchOSMax = args [8];
-var macOSMin = args [9];
-var macOSMax = args [10];
-var MacCatalystMin = args [11];
-var MacCatalystMax = args [12];
-
-var doc = new System.Xml.XmlDocument ();
-doc.Load (plistPath);
-
-var failed = false;
-
-var check = new Action<string, string, string> ((product, min, max) =>
-{
-	var minVersion = Version.Parse (min);
-	var maxVersion = Version.Parse (max);
-	var foundMax = false;
-	var foundMin = false;
-	var versions = doc.SelectNodes ($"/plist/dict/key[text()='KnownVersions']/following-sibling::dict[1]/key[text()='{product}']/following-sibling::array[1]/string");
-	if (versions.Count == 0) {
-		// Skip this (iOS/tvOS/watchOS versions for macOS, or vice versa)
+try {
+	var args = Environment.GetCommandLineArgs ();
+	var defaultArgumentsCount = 3;
+	var expectedArgumentCount = 11;
+	if (args.Length != defaultArgumentsCount + expectedArgumentCount) {
+		// first arg is "/Library/Frameworks/Mono.framework/Versions/4.8.0/lib/mono/4.5/csharp.exe"
+		// second arg the script itself
+		// then comes the ones we care about
+		Console.WriteLine ("Need 11 arguments, got {0}", args.Length - 2);
+		Environment.Exit (1);
 		return;
 	}
-	foreach (XmlNode node in versions) {
-		// Console.WriteLine ($"{product}: checking: {node.InnerText}");
-		var v = node.InnerText;
-		var version = Version.Parse (v);
-		if (version < minVersion) {
-			Console.Error.WriteLine ($"Found the {product} version {v} in {Path.GetFileName (plistPath)}, but it's smaller than the supported min {product} version we support ({min}).");
-			failed = true;
-		} else if (version > maxVersion) {
-			Console.Error.WriteLine ($"Found the {product} version {v} in {Path.GetFileName (plistPath)}, but it's higher than the supported max {product} version we support ({max}).");
+
+	args = args.Skip (defaultArgumentsCount).ToArray ();
+
+	var plistPath = args [0];
+	var iOSMin = args [1];
+	var iOSMax = args [2];
+	var tvOSMin = args [3];
+	var tvOSMax = args [4];
+	var watchOSMin = args [5];
+	var watchOSMax = args [6];
+	var macOSMin = args [7];
+	var macOSMax = args [8];
+	var MacCatalystMin = args [9];
+	var MacCatalystMax = args [10];
+
+	var doc = new System.Xml.XmlDocument ();
+	doc.Load (plistPath);
+
+	var failed = false;
+
+	var check = new Action<string, string, string> ((product, min, max) =>
+	{
+		var minVersion = Version.Parse (min);
+		var maxVersion = Version.Parse (max);
+		var foundMax = false;
+		var foundMin = false;
+		var versions = doc.SelectNodes ($"/plist/dict/key[text()='KnownVersions']/following-sibling::dict[1]/key[text()='{product}']/following-sibling::array[1]/string");
+		if (versions.Count == 0) {
+			// Skip this (iOS/tvOS/watchOS versions for macOS, or vice versa)
+			return;
+		}
+		foreach (XmlNode node in versions) {
+			// Console.WriteLine ($"{product}: checking: {node.InnerText}");
+			var v = node.InnerText;
+			var version = Version.Parse (v);
+			if (version < minVersion) {
+				Console.Error.WriteLine ($"Found the {product} version {v} in {Path.GetFileName (plistPath)}, but it's smaller than the supported min {product} version we support ({min}).");
+				failed = true;
+			} else if (version > maxVersion) {
+				Console.Error.WriteLine ($"Found the {product} version {v} in {Path.GetFileName (plistPath)}, but it's higher than the supported max {product} version we support ({max}).");
+				failed = true;
+			}
+			if (version == maxVersion)
+				foundMax = true;
+			if (version == minVersion)
+				foundMin = true;
+		}
+		if (!foundMax) {
+			Console.Error.WriteLine ($"Could not find the max {product} version {max} in {Path.GetFileName (plistPath)}.");
 			failed = true;
 		}
-		if (version == maxVersion)
-			foundMax = true;
-		if (version == minVersion)
-			foundMin = true;
-	}
-	if (!foundMax) {
-		Console.Error.WriteLine ($"Could not find the max {product} version {max} in {Path.GetFileName (plistPath)}.");
-		failed = true;
-	}
-	if (!foundMin) {
-		Console.Error.WriteLine ($"Could not find the min {product} version {min} in {Path.GetFileName (plistPath)}.");
-		failed = true;
-	}
-});
+		if (!foundMin) {
+			Console.Error.WriteLine ($"Could not find the min {product} version {min} in {Path.GetFileName (plistPath)}.");
+			failed = true;
+		}
+	});
 
-check ("iOS", iOSMin, iOSMax);
-check ("tvOS", tvOSMin, tvOSMax);
-check ("watchOS", watchOSMin, watchOSMax);
-check ("macOS", macOSMin, macOSMax);
-check ("MacCatalyst", MacCatalystMin, MacCatalystMax);
+	check ("iOS", iOSMin, iOSMax);
+	check ("tvOS", tvOSMin, tvOSMax);
+	check ("watchOS", watchOSMin, watchOSMax);
+	check ("macOS", macOSMin, macOSMax);
+	check ("MacCatalyst", MacCatalystMin, MacCatalystMax);
 
-Environment.Exit (failed ? 1 : 0);
+	Environment.Exit (failed ? 1 : 0);
+} catch (Exception e) {
+	Console.WriteLine (e);
+	Environment.Exit (1);
+}


### PR DESCRIPTION
* Pass -s to csharp to tell it the rest of the arguments are the script and its arguments.

    Fixes these warnings printed to the terminal:

        warning CS2002: Source file `7.0' specified multiple times
        warning CS2002: Source file `10.15' specified multiple times

* Add an exception handler and return 1 if there are any exceptions.