### PR TITLE
[monotouch-test] Change the url for the TestPACParsingScriptNoProxy test to be the Microsoft uri.

### DIFF
--- a/tests/monotouch-test/CoreFoundation/ProxyTest.cs
+++ b/tests/monotouch-test/CoreFoundation/ProxyTest.cs
@@ -199,7 +199,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 			string pacPath = Path.Combine (NSBundle.MainBundle.BundlePath, "example.pac");
 
 			var script = File.ReadAllText (pacPath);
-			var targetUri = NetworkResources.XamarinUri;
+			var targetUri = NetworkResources.MicrosoftUri;
 
 			Exception ex;
 			bool foundProxies;


### PR DESCRIPTION
All the other *NoProxy tests use the Microsoft uri, which seems to be the uri
that's not supposed to need a proxy (according to what I understand from the
code) - in other words, it looks like this was a c&p error.

Fixes this test failure when running on device:

    [FAIL] TestPACParsingAsyncNoProxy :   Expected: None
        But was:  HTTPS
	        at MonoTouchFixtures.CoreFoundation.ProxyTest.TestPACParsingAsyncNoProxy () [0x000fa] in /Users/rolf/work/maccore/onedotnet/xamarin-macios/tests/monotouch-test/CoreFoundation/ProxyTest.cs:238