### PR TITLE
[xcode12.5] [CI][VSTS] Bring back the API diff from stable

### DIFF
--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -439,7 +439,9 @@ function New-GitHubSummaryComment {
         } else {
             # read the json file, convert it to an object and add a line for each artifact
             $json =  Get-Content $APIDiff | ConvertFrom-Json
-            Write-Host "API diff json content is $APIDiff"
+            $content = Get-Content $APIDiff   
+            Write-Host "API diff json content is $content"
+            Write-Host "json is $json"
             Write-Host "Json count $($json.Count)"
             if ($json.Count -gt 0) {
                 # build the required list

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -454,7 +454,7 @@ function New-GitHubSummaryComment {
                 $sb.AppendLine("<details><summary>View API diff</summary>")
                 $sb.AppendLine("") # no new line results in a bad rendering in the links
 
-                foreach ($linkPlatform in @("index","iOS", "macOS", "tvOS", "watchOS")) {
+                foreach ($linkPlatform in @("iOS", "macOS", "tvOS", "watchOS")) {
                     $htmlLink = $json.html | Select-Object -ExpandProperty $linkPlatform 
                     $gistLink = $json.gist | Select-Object -ExpandProperty $linkPlatform 
                     $sb.AppendLine("* $linkPlatform [vsdrops]($htmlLink) [gist]($gistLink)")

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -439,7 +439,8 @@ function New-GitHubSummaryComment {
         } else {
             # read the json file, convert it to an object and add a line for each artifact
             $json =  Get-Content $APIDiff | ConvertFrom-Json
-            Write-Host "API diff json content is $json"
+            Write-Host "API diff json content is $APIDiff"
+            Write-Host "Json count $($json.Count)"
             if ($json.Count -gt 0) {
                 # build the required list
                 $sb.AppendLine("# API diff")

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -433,12 +433,13 @@ function New-GitHubSummaryComment {
         $sb.AppendLine("* [Html Report (VSDrops)]($Env:VSDROPS_INDEX)")
     }
     if (-not [string]::IsNullOrEmpty($APIDiff)) {
-        Write-Host "Parsing API diff"
+        Write-Host "Parsing API diff in path $APIDiff"
         if (-not (Test-Path $APIDiff -PathType Leaf)) {
             $sb.AppendLine("Path $APIDiff was not found!")
         } else {
             # read the json file, convert it to an object and add a line for each artifact
             $json =  Get-Content $APIDiff | ConvertFrom-Json
+            Write-Host "API diff json content is $json"
             if ($json.Count -gt 0) {
                 # build the required list
                 $sb.AppendLine("# API diff")
@@ -451,7 +452,9 @@ function New-GitHubSummaryComment {
                 }
                 $sb.AppendLine("</details>")
             } else {
-                $sb.AppendLine("No api diff data found.")
+                $sb.AppendLine("# API diff")
+                $sb.AppendLine("")
+                $sb.AppendLine("**No api diff data found.**")
             }
         }
         

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -30,6 +30,8 @@ function Invoke-Request {
                 $count = $count + 1
                 $seconds = 5 * $count
                 Write-Host "Error performing request trying in $seconds seconds"
+                Write-Host "Exception was:"
+                Write-Host "$($_.Exception)"
                 Start-Sleep -Seconds $seconds
             }
         }

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -32,6 +32,8 @@ function Invoke-Request {
                 Write-Host "Error performing request trying in $seconds seconds"
                 Write-Host "Exception was:"
                 Write-Host "$($_.Exception)"
+                Write-Host "Response was:"
+                Write-Host "$($_.Exception.Response)"
                 Start-Sleep -Seconds $seconds
             }
         }
@@ -448,7 +450,8 @@ function New-GitHubSummaryComment {
                 # build the required list
                 $sb.AppendLine("# API diff")
                 Write-Host "Message is '$($json.message)'"
-                $sb.AppendLine($json.message)
+                # TODO: Find the reason for github to complain 
+                # $sb.AppendLine($json.message)
                 $sb.AppendLine("<details><summary>View API diff</summary>")
                 $sb.AppendLine("") # no new line results in a bad rendering in the links
 

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -450,8 +450,7 @@ function New-GitHubSummaryComment {
                 # build the required list
                 $sb.AppendLine("# API diff")
                 Write-Host "Message is '$($json.message)'"
-                # TODO: Find the reason for github to complain 
-                # $sb.AppendLine($json.message)
+                $sb.AppendLine($json.message)
                 $sb.AppendLine("<details><summary>View API diff</summary>")
                 $sb.AppendLine("") # no new line results in a bad rendering in the links
 
@@ -480,6 +479,7 @@ function New-GitHubSummaryComment {
             # read the json file, convert it to an object and add a line for each artifact
             $json =  Get-Content $Artifacts | ConvertFrom-Json
             if ($json.Count -gt 0) {
+                $sb.AppendLine("# Packages generated")
                 $sb.AppendLine("<details><summary>View packages</summary>")
                 $sb.AppendLine("") # no new line results in a bad rendering in the links
                 foreach ($a in $json) {

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -449,11 +449,9 @@ function New-GitHubSummaryComment {
                 $sb.AppendLine("<details><summary>View API diff</summary>")
                 $sb.AppendLine("") # no new line results in a bad rendering in the links
 
-                $html = $json | Select-Object -ExpandProperty "html"
-                $gist = $json | Select-Object -ExpandProperty "gist"
                 foreach ($linkPlatform in @("index","iOS", "macOS", "tvOS", "watchOS")) {
-                    $htmlLink = $html | Select-Object -ExpandProperty $linkPlatform 
-                    $gistLink = $gist| Select-Object -ExpandProperty $linkPlatform 
+                    $htmlLink = $json.html | Select-Object -ExpandProperty $linkPlatform 
+                    $gistLink = $json.gist | Select-Object -ExpandProperty $linkPlatform 
                     $sb.AppendLine("* $linkPlatform [vsdrops]($htmlLink) [gist]($gistLink)")
                 }
 

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -439,20 +439,24 @@ function New-GitHubSummaryComment {
         } else {
             # read the json file, convert it to an object and add a line for each artifact
             $json =  Get-Content $APIDiff | ConvertFrom-Json
-            $content = Get-Content $APIDiff   
-            Write-Host "API diff json content is $content"
-            Write-Host "json is $json"
-            Write-Host "Json count $($json.Count)"
-            if ($json.Count -gt 0) {
+            # we are dealing with an object, not a dictionary
+            $hasHtmlLinks = "html" -in $json.PSobject.Properties.Name
+            $hasMDlinks = "gist" -in $json.PSobject.Properties.Name
+            if ($hasHtmlLinks -and $hasMDlinks) {
                 # build the required list
                 $sb.AppendLine("# API diff")
                 $sb.AppendLine($json.message)
                 $sb.AppendLine("<details><summary>View API diff</summary>")
                 $sb.AppendLine("") # no new line results in a bad rendering in the links
 
+                $html = $json | Select-Object -ExpandProperty "html"
+                $gist = $json | Select-Object -ExpandProperty "gist"
                 foreach ($linkPlatform in @("index","iOS", "macOS", "tvOS", "watchOS")) {
-                    $sb.AppendLine("* $linkPlatform [vsdrops]($($json.html[$linkPlatform])) [gist]($($json.gist[$linkPlatform]))")
+                    $htmlLink = $html | Select-Object -ExpandProperty $linkPlatform 
+                    $gistLink = $gist| Select-Object -ExpandProperty $linkPlatform 
+                    $sb.AppendLine("* $linkPlatform [vsdrops]($htmlLink) [gist]($gistLink)")
                 }
+
                 $sb.AppendLine("</details>")
             } else {
                 $sb.AppendLine("# API diff")

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -447,6 +447,7 @@ function New-GitHubSummaryComment {
             if ($hasHtmlLinks -and $hasMDlinks) {
                 # build the required list
                 $sb.AppendLine("# API diff")
+                Write-Host "Message is '$($json.message)'"
                 $sb.AppendLine($json.message)
                 $sb.AppendLine("<details><summary>View API diff</summary>")
                 $sb.AppendLine("") # no new line results in a bad rendering in the links

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -387,7 +387,7 @@ steps:
 - bash: |
     report_error ()
     {
-      MESSAGE="🔥 [Failed to create API Diff](%s/console) 🔥"
+      MESSAGE="🔥 [Failed to create API Diff] 🔥"
       echo "##vso[task.setvariable variable=APIDIFF_MESSAGE;isOutput=true]$MESSAGE"
       echo "##vso[task.setvariable variable=APIDIFF_BUILT;isOutput=true]False"
     }

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -387,7 +387,7 @@ steps:
 - bash: |
     report_error ()
     {
-      MESSAGE="🔥 [Failed to create API Diff] 🔥"
+      MESSAGE=$(printf ":fire: Failed to create API Diff from stable (%s/console) :fire:")
       echo "##vso[task.setvariable variable=APIDIFF_MESSAGE;isOutput=true]$MESSAGE"
       echo "##vso[task.setvariable variable=APIDIFF_BUILT;isOutput=true]False"
     }
@@ -398,7 +398,7 @@ steps:
     # remove some files that do not need to be uploaded
     cd $(Build.SourcesDirectory)/xamarin-macios/tools/apidiff/
     rm -Rf *.exe *.pdb *.stamp *.zip *.sh ./references ./temp
-    MESSAGE="✅ [API Diff (from stable)]"
+    MESSAGE=":white_check_mark: API Diff from stable"
     echo "##vso[task.setvariable variable=APIDIFF_MESSAGE;isOutput=true]$MESSAGE"
     echo "##vso[task.setvariable variable=APIDIFF_BUILT;isOutput=true]True"
   displayName: 'API diff (from stable)'

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -387,7 +387,7 @@ steps:
 - bash: |
     report_error ()
     {
-      MESSAGE="🔥 [Failed to create API Diff](%s/console) 🔥\\n"
+      MESSAGE="🔥 [Failed to create API Diff](%s/console) 🔥"
       echo "##vso[task.setvariable variable=APIDIFF_MESSAGE;isOutput=true]$MESSAGE"
       echo "##vso[task.setvariable variable=APIDIFF_BUILT;isOutput=true]False"
     }
@@ -398,7 +398,7 @@ steps:
     # remove some files that do not need to be uploaded
     cd $(Build.SourcesDirectory)/xamarin-macios/tools/apidiff/
     rm -Rf *.exe *.pdb *.stamp *.zip *.sh ./references ./temp
-    MESSAGE="✅ [API Diff (from stable)](%s)\\n" "$URL" >> "$WORKSPACE/jenkins/pr-comments.md"
+    MESSAGE="✅ [API Diff (from stable)]"
     echo "##vso[task.setvariable variable=APIDIFF_MESSAGE;isOutput=true]$MESSAGE"
     echo "##vso[task.setvariable variable=APIDIFF_BUILT;isOutput=true]True"
   displayName: 'API diff (from stable)'

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -385,12 +385,24 @@ steps:
   continueOnError: true
 
 - bash: |
+    report_error ()
+    {
+      MESSAGE="🔥 [Failed to create API Diff](%s/console) 🔥\\n"
+      echo "##vso[task.setvariable variable=APIDIFF_MESSAGE;isOutput=true]$MESSAGE"
+      echo "##vso[task.setvariable variable=APIDIFF_BUILT;isOutput=true]False"
+    }
+    trap report_error ERR
+
     make -j8 -C $(Build.SourcesDirectory)/xamarin-macios/tools/apidiff jenkins-api-diff
 
     # remove some files that do not need to be uploaded
     cd $(Build.SourcesDirectory)/xamarin-macios/tools/apidiff/
     rm -Rf *.exe *.pdb *.stamp *.zip *.sh ./references ./temp
+    MESSAGE="✅ [API Diff (from stable)](%s)\\n" "$URL" >> "$WORKSPACE/jenkins/pr-comments.md"
+    echo "##vso[task.setvariable variable=APIDIFF_MESSAGE;isOutput=true]$MESSAGE"
+    echo "##vso[task.setvariable variable=APIDIFF_BUILT;isOutput=true]True"
   displayName: 'API diff (from stable)'
+  name: apidiff
   condition: and(succeeded(), contains(variables['configuration.SkipPublicJenkins'], 'False'))
   continueOnError: true
   env:

--- a/tools/devops/automation/templates/build/download-artifacts.yml
+++ b/tools/devops/automation/templates/build/download-artifacts.yml
@@ -35,13 +35,6 @@ steps:
     allowFailedBuilds: true
     path: $(Build.SourcesDirectory)/artifacts
 
-- task: DownloadPipelineArtifact@2
-  displayName: Download artifacts.json
-  inputs:
-    patterns: '**/*.json'
-    allowFailedBuilds: true
-    path: $(Build.DefaultWorkingDirectory)/artifacts
-
 - pwsh: |
     Get-ChildItem -Recurse $Env:SYSTEM_DEFAULTWORKINGDIRECTORY
     Write-Host "##vso[task.setvariable variable=ARTIFACTS_JSON_PATH]$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\artifacts\pkg-info\artifacts.json"

--- a/tools/devops/automation/templates/build/download-artifacts.yml
+++ b/tools/devops/automation/templates/build/download-artifacts.yml
@@ -24,7 +24,7 @@ steps:
 
 - powershell: |
     Write-Host "##vso[task.setvariable variable=STABLE_APIDDIFF_PATH]$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\apidiff-stable"
-  displayName: Pusblish apidiff paths
+  displayName: Publish apidiff paths
   name: apidiff # not to be confused with the displayName, this is used to later use the name of the step to access the output variables from an other job
 
 # download the artifacts.json, which will use to find the URI of the built pkg to later be given to the user

--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -43,7 +43,7 @@ steps:
       "watchOS" = "watchos-*.md";
     }
 
-    [System.Collections.Generic.List[string]]$gistsObj = @()
+    [System.Collections.Generic.List[System.Object]]$gistsObj = @()
     $gists = @{}
 
     foreach ($key in $filePatterns.Keys) {

--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -44,7 +44,7 @@ steps:
     }
 
     [System.Collections.Generic.List[string]]$gistsObj = @()
-    [System.Collections.Generic.List[string]]$gists = @{}
+    $gists = @{}
 
     foreach ($key in $filePatterns.Keys) {
       $filter = $filePatterns[$key]

--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -64,7 +64,7 @@ steps:
     $gists.Add("index", $url)
 
     # similar dict but for the html links from vsdrops
-    $apiDiffRoot="$Env:VSDROPSPREFIX/$Env:BUILD_BUILDNUMBER/$Env:BUILD_BUILDID/APIDiff/;/
+    $apiDiffRoot="$Env:VSDROPSPREFIX/$Env:BUILD_BUILDNUMBER/$Env:BUILD_BUILDID/APIDiff/;/"
     $html =  @{
       "iOS" = $apiDiffRoot + "ios-api-diff.html"; 
       "macOS" = $apiDiffRoot + "mac-api-diff.html";

--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -38,9 +38,9 @@ steps:
     $apiDiffRoot = "$Env:STABLE_APIDDIFF_PATH"
     $filePatterns = @{
       "iOS" = "ios-*.md";
-      "macOS"="macos-*.md";
-      "tvOS"="tvos-*.md";
-      "watchOS"="watchos-*.md"
+      "macOS" = "macos-*.md";
+      "tvOS" = "tvos-*.md";
+      "watchOS" = "watchos-*.md"
     }
 
     [System.Collections.Generic.List[string]]$gistsObj = @()
@@ -61,14 +61,29 @@ steps:
 
     # create a gist with all diffs
     $url = New-GistWithFiles -Description "API diff from stable (all platforms)" -Files $gistsObj 
-    $gists.Add("all", $url)
+    $gists.Add("index", $url)
 
-    # set env variables to be used in later jobs
-    foreach ($key in $gists.Keys) {
-      $envVarName = "$($key.ToUpper())_STABLE_URL" # results in ALL_STABLE_URL/IOS_STABLE_URL etc
-      $url = $gists[$key]
-      Write-Host "##vso[task.setvariable variable=$envVarName]$url"
+    # similar dict but for the html links from vsdrops
+    $apiDiffRoot="$Env:VSDROPSPREFIX/$Env:BUILD_BUILDNUMBER/$Env:BUILD_BUILDID/APIDiff/;/
+    $html =  @{
+      "iOS" = $apiDiffRoot + "ios-api-diff.html" 
+      "macOS" = $apiDiffRoot + "mac-api-diff.html"
+      "tvOS" = $apiDiffRoot + "tvos-api-diff.html"
+      "watchOS" =$apiDiffRoot + "watchos-api-diff.html"
+      "index"= $apiDiffRoot + "api-diff.html"
     }
+
+    # build a json object that will be used by the comment to write the data for users
+    $apiDiffData = @{
+      "gist" = $gists
+      "html" = $html
+      "result" = $Env:APIDIFF_BUILT
+      "message" = $Env:APIDIFF_MESSAGE
+    }
+    # write to a file to be used by the comment to parse
+    $path = $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\apidiff.json"
+    $apiDiffData | ConvertTo-Json | Out-File $path
+    Write-Host "##vso[task.setvariable variable=APIDIFF_JSON_PATH]$path"
   displayName: 'Create API from stable diff gists'
   enabled: false
   timeoutInMinutes: 1
@@ -85,11 +100,11 @@ steps:
 
     if ($buildReason -ne "PullRequest" -or $Env:BUILD_PACKAGE -eq "True") {
       Write-Host "Json path is $Env:ARTIFACTS_JSON_PATH"
-      $response = New-GitHubSummaryComment -Context "$Env:CONTEXT" -TestSummaryPath "$Env:TESTS_SUMMARY" -Artifacts "$Env:ARTIFACTS_JSON_PATH"
+      $response = New-GitHubSummaryComment -Context "$Env:CONTEXT" -TestSummaryPath "$Env:TESTS_SUMMARY" -Artifacts "$Env:ARTIFACTS_JSON_PATH" -APIDiff "$Env:APIDIFF_JSON_PATH"
       Write-Host $response
     } else {
       Write-Host "Json path is $Env:ARTIFACTS_JSON_PATH"
-      $response = New-GitHubSummaryComment -Context "$Env:CONTEXT" -TestSummaryPath "$Env:TESTS_SUMMARY"
+      $response = New-GitHubSummaryComment -Context "$Env:CONTEXT" -TestSummaryPath "$Env:TESTS_SUMMARY" -APIDiff "$Env:APIDIFF_JSON_PATH"
       Write-Host $response
     }
     if($Env:TESTS_JOBSTATUS -ne "Succeeded")

--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -85,7 +85,6 @@ steps:
     $apiDiffData | ConvertTo-Json | Out-File $path
     Write-Host "##vso[task.setvariable variable=APIDIFF_JSON_PATH]$path"
   displayName: 'Create API from stable diff gists'
-  enabled: false
   timeoutInMinutes: 1
   env:
     GITHUB_TOKEN: $(GitHub.Token)

--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -40,7 +40,7 @@ steps:
       "iOS" = "ios-*.md";
       "macOS" = "macos-*.md";
       "tvOS" = "tvos-*.md";
-      "watchOS" = "watchos-*.md"
+      "watchOS" = "watchos-*.md";
     }
 
     [System.Collections.Generic.List[string]]$gistsObj = @()
@@ -66,19 +66,19 @@ steps:
     # similar dict but for the html links from vsdrops
     $apiDiffRoot="$Env:VSDROPSPREFIX/$Env:BUILD_BUILDNUMBER/$Env:BUILD_BUILDID/APIDiff/;/
     $html =  @{
-      "iOS" = $apiDiffRoot + "ios-api-diff.html" 
-      "macOS" = $apiDiffRoot + "mac-api-diff.html"
-      "tvOS" = $apiDiffRoot + "tvos-api-diff.html"
-      "watchOS" =$apiDiffRoot + "watchos-api-diff.html"
-      "index"= $apiDiffRoot + "api-diff.html"
+      "iOS" = $apiDiffRoot + "ios-api-diff.html"; 
+      "macOS" = $apiDiffRoot + "mac-api-diff.html";
+      "tvOS" = $apiDiffRoot + "tvos-api-diff.html";
+      "watchOS" =$apiDiffRoot + "watchos-api-diff.html";
+      "index"= $apiDiffRoot + "api-diff.html";
     }
 
     # build a json object that will be used by the comment to write the data for users
     $apiDiffData = @{
-      "gist" = $gists
-      "html" = $html
-      "result" = $Env:APIDIFF_BUILT
-      "message" = $Env:APIDIFF_MESSAGE
+      "gist" = $gists;
+      "html" = $html;
+      "result" = $Env:APIDIFF_BUILT;
+      "message" = $Env:APIDIFF_MESSAGE;
     }
     # write to a file to be used by the comment to parse
     $path = $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\apidiff.json"

--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -55,13 +55,13 @@ steps:
         # create a gist just for this file 
         $url = New-GistWithFiles -Description "$key API diff from stable" -Files @($obj)
         Write-Host "New gist created at $url"
-        $gists.Add($key, $url)
+        $gists[$key] = $url
       }
     }
 
     # create a gist with all diffs
     $url = New-GistWithFiles -Description "API diff from stable (all platforms)" -Files $gistsObj 
-    $gists.Add("index", $url)
+    $gists["index"] = $url
 
     # similar dict but for the html links from vsdrops
     $apiDiffRoot="$Env:VSDROPSPREFIX/$Env:BUILD_BUILDNUMBER/$Env:BUILD_BUILDID/APIDiff/;/"

--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -81,7 +81,7 @@ steps:
       "message" = $Env:APIDIFF_MESSAGE;
     }
     # write to a file to be used by the comment to parse
-    $path = $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\apidiff.json"
+    $path = "$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\apidiff.json"
     $apiDiffData | ConvertTo-Json | Out-File $path
     Write-Host "##vso[task.setvariable variable=APIDIFF_JSON_PATH]$path"
   displayName: 'Create API from stable diff gists'

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -110,7 +110,7 @@ jobs:
     workspace:
       clean: all
   steps:
-  - template: ../common/upload-vsdrops.yml
+  - template: upload-vsdrops.yml
     parameters:
       devicePrefix: sim
 
@@ -145,6 +145,8 @@ jobs:
     BUILD_PACKAGE: $[ dependencies.configure.outputs['labels.build-package'] ]
     TESTS_BOT: $[ dependencies.build.outputs['runTests.TESTS_BOT'] ]
     TESTS_JOBSTATUS: $[ dependencies.build.outputs['runTests.TESTS_JOBSTATUS'] ]
+    APIDIFF_MESSAGE: $[ dependencies.build.outputs['apidiff.APIDIFF_MESSAGE'] ]
+    APIDIFF_BUILT: $[ dependencies.build.outputs['apidiff.APIDIFF_BUILT'] ]
   pool:
     vmImage: 'windows-latest'
     workspace:

--- a/tools/devops/automation/templates/build/upload-vsdrops.yml
+++ b/tools/devops/automation/templates/build/upload-vsdrops.yml
@@ -35,4 +35,4 @@ steps:
     buildNumber: 'xamarin-macios/device-tests/$(Build.BuildNumber)/$(Build.BuildId)/APIDiff'
     sourcePath: $(STABLE_APIDDIFF_PATH)
     detailedLog: true
-    usePat: true 
+    usePat: true

--- a/tools/devops/automation/templates/build/upload-vsdrops.yml
+++ b/tools/devops/automation/templates/build/upload-vsdrops.yml
@@ -1,0 +1,38 @@
+
+# job that downloads the html report from the artifacts and uploads them into vsdrops.
+parameters:
+
+- name: devicePrefix
+  type: string 
+  default: 'ios' # default context, since we started dealing with iOS devices. 
+
+steps:
+
+- checkout: self
+  persistCredentials: true
+
+- template: download-artifacts.yml 
+  parameters:
+    devicePrefix: ${{ parameters.devicePrefix }}
+
+# Upload full report to vsdrops using the the build numer and id as uuids.
+- task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
+  displayName: 'Publish Html test report to Artifact Services Drop'
+  inputs:
+    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
+    dropMetadataContainerName: 'DropMetadata-${{ parameters.devicePrefix }}'
+    buildNumber: 'xamarin-macios/device-tests/$(Build.BuildNumber)/$(Build.BuildId)/${{ parameters.devicePrefix }}'
+    sourcePath: $(HTML_REPORT_PATH)
+    detailedLog: true
+    usePat: true 
+
+# Upload the API diff to vsdrops to be able to locate it
+- task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
+  displayName: 'Publish API diff to Artifact Services Drop'
+  inputs:
+    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
+    dropMetadataContainerName: 'DropMetadata-${{ parameters.devicePrefix }}'
+    buildNumber: 'xamarin-macios/device-tests/$(Build.BuildNumber)/$(Build.BuildId)/APIDiff'
+    sourcePath: $(STABLE_APIDDIFF_PATH)
+    detailedLog: true
+    usePat: true 

--- a/tools/devops/automation/templates/build/upload-vsdrops.yml
+++ b/tools/devops/automation/templates/build/upload-vsdrops.yml
@@ -31,7 +31,7 @@ steps:
   displayName: 'Publish API diff to Artifact Services Drop'
   inputs:
     dropServiceURI: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
-    dropMetadataContainerName: 'DropMetadata-${{ parameters.devicePrefix }}'
+    dropMetadataContainerName: 'DropMetadata-APIDiff'
     buildNumber: 'xamarin-macios/device-tests/$(Build.BuildNumber)/$(Build.BuildId)/APIDiff'
     sourcePath: $(STABLE_APIDDIFF_PATH)
     detailedLog: true


### PR DESCRIPTION
Bring back the status of the API diff for PRs and commits. The comment will look similar to [this](https://github.com/xamarin/xamarin-macios/commit/816b11f3c981189872caaaffae471959e31104df#commitcomment-47300105) with the diff that a message has been added and a title for the pkgs to make the message to have a nicer format.

API diff can be accessed via vsdrops for team members or via gists. The [gist](https://gist.github.com/vs-mobiletools-engineering-service2/82268da7cd3786afa79a9d2e8baef5bb) is an example of what a user will see.


Backport of #10682
