### PR TITLE
YAML build: Dump environment steps: Include HOSTNAME

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -1,5 +1,5 @@
 # YAML pipeline build definition
-# https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=13760&view=Tab_Tasks
+# https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=13947&view=Tab_Tasks
 #
 # YAML build pipeline based on the Jenkins multi-stage (main branch) build workflow
 # https://jenkins.internalx.com/view/Xamarin.MaciOS/job/macios/job/main/

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -42,6 +42,23 @@ steps:
     gci env: | format-table -autosize -wrap
   displayName: 'Dump Environment'
 
+- powershell: |
+    Write-Host "Python version"
+    python --version
+
+    Write-Host "Python location"
+    which python
+
+    Write-Host "Python2 location"
+    which python2
+
+    Write-Host "Python3 location"
+    which python3
+
+    Write-Host "Pip version"
+    pip -V
+  displayName: 'Python Information'
+
 - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/clean-bot.sh
   displayName: 'Clean bot'
   env:

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -29,6 +29,16 @@ steps:
   clean: true
 
 - powershell: |
+    Write-Host "IsMacOS: ${IsMacOS}"
+    Write-Host "IsWindows: ${IsWindows}"
+    Write-Host "IsLinux: ${IsLinux}"
+
+    if ($IsMacOS -or $IsLinux) {
+        Write-Host "HOSTNAME: ${env:HOSTNAME}"
+    } else {
+        Write-Host "COMPUTERNAME: ${env:COMPUTERNAME}"
+    }
+
     gci env: | format-table -autosize -wrap
   displayName: 'Dump Environment'
 

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -40,7 +40,7 @@ steps:
     }
 
     gci env: | format-table -autosize -wrap
-  displayName: 'Dump Environment'
+  displayName: 'Show Environment'
 
 - powershell: |
     Write-Host "Python version"
@@ -57,7 +57,7 @@ steps:
 
     Write-Host "Pip version"
     pip -V
-  displayName: 'Python Information'
+  displayName: 'Show Python information'
 
 - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/clean-bot.sh
   displayName: 'Clean bot'

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -34,7 +34,7 @@ steps:
     Write-Host "IsLinux: ${IsLinux}"
 
     if ($IsMacOS -or $IsLinux) {
-        Write-Host "HOSTNAME: ${env:HOSTNAME}"
+        Write-Host "HOSTNAME: $(hostname)"
     } else {
         Write-Host "COMPUTERNAME: ${env:COMPUTERNAME}"
     }

--- a/tools/devops/automation/templates/devices/build.yml
+++ b/tools/devops/automation/templates/devices/build.yml
@@ -70,7 +70,7 @@ steps:
     Write-Host "IsLinux: ${IsLinux}"
 
     if ($IsMacOS -or $IsLinux) {
-        Write-Host "HOSTNAME: ${env:HOSTNAME}"
+        Write-Host "HOSTNAME: $(hostname)"
     } else {
         Write-Host "COMPUTERNAME: ${env:COMPUTERNAME}"
     }

--- a/tools/devops/automation/templates/devices/build.yml
+++ b/tools/devops/automation/templates/devices/build.yml
@@ -65,6 +65,16 @@ steps:
   displayName: 'Run pipeline script tests'
 
 - pwsh : |
+    Write-Host "IsMacOS: ${IsMacOS}"
+    Write-Host "IsWindows: ${IsWindows}"
+    Write-Host "IsLinux: ${IsLinux}"
+
+    if ($IsMacOS -or $IsLinux) {
+        Write-Host "HOSTNAME: ${env:HOSTNAME}"
+    } else {
+        Write-Host "COMPUTERNAME: ${env:COMPUTERNAME}"
+    }
+
     gci env: | format-table -autosize -wrap
   displayName: 'Dump Environment'
 

--- a/tools/devops/automation/templates/devices/build.yml
+++ b/tools/devops/automation/templates/devices/build.yml
@@ -76,7 +76,7 @@ steps:
     }
 
     gci env: | format-table -autosize -wrap
-  displayName: 'Dump Environment'
+  displayName: 'Show Environment'
 
 # Use a cmdlet to check if the space available in the devices root system is larger than 50 gb. If there is not
 # enough space available it:

--- a/tools/devops/automation/templates/governance-checks.yml
+++ b/tools/devops/automation/templates/governance-checks.yml
@@ -17,7 +17,7 @@ steps:
 
     Dir $(Build.SourcesDirectory)
     Dir $(System.DefaultWorkingDirectory)
-  displayName: Dump enviroment
+  displayName: Show directories
 
 - powershell: |
     Write-Host "IsMacOS: ${IsMacOS}"
@@ -31,7 +31,7 @@ steps:
     }
 
     gci env: | format-table -autosize -wrap
-  displayName: 'Dump Environment'
+  displayName: 'Show Environment'
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'

--- a/tools/devops/automation/templates/governance-checks.yml
+++ b/tools/devops/automation/templates/governance-checks.yml
@@ -20,6 +20,16 @@ steps:
   displayName: Dump enviroment
 
 - powershell: |
+    Write-Host "IsMacOS: ${IsMacOS}"
+    Write-Host "IsWindows: ${IsWindows}"
+    Write-Host "IsLinux: ${IsLinux}"
+
+    if ($IsMacOS -or $IsLinux) {
+        Write-Host "HOSTNAME: ${env:HOSTNAME}"
+    } else {
+        Write-Host "COMPUTERNAME: ${env:COMPUTERNAME}"
+    }
+
     gci env: | format-table -autosize -wrap
   displayName: 'Dump Environment'
 

--- a/tools/devops/automation/templates/governance-checks.yml
+++ b/tools/devops/automation/templates/governance-checks.yml
@@ -25,7 +25,7 @@ steps:
     Write-Host "IsLinux: ${IsLinux}"
 
     if ($IsMacOS -or $IsLinux) {
-        Write-Host "HOSTNAME: ${env:HOSTNAME}"
+        Write-Host "HOSTNAME: $(hostname)"
     } else {
         Write-Host "COMPUTERNAME: ${env:COMPUTERNAME}"
     }


### PR DESCRIPTION
The agent name and HOSTNAME sometimes don't match; particularly, for test machines.  Include the HOSTNAME as a means to better locate the actual machine that the pipeline is running on.

Includes an update to use the correct build definition link as the build definition was recreated at one point.