### PR TITLE
[dotnet] Don't AOT compile resource assemblies.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -336,6 +336,9 @@
 
 		<ItemGroup>
 			<_AssembliesToAOT Include="@(ResolvedFileToPublish)" Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe' " />
+			<!-- Exclude resource assemblies from AOT compilation -->
+			<_AssembliesToAOT Remove="@(ReferenceSatellitePaths)" /> <!-- this seems to be from referenced projects with satellite assemblies -->
+			<_AssembliesToAOT Remove="@(ResourceCopyLocalItems)" /> <!-- this seems to be from NuGets with satellite assemblies -->
 		</ItemGroup>
 	</Target>
 


### PR DESCRIPTION
Xamarin.iOS don't AOT compile resource assemblies, so we shouldn't do so in
.NET either (and in any case they end up causing native linking failures due
to duplicate native symbols).