### PR TITLE
[CI][VSTS] Remove warning from mac tests upload.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -378,8 +378,8 @@ steps:
 - task: PublishPipelineArtifact@1
   displayName: 'Publish Xamarin.Mac tests'
   inputs:
-    targetPath: $(Build.SourcesDirectory)/xamarin-macios/tests/*.7z
-    artifactName: package-internal
+    targetPath: $(Build.SourcesDirectory)/xamarin-macios/tests/mac-test-package.7z
+    artifactName: mac-test-package 
   condition: and(succeeded(), contains(variables['configuration.RunMacTests'], 'True'))
   continueOnError: true
 


### PR DESCRIPTION
The template does not expand wildcards. The template does not know how to
reuse paths.