### PR TITLE
[mlaunch] Improve make logic to only install bin/mlaunch if it changed.

### DIFF
--- a/tools/mlaunch/Makefile
+++ b/tools/mlaunch/Makefile
@@ -32,10 +32,16 @@ endif
 
 ifdef ENABLE_DOTNET
 all-local:: build-and-install
+	$(MAKE) $(foreach platform,$(DOTNET_PLATFORMS_MOBILE),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/tools/bin/mlaunch)
 	$(Q) for platform in $(DOTNET_PLATFORMS_MOBILE); do \
-		$(CP) -R $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch $(DOTNET_DESTDIR)/Microsoft.$$platform.Sdk/tools/bin; \
 		$(CP) -R $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mlaunch $(DOTNET_DESTDIR)/Microsoft.$$platform.Sdk/tools/lib; \
 	done
+
+$(DOTNET_DESTDIR)/Microsoft.%.Sdk/tools/bin/mlaunch: $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch | $(DOTNET_DESTDIR)/Microsoft.%.Sdk/tools/bin
+	$(Q) $(CP) $< $@
+
+$(DOTNET_DESTDIR)/Microsoft.%.Sdk/tools/bin:
+	$(Q) mkdir -p $@
 endif
 
 ifdef ENABLE_XAMARIN


### PR DESCRIPTION
This way the bin directory doesn't unnecessarily get an updated timestamp, so
that some build targets in the dotnet/ directory don't rebuild unnecessarily.