### PR TITLE
[dotnet-linker] Add the RemoveUserResources sub step.

### DIFF
--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -302,18 +302,18 @@ namespace Xamarin.Tests {
 				var asm = assemblies.First ();
 				Assert.That (asm, Does.Exist, "Assembly existence");
 
-				// Verify that the resources
+				// Verify that the resources have been linked away
 				var asmDir = Path.GetDirectoryName (asm);
 				var ad = AssemblyDefinition.ReadAssembly (asm, new ReaderParameters { ReadingMode = ReadingMode.Deferred });
 				Assert.That (ad.MainModule.Resources.Count, Is.EqualTo (0), "0 resources for interdependent-binding-projects.dll");
 
 				var ad1 = AssemblyDefinition.ReadAssembly (Path.Combine (asmDir, "bindings-test.dll"), new ReaderParameters { ReadingMode = ReadingMode.Deferred });
-				Assert.That (ad1.MainModule.Resources.Count, Is.EqualTo (1), "1 resource for bindings-test.dll");
-				Assert.That (ad1.MainModule.Resources [0].Name, Is.EqualTo ("libtest.a"), "libtest.a - bindings-test.dll");
+				// The native library is removed from the resources by the linker
+				Assert.That (ad1.MainModule.Resources.Count, Is.EqualTo (0), "0 resources for bindings-test.dll");
 
 				var ad2 = AssemblyDefinition.ReadAssembly (Path.Combine (asmDir, "bindings-test2.dll"), new ReaderParameters { ReadingMode = ReadingMode.Deferred });
-				Assert.That (ad2.MainModule.Resources.Count, Is.EqualTo (1), "1 resource for bindings-test2.dll");
-				Assert.That (ad2.MainModule.Resources [0].Name, Is.EqualTo ("libtest2.a"), "libtest2.a - bindings-test2.dll");
+				// The native library is removed from the resources by the linker
+				Assert.That (ad2.MainModule.Resources.Count, Is.EqualTo (0), "0 resources for bindings-test2.dll");
 			} finally {
 				foreach (var file in cleanupSupportFiles)
 					File.Delete (file);

--- a/tools/dotnet-linker/SetupStep.cs
+++ b/tools/dotnet-linker/SetupStep.cs
@@ -85,9 +85,10 @@ namespace Xamarin {
 				post_sweep_substeps.Add (new RemoveAttributesStep ());
 			}
 
-			Steps.Add (new ListExportedSymbols (null));
-			Steps.Add (new LoadNonSkippedAssembliesStep ());
-			Steps.Add (new ExtractBindingLibrariesStep ());
+			InsertBefore (new ListExportedSymbols (null), "OutputStep");
+			InsertBefore (new LoadNonSkippedAssembliesStep (), "OutputStep");
+			InsertBefore (new ExtractBindingLibrariesStep (), "OutputStep");
+			InsertBefore (new DotNetSubStepDispatcher (new RemoveUserResourcesSubStep ()), "OutputStep");
 			Steps.Add (new RegistrarStep ());
 			Steps.Add (new GenerateMainStep ());
 			Steps.Add (new GenerateReferencesStep ());

--- a/tools/dotnet-linker/Steps/DotNetSubStepDispatcher.cs
+++ b/tools/dotnet-linker/Steps/DotNetSubStepDispatcher.cs
@@ -3,6 +3,15 @@ using Mono.Linker.Steps;
 namespace Xamarin.Linker.Steps {
 	// SubStepsDispatcher is abstract, so create a subclass we can instantiate
 	class DotNetSubStepDispatcher : SubStepsDispatcher {
+		public DotNetSubStepDispatcher ()
+		{
+		}
+
+		public DotNetSubStepDispatcher (params BaseSubStep[] subSteps)
+		{
+			foreach (var ss in subSteps)
+				Add (ss);
+		}
 	}
 }
 

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -182,6 +182,9 @@
     <Compile Include="..\common\BitCodeMode.cs">
       <Link>external\tools\common\BitCodeMode.cs</Link>
     </Compile>
+    <Compile Include="..\linker\RemoveUserResourcesSubStep.cs">
+      <Link>external\tools\linker\RemoveUserResourcesSubStep.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\mtouch\Errors.resx">

--- a/tools/linker/RemoveUserResourcesSubStep.cs
+++ b/tools/linker/RemoveUserResourcesSubStep.cs
@@ -3,27 +3,56 @@ using System.Collections.Generic;
 
 using Mono.Cecil;
 using Mono.Linker;
+#if NET
+using Mono.Linker.Steps;
+#endif
 using Mono.Tuner;
+
+using Xamarin.Bundler;
+using Xamarin.Utils;
 
 namespace Xamarin.Linker {
 
 	public class RemoveUserResourcesSubStep : ExceptionalSubStep {
 
-#if MTOUCH
-		const string Content = "__monotouch_content_";
-		const string Page = "__monotouch_page_";
-#else
-		const string Content = "__xammac_content_";
-		const string Page = "__xammac_page_";
-#endif
+		const string iOS_Content = "__monotouch_content_";
+		const string iOS_Page = "__monotouch_page_";
+		const string Mac_Content = "__xammac_content_";
+		const string Mac_Page = "__xammac_page_";
+
+		string Content;
+		string Page;
+		
 		public override SubStepTargets Targets {
 			get { return SubStepTargets.Assembly; }
 		}
 
-		public bool Device { get { return LinkContext.App.IsDeviceBuild; } }
+		public bool Simulator { get { return LinkContext.App.IsSimulatorBuild; } }
 
 		protected override string Name { get; } = "Removing User Resources";
 		protected override int ErrorCode { get; } = 2030;
+
+		public override void Initialize (LinkContext context)
+		{
+			base.Initialize (context);
+
+			switch (LinkContext.App.Platform) {
+			case ApplePlatform.iOS:
+			case ApplePlatform.TVOS:
+			case ApplePlatform.WatchOS:
+			case ApplePlatform.MacCatalyst:
+				Content = iOS_Content;
+				Page = iOS_Page;
+				break;
+			case ApplePlatform.MacOSX:
+				Content = Mac_Content;
+				Page = Mac_Page;
+				break;
+			default:
+				Report (ErrorHelper.CreateError (71, Errors.MX0071, LinkContext.App.Platform, LinkContext.App.ProductName));
+				break;
+			}
+		}
 
 		protected override void Process (AssemblyDefinition assembly)
 		{
@@ -71,10 +100,10 @@ namespace Xamarin.Linker {
 
 		bool IsMonoTouchResource (string resourceName)
 		{
-#if MTOUCH
-			if (!Device)
+			// Don't bother removing the resources if we're building for the simulator
+			if (Simulator)
 				return false;
-#endif
+
 			if (resourceName.StartsWith (Content, StringComparison.OrdinalIgnoreCase))
 				return true;
 


### PR DESCRIPTION
This comes with a few changes to the RemoveUserResources sub step as well:

* Bail out earlier if we're in the simulator (no need to do any processing at
  all - we know at the very beginning if we're building for the simulator).
* Do a positive simulator check, instead of a negative device check (because
  Mac[Catalyst] are neither devices - so they pass the negative device check).
* Remove all the conditional mtouch/mmp code, and figure out at runtime which
  resource prefixes we need to check for.

It was also necessary to change where steps are added to the pipeline: we have
to remove resources before the OutputStep, but at the same time we have to do
it after the ExtractBindingLibraries step, otherwise the
ExtractBindingLibraries step won't find any binding libraries to extract. So
move the ExtractBindingLibraries, LoadNonSkippedAssemblies and
ListExportedSymbols to before the OutputStep (to keep their internal order),
and then add the RemoveUserResources after those.

This fixes the following link sdk/link all test when running on device:

    BundledResources.ResourcesTest
        [FAIL] Bundled :   No resources
            Expected: 0
            But was:  2