### PR TITLE
[msbuild] Unify how CFBundleName is calculated.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/CompileAppManifestTaskCore.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/CompileAppManifestTaskCore.cs
@@ -8,7 +8,6 @@ namespace Xamarin.Mac.Tasks {
 		{
 			if (!IsAppExtension || (IsAppExtension && IsXPCService))
 				plist.SetIfNotPresent ("MonoBundleExecutable", AssemblyName + ".exe");
-			plist.SetIfNotPresent (ManifestKeys.CFBundleName, AppBundleName);
 
 			return !Log.HasLoggedErrors;
 		}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -94,6 +94,7 @@ namespace Xamarin.MacDev.Tasks
 			plist.SetIfNotPresent (ManifestKeys.CFBundleSignature, "????");
 			plist.SetIfNotPresent (ManifestKeys.CFBundleVersion, "1.0");
 			plist.SetIfNotPresent (ManifestKeys.CFBundleExecutable, AssemblyName);
+			plist.SetIfNotPresent (ManifestKeys.CFBundleName, AppBundleName);
 
 			if (!Compile (plist))
 				return false;

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskCore.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskCore.cs
@@ -61,13 +61,6 @@ namespace Xamarin.iOS.Tasks
 					LogAppManifestError (MSBStrings.E0014, executable);
 			}
 
-			if (IsIOS) {
-				if (!plist.ContainsKey (ManifestKeys.CFBundleName))
-					plist [ManifestKeys.CFBundleName] = plist.ContainsKey (ManifestKeys.CFBundleDisplayName) ? plist.GetString (ManifestKeys.CFBundleDisplayName).Clone () : new PString (AppBundleName);
-			} else {
-				plist.SetIfNotPresent (ManifestKeys.CFBundleName, AppBundleName);
-			}
-
 			if (!string.IsNullOrEmpty (ResourceRules))
 				plist.SetIfNotPresent (ManifestKeys.CFBundleResourceSpecification, Path.GetFileName (ResourceRules));
 			if (!plist.ContainsKey (ManifestKeys.CFBundleSupportedPlatforms))

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_iOS.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_iOS.cs
@@ -29,7 +29,7 @@ namespace Xamarin.iOS.Tasks
 		public override void BundleName ()
 		{
 			Assert.That (CompiledPlist.ContainsKey (ManifestKeys.CFBundleName), "#1");
-			Assert.AreEqual (CompiledPlist.Get<PString> (ManifestKeys.CFBundleName).Value, displayName, "#2");
+			Assert.AreEqual (CompiledPlist.Get<PString> (ManifestKeys.CFBundleName).Value, appBundleName, "#2");
 		}
 
 		[Test]


### PR DESCRIPTION
Previously, CFBundleName would default to:

* iOS: CFBundleDisplayName (if set), otherwise the app bundle name.
* all other platforms: the app bundle name.

Now unify the logic so that we have the same behavior on all platforms.

This is a breaking change under the following conditions:

* Building for iOS
* CFBundleName is not set in the Info.plist
* CFBundleDisplayName is set in the Info.plist
* CFBundleDisplayName from the Info.plist is different from AssemblyName in
  the csproj (which is the value used to calculate the app bundle name).

The fix would be to:

* Set CFBundleName in the Info.plist to the desired value.

This change works in previous versions of Xamarin.iOS as well.