### PR TITLE
[builds] Download the runtime packs for our platforms.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -542,6 +542,9 @@ DOTNET_WINDOWS_PLATFORMS = iOS
 # Create variables prefixed with the correctly cased platform name from the upper-cased platform name. This simplifies code in a few areas (whenever we foreach over DOTNET_PLATFORMS).
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval DOTNET_$(platform)_RUNTIME_IDENTIFIERS:=$(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS)))
 
+# Create a variable with all the runtime identifiers
+DOTNET_RUNTIME_IDENTIFIERS=$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS))
+
 # Create a variable with the platform in uppercase
 DOTNET_PLATFORMS_UPPERCASE:=$(shell echo $(DOTNET_PLATFORMS) | tr a-z A-Z)
 

--- a/builds/.gitignore
+++ b/builds/.gitignore
@@ -1,3 +1,4 @@
+BundledNETCorePlatformsPackageVersion.txt
 downloads
 .stamp*
 .deps.*.mk

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -113,9 +113,33 @@ x:
 	$(MAKE) download-mono
 	$(Q) touch $@
 
+.stamp-download-dotnet-packages: $(TOP)/Make.config downloads/$(basename $(basename $(DOTNET6_TARBALL_NAME))) package-download/global.json package-download/NuGet.config
+	$(Q_GEN) cd package-download && $(DOTNET6) \
+		build \
+		download-packages.proj \
+		/t:WriteBundledNETCorePlatformsPackageVersion \
+		/p:WriteFilePath=$(CURDIR)/BundledNETCorePlatformsPackageVersion.txt \
+		/p:PackageRuntimeIdentifiers="$(DOTNET_RUNTIME_IDENTIFIERS)" \
+		/bl \
+		/v:quiet
+	$(Q) touch $@
+
+BundledNETCorePlatformsPackageVersion.txt: .stamp-download-dotnet-packages
+
+package-download/global.json: $(TOP)/global6.json Makefile
+	$(Q) $(CP) $< $@
+
+# put any downloaded packages in our own directory, not in ~
+package-download/NuGet.config: $(TOP)/NuGet.config Makefile
+	$(Q) $(CP) $< $@
+	$(Q) $(CP) $< $@.tmp
+	$(Q) nuget config -Set globalPackagesFolder=$(abspath $(CURDIR)/downloads) -Config $@.tmp
+	$(Q) mv $@.tmp $@
+
 DOTNET_DOWNLOADS = \
 	downloads/$(basename $(DOTNET5_BCL_REF_NAME)) \
 	downloads/$(basename $(basename $(DOTNET6_TARBALL_NAME))) \
+	.stamp-download-dotnet-packages \
 
 dotnet: $(DOTNET_DOWNLOADS)
 ifdef ENABLE_DOTNET

--- a/builds/package-download/.gitignore
+++ b/builds/package-download/.gitignore
@@ -1,0 +1,3 @@
+NuGet.config
+global.json
+

--- a/builds/package-download/download-packages.proj
+++ b/builds/package-download/download-packages.proj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Download any runtime packs as specified using the PackageRuntimeIdentifiers property -->
+    <PackageRuntimeIdentifiers Include="$(PackageRuntimeIdentifiers.Split(' '))" />
+
+    <!-- Download the mono osx pack as well -->
+    <!-- I wasn't able to figure out how to only do this if 'osx-x64' is already included -->
+    <PackageRuntimeIdentifiers Include="Mono.osx-x64" />
+    
+    <!-- we don't have mac catalyst packs yet -->
+    <PackageRuntimeIdentifiers Remove="maccatalyst-x64" />
+
+    <!-- download the runtime packs -->
+    <PackageDownload Include="@(PackageRuntimeIdentifiers -> 'Microsoft.NETCore.App.Runtime.%(Identity)')" Version="[$(BundledNETCorePlatformsPackageVersion)]" />
+
+    <!-- download the reference assemblies -->
+    <PackageDownload Include="microsoft.netcore.app.ref" Version="[5.0.0]" />
+  </ItemGroup>
+
+  <!-- target to write out the BundledNETCorePlatformsPackageVersion to a file -->
+  <Target Name="WriteBundledNETCorePlatformsPackageVersion" Condition="'$(WriteFilePath)' != ''">
+    <WriteLinesToFile File="$(WriteFilePath)" Lines="$(BundledNETCorePlatformsPackageVersion)" Overwrite="true" />
+  </Target>
+</Project>


### PR DESCRIPTION
These will soon be used to build a .NET version of libxamarin (we need the
dylibs shipped with the runtime packs to link libxamarin.dylib).

We also write out the version of the runtime packs
(BundledNETCorePlatformsPackageVersion) so that we can use the version later
in our Makefiles.