### PR TITLE
[dotnet-linker] Compute per-assembly linker flags.

### DIFF
--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -563,6 +563,14 @@ namespace Xamarin.Bundler {
 						if (Frameworks.Add ("OpenAL"))
 							Driver.Log (3, "Linking with the framework OpenAL because {0} is referenced by a module reference in {1}", file, FileName);
 						break;
+#if NET
+					case "Carbon":
+						if (App.Platform != ApplePlatform.MacOSX) {
+							Driver.Log (3, $"Not linking with the framework {file} (referenced by a module reference in {FileName}) because it doesn't exist on the target platform.");
+							break;
+						}
+						break;
+#endif
 					default:
 						if (App.Platform == ApplePlatform.MacOSX) {
 							string path = Path.GetDirectoryName (name);

--- a/tools/dotnet-linker/Steps/GatherFrameworksStep.cs
+++ b/tools/dotnet-linker/Steps/GatherFrameworksStep.cs
@@ -26,6 +26,14 @@ namespace Xamarin {
 
 		protected override void TryEndProcess ()
 		{
+
+			Configuration.Target.ComputeLinkerFlags ();
+
+			foreach (var asm in Configuration.Target.Assemblies) {
+				Frameworks.UnionWith (asm.Frameworks);
+				WeakFrameworks.UnionWith (asm.WeakFrameworks);
+			}
+
 			// Remove duplicates. WeakFrameworks takes precedence
 			Frameworks.ExceptWith (WeakFrameworks);
 


### PR DESCRIPTION
This way we link with any system frameworks referenced by P/Invokes.