### PR TITLE
[VSTS][CI] Fix issues with the internal pool and VSTS git usage.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -34,7 +34,7 @@ steps:
     git config --global credential.helper store
     Set-Content -Path "$HOME/.git-credentials" -Value "https://$(GitHub.Token):x-oauth-basic@github.com`n" -NoNewline
 
-    # maccore is special, we use fetch there in some bash scripts, but VSTS uses https.. and some pools don't likve the above.. :/
+    # maccore is special, we use fetch there in some bash scripts, but VSTS uses https.. and some pools don't like the above.. :/
     cd $(System.DefaultWorkingDirectory)/maccore 
     git remote remove origin
     git remote add origin https://$(GitHub.Token)@github.com/xamarin/maccore.git

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -29,10 +29,17 @@ steps:
   clean: true
 
 - pwsh: |
-    rm -Rf "$HOME\.git-credentials"
+    # should we need sudo, no, but someone did something wrong in the images..
+    sudo rm -Rf "$HOME/.git-credentials"
     git config --global credential.helper store
-    Set-Content -Path "$HOME\.git-credentials" -Value "https://$(GitHub.Token):x-oauth-basic@github.com`n" -NoNewline
-  displayName: 'Add git creds store'
+    Set-Content -Path "$HOME/.git-credentials" -Value "https://$(GitHub.Token):x-oauth-basic@github.com`n" -NoNewline
+
+    # maccore is special, we use fetch there in some bash scripts, but VSTS uses https.. and some pools don't likve the above.. :/
+    cd $(System.DefaultWorkingDirectory)/maccore 
+    git remote remove origin
+    git remote add origin https://$(GitHub.Token)@github.com/xamarin/maccore.git
+    git remote # don't add -v else we see the pat
+  displayName: 'Clean git mess from VSTS'
 
 - powershell: |
     Write-Host "IsMacOS: ${IsMacOS}"
@@ -508,6 +515,7 @@ steps:
   condition: and(succeededOrFailed(), contains(variables['runTests.TESTS_RAN'], 'True')) # if tests did not run, there is nothing to do
 
 - pwsh: |
-    rm -Rf "$HOME\.git-credentials"
+    # should we need sudo, no, but someone did something wrong in the images..
+    sudo rm -Rf "$HOME/.git-credentials"
   displayName: 'Remove git creds store'
   condition: always()


### PR DESCRIPTION
The internal pool, for some reason, do not like the cred store. We need
this to fix the interaction with the maccore repo.

1. VSTS uses https
2. We need to set the pat and try no to modify all bash scripts.

We do so by changing the remote url of maccores git repo so that it
includes the pat.