### PR TITLE
[generator] Reduce the number of duplicate availability attributes in generated code

### DIFF
--- a/src/generator-filters.cs
+++ b/src/generator-filters.cs
@@ -146,14 +146,14 @@ public partial class Generator {
 
 			print ("");
 			print ($"// {pname} protocol members ");
-			GenerateProperties (i, fromProtocol: true);
+			GenerateProperties (i, type);
 
 			// also include base interfaces/protocols
 			GenerateProtocolProperties (i, processed);
 		}
 	}
 
-	void GenerateProperties (Type type, bool fromProtocol = false)
+	void GenerateProperties (Type type, Type originalType = null)
 	{
 		foreach (var p in type.GetProperties (BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)) {
 			if (p.IsUnavailable (this))
@@ -162,7 +162,7 @@ public partial class Generator {
 				continue;
 			
 			print ("");
-			PrintPropertyAttributes (p);
+			PrintPropertyAttributes (p, originalType);
 			print_generated_code ();
 
 			var ptype = p.PropertyType.Name;
@@ -189,7 +189,7 @@ public partial class Generator {
 			case "CIColor":
 			case "CIImage":
 				// protocol-based bindings have annotations - but the older, key-based, versions did not
-				if (!fromProtocol)
+				if (originalType == null)
 					nullable = true;
 				break;
 			}

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3202,6 +3202,21 @@ public partial class Generator : IMemberGatherer {
 			w.WriteLine (a);
 	}
 
+	bool Duplicated (AvailabilityBaseAttribute candidate, AvailabilityBaseAttribute[] attributes)
+	{
+		foreach (var a in attributes) {
+			if (candidate.AvailabilityKind != a.AvailabilityKind)
+				continue;
+			if (candidate.Platform != a.Platform)
+				continue;
+			if (candidate.Version != a.Version)
+				continue;
+			// the actual message (when present) is not really important
+			return true;
+		}
+		return false;
+	}
+
 	public void PrintPlatformAttributes (MemberInfo mi)
 	{
 		if (mi == null)
@@ -3221,6 +3236,8 @@ public partial class Generator : IMemberGatherer {
 				print (availability.ToString ());
 				continue;
 			}
+			if (Duplicated (availability, type_ca))
+				continue;
 			switch (availability.AvailabilityKind) {
 			case AvailabilityKind.Unavailable:
 				// an unavailable member can override type-level attribute

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3217,7 +3217,7 @@ public partial class Generator : IMemberGatherer {
 		return false;
 	}
 
-	public void PrintPlatformAttributes (MemberInfo mi)
+	public void PrintPlatformAttributes (MemberInfo mi, Type type = null)
 	{
 		if (mi == null)
 			return;
@@ -3227,7 +3227,7 @@ public partial class Generator : IMemberGatherer {
 		foreach (var availability in AttributeManager.GetCustomAttributes<AvailabilityBaseAttribute> (mi)) {
 			if (type_ca == null) {
 				if (mi.DeclaringType != null)
-					type_ca = AttributeManager.GetCustomAttributes<AvailabilityBaseAttribute> (mi.DeclaringType);
+					type_ca = AttributeManager.GetCustomAttributes<AvailabilityBaseAttribute> (type ?? mi.DeclaringType);
 				else
 					type_ca = Array.Empty<AvailabilityBaseAttribute> ();
 			}
@@ -4740,7 +4740,7 @@ public partial class Generator : IMemberGatherer {
 		}
 	}
 
-	void PrintPropertyAttributes (PropertyInfo pi)
+	void PrintPropertyAttributes (PropertyInfo pi, Type type = null)
 	{
 		foreach (var oa in AttributeManager.GetCustomAttributes<ObsoleteAttribute> (pi)) {
 			print ("[Obsolete (\"{0}\", {1})]", oa.Message, oa.IsError ? "true" : "false");
@@ -4759,7 +4759,7 @@ public partial class Generator : IMemberGatherer {
 			print ("[DebuggerBrowsable (DebuggerBrowsableState.Never)]");
 		}
 
-		PrintPlatformAttributes (pi);
+		PrintPlatformAttributes (pi, type);
 
 		foreach (var sa in AttributeManager.GetCustomAttributes<ThreadSafeAttribute> (pi))
 			print (sa.Safe ? "[ThreadSafe]" : "[ThreadSafe (false)]");


### PR DESCRIPTION
This does not have a huge impact (e.g. size) by itself. However it helps
to find duplicates in non-generated (manual) bindings and that will (in
future PR) remove them, which means less (manual) work to update the
attributes for net6.

Before (iOS)
> [FAIL] Duplicates: 555 API with members duplicating type-level attributes

After (iOS)
> [FAIL] Duplicates : 64 API with members duplicating type-level attributes

Notes

* The above test will be added in a PR, one that has 0 failure :)

* Ideally the duplicated entries would be removed from binding files (as
  they are not needed, just noise) but that more work and a common source
  of merge conflicts

* Some dupes exists due to protocol members inlining (and we might want
  to fix this later)

* Bots are not produce the generator diff right now. Here's a manually
  generated link to that diff
  https://gist.githubusercontent.com/spouliot/4b3f277e0c6d58ccbd09293bbb16bebf/raw/26915a5ad160a1bfe917436917700afeae489bf4/gistfile1.txt