### PR TITLE
[.NET 6] make sure Run target depends on Build

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -681,7 +681,8 @@
 		<Exec Command="$(_MlaunchPath) $(_MlaunchInstallArguments)" />
 	</Target>
 
-	<Target Name="_PrepareRunMobile" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_InstallMobile" >
+	<!-- This is only needed for mobile platforms, RunCommand and RunArguments are defined for macOS in Microsoft.macOS.Sdk.targets. -->
+	<Target Name="_PrepareRunMobile" DependsOnTargets="_InstallMobile" Condition="'$(_PlatformName)' != 'macOS'">
 		<PropertyGroup>
 			<!-- capture output by default -->
 			<_MlaunchCaptureOutput Condition="'$(_MlaunchCaptureOutput)' == ''">true</_MlaunchCaptureOutput>
@@ -714,8 +715,7 @@
 		</PropertyGroup>
 	</Target>
 
-	<!-- This is only needed for mobile platforms, RunCommand and RunArguments are defined for macOS in Microsoft.macOS.Sdk.targets. -->
-	<Target Name="_PrepareRun" DependsOnTargets="_PrepareRunMobile" BeforeTargets="Run" Condition="'$(_PlatformName)' != 'macOS'" />
+	<Target Name="_PrepareRun" DependsOnTargets="Build;_PrepareRunMobile" BeforeTargets="Run" />
 
 	<!-- Import existing targets -->
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-macios/issues/10575

Running `dotnet build -t:Run` on a new project fails with:

    Xamarin.Shared.Sdk.targets(692,3): error MSB4018: The "GetMlaunchArguments" task failed unexpectedly.
    Xamarin.Shared.Sdk.targets(692,3): error MSB4018: System.IO.DirectoryNotFoundException: Could not find a part of the path '/Users/jopepper/src/net6-samples/HelloiOS/bin/Debug/net6.0-ios/ios-x64/HelloiOS.app\Info.plist'.
    Xamarin.Shared.Sdk.targets(692,3): error MSB4018:    at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirectory, Func`2 errorRewriter)
    Xamarin.Shared.Sdk.targets(692,3): error MSB4018:    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode)
    Xamarin.Shared.Sdk.targets(692,3): error MSB4018:    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
    Xamarin.Shared.Sdk.targets(692,3): error MSB4018:    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access)
    Xamarin.Shared.Sdk.targets(692,3): error MSB4018:    at Xamarin.MacDev.PObject.FromFile(String fileName, Boolean& isBinary) in /Users/builder/azdo/_work/1/s/xamarin-macios/external/Xamarin.MacDev/Xamarin.MacDev/PListObject.cs:line 344
    Xamarin.Shared.Sdk.targets(692,3): error MSB4018:    at Xamarin.MacDev.PDictionary.FromFile(String fileName, Boolean& isBinary) in /Users/builder/azdo/_work/1/s/xamarin-macios/external/Xamarin.MacDev/Xamarin.MacDev/PListObject.cs:line 774
    Xamarin.Shared.Sdk.targets(692,3): error MSB4018:    at Xamarin.MacDev.PDictionary.FromFile(String fileName) in /Users/builder/azdo/_work/1/s/xamarin-macios/external/Xamarin.MacDev/Xamarin.MacDev/PListObject.cs:line 761
    Xamarin.Shared.Sdk.targets(692,3): error MSB4018:    at Xamarin.iOS.Tasks.GetMlaunchArgumentsTaskBase.get_DeviceType() in /Users/builder/azdo/_work/1/s/xamarin-macios/msbuild/Xamarin.iOS.Tasks.Core/Tasks/GetMlaunchArgumentsTaskBase.cs:line 53
    Xamarin.Shared.Sdk.targets(692,3): error MSB4018:    at Xamarin.iOS.Tasks.GetMlaunchArgumentsTaskBase.GetDeviceTypes() in /Users/builder/azdo/_work/1/s/xamarin-macios/msbuild/Xamarin.iOS.Tasks.Core/Tasks/GetMlaunchArgumentsTaskBase.cs:line 72
    Xamarin.Shared.Sdk.targets(692,3): error MSB4018:    at Xamarin.iOS.Tasks.GetMlaunchArgumentsTaskBase.GenerateCommandLineCommands() in /Users/builder/azdo/_work/1/s/xamarin-macios/msbuild/Xamarin.iOS.Tasks.Core/Tasks/GetMlaunchArgumentsTaskBase.cs:line 128
    Xamarin.Shared.Sdk.targets(692,3): error MSB4018:    at Xamarin.iOS.Tasks.GetMlaunchArgumentsTaskBase.Execute() in /Users/builder/azdo/_work/1/s/xamarin-macios/msbuild/Xamarin.iOS.Tasks.Core/Tasks/GetMlaunchArgumentsTaskBase.cs:line 199
    Xamarin.Shared.Sdk.targets(692,3): error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
    Xamarin.Shared.Sdk.targets(692,3): error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)

Unless you do `dotnet build` and `dotnet build -t:Run` in two steps.

It doesn't look like the built-in .NET 6 `Run` target depends on `Build`
at all:

https://github.com/dotnet/sdk/blob/91c1326f478598c13095bf8bd5ee06246633730c/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets#L865-L867

So let's reorganize things to fix this:

* `_PrepareRun` now runs on all platforms, it depends on `Build`.
* `_PrepareRunMobile` now has the condition so it will not run on macOS.
* `_PrepareRunMobile` doesn't need as many targets listed in
`DependsOnTargets` now, because `Build` has already run.