### PR TITLE
[main] Update NuGet feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,10 +4,14 @@
 		<add key="repositorypath" value="packages" />
 	</config>
 	<packageSources>
-		<add key="Nuget Official" value ="https://www.nuget.org/api/v2/" />
+		<clear />
+		<add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
 		<add key="Dotnet arcade" value ="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
 		<add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
 		<add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
 	</packageSources>
+	<disabledPackageSources>
+		<clear />
+	</disabledPackageSources>
 </configuration>
 

--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 0dfeb85ff607f6d0bb4063de4f4b91c4161b8e55
+NEEDED_MACCORE_VERSION := b5332e51dd2c93a79f770139038304b7847d41bb
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
bump maccore for dependencies updates

New commits in xamarin/maccore:

* xamarin/maccore@b5332e51dd Remove dependency on XmlDocSync repo/tools (#2391)
* xamarin/maccore@e2a8db0a93 Update NuGet.config to enforce a single feed (#2372)
* xamarin/maccore@1a2648bfea Keychain file computed incorrectly on Big Sur (#2388)
* xamarin/maccore@de616ca53e [mlaunch] Fix dependencies for Xcode 12.5 beta 1 (#2387)
* xamarin/maccore@e93375583c [Actions] Fix rebase trigger.

Diff: https://github.com/xamarin/maccore/compare/0dfeb85ff607f6d0bb4063de4f4b91c4161b8e55..b5332e51dd2c93a79f770139038304b7847d41bb