### PR TITLE
[d16-9] [CI][VSTS] Add the correct mac pkg file name.

### DIFF
--- a/tools/devops/automation/templates/packages/upload-azure.yml
+++ b/tools/devops/automation/templates/packages/upload-azure.yml
@@ -126,7 +126,7 @@ steps:
     Write-Host "iOS PKG is $iOSPkg"
 
     $macPkg = Get-ChildItem -Path $pkgsPath -File -Force -Name xamarin.mac-*.pkg
-    Write-Host "mac PKG is $iOSPkg"
+    Write-Host "mac PKG is $macPkg"
 
     if (Test-Path "$pkgsPath\$iOSPkg" -PathType Leaf) {
         Set-GitHubStatus -Status "success" -Description $iOSPkg -TargetUrl "$pkgsVirtualUrl/$iOSPkg" -Context "PKG-Xamarin.iOS"
@@ -141,13 +141,13 @@ steps:
     }
 
     if (Test-Path "$pkgsPath\xamarin.mac-*.pkg" -PathType Leaf) {
-       Set-GitHubStatus -Status "success" -Description "$pkgsPath" -TargetUrl "$pkgsVirtualUrl/$macPkg" -Context "PKG-Xamarin.Mac"
+       Set-GitHubStatus -Status "success" -Description "$macPkg" -TargetUrl "$pkgsVirtualUrl/$macPkg" -Context "PKG-Xamarin.Mac"
     } else {
        Set-GitHubStatus -Status "error" -Description "xamarin.mac pkg not found." -Context "PKG-Xamarin.Mac"
     }
 
     if (Test-Path "$pkgsPath\notarized\xamarin.mac-*.pkg" -PathType Leaf) {
-        Set-GitHubStatus -Status "success" -Description "$pkgsPath (Notarized)" -TargetUrl "$pkgsVirtualUrl/notarized/$macPkg" -Context "PKG-Xamarin.Mac-notarized"
+        Set-GitHubStatus -Status "success" -Description "$macPkg (Notarized)" -TargetUrl "$pkgsVirtualUrl/notarized/$macPkg" -Context "PKG-Xamarin.Mac-notarized"
     } else {
        Set-GitHubStatus -Status "error" -Description "Notarized xamarin.mac pkg not found." -Context "PKG-Xamarin.Mac-notarized"
     }


### PR DESCRIPTION
The wrong variable was used and therefore the dir path was used instead
of the mac pkg name.

fixes: https://github.com/xamarin/maccore/issues/2353 

Backport of #10347