### PR TITLE
[d16-9] [msbuild] Remove duplicate trailing slash from _XamarinBclPath. Fixes #10446.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.TargetFrameworkFix.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.TargetFrameworkFix.targets
@@ -33,7 +33,7 @@ Copyright (c) 2018 Microsoft Corp. (www.microsoft.com)
 	<Target Name="FixDesignTimeFacades" AfterTargets="GetReferenceAssemblyPaths" Condition="('$(OS)' != 'Windows_NT')">
 		<ItemGroup>
 			<DesignTimeFacadeDirectories Remove="@(DesignTimeFacadeDirectories)" />
-			<DesignTimeFacadeDirectories Include="$(_XamarinBclPath)/Facades/" />
+			<DesignTimeFacadeDirectories Include="$(_XamarinBclPath)Facades/" />
 		</ItemGroup>
 	</Target>
 </Project>


### PR DESCRIPTION
_XamarinBclPath always has a trailing slash, so no need to add another one
when adding subdirectories to it.

Fixes https://github.com/xamarin/xamarin-macios/issues/10446.

Backport of #10449