### PR TITLE
[dotnet-linker] Link with GSS when building for iOS/Mac Catalyst.

### DIFF
--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -46,6 +46,8 @@ namespace Xamarin.Linker {
 		
 		string user_optimize_flags;
 
+		Dictionary<string, List<MSBuildItem>> msbuild_items = new Dictionary<string, List<MSBuildItem>> ();
+
 		public static LinkerConfiguration GetInstance (LinkContext context, bool createIfNotFound = true)
 		{
 			if (!configurations.TryGetValue (context, out var instance) && createIfNotFound) {
@@ -270,18 +272,32 @@ namespace Xamarin.Linker {
 
 		public void WriteOutputForMSBuild (string itemName, List<MSBuildItem> items)
 		{
-			var xmlNs = XNamespace.Get ("http://schemas.microsoft.com/developer/msbuild/2003");
-			var elements = items.Select (item =>
-				new XElement (xmlNs + itemName,
-					new XAttribute ("Include", item.Include),
-						item.Metadata.Select (metadata => new XElement (xmlNs + metadata.Key, metadata.Value))));
+			if (!msbuild_items.TryGetValue (itemName, out var list)) {
+				msbuild_items [itemName] = items;
+			} else {
+				list.AddRange (items);
+			}
+		}
 
-			var document = new XDocument (
-				new XElement (xmlNs + "Project",
-					new XElement (xmlNs + "ItemGroup",
-						elements)));
+		public void FlushOutputForMSBuild ()
+		{
+			foreach (var kvp in msbuild_items) {
+				var itemName = kvp.Key;
+				var items = kvp.Value;
 
-			document.Save (Path.Combine (ItemsDirectory, itemName + ".items"));
+				var xmlNs = XNamespace.Get ("http://schemas.microsoft.com/developer/msbuild/2003");
+				var elements = items.Select (item =>
+					new XElement (xmlNs + itemName,
+						new XAttribute ("Include", item.Include),
+							item.Metadata.Select (metadata => new XElement (xmlNs + metadata.Key, metadata.Value))));
+
+				var document = new XDocument (
+					new XElement (xmlNs + "Project",
+						new XElement (xmlNs + "ItemGroup",
+							elements)));
+
+				document.Save (Path.Combine (ItemsDirectory, itemName + ".items"));
+			}
 		}
 
 		public static void Report (LinkContext Context, params Exception [] exceptions)

--- a/tools/dotnet-linker/SetupStep.cs
+++ b/tools/dotnet-linker/SetupStep.cs
@@ -92,6 +92,7 @@ namespace Xamarin {
 			Steps.Add (new GenerateMainStep ());
 			Steps.Add (new GenerateReferencesStep ());
 			Steps.Add (new GatherFrameworksStep ());
+			Steps.Add (new DoneStep ()); // Must be the last step.
 
 			Configuration.Write ();
 

--- a/tools/dotnet-linker/SetupStep.cs
+++ b/tools/dotnet-linker/SetupStep.cs
@@ -92,6 +92,7 @@ namespace Xamarin {
 			Steps.Add (new GenerateMainStep ());
 			Steps.Add (new GenerateReferencesStep ());
 			Steps.Add (new GatherFrameworksStep ());
+			Steps.Add (new ComputeNativeBuildFlagsStep ());
 			Steps.Add (new DoneStep ()); // Must be the last step.
 
 			Configuration.Write ();

--- a/tools/dotnet-linker/Steps/ComputeNativeBuildFlagsStep.cs
+++ b/tools/dotnet-linker/Steps/ComputeNativeBuildFlagsStep.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+using Xamarin.Utils;
+
+namespace Xamarin.Linker {
+	// The static registrar may need access to information that has been linked away,
+	// in particular types and interfaces, so we need to store those somewhere
+	// so that the static registrar can access them.
+	public class ComputeNativeBuildFlagsStep : ConfigurationAwareStep {
+		protected override string Name { get; } = "Compute Native Build Flags";
+		protected override int ErrorCode { get; } = 2340;
+
+		protected override void TryEndProcess ()
+		{
+			base.TryEndProcess ();
+
+			var linkerFrameworks = new List<MSBuildItem> ();
+
+			switch (Configuration.Platform) {
+			case ApplePlatform.iOS:
+			case ApplePlatform.MacCatalyst:
+				linkerFrameworks.Add (new MSBuildItem {
+					Include = "GSS",
+					Metadata = { { "IsWeak", "false" } },
+				});
+				break;
+			}
+
+			Configuration.WriteOutputForMSBuild ("_LinkerFrameworks", linkerFrameworks);
+		}
+	}
+}

--- a/tools/dotnet-linker/Steps/DoneStep.cs
+++ b/tools/dotnet-linker/Steps/DoneStep.cs
@@ -1,0 +1,13 @@
+namespace Xamarin.Linker {
+	public class DoneStep : ConfigurationAwareStep {
+		protected override string Name { get; } = "Done";
+		protected override int ErrorCode { get; } = 2350;
+
+		protected override void TryEndProcess ()
+		{
+			base.TryEndProcess ();
+
+			Configuration.FlushOutputForMSBuild ();
+		}
+	}
+}


### PR DESCRIPTION
Add a ComputeNativeBuildFlagsStep, which computes the flags to pass to the
native compiler + native linker. This is currently a very simple
implementation, but it will become more complex as support for missing
features are added.

This also required adding support for writing to the same MSBuild output items
multiple times:

* Split parts of LinkerConfiguration.WriteOutputForMSBuild into a
  FlushOutputForMSBuild method (the part that does the actual writing).
* Make WriteOutputForMSBuild just store the items in a dictionary.
* Add a DoneStep that runs at the very end and that writes out the MSBuild
  output items.