### PR TITLE
[msbuild] Fix semi-conflicting options to set codesign timestamp

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -952,7 +952,13 @@ namespace Xamarin.Localization.MSBuild {
                 return ResourceManager.GetString("E0175", resourceCulture);
             }
         }
-        
+
+        public static string W0176 {
+            get {
+                return ResourceManager.GetString("W0176", resourceCulture);
+            }
+        }
+		
         public static string E7001 {
             get {
                 return ResourceManager.GetString("E7001", resourceCulture);

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -834,6 +834,11 @@
         </value>
     </data>
 
+    <data name="W0176" xml:space="preserve">
+        <value>Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </value>
+    </data>
+
     <data name="E7001" xml:space="preserve">
         <value>Could not resolve host IPs for WiFi debugger settings.
         </value>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.cs.xlf
@@ -1579,6 +1579,13 @@
         </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="W0176">
+        <source>Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </source>
+        <target state="new">Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.de.xlf
@@ -1579,6 +1579,13 @@
         </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="W0176">
+        <source>Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </source>
+        <target state="new">Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.es.xlf
@@ -1579,6 +1579,13 @@
         </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="W0176">
+        <source>Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </source>
+        <target state="new">Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.fr.xlf
@@ -1579,6 +1579,13 @@
         </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="W0176">
+        <source>Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </source>
+        <target state="new">Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.it.xlf
@@ -1579,6 +1579,13 @@
         </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="W0176">
+        <source>Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </source>
+        <target state="new">Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ja.xlf
@@ -1579,6 +1579,13 @@
         </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="W0176">
+        <source>Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </source>
+        <target state="new">Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ko.xlf
@@ -1579,6 +1579,13 @@
         </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="W0176">
+        <source>Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </source>
+        <target state="new">Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pl.xlf
@@ -1579,6 +1579,13 @@
         </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="W0176">
+        <source>Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </source>
+        <target state="new">Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.pt-BR.xlf
@@ -1579,6 +1579,13 @@
         </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="W0176">
+        <source>Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </source>
+        <target state="new">Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.ru.xlf
@@ -1579,6 +1579,13 @@
         </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="W0176">
+        <source>Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </source>
+        <target state="new">Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.tr.xlf
@@ -1579,6 +1579,13 @@
         </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="W0176">
+        <source>Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </source>
+        <target state="new">Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hans.xlf
@@ -1579,6 +1579,13 @@
 </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="W0176">
+        <source>Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </source>
+        <target state="new">Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
+++ b/msbuild/Xamarin.Localization.MSBuild/xlf/MSBStrings.zh-Hant.xlf
@@ -1579,6 +1579,13 @@
         </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="W0176">
+        <source>Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </source>
+        <target state="new">Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+        </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -111,9 +111,13 @@ namespace Xamarin.MacDev.Tasks
 				args.Add ("runtime");
 			}
 
-			if (UseSecureTimestamp)
+			if (UseSecureTimestamp) {
+				if (DisableTimestamp) {
+					// Conflicting '{0}' and '{1}' options. '{1}' will be ignored.
+					Log.LogWarning (MSBStrings.W0176, "UseSecureTimestamp", "DisableTimestamp");
+				}
 				args.Add ("--timestamp");
-			else
+			} else
 				args.Add ("--timestamp=none");
 
 			args.Add ("--sign");
@@ -133,9 +137,6 @@ namespace Xamarin.MacDev.Tasks
 				args.Add ("--entitlements");
 				args.Add (Path.GetFullPath (Entitlements));
 			}
-
-			if (DisableTimestamp)
-				args.Add ("--timestamp=none");
 
 			if (!string.IsNullOrEmpty (ExtraArgs))
 				args.Add (ExtraArgs);

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/LocalizationIgnore/common-Translations.ignore
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/LocalizationIgnore/common-Translations.ignore
@@ -1,6 +1,7 @@
 # Insert Error codes that are waiting on translations below (one per line)
 E0174
 E0175
+W0176
 E7069
 E7070
 InvalidFramework


### PR DESCRIPTION
TL&DR:

This effectively change nothing - but prevents (warn) if both options
contradict themselves.

Long Story....

So we have two ways to control the codesign's `--timetamp` option but
they both ignore each other so we can end up with the option being
set more than once at build time.

`DisableTimestamp` was the original one. It was meant for iOS (and
derivative OS) and disable the option (which requires the network)
for simulator or debug builds. IOW we _wanted_ timestamps when doing
release builds for devices.

```
DisableTimestamp="$(_CodesignDisableTimestamp)"
```

```
<_CodesignDisableTimestamp>False</_CodesignDisableTimestamp>
<_CodesignDisableTimestamp Condition="'$(_SdkIsSimulator)' == 'true' Or '$(_BundlerDebug)' == 'true'">True</_CodesignDisableTimestamp>
```

Now disabling the timestamp did not mean it was enabled. We did not ask
for a timestamp, leaving it to the default which from `man codesign`
means:

> If this option is not given at all, a system-specific default behavior is invoked.
> This may result in some but not all code signatures being timestamped.

Then `UseSecureTimestamp` was added for macOS builds. If hardening is
enabled then a secure timestamp is required.

`msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets` `_CodesignAppBundle`

```
UseSecureTimestamp="$(UseHardenedRuntime)"
```

However it's also exposed for iOS (shared target) in
`msbuild/Xamarin.Shared/Xamarin.Shared.targets` `__CodesignNativeLibraries`
but it would always be `false` in that case.

Adding this option means there's now always a `--timestamp` option given,
either to enable it (no URL so it means using Apple's server) or to
disable it (`=none`) but since it's controlled by `UseHardenedRuntime`,
which is macOS only, then iOS device builds are never timestamped.

An alternative would be to have `UseSecureTimestamp` as a macOS-only
option - but that would change how we currently sign the iOS applications
and I'd rather not change things that are known to work.