### PR TITLE
[xcode12.5] Bump minimum version of simulators (as required for BigSur)

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -183,13 +183,13 @@ MIN_TVOS_SDK_VERSION=9.0
 MIN_MACCATALYST_SDK_VERSION=13.1
 
 # The min simulator version available in the Xcode we're using
-MIN_IOS_SIMULATOR_VERSION=10.3
-MIN_WATCHOS_SIMULATOR_VERSION=3.2
+MIN_IOS_SIMULATOR_VERSION=11.4
+MIN_WATCHOS_SIMULATOR_VERSION=5.0
 # This is the iOS version that matches the watchOS version (i.e same Xcode)
-MIN_WATCHOS_COMPANION_SIMULATOR_VERSION=10.3
-MIN_TVOS_SIMULATOR_VERSION=10.2
+MIN_WATCHOS_COMPANION_SIMULATOR_VERSION=12.0
+MIN_TVOS_SIMULATOR_VERSION=11.4
 # These are the simulator package ids for the versions above
-EXTRA_SIMULATORS=com.apple.pkg.iPhoneSimulatorSDK10_3 com.apple.pkg.AppleTVSimulatorSDK10_2 com.apple.pkg.WatchSimulatorSDK3_2
+EXTRA_SIMULATORS=com.apple.pkg.iPhoneSimulatorSDK11_4 com.apple.pkg.iPhoneSimulatorSDK12_0 com.apple.pkg.AppleTVSimulatorSDK11_4 com.apple.pkg.WatchSimulatorSDK5_0
 
 INCLUDE_IOS=1
 INCLUDE_MAC=1

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -1995,7 +1995,7 @@ namespace CoreImage {
 		[Export ("initWithPortaitEffectsMatte:options:")] // selector typo, rdar filled 42894821
 		IntPtr Constructor (AVPortraitEffectsMatte matte, [NullAllowed] NSDictionary options);
 
-		[TV (11,0), iOS (11,0), Mac (10, 14)]
+		[TV (12,0), iOS (12,0), Mac (10, 14)]
 		[Export ("initWithPortaitEffectsMatte:")] // selector typo, rdar filled 42894821
 		IntPtr Constructor (AVPortraitEffectsMatte matte);
 

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -13684,7 +13684,7 @@ namespace Intents {
 		INCallCapability CallCapability { get; }
 	}
 
-	[Watch (4,0), NoTV, NoMac, iOS (11,0)]
+	[Watch (7,0), NoTV, NoMac, iOS (14,0)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	interface INCallRecordResolutionResult {
 

--- a/tests/introspection/iOS/iOSApiProtocolTest.cs
+++ b/tests/introspection/iOS/iOSApiProtocolTest.cs
@@ -158,6 +158,15 @@ namespace Introspection {
 				if (protocolName == "UIUserActivityRestoring")
 					return true;
 				break;
+			case "ARImageAnchor":
+				// both type and protocol were added in iOS 11.3 but the conformance, for that type, started with iOS 12.0
+				if (protocolName == "ARTrackable")
+					return !TestRuntime.CheckXcodeVersion (10,0);
+				break;
+			case "PHLivePhoto":
+				if (protocolName == "NSItemProviderReading")
+					return !TestRuntime.CheckXcodeVersion (10,0);
+				break;
 			}
 
 			switch (protocolName) {

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -386,6 +386,15 @@ namespace Introspection {
 					break;
 				}
 				break;
+			// ARImageAnchor was added in iOS 11.3 but the conformance to ARTrackable, where `isTracked` comes from, started with iOS 12.0
+			case "ARImageAnchor":
+				switch (name) {
+				case "isTracked":
+					if (!TestRuntime.CheckXcodeVersion (10,0))
+						return true;
+					break;
+				}
+				break;
 #endif
 			break;
 		}
@@ -789,6 +798,10 @@ namespace Introspection {
 				case "SKAttributeValue":
 					return !TestRuntime.CheckXcodeVersion (7, 2);
 #endif
+				case "MLDictionaryFeatureProvider":
+				case "MLMultiArray":
+				case "MLFeatureValue":
+					return !TestRuntime.CheckXcodeVersion (10,0);
 				}
 				break;
 			case "mutableCopyWithZone:":
@@ -824,6 +837,16 @@ namespace Introspection {
 						return true;
 					// was a private framework (on iOS) before Xcode 9.0 (shortcut logic)
 					if (!TestRuntime.CheckXcodeVersion (9, 0))
+						return true;
+					break;
+				}
+				break;
+			case "objectWithItemProviderData:typeIdentifier:error:":
+			case "readableTypeIdentifiersForItemProvider":
+				switch (declaredType.Name) {
+				case "PHLivePhoto":
+					// not yet conforming to NSItemProviderReading
+					if (!TestRuntime.CheckXcodeVersion (10,0))
 						return true;
 					break;
 				}


### PR DESCRIPTION
Moving to macOS 11.x (BigSur) requires us to bump the minimum/tested
version of simulators to the oldest supported by the required OS.

This means iOS 11.4, tvOS 11.4 and watchOS 5.0 (with iOS 12).

xharness needs to be updated in order for watchOS 5.0, which needs
series 3, to work properly.

Filed as https://github.com/xamarin/xamarin-macios/issues/10593