### PR TITLE
[mtouch] Hardcode 'Xamarin.iOS' as an SDK assembly for the linker.

### DIFF
--- a/tools/linker/MonoTouch.Tuner/MonoTouchProfile.cs
+++ b/tools/linker/MonoTouch.Tuner/MonoTouchProfile.cs
@@ -11,6 +11,7 @@ namespace MonoTouch.Tuner {
 			switch (assemblyName) {
 			case "MonoTouch.Dialog-1":
 			case "MonoTouch.NUnitLite":
+			case "Xamarin.iOS": // The Xamarin.iOS.dll implementation assembly for Mac Catalyst.
 				return true;
 			default:
 				return assemblyName == product_assembly;


### PR DESCRIPTION
This is required for Mac Catalyst, where Xamarin.iOS is a special case.