### PR TITLE
[monotouch-test] Clean up keychain items after test completions.

### DIFF
--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -609,6 +609,7 @@ namespace MonoTouchFixtures.Security {
 
 #if IOS
 				var att2 = new SecPublicPrivateKeyAttrs ();
+				att2.Label = att.Label;
 				att2.IsPermanent = false;
 				att2.EffectiveKeySize = 1024;
 				att2.CanEncrypt = true;
@@ -628,14 +629,7 @@ namespace MonoTouchFixtures.Security {
 					}
 				}
 			} finally {
-				var query = new SecRecord (SecKind.Key) {
-					Label = att.Label,
-				};
-				SecStatusCode code;
-				do {
-					// For some reason each call to SecKeyChain will only remove a single key, so do a loop.
-					code = SecKeyChain.Remove (query);
-				} while (code == SecStatusCode.Success);
+				KeyTest.DeleteKeysWithLabel (att.Label);
 			}
 		}
 

--- a/tests/monotouch-test/Security/KeyTest.cs
+++ b/tests/monotouch-test/Security/KeyTest.cs
@@ -48,6 +48,18 @@ namespace MonoTouchFixtures.Security {
 			}
 		}
 
+		public static void DeleteKeysWithLabel (string label)
+		{
+			var query = new SecRecord (SecKind.Key) {
+				Label = label,
+			};
+			SecStatusCode code;
+			do {
+				// For some reason each call to SecKeyChain will only remove a single key, so do a loop.
+				code = SecKeyChain.Remove (query);
+			} while (code == SecStatusCode.Success);
+		}
+
 		[Test]
 #if NET
 		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainCreate")] // https://github.com/dotnet/runtime/issues/36897
@@ -111,85 +123,88 @@ namespace MonoTouchFixtures.Security {
 			NSError error;
 			SecKey private_key;
 			SecKey public_key;
-			using (var record = new SecRecord (SecKind.Key)) {
-				record.KeyType = SecKeyType.RSA;
-				record.KeySizeInBits = MinRsaKeySize; // it's not a performance test :)
+			var label = $"KeyTest.RoundtripRSAMinPKCS1-{CFBundle.GetMain ().Identifier}-{GetType ().FullName}-{Process.GetCurrentProcess ().Id}";
 
-				Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair");
+			try {
+				using (var record = new SecRecord (SecKind.Key)) {
+					record.KeyType = SecKeyType.RSA;
+					record.KeySizeInBits = MinRsaKeySize; // it's not a performance test :)
+					record.Label = label;
 
-				byte [] plain = new byte [20] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-				byte [] cipher;
-				if (TestRuntime.CheckXcodeVersion (8,0)) {
-					Assert.True (public_key.IsAlgorithmSupported (SecKeyOperationType.Encrypt, SecKeyAlgorithm.RsaEncryptionPkcs1), "public/IsAlgorithmSupported/Encrypt");
+					Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair");
 
-#if MONOMAC
-					Assert.That (public_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionPkcs1), Is.EqualTo (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 13)), "public/IsAlgorithmSupported/Decrypt");
-
-					using (var pub = public_key.GetPublicKey ()) {
-						// macOS behaviour is not consistent - but the test main goal is to check we get a key
-						Assert.That (pub.Handle, Is.Not.EqualTo (IntPtr.Zero), "public/GetPublicKey");
-					}
-#else
-					Assert.True (public_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionPkcs1), "public/IsAlgorithmSupported/Decrypt");
-
-					using (var pub = public_key.GetPublicKey ())
-					{
-						// a new native instance of the key is returned (so having a new managed SecKey is fine)
-						Assert.False (pub.Handle == public_key.Handle, "public/GetPublicKey");
-					}
-#endif
-
-					using (var attrs = public_key.GetAttributes ()) {
-						Assert.That (attrs.Count, Is.GreaterThan ((nuint) 0), "public/GetAttributes");
-					}
-					using (var data = public_key.GetExternalRepresentation (out error)) {
-						Assert.Null (error, "public/error-1");
-						Assert.NotNull (data, "public/GetExternalRepresentation");
-
-						using (var key = SecKey.Create (data, SecKeyType.RSA, SecKeyClass.Public, MinRsaKeySize, null, out error)) {
-							Assert.Null (error, "public/Create/error-1");
-						}
-					}
-				}
-				Assert.That (public_key.Encrypt (SecPadding.PKCS1, plain, out cipher), Is.EqualTo (SecStatusCode.Success), "Encrypt");
-
-				byte[] result;
-				if (TestRuntime.CheckXcodeVersion (8,0)) {
-					Assert.False (private_key.IsAlgorithmSupported (SecKeyOperationType.Encrypt, SecKeyAlgorithm.RsaEncryptionPkcs1), "private/IsAlgorithmSupported/Encrypt");
-					Assert.True (private_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionPkcs1), "private/IsAlgorithmSupported/Decrypt");
+					byte [] plain = new byte [20] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+					byte [] cipher;
+					if (TestRuntime.CheckXcodeVersion (8,0)) {
+						Assert.True (public_key.IsAlgorithmSupported (SecKeyOperationType.Encrypt, SecKeyAlgorithm.RsaEncryptionPkcs1), "public/IsAlgorithmSupported/Encrypt");
 
 #if MONOMAC
-					using (var pub2 = private_key.GetPublicKey ()) {
-						Assert.That (pub2.Handle, Is.EqualTo (public_key.Handle), "private/GetPublicKey");
-					}
-#else
-					using (var pub2 = private_key.GetPublicKey ()) {
-						// a new native instance of the key is returned (so having a new managed SecKey is fine)
-						Assert.That (pub2.Handle, Is.Not.EqualTo (public_key.Handle), "private/GetPublicKey");
-					}
-#endif
-					using (var attrs = private_key.GetAttributes ()) {
-						Assert.That (attrs.Count, Is.GreaterThan ((nuint) 0), "private/GetAttributes");
-					}
-					using (var data2 = private_key.GetExternalRepresentation (out error)) {
-						Assert.Null (error, "private/error-1");
-						Assert.NotNull (data2, "private/GetExternalRepresentation");
+						Assert.That (public_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionPkcs1), Is.EqualTo (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 13)), "public/IsAlgorithmSupported/Decrypt");
 
-						using (var key = SecKey.Create (data2, SecKeyType.RSA, SecKeyClass.Private, MinRsaKeySize, null, out error)) {
-							Assert.Null (error, "private/Create/error-1");
+						using (var pub = public_key.GetPublicKey ()) {
+							// macOS behaviour is not consistent - but the test main goal is to check we get a key
+							Assert.That (pub.Handle, Is.Not.EqualTo (IntPtr.Zero), "public/GetPublicKey");
+						}
+#else
+						Assert.True (public_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionPkcs1), "public/IsAlgorithmSupported/Decrypt");
+
+						using (var pub = public_key.GetPublicKey ())
+						{
+							// a new native instance of the key is returned (so having a new managed SecKey is fine)
+							Assert.False (pub.Handle == public_key.Handle, "public/GetPublicKey");
+						}
+#endif
+
+						using (var attrs = public_key.GetAttributes ()) {
+							Assert.That (attrs.Count, Is.GreaterThan ((nuint) 0), "public/GetAttributes");
+						}
+						using (var data = public_key.GetExternalRepresentation (out error)) {
+							Assert.Null (error, "public/error-1");
+							Assert.NotNull (data, "public/GetExternalRepresentation");
+
+							using (var key = SecKey.Create (data, SecKeyType.RSA, SecKeyClass.Public, MinRsaKeySize, null, out error)) {
+								Assert.Null (error, "public/Create/error-1");
+							}
 						}
 					}
-				}
-				public_key.Dispose ();
-				var expectedResult = SecStatusCode.Success;
+					Assert.That (public_key.Encrypt (SecPadding.PKCS1, plain, out cipher), Is.EqualTo (SecStatusCode.Success), "Encrypt");
+
+					byte[] result;
+					if (TestRuntime.CheckXcodeVersion (8,0)) {
+						Assert.False (private_key.IsAlgorithmSupported (SecKeyOperationType.Encrypt, SecKeyAlgorithm.RsaEncryptionPkcs1), "private/IsAlgorithmSupported/Encrypt");
+						Assert.True (private_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionPkcs1), "private/IsAlgorithmSupported/Decrypt");
+
+						using (var pub2 = private_key.GetPublicKey ()) {
+							// a new native instance of the key is returned (so having a new managed SecKey is fine)
+							Assert.That (pub2.Handle, Is.Not.EqualTo (public_key.Handle), "private/GetPublicKey");
+						}
+
+						using (var attrs = private_key.GetAttributes ()) {
+							Assert.That (attrs.Count, Is.GreaterThan ((nuint) 0), "private/GetAttributes");
+						}
+						using (var data2 = private_key.GetExternalRepresentation (out error)) {
+							Assert.Null (error, "private/error-1");
+							Assert.NotNull (data2, "private/GetExternalRepresentation");
+
+							using (var key = SecKey.Create (data2, SecKeyType.RSA, SecKeyClass.Private, MinRsaKeySize, null, out error)) {
+								Assert.Null (error, "private/Create/error-1");
+							}
+						}
+					}
+					public_key.Dispose ();
+					var expectedResult = SecStatusCode.Success;
 #if __MACOS__
-				if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 8))
-					expectedResult = SecStatusCode.InvalidData;
+					if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 8))
+						expectedResult = SecStatusCode.InvalidData;
 #endif
-				Assert.That (private_key.Decrypt (SecPadding.PKCS1, cipher, out result), Is.EqualTo (expectedResult), "Decrypt");
-				if (expectedResult != SecStatusCode.InvalidData)
-					Assert.That (plain, Is.EqualTo (result), "match");
-				private_key.Dispose ();
+					Assert.That (private_key.Decrypt (SecPadding.PKCS1, cipher, out result), Is.EqualTo (expectedResult), "Decrypt");
+					if (expectedResult != SecStatusCode.InvalidData)
+						Assert.That (plain, Is.EqualTo (result), "match");
+					private_key.Dispose ();
+				}
+			} finally {
+				// Clean up after us
+				DeleteKeysWithLabel (label);
 			}
 		}
 
@@ -198,26 +213,35 @@ namespace MonoTouchFixtures.Security {
 		{
 			SecKey private_key;
 			SecKey public_key;
-			using (var record = new SecRecord (SecKind.Key)) {
-				record.KeyType = SecKeyType.RSA;
-				record.KeySizeInBits = MinRsaKeySize; // it's not a performance test :)
+			var label = $"KeyTest.EncryptTooLarge-{CFBundle.GetMain ().Identifier}-{GetType ().FullName}-{Process.GetCurrentProcess ().Id}";
 
-				Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair");
+			try {
+				using (var record = new SecRecord (SecKind.Key)) {
+					record.KeyType = SecKeyType.RSA;
+					record.KeySizeInBits = MinRsaKeySize; // it's not a performance test :)
+					record.Label = label;
 
-				byte [] plain = new byte [MinRsaKeySize / 8];
-				byte [] cipher;
-				var rv = public_key.Encrypt (SecPadding.PKCS1, plain, out cipher);
-				var expectedStatus = SecStatusCode.Param;
+					Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair");
+
+					byte [] plain = new byte [MinRsaKeySize / 8];
+					byte [] cipher;
+					var rv = public_key.Encrypt (SecPadding.PKCS1, plain, out cipher);
+					var expectedStatus = SecStatusCode.Param;
+
 #if __MACOS__
-				if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 8))
-					expectedStatus = SecStatusCode.Success;
-				else if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 12))
-					expectedStatus = SecStatusCode.OutputLengthError;
+					if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 8))
+						expectedStatus = SecStatusCode.Success;
+					else if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 12))
+						expectedStatus = SecStatusCode.OutputLengthError;
 #endif
-				Assert.That (rv, Is.EqualTo (expectedStatus), "Encrypt");
+					Assert.That (rv, Is.EqualTo (expectedStatus), "Encrypt");
 
-				public_key.Dispose ();
-				private_key.Dispose ();
+					public_key.Dispose ();
+					private_key.Dispose ();
+				}
+			} finally {
+				// Clean up after us
+				DeleteKeysWithLabel (label);
 			}
 		}
 
@@ -226,43 +250,51 @@ namespace MonoTouchFixtures.Security {
 		{
 			SecKey private_key;
 			SecKey public_key;
-			using (var record = new SecRecord (SecKind.Key)) {
-				record.KeyType = SecKeyType.RSA;
-				record.KeySizeInBits = 1024; // it's not a performance test :)
+			var label = $"KeyTest.RoundtripRSA1024OAEP-{CFBundle.GetMain ().Identifier}-{GetType ().FullName}-{Process.GetCurrentProcess ().Id}";
 
-				Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair");
+			try {
+				using (var record = new SecRecord (SecKind.Key)) {
+					record.KeyType = SecKeyType.RSA;
+					record.KeySizeInBits = 1024; // it's not a performance test :)
+					record.Label = label;
 
-				byte [] plain = new byte [0];
-				byte [] cipher;
-				if (TestRuntime.CheckXcodeVersion (8,0)) {
-					Assert.True (public_key.IsAlgorithmSupported (SecKeyOperationType.Encrypt, SecKeyAlgorithm.RsaEncryptionOaepSha1), "public/IsAlgorithmSupported/Encrypt");
-					// I would have expect false
+					Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair");
+
+					byte [] plain = new byte [0];
+					byte [] cipher;
+					if (TestRuntime.CheckXcodeVersion (8,0)) {
+						Assert.True (public_key.IsAlgorithmSupported (SecKeyOperationType.Encrypt, SecKeyAlgorithm.RsaEncryptionOaepSha1), "public/IsAlgorithmSupported/Encrypt");
+						// I would have expect false
 #if MONOMAC
-					Assert.That (public_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionOaepSha1), Is.EqualTo (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 13)), "public/IsAlgorithmSupported/Decrypt");
+						Assert.That (public_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionOaepSha1), Is.EqualTo (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 13)), "public/IsAlgorithmSupported/Decrypt");
 #else
- 					Assert.True (public_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionOaepSha1), "public/IsAlgorithmSupported/Decrypt");
+						Assert.True (public_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionOaepSha1), "public/IsAlgorithmSupported/Decrypt");
 #endif
-				}
-				Assert.That (public_key.Encrypt (SecPadding.OAEP, plain, out cipher), Is.EqualTo (SecStatusCode.Success), "Encrypt");
-				public_key.Dispose ();
+					}
+					Assert.That (public_key.Encrypt (SecPadding.OAEP, plain, out cipher), Is.EqualTo (SecStatusCode.Success), "Encrypt");
+					public_key.Dispose ();
 
-				byte[] result;
-				if (TestRuntime.CheckXcodeVersion (8,0)) {
-					Assert.False (private_key.IsAlgorithmSupported (SecKeyOperationType.Encrypt, SecKeyAlgorithm.RsaEncryptionOaepSha1), "private/IsAlgorithmSupported/Encrypt");
-					Assert.True (private_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionOaepSha1), "private/IsAlgorithmSupported/Decrypt");
-				}
-				Assert.That (private_key.Decrypt (SecPadding.OAEP, cipher, out result), Is.EqualTo (SecStatusCode.Success), "Decrypt");
-				var expectEmpty = false;
+					byte[] result;
+					if (TestRuntime.CheckXcodeVersion (8,0)) {
+						Assert.False (private_key.IsAlgorithmSupported (SecKeyOperationType.Encrypt, SecKeyAlgorithm.RsaEncryptionOaepSha1), "private/IsAlgorithmSupported/Encrypt");
+						Assert.True (private_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionOaepSha1), "private/IsAlgorithmSupported/Decrypt");
+					}
+					Assert.That (private_key.Decrypt (SecPadding.OAEP, cipher, out result), Is.EqualTo (SecStatusCode.Success), "Decrypt");
+					var expectEmpty = false;
 #if __MACOS__
-				if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 12))
-					expectEmpty = true;
+					if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 12))
+						expectEmpty = true;
 #endif
-				if (expectEmpty) {
-					Assert.That (plain, Is.EqualTo (new byte [0]), "match (empty)");
-				} else {
-					Assert.That (plain, Is.EqualTo (result), "match");
+					if (expectEmpty) {
+						Assert.That (plain, Is.EqualTo (new byte [0]), "match (empty)");
+					} else {
+						Assert.That (plain, Is.EqualTo (result), "match");
+					}
+					private_key.Dispose ();
 				}
-				private_key.Dispose ();
+			} finally {
+				// Clean up after us
+				DeleteKeysWithLabel (label);
 			}
 		}
 
@@ -272,24 +304,32 @@ namespace MonoTouchFixtures.Security {
 		{
 			SecKey private_key;
 			SecKey public_key;
-			using (var record = new SecRecord (SecKind.Key)) {
-				record.KeyType = SecKeyType.RSA;
-				record.KeySizeInBits = MinRsaKeySize; // it's not a performance test :)
+			var label = $"KeyTest.SignVerifyRSAMinPKCS1SHA1-{CFBundle.GetMain ().Identifier}-{GetType ().FullName}-{Process.GetCurrentProcess ().Id}";
 
-				Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair");
+			try {
+				using (var record = new SecRecord (SecKind.Key)) {
+					record.KeyType = SecKeyType.RSA;
+					record.KeySizeInBits = MinRsaKeySize; // it's not a performance test :)
+					record.Label = label;
 
-				byte [] hash = new byte [20] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-				byte [] sign;
-				Assert.That (private_key.RawSign (SecPadding.PKCS1SHA1, hash, out sign), Is.EqualTo (SecStatusCode.Success), "RawSign");
-				Assert.That (public_key.RawVerify (SecPadding.PKCS1SHA1, hash, sign), Is.EqualTo (SecStatusCode.Success), "RawVerify");
+					Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair");
 
-				var empty = new byte [0];
-				Assert.That (private_key.RawSign (SecPadding.PKCS1, empty, out sign), Is.EqualTo (SecStatusCode.Success), "RawSign-empty");
-				// results vary per iOS version - but that's out of our control and we only care that it does not crash
-				public_key.RawVerify (SecPadding.PKCS1SHA1, empty, empty);
+					byte [] hash = new byte [20] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+					byte [] sign;
+					Assert.That (private_key.RawSign (SecPadding.PKCS1SHA1, hash, out sign), Is.EqualTo (SecStatusCode.Success), "RawSign");
+					Assert.That (public_key.RawVerify (SecPadding.PKCS1SHA1, hash, sign), Is.EqualTo (SecStatusCode.Success), "RawVerify");
 
-				private_key.Dispose ();
-				public_key.Dispose ();
+					var empty = new byte [0];
+					Assert.That (private_key.RawSign (SecPadding.PKCS1, empty, out sign), Is.EqualTo (SecStatusCode.Success), "RawSign-empty");
+					// results vary per iOS version - but that's out of our control and we only care that it does not crash
+					public_key.RawVerify (SecPadding.PKCS1SHA1, empty, empty);
+
+					private_key.Dispose ();
+					public_key.Dispose ();
+				}
+			} finally {
+				// Clean up after us
+				DeleteKeysWithLabel (label);
 			}
 		}
 
@@ -300,26 +340,34 @@ namespace MonoTouchFixtures.Security {
 
 			SecKey private_key;
 			SecKey public_key;
-			using (var record = new SecRecord (SecKind.Key)) {
-				record.KeyType = SecKeyType.EC;
-				record.KeySizeInBits = 256; // it's not a performance test :)
+			var label = $"KeyTest.SignVerifyECSHA1-{CFBundle.GetMain ().Identifier}-{GetType ().FullName}-{Process.GetCurrentProcess ().Id}";
 
-				Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair");
+			try {
+				using (var record = new SecRecord (SecKind.Key)) {
+					record.KeyType = SecKeyType.EC;
+					record.KeySizeInBits = 256; // it's not a performance test :)
+					record.Label = label;
 
-				byte [] hash = new byte [20] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-				byte [] sign;
-				// PKCS1SHA1 implies RSA (oid)
-				Assert.That (private_key.RawSign (SecPadding.PKCS1, hash, out sign), Is.EqualTo (SecStatusCode.Success), "RawSign");
-				Assert.That (public_key.RawVerify (SecPadding.PKCS1, hash, sign), Is.EqualTo (SecStatusCode.Success), "RawVerify");
+					Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair");
 
-				var empty = new byte [0];
-				// there does not seem to be a length-check on PKCS1, likely because not knowning the hash algorithm makes it harder
-				Assert.That (private_key.RawSign (SecPadding.PKCS1, empty, out sign), Is.EqualTo (SecStatusCode.Success), "RawSign-empty");
-				// results vary per iOS version - but that's out of our control and we only care that it does not crash
-				public_key.RawVerify (SecPadding.PKCS1, empty, empty);
+					byte [] hash = new byte [20] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+					byte [] sign;
+					// PKCS1SHA1 implies RSA (oid)
+					Assert.That (private_key.RawSign (SecPadding.PKCS1, hash, out sign), Is.EqualTo (SecStatusCode.Success), "RawSign");
+					Assert.That (public_key.RawVerify (SecPadding.PKCS1, hash, sign), Is.EqualTo (SecStatusCode.Success), "RawVerify");
 
-				private_key.Dispose ();
-				public_key.Dispose ();
+					var empty = new byte [0];
+					// there does not seem to be a length-check on PKCS1, likely because not knowning the hash algorithm makes it harder
+					Assert.That (private_key.RawSign (SecPadding.PKCS1, empty, out sign), Is.EqualTo (SecStatusCode.Success), "RawSign-empty");
+					// results vary per iOS version - but that's out of our control and we only care that it does not crash
+					public_key.RawVerify (SecPadding.PKCS1, empty, empty);
+
+					private_key.Dispose ();
+					public_key.Dispose ();
+				}
+			} finally {
+				// Clean up after us
+				DeleteKeysWithLabel (label);
 			}
 		}
 
@@ -328,28 +376,36 @@ namespace MonoTouchFixtures.Security {
 		{
 			SecKey private_key;
 			SecKey public_key;
-			using (var record = new SecRecord (SecKind.Key)) {
-				record.KeyType = SecKeyType.RSA;
-				// maximum documented as 2048, .NET maximum is 16384
-				record.KeySizeInBits = 16384; 
-				Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Param), "16384");
-				record.KeySizeInBits = 8192; 
-				if (TestRuntime.CheckXcodeVersion (7, 0)) {
-					// It seems iOS 9 supports 8192, but it takes a long time to generate (~40 seconds on my iPad Air 2), so skip it.
-//					Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "8192");
-				} else {
-					Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Param), "8192");
+			var label = $"KeyTest.GenerateKeyPairTooLargeRSA-{CFBundle.GetMain ().Identifier}-{GetType ().FullName}-{Process.GetCurrentProcess ().Id}";
+
+			try {
+				using (var record = new SecRecord (SecKind.Key)) {
+					record.KeyType = SecKeyType.RSA;
+					// maximum documented as 2048, .NET maximum is 16384
+					record.KeySizeInBits = 16384;
+					record.Label = label;
+					Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Param), "16384");
+					record.KeySizeInBits = 8192;
+					if (TestRuntime.CheckXcodeVersion (7, 0)) {
+						// It seems iOS 9 supports 8192, but it takes a long time to generate (~40 seconds on my iPad Air 2), so skip it.
+	//					Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "8192");
+					} else {
+						Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Param), "8192");
+					}
 				}
+				/* On iOS 7.1 the device console logs will show:
+				 *
+				 * Mar 18 08:27:30 Mercure monotouchtest[1397] <Warning>:  SecRSAPrivateKeyInit Invalid or missing key size in: {
+				 * 	    bsiz = 16384;
+				 * 	    class = keys;
+				 * 	    type = 42;
+				 * 	}
+				 * Mar 18 08:27:30 Mercure monotouchtest[1397] <Warning>:  SecKeyCreate init RSAPrivateKey key: -50
+				*/
+			} finally {
+				// Clean up after us
+				DeleteKeysWithLabel (label);
 			}
-			/* On iOS 7.1 the device console logs will show:
-			 * 
-			 * Mar 18 08:27:30 Mercure monotouchtest[1397] <Warning>:  SecRSAPrivateKeyInit Invalid or missing key size in: {
-			 * 	    bsiz = 16384;
-			 * 	    class = keys;
-			 * 	    type = 42;
-			 * 	}
-			 * Mar 18 08:27:30 Mercure monotouchtest[1397] <Warning>:  SecKeyCreate init RSAPrivateKey key: -50
-			*/
 		}
 
 		[Test]
@@ -386,35 +442,43 @@ namespace MonoTouchFixtures.Security {
 		{
 			SecKey private_key;
 			SecKey public_key;
-			using (var record = new SecRecord (SecKind.Key)) {
-				record.KeyType = SecKeyType.RSA;
-				record.KeySizeInBits = 4096;
+			var label = $"KeyTest.BenchmarkNative4096-{CFBundle.GetMain ().Identifier}-{GetType ().FullName}-{Process.GetCurrentProcess ().Id}";
 
-				var chrono = new Stopwatch ();
-				chrono.Start ();
-				Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair");
-				Console.WriteLine ("Key generation {0} ms", chrono.ElapsedMilliseconds);
-				chrono.Restart ();
+			try {
+				using (var record = new SecRecord (SecKind.Key)) {
+					record.KeyType = SecKeyType.RSA;
+					record.KeySizeInBits = 4096;
+					record.Label = label;
 
-				byte [] hash = new byte [20] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-				byte[] result;
-				public_key.Encrypt (SecPadding.OAEP, hash, out result);
-				Console.WriteLine ("Encrypt {0} ms", chrono.ElapsedMilliseconds);
-				chrono.Restart ();
+					var chrono = new Stopwatch ();
+					chrono.Start ();
+					Assert.That (SecKey.GenerateKeyPair (record.ToDictionary (), out public_key, out private_key), Is.EqualTo (SecStatusCode.Success), "GenerateKeyPair");
+					Console.WriteLine ("Key generation {0} ms", chrono.ElapsedMilliseconds);
+					chrono.Restart ();
 
-				private_key.Decrypt (SecPadding.OAEP, result, out result);
-				Console.WriteLine ("Decrypt {0} ms", chrono.ElapsedMilliseconds);
-				chrono.Restart ();
+					byte [] hash = new byte [20] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+					byte[] result;
+					public_key.Encrypt (SecPadding.OAEP, hash, out result);
+					Console.WriteLine ("Encrypt {0} ms", chrono.ElapsedMilliseconds);
+					chrono.Restart ();
 
-				private_key.RawSign (SecPadding.PKCS1SHA1, hash, out result);
-				Console.WriteLine ("Sign {0} ms", chrono.ElapsedMilliseconds);
-				chrono.Restart ();
+					private_key.Decrypt (SecPadding.OAEP, result, out result);
+					Console.WriteLine ("Decrypt {0} ms", chrono.ElapsedMilliseconds);
+					chrono.Restart ();
 
-				public_key.RawVerify (SecPadding.PKCS1SHA1, hash, result);
-				Console.WriteLine ("Verify {0} ms", chrono.ElapsedMilliseconds);
+					private_key.RawSign (SecPadding.PKCS1SHA1, hash, out result);
+					Console.WriteLine ("Sign {0} ms", chrono.ElapsedMilliseconds);
+					chrono.Restart ();
 
-				private_key.Dispose ();
-				public_key.Dispose ();
+					public_key.RawVerify (SecPadding.PKCS1SHA1, hash, result);
+					Console.WriteLine ("Verify {0} ms", chrono.ElapsedMilliseconds);
+
+					private_key.Dispose ();
+					public_key.Dispose ();
+				}
+			} finally {
+				// Clean up after us
+				DeleteKeysWithLabel (label);
 			}
 		}
 

--- a/tests/monotouch-test/Security/RecordTest.cs
+++ b/tests/monotouch-test/Security/RecordTest.cs
@@ -107,24 +107,29 @@ namespace MonoTouchFixtures.Security {
 		void Protocol (SecProtocol protocol)
 		{
 			var rec = new SecRecord (SecKind.InternetPassword) {
-				Account = "Protocol"
+				Account = $"Protocol-{protocol}-{CFBundle.GetMain ().Identifier}-{GetType ().FullName}-{Process.GetCurrentProcess ().Id}",
 			};
-			SecKeyChain.Remove (rec); // it might already exists (or not)
+			try {
+				SecKeyChain.Remove (rec); // it might already exists (or not)
 
-			rec = new SecRecord (SecKind.InternetPassword) {
-				Account = "Protocol",
-				ValueData = NSData.FromString ("Password"),
-				Protocol = protocol,
-				Server = "www.xamarin.com"
-			};
+				rec = new SecRecord (SecKind.InternetPassword) {
+					Account = "Protocol",
+					ValueData = NSData.FromString ("Password"),
+					Protocol = protocol,
+					Server = "www.xamarin.com"
+				};
 
-			Assert.That (SecKeyChain.Add (rec), Is.EqualTo (SecStatusCode.Success), "Add");
+				Assert.That (SecKeyChain.Add (rec), Is.EqualTo (SecStatusCode.Success), "Add");
 
-			SecStatusCode code;
-			var match = SecKeyChain.QueryAsRecord (rec, out code);
-			Assert.That (code, Is.EqualTo (SecStatusCode.Success), "QueryAsRecord");
+				SecStatusCode code;
+				var match = SecKeyChain.QueryAsRecord (rec, out code);
+				Assert.That (code, Is.EqualTo (SecStatusCode.Success), "QueryAsRecord");
 
-			Assert.That (match.Protocol, Is.EqualTo (protocol), "Protocol");
+				Assert.That (match.Protocol, Is.EqualTo (protocol), "Protocol");
+			} finally {
+				// Clean up after us
+				SecKeyChain.Remove (rec);
+			}
 		}
 
 		[Test]
@@ -180,19 +185,24 @@ namespace MonoTouchFixtures.Security {
 				Server = "www.xamarin.com"
 			};
 
-			Assert.That (SecKeyChain.Add (rec), Is.EqualTo (SecStatusCode.Success), "Add");
+			try {
+				Assert.That (SecKeyChain.Add (rec), Is.EqualTo (SecStatusCode.Success), "Add");
 
-			var query = new SecRecord (SecKind.InternetPassword) {
-				Account = rec.Account,
-				AuthenticationType = rec.AuthenticationType,
-				Server = rec.Server,
-			};
+				var query = new SecRecord (SecKind.InternetPassword) {
+					Account = rec.Account,
+					AuthenticationType = rec.AuthenticationType,
+					Server = rec.Server,
+				};
 
-			SecStatusCode code;
-			var match = SecKeyChain.QueryAsRecord (query, out code);
-			Assert.That (code, Is.EqualTo (SecStatusCode.Success), "QueryAsRecord");
+				SecStatusCode code;
+				var match = SecKeyChain.QueryAsRecord (query, out code);
+				Assert.That (code, Is.EqualTo (SecStatusCode.Success), "QueryAsRecord");
 
-			Assert.That (match.AuthenticationType, Is.EqualTo (type), "AuthenticationType");
+				Assert.That (match.AuthenticationType, Is.EqualTo (type), "AuthenticationType");
+			} finally {
+				// Clean up after us
+				SecKeyChain.Remove (rec);
+			}
 		}
 
 #if __MACCATALYST__


### PR DESCRIPTION
This fixes at least some variations of this failure:

    * Protocol_17579: Add
        Expected: Success
        But was: DuplicateItem

In this test we try to delete any existing keychain items, but it seems that
may fail if the keychain item in question was created by a different app, in
which case we wouldn't have permission to delete it (but adding a new one
would still fail with a duplicate item error). Cleaning up any added keychain
items by the same test (and process) that added them avoids the permissions
problem.

Also clean up in other tests as well, to avoid filling up our keychain with
test stuff.

This PR is best reviewed by ignoring whitespace.