### PR TITLE
[tools] Fix issue with default verbosity.

### DIFF
--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -287,13 +287,14 @@ namespace Xamarin.Bundler {
 			}
 		}
 
-		static int verbose = GetDefaultVerbosity ();
 		public static int Verbosity {
-			get { return verbose; }
-			set {
-				verbose = value;
-				ErrorHelper.Verbosity = Verbosity;
-			}
+			get { return ErrorHelper.Verbosity; }
+			set { ErrorHelper.Verbosity = value; }
+		}
+
+		static Driver ()
+		{
+			Verbosity = GetDefaultVerbosity ();
 		}
 
 		static int GetDefaultVerbosity ()


### PR DESCRIPTION
* Store verbosity in only one place (ErrorHelper.Verbosity).
* Initialize to the default value in the Driver's static constructor.

There was an issue where the default verbosity wasn't set everywhere, because
ErrorHelper.Verbosity was only set when Driver.Verbosity was assigned, which
wouldn't happen if no -v/-q was passed on the command line. The result would
be that any files in $HOME that specifies a default verbosity would not be
taken into account in ErrorHelper.