### PR TITLE
[d16-9] [monotouch-test] Rework big parts of KeyChainTest. Fixes #xamarin/maccore@2365.

### DIFF
--- a/tests/monotouch-test/Security/KeyChainTest.cs
+++ b/tests/monotouch-test/Security/KeyChainTest.cs
@@ -194,24 +194,15 @@ namespace MonoTouchFixtures.Security {
 			record.Generic = NSData.FromString (Convert.ToString (setID), NSStringEncoding.UTF8);
 			record.Accessible = SecAccessible.Always;
 			record.Label = RecordLabel;
-
-			Query (queryRec, "SetID 1 - before add");
-
 			SecStatusCode code = SecKeyChain.Add (record);
-
-			Query (queryRec, $"SetID 1 - after add, rv: {code}");
-
 			if (code == SecStatusCode.DuplicateItem) {
 				code = RemoveID ();
-				Query (queryRec, $"SetID 1 - after remove, rv: {code}");
-				if (code == SecStatusCode.Success) {
+				if (code == SecStatusCode.Success)
 					code = SecKeyChain.Add (record);
-					Query (queryRec, $"SetID 1 - after readd, rv: {code}");
-				}
 			}
 			return code;
 		}
-
+		
 		[Test]
 		public void CheckId ()
 		{
@@ -219,75 +210,12 @@ namespace MonoTouchFixtures.Security {
 			// test case from http://stackoverflow.com/questions/9481860/monotouch-cant-get-value-of-existing-keychain-item
 			// not a bug (no class lib fix) just a misuse of the API wrt status codes
 			Guid g = Guid.NewGuid ();
-			Query ("CheckID before add");
 			try {
 				Assert.That (SetID (g), Is.EqualTo (SecStatusCode.Success), "success");
-				Query ("CheckID after add");
 				Assert.That (GetID (), Is.EqualTo (g), "same guid");
 			} finally {
 				RemoveID ();
-				Query ("CheckID after cleanup");
 			}
-		}
-
-		void Query (SecRecord query, string name = "Query.")
-		{
-			Console.WriteLine ($"{name} Service: {query.Service} Label: {query.Label} Account: {query.Account}");
-			var records = SecKeyChain.QueryAsRecord (query, 10, out var code);
-			if (records != null) {
-				Console.WriteLine ($"    Query result: {code}. Got back {records?.Length} records:");
-				if (records != null) {
-					for (var i = 0; i < records.Length; i++) {
-						var rec = records [i];
-						Console.WriteLine ($"        #{i + 1}: {rec} - Service: {rec.Service} Label: {rec.Label} Account: {rec.Account}");
-					}
-				}
-			} else {
-				Console.WriteLine ($"    Query result: {code}. No results.");
-			}
-		}
-
-		void Query (string name = "Query:")
-		{
-			var queryRec = new SecRecord (SecKind.GenericPassword) {
-				Service = "KEYCHAIN_SERVICE",
-				Label = RecordLabel,
-				Account = "KEYCHAIN_ACCOUNT"
-			};
-			Query (queryRec, name);
-
-
-			queryRec = new SecRecord (SecKind.GenericPassword) {
-				Label = RecordLabel,
-				Account = "KEYCHAIN_ACCOUNT"
-			};
-
-			queryRec = new SecRecord (SecKind.GenericPassword) {
-				Service = "KEYCHAIN_SERVICE",
-				Account = "KEYCHAIN_ACCOUNT"
-			};
-			Query (queryRec, name);
-
-			queryRec = new SecRecord (SecKind.GenericPassword) {
-				Service = "KEYCHAIN_SERVICE",
-				Label = RecordLabel,
-			};
-			Query (queryRec, name);
-
-
-			queryRec = new SecRecord (SecKind.GenericPassword) {
-				Account = "KEYCHAIN_ACCOUNT"
-			};
-			Query (queryRec, name);
-
-			queryRec = new SecRecord (SecKind.GenericPassword) {
-				Label = RecordLabel,
-			};
-			Query (queryRec, name);
-			queryRec = new SecRecord (SecKind.GenericPassword) {
-				Service = "KEYCHAIN_SERVICE",
-			};
-			Query (queryRec, name);
 		}
 	}
 }

--- a/tests/monotouch-test/Security/KeyChainTest.cs
+++ b/tests/monotouch-test/Security/KeyChainTest.cs
@@ -194,15 +194,24 @@ namespace MonoTouchFixtures.Security {
 			record.Generic = NSData.FromString (Convert.ToString (setID), NSStringEncoding.UTF8);
 			record.Accessible = SecAccessible.Always;
 			record.Label = RecordLabel;
+
+			Query (queryRec, "SetID 1 - before add");
+
 			SecStatusCode code = SecKeyChain.Add (record);
+
+			Query (queryRec, $"SetID 1 - after add, rv: {code}");
+
 			if (code == SecStatusCode.DuplicateItem) {
 				code = RemoveID ();
-				if (code == SecStatusCode.Success)
+				Query (queryRec, $"SetID 1 - after remove, rv: {code}");
+				if (code == SecStatusCode.Success) {
 					code = SecKeyChain.Add (record);
+					Query (queryRec, $"SetID 1 - after readd, rv: {code}");
+				}
 			}
 			return code;
 		}
-		
+
 		[Test]
 		public void CheckId ()
 		{
@@ -210,12 +219,75 @@ namespace MonoTouchFixtures.Security {
 			// test case from http://stackoverflow.com/questions/9481860/monotouch-cant-get-value-of-existing-keychain-item
 			// not a bug (no class lib fix) just a misuse of the API wrt status codes
 			Guid g = Guid.NewGuid ();
+			Query ("CheckID before add");
 			try {
 				Assert.That (SetID (g), Is.EqualTo (SecStatusCode.Success), "success");
+				Query ("CheckID after add");
 				Assert.That (GetID (), Is.EqualTo (g), "same guid");
 			} finally {
 				RemoveID ();
+				Query ("CheckID after cleanup");
 			}
+		}
+
+		void Query (SecRecord query, string name = "Query.")
+		{
+			Console.WriteLine ($"{name} Service: {query.Service} Label: {query.Label} Account: {query.Account}");
+			var records = SecKeyChain.QueryAsRecord (query, 10, out var code);
+			if (records != null) {
+				Console.WriteLine ($"    Query result: {code}. Got back {records?.Length} records:");
+				if (records != null) {
+					for (var i = 0; i < records.Length; i++) {
+						var rec = records [i];
+						Console.WriteLine ($"        #{i + 1}: {rec} - Service: {rec.Service} Label: {rec.Label} Account: {rec.Account}");
+					}
+				}
+			} else {
+				Console.WriteLine ($"    Query result: {code}. No results.");
+			}
+		}
+
+		void Query (string name = "Query:")
+		{
+			var queryRec = new SecRecord (SecKind.GenericPassword) {
+				Service = "KEYCHAIN_SERVICE",
+				Label = RecordLabel,
+				Account = "KEYCHAIN_ACCOUNT"
+			};
+			Query (queryRec, name);
+
+
+			queryRec = new SecRecord (SecKind.GenericPassword) {
+				Label = RecordLabel,
+				Account = "KEYCHAIN_ACCOUNT"
+			};
+
+			queryRec = new SecRecord (SecKind.GenericPassword) {
+				Service = "KEYCHAIN_SERVICE",
+				Account = "KEYCHAIN_ACCOUNT"
+			};
+			Query (queryRec, name);
+
+			queryRec = new SecRecord (SecKind.GenericPassword) {
+				Service = "KEYCHAIN_SERVICE",
+				Label = RecordLabel,
+			};
+			Query (queryRec, name);
+
+
+			queryRec = new SecRecord (SecKind.GenericPassword) {
+				Account = "KEYCHAIN_ACCOUNT"
+			};
+			Query (queryRec, name);
+
+			queryRec = new SecRecord (SecKind.GenericPassword) {
+				Label = RecordLabel,
+			};
+			Query (queryRec, name);
+			queryRec = new SecRecord (SecKind.GenericPassword) {
+				Service = "KEYCHAIN_SERVICE",
+			};
+			Query (queryRec, name);
 		}
 	}
 }

--- a/tests/monotouch-test/Security/RecordTest.cs
+++ b/tests/monotouch-test/Security/RecordTest.cs
@@ -1,6 +1,9 @@
 // Copyright 2014-2015 Xamarin Inc. All rights reserved
 
 using System;
+using System.Diagnostics;
+
+using CoreFoundation;
 using Foundation;
 using Security;
 #if MONOMAC
@@ -165,7 +168,7 @@ namespace MonoTouchFixtures.Security {
 			SecKeyChain.Remove (rec); // it might already exists (or not)
 
 			rec = new SecRecord (SecKind.InternetPassword) {
-				Account = "AuthenticationType",
+				Account = $"{CFBundle.GetMain ().Identifier}-{GetType ().FullName}-{Process.GetCurrentProcess ().Id}",
 				ValueData = NSData.FromString ("Password"),
 				AuthenticationType = type,
 				Server = "www.xamarin.com"
@@ -173,8 +176,14 @@ namespace MonoTouchFixtures.Security {
 
 			Assert.That (SecKeyChain.Add (rec), Is.EqualTo (SecStatusCode.Success), "Add");
 
+			var query = new SecRecord (SecKind.InternetPassword) {
+				Account = rec.Account,
+				AuthenticationType = rec.AuthenticationType,
+				Server = rec.Server,
+			};
+
 			SecStatusCode code;
-			var match = SecKeyChain.QueryAsRecord (rec, out code);
+			var match = SecKeyChain.QueryAsRecord (query, out code);
 			Assert.That (code, Is.EqualTo (SecStatusCode.Success), "QueryAsRecord");
 
 			Assert.That (match.AuthenticationType, Is.EqualTo (type), "AuthenticationType");


### PR DESCRIPTION
'GenericPassword' keychain items are unique by their Service+Account
properties [1]. This means that changing the Label property will not create a
different 'GenericPassword', which has a few consequences:

* It's possible to filter (and try to delete) using the Label property.
* It's possible to try to delete a 'GenericPassword' item, and have that
  deletion attempt fail with 'no item found', and then subsequently trying to
  add the same item will fail with a DuplicateItem, because the deletion
  was filtered using the Label property.

The change I've made is to:

* Make the Label property much more descriptive, and unique per process. This
  makes it easier to figure out where things come from in the Keychain Access
  app.
* Make the Service property unique per process. This way these tests are
  parallel safe and they won't stomp on eachother.
* Keep the Account property the same (a constant value), so that it's easy to
  filter to just these items in the Keychain Access app.
* Remove the Label property from all queries, it doesn't matter anyway. The
  Label property is still set when adding items to the keychain.

Finally try to clean up after ourselves as good as possible. This way we don't
fill the keychain with test stuff. This involves removing certificates and
passwords we add to the keychain at the end of tests.

Fixes https://github.com/xamarin/maccore/issues/2365.

[1]: https://stackoverflow.com/a/11672200/183422


Backport of #10492
