### PR TITLE
[monotouch-test] Adjust CaptiveNetworkTest.TryCopyCurrentNetworkInfo to work on iOS 10.3.3

### DIFF
--- a/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
+++ b/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
@@ -74,11 +74,16 @@ namespace MonoTouchFixtures.SystemConfiguration {
 				return;
 
 			Assert.AreEqual (StatusCode.OK, status, "Status");
-			// To get a non-null dictionary back, we must (https://developer.apple.com/documentation/systemconfiguration/1614126-cncopycurrentnetworkinfo)
+			// To get a non-null dictionary back, starting in iOS 12, we must (https://developer.apple.com/documentation/systemconfiguration/1614126-cncopycurrentnetworkinfo)
 			// * Use core location, and request (and get) authorization to use location information
 			// * Add the 'com.apple.developer.networking.wifi-info' entitlement
-			// I tried this, and still got null back, so just assert that we get null.
-			Assert.IsNull (dict, "Dictionary");
+			// We're not using custom entitlements when building for device, which means that we can't make this work at the moment.
+			// So just assert that we get null if running on iOS 12+.
+			if (TestRuntime.CheckXcodeVersion (10, 0)) {
+				Assert.IsNull (dict, "Dictionary");
+			} else {
+				Assert.IsNotNull (dict, "Dictionary");
+			}
 #endif
 		}
 


### PR DESCRIPTION
According to Apple's documentation, an app linked with iOS 12 or later must
enable a specific entitlement, otherwise calls to CNCopyCurrentNetworkInfo
will always return NULL.