### PR TITLE
[msbuild] Simplify resolving xcframeworks

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -205,10 +205,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		Inputs="@(_CompileToNativeInput);@(_FileNativeReference);@(BundleDependentFiles)"
 		Outputs="$(_AppBundlePath)Contents\MacOS\$(_AppBundleName);$(DeviceSpecificOutputPath)bundler.stamp">
 
-		<ItemGroup>
-			<_FrameworkNativeReference Include="@(_FrameworkNativeReference -> '%(Identity)/%(Filename)')" Condition="'%(Extension)' == '.framework' Or '%(Extension)' == '.xcframework'" />
-		</ItemGroup>
-
 		<Mmp
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
@@ -227,7 +223,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			I18n="$(I18n)"
 			Profiling="$(Profiling)"
 			ExtraArgs="$(_BundlerArguments)"
-			NativeReferences="@(NativeReference);@(_FrameworkNativeReference);@(_FileNativeReference)"
+			NativeReferences="@(_FrameworkNativeReference);@(_FileNativeReference)"
 			References="@(ReferencePath);@(_BundlerReferencePath)"
 			ResponseFilePath="$(IntermediateOutputPath)response-file.rsp"
 			SdkRoot="$(_SdkDevPath)"

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ResolveFrameworksBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ResolveFrameworksBase.cs
@@ -20,11 +20,11 @@ namespace Xamarin.MacDev.Tasks {
 		#region Inputs
 
 		[Required]
-		public string Architectures { get; set; }
+		public string? Architectures { get; set; }
 
-		public ITaskItem [] NativeReferences { get; set; }
+		public ITaskItem []? NativeReferences { get; set; }
 
-		public ITaskItem[] References { get; set; }
+		public ITaskItem []? References { get; set; }
 
 		[Required]
 		public bool SdkIsSimulator { get; set; }
@@ -34,7 +34,7 @@ namespace Xamarin.MacDev.Tasks {
 		#region Outputs
 
 		[Output]
-		public ITaskItem[] NativeFrameworks { get; set; }
+		public ITaskItem []? NativeFrameworks { get; set; }
 
 		#endregion
 
@@ -122,7 +122,7 @@ namespace Xamarin.MacDev.Tasks {
 			return !Log.HasLoggedErrors;
 		}
 
-		protected string ResolveXCFramework (string xcframework)
+		protected string? ResolveXCFramework (string xcframework)
 		{
 			var platformName = PlatformFrameworkHelper.GetOperatingSystem (TargetFrameworkMoniker);
 			// PlatformFrameworkHelper.GetOperatingSystem returns "osx" which does not work for xcframework
@@ -132,13 +132,13 @@ namespace Xamarin.MacDev.Tasks {
 			var variant = SdkIsSimulator ? "simulator" : null;
 			try {
 				var plist = PDictionary.FromFile (Path.Combine (xcframework, "Info.plist"));
-				var dir = ResolveXCFramework (plist, platformName, variant, Architectures);
-				if (!String.IsNullOrEmpty (dir))
-					return Path.Combine (xcframework, dir);
+				var path = ResolveXCFramework (plist, platformName, variant, Architectures!);
+				if (!String.IsNullOrEmpty (path))
+					return Path.Combine (xcframework, path);
 
 				// either the format was incorrect or we could not find a matching framework
 				// note: last part is not translated since it match the (non-translated) keys inside the `Info.plist`
-				var msg = (dir == null) ? MSBStrings.E0174 : MSBStrings.E0175 + $" SupportedPlatform: '{platformName}', SupportedPlatformVariant: '{variant}', SupportedArchitectures: '{Architectures}'.";
+				var msg = (path == null) ? MSBStrings.E0174 : MSBStrings.E0175 + $" SupportedPlatform: '{platformName}', SupportedPlatformVariant: '{variant}', SupportedArchitectures: '{Architectures}'.";
 				Log.LogError (msg, xcframework);
 			}
 			catch (Exception) {
@@ -147,7 +147,7 @@ namespace Xamarin.MacDev.Tasks {
 			return null;
 		}
 
-		internal static string? ResolveXCFramework (PDictionary plist, string platformName, string variant, string architectures)
+		internal static string? ResolveXCFramework (PDictionary plist, string platformName, string? variant, string architectures)
 		{
 			// plist structure https://github.com/spouliot/xcframework#infoplist
 			var bundle_package_type = (PString) plist ["CFBundlePackageType"];
@@ -182,7 +182,7 @@ namespace Xamarin.MacDev.Tasks {
 				}
 				var library_path = (PString) item ["LibraryPath"];
 				var library_identifier = (PString) item ["LibraryIdentifier"];
-				return Path.Combine (library_identifier, library_path);
+				return Path.Combine (library_identifier, library_path, Path.GetFileNameWithoutExtension (library_path));
 			}
 			return String.Empty;
 		}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -145,7 +145,11 @@ namespace Xamarin.iOS.Tasks
 					if (!string.IsNullOrEmpty (value) && bool.TryParse (value, out boolean) && boolean)
 						gcc.Cxx = true;
 				} else if (kind == NativeReferenceKind.Framework) {
-					gcc.Frameworks.Add (item.ItemSpec);
+					var path = item.ItemSpec;
+					// in case the full path to the library is given (msbuild)
+					if (Path.GetExtension (path) != ".framework")
+						path = Path.GetDirectoryName (path);
+					gcc.Frameworks.Add (path);
 				} else {
 					Log.LogWarning (MSBStrings.W0052, item.ItemSpec);
 					continue;
@@ -399,10 +403,10 @@ namespace Xamarin.iOS.Tasks
 			gcc.Arguments.AddQuoted (LinkNativeCodeTaskBase.GetEmbedEntitlementsInExecutableLinkerFlags (CompiledEntitlements));
 
 			foreach (var framework in gcc.Frameworks)
-				args.AddQuotedLine ($"--framework={framework}");
+				args.AddQuotedLine ($"--framework={Path.GetFullPath (framework)}");
 
 			foreach (var framework in gcc.WeakFrameworks)
-				args.AddQuotedLine ($"--weak-framework={framework}");
+				args.AddQuotedLine ($"--weak-framework={Path.GetFullPath (framework)}");
 
 			if (gcc.Cxx)
 				args.AddLine ("--cxx");

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -443,7 +443,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			LinkMode="$(_LinkMode)"
 			MainAssembly="$(TargetPath)"
 			MinimumOSVersion="$(_MinimumOSVersion)"
-			NativeReferences="@(NativeReference);@(_FrameworkNativeReference);@(_FileNativeReference)"
+			NativeReferences="@(_FrameworkNativeReference);@(_FileNativeReference)"
 			OutputPath="$(DeviceSpecificOutputPath)"
 			Profiling="$(MtouchProfiling)"
 			ProjectDir="$(MtouchProjectDirectory)"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -418,10 +418,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Inputs="@(_CompileToNativeInput);@(_FileNativeReference);@(BundleDependentFiles)"
 		Outputs="$(_NativeExecutable);$(DeviceSpecificOutputPath)bundler.stamp">
 
-		<ItemGroup>
-			<_FrameworkNativeReference Include="@(_FrameworkNativeReference -> '%(Identity)/%(Filename)')" Condition="'%(Extension)' == '.framework' Or '%(Extension)' == '.xcframework'" />
-		</ItemGroup>
-
 		<MTouch
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ResolveNativeReferencesTaskTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ResolveNativeReferencesTaskTest.cs
@@ -9,16 +9,16 @@ namespace Xamarin.MacDev.Tasks.Tests {
 	public class ResolveNativeReferencesTaskTest {
 
 		// single arch request (subset are fine)
-		[TestCase ("iOS", null, "arm64", "ios-arm64/Universal.framework")]
-		[TestCase ("iOS", "simulator", "x86_64", "ios-arm64_x86_64-simulator/Universal.framework")] // subset
-		[TestCase ("iOS", "maccatalyst", "x86_64", "ios-arm64_x86_64-maccatalyst/Universal.framework")] // subset
-		[TestCase ("tvOS", null, "arm64", "tvos-arm64/Universal.framework")]
-		[TestCase ("tvOS", "simulator", "x86_64", "tvos-arm64_x86_64-simulator/Universal.framework")] // subset
-		[TestCase ("watchOS", null, "arm64_32", "watchos-arm64_32_armv7k/Universal.framework")]
-		[TestCase ("watchOS", "simulator", "x86_64", "watchos-arm64_x86_64-simulator/Universal.framework")] // subset
-		[TestCase ("macOS", null, "x86_64", "macos-arm64_x86_64/Universal.framework")] // subset
+		[TestCase ("iOS", null, "arm64", "ios-arm64/Universal.framework/Universal")]
+		[TestCase ("iOS", "simulator", "x86_64", "ios-arm64_x86_64-simulator/Universal.framework/Universal")] // subset
+		[TestCase ("iOS", "maccatalyst", "x86_64", "ios-arm64_x86_64-maccatalyst/Universal.framework/Universal")] // subset
+		[TestCase ("tvOS", null, "arm64", "tvos-arm64/Universal.framework/Universal")]
+		[TestCase ("tvOS", "simulator", "x86_64", "tvos-arm64_x86_64-simulator/Universal.framework/Universal")] // subset
+		[TestCase ("watchOS", null, "arm64_32", "watchos-arm64_32_armv7k/Universal.framework/Universal")]
+		[TestCase ("watchOS", "simulator", "x86_64", "watchos-arm64_x86_64-simulator/Universal.framework/Universal")] // subset
+		[TestCase ("macOS", null, "x86_64", "macos-arm64_x86_64/Universal.framework/Universal")] // subset
 		// multiple arch request (all must be present)
-		[TestCase ("macOS", null, "x86_64, arm64", "macos-arm64_x86_64/Universal.framework")]
+		[TestCase ("macOS", null, "x86_64, arm64", "macos-arm64_x86_64/Universal.framework/Universal")]
 		// failure to resolve requested architecture
 		[TestCase ("iOS", "simulator", "i386, x86_64", "")] // i386 not available
 		// failure to resolve mismatched variant
@@ -34,10 +34,10 @@ namespace Xamarin.MacDev.Tasks.Tests {
 			Assert.That (result, Is.EqualTo (expected), expected);
 		}
 
-		[TestCase ("iOS", null, "ARMv7", "ios-arm64_armv7_armv7s/XTest.framework")]
+		[TestCase ("iOS", null, "ARMv7", "ios-arm64_armv7_armv7s/XTest.framework/XTest")]
 		// there was no 64bits simulator for watchOS but a i386 one was available
 		[TestCase ("watchOS", "simulator", "x86_64", "")]
-		[TestCase ("watchOS", "simulator", "i386", "watchos-i386-simulator/XTest.framework")]
+		[TestCase ("watchOS", "simulator", "i386", "watchos-i386-simulator/XTest.framework/XTest")]
 		public void PreXcode12 (string platform, string variant, string architecture, string expected)
 		{
 			var path = Path.Combine (Path.GetDirectoryName (GetType ().Assembly.Location), "Resources", "xcf-prexcode12.plist");

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -211,6 +211,12 @@ namespace Xamarin.Bundler {
 						native_references.Add (v);
 						if (v.EndsWith (".framework", true, CultureInfo.InvariantCulture))
 							App.Frameworks.Add (v);
+						else {
+							// allow specifying the library inside the framework directory
+							var p = Path.GetDirectoryName (v);
+							if (p.EndsWith (".framework", true, CultureInfo.InvariantCulture))
+								App.Frameworks.Add (p);
+						}
 					}
 				},
 				{ "custom_bundle_name=", "Specify a custom name for the MonoBundle folder.", v => App.CustomBundleName = v, true }, // Hidden hack for "universal binaries"
@@ -1267,6 +1273,10 @@ namespace Xamarin.Bundler {
 			// If we're passed in a framework, ignore
 			if (App.Frameworks.Contains (library))
 				return;
+			// Frameworks don't include the lib name, e.g. `../foo.framework` not `../foo.framework/foo` so check again
+			string path = Path.GetDirectoryName (library);
+			if (App.Frameworks.Contains (path))
+				return;
 
 			// We need to check both the name and the shortened name, since we might get passed:
 			// full path - /foo/bar/libFoo.dylib
@@ -1289,7 +1299,6 @@ namespace Xamarin.Bundler {
 				src = monoDirPath;
 
 			// Now let's check in path with our libName
-			string path = Path.GetDirectoryName (library);
 			if (src == null && !String.IsNullOrEmpty (path)) {
 				string pathWithLibName = Path.Combine (path, name);
 				if (File.Exists (pathWithLibName))


### PR DESCRIPTION
TD&LR: This PR simplifies how we refer to user frameworks and fixes both
warnings and non-optimal (app) output.

Much longer story:

Additional testing on macOS showed some build-time warnings and an
[extra (dupe) file](https://github.com/spouliot/xcframework/commit/a20f8aba419e32e2338cb7c5e4b45d0f38862893#diff-54fd7d9cd5deae57f30195be0a43133eace03c1132401741a317e0ae8d5e13fdR34).

Logs shows that we referred to the xcframework several times, where once
should have been enough.

```
/native-reference:/Users/poupou/git/spouliot/xcframework/Universal.xcframework
/native-reference:/Users/poupou/git/spouliot/xcframework/Universal.xcframework/macos-arm64_x86_64/Universal.framework
/native-reference:/Users/poupou/git/spouliot/xcframework/Universal.xcframework/macos-arm64_x86_64/Universal.framework/Universal
```

The first `/native-reference` line produced a warning like:

```
MMP warning MM2006: Native library 'Universal.xcframework' was referenced but could not be found.
```

which makes sense as the tools (both `mmp` and `mtouch`) are not, by
design, aware of (unresolved) xcframeworks.

Removing `{NativeReference}` from `Xamarin.Mac.Common.targets` (and
`Xamarin.iOS.Common.targets`) as it has already been processed by
`_ExpandNativeReferences` solves this.

The other part of the issue (next two lines) is because `msbuild` does
not track changes to directories like it does for files - and the
workaround (in `_ExpandNativeReferences`) had to be copied in other
places (both XI and XM `_CompileToNative`) and that was not enough (and
would eventually need to be duplicated again and again).

This could lead to duplicate entries (i msbuild logs) like

```
NativeReferences
../../Universal.xcframework/macos-arm64_x86_64/Universal.framework
../../Universal.xcframework/macos-arm64_x86_64/Universal.framework/Univeral
```
which maps to our extra entries.

In order to simplify things we make the `_ExpandNativeReferences` resolve
the full path to the library name (not the `.framework` directory) which
simplifies both `_CompileToNative` and ensure a single way (at least for
`msbuild`) to provide this data to the tools (`mmp` and `mtouch`).

Using a file, instead of a directory, is also more consistent for the
existing `-framework` option, e.g. we provide the names like:

```
--framework=CoreLocation
--framework=ModelIO
```

So adding a full path that include the name is more appropriate, e.g.

```
--framework=/Users/poupou/git/master/xamarin-macios/tests/xharness/tmp-test-dir/xcframework-test760/bin/AnyCPU/Debug/bindings-xcframework-test.resources/XTest.xcframework/ios-i386_x86_64-simulator/XTest.framework/XTest
```

Finally for macOS applications it turns out we were embedding yet another
copy of the framework's library inside the `MonoBundle`, which is clearly
wrong, because of the last entry.

```
$ l bin/Release/xcf-mac.app/Contents/MonoBundle/Universal
-rwxr-xr-x  1 poupou  staff  167152  2 Dec 16:16 bin/Release/xcf-mac.app/Contents/MonoBundle/Universal
```

The tool now checks if a provided library is inside a framework (or not)
which is a good validation to have anyway when it gets called directly,
i.e. not thru `msbuild`.