### PR TITLE
[introspection] Stop hardcoding minimum OS versions.

### DIFF
--- a/src/MediaToolbox/MTAudioProcessingTap.cs
+++ b/src/MediaToolbox/MTAudioProcessingTap.cs
@@ -43,7 +43,6 @@ using CoreMedia;
 
 namespace MediaToolbox
 {
-	[iOS (6,0)][Mac (10,9)]
 	public class MTAudioProcessingTap : INativeObject
 #if !COREBUILD
 , IDisposable

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -3878,7 +3878,7 @@ namespace AVFoundation {
 		[Export ("finishLoadingWithResponse:data:redirect:")]
 		[Deprecated (PlatformName.MacOSX, 10, 15, message : "Use the 'Response', 'Redirect' properties and the 'AVAssetResourceLoadingDataRequest.Responds' and 'AVAssetResourceLoadingRequest.FinishLoading' methods instead.")]
 		[Deprecated (PlatformName.TvOS, 9, 0, message : "Use the 'Response', 'Redirect' properties and the 'AVAssetResourceLoadingDataRequest.Responds' and 'AVAssetResourceLoadingRequest.FinishLoading' methods instead.")]
-		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_7_0, Message = "Use the 'Response', 'Redirect' properties and the 'AVAssetResourceLoadingDataRequest.Responds' and 'AVAssetResourceLoadingRequest.FinishLoading' methods instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'Response', 'Redirect' properties and the 'AVAssetResourceLoadingDataRequest.Responds' and 'AVAssetResourceLoadingRequest.FinishLoading' methods instead.")]
 		void FinishLoading ([NullAllowed] NSUrlResponse usingResponse, [NullAllowed] NSData data, [NullAllowed] NSUrlRequest redirect);
 
 		[Export ("finishLoadingWithError:")]

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -610,7 +610,7 @@ namespace CoreBluetooth {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_8_4)]
+		[Availability (Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_8_4)]
 		[Export ("peripheralDidInvalidateServices:")]
 		void InvalidatedService (CBPeripheral peripheral);	
 

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -15796,7 +15796,6 @@ namespace Foundation
 		string ToString (NSUnit unit);
 	}
 
-	[Mac (10, 9)][iOS (6, 0)][Watch (2, 0)][TV (9, 0)]
 	[BaseType (typeof (NSObject), Name = "NSXPCConnection")]
 	[DisableDefaultCtor]
 	interface NSXpcConnection
@@ -15878,7 +15877,6 @@ namespace Foundation
 
 	interface INSXpcListenerDelegate {}
 
-	[Mac (10, 9)][iOS (6, 0)][Watch (2, 0)][TV (9, 0)]
 	[BaseType (typeof (NSObject), Name = "NSXPCListener", Delegates = new string[] { "WeakDelegate" })]
 	[DisableDefaultCtor]
 	interface NSXpcListener
@@ -15925,7 +15923,6 @@ namespace Foundation
 	}
 
 	[BaseType (typeof (NSObject), Name = "NSXPCInterface")]
-	[Mac (10, 9)][iOS (6, 0)][Watch (2, 0)][TV (9, 0)]
 	[DisableDefaultCtor]
 	interface NSXpcInterface
 	{
@@ -15945,7 +15942,6 @@ namespace Foundation
 		// Methods taking xpc_type_t have been skipped.
 	}
 
-	[iOS (6,0), Watch (2,0), TV (9,0)]
 	[BaseType (typeof (NSObject), Name = "NSXPCListenerEndpoint")]
 	[DisableDefaultCtor]
 	interface NSXpcListenerEndpoint : NSSecureCoding

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -89,7 +89,7 @@ public static class ReflectionExtensions {
 	// of [NoiOS] or [NoMac] are applied.
 	//
 	// This needs to merge, because we might have multiple attributes in
-	// use, for example, the availability (iOS (6,0)) and the fact that this
+	// use, for example, the availability (iOS (7,0)) and the fact that this
 	// is not available on Mac (NoMac).
 	//
 	public static bool IsUnavailable (this ICustomAttributeProvider provider, Generator generator)

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -8585,7 +8585,7 @@ namespace UIKit {
 
 		[NoTV]
 		[Export ("adjustsLetterSpacingToFitWidth")]
-		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_7_0, Message = "Use 'NSKernAttributeName' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'NSKernAttributeName' instead.")]
 		bool AdjustsLetterSpacingToFitWidth { get; set;  }
 
 		[Export ("minimumScaleFactor")]

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -38,18 +38,16 @@ namespace Introspection {
 			Maximum = Version.Parse (Constants.SdkVersion);
 #if __IOS__
 			Platform = PlatformName.iOS;
-			Minimum = new Version (6,0);
+			Minimum = Xamarin.SdkVersions.MiniOSVersion;
 #elif __TVOS__
 			Platform = PlatformName.TvOS;
-			Minimum = new Version (9,0);
+			Minimum = Xamarin.SdkVersions.MinTVOSVersion;
 #elif __WATCHOS__
 			Platform = PlatformName.WatchOS;
-			Minimum = new Version (2,0);
-			// Need to special case watchOS 'Maximum' version for OS minor subversions (can't change Constants.SdkVersion)
-			//Maximum = new Version (6,2,5);
+			Minimum = Xamarin.SdkVersions.MinWatchOSVersion;
 #else
 			Platform = PlatformName.MacOSX;
-			Minimum = new Version (10,9);
+			Minimum = Xamarin.SdkVersions.MinOSXVersion;
 			// Need to special case macOS 'Maximum' version for OS minor subversions (can't change Constants.SdkVersion)
 			// Please comment the code below if needed
 			Maximum = new Version (11,1,0);

--- a/tests/introspection/Mac/introspection-mac.csproj
+++ b/tests/introspection/Mac/introspection-mac.csproj
@@ -136,6 +136,9 @@
     <Compile Include="..\..\..\tools\common\Frameworks.cs">
       <Link>Frameworks.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="..\ApiFrameworkTest.cs">
       <Link>ApiFrameworkTest.cs</Link>
     </Compile>

--- a/tests/introspection/dotnet/iOS/introspection.csproj
+++ b/tests/introspection/dotnet/iOS/introspection.csproj
@@ -109,6 +109,9 @@
     <Compile Include="..\..\..\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="..\..\ApiFrameworkTest.cs">
       <Link>ApiFrameworkTest.cs</Link>
     </Compile>

--- a/tests/introspection/dotnet/tvOS/introspection.csproj
+++ b/tests/introspection/dotnet/tvOS/introspection.csproj
@@ -106,6 +106,9 @@
     <Compile Include="..\..\..\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="..\..\ApiFrameworkTest.cs">
       <Link>ApiFrameworkTest.cs</Link>
     </Compile>

--- a/tests/introspection/iOS/introspection-ios.csproj
+++ b/tests/introspection/iOS/introspection-ios.csproj
@@ -230,6 +230,9 @@
     <Compile Include="..\..\..\tools\common\Frameworks.cs">
       <Link>Frameworks.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="..\ApiFrameworkTest.cs">
       <Link>ApiFrameworkTest.cs</Link>
     </Compile>


### PR DESCRIPTION
Stop hardcoding minimum OS versions, we have this information already in
source format, so use that.

This also showed that we had a few unnecessary availability attributes, so I
removed those.