### PR TITLE
[mtouch][mmp] Exclude extraneous framework files from being copied into apps

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -697,19 +697,16 @@ namespace Xamarin.Bundler {
 			FileCopier.UpdateDirectory (source, target);
 		}
 
+		static string[] NonEssentialDirectoriesInsideFrameworks = { "CVS", ".svn", ".git", ".hg", "Headers", "PrivateHeaders", "Modules" };
+
 		// Duplicate xcode's `builtin-copy` exclusions
 		public static void ExcludeNonEssentialFrameworkFiles (string framework)
 		{
 			// builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -exclude Headers -exclude PrivateHeaders -exclude Modules -exclude \*.tbd
 			File.Delete (Path.Combine (framework, ".DS_Store"));
-			DeleteDir (Path.Combine (framework, "CVS"));
-			DeleteDir (Path.Combine (framework, ".svn"));
-			DeleteDir (Path.Combine (framework, ".git"));
-			DeleteDir (Path.Combine (framework, ".hg"));
-			DeleteDir (Path.Combine (framework, "Headers"));
-			DeleteDir (Path.Combine (framework, "PrivateHeaders"));
-			DeleteDir (Path.Combine (framework, "Modules"));
 			File.Delete (Path.Combine (framework, "*.tbd"));
+			foreach (var dir in NonEssentialDirectoriesInsideFrameworks)
+				DeleteDir (Path.Combine (framework, dir));
 		}
 
 		static void DeleteDir (string dir)

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -697,6 +697,33 @@ namespace Xamarin.Bundler {
 			FileCopier.UpdateDirectory (source, target);
 		}
 
+		// Duplicate xcode's `builtin-copy` exclusions
+		public static void ExcludeNonEssentialFrameworkFiles (string framework)
+		{
+			// builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -exclude Headers -exclude PrivateHeaders -exclude Modules -exclude \*.tbd
+			File.Delete (Path.Combine (framework, ".DS_Store"));
+			DeleteDir (Path.Combine (framework, "CVS"));
+			DeleteDir (Path.Combine (framework, ".svn"));
+			DeleteDir (Path.Combine (framework, ".git"));
+			DeleteDir (Path.Combine (framework, ".hg"));
+			DeleteDir (Path.Combine (framework, "Headers"));
+			DeleteDir (Path.Combine (framework, "PrivateHeaders"));
+			DeleteDir (Path.Combine (framework, "Modules"));
+			File.Delete (Path.Combine (framework, "*.tbd"));
+		}
+
+		static void DeleteDir (string dir)
+		{
+			// Xcode generates symlinks inside macOS frameworks
+			var realdir = Target.GetRealPath (dir);
+			// unlike File.Delete this would throw if the directory does not exists
+			if (Directory.Exists (realdir)) {
+				Directory.Delete (realdir, true);
+				if (realdir != dir)
+					File.Delete (dir); // because a symlink is a file :)
+			}
+		}
+
 		[DllImport (Constants.libSystemLibrary)]
 		static extern int readlink (string path, IntPtr buf, int len);
 

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -715,7 +715,7 @@ namespace Xamarin.Bundler {
 		static void DeleteDir (string dir)
 		{
 			// Xcode generates symlinks inside macOS frameworks
-			var realdir = Target.GetRealPath (dir);
+			var realdir = Target.GetRealPath (dir, warnIfNoSuchPathExists: false);
 			// unlike File.Delete this would throw if the directory does not exists
 			if (Directory.Exists (realdir)) {
 				Directory.Delete (realdir, true);

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -138,7 +138,7 @@ namespace Xamarin.Bundler {
 		[DllImport (Constants.libSystemLibrary, SetLastError = true)]
 		static extern string realpath (string path, IntPtr zero);
 
-		public static string GetRealPath (string path)
+		public static string GetRealPath (string path, bool warnIfNoSuchPathExists = true)
 		{
 			// For some reason realpath doesn't always like filenames only, and will randomly fail.
 			// Prepend the current directory if there's no directory specified.
@@ -150,7 +150,8 @@ namespace Xamarin.Bundler {
 				return rv;
 
 			var errno = Marshal.GetLastWin32Error ();
-			ErrorHelper.Warning (54, Errors.MT0054, path, FileCopier.strerror (errno), errno);
+			if (warnIfNoSuchPathExists || (errno !=2))
+				ErrorHelper.Warning (54, Errors.MT0054, path, FileCopier.strerror (errno), errno);
 			return path;
 		}
 

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -767,10 +767,12 @@ namespace Xamarin.Bundler {
 
 			CreateDirectoryIfNeeded (frameworks_dir);
 			Application.UpdateDirectory (framework, frameworks_dir);
+			var fxdir = Path.Combine (frameworks_dir, name + ".framework");
+			Application.ExcludeNonEssentialFrameworkFiles (fxdir);
 			frameworks_copied_to_bundle_dir = true;
 
 			if (App.Optimizations.TrimArchitectures == true)
-				LipoLibrary (framework, Path.Combine (name, Path.Combine (frameworks_dir, name + ".framework", name)));
+				LipoLibrary (framework, Path.Combine (name, Path.Combine (fxdir, name)));
 		}
 
 		static void CheckSystemMonoVersion ()

--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -1282,6 +1282,7 @@ namespace Xamarin.Bundler {
 						var macho_last_write_time = macho_info.LastWriteTimeUtc; // this returns a date in the 17th century if the file doesn't exist.
 						UpdateDirectory (framework_src, Path.GetDirectoryName (targetPath));
 						if (IsDeviceBuild) {
+							ExcludeNonEssentialFrameworkFiles (targetPath);
 							// Remove architectures we don't care about.
 							MachO.SelectArchitectures (macho_file, AllArchitectures);
 							// Strip bitcode if needed.


### PR DESCRIPTION
Today both `mtouch` and `mmp` are copying the entire `.framework`
directories inside the `.app\[Contents\]Frameworks\` directory.

However not everything in a framework is required at runtime. The most
common unrequired files would be headers (`Headers/*.h`) and modules
(`Modules/*`).

Looking at Xcode build output we can see something like:

```
builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -exclude Headers -exclude PrivateHeaders -exclude Modules -exclude \*.tbd -bitcode-strip replace-with-marker -bitcode-strip-tool
```

which excludes a few more, less common, files.

This _builtin_ command is not available externally (for us to re-use)
but it hints that Xcode is likely using `rsync` to avoid copying part of
the files.

Note: the builtin command also _likely_ calls `bitcode_strip` too (or has
similar code embedded) and `mtouch` already does so too

There's a cost to spawning an external process, like `rsync`, which we
avoid by having our own file copier, which clones files (almost zero
cost). That does not support excluding files, but deleting files is also
very cheap. Testing shows copying a framework to be less than 1 ms, even
with with extra deletion step.