### PR TITLE
[xcode12.3] [CI][VSTS] Move to ESRP for notarization.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -59,6 +59,8 @@ variables:
   value: 'https://vsdrop.corp.microsoft.com/file/v1/xamarin-macios/device-tests'
 - name: USE_TCP_TUNNEL                                        # Needed to ensure that devices uses the usb cable to communicate with the devices to run the tests.
   value: true
+- name: TeamName
+  value: 'xamarin-macios'
 
 trigger:
   branches:

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -304,7 +304,8 @@ steps:
   env: 
       SYSTEM_ACCESSTOKEN: $(System.AccessToken) 
 
-- pwsh: $(Build.SourcesDirectory)/release-scripts/notarize.ps1 -FolderForApps $(Build.SourcesDirectory)/package 
+- pwsh: $(Build.SourcesDirectory)/release-scripts/notarize.ps1 -FolderForApps $(Build.SourcesDirectory)/package/notarized 
+  displayName: 'ESRP notarizing packags' 
 
 - template: generate-workspace-info.yml@templates
   parameters:

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -305,7 +305,7 @@ steps:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken) 
 
 - pwsh: $(Build.SourcesDirectory)/release-scripts/notarize.ps1 -FolderForApps $(Build.SourcesDirectory)/package/notarized 
-  displayName: 'ESRP notarizing packags' 
+  displayName: 'ESRP notarizing packages' 
 
 - template: generate-workspace-info.yml@templates
   parameters:

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -278,7 +278,8 @@ steps:
     PACKAGES="$IOS_PKG $MAC_PKG"
     echo "Packages found at $PACKAGES"
 
-    echo "$PACKAGES" | xargs python $(Build.SourcesDirectory)/release-scripts/sign_and_notarize.py -a "$APP_ID" -i "$INSTALL_ID" -u "$APPLE_ACCOUNT" -p "$APPLE_PASS" -t "$TEAM_ID" -d $(Build.SourcesDirectory)/package/notarized -e "$MAC_ENTITLEMENTS" -k "$KEYCHAIN"
+    echo "$PACKAGES" | xargs python $(Build.SourcesDirectory)/release-scripts/sign_and_notarize.py --no_notarization -a "$APP_ID" -i "$INSTALL_ID" -u "$APPLE_ACCOUNT" -p "$APPLE_PASS" -t "$TEAM_ID" -d $(Build.SourcesDirectory)/package/notarized -e "$MAC_ENTITLEMENTS" -k "$KEYCHAIN"
+    ls -R $(Build.SourcesDirectory)/package
   env:
     PRODUCTSIGN_KEYCHAIN_PASSWORD: $(OSX_KEYCHAIN_PASS)
     MAC_ENTITLEMENTS: $(Build.SourcesDirectory)/xamarin-macios/mac-entitlements.plist
@@ -292,6 +293,18 @@ steps:
   displayName: 'Signing Release Build'
   condition: and(succeeded(), contains(variables['configuration.SignPkgs'], 'True'), contains(variables['configuration.IsPr'], 'False'))
   timeoutInMinutes: 90
+
+- task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@3 
+  displayName: 'Install Signing Plugin' 
+  inputs: 
+    signType: 'Real'  # test is not present for mac.. 
+    azureSubscription: 'MicroBuild Signing Task (DevDiv)'
+    version: 1.1.352-g82fc43b9d7
+    feedSource: 'https://pkgs.dev.azure.com/devdiv/_packaging/VS_TempPkgs/nuget/v3/index.json'
+  env: 
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken) 
+
+- pwsh: $(Build.SourcesDirectory)/release-scripts/notarize.ps1 -FolderForApps $(Build.SourcesDirectory)/package 
 
 - template: generate-workspace-info.yml@templates
   parameters:

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -274,20 +274,11 @@ steps:
     prependToPath: '/Users/builder/Library/Python/2.7/bin'
 
 - bash: |
-    VIRTUAL_ENV_PATH=$(Build.SourcesDirectory)/venv
-    pip install virtualenv
-    virtualenv "$VIRTUAL_ENV_PATH" --system-site-packages
-    source "$VIRTUAL_ENV_PATH/bin/activate"
-    pip install python-magic
-
     security unlock-keychain -p $PRODUCTSIGN_KEYCHAIN_PASSWORD builder.keychain
     PACKAGES="$IOS_PKG $MAC_PKG"
     echo "Packages found at $PACKAGES"
 
     echo "$PACKAGES" | xargs python $(Build.SourcesDirectory)/release-scripts/sign_and_notarize.py -a "$APP_ID" -i "$INSTALL_ID" -u "$APPLE_ACCOUNT" -p "$APPLE_PASS" -t "$TEAM_ID" -d $(Build.SourcesDirectory)/package/notarized -e "$MAC_ENTITLEMENTS" -k "$KEYCHAIN"
-
-    deactivate
-    rm -Rf "$VIRTUAL_ENV_PATH"
   env:
     PRODUCTSIGN_KEYCHAIN_PASSWORD: $(OSX_KEYCHAIN_PASS)
     MAC_ENTITLEMENTS: $(Build.SourcesDirectory)/xamarin-macios/mac-entitlements.plist

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -301,6 +301,7 @@ steps:
     azureSubscription: 'MicroBuild Signing Task (DevDiv)'
     version: 1.1.352-g82fc43b9d7
     feedSource: 'https://pkgs.dev.azure.com/devdiv/_packaging/VS_TempPkgs/nuget/v3/index.json'
+  condition: and(succeeded(), contains(variables['configuration.SignPkgs'], 'True'), contains(variables['configuration.IsPr'], 'False')) # if we are a PR, the installation of the plugin will return a 403 and everything will collapse
   env: 
       SYSTEM_ACCESSTOKEN: $(System.AccessToken) 
 

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -59,7 +59,7 @@ steps:
     provisioning_script: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/provision-brew-packages.csx
     provisioning_extra_args: '-vvvv'
   timeoutInMinutes: 30
-  enabled: false
+  enabled: true 
 
 - bash: |
     make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops build-provisioning.csx

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -70,6 +70,7 @@ jobs:
     demands:
     - Agent.OS -equals Darwin
     - Agent.OSVersion -equals 10.15
+    - macios_image -equals v1
   workspace:
     clean: all
 

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -66,7 +66,7 @@ jobs:
     # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
     BRANCH_NAME: $(Build.SourceBranchName)
   pool:
-    name: VSEng-Xamarin-RedmondMacBuildPool-Test
+    name: $(AgentPoolComputed)
     demands:
     - Agent.OS -equals Darwin
     - Agent.OSVersion -equals 10.15

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -66,7 +66,7 @@ jobs:
     # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
     BRANCH_NAME: $(Build.SourceBranchName)
   pool:
-    name: $(AgentPoolComputed)
+    name: VSEng-Xamarin-RedmondMacBuildPool-Test
     demands:
     - Agent.OS -equals Darwin
     - Agent.OSVersion -equals 10.15

--- a/tools/devops/provision-brew-packages.csx
+++ b/tools/devops/provision-brew-packages.csx
@@ -4,8 +4,7 @@ BrewPackages (
     "automake",
     "libtool",
     "p7zip",
-    "python",
-    "libmagic", 
     "msitools",
-    "wget"
+    "wget",
+    "azure-cli"
  );


### PR DESCRIPTION
This PR contains just the required changes to add notarization via ESRP. Signing the pkg is done by the old python script (pay attention to the args). The artifacts are named the same and are in the same location, we only splinted the work. 

Backport of #10444