### PR TITLE
[msbuild] Simplify some code in DetectSigningIdentityTask.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
@@ -525,12 +525,11 @@ namespace Xamarin.MacDev.Tasks
 				Log.LogError (null, null, null, AppManifest, 0, 0, 0, 0, MSBStrings.E0139, AppManifest);
 				return false;
 			}
+			DetectedBundleId = identity.BundleId;
+			DetectedAppId = DetectedBundleId; // default value that can be changed below
 
 			if (Platform == ApplePlatform.MacOSX) {
 				if (!RequireCodeSigning || !string.IsNullOrEmpty (DetectedCodeSigningKey)) {
-					DetectedBundleId = identity.BundleId;
-					DetectedAppId = DetectedBundleId;
-
 					ReportDetectedCodesignInfo ();
 
 					return !Log.HasLoggedErrors;
@@ -540,9 +539,6 @@ namespace Xamarin.MacDev.Tasks
 				if (RequireProvisioningProfile)
 					doesNotNeedCodeSigningCertificate = false;
 				if (doesNotNeedCodeSigningCertificate) {
-					DetectedBundleId = identity.BundleId;
-					DetectedAppId = DetectedBundleId;
-
 					DetectedCodeSigningKey = "-";
 
 					ReportDetectedCodesignInfo ();
@@ -576,8 +572,6 @@ namespace Xamarin.MacDev.Tasks
 
 							DetectedProvisioningProfile = identity.Profile.Uuid;
 							DetectedDistributionType = identity.Profile.DistributionType.ToString ();
-							DetectedBundleId = identity.BundleId;
-							DetectedAppId = DetectedBundleId;
 						} else {
 							certs = new X509Certificate2[0];
 
@@ -597,15 +591,11 @@ namespace Xamarin.MacDev.Tasks
 								provisioningProfileName = identity.Profile.Name;
 							}
 
-							DetectedBundleId = identity.BundleId;
 							DetectedAppId = identity.AppId;
 						}
 					} else {
 						// Note: Do not codesign. Codesigning seems to break the iOS Simulator in older versions of Xcode.
 						DetectedCodeSigningKey = null;
-
-						DetectedBundleId = identity.BundleId;
-						DetectedAppId = DetectedBundleId;
 					}
 
 					ReportDetectedCodesignInfo ();
@@ -637,8 +627,6 @@ namespace Xamarin.MacDev.Tasks
 
 				codesignCommonName = SecKeychain.GetCertificateCommonName (certs[0]);
 				DetectedCodeSigningKey = certs[0].Thumbprint;
-				DetectedBundleId = identity.BundleId;
-				DetectedAppId = DetectedBundleId;
 
 				ReportDetectedCodesignInfo ();
 
@@ -678,7 +666,6 @@ namespace Xamarin.MacDev.Tasks
 
 				DetectedProvisioningProfile = identity.Profile.Uuid;
 				DetectedDistributionType = identity.Profile.DistributionType.ToString ();
-				DetectedBundleId = identity.BundleId;
 				DetectedAppId = identity.AppId;
 
 				ReportDetectedCodesignInfo ();
@@ -700,7 +687,6 @@ namespace Xamarin.MacDev.Tasks
 
 				DetectedCodeSigningKey = identity.SigningKey?.Thumbprint;
 				DetectedProvisioningProfile = identity.Profile.Uuid;
-				DetectedBundleId = identity.BundleId;
 				DetectedAppId = identity.AppId;
 
 				ReportDetectedCodesignInfo ();


### PR DESCRIPTION
* We assigned the same value to DetectedBundleId in every branch, so instead
  assign it once at the beginning.
* We assigned the same value to DetectedAppId to most branches, so instead
  assign that value at the beginning as a default value.