### PR TITLE
[monotouch-test] Be more descriptive and clean up stuff added to the keychain.

### DIFF
--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -597,30 +597,43 @@ namespace MonoTouchFixtures.Security {
 			att.CanVerify = false;
 			att.CanUnwrap = false;
 
-			Assert.That (SecKey.GenerateKeyPair (SecKeyType.RSA, 1024, att, out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair");
-			Assert.Throws<ArgumentException> (() => { SecKey.GenerateKeyPair (SecKeyType.Invalid, -1, null, out _, out _); }, "GenerateKeyPair - Invalid");
-			Assert.That (SecKey.GenerateKeyPair (SecKeyType.RSA, -1, null, out _, out _), Is.EqualTo (SecStatusCode.Param), "GenerateKeyPair - Param issue, invalid RSA key size");
-			Assert.That (SecKey.GenerateKeyPair (SecKeyType.RSA, 1024, null, out _, out _), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair - Null optional params, success");
+			try {
+				Assert.That (SecKey.GenerateKeyPair (SecKeyType.RSA, 1024, att, out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair");
+
+
+				Assert.Throws<ArgumentException> (() => { SecKey.GenerateKeyPair (SecKeyType.Invalid, -1, null, out _, out _); }, "GenerateKeyPair - Invalid");
+				Assert.That (SecKey.GenerateKeyPair (SecKeyType.RSA, -1, null, out _, out _), Is.EqualTo (SecStatusCode.Param), "GenerateKeyPair - Param issue, invalid RSA key size");
+				Assert.That (SecKey.GenerateKeyPair (SecKeyType.RSA, 1024, null, out _, out _), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair - Null optional params, success");
 
 #if IOS
-			var att2 = new SecPublicPrivateKeyAttrs ();
-			att2.IsPermanent = false;
-			att2.EffectiveKeySize = 1024;
-			att2.CanEncrypt = true;
-			att2.CanDecrypt = true;
-			att2.CanDerive = true;
-			att2.CanSign = true;
-			att2.CanVerify = true;
-			att2.CanUnwrap = true;
-			Assert.That (SecKey.GenerateKeyPair (SecKeyType.RSA, 1024, att, att2, out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair - iOS Only API");
+				var att2 = new SecPublicPrivateKeyAttrs ();
+				att2.IsPermanent = false;
+				att2.EffectiveKeySize = 1024;
+				att2.CanEncrypt = true;
+				att2.CanDecrypt = true;
+				att2.CanDerive = true;
+				att2.CanSign = true;
+				att2.CanVerify = true;
+				att2.CanUnwrap = true;
+				Assert.That (SecKey.GenerateKeyPair (SecKeyType.RSA, 1024, att, att2, out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair - iOS Only API");
 #endif
-			if (TestRuntime.CheckXcodeVersion (8,0)) {
-				using (var attrs = public_key.GetAttributes ()) {
-					Assert.That (attrs.Count, Is.GreaterThan ((nuint) 0), "public/GetAttributes");
+				if (TestRuntime.CheckXcodeVersion (8, 0)) {
+					using (var attrs = public_key.GetAttributes ()) {
+						Assert.That (attrs.Count, Is.GreaterThan ((nuint) 0), "public/GetAttributes");
+					}
+					using (var attrs = private_key.GetAttributes ()) {
+						Assert.That (attrs.Count, Is.GreaterThan ((nuint) 0), "private/GetAttributes");
+					}
 				}
-				using (var attrs = private_key.GetAttributes ()) {
-					Assert.That (attrs.Count, Is.GreaterThan ((nuint) 0), "private/GetAttributes");
-				}
+			} finally {
+				var query = new SecRecord (SecKind.Key) {
+					Label = att.Label,
+				};
+				SecStatusCode code;
+				do {
+					// For some reason each call to SecKeyChain will only remove a single key, so do a loop.
+					code = SecKeyChain.Remove (query);
+				} while (code == SecStatusCode.Success);
 			}
 		}
 

--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -8,9 +8,12 @@
 //
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+
+using CoreFoundation;
 using Foundation;
 using Security;
 using ObjCRuntime;
@@ -583,8 +586,8 @@ namespace MonoTouchFixtures.Security {
 			SecKey private_key;
 			SecKey public_key;
 			var att = new SecPublicPrivateKeyAttrs ();
-			att.Label = "NotDefault";
-			att.IsPermanent = true;
+			att.Label = $"{CFBundle.GetMain ().Identifier}-{GetType ().FullName}-{Process.GetCurrentProcess ().Id}";
+			att.IsPermanent = false;
 			att.ApplicationTag = new NSData ();
 			att.EffectiveKeySize = 1024;
 			att.CanEncrypt = false;

--- a/tests/monotouch-test/Security/KeyTest.cs
+++ b/tests/monotouch-test/Security/KeyTest.cs
@@ -12,6 +12,8 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+
+using CoreFoundation;
 using Foundation;
 using Security;
 using ObjCRuntime;
@@ -531,7 +533,7 @@ namespace MonoTouchFixtures.Security {
 			keyGenerationParameters.IsPermanent = false;
 			var privateKeyAttributes = new SecKeyParameters ();
 			privateKeyAttributes.AccessControl = new SecAccessControl (SecAccessible.WhenUnlockedThisDeviceOnly, SecAccessControlCreateFlags.PrivateKeyUsage | SecAccessControlCreateFlags.UserPresence);
-			privateKeyAttributes.Label = "NotDefault";
+			privateKeyAttributes.Label = $"{CFBundle.GetMain ().Identifier}-{GetType ().FullName}-{Process.GetCurrentProcess ().Id}";
 			keyGenerationParameters.PrivateKeyAttrs = privateKeyAttributes;
 
 			NSError error;


### PR DESCRIPTION
Also make some generated keys non-permanent so that they're not added to the
keychain in the first place.