### PR TITLE
[dotnet] Bump ILLink to get an updated linker reference assembly.

### DIFF
--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -318,7 +318,7 @@ namespace Xamarin.Linker {
 				// Revisit the error code after https://github.com/mono/linker/issues/1596 has been fixed.
 				var instance = GetInstance (context, false);
 				var platform = (instance?.Platform)?.ToString () ?? "unknown";
-				var msg = MessageContainer.CreateErrorMessage ("Failed to execute the custom steps.", 1999, platform);
+				var msg = MessageContainer.CreateCustomErrorMessage ("Failed to execute the custom steps.", 6999, platform);
 				context.LogMessage (msg);
 			}
 			// ErrorHelper.Show will print our errors and warnings to stderr.

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="XliffTasks" Version="1.0.0-beta.20154.1" />
-    <PackageReference Include="Microsoft.NET.ILLink" Version="5.0.0-preview.3.20417.4" />
+    <PackageReference Include="Microsoft.NET.ILLink" Version="6.0.0-alpha.1.21065.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\common\ApplePlatform.cs">

--- a/tools/linker/MonoTouch.Tuner/PreserveSmartEnumConversionsSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/PreserveSmartEnumConversionsSubStep.cs
@@ -48,18 +48,6 @@ namespace Xamarin.Linker.Steps
 
 		void Preserve (Tuple<MethodDefinition, MethodDefinition> pair, MethodDefinition conditionA, MethodDefinition conditionB = null)
 		{
-#if NET
-			// The AddPreservedMethod (MethodDefinition, MethodDefinition) has not been exposed yet, so preserve the entire containing type instead.
-			// https://github.com/mono/linker/issues/1456
-			if (conditionA != null) {
-				context.Annotations.AddPreservedMethod (conditionA.DeclaringType, pair.Item1);
-				context.Annotations.AddPreservedMethod (conditionA.DeclaringType, pair.Item2);
-			}
-			if (conditionB != null) {
-				context.Annotations.AddPreservedMethod (conditionB.DeclaringType, pair.Item1);
-				context.Annotations.AddPreservedMethod (conditionB.DeclaringType, pair.Item2);
-			}
-#else
 			if (conditionA != null) {
 				context.Annotations.AddPreservedMethod (conditionA, pair.Item1);
 				context.Annotations.AddPreservedMethod (conditionA, pair.Item2);
@@ -68,7 +56,6 @@ namespace Xamarin.Linker.Steps
 				context.Annotations.AddPreservedMethod (conditionB, pair.Item1);
 				context.Annotations.AddPreservedMethod (conditionB, pair.Item2);
 			}
-#endif
 		}
 
 		void ProcessAttributeProvider (ICustomAttributeProvider provider, MethodDefinition conditionA, MethodDefinition conditionB = null)


### PR DESCRIPTION
This allows us to undo a workaround we made for a missing API in the linker
reference assembly (an AnnotationStore.AddPreservedMethod overload).

This also requires a change to use MessageContainer.CreateCustomErrorMessage
instead of MessageContainer.CreateErrorMessage, because apparently having a
reference assembly doesn't mean there can't be incompatible changes in it 😒.