### PR TITLE
[d16-9] [CI][VSTS] Set to no output vars back to be in the env.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -105,10 +105,10 @@ steps:
     $configVars = @{} # var name/value pair, later print twice, to process and debug
 
     $xamTop = "$(Build.SourcesDirectory)/xamarin-macios/"
-    $configVars.Add("XAM_TOP", $xamTop)
+    Write-Host "##vso[task.setvariable variable=XAM_TOP]$xamTop"
 
     $maccoreTop = "$(Build.SourcesDirectory)/maccore/"
-    $configVars.Add("MACCORE_TOP", $maccoreTop)
+    Write-Host "##vso[task.setvariable variable=MACCORE_TOP]$maccoreTop"
 
     $buildReason = "$(Build.Reason)"
     $buildSourceBranchName = "$(Build.SourceBranchName)"


### PR DESCRIPTION
If we set the variables as output variables they are not accessible by
the bash scripts resulting in a warning. This is a revert, all other are output vars and should be used the way they are.\n\nBackport of #10515