### PR TITLE
[monotouch-test] Add a few Xcode version checks to ColorTest and AvoidOccluderConstraintTest.

### DIFF
--- a/tests/monotouch-test/CoreGraphics/ColorTest.cs
+++ b/tests/monotouch-test/CoreGraphics/ColorTest.cs
@@ -110,7 +110,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 		[Test]
 		public void CreateByMatchingToColorSpace ()
 		{
-			TestRuntime.AssertXcodeVersion (8, 0);
+			TestRuntime.AssertXcodeVersion (11, 0);
 			using (var c = CGColor.CreateByMatchingToColorSpace (null, CGColorRenderingIntent.Default, null, null)) {
 				Assert.IsNull (c, "0");
 			}

--- a/tests/monotouch-test/SceneKit/AvoidOccluderConstraintTest.cs
+++ b/tests/monotouch-test/SceneKit/AvoidOccluderConstraintTest.cs
@@ -13,6 +13,8 @@ namespace MonoTouchFixtures.SceneKit {
 		[Test]
 		public void Delegate_Nullability ()
 		{
+			TestRuntime.AssertXcodeVersion (9, 0);
+
 			using (var aoc = SCNAvoidOccluderConstraint.FromTarget (null)) {
 				// header says non-null but it's null by default
 				Assert.That (aoc.Delegate, Is.Null, "get");


### PR DESCRIPTION
This makes these tests not fail on iOS 10.3.3.