### PR TITLE
[msbuild/tests] Fix support for XCFrameworks for Mac Catalyst.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ResolveFrameworksBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ResolveFrameworksBase.cs
@@ -124,12 +124,28 @@ namespace Xamarin.MacDev.Tasks {
 
 		protected string? ResolveXCFramework (string xcframework)
 		{
-			var platformName = PlatformFrameworkHelper.GetOperatingSystem (TargetFrameworkMoniker);
-			// PlatformFrameworkHelper.GetOperatingSystem returns "osx" which does not work for xcframework
-			if (platformName == "osx")
-				platformName = "macos";
+			string platformName;
 
-			var variant = SdkIsSimulator ? "simulator" : null;
+			switch (Platform) {
+			case Utils.ApplePlatform.MacCatalyst:
+				platformName = "ios";
+				break;
+			case Utils.ApplePlatform.MacOSX:
+				// PlatformFrameworkHelper.GetOperatingSystem returns "osx" which does not work for xcframework
+				platformName = "macos";
+				break;
+			default:
+				platformName = PlatformFrameworkHelper.GetOperatingSystem (TargetFrameworkMoniker);
+				break;
+			}
+
+			string? variant = null;
+			if (Platform == Utils.ApplePlatform.MacCatalyst) {
+				variant = "maccatalyst";
+			} else if (SdkIsSimulator) {
+				variant = "simulator";
+			}
+
 			try {
 				var plist = PDictionary.FromFile (Path.Combine (xcframework, "Info.plist"));
 				var path = ResolveXCFramework (plist, platformName, variant, Architectures!);

--- a/tests/xcframework-test/iOS/xcframework-test-ios.csproj
+++ b/tests/xcframework-test/iOS/xcframework-test-ios.csproj
@@ -30,7 +30,7 @@
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchFastDev>true</MtouchFastDev>
     <MtouchDebug>true</MtouchDebug>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>Apple Development</CodesignKey>
     <MtouchProfiling>true</MtouchProfiling>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <DeviceSpecificBuild>false</DeviceSpecificBuild>
@@ -44,7 +44,7 @@
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchFloat32>true</MtouchFloat32>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>Apple Development</CodesignKey>
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
@@ -57,7 +57,7 @@
     <MtouchArch>ARMv7</MtouchArch>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchFloat32>true</MtouchFloat32>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>Apple Development</CodesignKey>
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
@@ -70,7 +70,7 @@
     <MtouchArch>ARM64</MtouchArch>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchFloat32>true</MtouchFloat32>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>Apple Development</CodesignKey>
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
@@ -83,7 +83,7 @@
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchFloat32>true</MtouchFloat32>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>Apple Development</CodesignKey>
     <MtouchExtraArgs>--bitcode:full</MtouchExtraArgs>
     <MtouchUseLlvm>true</MtouchUseLlvm>
     <MtouchLink>SdkOnly</MtouchLink>
@@ -96,7 +96,7 @@
     <WarningLevel>4</WarningLevel>
     <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>Apple Development</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
@@ -110,7 +110,7 @@
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchFloat32>true</MtouchFloat32>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>Apple Development</CodesignKey>
     <DeviceSpecificBuild>true</DeviceSpecificBuild>
     <MtouchDebug>true</MtouchDebug>
     <MtouchProfiling>true</MtouchProfiling>
@@ -127,7 +127,7 @@
     <MtouchArch>ARMv7</MtouchArch>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchFloat32>true</MtouchFloat32>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>Apple Development</CodesignKey>
     <DeviceSpecificBuild>true</DeviceSpecificBuild>
     <MtouchDebug>true</MtouchDebug>
     <MtouchProfiling>true</MtouchProfiling>
@@ -144,7 +144,7 @@
     <MtouchArch>ARM64</MtouchArch>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchFloat32>true</MtouchFloat32>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>Apple Development</CodesignKey>
     <DeviceSpecificBuild>true</DeviceSpecificBuild>
     <MtouchDebug>true</MtouchDebug>
     <MtouchProfiling>true</MtouchProfiling>

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -393,7 +393,10 @@ namespace Xharness {
 				Name = "framework-test",
 				IgnoreMacCatalystVariation = false,
 			});
-			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "xcframework-test", "iOS", "xcframework-test-ios.csproj"))) { Name = "xcframework-test" });
+			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "xcframework-test", "iOS", "xcframework-test-ios.csproj"))) {
+				Name = "xcframework-test",
+				IgnoreMacCatalystVariation = false,
+			});
 
 			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bindings-test", "iOS", "bindings-test.csproj")), false) { Name = "bindings-test" });
 


### PR DESCRIPTION
This fixes the xcframework-test on Mac Catalyst.

Contributes to https://github.com/xamarin/xamarin-macios/issues/10440.