### PR TITLE
[tests] Preserve a required method in System.Private.CoreLib to work around a bug in .NET 6.

### DIFF
--- a/tests/monotouch-test/dotnet/extra-linker-defs.xml
+++ b/tests/monotouch-test/dotnet/extra-linker-defs.xml
@@ -1,0 +1,9 @@
+<linker>
+	<assembly fullname="System.Private.CoreLib">
+		<type fullname="System.Runtime.Loader.AssemblyLoadContext">
+			<!-- https://github.com/dotnet/runtime/issues/46908 -->
+			<!-- native-library.c: netcore_resolve_with_resolving_event () -->
+			<method name="MonoResolveUnmanagedDllUsingEvent" />
+		</type>
+	</assembly>
+</linker>

--- a/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
@@ -16,6 +16,7 @@
     <DefineConstants Condition="'$(Platform)' == 'iPhoneSimulator'">$(DefineConstants);DYNAMIC_REGISTRAR</DefineConstants>
     <DefineConstants Condition="'$(Platform)' != 'iPhoneSimulator'">$(DefineConstants);DEVICE</DefineConstants>
     <RootTestsDirectory>..\..\..</RootTestsDirectory>
+    <MtouchExtraArgs>-xml=${ProjectDir}/../extra-linker-defs.xml</MtouchExtraArgs>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Ref: https://github.com/dotnet/runtime/issues/46908.