### PR TITLE
[UIKit] Add the same UIBarItem.SetTitleTextAttributes overload to Mac Catalyst as iOS has.

### DIFF
--- a/src/UIKit/UIBarItem.cs
+++ b/src/UIKit/UIBarItem.cs
@@ -21,6 +21,19 @@ using TextAttributes = UIKit.UITextAttributes;
 
 namespace UIKit {
 	public partial class UIBarItem {
+#if __MACCATALYST__ && !NET
+		// This method exists to improve compatibility with assemblies that reference Xamarin.iOS.dll in Mac Catalyst,
+		// such as Xamarin.Forms. Setting the IsError field to true in the attribute means that everything will work at runtime,
+		// but that nobody can use this method at compile time.
+		// This is disabled in .NET because we won't try to be compatible with Xamarin.iOS.dll in .NET.
+		[Obsolete ("Use the overload that takes a 'UIStringAttributes' instead.", true)]
+		public void SetTitleTextAttributes (UIKit.UITextAttributes attributes, UIControlState state)
+		{
+			using (var dict = attributes == null ? null : attributes.Dictionary)
+				_SetTitleTextAttributes (dict, state);
+		}
+#endif
+
 		public void SetTitleTextAttributes (TextAttributes attributes, UIControlState state)
 		{
 			using (var dict = attributes == null ? null : attributes.Dictionary)


### PR DESCRIPTION
Mac Catalyst will be able to reference assemblies built for Xamarin.iOS, but
without any guarantees that it will actually work.

However, we'll want to make basic scenarios work, and with this change we're
adding an overload of UIBarItem.SetTitleTextAttributes that would not normally
exist in Mac Catalyst, so that existing code built for Xamarin.iOS works just
fine at runtime (in particular Xamarin.Forms runs into this).