### PR TITLE
[dotnet] Force the GC mode to be preemptive.

### DIFF
--- a/tools/dotnet-linker/Steps/GenerateMainStep.cs
+++ b/tools/dotnet-linker/Steps/GenerateMainStep.cs
@@ -31,6 +31,7 @@ namespace Xamarin {
 				contents.AppendLine ("static void xamarin_initialize_dotnet ()");
 				contents.AppendLine ("{");
 				contents.AppendLine ("\tsetenv (\"DOTNET_SYSTEM_GLOBALIZATION_INVARIANT\", \"1\", 1); // https://github.com/xamarin/xamarin-macios/issues/8906");
+				contents.AppendLine ("\tsetenv (\"MONO_THREADS_SUSPEND\", \"preemptive\", 1); // https://github.com/dotnet/runtime/issues/47121");
 				contents.AppendLine ("}");
 				contents.AppendLine ();
 


### PR DESCRIPTION
The default was changed to be hybrid suspend, and due to bugs in Mono that
crashes:

https://github.com/dotnet/runtime/issues/47121

In the meantime we can go back to the older GC mode until Mono has fixed any
issues with the hybrid suspend mode.