### PR TITLE
[CI] Nugets should not stop the build.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -367,6 +367,7 @@ steps:
     nuGetFeedType: external
     publishFeedCredentials: xamarin-impl public feed
   condition: and(succeeded(), eq(variables['configuration.BuildNugets'], 'True'))
+  continueOnError: true # should not stop the build since is not official just yet.
 
 - bash: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/productsign.sh
   env:


### PR DESCRIPTION
This happens just in very few cases when we have two builds for the same hash in different branches. This is not common, except when we are branching. A cherry-pick does create a new hash yet same message and change, therefore cherry-picks have never been an issue, just branching without new commits.