### PR TITLE
[msbuild] Fix computing the frameworks directory for Mac Catalyst.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -973,8 +973,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<Target Name="_CollectFrameworks" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="$(_CollectFrameworksDependsOn)">
 		<PropertyGroup>
-			<_FrameworksDirectory Condition="'$(_PlatformName)' != 'macOS'">$(_AppBundlePath)/Frameworks</_FrameworksDirectory>
-			<_FrameworksDirectory Condition="'$(_PlatformName)' == 'macOS'">$(_AppBundlePath)/Contents/Frameworks</_FrameworksDirectory>
+			<_FrameworksDirectory Condition="'$(_FrameworksDirectory)' == '' And '$(_IsMacCatalyst)' == 'true'">$(_AppBundlePath)/Contents/Frameworks</_FrameworksDirectory>
+			<_FrameworksDirectory Condition="'$(_FrameworksDirectory)' == '' And '$(_PlatformName)' != 'macOS'">$(_AppBundlePath)/Frameworks</_FrameworksDirectory>
+			<_FrameworksDirectory Condition="'$(_FrameworksDirectory)' == '' And '$(_PlatformName)' == 'macOS'">$(_AppBundlePath)/Contents/Frameworks</_FrameworksDirectory>
 		</PropertyGroup>
 		<CollectFrameworks
 			SessionId="$(BuildSessionId)"


### PR DESCRIPTION
This is part 2 of making framework-test build on Mac Catalyst.

Contributes to https://github.com/xamarin/xamarin-macios/issues/10440.