### PR TITLE
[main] Fix running introspection on iOS 11.4 simulators

### DIFF
--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -2015,7 +2015,7 @@ namespace CoreImage {
 		[Export ("initWithPortaitEffectsMatte:options:")] // selector typo, rdar filled 42894821
 		IntPtr Constructor (AVPortraitEffectsMatte matte, [NullAllowed] NSDictionary options);
 
-		[TV (11,0), iOS (11,0), Mac (10, 14)]
+		[TV (12,0), iOS (12,0), Mac (10, 14)]
 		[Export ("initWithPortaitEffectsMatte:")] // selector typo, rdar filled 42894821
 		IntPtr Constructor (AVPortraitEffectsMatte matte);
 

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -13684,7 +13684,7 @@ namespace Intents {
 		INCallCapability CallCapability { get; }
 	}
 
-	[Watch (4,0), NoTV, NoMac, iOS (11,0)]
+	[Watch (7,0), NoTV, NoMac, iOS (14,0)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	interface INCallRecordResolutionResult {
 

--- a/tests/introspection/iOS/iOSApiProtocolTest.cs
+++ b/tests/introspection/iOS/iOSApiProtocolTest.cs
@@ -158,6 +158,15 @@ namespace Introspection {
 				if (protocolName == "UIUserActivityRestoring")
 					return true;
 				break;
+			case "ARImageAnchor":
+				// both type and protocol were added in iOS 11.3 but the conformance, for that type, started with iOS 12.0
+				if (protocolName == "ARTrackable")
+					return !TestRuntime.CheckXcodeVersion (10,0);
+				break;
+			case "PHLivePhoto":
+				if (protocolName == "NSItemProviderReading")
+					return !TestRuntime.CheckXcodeVersion (10,0);
+				break;
 			}
 
 			switch (protocolName) {

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -386,6 +386,15 @@ namespace Introspection {
 					break;
 				}
 				break;
+			// ARImageAnchor was added in iOS 11.3 but the conformance to ARTrackable, where `isTracked` comes from, started with iOS 12.0
+			case "ARImageAnchor":
+				switch (name) {
+				case "isTracked":
+					if (!TestRuntime.CheckXcodeVersion (10,0))
+						return true;
+					break;
+				}
+				break;
 #endif
 			break;
 		}
@@ -789,6 +798,10 @@ namespace Introspection {
 				case "SKAttributeValue":
 					return !TestRuntime.CheckXcodeVersion (7, 2);
 #endif
+				case "MLDictionaryFeatureProvider":
+				case "MLMultiArray":
+				case "MLFeatureValue":
+					return !TestRuntime.CheckXcodeVersion (10,0);
 				}
 				break;
 			case "mutableCopyWithZone:":
@@ -824,6 +837,16 @@ namespace Introspection {
 						return true;
 					// was a private framework (on iOS) before Xcode 9.0 (shortcut logic)
 					if (!TestRuntime.CheckXcodeVersion (9, 0))
+						return true;
+					break;
+				}
+				break;
+			case "objectWithItemProviderData:typeIdentifier:error:":
+			case "readableTypeIdentifiersForItemProvider":
+				switch (declaredType.Name) {
+				case "PHLivePhoto":
+					// not yet conforming to NSItemProviderReading
+					if (!TestRuntime.CheckXcodeVersion (10,0))
 						return true;
 					break;
 				}


### PR DESCRIPTION
Once you have BigSur installed, to work with xcode12.5, then you
need to bump the minimum simulator versions (to 11.4) and this picked up
a few mistakes in availability and when checking protocol conformance

The bots won't run into those issues, as long as `xcode12.5` is not
merged or while they run on macOS Catalina, but it's nice to have green
tests locally :)

Subset of 8513316015b1fca1d59f0ec47072befd2443acba already in `xcode12.5`