### PR TITLE
[CI][VSTS] Add the donet 6 pkg as a dependency.

### DIFF
--- a/tools/devops/Makefile
+++ b/tools/devops/Makefile
@@ -17,6 +17,7 @@ build-provisioning.csx: build-provisioning.csx.in Makefile $(TOP)/Make.config
 		-e 's#@VS_PACKAGE@#$(MIN_VISUAL_STUDIO_URL)#g' \
 		-e 's#@MIN_SHARPIE_URL@#$(MIN_SHARPIE_URL)#g' \
 		-e 's#@DOTNET_VERSION@#$(DOTNET_VERSION)#g' \
+		-e 's#@DOTNET6_VERSION@#$(DOTNET6_VERSION)#g' \
 		$< > $@;
 
 all check:

--- a/tools/devops/build-provisioning.csx.in
+++ b/tools/devops/build-provisioning.csx.in
@@ -14,3 +14,4 @@ Item ("@MONO_PACKAGE@");
 Item ("@MIN_SHARPIE_URL@");
 Item ("@VS_PACKAGE@");
 DotNetCoreSdk ("@DOTNET_VERSION@");
+DotNetCoreSdk ("@DOTNET6_VERSION@");


### PR DESCRIPTION
Ensure that the new dotnet 6 is installed so that we do build with the
support for it.

fixes: https://github.com/xamarin/maccore/issues/2354