### PR TITLE
[CI][VSTS] Add comments to PR not only to commits.

### DIFF
--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -195,7 +195,7 @@ function New-GitHubComment {
     $msg.AppendLine()
     $msg.AppendLine("[Pipeline]($targetUrl) on Agent $Env:TESTS_BOT") # Env:TESTS_BOT is added by the pipeline as a variable coming from the execute tests job
 
-    # if the build was due to PR, we want to write the comment in the PR rather than in teh comment
+    # if the build was due to PR, we want to write the comment in the PR rather than in the comment
     if ($Env:BUILD_REASON -eq "PullRequest") {
         # calcualte the change ID which is the PR number 
         $buildSourceBranch = $Env:BUILD_SOURCEBRANCH


### PR DESCRIPTION
The GitHup url to be used to create comments in PRs is diff to the one
for comments. Use the build reason AND the changeID to identify if we
are building due to a PR and use the correct url.

fixes: https://github.com/xamarin/maccore/issues/2356