### PR TITLE
[d16-9] [msbuild] Fix codesign `StampPath`. Fix #10445

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -76,7 +76,9 @@ namespace Xamarin.MacDev.Tasks
 
 		string GetOutputPath (ITaskItem item)
 		{
-			return Path.Combine (StampPath, item.ItemSpec);
+			var path = item.ItemSpec;
+			var app = path.LastIndexOf (".app/");
+			return Path.Combine (StampPath, path.Substring (app + ".app/".Length));
 		}
 
 		bool NeedsCodesign (ITaskItem item)


### PR DESCRIPTION
Using `Path.Combine` with a full qualified path for the 2nd argument will
return that 2nd argument (ignoring the first one).

That meant the `StampPath` was pointing to the actual files that were
just signed - overwriting them with a 0-length data (empty).

The solution is to make the 2nd argument relative, starting after
`.app/` so `Path.Combine` works as expected (being relative) while
allowing signing multiple files that have the same name (in different
directories).

ref: https://github.com/xamarin/xamarin-macios/issues/10445

Backport of #10459