### PR TITLE
[msbuild] Bump Xamarin.MacDev and use AppleSdkVersion instead of MacOSXSdkVersion/IPhoneSdkVersion.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
@@ -7,7 +7,8 @@ namespace Xamarin.Mac.Tasks
 	{
 		protected override IAppleSdkVersion GetDefaultSdkVersion ()
 		{
-			return MacOSXSdkVersion.GetDefault (CurrentSdk);
+			var v = CurrentSdk.GetInstalledSdkVersions (false);
+			return v.Count > 0 ? v [v.Count - 1] : AppleSdkVersion.UseDefault;
 		}
 
 		protected override string GetDefaultXamarinSdkRoot ()

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskCore.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskCore.cs
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks
 	public abstract class CompileAppManifestTaskCore : CompileAppManifestTaskBase
 	{
 		IPhoneDeviceType supportedDevices;
-		IPhoneSdkVersion sdkVersion;
+		AppleSdkVersion sdkVersion;
 
 		bool IsIOS { get { return Platform == ApplePlatform.iOS; } }
 
@@ -23,7 +23,7 @@ namespace Xamarin.iOS.Tasks
 		{
 			var currentSDK = Sdks.GetAppleSdk (Platform);
 
-			sdkVersion = IPhoneSdkVersion.Parse (DefaultSdkVersion);
+			sdkVersion = AppleSdkVersion.Parse (DefaultSdkVersion);
 			if (!currentSDK.SdkIsInstalled (sdkVersion, SdkIsSimulator)) {
 				Log.LogError (null, null, null, null, 0, 0, 0, 0, MSBStrings.E0013, Platform, sdkVersion);
 				return false;
@@ -295,7 +295,7 @@ namespace Xamarin.iOS.Tasks
 			var supportsIPad = (supportedDevices & IPhoneDeviceType.IPad) != 0;
 
 			// Validation...
-			if (!IsAppExtension && sdkVersion >= IPhoneSdkVersion.V3_2) {
+			if (!IsAppExtension && sdkVersion >= AppleSdkVersion.V3_2) {
 				IPhoneOrientation orientation;
 
 				if (supportsIPhone) {

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
@@ -9,7 +9,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		protected override IAppleSdkVersion GetDefaultSdkVersion ()
 		{
-			return IPhoneSdkVersion.UseDefault;
+			return AppleSdkVersion.UseDefault;
 		}
 
 		public override bool Execute ()

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ResolveNativeWatchAppTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ResolveNativeWatchAppTaskBase.cs
@@ -39,11 +39,11 @@ namespace Xamarin.iOS.Tasks
 		public override bool Execute ()
 		{
 			var currentSdk = Sdks.GetSdk (TargetFrameworkMoniker);
-			IPhoneSdkVersion version;
+			AppleSdkVersion version;
 			string sdk_path;
 
 			if (IsWatchFramework) {
-				if (!IPhoneSdkVersion.TryParse (SdkVersion, out version)) {
+				if (!AppleSdkVersion.TryParse (SdkVersion, out version)) {
 					Log.LogError (MSBStrings.E0066, SdkVersion);
 					return false;
 				}
@@ -60,12 +60,12 @@ namespace Xamarin.iOS.Tasks
 					return false;
 				}
 
-				if (!IPhoneSdkVersion.TryParse (SdkVersion, out version)) {
+				if (!AppleSdkVersion.TryParse (SdkVersion, out version)) {
 					Log.LogError (MSBStrings.E0066, SdkVersion);
 					return false;
 				}
 
-				if (version < IPhoneSdkVersion.V8_2) {
+				if (version < AppleSdkVersion.V8_2) {
 					Log.LogError (MSBStrings.E0069, version);
 					return false;
 				}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_iOS.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_iOS.cs
@@ -11,7 +11,7 @@ namespace Xamarin.iOS.Tasks
 		public override void ConfigureTask ()
 		{
 			base.ConfigureTask ();
-			Task.DefaultSdkVersion = Sdks.IOS.GetClosestInstalledSdk (IPhoneSdkVersion.V6_1, true).ToString ();
+			Task.DefaultSdkVersion = Sdks.IOS.GetClosestInstalledSdk (AppleSdkVersion.V6_1, true).ToString ();
 			Task.TargetFrameworkMoniker = "Xamarin.iOS,v1.0";
 			Task.TargetArchitectures = "ARM64";
 		}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_tvOS.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_tvOS.cs
@@ -9,7 +9,7 @@ namespace Xamarin.iOS.Tasks
 		public override void ConfigureTask ()
 		{
 			base.ConfigureTask ();
-			Task.DefaultSdkVersion = Sdks.TVOS.GetClosestInstalledSdk (IPhoneSdkVersion.V9_0, true).ToString ();
+			Task.DefaultSdkVersion = Sdks.TVOS.GetClosestInstalledSdk (AppleSdkVersion.V9_0, true).ToString ();
 			Task.TargetFrameworkMoniker = "Xamarin.TVOS,v1.0";
 		}
 	}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_watchOS.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_watchOS.cs
@@ -9,7 +9,7 @@ namespace Xamarin.iOS.Tasks
 		public override void ConfigureTask ()
 		{
 			base.ConfigureTask ();
-			Task.DefaultSdkVersion = Sdks.Watch.GetClosestInstalledSdk (IPhoneSdkVersion.V2_0, true).ToString ();
+			Task.DefaultSdkVersion = Sdks.Watch.GetClosestInstalledSdk (AppleSdkVersion.V2_0, true).ToString ();
 			Task.TargetFrameworkMoniker = "Xamarin.WatchOS,v1.0";
 		}
 	}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/IBToolTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/IBToolTaskTests.cs
@@ -21,7 +21,7 @@ namespace Xamarin.iOS.Tasks
 		{
 			var interfaceDefinitions = new List<ITaskItem> ();
 			var sdk = Sdks.GetSdk (framework);
-			var version = IPhoneSdkVersion.GetDefault (sdk, false);
+			var version = AppleSdkVersion.GetDefault (sdk, false);
 			var root = sdk.GetSdkPath (version, false);
 			var usr = Path.Combine (sdk.DeveloperRoot, "usr");
 			var bin = Path.Combine (usr, "bin");


### PR DESCRIPTION
This requires bumping Xamarin.MacDev.

New commits in xamarin/Xamarin.MacDev:

* xamarin/Xamarin.MacDev@02d6d05 [Xamarin.MacDev] Add an AppleSdkVersion struct which replaces IPhoneSdkVersion and MacOSXSdkVersion. (#87)
* xamarin/Xamarin.MacDev@e7ec7ef [Xamarin.MacDev] Fail gracefully if trying to grab a PList entry from a file that doesn't exist. (#86)

Diff: https://github.com/xamarin/Xamarin.MacDev/compare/fae0237704b792004adf592d8c9038a9d46aafff..02d6d05be3506c89a3b4fa8a8ceb7f33712a8f46