### PR TITLE
[d16-9] [CI][VSTS] Ensure that the required simulators are present in the machine

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -74,6 +74,12 @@ steps:
 
 - bash: |
     set -x
+    set -e
+    $(Build.SourcesDirectory)/xamarin-macios/system-dependencies.sh --provision-simulators
+  displayName: 'Provision simulators'
+
+- bash: |
+    set -x
     sudo rm -Rf /Developer/MonoTouch
     sudo rm -Rf /Library/Frameworks/Xamarin.iOS.framework
     sudo rm -Rf /Library/Frameworks/Xamarin.Mac.framework


### PR DESCRIPTION
There are two issues:

1. The pipeline should provision the simulators.
2. An issue in how xharness reports the failure: https://github.com/xamarin/maccore/issues/2375

This will ensure we are back running the tests as shown in https://github.com/xamarin/xamarin-macios/commit/65f1c3903a8e6892cd4e1830a43a42d81f78da60

Backport of #10486