### PR TITLE
[xcode12.3] [CI][VSTS] Do not use ESRP when no pkgs is present or in a PR.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -318,6 +318,7 @@ steps:
 
 - pwsh: $(Build.SourcesDirectory)/release-scripts/notarize.ps1 -FolderForApps $(Build.SourcesDirectory)/package/notarized 
   displayName: 'ESRP notarizing packages' 
+  condition: and(succeeded(), contains(variables['configuration.SignPkgs'], 'True'), contains(variables['configuration.IsPr'], 'False')) # if we are a PR, do not use ESRP since is not supported
 
 - template: generate-workspace-info.yml@templates
   parameters:


### PR DESCRIPTION
Just executed if:

* succeeded - previous step that installs the plugin.
* we do want to sign pkgs
* we are not a pr.

Contains is used because 'eq' is buggy in certain hosts.

Backport of #10516