### PR TITLE
[xcode12.3] [CI][VSTS] Remove ALL .xip

### DIFF
--- a/tools/devops/automation/scripts/bash/clean-bot.sh
+++ b/tools/devops/automation/scripts/bash/clean-bot.sh
@@ -107,7 +107,7 @@ oldXcodes=(
 
 # remove wrongly added .xip files under /Applications, confuses provisionator and 
 # are not needed and wrong
-sudo rm -Rf /Applications/Xcode*.xip
+sudo rm -Rf /Applications/*.xip
 
 for oldXcode in "${oldXcodes[@]}"; do
     sudo rm -Rf "$oldXcode"


### PR DESCRIPTION
This is clearly something that has a human behind it and not a script. We
have seen Xcode*.xip which is the download name BUT also xcode12.xip
which looks like a point&click intervention
(https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4387395&view=logs&j=f0137cdf-e292-5541-69aa-72303a08a0ba&t=59bea1c0-f907-5818-000e-f6fef9d3ffa2&l=234)

Backport of #10483