### PR TITLE
[xcode12.4] [mmp] Use the right pkg-config directory.

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1086,7 +1086,7 @@ namespace Xamarin.Bundler {
 			Dictionary<string, string> env = null;
 
 			if (!IsUnifiedFullSystemFramework && !force_system_mono)
-				env = new Dictionary<string, string> { { "PKG_CONFIG_PATH", Path.Combine (FrameworkLibDirectory, "pkgconfig") } };
+				env = new Dictionary<string, string> { { "PKG_CONFIG_PATH", Path.Combine (GetProductSdkLibDirectory (App), "pkgconfig") } };
 
 			var sb = new StringBuilder ();
 			int rv;


### PR DESCRIPTION
Change the code to look in the right place for pig-config files.

`FrameworkLibDirectory` is:

https://github.com/xamarin/xamarin-macios/blob/4b0fd5529cb7728aaf6946be37e6080ee29e3874/tools/common/Driver.cs#L783-L786

and `GetProductSdkDirectory` is:

https://github.com/xamarin/xamarin-macios/blob/4b0fd5529cb7728aaf6946be37e6080ee29e3874/tools/common/Driver.cs#L864

and that's where we install `mono-2.pc`:

https://github.com/xamarin/xamarin-macios/blob/4b0fd5529cb7728aaf6946be37e6080ee29e3874/builds/Makefile#L699-L700

given that `XAMARIN_MACOS_SDK` is:

https://github.com/xamarin/xamarin-macios/blob/4b0fd5529cb7728aaf6946be37e6080ee29e3874/Make.config#L317


Backport of #9105
