### PR TITLE
[d16-9] [CI][VSTS] Clean .xip files.

### DIFF
--- a/tools/devops/automation/scripts/bash/clean-bot.sh
+++ b/tools/devops/automation/scripts/bash/clean-bot.sh
@@ -107,7 +107,7 @@ oldXcodes=(
 
 # remove wrongly added .xip files under /Applications, confuses provisionator and 
 # are not needed and wrong
-sudo rm -Rf "/Applications/Xcode*.xip"
+sudo rm -Rf /Applications/Xcode*.xip
 
 for oldXcode in "${oldXcodes[@]}"; do
     sudo rm -Rf "$oldXcode"

--- a/tools/devops/automation/scripts/bash/clean-bot.sh
+++ b/tools/devops/automation/scripts/bash/clean-bot.sh
@@ -105,6 +105,10 @@ oldXcodes=(
 	"/Applications/Xcode_12.2.0-rc.app"
 )
 
+# remove wrongly added .xip files under /Applications, confuses provisionator and 
+# are not needed and wrong
+sudo rm -Rf "/Applications/Xcode*.xip"
+
 for oldXcode in "${oldXcodes[@]}"; do
     sudo rm -Rf "$oldXcode"
 done


### PR DESCRIPTION
At some point either due to a manual error or a bug in provisionator a
*.xip file was left behind. Those files make provisioantor fail, for
example: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4361631&view=logs&j=f0137cdf-e292-5541-69aa-72303a08a0ba&t=59bea1c0-f907-5818-000e-f6fef9d3ffa2&l=230

We will remove those files to make sure provisionator works and we get
device tests back. 

Backport of #10398