### PR TITLE
[mtouch] Fix embedding Mono (and Xamarin) as frameworks. Fixes #10382

### DIFF
--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -1163,7 +1163,7 @@ namespace Xamarin.Bundler {
 			// Make sure we bundle Mono.framework if we need to.
 			if (PackageMonoFramework == true) {
 				BundleFileInfo info;
-				var name = "Frameworks/Mono.framework";
+				var name = "Mono.framework";
 				bundle_files [name] = info = new BundleFileInfo ();
 				info.Sources.Add (GetLibMono (AssemblyBuildTarget.Framework));
 			}

--- a/tools/mtouch/Target.mtouch.cs
+++ b/tools/mtouch/Target.mtouch.cs
@@ -87,14 +87,8 @@ namespace Xamarin.Bundler
 		{
 			BundleFileInfo info;
 
-			if (bundle_path == null) {
-				if (source.EndsWith (".framework", StringComparison.Ordinal)) {
-					var bundle_name = Path.GetFileNameWithoutExtension (source);
-					bundle_path = $"Frameworks/{bundle_name}.framework";
-				} else {
-					bundle_path = Path.GetFileName (source);
-				}
-			}
+			if (bundle_path == null)
+				bundle_path = Path.GetFileName (source);
 
 			if (!BundleFiles.TryGetValue (bundle_path, out info))
 				BundleFiles [bundle_path] = info = new BundleFileInfo () { DylibToFramework = dylib_to_framework_conversion };


### PR DESCRIPTION
This broke with 1582bf47cc272640973cbe6933834b2debb80769 and cause the
frameworks to be nested under another `Frameworks` directory.

See https://github.com/xamarin/xamarin-macios/issues/10382