### PR TITLE
[CI][VSTS] Continue on profiles failure.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -368,6 +368,7 @@ steps:
     ./install-qa-provisioning-profiles.sh -v 
   displayName: 'Add tests provisioning profiles'
   timeoutInMinutes: 30
+  continueOnError: true # should not stop the build will result in test failures but we do want the pkg
   env:
     LOGIN_KEYCHAIN_PASSWORD: ${{ parameters.keyringPass }}
     SOURCES_DIR: $(Build.SourcesDirectory)


### PR DESCRIPTION
We want to continue and generate the pkgs, the failure of this step only
results in failing tests.

fixes: https://github.com/xamarin/maccore/issues/2376