### PR TITLE
[xcode12.3] [Xharness] Fix the xharness links to work with vsdrops.

### DIFF
--- a/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
+++ b/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
@@ -116,7 +116,7 @@ namespace Xharness.Jenkins.Reports {
 
 			writer.WriteLine ($"<span id='x{id_counter++}' class='autorefreshable'>");
 			foreach (var log in jenkins.Logs)
-				writer.WriteLine ("<a href='{0}' type='text/plain;charset=UTF-8'>{1}</a><br />", log.FullPath.Substring (jenkins.LogDirectory.Length + 1), log.Description);
+				writer.WriteLine ("<a href='{0}' type='text/plain;charset=UTF-8'>{1}</a><br />", GetLinkFullPath (log.FullPath.Substring (jenkins.LogDirectory.Length + 1)), log.Description);
 			writer.WriteLine ("</span>");
 
 			var headerColor = "black";


### PR DESCRIPTION
We need to add the prefix to the xharness logs or we will not be able to
acceess them via a click.

Backport of #10469