### PR TITLE
[xharness] Bump the shared library version

### DIFF
--- a/tests/xharness/Xharness.Tests/Xharness.Tests.csproj
+++ b/tests/xharness/Xharness.Tests/Xharness.Tests.csproj
@@ -38,10 +38,10 @@
       <HintPath>..\..\..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0-rc.1.20451.14\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.DotNet.XHarness.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.DotNet.XHarness.Common.1.0.0-prerelease.20562.1\lib\netstandard2.0\Microsoft.DotNet.XHarness.Common.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.DotNet.XHarness.Common.1.0.0-prerelease.20621.4\lib\netstandard2.0\Microsoft.DotNet.XHarness.Common.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.DotNet.XHarness.iOS.Shared, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.DotNet.XHarness.iOS.Shared.1.0.0-prerelease.20562.1\lib\netstandard2.0\Microsoft.DotNet.XHarness.iOS.Shared.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.DotNet.XHarness.iOS.Shared.1.0.0-prerelease.20621.4\lib\netstandard2.0\Microsoft.DotNet.XHarness.iOS.Shared.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Configuration, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Extensions.Configuration.5.0.0-rc.1.20451.14\lib\net461\Microsoft.Extensions.Configuration.dll</HintPath>

--- a/tests/xharness/Xharness.Tests/packages.config
+++ b/tests/xharness/Xharness.Tests/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Castle.Core" version="4.4.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0-rc.1.20451.14" targetFramework="net472" />
-  <package id="Microsoft.DotNet.XHarness.Common" version="1.0.0-prerelease.20562.1" targetFramework="net472" />
-  <package id="Microsoft.DotNet.XHarness.iOS.Shared" version="1.0.0-prerelease.20562.1" targetFramework="net472" />
+  <package id="Microsoft.DotNet.XHarness.Common" version="1.0.0-prerelease.20621.4" targetFramework="net472" />
+  <package id="Microsoft.DotNet.XHarness.iOS.Shared" version="1.0.0-prerelease.20621.4" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration" version="5.0.0-rc.1.20451.14" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration.Abstractions" version="5.0.0-rc.1.20451.14" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration.Binder" version="5.0.0-rc.1.20451.14" targetFramework="net472" />

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -71,7 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.XHarness.iOS.Shared">
-      <Version>1.0.0-prerelease.20562.1</Version>
+      <Version>1.0.0-prerelease.20621.4</Version>
     </PackageReference>
     <PackageReference Include="Mono.Cecil">
       <Version>0.11.2</Version>


### PR DESCRIPTION
This is mainly to bring in this fix: https://github.com/dotnet/xharness/commit/841114a759e81043973856abe0917329b3ef5749
(two parameters were swapped and `BundleIdentifier` was set to `AppPath`)

Other changes contained:
- We don't log the full XML when listing devices anymore, just the file size
- `SimulatorLoader` has a new method that accepts `retryCount`