### PR TITLE
[CI][VSTS] Do not run tests if the build fails.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -455,10 +455,6 @@ steps:
     GitHubToken: $(GitHub.Token)
     ArtifactDirectory: $(Build.SourcesDirectory)/package-internal
 
-- template: uninstall-certificates/v1.yml@templates
-  parameters:
-    HostedMacKeychainPassword: $(OSX_KEYCHAIN_PASS)
-
 # upload each of the pkgs into the pipeline artifacts
 - task: PublishPipelineArtifact@1
   displayName: 'Publish Build Artifacts'
@@ -603,6 +599,11 @@ steps:
     artifactName: HtmlReport-sim
   continueOnError: true
   condition: and(succeededOrFailed(), contains(variables['runTests.TESTS_RAN'], 'True')) # if tests did not run, there is nothing to do
+
+# this will always be executed, is the default condition in the template
+- template: uninstall-certificates/v1.yml@templates
+  parameters:
+    HostedMacKeychainPassword: $(OSX_KEYCHAIN_PASS)
 
 - pwsh: |
     # should we need sudo, no, but someone did something wrong in the images..


### PR DESCRIPTION
The issue is due to the fact that the uninstall ceerts has an always
condition, that means that it gets executed and results in a success.
Because is a batch project and not a state machine.. the following steps
believe that everything was a success making the steps execute.

For ref: https://github.com/xamarin/yaml-templates/blob/main/uninstall-certificates/v1.yml