### PR TITLE
[d16-9] [CI][VSTS] Ensure that xharness creates an index with the correct uris.

### DIFF
--- a/tools/devops/automation/templates/devices/build.yml
+++ b/tools/devops/automation/templates/devices/build.yml
@@ -215,7 +215,7 @@ steps:
     WORKING_DIR: $(System.DefaultWorkingDirectory) 
     TESTS_EXTRA_ARGUMENTS: ${{ parameters.testsLabels }}
     USE_XAMARIN_STORAGE: ${{ parameters.useXamarinStorage }}
-    VSDROPS_URI: '${{ parameters.vsdropsPrefix }}/$(Build.BuildNumber)/$(Build.BuildId);/tests/' # uri used to create the vsdrops index using full uri
+    VSDROPS_URI: '${{ parameters.vsdropsPrefix }}/$(Build.BuildNumber)/$(Build.BuildId)/${{ parameters.devicePrefix }};/tests/' # uri used to create the vsdrops index using full uri
     USE_TCP_TUNNEL: 'true'
   displayName: 'Run tests'
   name: runTests # not to be confused with the displayName, this is used to later use the name of the step to access the output variables from an other job

--- a/tools/devops/automation/templates/packages/build.yml
+++ b/tools/devops/automation/templates/packages/build.yml
@@ -400,7 +400,7 @@ steps:
   env:
     BUILD_REVISION: jenkins
     TARGET: 'wrench-jenkins'
-    VSDROPS_URI: '${{ parameters.vsdropsPrefix }}/$(Build.BuildNumber)/$(Build.BuildId);/tests/' # uri used to create the vsdrops index using full uri
+    VSDROPS_URI: '${{ parameters.vsdropsPrefix }}/$(Build.BuildNumber)/$(Build.BuildId)/sim;/tests/' # uri used to create the vsdrops index using full uri
 
 # Upload TestSummary as an artifact.
 - task: PublishPipelineArtifact@1


### PR DESCRIPTION
The prefix of the location of the logs depends on the platform where it
was executed (else we step on them) but that was not added in the env
var use by xharness.

fixes: https://github.com/xamarin/maccore/issues/2349 

Backport of #10345