### PR TITLE
[d16-9] [Actions] Backports should use forks.

### DIFF
--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -21,3 +21,4 @@ jobs:
           backport_pipeline_id: ${{ secrets.BACKPORT_PIPELINEID }}
           ado_build_pat: ${{ secrets.ADO_BUILDPAT }}
           github_account_pat: ${{ secrets.SERVICEACCOUNT_PAT }}
+          use_fork: true


### PR DESCRIPTION
I updated the backport bot code to allow the use of a fork, but the default is false to minimize the impact in other teams.


Backport of #10530
