### PR TITLE
[xharness] Fix warning about unknown file wrt default inclusion.

### DIFF
--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -160,6 +160,7 @@ namespace Xharness {
 							break;
 						case ".gitignore":
 						case ".csproj":
+						case ".fsproj":
 						case ".props": // Directory.Build.props
 						case "": // Makefile
 							break; // ignore these files


### PR DESCRIPTION
Fixes this warning when running xharness:

    Unknown file: fsharplibrary.fsproj (extension: .fsproj). There might be a default inclusion behavior for this file.