### PR TITLE
[msbuild] Fix code signing logic for Mac Catalyst.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
@@ -458,10 +458,24 @@ namespace Xamarin.MacDev.Tasks
 				return false;
 			}
 
-			if (Platform == ApplePlatform.MacOSX || Platform == ApplePlatform.MacCatalyst) {
+			if (Platform == ApplePlatform.MacOSX) {
 				if (!RequireCodeSigning || !string.IsNullOrEmpty (DetectedCodeSigningKey)) {
 					DetectedBundleId = identity.BundleId;
 					DetectedAppId = DetectedBundleId;
+
+					ReportDetectedCodesignInfo ();
+
+					return !Log.HasLoggedErrors;
+				}
+			} else if (Platform == ApplePlatform.MacCatalyst) {
+				var doesNotNeedCodeSigningCertificate = !RequireCodeSigning || !string.IsNullOrEmpty (DetectedCodeSigningKey);
+				if (RequireProvisioningProfile)
+					doesNotNeedCodeSigningCertificate = false;
+				if (doesNotNeedCodeSigningCertificate) {
+					DetectedBundleId = identity.BundleId;
+					DetectedAppId = DetectedBundleId;
+
+					DetectedCodeSigningKey = "-";
 
 					ReportDetectedCodesignInfo ();
 


### PR DESCRIPTION
Code signing for Mac Catalyst is very much like code signing for macOS, except that:

* If a provisioning profile is required, then we must find a code signing certificate.
* Provide a code signing key even if we don't need a code signing certificate.

This makes the tests in monotouch-test that require a correctly signed app pass.