### PR TITLE
[bgen] Remove trailing newlines from warning/error messages.

### DIFF
--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -140,43 +140,35 @@
 	</data>
 
 	<data name="BI0026" xml:space="preserve">
-		<value>Could not parse the command line argument '--warnaserror': {0}
-		</value>
+		<value>Could not parse the command line argument '--warnaserror': {0}</value>
 	</data>
 
 	<data name="BI0068" xml:space="preserve">
-		<value>Invalid value for target framework: {0}.
-		</value>
+		<value>Invalid value for target framework: {0}.</value>
 	</data>
 
 	<data name="BI0070" xml:space="preserve">
-		<value>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</value>
+		<value>Invalid target framework: {0}. Valid target frameworks are: {1}.</value>
 	</data>
 
 	<data name="BI0086" xml:space="preserve">
-		<value>A target framework (--target-framework) must be specified.
-		</value>
+		<value>A target framework (--target-framework) must be specified.</value>
 	</data>
 
 	<data name="BI0087" xml:space="preserve">
-		<value>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</value>
+		<value>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</value>
 	</data>
 	
 	<data name="BI0088" xml:space="preserve">
-		<value>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</value>
+		<value>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</value>
 	</data>
 	
 	<data name="BI0089" xml:space="preserve">
-		<value>Internal error: property {0} doesn't have neither a getter nor a setter.
-		</value>
+		<value>Internal error: property {0} doesn't have neither a getter nor a setter.</value>
 	</data>
 	
 	<data name="BI0099" xml:space="preserve">
-		<value>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</value>
+		<value>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</value>
 	</data>
 
 	<data name="BI1000" xml:space="preserve">
@@ -186,168 +178,135 @@
 	</data>
 
 	<data name="BI1001" xml:space="preserve">
-		<value>Do not know how to make a trampoline for {0}
-		</value>
+		<value>Do not know how to make a trampoline for {0}</value>
 	</data>
 
 	<data name="BI1002" xml:space="preserve">
-		<value>Unknown kind {0} in method '{1}.{2}'
-		</value>
+		<value>Unknown kind {0} in method '{1}.{2}'</value>
 	</data>
 
 	<data name="BI1003" xml:space="preserve">
-		<value>The delegate method {0}.{1} needs to take at least one parameter
-		</value>
+		<value>The delegate method {0}.{1} needs to take at least one parameter</value>
 	</data>
 
 	<data name="BI1004" xml:space="preserve">
-		<value>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</value>
+		<value>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</value>
 	</data>
 
 	<data name="BI1005" xml:space="preserve">
-		<value>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</value>
+		<value>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</value>
 	</data>
 
 	<data name="BI1006" xml:space="preserve">
-		<value>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</value>
+		<value>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</value>
 	</data>
 
 	<data name="BI1007" xml:space="preserve">
-		<value>Unknown attribute {0} on {1}.{2}
-		</value>
+		<value>Unknown attribute {0} on {1}.{2}</value>
 	</data>
 
 	<data name="BI1008" xml:space="preserve">
-		<value>[IsThreadStatic] is only valid on properties that are also [Static]
-		</value>
+		<value>[IsThreadStatic] is only valid on properties that are also [Static]</value>
 	</data>
 
 	<data name="BI1009" xml:space="preserve">
-		<value>No selector specified for method `{0}.{1}'
-		</value>
+		<value>No selector specified for method `{0}.{1}'</value>
 	</data>
 
 	<data name="BI1010" xml:space="preserve">
-		<value>No Export attribute on {0}.{1} property
-		</value>
+		<value>No Export attribute on {0}.{1} property</value>
 	</data>
 
 	<data name="BI1011" xml:space="preserve">
-		<value>Do not know how to extract type {0}/{1} from an NSDictionary
-		</value>
+		<value>Do not know how to extract type {0}/{1} from an NSDictionary</value>
 	</data>
 
 	<data name="BI1012" xml:space="preserve">
-		<value>No Export or Bind attribute defined on {0}.{1}
-		</value>
+		<value>No Export or Bind attribute defined on {0}.{1}</value>
 	</data>
 
 	<data name="BI1013" xml:space="preserve">
-		<value>Unsupported type for Fields (string), you probably meant NSString
-		</value>
+		<value>Unsupported type for Fields (string), you probably meant NSString</value>
 	</data>
 
 	<data name="BI1014" xml:space="preserve">
-		<value>Unsupported type for Fields: {0} for '{1}'.
-		</value>
+		<value>Unsupported type for Fields: {0} for '{1}'.</value>
 	</data>
 
 	<data name="BI1015" xml:space="preserve">
-		<value>In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</value>
+		<value>In class {0} You specified the Events property, but did not bind those to names with Delegates</value>
 	</data>
 
 	<data name="BI1016" xml:space="preserve">
-		<value>The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</value>
+		<value>The delegate method {0}.{1} is missing the [DefaultValue] attribute</value>
 	</data>
 
 	<data name="BI1017" xml:space="preserve">
-		<value>Do not know how to make a signature for {0}
-		</value>
+		<value>Do not know how to make a signature for {0}</value>
 	</data>
 
 	<data name="BI1018" xml:space="preserve">
-		<value>No [Export] attribute on property {0}.{1}
-		</value>
+		<value>No [Export] attribute on property {0}.{1}</value>
 	</data>
 
 	<data name="BI1019" xml:space="preserve">
-		<value>Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</value>
+		<value>Invalid [NoDefaultValue] attribute on method '{0}.{1}'</value>
 	</data>
 
 	<data name="BI1020" xml:space="preserve">
-		<value>Unsupported type {0} used on exported method {1}.{2} -> {3}
-		</value>
+		<value>Unsupported type {0} used on exported method {1}.{2} -> {3}</value>
 	</data>
 
 	<data name="BI1021" xml:space="preserve">
-		<value>Unsupported type for read/write Fields: {0} for {1}.{2}
-		</value>
+		<value>Unsupported type for read/write Fields: {0} for {1}.{2}</value>
 	</data>
 
 	<data name="BI1022" xml:space="preserve">
-		<value>Model classes can not be categories
-		</value>
+		<value>Model classes can not be categories</value>
 	</data>
 
 	<data name="BI1023" xml:space="preserve">
-		<value>The number of Events (Type) and Delegates (string) must match for `{0}`
-		</value>
+		<value>The number of Events (Type) and Delegates (string) must match for `{0}`</value>
 	</data>
 
 	<data name="BI1024" xml:space="preserve">
-		<value>No selector specified for property '{0}.{1}'
-		</value>
+		<value>No selector specified for property '{0}.{1}'</value>
 	</data>
 
 	<data name="BI1025" xml:space="preserve">
-		<value>[Static] and [Protocol] are mutually exclusive ({0})
-		</value>
+		<value>[Static] and [Protocol] are mutually exclusive ({0})</value>
 	</data>
 
 	<data name="BI1026" xml:space="preserve">
-		<value>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</value>
+		<value>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</value>
 	</data>
 
 	<data name="BI1027" xml:space="preserve">
-		<value>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</value>
+		<value>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</value>
 	</data>
 
 	<data name="BI1028" xml:space="preserve">
-		<value>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</value>
+		<value>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</value>
 	</data>
 
 	<data name="BI1029" xml:space="preserve">
-		<value>Internal error: invalid enum mode for type '{0}'
-		</value>
+		<value>Internal error: invalid enum mode for type '{0}'</value>
 	</data>
 
 	<data name="BI1030" xml:space="preserve">
-		<value>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</value>
+		<value>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</value>
 	</data>
 
 	<data name="BI1031" xml:space="preserve">
-		<value>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</value>
+		<value>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</value>
 	</data>
 	
 	<data name="BI1032" xml:space="preserve">
-		<value>No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</value>
+		<value>No support for setters in StrongDictionary classes for type {0} in {1}.{2}</value>
 	</data>
 	
 	<data name="BI1033" xml:space="preserve">
-		<value>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</value>
+		<value>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</value>
 		<comment>Generating a strongly typed dictionary for type '{0}' is not supported.
 {0} - the property type.
 {1} - the dictionary type.
@@ -356,38 +315,31 @@
 	</data>
 		
 	<data name="BI1034" xml:space="preserve">
-		<value>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</value>
+		<value>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</value>
 	</data>
 
 	<data name="BI1035" xml:space="preserve">
-		<value>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</value>
+		<value>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</value>
 	</data>
 
 	<data name="BI1036" xml:space="preserve">
-		<value>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</value>
+		<value>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</value>
 	</data>
 
 	<data name="BI1037" xml:space="preserve">
-		<value>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</value>
+		<value>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</value>
 	</data>
 
 	<data name="BI1038" xml:space="preserve">
-		<value>The selector {0} on type {1} is found multiple times with different return types.
-		</value>
+		<value>The selector {0} on type {1} is found multiple times with different return types.</value>
 	</data>
 
 	<data name="BI1039" xml:space="preserve">
-		<value>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</value>
+		<value>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</value>
 	</data>
 
 	<data name="BI1040" xml:space="preserve">
-		<value>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</value>
+		<value>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</value>
 	</data>
 
 	<data name="BI1041" xml:space="preserve">
@@ -395,301 +347,241 @@
 	</data>
 
 	<data name="BI1042" xml:space="preserve">
-		<value>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</value>
+		<value>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</value>
 	</data>
 
 	<data name="BI1043" xml:space="preserve">
-		<value>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</value>
+		<value>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</value>
 	</data>
 
 	<data name="BI1044" xml:space="preserve">
-		<value>Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</value>
+		<value>Repeated name '{0}' provided in [DelegateApiNameAttribute].</value>
 	</data>
 
 	<data name="BI1045" xml:space="preserve">
-		<value>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</value>
+		<value>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</value>
 	</data>
 
 	<data name="BI1046" xml:space="preserve">
-		<value>The [Field] constant {0} cannot only be used once inside enum {1}.
-		</value>
+		<value>The [Field] constant {0} cannot only be used once inside enum {1}.</value>
 	</data>
 
 	<data name="BI1047" xml:space="preserve">
-		<value>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</value>
+		<value>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</value>
 	</data>
 
 	<data name="BI1048" xml:space="preserve">
-		<value>Unsupported type {0} decorated with [BindAs]
-		</value>
+		<value>Unsupported type {0} decorated with [BindAs]</value>
 	</data>
 
 	<data name="BI1049" xml:space="preserve">
-		<value>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</value>
+		<value>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</value>
 	</data>
 
 	<data name="BI1050" xml:space="preserve">
-		<value>[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</value>
+		<value>[BindAs] cannot be used inside Protocol or Model types. Type: {0}</value>
 	</data>
 
 	<data name="BI1051" xml:space="preserve">
-		<value>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</value>
+		<value>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</value>
 	</data>
 
 	<data name="BI1052" xml:space="preserve">
-		<value>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</value>
+		<value>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</value>
 	</data>
 
 	<data name="BI1053" xml:space="preserve">
-		<value>Internal error: unknown target framework '{0}'.
-		</value>
+		<value>Internal error: unknown target framework '{0}'.</value>
 	</data>
 
 	<data name="BI1054" xml:space="preserve">
-		<value>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</value>
+		<value>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</value>
 	</data>
 
 	<data name="BI1055" xml:space="preserve">
-		<value>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</value>
+		<value>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</value>
 	</data>
 
 	<data name="BI1056" xml:space="preserve">
-		<value>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</value>
+		<value>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</value>
 	</data>
 
 	<data name="BI1057" xml:space="preserve">
-		<value>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</value>
+		<value>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</value>
 	</data>
 
 	<data name="BI1058" xml:space="preserve">
-		<value>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</value>
+		<value>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</value>
 	</data>
 
 	<data name="BI1059" xml:space="preserve">
-		<value>Found {0} {1} attributes on the member {2}. At most one was expected.
-		</value>
+		<value>Found {0} {1} attributes on the member {2}. At most one was expected.</value>
 	</data>
 
 	<data name="BI1060" xml:space="preserve">
-		<value>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</value>
+		<value>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</value>
 	</data>
 
 	<data name="BI1061" xml:space="preserve">
-		<value>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</value>
+		<value>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</value>
 	</data>
 
 	<data name="BI1062" xml:space="preserve">
-		<value>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</value>
+		<value>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</value>
 	</data>
 
 	<data name="BI1063" xml:space="preserve">
-		<value>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</value>
+		<value>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</value>
 	</data>
 
 	<data name="BI1064" xml:space="preserve">
-		<value>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</value>
+		<value>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</value>
 	</data>
 
 	<data name="BI1065" xml:space="preserve">
-		<value>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</value>
+		<value>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</value>
 	</data>
 
 	<data name="BI1066" xml:space="preserve">
-		<value>Unsupported return type '{0}' in {1}.{2}.
-		</value>
+		<value>Unsupported return type '{0}' in {1}.{2}.</value>
 	</data>
 
 	<data name="BI1067" xml:space="preserve">
-		<value>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</value>
+		<value>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</value>
 	</data>
 
 	<data name="BI1068" xml:space="preserve">
-		<value>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</value>
+		<value>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</value>
 	</data>
 
 	<data name="BI1069" xml:space="preserve">
-		<value>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</value>
+		<value>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</value>
 	</data>
 
 	<data name="BI1070" xml:space="preserve">
-		<value>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</value>
+		<value>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</value>
 	</data>
 
 	<data name="BI1071" xml:space="preserve">
-		<value>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</value>
+		<value>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</value>
 	</data>
 
 	<data name="BI1072" xml:space="preserve">
-		<value>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</value>
+		<value>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</value>
 	</data>
 	
 	<data name="BI1073" xml:space="preserve">
-		<value>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</value>
+		<value>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</value>
 	</data>
 	
 	<data name="BI1074" xml:space="preserve">
-		<value> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</value>
+		<value> Missing [CoreImageFilterProperty] attribute on {0} property {1}</value>
 	</data>
 	
 	<data name="BI1075" xml:space="preserve">
-		<value>Unimplemented CoreImage property type {0}
-		</value>
+		<value>Unimplemented CoreImage property type {0}</value>
 	</data>
 	
 	<data name="BI1076" xml:space="preserve">
-		<value>Unable to find selector for {0} on {1} on self or base class
-		</value>
+		<value>Unable to find selector for {0} on {1} on self or base class</value>
 	</data>
 	
 	<data name="BI1077" xml:space="preserve">
-		<value>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</value>
+		<value>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</value>
 		<comment>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
 {0} - The method name.
 		</comment>
 	</data>
 	
 	<data name="BI1078" xml:space="preserve">
-		<value>{0} in method `{1}'
-		</value>
+		<value>{0} in method `{1}'</value>
 	</data>
 	
 	<data name="BI1079" xml:space="preserve">
-		<value>{0} in parameter `{1}' from {2}.{3}
-		</value>
+		<value>{0} in parameter `{1}' from {2}.{3}</value>
 	</data>
 	
 	<data name="BI1080" xml:space="preserve">
-		<value>Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</value>
+		<value>Unsupported type 'ref/out {0}' decorated with [BindAs]</value>
 	</data>
 	
     <data name="BI1081" xml:space="preserve">
-        <value>Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </value>
+        <value>Unable to find the assembly '{0}'. Add it as a reference using its full path.</value>
     </data>
 	
 	<data name="BI1101" xml:space="preserve">
-		<value>Trying to use a string as a [Target]
-		</value>
+		<value>Trying to use a string as a [Target]</value>
 	</data>
 
 	<data name="BI1102" xml:space="preserve">
-		<value>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</value>
+		<value>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</value>
 	</data>
 
 	<data name="BI1103" xml:space="preserve">
-		<value>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</value>
+		<value>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</value>
 	</data>
 
 	<data name="BI1104" xml:space="preserve">
-		<value>Could not load the referenced library '{0}': {1}.
-		</value>
+		<value>Could not load the referenced library '{0}': {1}.</value>
 	</data>
 
 	<data name="BI1105" xml:space="preserve">
-		<value>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</value>
+		<value>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</value>
 	</data>
 
 	<data name="BI1106" xml:space="preserve">
-		<value>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</value>
+		<value>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</value>
 	</data>
 
 	<data name="BI1107" xml:space="preserve">
-		<value>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</value>
+		<value>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</value>
 	</data>
 
 	<data name="BI1108" xml:space="preserve">
-		<value>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</value>
+		<value>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</value>
 	</data>
 
 	<data name="BI1109" xml:space="preserve">
-		<value>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</value>
+		<value>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</value>
 	</data>
 
 	<data name="BI1110" xml:space="preserve">
-		<value>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</value>
+		<value>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</value>
 	</data>
 
 	<data name="BI1111" xml:space="preserve">
-		<value>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</value>
+		<value>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</value>
 	</data>
 
 	<data name="BI1112" xml:space="preserve">
-		<value>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</value>
+		<value>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</value>
 	</data>
-	
 
 	<data name="BI1113" xml:space="preserve">
-		<value>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</value>
+		<value>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</value>
 	</data>
 
 	<data name="BI1114" xml:space="preserve">
-		<value>Binding error: test unable to find property: {0} on {1}
-		</value>
+		<value>Binding error: test unable to find property: {0} on {1}</value>
 	</data>
 		
 	<data name="BI1115" xml:space="preserve">
-		<value>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</value>
+		<value>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</value>
 	</data>
 
 	<data name="BI1116" xml:space="preserve">
-		<value>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</value>
+		<value>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</value>
 	</data>
 
 	<data name="BI1117" xml:space="preserve">
-		<value>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</value>
+		<value>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</value>
 	</data>
 
 	<data name="BI1118" xml:space="preserve">
-		<value>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</value>
+		<value>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</value>
 	</data>
 
 	<data name="BI1119" xml:space="preserve">
-		<value>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</value>
+		<value>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</value>
 	</data>
 </root>

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="BI0000">
         <source>Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0001">
         <source>The .NET runtime could not load the {0} type. Message: {1}</source>
         <target state="new">The .NET runtime could not load the {0} type. Message: {1}</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0002">
         <source>Could not compile the API bindings.
@@ -21,72 +19,47 @@
         <target state="new">Could not compile the API bindings.
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0026">
-        <source>Could not parse the command line argument '--warnaserror': {0}
-		</source>
-        <target state="new">Could not parse the command line argument '--warnaserror': {0}
-		</target>
-        <note>
-		</note>
+        <source>Could not parse the command line argument '--warnaserror': {0}</source>
+        <target state="new">Could not parse the command line argument '--warnaserror': {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0068">
-        <source>Invalid value for target framework: {0}.
-		</source>
-        <target state="new">Invalid value for target framework: {0}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid value for target framework: {0}.</source>
+        <target state="new">Invalid value for target framework: {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0086">
-        <source>A target framework (--target-framework) must be specified.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified.
-		</target>
-        <note>
-		</note>
+        <source>A target framework (--target-framework) must be specified.</source>
+        <target state="new">A target framework (--target-framework) must be specified.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0087">
-        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</source>
-        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</target>
-        <note>
-		</note>
+        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</source>
+        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0088">
-        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0089">
-        <source>Internal error: property {0} doesn't have neither a getter nor a setter.
-		</source>
-        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: property {0} doesn't have neither a getter nor a setter.</source>
+        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0099">
-        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1000">
         <source>Could not compile the generated API bindings.	
@@ -95,270 +68,171 @@
         <target state="new">Could not compile the generated API bindings.	
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1001">
-        <source>Do not know how to make a trampoline for {0}
-		</source>
-        <target state="new">Do not know how to make a trampoline for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a trampoline for {0}</source>
+        <target state="new">Do not know how to make a trampoline for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1002">
-        <source>Unknown kind {0} in method '{1}.{2}'
-		</source>
-        <target state="new">Unknown kind {0} in method '{1}.{2}'
-		</target>
-        <note>
-		</note>
+        <source>Unknown kind {0} in method '{1}.{2}'</source>
+        <target state="new">Unknown kind {0} in method '{1}.{2}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1003">
-        <source>The delegate method {0}.{1} needs to take at least one parameter
-		</source>
-        <target state="new">The delegate method {0}.{1} needs to take at least one parameter
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} needs to take at least one parameter</source>
+        <target state="new">The delegate method {0}.{1} needs to take at least one parameter</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1004">
-        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1005">
-        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</source>
-        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</target>
-        <note>
-		</note>
+        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</source>
+        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1006">
-        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1007">
-        <source>Unknown attribute {0} on {1}.{2}
-		</source>
-        <target state="new">Unknown attribute {0} on {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unknown attribute {0} on {1}.{2}</source>
+        <target state="new">Unknown attribute {0} on {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1008">
-        <source>[IsThreadStatic] is only valid on properties that are also [Static]
-		</source>
-        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]
-		</target>
-        <note>
-		</note>
+        <source>[IsThreadStatic] is only valid on properties that are also [Static]</source>
+        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1009">
-        <source>No selector specified for method `{0}.{1}'
-		</source>
-        <target state="new">No selector specified for method `{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for method `{0}.{1}'</source>
+        <target state="new">No selector specified for method `{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1010">
-        <source>No Export attribute on {0}.{1} property
-		</source>
-        <target state="new">No Export attribute on {0}.{1} property
-		</target>
-        <note>
-		</note>
+        <source>No Export attribute on {0}.{1} property</source>
+        <target state="new">No Export attribute on {0}.{1} property</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1011">
-        <source>Do not know how to extract type {0}/{1} from an NSDictionary
-		</source>
-        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to extract type {0}/{1} from an NSDictionary</source>
+        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1012">
-        <source>No Export or Bind attribute defined on {0}.{1}
-		</source>
-        <target state="new">No Export or Bind attribute defined on {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No Export or Bind attribute defined on {0}.{1}</source>
+        <target state="new">No Export or Bind attribute defined on {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1013">
-        <source>Unsupported type for Fields (string), you probably meant NSString
-		</source>
-        <target state="new">Unsupported type for Fields (string), you probably meant NSString
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields (string), you probably meant NSString</source>
+        <target state="new">Unsupported type for Fields (string), you probably meant NSString</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1014">
-        <source>Unsupported type for Fields: {0} for '{1}'.
-		</source>
-        <target state="new">Unsupported type for Fields: {0} for '{1}'.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields: {0} for '{1}'.</source>
+        <target state="new">Unsupported type for Fields: {0} for '{1}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1015">
-        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</source>
-        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</target>
-        <note>
-		</note>
+        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates</source>
+        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1016">
-        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1017">
-        <source>Do not know how to make a signature for {0}
-		</source>
-        <target state="new">Do not know how to make a signature for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a signature for {0}</source>
+        <target state="new">Do not know how to make a signature for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1018">
-        <source>No [Export] attribute on property {0}.{1}
-		</source>
-        <target state="new">No [Export] attribute on property {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No [Export] attribute on property {0}.{1}</source>
+        <target state="new">No [Export] attribute on property {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1019">
-        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</source>
-        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'</source>
+        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1020">
-        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</source>
-        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</source>
+        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1021">
-        <source>Unsupported type for read/write Fields: {0} for {1}.{2}
-		</source>
-        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for read/write Fields: {0} for {1}.{2}</source>
+        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1022">
-        <source>Model classes can not be categories
-		</source>
-        <target state="new">Model classes can not be categories
-		</target>
-        <note>
-		</note>
+        <source>Model classes can not be categories</source>
+        <target state="new">Model classes can not be categories</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1023">
-        <source>The number of Events (Type) and Delegates (string) must match for `{0}`
-		</source>
-        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`
-		</target>
-        <note>
-		</note>
+        <source>The number of Events (Type) and Delegates (string) must match for `{0}`</source>
+        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1024">
-        <source>No selector specified for property '{0}.{1}'
-		</source>
-        <target state="new">No selector specified for property '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for property '{0}.{1}'</source>
+        <target state="new">No selector specified for property '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1025">
-        <source>[Static] and [Protocol] are mutually exclusive ({0})
-		</source>
-        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})
-		</target>
-        <note>
-		</note>
+        <source>[Static] and [Protocol] are mutually exclusive ({0})</source>
+        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1026">
-        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</source>
-        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</target>
-        <note>
-		</note>
+        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</source>
+        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1027">
-        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</source>
-        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</target>
-        <note>
-		</note>
+        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</source>
+        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1028">
-        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1029">
-        <source>Internal error: invalid enum mode for type '{0}'
-		</source>
-        <target state="new">Internal error: invalid enum mode for type '{0}'
-		</target>
-        <note>
-		</note>
+        <source>Internal error: invalid enum mode for type '{0}'</source>
+        <target state="new">Internal error: invalid enum mode for type '{0}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1030">
-        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</source>
-        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</target>
-        <note>
-		</note>
+        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</source>
+        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1031">
-        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</source>
-        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</target>
-        <note>
-		</note>
+        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</source>
+        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1032">
-        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</source>
-        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}</source>
+        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1033">
-        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</source>
-        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</target>
+        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</source>
+        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</target>
         <note>Generating a strongly typed dictionary for type '{0}' is not supported.
 {0} - the property type.
 {1} - the dictionary type.
@@ -366,538 +240,341 @@
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
-        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</source>
-        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</source>
+        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1035">
-        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</source>
-        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</target>
-        <note>
-		</note>
+        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</source>
+        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1036">
-        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</source>
-        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</target>
-        <note>
-		</note>
+        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</source>
+        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1037">
-        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1038">
-        <source>The selector {0} on type {1} is found multiple times with different return types.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different return types.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different return types.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different return types.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1039">
-        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1040">
-        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1041">
         <source>The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</source>
         <target state="new">The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1042">
-        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</source>
-        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</target>
-        <note>
-		</note>
+        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</source>
+        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1043">
-        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</source>
-        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</target>
-        <note>
-		</note>
+        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</source>
+        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1044">
-        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</source>
-        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</target>
-        <note>
-		</note>
+        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].</source>
+        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1045">
-        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</source>
-        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</target>
-        <note>
-		</note>
+        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</source>
+        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1046">
-        <source>The [Field] constant {0} cannot only be used once inside enum {1}.
-		</source>
-        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.
-		</target>
-        <note>
-		</note>
+        <source>The [Field] constant {0} cannot only be used once inside enum {1}.</source>
+        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1047">
-        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1048">
-        <source>Unsupported type {0} decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type {0} decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} decorated with [BindAs]</source>
+        <target state="new">Unsupported type {0} decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1049">
-        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</source>
-        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</target>
-        <note>
-		</note>
+        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</source>
+        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1050">
-        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</source>
-        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</target>
-        <note>
-		</note>
+        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}</source>
+        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1051">
-        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1052">
-        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1053">
-        <source>Internal error: unknown target framework '{0}'.
-		</source>
-        <target state="new">Internal error: unknown target framework '{0}'.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: unknown target framework '{0}'.</source>
+        <target state="new">Internal error: unknown target framework '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1054">
-        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1055">
-        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1056">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1057">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1058">
-        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
+        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
         <note />
       </trans-unit>
       <trans-unit id="BI1059">
-        <source>Found {0} {1} attributes on the member {2}. At most one was expected.
-		</source>
-        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.
-		</target>
-        <note>
-		</note>
+        <source>Found {0} {1} attributes on the member {2}. At most one was expected.</source>
+        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1060">
-        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</source>
-        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</target>
-        <note>
-		</note>
+        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</source>
+        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1061">
-        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</source>
-        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</target>
-        <note>
-		</note>
+        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</source>
+        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1062">
-        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</source>
-        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</source>
+        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1063">
-        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</source>
-        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</source>
+        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1064">
-        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1065">
-        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1066">
-        <source>Unsupported return type '{0}' in {1}.{2}.
-		</source>
-        <target state="new">Unsupported return type '{0}' in {1}.{2}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported return type '{0}' in {1}.{2}.</source>
+        <target state="new">Unsupported return type '{0}' in {1}.{2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1067">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1068">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1069">
-        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</source>
-        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</source>
+        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1070">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1071">
-        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</source>
-        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</source>
+        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1072">
-        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</source>
-        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</source>
+        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1073">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1074">
-        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</source>
-        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</target>
-        <note>
-		</note>
+        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}</source>
+        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1075">
-        <source>Unimplemented CoreImage property type {0}
-		</source>
-        <target state="new">Unimplemented CoreImage property type {0}
-		</target>
-        <note>
-		</note>
+        <source>Unimplemented CoreImage property type {0}</source>
+        <target state="new">Unimplemented CoreImage property type {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1076">
-        <source>Unable to find selector for {0} on {1} on self or base class
-		</source>
-        <target state="new">Unable to find selector for {0} on {1} on self or base class
-		</target>
-        <note>
-		</note>
+        <source>Unable to find selector for {0} on {1} on self or base class</source>
+        <target state="new">Unable to find selector for {0} on {1} on self or base class</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1077">
-        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</source>
-        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</target>
+        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</source>
+        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</target>
         <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
 {0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">
-        <source>{0} in method `{1}'
-		</source>
-        <target state="new">{0} in method `{1}'
-		</target>
-        <note>
-		</note>
+        <source>{0} in method `{1}'</source>
+        <target state="new">{0} in method `{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1079">
-        <source>{0} in parameter `{1}' from {2}.{3}
-		</source>
-        <target state="new">{0} in parameter `{1}' from {2}.{3}
-		</target>
-        <note>
-		</note>
+        <source>{0} in parameter `{1}' from {2}.{3}</source>
+        <target state="new">{0} in parameter `{1}' from {2}.{3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1080">
-        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]</source>
+        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1081">
-        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </source>
-        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </target>
-        <note>
-        </note>
+        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.</source>
+        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1101">
-        <source>Trying to use a string as a [Target]
-		</source>
-        <target state="new">Trying to use a string as a [Target]
-		</target>
-        <note>
-		</note>
+        <source>Trying to use a string as a [Target]</source>
+        <target state="new">Trying to use a string as a [Target]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1102">
-        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</source>
-        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</target>
-        <note>
-		</note>
+        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</source>
+        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1103">
-        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</source>
-        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</target>
-        <note>
-		</note>
+        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</source>
+        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1104">
-        <source>Could not load the referenced library '{0}': {1}.
-		</source>
-        <target state="new">Could not load the referenced library '{0}': {1}.
-		</target>
-        <note>
-		</note>
+        <source>Could not load the referenced library '{0}': {1}.</source>
+        <target state="new">Could not load the referenced library '{0}': {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1105">
-        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</source>
-        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</target>
-        <note>
-		</note>
+        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</source>
+        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1106">
-        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</source>
-        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</target>
-        <note>
-		</note>
+        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</source>
+        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1107">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1108">
-        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</source>
-        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</source>
+        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1109">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1110">
-        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1111">
-        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</source>
-        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</target>
-        <note>
-		</note>
+        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</source>
+        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1112">
-        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</source>
-        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</target>
-        <note>
-		</note>
+        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</source>
+        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1113">
-        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</source>
-        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</target>
-        <note>
-		</note>
+        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</source>
+        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1114">
-        <source>Binding error: test unable to find property: {0} on {1}
-		</source>
-        <target state="new">Binding error: test unable to find property: {0} on {1}
-		</target>
-        <note>
-		</note>
+        <source>Binding error: test unable to find property: {0} on {1}</source>
+        <target state="new">Binding error: test unable to find property: {0} on {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1115">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1116">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1117">
-        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</source>
-        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</source>
+        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1118">
-        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</source>
-        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</target>
-        <note>
-		</note>
+        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</source>
+        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1119">
-        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="BI0000">
         <source>Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0001">
         <source>The .NET runtime could not load the {0} type. Message: {1}</source>
         <target state="new">The .NET runtime could not load the {0} type. Message: {1}</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0002">
         <source>Could not compile the API bindings.
@@ -21,72 +19,47 @@
         <target state="new">Could not compile the API bindings.
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0026">
-        <source>Could not parse the command line argument '--warnaserror': {0}
-		</source>
-        <target state="new">Could not parse the command line argument '--warnaserror': {0}
-		</target>
-        <note>
-		</note>
+        <source>Could not parse the command line argument '--warnaserror': {0}</source>
+        <target state="new">Could not parse the command line argument '--warnaserror': {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0068">
-        <source>Invalid value for target framework: {0}.
-		</source>
-        <target state="new">Invalid value for target framework: {0}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid value for target framework: {0}.</source>
+        <target state="new">Invalid value for target framework: {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0086">
-        <source>A target framework (--target-framework) must be specified.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified.
-		</target>
-        <note>
-		</note>
+        <source>A target framework (--target-framework) must be specified.</source>
+        <target state="new">A target framework (--target-framework) must be specified.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0087">
-        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</source>
-        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</target>
-        <note>
-		</note>
+        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</source>
+        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0088">
-        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0089">
-        <source>Internal error: property {0} doesn't have neither a getter nor a setter.
-		</source>
-        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: property {0} doesn't have neither a getter nor a setter.</source>
+        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0099">
-        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1000">
         <source>Could not compile the generated API bindings.	
@@ -95,270 +68,171 @@
         <target state="new">Could not compile the generated API bindings.	
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1001">
-        <source>Do not know how to make a trampoline for {0}
-		</source>
-        <target state="new">Do not know how to make a trampoline for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a trampoline for {0}</source>
+        <target state="new">Do not know how to make a trampoline for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1002">
-        <source>Unknown kind {0} in method '{1}.{2}'
-		</source>
-        <target state="new">Unknown kind {0} in method '{1}.{2}'
-		</target>
-        <note>
-		</note>
+        <source>Unknown kind {0} in method '{1}.{2}'</source>
+        <target state="new">Unknown kind {0} in method '{1}.{2}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1003">
-        <source>The delegate method {0}.{1} needs to take at least one parameter
-		</source>
-        <target state="new">The delegate method {0}.{1} needs to take at least one parameter
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} needs to take at least one parameter</source>
+        <target state="new">The delegate method {0}.{1} needs to take at least one parameter</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1004">
-        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1005">
-        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</source>
-        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</target>
-        <note>
-		</note>
+        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</source>
+        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1006">
-        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1007">
-        <source>Unknown attribute {0} on {1}.{2}
-		</source>
-        <target state="new">Unknown attribute {0} on {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unknown attribute {0} on {1}.{2}</source>
+        <target state="new">Unknown attribute {0} on {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1008">
-        <source>[IsThreadStatic] is only valid on properties that are also [Static]
-		</source>
-        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]
-		</target>
-        <note>
-		</note>
+        <source>[IsThreadStatic] is only valid on properties that are also [Static]</source>
+        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1009">
-        <source>No selector specified for method `{0}.{1}'
-		</source>
-        <target state="new">No selector specified for method `{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for method `{0}.{1}'</source>
+        <target state="new">No selector specified for method `{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1010">
-        <source>No Export attribute on {0}.{1} property
-		</source>
-        <target state="new">No Export attribute on {0}.{1} property
-		</target>
-        <note>
-		</note>
+        <source>No Export attribute on {0}.{1} property</source>
+        <target state="new">No Export attribute on {0}.{1} property</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1011">
-        <source>Do not know how to extract type {0}/{1} from an NSDictionary
-		</source>
-        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to extract type {0}/{1} from an NSDictionary</source>
+        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1012">
-        <source>No Export or Bind attribute defined on {0}.{1}
-		</source>
-        <target state="new">No Export or Bind attribute defined on {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No Export or Bind attribute defined on {0}.{1}</source>
+        <target state="new">No Export or Bind attribute defined on {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1013">
-        <source>Unsupported type for Fields (string), you probably meant NSString
-		</source>
-        <target state="new">Unsupported type for Fields (string), you probably meant NSString
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields (string), you probably meant NSString</source>
+        <target state="new">Unsupported type for Fields (string), you probably meant NSString</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1014">
-        <source>Unsupported type for Fields: {0} for '{1}'.
-		</source>
-        <target state="new">Unsupported type for Fields: {0} for '{1}'.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields: {0} for '{1}'.</source>
+        <target state="new">Unsupported type for Fields: {0} for '{1}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1015">
-        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</source>
-        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</target>
-        <note>
-		</note>
+        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates</source>
+        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1016">
-        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1017">
-        <source>Do not know how to make a signature for {0}
-		</source>
-        <target state="new">Do not know how to make a signature for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a signature for {0}</source>
+        <target state="new">Do not know how to make a signature for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1018">
-        <source>No [Export] attribute on property {0}.{1}
-		</source>
-        <target state="new">No [Export] attribute on property {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No [Export] attribute on property {0}.{1}</source>
+        <target state="new">No [Export] attribute on property {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1019">
-        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</source>
-        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'</source>
+        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1020">
-        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</source>
-        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</source>
+        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1021">
-        <source>Unsupported type for read/write Fields: {0} for {1}.{2}
-		</source>
-        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for read/write Fields: {0} for {1}.{2}</source>
+        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1022">
-        <source>Model classes can not be categories
-		</source>
-        <target state="new">Model classes can not be categories
-		</target>
-        <note>
-		</note>
+        <source>Model classes can not be categories</source>
+        <target state="new">Model classes can not be categories</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1023">
-        <source>The number of Events (Type) and Delegates (string) must match for `{0}`
-		</source>
-        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`
-		</target>
-        <note>
-		</note>
+        <source>The number of Events (Type) and Delegates (string) must match for `{0}`</source>
+        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1024">
-        <source>No selector specified for property '{0}.{1}'
-		</source>
-        <target state="new">No selector specified for property '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for property '{0}.{1}'</source>
+        <target state="new">No selector specified for property '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1025">
-        <source>[Static] and [Protocol] are mutually exclusive ({0})
-		</source>
-        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})
-		</target>
-        <note>
-		</note>
+        <source>[Static] and [Protocol] are mutually exclusive ({0})</source>
+        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1026">
-        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</source>
-        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</target>
-        <note>
-		</note>
+        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</source>
+        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1027">
-        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</source>
-        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</target>
-        <note>
-		</note>
+        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</source>
+        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1028">
-        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1029">
-        <source>Internal error: invalid enum mode for type '{0}'
-		</source>
-        <target state="new">Internal error: invalid enum mode for type '{0}'
-		</target>
-        <note>
-		</note>
+        <source>Internal error: invalid enum mode for type '{0}'</source>
+        <target state="new">Internal error: invalid enum mode for type '{0}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1030">
-        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</source>
-        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</target>
-        <note>
-		</note>
+        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</source>
+        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1031">
-        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</source>
-        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</target>
-        <note>
-		</note>
+        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</source>
+        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1032">
-        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</source>
-        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}</source>
+        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1033">
-        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</source>
-        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</target>
+        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</source>
+        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</target>
         <note>Generating a strongly typed dictionary for type '{0}' is not supported.
 {0} - the property type.
 {1} - the dictionary type.
@@ -366,538 +240,341 @@
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
-        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</source>
-        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</source>
+        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1035">
-        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</source>
-        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</target>
-        <note>
-		</note>
+        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</source>
+        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1036">
-        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</source>
-        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</target>
-        <note>
-		</note>
+        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</source>
+        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1037">
-        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1038">
-        <source>The selector {0} on type {1} is found multiple times with different return types.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different return types.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different return types.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different return types.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1039">
-        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1040">
-        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1041">
         <source>The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</source>
         <target state="new">The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1042">
-        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</source>
-        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</target>
-        <note>
-		</note>
+        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</source>
+        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1043">
-        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</source>
-        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</target>
-        <note>
-		</note>
+        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</source>
+        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1044">
-        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</source>
-        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</target>
-        <note>
-		</note>
+        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].</source>
+        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1045">
-        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</source>
-        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</target>
-        <note>
-		</note>
+        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</source>
+        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1046">
-        <source>The [Field] constant {0} cannot only be used once inside enum {1}.
-		</source>
-        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.
-		</target>
-        <note>
-		</note>
+        <source>The [Field] constant {0} cannot only be used once inside enum {1}.</source>
+        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1047">
-        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1048">
-        <source>Unsupported type {0} decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type {0} decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} decorated with [BindAs]</source>
+        <target state="new">Unsupported type {0} decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1049">
-        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</source>
-        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</target>
-        <note>
-		</note>
+        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</source>
+        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1050">
-        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</source>
-        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</target>
-        <note>
-		</note>
+        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}</source>
+        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1051">
-        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1052">
-        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1053">
-        <source>Internal error: unknown target framework '{0}'.
-		</source>
-        <target state="new">Internal error: unknown target framework '{0}'.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: unknown target framework '{0}'.</source>
+        <target state="new">Internal error: unknown target framework '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1054">
-        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1055">
-        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1056">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1057">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1058">
-        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
+        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
         <note />
       </trans-unit>
       <trans-unit id="BI1059">
-        <source>Found {0} {1} attributes on the member {2}. At most one was expected.
-		</source>
-        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.
-		</target>
-        <note>
-		</note>
+        <source>Found {0} {1} attributes on the member {2}. At most one was expected.</source>
+        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1060">
-        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</source>
-        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</target>
-        <note>
-		</note>
+        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</source>
+        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1061">
-        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</source>
-        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</target>
-        <note>
-		</note>
+        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</source>
+        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1062">
-        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</source>
-        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</source>
+        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1063">
-        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</source>
-        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</source>
+        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1064">
-        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1065">
-        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1066">
-        <source>Unsupported return type '{0}' in {1}.{2}.
-		</source>
-        <target state="new">Unsupported return type '{0}' in {1}.{2}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported return type '{0}' in {1}.{2}.</source>
+        <target state="new">Unsupported return type '{0}' in {1}.{2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1067">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1068">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1069">
-        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</source>
-        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</source>
+        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1070">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1071">
-        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</source>
-        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</source>
+        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1072">
-        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</source>
-        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</source>
+        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1073">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1074">
-        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</source>
-        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</target>
-        <note>
-		</note>
+        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}</source>
+        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1075">
-        <source>Unimplemented CoreImage property type {0}
-		</source>
-        <target state="new">Unimplemented CoreImage property type {0}
-		</target>
-        <note>
-		</note>
+        <source>Unimplemented CoreImage property type {0}</source>
+        <target state="new">Unimplemented CoreImage property type {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1076">
-        <source>Unable to find selector for {0} on {1} on self or base class
-		</source>
-        <target state="new">Unable to find selector for {0} on {1} on self or base class
-		</target>
-        <note>
-		</note>
+        <source>Unable to find selector for {0} on {1} on self or base class</source>
+        <target state="new">Unable to find selector for {0} on {1} on self or base class</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1077">
-        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</source>
-        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</target>
+        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</source>
+        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</target>
         <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
 {0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">
-        <source>{0} in method `{1}'
-		</source>
-        <target state="new">{0} in method `{1}'
-		</target>
-        <note>
-		</note>
+        <source>{0} in method `{1}'</source>
+        <target state="new">{0} in method `{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1079">
-        <source>{0} in parameter `{1}' from {2}.{3}
-		</source>
-        <target state="new">{0} in parameter `{1}' from {2}.{3}
-		</target>
-        <note>
-		</note>
+        <source>{0} in parameter `{1}' from {2}.{3}</source>
+        <target state="new">{0} in parameter `{1}' from {2}.{3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1080">
-        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]</source>
+        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1081">
-        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </source>
-        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </target>
-        <note>
-        </note>
+        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.</source>
+        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1101">
-        <source>Trying to use a string as a [Target]
-		</source>
-        <target state="new">Trying to use a string as a [Target]
-		</target>
-        <note>
-		</note>
+        <source>Trying to use a string as a [Target]</source>
+        <target state="new">Trying to use a string as a [Target]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1102">
-        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</source>
-        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</target>
-        <note>
-		</note>
+        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</source>
+        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1103">
-        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</source>
-        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</target>
-        <note>
-		</note>
+        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</source>
+        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1104">
-        <source>Could not load the referenced library '{0}': {1}.
-		</source>
-        <target state="new">Could not load the referenced library '{0}': {1}.
-		</target>
-        <note>
-		</note>
+        <source>Could not load the referenced library '{0}': {1}.</source>
+        <target state="new">Could not load the referenced library '{0}': {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1105">
-        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</source>
-        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</target>
-        <note>
-		</note>
+        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</source>
+        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1106">
-        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</source>
-        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</target>
-        <note>
-		</note>
+        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</source>
+        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1107">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1108">
-        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</source>
-        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</source>
+        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1109">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1110">
-        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1111">
-        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</source>
-        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</target>
-        <note>
-		</note>
+        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</source>
+        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1112">
-        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</source>
-        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</target>
-        <note>
-		</note>
+        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</source>
+        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1113">
-        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</source>
-        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</target>
-        <note>
-		</note>
+        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</source>
+        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1114">
-        <source>Binding error: test unable to find property: {0} on {1}
-		</source>
-        <target state="new">Binding error: test unable to find property: {0} on {1}
-		</target>
-        <note>
-		</note>
+        <source>Binding error: test unable to find property: {0} on {1}</source>
+        <target state="new">Binding error: test unable to find property: {0} on {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1115">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1116">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1117">
-        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</source>
-        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</source>
+        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1118">
-        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</source>
-        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</target>
-        <note>
-		</note>
+        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</source>
+        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1119">
-        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="BI0000">
         <source>Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0001">
         <source>The .NET runtime could not load the {0} type. Message: {1}</source>
         <target state="new">The .NET runtime could not load the {0} type. Message: {1}</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0002">
         <source>Could not compile the API bindings.
@@ -21,72 +19,47 @@
         <target state="new">Could not compile the API bindings.
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0026">
-        <source>Could not parse the command line argument '--warnaserror': {0}
-		</source>
-        <target state="new">Could not parse the command line argument '--warnaserror': {0}
-		</target>
-        <note>
-		</note>
+        <source>Could not parse the command line argument '--warnaserror': {0}</source>
+        <target state="new">Could not parse the command line argument '--warnaserror': {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0068">
-        <source>Invalid value for target framework: {0}.
-		</source>
-        <target state="new">Invalid value for target framework: {0}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid value for target framework: {0}.</source>
+        <target state="new">Invalid value for target framework: {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0086">
-        <source>A target framework (--target-framework) must be specified.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified.
-		</target>
-        <note>
-		</note>
+        <source>A target framework (--target-framework) must be specified.</source>
+        <target state="new">A target framework (--target-framework) must be specified.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0087">
-        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</source>
-        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</target>
-        <note>
-		</note>
+        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</source>
+        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0088">
-        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0089">
-        <source>Internal error: property {0} doesn't have neither a getter nor a setter.
-		</source>
-        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: property {0} doesn't have neither a getter nor a setter.</source>
+        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0099">
-        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1000">
         <source>Could not compile the generated API bindings.	
@@ -95,270 +68,171 @@
         <target state="new">Could not compile the generated API bindings.	
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1001">
-        <source>Do not know how to make a trampoline for {0}
-		</source>
-        <target state="new">Do not know how to make a trampoline for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a trampoline for {0}</source>
+        <target state="new">Do not know how to make a trampoline for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1002">
-        <source>Unknown kind {0} in method '{1}.{2}'
-		</source>
-        <target state="new">Unknown kind {0} in method '{1}.{2}'
-		</target>
-        <note>
-		</note>
+        <source>Unknown kind {0} in method '{1}.{2}'</source>
+        <target state="new">Unknown kind {0} in method '{1}.{2}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1003">
-        <source>The delegate method {0}.{1} needs to take at least one parameter
-		</source>
-        <target state="new">The delegate method {0}.{1} needs to take at least one parameter
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} needs to take at least one parameter</source>
+        <target state="new">The delegate method {0}.{1} needs to take at least one parameter</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1004">
-        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1005">
-        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</source>
-        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</target>
-        <note>
-		</note>
+        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</source>
+        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1006">
-        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1007">
-        <source>Unknown attribute {0} on {1}.{2}
-		</source>
-        <target state="new">Unknown attribute {0} on {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unknown attribute {0} on {1}.{2}</source>
+        <target state="new">Unknown attribute {0} on {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1008">
-        <source>[IsThreadStatic] is only valid on properties that are also [Static]
-		</source>
-        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]
-		</target>
-        <note>
-		</note>
+        <source>[IsThreadStatic] is only valid on properties that are also [Static]</source>
+        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1009">
-        <source>No selector specified for method `{0}.{1}'
-		</source>
-        <target state="new">No selector specified for method `{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for method `{0}.{1}'</source>
+        <target state="new">No selector specified for method `{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1010">
-        <source>No Export attribute on {0}.{1} property
-		</source>
-        <target state="new">No Export attribute on {0}.{1} property
-		</target>
-        <note>
-		</note>
+        <source>No Export attribute on {0}.{1} property</source>
+        <target state="new">No Export attribute on {0}.{1} property</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1011">
-        <source>Do not know how to extract type {0}/{1} from an NSDictionary
-		</source>
-        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to extract type {0}/{1} from an NSDictionary</source>
+        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1012">
-        <source>No Export or Bind attribute defined on {0}.{1}
-		</source>
-        <target state="new">No Export or Bind attribute defined on {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No Export or Bind attribute defined on {0}.{1}</source>
+        <target state="new">No Export or Bind attribute defined on {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1013">
-        <source>Unsupported type for Fields (string), you probably meant NSString
-		</source>
-        <target state="new">Unsupported type for Fields (string), you probably meant NSString
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields (string), you probably meant NSString</source>
+        <target state="new">Unsupported type for Fields (string), you probably meant NSString</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1014">
-        <source>Unsupported type for Fields: {0} for '{1}'.
-		</source>
-        <target state="new">Unsupported type for Fields: {0} for '{1}'.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields: {0} for '{1}'.</source>
+        <target state="new">Unsupported type for Fields: {0} for '{1}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1015">
-        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</source>
-        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</target>
-        <note>
-		</note>
+        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates</source>
+        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1016">
-        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1017">
-        <source>Do not know how to make a signature for {0}
-		</source>
-        <target state="new">Do not know how to make a signature for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a signature for {0}</source>
+        <target state="new">Do not know how to make a signature for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1018">
-        <source>No [Export] attribute on property {0}.{1}
-		</source>
-        <target state="new">No [Export] attribute on property {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No [Export] attribute on property {0}.{1}</source>
+        <target state="new">No [Export] attribute on property {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1019">
-        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</source>
-        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'</source>
+        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1020">
-        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</source>
-        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</source>
+        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1021">
-        <source>Unsupported type for read/write Fields: {0} for {1}.{2}
-		</source>
-        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for read/write Fields: {0} for {1}.{2}</source>
+        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1022">
-        <source>Model classes can not be categories
-		</source>
-        <target state="new">Model classes can not be categories
-		</target>
-        <note>
-		</note>
+        <source>Model classes can not be categories</source>
+        <target state="new">Model classes can not be categories</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1023">
-        <source>The number of Events (Type) and Delegates (string) must match for `{0}`
-		</source>
-        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`
-		</target>
-        <note>
-		</note>
+        <source>The number of Events (Type) and Delegates (string) must match for `{0}`</source>
+        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1024">
-        <source>No selector specified for property '{0}.{1}'
-		</source>
-        <target state="new">No selector specified for property '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for property '{0}.{1}'</source>
+        <target state="new">No selector specified for property '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1025">
-        <source>[Static] and [Protocol] are mutually exclusive ({0})
-		</source>
-        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})
-		</target>
-        <note>
-		</note>
+        <source>[Static] and [Protocol] are mutually exclusive ({0})</source>
+        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1026">
-        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</source>
-        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</target>
-        <note>
-		</note>
+        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</source>
+        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1027">
-        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</source>
-        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</target>
-        <note>
-		</note>
+        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</source>
+        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1028">
-        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1029">
-        <source>Internal error: invalid enum mode for type '{0}'
-		</source>
-        <target state="new">Internal error: invalid enum mode for type '{0}'
-		</target>
-        <note>
-		</note>
+        <source>Internal error: invalid enum mode for type '{0}'</source>
+        <target state="new">Internal error: invalid enum mode for type '{0}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1030">
-        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</source>
-        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</target>
-        <note>
-		</note>
+        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</source>
+        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1031">
-        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</source>
-        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</target>
-        <note>
-		</note>
+        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</source>
+        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1032">
-        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</source>
-        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}</source>
+        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1033">
-        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</source>
-        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</target>
+        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</source>
+        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</target>
         <note>Generating a strongly typed dictionary for type '{0}' is not supported.
 {0} - the property type.
 {1} - the dictionary type.
@@ -366,538 +240,341 @@
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
-        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</source>
-        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</source>
+        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1035">
-        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</source>
-        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</target>
-        <note>
-		</note>
+        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</source>
+        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1036">
-        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</source>
-        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</target>
-        <note>
-		</note>
+        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</source>
+        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1037">
-        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1038">
-        <source>The selector {0} on type {1} is found multiple times with different return types.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different return types.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different return types.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different return types.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1039">
-        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1040">
-        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1041">
         <source>The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</source>
         <target state="new">The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1042">
-        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</source>
-        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</target>
-        <note>
-		</note>
+        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</source>
+        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1043">
-        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</source>
-        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</target>
-        <note>
-		</note>
+        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</source>
+        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1044">
-        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</source>
-        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</target>
-        <note>
-		</note>
+        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].</source>
+        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1045">
-        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</source>
-        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</target>
-        <note>
-		</note>
+        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</source>
+        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1046">
-        <source>The [Field] constant {0} cannot only be used once inside enum {1}.
-		</source>
-        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.
-		</target>
-        <note>
-		</note>
+        <source>The [Field] constant {0} cannot only be used once inside enum {1}.</source>
+        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1047">
-        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1048">
-        <source>Unsupported type {0} decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type {0} decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} decorated with [BindAs]</source>
+        <target state="new">Unsupported type {0} decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1049">
-        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</source>
-        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</target>
-        <note>
-		</note>
+        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</source>
+        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1050">
-        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</source>
-        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</target>
-        <note>
-		</note>
+        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}</source>
+        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1051">
-        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1052">
-        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1053">
-        <source>Internal error: unknown target framework '{0}'.
-		</source>
-        <target state="new">Internal error: unknown target framework '{0}'.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: unknown target framework '{0}'.</source>
+        <target state="new">Internal error: unknown target framework '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1054">
-        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1055">
-        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1056">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1057">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1058">
-        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
+        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
         <note />
       </trans-unit>
       <trans-unit id="BI1059">
-        <source>Found {0} {1} attributes on the member {2}. At most one was expected.
-		</source>
-        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.
-		</target>
-        <note>
-		</note>
+        <source>Found {0} {1} attributes on the member {2}. At most one was expected.</source>
+        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1060">
-        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</source>
-        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</target>
-        <note>
-		</note>
+        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</source>
+        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1061">
-        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</source>
-        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</target>
-        <note>
-		</note>
+        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</source>
+        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1062">
-        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</source>
-        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</source>
+        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1063">
-        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</source>
-        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</source>
+        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1064">
-        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1065">
-        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1066">
-        <source>Unsupported return type '{0}' in {1}.{2}.
-		</source>
-        <target state="new">Unsupported return type '{0}' in {1}.{2}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported return type '{0}' in {1}.{2}.</source>
+        <target state="new">Unsupported return type '{0}' in {1}.{2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1067">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1068">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1069">
-        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</source>
-        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</source>
+        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1070">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1071">
-        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</source>
-        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</source>
+        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1072">
-        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</source>
-        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</source>
+        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1073">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1074">
-        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</source>
-        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</target>
-        <note>
-		</note>
+        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}</source>
+        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1075">
-        <source>Unimplemented CoreImage property type {0}
-		</source>
-        <target state="new">Unimplemented CoreImage property type {0}
-		</target>
-        <note>
-		</note>
+        <source>Unimplemented CoreImage property type {0}</source>
+        <target state="new">Unimplemented CoreImage property type {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1076">
-        <source>Unable to find selector for {0} on {1} on self or base class
-		</source>
-        <target state="new">Unable to find selector for {0} on {1} on self or base class
-		</target>
-        <note>
-		</note>
+        <source>Unable to find selector for {0} on {1} on self or base class</source>
+        <target state="new">Unable to find selector for {0} on {1} on self or base class</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1077">
-        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</source>
-        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</target>
+        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</source>
+        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</target>
         <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
 {0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">
-        <source>{0} in method `{1}'
-		</source>
-        <target state="new">{0} in method `{1}'
-		</target>
-        <note>
-		</note>
+        <source>{0} in method `{1}'</source>
+        <target state="new">{0} in method `{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1079">
-        <source>{0} in parameter `{1}' from {2}.{3}
-		</source>
-        <target state="new">{0} in parameter `{1}' from {2}.{3}
-		</target>
-        <note>
-		</note>
+        <source>{0} in parameter `{1}' from {2}.{3}</source>
+        <target state="new">{0} in parameter `{1}' from {2}.{3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1080">
-        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]</source>
+        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1081">
-        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </source>
-        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </target>
-        <note>
-        </note>
+        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.</source>
+        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1101">
-        <source>Trying to use a string as a [Target]
-		</source>
-        <target state="new">Trying to use a string as a [Target]
-		</target>
-        <note>
-		</note>
+        <source>Trying to use a string as a [Target]</source>
+        <target state="new">Trying to use a string as a [Target]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1102">
-        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</source>
-        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</target>
-        <note>
-		</note>
+        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</source>
+        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1103">
-        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</source>
-        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</target>
-        <note>
-		</note>
+        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</source>
+        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1104">
-        <source>Could not load the referenced library '{0}': {1}.
-		</source>
-        <target state="new">Could not load the referenced library '{0}': {1}.
-		</target>
-        <note>
-		</note>
+        <source>Could not load the referenced library '{0}': {1}.</source>
+        <target state="new">Could not load the referenced library '{0}': {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1105">
-        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</source>
-        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</target>
-        <note>
-		</note>
+        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</source>
+        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1106">
-        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</source>
-        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</target>
-        <note>
-		</note>
+        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</source>
+        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1107">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1108">
-        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</source>
-        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</source>
+        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1109">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1110">
-        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1111">
-        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</source>
-        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</target>
-        <note>
-		</note>
+        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</source>
+        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1112">
-        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</source>
-        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</target>
-        <note>
-		</note>
+        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</source>
+        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1113">
-        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</source>
-        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</target>
-        <note>
-		</note>
+        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</source>
+        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1114">
-        <source>Binding error: test unable to find property: {0} on {1}
-		</source>
-        <target state="new">Binding error: test unable to find property: {0} on {1}
-		</target>
-        <note>
-		</note>
+        <source>Binding error: test unable to find property: {0} on {1}</source>
+        <target state="new">Binding error: test unable to find property: {0} on {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1115">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1116">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1117">
-        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</source>
-        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</source>
+        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1118">
-        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</source>
-        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</target>
-        <note>
-		</note>
+        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</source>
+        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1119">
-        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="BI0000">
         <source>Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0001">
         <source>The .NET runtime could not load the {0} type. Message: {1}</source>
         <target state="new">The .NET runtime could not load the {0} type. Message: {1}</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0002">
         <source>Could not compile the API bindings.
@@ -21,72 +19,47 @@
         <target state="new">Could not compile the API bindings.
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0026">
-        <source>Could not parse the command line argument '--warnaserror': {0}
-		</source>
-        <target state="new">Could not parse the command line argument '--warnaserror': {0}
-		</target>
-        <note>
-		</note>
+        <source>Could not parse the command line argument '--warnaserror': {0}</source>
+        <target state="new">Could not parse the command line argument '--warnaserror': {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0068">
-        <source>Invalid value for target framework: {0}.
-		</source>
-        <target state="new">Invalid value for target framework: {0}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid value for target framework: {0}.</source>
+        <target state="new">Invalid value for target framework: {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0086">
-        <source>A target framework (--target-framework) must be specified.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified.
-		</target>
-        <note>
-		</note>
+        <source>A target framework (--target-framework) must be specified.</source>
+        <target state="new">A target framework (--target-framework) must be specified.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0087">
-        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</source>
-        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</target>
-        <note>
-		</note>
+        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</source>
+        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0088">
-        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0089">
-        <source>Internal error: property {0} doesn't have neither a getter nor a setter.
-		</source>
-        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: property {0} doesn't have neither a getter nor a setter.</source>
+        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0099">
-        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1000">
         <source>Could not compile the generated API bindings.	
@@ -95,270 +68,171 @@
         <target state="new">Could not compile the generated API bindings.	
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1001">
-        <source>Do not know how to make a trampoline for {0}
-		</source>
-        <target state="new">Do not know how to make a trampoline for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a trampoline for {0}</source>
+        <target state="new">Do not know how to make a trampoline for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1002">
-        <source>Unknown kind {0} in method '{1}.{2}'
-		</source>
-        <target state="new">Unknown kind {0} in method '{1}.{2}'
-		</target>
-        <note>
-		</note>
+        <source>Unknown kind {0} in method '{1}.{2}'</source>
+        <target state="new">Unknown kind {0} in method '{1}.{2}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1003">
-        <source>The delegate method {0}.{1} needs to take at least one parameter
-		</source>
-        <target state="new">The delegate method {0}.{1} needs to take at least one parameter
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} needs to take at least one parameter</source>
+        <target state="new">The delegate method {0}.{1} needs to take at least one parameter</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1004">
-        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1005">
-        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</source>
-        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</target>
-        <note>
-		</note>
+        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</source>
+        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1006">
-        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1007">
-        <source>Unknown attribute {0} on {1}.{2}
-		</source>
-        <target state="new">Unknown attribute {0} on {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unknown attribute {0} on {1}.{2}</source>
+        <target state="new">Unknown attribute {0} on {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1008">
-        <source>[IsThreadStatic] is only valid on properties that are also [Static]
-		</source>
-        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]
-		</target>
-        <note>
-		</note>
+        <source>[IsThreadStatic] is only valid on properties that are also [Static]</source>
+        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1009">
-        <source>No selector specified for method `{0}.{1}'
-		</source>
-        <target state="new">No selector specified for method `{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for method `{0}.{1}'</source>
+        <target state="new">No selector specified for method `{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1010">
-        <source>No Export attribute on {0}.{1} property
-		</source>
-        <target state="new">No Export attribute on {0}.{1} property
-		</target>
-        <note>
-		</note>
+        <source>No Export attribute on {0}.{1} property</source>
+        <target state="new">No Export attribute on {0}.{1} property</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1011">
-        <source>Do not know how to extract type {0}/{1} from an NSDictionary
-		</source>
-        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to extract type {0}/{1} from an NSDictionary</source>
+        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1012">
-        <source>No Export or Bind attribute defined on {0}.{1}
-		</source>
-        <target state="new">No Export or Bind attribute defined on {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No Export or Bind attribute defined on {0}.{1}</source>
+        <target state="new">No Export or Bind attribute defined on {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1013">
-        <source>Unsupported type for Fields (string), you probably meant NSString
-		</source>
-        <target state="new">Unsupported type for Fields (string), you probably meant NSString
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields (string), you probably meant NSString</source>
+        <target state="new">Unsupported type for Fields (string), you probably meant NSString</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1014">
-        <source>Unsupported type for Fields: {0} for '{1}'.
-		</source>
-        <target state="new">Unsupported type for Fields: {0} for '{1}'.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields: {0} for '{1}'.</source>
+        <target state="new">Unsupported type for Fields: {0} for '{1}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1015">
-        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</source>
-        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</target>
-        <note>
-		</note>
+        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates</source>
+        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1016">
-        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1017">
-        <source>Do not know how to make a signature for {0}
-		</source>
-        <target state="new">Do not know how to make a signature for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a signature for {0}</source>
+        <target state="new">Do not know how to make a signature for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1018">
-        <source>No [Export] attribute on property {0}.{1}
-		</source>
-        <target state="new">No [Export] attribute on property {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No [Export] attribute on property {0}.{1}</source>
+        <target state="new">No [Export] attribute on property {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1019">
-        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</source>
-        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'</source>
+        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1020">
-        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</source>
-        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</source>
+        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1021">
-        <source>Unsupported type for read/write Fields: {0} for {1}.{2}
-		</source>
-        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for read/write Fields: {0} for {1}.{2}</source>
+        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1022">
-        <source>Model classes can not be categories
-		</source>
-        <target state="new">Model classes can not be categories
-		</target>
-        <note>
-		</note>
+        <source>Model classes can not be categories</source>
+        <target state="new">Model classes can not be categories</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1023">
-        <source>The number of Events (Type) and Delegates (string) must match for `{0}`
-		</source>
-        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`
-		</target>
-        <note>
-		</note>
+        <source>The number of Events (Type) and Delegates (string) must match for `{0}`</source>
+        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1024">
-        <source>No selector specified for property '{0}.{1}'
-		</source>
-        <target state="new">No selector specified for property '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for property '{0}.{1}'</source>
+        <target state="new">No selector specified for property '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1025">
-        <source>[Static] and [Protocol] are mutually exclusive ({0})
-		</source>
-        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})
-		</target>
-        <note>
-		</note>
+        <source>[Static] and [Protocol] are mutually exclusive ({0})</source>
+        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1026">
-        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</source>
-        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</target>
-        <note>
-		</note>
+        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</source>
+        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1027">
-        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</source>
-        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</target>
-        <note>
-		</note>
+        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</source>
+        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1028">
-        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1029">
-        <source>Internal error: invalid enum mode for type '{0}'
-		</source>
-        <target state="new">Internal error: invalid enum mode for type '{0}'
-		</target>
-        <note>
-		</note>
+        <source>Internal error: invalid enum mode for type '{0}'</source>
+        <target state="new">Internal error: invalid enum mode for type '{0}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1030">
-        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</source>
-        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</target>
-        <note>
-		</note>
+        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</source>
+        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1031">
-        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</source>
-        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</target>
-        <note>
-		</note>
+        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</source>
+        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1032">
-        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</source>
-        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}</source>
+        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1033">
-        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</source>
-        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</target>
+        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</source>
+        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</target>
         <note>Generating a strongly typed dictionary for type '{0}' is not supported.
 {0} - the property type.
 {1} - the dictionary type.
@@ -366,538 +240,341 @@
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
-        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</source>
-        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</source>
+        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1035">
-        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</source>
-        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</target>
-        <note>
-		</note>
+        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</source>
+        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1036">
-        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</source>
-        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</target>
-        <note>
-		</note>
+        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</source>
+        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1037">
-        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1038">
-        <source>The selector {0} on type {1} is found multiple times with different return types.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different return types.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different return types.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different return types.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1039">
-        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1040">
-        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1041">
         <source>The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</source>
         <target state="new">The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1042">
-        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</source>
-        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</target>
-        <note>
-		</note>
+        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</source>
+        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1043">
-        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</source>
-        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</target>
-        <note>
-		</note>
+        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</source>
+        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1044">
-        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</source>
-        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</target>
-        <note>
-		</note>
+        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].</source>
+        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1045">
-        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</source>
-        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</target>
-        <note>
-		</note>
+        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</source>
+        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1046">
-        <source>The [Field] constant {0} cannot only be used once inside enum {1}.
-		</source>
-        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.
-		</target>
-        <note>
-		</note>
+        <source>The [Field] constant {0} cannot only be used once inside enum {1}.</source>
+        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1047">
-        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1048">
-        <source>Unsupported type {0} decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type {0} decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} decorated with [BindAs]</source>
+        <target state="new">Unsupported type {0} decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1049">
-        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</source>
-        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</target>
-        <note>
-		</note>
+        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</source>
+        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1050">
-        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</source>
-        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</target>
-        <note>
-		</note>
+        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}</source>
+        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1051">
-        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1052">
-        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1053">
-        <source>Internal error: unknown target framework '{0}'.
-		</source>
-        <target state="new">Internal error: unknown target framework '{0}'.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: unknown target framework '{0}'.</source>
+        <target state="new">Internal error: unknown target framework '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1054">
-        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1055">
-        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1056">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1057">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1058">
-        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
+        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
         <note />
       </trans-unit>
       <trans-unit id="BI1059">
-        <source>Found {0} {1} attributes on the member {2}. At most one was expected.
-		</source>
-        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.
-		</target>
-        <note>
-		</note>
+        <source>Found {0} {1} attributes on the member {2}. At most one was expected.</source>
+        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1060">
-        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</source>
-        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</target>
-        <note>
-		</note>
+        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</source>
+        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1061">
-        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</source>
-        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</target>
-        <note>
-		</note>
+        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</source>
+        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1062">
-        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</source>
-        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</source>
+        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1063">
-        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</source>
-        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</source>
+        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1064">
-        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1065">
-        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1066">
-        <source>Unsupported return type '{0}' in {1}.{2}.
-		</source>
-        <target state="new">Unsupported return type '{0}' in {1}.{2}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported return type '{0}' in {1}.{2}.</source>
+        <target state="new">Unsupported return type '{0}' in {1}.{2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1067">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1068">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1069">
-        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</source>
-        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</source>
+        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1070">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1071">
-        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</source>
-        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</source>
+        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1072">
-        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</source>
-        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</source>
+        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1073">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1074">
-        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</source>
-        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</target>
-        <note>
-		</note>
+        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}</source>
+        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1075">
-        <source>Unimplemented CoreImage property type {0}
-		</source>
-        <target state="new">Unimplemented CoreImage property type {0}
-		</target>
-        <note>
-		</note>
+        <source>Unimplemented CoreImage property type {0}</source>
+        <target state="new">Unimplemented CoreImage property type {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1076">
-        <source>Unable to find selector for {0} on {1} on self or base class
-		</source>
-        <target state="new">Unable to find selector for {0} on {1} on self or base class
-		</target>
-        <note>
-		</note>
+        <source>Unable to find selector for {0} on {1} on self or base class</source>
+        <target state="new">Unable to find selector for {0} on {1} on self or base class</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1077">
-        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</source>
-        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</target>
+        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</source>
+        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</target>
         <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
 {0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">
-        <source>{0} in method `{1}'
-		</source>
-        <target state="new">{0} in method `{1}'
-		</target>
-        <note>
-		</note>
+        <source>{0} in method `{1}'</source>
+        <target state="new">{0} in method `{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1079">
-        <source>{0} in parameter `{1}' from {2}.{3}
-		</source>
-        <target state="new">{0} in parameter `{1}' from {2}.{3}
-		</target>
-        <note>
-		</note>
+        <source>{0} in parameter `{1}' from {2}.{3}</source>
+        <target state="new">{0} in parameter `{1}' from {2}.{3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1080">
-        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]</source>
+        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1081">
-        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </source>
-        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </target>
-        <note>
-        </note>
+        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.</source>
+        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1101">
-        <source>Trying to use a string as a [Target]
-		</source>
-        <target state="new">Trying to use a string as a [Target]
-		</target>
-        <note>
-		</note>
+        <source>Trying to use a string as a [Target]</source>
+        <target state="new">Trying to use a string as a [Target]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1102">
-        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</source>
-        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</target>
-        <note>
-		</note>
+        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</source>
+        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1103">
-        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</source>
-        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</target>
-        <note>
-		</note>
+        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</source>
+        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1104">
-        <source>Could not load the referenced library '{0}': {1}.
-		</source>
-        <target state="new">Could not load the referenced library '{0}': {1}.
-		</target>
-        <note>
-		</note>
+        <source>Could not load the referenced library '{0}': {1}.</source>
+        <target state="new">Could not load the referenced library '{0}': {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1105">
-        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</source>
-        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</target>
-        <note>
-		</note>
+        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</source>
+        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1106">
-        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</source>
-        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</target>
-        <note>
-		</note>
+        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</source>
+        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1107">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1108">
-        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</source>
-        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</source>
+        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1109">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1110">
-        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1111">
-        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</source>
-        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</target>
-        <note>
-		</note>
+        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</source>
+        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1112">
-        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</source>
-        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</target>
-        <note>
-		</note>
+        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</source>
+        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1113">
-        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</source>
-        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</target>
-        <note>
-		</note>
+        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</source>
+        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1114">
-        <source>Binding error: test unable to find property: {0} on {1}
-		</source>
-        <target state="new">Binding error: test unable to find property: {0} on {1}
-		</target>
-        <note>
-		</note>
+        <source>Binding error: test unable to find property: {0} on {1}</source>
+        <target state="new">Binding error: test unable to find property: {0} on {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1115">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1116">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1117">
-        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</source>
-        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</source>
+        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1118">
-        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</source>
-        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</target>
-        <note>
-		</note>
+        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</source>
+        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1119">
-        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="BI0000">
         <source>Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0001">
         <source>The .NET runtime could not load the {0} type. Message: {1}</source>
         <target state="new">The .NET runtime could not load the {0} type. Message: {1}</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0002">
         <source>Could not compile the API bindings.
@@ -21,72 +19,47 @@
         <target state="new">Could not compile the API bindings.
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0026">
-        <source>Could not parse the command line argument '--warnaserror': {0}
-		</source>
-        <target state="new">Could not parse the command line argument '--warnaserror': {0}
-		</target>
-        <note>
-		</note>
+        <source>Could not parse the command line argument '--warnaserror': {0}</source>
+        <target state="new">Could not parse the command line argument '--warnaserror': {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0068">
-        <source>Invalid value for target framework: {0}.
-		</source>
-        <target state="new">Invalid value for target framework: {0}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid value for target framework: {0}.</source>
+        <target state="new">Invalid value for target framework: {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0086">
-        <source>A target framework (--target-framework) must be specified.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified.
-		</target>
-        <note>
-		</note>
+        <source>A target framework (--target-framework) must be specified.</source>
+        <target state="new">A target framework (--target-framework) must be specified.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0087">
-        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</source>
-        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</target>
-        <note>
-		</note>
+        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</source>
+        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0088">
-        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0089">
-        <source>Internal error: property {0} doesn't have neither a getter nor a setter.
-		</source>
-        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: property {0} doesn't have neither a getter nor a setter.</source>
+        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0099">
-        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1000">
         <source>Could not compile the generated API bindings.	
@@ -95,270 +68,171 @@
         <target state="new">Could not compile the generated API bindings.	
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1001">
-        <source>Do not know how to make a trampoline for {0}
-		</source>
-        <target state="new">Do not know how to make a trampoline for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a trampoline for {0}</source>
+        <target state="new">Do not know how to make a trampoline for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1002">
-        <source>Unknown kind {0} in method '{1}.{2}'
-		</source>
-        <target state="new">Unknown kind {0} in method '{1}.{2}'
-		</target>
-        <note>
-		</note>
+        <source>Unknown kind {0} in method '{1}.{2}'</source>
+        <target state="new">Unknown kind {0} in method '{1}.{2}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1003">
-        <source>The delegate method {0}.{1} needs to take at least one parameter
-		</source>
-        <target state="new">The delegate method {0}.{1} needs to take at least one parameter
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} needs to take at least one parameter</source>
+        <target state="new">The delegate method {0}.{1} needs to take at least one parameter</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1004">
-        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1005">
-        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</source>
-        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</target>
-        <note>
-		</note>
+        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</source>
+        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1006">
-        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1007">
-        <source>Unknown attribute {0} on {1}.{2}
-		</source>
-        <target state="new">Unknown attribute {0} on {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unknown attribute {0} on {1}.{2}</source>
+        <target state="new">Unknown attribute {0} on {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1008">
-        <source>[IsThreadStatic] is only valid on properties that are also [Static]
-		</source>
-        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]
-		</target>
-        <note>
-		</note>
+        <source>[IsThreadStatic] is only valid on properties that are also [Static]</source>
+        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1009">
-        <source>No selector specified for method `{0}.{1}'
-		</source>
-        <target state="new">No selector specified for method `{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for method `{0}.{1}'</source>
+        <target state="new">No selector specified for method `{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1010">
-        <source>No Export attribute on {0}.{1} property
-		</source>
-        <target state="new">No Export attribute on {0}.{1} property
-		</target>
-        <note>
-		</note>
+        <source>No Export attribute on {0}.{1} property</source>
+        <target state="new">No Export attribute on {0}.{1} property</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1011">
-        <source>Do not know how to extract type {0}/{1} from an NSDictionary
-		</source>
-        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to extract type {0}/{1} from an NSDictionary</source>
+        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1012">
-        <source>No Export or Bind attribute defined on {0}.{1}
-		</source>
-        <target state="new">No Export or Bind attribute defined on {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No Export or Bind attribute defined on {0}.{1}</source>
+        <target state="new">No Export or Bind attribute defined on {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1013">
-        <source>Unsupported type for Fields (string), you probably meant NSString
-		</source>
-        <target state="new">Unsupported type for Fields (string), you probably meant NSString
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields (string), you probably meant NSString</source>
+        <target state="new">Unsupported type for Fields (string), you probably meant NSString</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1014">
-        <source>Unsupported type for Fields: {0} for '{1}'.
-		</source>
-        <target state="new">Unsupported type for Fields: {0} for '{1}'.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields: {0} for '{1}'.</source>
+        <target state="new">Unsupported type for Fields: {0} for '{1}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1015">
-        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</source>
-        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</target>
-        <note>
-		</note>
+        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates</source>
+        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1016">
-        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1017">
-        <source>Do not know how to make a signature for {0}
-		</source>
-        <target state="new">Do not know how to make a signature for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a signature for {0}</source>
+        <target state="new">Do not know how to make a signature for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1018">
-        <source>No [Export] attribute on property {0}.{1}
-		</source>
-        <target state="new">No [Export] attribute on property {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No [Export] attribute on property {0}.{1}</source>
+        <target state="new">No [Export] attribute on property {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1019">
-        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</source>
-        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'</source>
+        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1020">
-        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</source>
-        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</source>
+        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1021">
-        <source>Unsupported type for read/write Fields: {0} for {1}.{2}
-		</source>
-        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for read/write Fields: {0} for {1}.{2}</source>
+        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1022">
-        <source>Model classes can not be categories
-		</source>
-        <target state="new">Model classes can not be categories
-		</target>
-        <note>
-		</note>
+        <source>Model classes can not be categories</source>
+        <target state="new">Model classes can not be categories</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1023">
-        <source>The number of Events (Type) and Delegates (string) must match for `{0}`
-		</source>
-        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`
-		</target>
-        <note>
-		</note>
+        <source>The number of Events (Type) and Delegates (string) must match for `{0}`</source>
+        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1024">
-        <source>No selector specified for property '{0}.{1}'
-		</source>
-        <target state="new">No selector specified for property '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for property '{0}.{1}'</source>
+        <target state="new">No selector specified for property '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1025">
-        <source>[Static] and [Protocol] are mutually exclusive ({0})
-		</source>
-        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})
-		</target>
-        <note>
-		</note>
+        <source>[Static] and [Protocol] are mutually exclusive ({0})</source>
+        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1026">
-        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</source>
-        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</target>
-        <note>
-		</note>
+        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</source>
+        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1027">
-        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</source>
-        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</target>
-        <note>
-		</note>
+        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</source>
+        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1028">
-        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1029">
-        <source>Internal error: invalid enum mode for type '{0}'
-		</source>
-        <target state="new">Internal error: invalid enum mode for type '{0}'
-		</target>
-        <note>
-		</note>
+        <source>Internal error: invalid enum mode for type '{0}'</source>
+        <target state="new">Internal error: invalid enum mode for type '{0}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1030">
-        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</source>
-        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</target>
-        <note>
-		</note>
+        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</source>
+        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1031">
-        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</source>
-        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</target>
-        <note>
-		</note>
+        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</source>
+        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1032">
-        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</source>
-        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}</source>
+        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1033">
-        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</source>
-        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</target>
+        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</source>
+        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</target>
         <note>Generating a strongly typed dictionary for type '{0}' is not supported.
 {0} - the property type.
 {1} - the dictionary type.
@@ -366,538 +240,341 @@
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
-        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</source>
-        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</source>
+        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1035">
-        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</source>
-        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</target>
-        <note>
-		</note>
+        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</source>
+        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1036">
-        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</source>
-        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</target>
-        <note>
-		</note>
+        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</source>
+        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1037">
-        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1038">
-        <source>The selector {0} on type {1} is found multiple times with different return types.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different return types.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different return types.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different return types.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1039">
-        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1040">
-        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1041">
         <source>The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</source>
         <target state="new">The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1042">
-        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</source>
-        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</target>
-        <note>
-		</note>
+        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</source>
+        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1043">
-        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</source>
-        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</target>
-        <note>
-		</note>
+        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</source>
+        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1044">
-        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</source>
-        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</target>
-        <note>
-		</note>
+        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].</source>
+        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1045">
-        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</source>
-        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</target>
-        <note>
-		</note>
+        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</source>
+        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1046">
-        <source>The [Field] constant {0} cannot only be used once inside enum {1}.
-		</source>
-        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.
-		</target>
-        <note>
-		</note>
+        <source>The [Field] constant {0} cannot only be used once inside enum {1}.</source>
+        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1047">
-        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1048">
-        <source>Unsupported type {0} decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type {0} decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} decorated with [BindAs]</source>
+        <target state="new">Unsupported type {0} decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1049">
-        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</source>
-        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</target>
-        <note>
-		</note>
+        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</source>
+        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1050">
-        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</source>
-        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</target>
-        <note>
-		</note>
+        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}</source>
+        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1051">
-        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1052">
-        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1053">
-        <source>Internal error: unknown target framework '{0}'.
-		</source>
-        <target state="new">Internal error: unknown target framework '{0}'.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: unknown target framework '{0}'.</source>
+        <target state="new">Internal error: unknown target framework '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1054">
-        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1055">
-        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1056">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1057">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1058">
-        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
+        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
         <note />
       </trans-unit>
       <trans-unit id="BI1059">
-        <source>Found {0} {1} attributes on the member {2}. At most one was expected.
-		</source>
-        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.
-		</target>
-        <note>
-		</note>
+        <source>Found {0} {1} attributes on the member {2}. At most one was expected.</source>
+        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1060">
-        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</source>
-        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</target>
-        <note>
-		</note>
+        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</source>
+        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1061">
-        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</source>
-        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</target>
-        <note>
-		</note>
+        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</source>
+        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1062">
-        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</source>
-        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</source>
+        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1063">
-        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</source>
-        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</source>
+        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1064">
-        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1065">
-        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1066">
-        <source>Unsupported return type '{0}' in {1}.{2}.
-		</source>
-        <target state="new">Unsupported return type '{0}' in {1}.{2}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported return type '{0}' in {1}.{2}.</source>
+        <target state="new">Unsupported return type '{0}' in {1}.{2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1067">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1068">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1069">
-        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</source>
-        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</source>
+        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1070">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1071">
-        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</source>
-        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</source>
+        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1072">
-        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</source>
-        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</source>
+        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1073">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1074">
-        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</source>
-        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</target>
-        <note>
-		</note>
+        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}</source>
+        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1075">
-        <source>Unimplemented CoreImage property type {0}
-		</source>
-        <target state="new">Unimplemented CoreImage property type {0}
-		</target>
-        <note>
-		</note>
+        <source>Unimplemented CoreImage property type {0}</source>
+        <target state="new">Unimplemented CoreImage property type {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1076">
-        <source>Unable to find selector for {0} on {1} on self or base class
-		</source>
-        <target state="new">Unable to find selector for {0} on {1} on self or base class
-		</target>
-        <note>
-		</note>
+        <source>Unable to find selector for {0} on {1} on self or base class</source>
+        <target state="new">Unable to find selector for {0} on {1} on self or base class</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1077">
-        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</source>
-        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</target>
+        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</source>
+        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</target>
         <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
 {0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">
-        <source>{0} in method `{1}'
-		</source>
-        <target state="new">{0} in method `{1}'
-		</target>
-        <note>
-		</note>
+        <source>{0} in method `{1}'</source>
+        <target state="new">{0} in method `{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1079">
-        <source>{0} in parameter `{1}' from {2}.{3}
-		</source>
-        <target state="new">{0} in parameter `{1}' from {2}.{3}
-		</target>
-        <note>
-		</note>
+        <source>{0} in parameter `{1}' from {2}.{3}</source>
+        <target state="new">{0} in parameter `{1}' from {2}.{3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1080">
-        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]</source>
+        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1081">
-        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </source>
-        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </target>
-        <note>
-        </note>
+        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.</source>
+        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1101">
-        <source>Trying to use a string as a [Target]
-		</source>
-        <target state="new">Trying to use a string as a [Target]
-		</target>
-        <note>
-		</note>
+        <source>Trying to use a string as a [Target]</source>
+        <target state="new">Trying to use a string as a [Target]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1102">
-        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</source>
-        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</target>
-        <note>
-		</note>
+        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</source>
+        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1103">
-        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</source>
-        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</target>
-        <note>
-		</note>
+        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</source>
+        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1104">
-        <source>Could not load the referenced library '{0}': {1}.
-		</source>
-        <target state="new">Could not load the referenced library '{0}': {1}.
-		</target>
-        <note>
-		</note>
+        <source>Could not load the referenced library '{0}': {1}.</source>
+        <target state="new">Could not load the referenced library '{0}': {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1105">
-        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</source>
-        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</target>
-        <note>
-		</note>
+        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</source>
+        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1106">
-        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</source>
-        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</target>
-        <note>
-		</note>
+        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</source>
+        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1107">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1108">
-        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</source>
-        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</source>
+        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1109">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1110">
-        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1111">
-        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</source>
-        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</target>
-        <note>
-		</note>
+        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</source>
+        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1112">
-        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</source>
-        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</target>
-        <note>
-		</note>
+        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</source>
+        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1113">
-        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</source>
-        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</target>
-        <note>
-		</note>
+        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</source>
+        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1114">
-        <source>Binding error: test unable to find property: {0} on {1}
-		</source>
-        <target state="new">Binding error: test unable to find property: {0} on {1}
-		</target>
-        <note>
-		</note>
+        <source>Binding error: test unable to find property: {0} on {1}</source>
+        <target state="new">Binding error: test unable to find property: {0} on {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1115">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1116">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1117">
-        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</source>
-        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</source>
+        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1118">
-        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</source>
-        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</target>
-        <note>
-		</note>
+        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</source>
+        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1119">
-        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="BI0000">
         <source>Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0001">
         <source>The .NET runtime could not load the {0} type. Message: {1}</source>
         <target state="new">The .NET runtime could not load the {0} type. Message: {1}</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0002">
         <source>Could not compile the API bindings.
@@ -21,72 +19,47 @@
         <target state="new">Could not compile the API bindings.
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0026">
-        <source>Could not parse the command line argument '--warnaserror': {0}
-		</source>
-        <target state="new">Could not parse the command line argument '--warnaserror': {0}
-		</target>
-        <note>
-		</note>
+        <source>Could not parse the command line argument '--warnaserror': {0}</source>
+        <target state="new">Could not parse the command line argument '--warnaserror': {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0068">
-        <source>Invalid value for target framework: {0}.
-		</source>
-        <target state="new">Invalid value for target framework: {0}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid value for target framework: {0}.</source>
+        <target state="new">Invalid value for target framework: {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0086">
-        <source>A target framework (--target-framework) must be specified.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified.
-		</target>
-        <note>
-		</note>
+        <source>A target framework (--target-framework) must be specified.</source>
+        <target state="new">A target framework (--target-framework) must be specified.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0087">
-        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</source>
-        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</target>
-        <note>
-		</note>
+        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</source>
+        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0088">
-        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0089">
-        <source>Internal error: property {0} doesn't have neither a getter nor a setter.
-		</source>
-        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: property {0} doesn't have neither a getter nor a setter.</source>
+        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0099">
-        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1000">
         <source>Could not compile the generated API bindings.	
@@ -95,270 +68,171 @@
         <target state="new">Could not compile the generated API bindings.	
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1001">
-        <source>Do not know how to make a trampoline for {0}
-		</source>
-        <target state="new">Do not know how to make a trampoline for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a trampoline for {0}</source>
+        <target state="new">Do not know how to make a trampoline for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1002">
-        <source>Unknown kind {0} in method '{1}.{2}'
-		</source>
-        <target state="new">Unknown kind {0} in method '{1}.{2}'
-		</target>
-        <note>
-		</note>
+        <source>Unknown kind {0} in method '{1}.{2}'</source>
+        <target state="new">Unknown kind {0} in method '{1}.{2}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1003">
-        <source>The delegate method {0}.{1} needs to take at least one parameter
-		</source>
-        <target state="new">The delegate method {0}.{1} needs to take at least one parameter
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} needs to take at least one parameter</source>
+        <target state="new">The delegate method {0}.{1} needs to take at least one parameter</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1004">
-        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1005">
-        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</source>
-        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</target>
-        <note>
-		</note>
+        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</source>
+        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1006">
-        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1007">
-        <source>Unknown attribute {0} on {1}.{2}
-		</source>
-        <target state="new">Unknown attribute {0} on {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unknown attribute {0} on {1}.{2}</source>
+        <target state="new">Unknown attribute {0} on {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1008">
-        <source>[IsThreadStatic] is only valid on properties that are also [Static]
-		</source>
-        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]
-		</target>
-        <note>
-		</note>
+        <source>[IsThreadStatic] is only valid on properties that are also [Static]</source>
+        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1009">
-        <source>No selector specified for method `{0}.{1}'
-		</source>
-        <target state="new">No selector specified for method `{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for method `{0}.{1}'</source>
+        <target state="new">No selector specified for method `{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1010">
-        <source>No Export attribute on {0}.{1} property
-		</source>
-        <target state="new">No Export attribute on {0}.{1} property
-		</target>
-        <note>
-		</note>
+        <source>No Export attribute on {0}.{1} property</source>
+        <target state="new">No Export attribute on {0}.{1} property</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1011">
-        <source>Do not know how to extract type {0}/{1} from an NSDictionary
-		</source>
-        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to extract type {0}/{1} from an NSDictionary</source>
+        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1012">
-        <source>No Export or Bind attribute defined on {0}.{1}
-		</source>
-        <target state="new">No Export or Bind attribute defined on {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No Export or Bind attribute defined on {0}.{1}</source>
+        <target state="new">No Export or Bind attribute defined on {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1013">
-        <source>Unsupported type for Fields (string), you probably meant NSString
-		</source>
-        <target state="new">Unsupported type for Fields (string), you probably meant NSString
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields (string), you probably meant NSString</source>
+        <target state="new">Unsupported type for Fields (string), you probably meant NSString</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1014">
-        <source>Unsupported type for Fields: {0} for '{1}'.
-		</source>
-        <target state="new">Unsupported type for Fields: {0} for '{1}'.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields: {0} for '{1}'.</source>
+        <target state="new">Unsupported type for Fields: {0} for '{1}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1015">
-        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</source>
-        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</target>
-        <note>
-		</note>
+        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates</source>
+        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1016">
-        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1017">
-        <source>Do not know how to make a signature for {0}
-		</source>
-        <target state="new">Do not know how to make a signature for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a signature for {0}</source>
+        <target state="new">Do not know how to make a signature for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1018">
-        <source>No [Export] attribute on property {0}.{1}
-		</source>
-        <target state="new">No [Export] attribute on property {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No [Export] attribute on property {0}.{1}</source>
+        <target state="new">No [Export] attribute on property {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1019">
-        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</source>
-        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'</source>
+        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1020">
-        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</source>
-        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</source>
+        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1021">
-        <source>Unsupported type for read/write Fields: {0} for {1}.{2}
-		</source>
-        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for read/write Fields: {0} for {1}.{2}</source>
+        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1022">
-        <source>Model classes can not be categories
-		</source>
-        <target state="new">Model classes can not be categories
-		</target>
-        <note>
-		</note>
+        <source>Model classes can not be categories</source>
+        <target state="new">Model classes can not be categories</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1023">
-        <source>The number of Events (Type) and Delegates (string) must match for `{0}`
-		</source>
-        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`
-		</target>
-        <note>
-		</note>
+        <source>The number of Events (Type) and Delegates (string) must match for `{0}`</source>
+        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1024">
-        <source>No selector specified for property '{0}.{1}'
-		</source>
-        <target state="new">No selector specified for property '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for property '{0}.{1}'</source>
+        <target state="new">No selector specified for property '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1025">
-        <source>[Static] and [Protocol] are mutually exclusive ({0})
-		</source>
-        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})
-		</target>
-        <note>
-		</note>
+        <source>[Static] and [Protocol] are mutually exclusive ({0})</source>
+        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1026">
-        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</source>
-        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</target>
-        <note>
-		</note>
+        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</source>
+        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1027">
-        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</source>
-        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</target>
-        <note>
-		</note>
+        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</source>
+        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1028">
-        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1029">
-        <source>Internal error: invalid enum mode for type '{0}'
-		</source>
-        <target state="new">Internal error: invalid enum mode for type '{0}'
-		</target>
-        <note>
-		</note>
+        <source>Internal error: invalid enum mode for type '{0}'</source>
+        <target state="new">Internal error: invalid enum mode for type '{0}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1030">
-        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</source>
-        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</target>
-        <note>
-		</note>
+        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</source>
+        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1031">
-        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</source>
-        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</target>
-        <note>
-		</note>
+        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</source>
+        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1032">
-        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</source>
-        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}</source>
+        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1033">
-        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</source>
-        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</target>
+        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</source>
+        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</target>
         <note>Generating a strongly typed dictionary for type '{0}' is not supported.
 {0} - the property type.
 {1} - the dictionary type.
@@ -366,538 +240,341 @@
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
-        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</source>
-        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</source>
+        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1035">
-        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</source>
-        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</target>
-        <note>
-		</note>
+        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</source>
+        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1036">
-        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</source>
-        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</target>
-        <note>
-		</note>
+        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</source>
+        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1037">
-        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1038">
-        <source>The selector {0} on type {1} is found multiple times with different return types.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different return types.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different return types.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different return types.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1039">
-        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1040">
-        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1041">
         <source>The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</source>
         <target state="new">The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1042">
-        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</source>
-        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</target>
-        <note>
-		</note>
+        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</source>
+        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1043">
-        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</source>
-        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</target>
-        <note>
-		</note>
+        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</source>
+        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1044">
-        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</source>
-        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</target>
-        <note>
-		</note>
+        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].</source>
+        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1045">
-        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</source>
-        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</target>
-        <note>
-		</note>
+        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</source>
+        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1046">
-        <source>The [Field] constant {0} cannot only be used once inside enum {1}.
-		</source>
-        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.
-		</target>
-        <note>
-		</note>
+        <source>The [Field] constant {0} cannot only be used once inside enum {1}.</source>
+        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1047">
-        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1048">
-        <source>Unsupported type {0} decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type {0} decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} decorated with [BindAs]</source>
+        <target state="new">Unsupported type {0} decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1049">
-        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</source>
-        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</target>
-        <note>
-		</note>
+        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</source>
+        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1050">
-        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</source>
-        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</target>
-        <note>
-		</note>
+        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}</source>
+        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1051">
-        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1052">
-        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1053">
-        <source>Internal error: unknown target framework '{0}'.
-		</source>
-        <target state="new">Internal error: unknown target framework '{0}'.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: unknown target framework '{0}'.</source>
+        <target state="new">Internal error: unknown target framework '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1054">
-        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1055">
-        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1056">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1057">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1058">
-        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
+        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
         <note />
       </trans-unit>
       <trans-unit id="BI1059">
-        <source>Found {0} {1} attributes on the member {2}. At most one was expected.
-		</source>
-        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.
-		</target>
-        <note>
-		</note>
+        <source>Found {0} {1} attributes on the member {2}. At most one was expected.</source>
+        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1060">
-        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</source>
-        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</target>
-        <note>
-		</note>
+        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</source>
+        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1061">
-        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</source>
-        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</target>
-        <note>
-		</note>
+        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</source>
+        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1062">
-        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</source>
-        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</source>
+        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1063">
-        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</source>
-        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</source>
+        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1064">
-        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1065">
-        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1066">
-        <source>Unsupported return type '{0}' in {1}.{2}.
-		</source>
-        <target state="new">Unsupported return type '{0}' in {1}.{2}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported return type '{0}' in {1}.{2}.</source>
+        <target state="new">Unsupported return type '{0}' in {1}.{2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1067">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1068">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1069">
-        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</source>
-        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</source>
+        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1070">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1071">
-        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</source>
-        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</source>
+        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1072">
-        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</source>
-        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</source>
+        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1073">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1074">
-        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</source>
-        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</target>
-        <note>
-		</note>
+        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}</source>
+        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1075">
-        <source>Unimplemented CoreImage property type {0}
-		</source>
-        <target state="new">Unimplemented CoreImage property type {0}
-		</target>
-        <note>
-		</note>
+        <source>Unimplemented CoreImage property type {0}</source>
+        <target state="new">Unimplemented CoreImage property type {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1076">
-        <source>Unable to find selector for {0} on {1} on self or base class
-		</source>
-        <target state="new">Unable to find selector for {0} on {1} on self or base class
-		</target>
-        <note>
-		</note>
+        <source>Unable to find selector for {0} on {1} on self or base class</source>
+        <target state="new">Unable to find selector for {0} on {1} on self or base class</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1077">
-        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</source>
-        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</target>
+        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</source>
+        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</target>
         <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
 {0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">
-        <source>{0} in method `{1}'
-		</source>
-        <target state="new">{0} in method `{1}'
-		</target>
-        <note>
-		</note>
+        <source>{0} in method `{1}'</source>
+        <target state="new">{0} in method `{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1079">
-        <source>{0} in parameter `{1}' from {2}.{3}
-		</source>
-        <target state="new">{0} in parameter `{1}' from {2}.{3}
-		</target>
-        <note>
-		</note>
+        <source>{0} in parameter `{1}' from {2}.{3}</source>
+        <target state="new">{0} in parameter `{1}' from {2}.{3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1080">
-        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]</source>
+        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1081">
-        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </source>
-        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </target>
-        <note>
-        </note>
+        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.</source>
+        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1101">
-        <source>Trying to use a string as a [Target]
-		</source>
-        <target state="new">Trying to use a string as a [Target]
-		</target>
-        <note>
-		</note>
+        <source>Trying to use a string as a [Target]</source>
+        <target state="new">Trying to use a string as a [Target]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1102">
-        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</source>
-        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</target>
-        <note>
-		</note>
+        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</source>
+        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1103">
-        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</source>
-        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</target>
-        <note>
-		</note>
+        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</source>
+        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1104">
-        <source>Could not load the referenced library '{0}': {1}.
-		</source>
-        <target state="new">Could not load the referenced library '{0}': {1}.
-		</target>
-        <note>
-		</note>
+        <source>Could not load the referenced library '{0}': {1}.</source>
+        <target state="new">Could not load the referenced library '{0}': {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1105">
-        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</source>
-        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</target>
-        <note>
-		</note>
+        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</source>
+        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1106">
-        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</source>
-        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</target>
-        <note>
-		</note>
+        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</source>
+        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1107">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1108">
-        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</source>
-        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</source>
+        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1109">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1110">
-        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1111">
-        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</source>
-        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</target>
-        <note>
-		</note>
+        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</source>
+        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1112">
-        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</source>
-        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</target>
-        <note>
-		</note>
+        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</source>
+        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1113">
-        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</source>
-        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</target>
-        <note>
-		</note>
+        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</source>
+        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1114">
-        <source>Binding error: test unable to find property: {0} on {1}
-		</source>
-        <target state="new">Binding error: test unable to find property: {0} on {1}
-		</target>
-        <note>
-		</note>
+        <source>Binding error: test unable to find property: {0} on {1}</source>
+        <target state="new">Binding error: test unable to find property: {0} on {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1115">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1116">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1117">
-        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</source>
-        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</source>
+        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1118">
-        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</source>
-        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</target>
-        <note>
-		</note>
+        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</source>
+        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1119">
-        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="BI0000">
         <source>Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0001">
         <source>The .NET runtime could not load the {0} type. Message: {1}</source>
         <target state="new">The .NET runtime could not load the {0} type. Message: {1}</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0002">
         <source>Could not compile the API bindings.
@@ -21,72 +19,47 @@
         <target state="new">Could not compile the API bindings.
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0026">
-        <source>Could not parse the command line argument '--warnaserror': {0}
-		</source>
-        <target state="new">Could not parse the command line argument '--warnaserror': {0}
-		</target>
-        <note>
-		</note>
+        <source>Could not parse the command line argument '--warnaserror': {0}</source>
+        <target state="new">Could not parse the command line argument '--warnaserror': {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0068">
-        <source>Invalid value for target framework: {0}.
-		</source>
-        <target state="new">Invalid value for target framework: {0}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid value for target framework: {0}.</source>
+        <target state="new">Invalid value for target framework: {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0086">
-        <source>A target framework (--target-framework) must be specified.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified.
-		</target>
-        <note>
-		</note>
+        <source>A target framework (--target-framework) must be specified.</source>
+        <target state="new">A target framework (--target-framework) must be specified.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0087">
-        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</source>
-        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</target>
-        <note>
-		</note>
+        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</source>
+        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0088">
-        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0089">
-        <source>Internal error: property {0} doesn't have neither a getter nor a setter.
-		</source>
-        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: property {0} doesn't have neither a getter nor a setter.</source>
+        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0099">
-        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1000">
         <source>Could not compile the generated API bindings.	
@@ -95,270 +68,171 @@
         <target state="new">Could not compile the generated API bindings.	
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1001">
-        <source>Do not know how to make a trampoline for {0}
-		</source>
-        <target state="new">Do not know how to make a trampoline for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a trampoline for {0}</source>
+        <target state="new">Do not know how to make a trampoline for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1002">
-        <source>Unknown kind {0} in method '{1}.{2}'
-		</source>
-        <target state="new">Unknown kind {0} in method '{1}.{2}'
-		</target>
-        <note>
-		</note>
+        <source>Unknown kind {0} in method '{1}.{2}'</source>
+        <target state="new">Unknown kind {0} in method '{1}.{2}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1003">
-        <source>The delegate method {0}.{1} needs to take at least one parameter
-		</source>
-        <target state="new">The delegate method {0}.{1} needs to take at least one parameter
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} needs to take at least one parameter</source>
+        <target state="new">The delegate method {0}.{1} needs to take at least one parameter</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1004">
-        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1005">
-        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</source>
-        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</target>
-        <note>
-		</note>
+        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</source>
+        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1006">
-        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1007">
-        <source>Unknown attribute {0} on {1}.{2}
-		</source>
-        <target state="new">Unknown attribute {0} on {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unknown attribute {0} on {1}.{2}</source>
+        <target state="new">Unknown attribute {0} on {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1008">
-        <source>[IsThreadStatic] is only valid on properties that are also [Static]
-		</source>
-        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]
-		</target>
-        <note>
-		</note>
+        <source>[IsThreadStatic] is only valid on properties that are also [Static]</source>
+        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1009">
-        <source>No selector specified for method `{0}.{1}'
-		</source>
-        <target state="new">No selector specified for method `{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for method `{0}.{1}'</source>
+        <target state="new">No selector specified for method `{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1010">
-        <source>No Export attribute on {0}.{1} property
-		</source>
-        <target state="new">No Export attribute on {0}.{1} property
-		</target>
-        <note>
-		</note>
+        <source>No Export attribute on {0}.{1} property</source>
+        <target state="new">No Export attribute on {0}.{1} property</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1011">
-        <source>Do not know how to extract type {0}/{1} from an NSDictionary
-		</source>
-        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to extract type {0}/{1} from an NSDictionary</source>
+        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1012">
-        <source>No Export or Bind attribute defined on {0}.{1}
-		</source>
-        <target state="new">No Export or Bind attribute defined on {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No Export or Bind attribute defined on {0}.{1}</source>
+        <target state="new">No Export or Bind attribute defined on {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1013">
-        <source>Unsupported type for Fields (string), you probably meant NSString
-		</source>
-        <target state="new">Unsupported type for Fields (string), you probably meant NSString
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields (string), you probably meant NSString</source>
+        <target state="new">Unsupported type for Fields (string), you probably meant NSString</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1014">
-        <source>Unsupported type for Fields: {0} for '{1}'.
-		</source>
-        <target state="new">Unsupported type for Fields: {0} for '{1}'.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields: {0} for '{1}'.</source>
+        <target state="new">Unsupported type for Fields: {0} for '{1}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1015">
-        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</source>
-        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</target>
-        <note>
-		</note>
+        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates</source>
+        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1016">
-        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1017">
-        <source>Do not know how to make a signature for {0}
-		</source>
-        <target state="new">Do not know how to make a signature for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a signature for {0}</source>
+        <target state="new">Do not know how to make a signature for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1018">
-        <source>No [Export] attribute on property {0}.{1}
-		</source>
-        <target state="new">No [Export] attribute on property {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No [Export] attribute on property {0}.{1}</source>
+        <target state="new">No [Export] attribute on property {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1019">
-        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</source>
-        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'</source>
+        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1020">
-        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</source>
-        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</source>
+        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1021">
-        <source>Unsupported type for read/write Fields: {0} for {1}.{2}
-		</source>
-        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for read/write Fields: {0} for {1}.{2}</source>
+        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1022">
-        <source>Model classes can not be categories
-		</source>
-        <target state="new">Model classes can not be categories
-		</target>
-        <note>
-		</note>
+        <source>Model classes can not be categories</source>
+        <target state="new">Model classes can not be categories</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1023">
-        <source>The number of Events (Type) and Delegates (string) must match for `{0}`
-		</source>
-        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`
-		</target>
-        <note>
-		</note>
+        <source>The number of Events (Type) and Delegates (string) must match for `{0}`</source>
+        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1024">
-        <source>No selector specified for property '{0}.{1}'
-		</source>
-        <target state="new">No selector specified for property '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for property '{0}.{1}'</source>
+        <target state="new">No selector specified for property '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1025">
-        <source>[Static] and [Protocol] are mutually exclusive ({0})
-		</source>
-        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})
-		</target>
-        <note>
-		</note>
+        <source>[Static] and [Protocol] are mutually exclusive ({0})</source>
+        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1026">
-        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</source>
-        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</target>
-        <note>
-		</note>
+        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</source>
+        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1027">
-        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</source>
-        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</target>
-        <note>
-		</note>
+        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</source>
+        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1028">
-        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1029">
-        <source>Internal error: invalid enum mode for type '{0}'
-		</source>
-        <target state="new">Internal error: invalid enum mode for type '{0}'
-		</target>
-        <note>
-		</note>
+        <source>Internal error: invalid enum mode for type '{0}'</source>
+        <target state="new">Internal error: invalid enum mode for type '{0}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1030">
-        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</source>
-        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</target>
-        <note>
-		</note>
+        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</source>
+        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1031">
-        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</source>
-        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</target>
-        <note>
-		</note>
+        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</source>
+        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1032">
-        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</source>
-        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}</source>
+        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1033">
-        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</source>
-        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</target>
+        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</source>
+        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</target>
         <note>Generating a strongly typed dictionary for type '{0}' is not supported.
 {0} - the property type.
 {1} - the dictionary type.
@@ -366,538 +240,341 @@
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
-        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</source>
-        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</source>
+        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1035">
-        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</source>
-        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</target>
-        <note>
-		</note>
+        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</source>
+        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1036">
-        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</source>
-        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</target>
-        <note>
-		</note>
+        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</source>
+        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1037">
-        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1038">
-        <source>The selector {0} on type {1} is found multiple times with different return types.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different return types.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different return types.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different return types.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1039">
-        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1040">
-        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1041">
         <source>The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</source>
         <target state="new">The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1042">
-        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</source>
-        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</target>
-        <note>
-		</note>
+        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</source>
+        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1043">
-        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</source>
-        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</target>
-        <note>
-		</note>
+        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</source>
+        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1044">
-        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</source>
-        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</target>
-        <note>
-		</note>
+        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].</source>
+        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1045">
-        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</source>
-        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</target>
-        <note>
-		</note>
+        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</source>
+        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1046">
-        <source>The [Field] constant {0} cannot only be used once inside enum {1}.
-		</source>
-        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.
-		</target>
-        <note>
-		</note>
+        <source>The [Field] constant {0} cannot only be used once inside enum {1}.</source>
+        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1047">
-        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1048">
-        <source>Unsupported type {0} decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type {0} decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} decorated with [BindAs]</source>
+        <target state="new">Unsupported type {0} decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1049">
-        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</source>
-        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</target>
-        <note>
-		</note>
+        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</source>
+        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1050">
-        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</source>
-        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</target>
-        <note>
-		</note>
+        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}</source>
+        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1051">
-        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1052">
-        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1053">
-        <source>Internal error: unknown target framework '{0}'.
-		</source>
-        <target state="new">Internal error: unknown target framework '{0}'.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: unknown target framework '{0}'.</source>
+        <target state="new">Internal error: unknown target framework '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1054">
-        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1055">
-        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1056">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1057">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1058">
-        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
+        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
         <note />
       </trans-unit>
       <trans-unit id="BI1059">
-        <source>Found {0} {1} attributes on the member {2}. At most one was expected.
-		</source>
-        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.
-		</target>
-        <note>
-		</note>
+        <source>Found {0} {1} attributes on the member {2}. At most one was expected.</source>
+        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1060">
-        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</source>
-        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</target>
-        <note>
-		</note>
+        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</source>
+        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1061">
-        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</source>
-        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</target>
-        <note>
-		</note>
+        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</source>
+        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1062">
-        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</source>
-        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</source>
+        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1063">
-        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</source>
-        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</source>
+        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1064">
-        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1065">
-        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1066">
-        <source>Unsupported return type '{0}' in {1}.{2}.
-		</source>
-        <target state="new">Unsupported return type '{0}' in {1}.{2}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported return type '{0}' in {1}.{2}.</source>
+        <target state="new">Unsupported return type '{0}' in {1}.{2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1067">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1068">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1069">
-        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</source>
-        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</source>
+        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1070">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1071">
-        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</source>
-        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</source>
+        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1072">
-        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</source>
-        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</source>
+        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1073">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1074">
-        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</source>
-        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</target>
-        <note>
-		</note>
+        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}</source>
+        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1075">
-        <source>Unimplemented CoreImage property type {0}
-		</source>
-        <target state="new">Unimplemented CoreImage property type {0}
-		</target>
-        <note>
-		</note>
+        <source>Unimplemented CoreImage property type {0}</source>
+        <target state="new">Unimplemented CoreImage property type {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1076">
-        <source>Unable to find selector for {0} on {1} on self or base class
-		</source>
-        <target state="new">Unable to find selector for {0} on {1} on self or base class
-		</target>
-        <note>
-		</note>
+        <source>Unable to find selector for {0} on {1} on self or base class</source>
+        <target state="new">Unable to find selector for {0} on {1} on self or base class</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1077">
-        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</source>
-        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</target>
+        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</source>
+        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</target>
         <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
 {0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">
-        <source>{0} in method `{1}'
-		</source>
-        <target state="new">{0} in method `{1}'
-		</target>
-        <note>
-		</note>
+        <source>{0} in method `{1}'</source>
+        <target state="new">{0} in method `{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1079">
-        <source>{0} in parameter `{1}' from {2}.{3}
-		</source>
-        <target state="new">{0} in parameter `{1}' from {2}.{3}
-		</target>
-        <note>
-		</note>
+        <source>{0} in parameter `{1}' from {2}.{3}</source>
+        <target state="new">{0} in parameter `{1}' from {2}.{3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1080">
-        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]</source>
+        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1081">
-        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </source>
-        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </target>
-        <note>
-        </note>
+        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.</source>
+        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1101">
-        <source>Trying to use a string as a [Target]
-		</source>
-        <target state="new">Trying to use a string as a [Target]
-		</target>
-        <note>
-		</note>
+        <source>Trying to use a string as a [Target]</source>
+        <target state="new">Trying to use a string as a [Target]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1102">
-        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</source>
-        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</target>
-        <note>
-		</note>
+        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</source>
+        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1103">
-        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</source>
-        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</target>
-        <note>
-		</note>
+        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</source>
+        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1104">
-        <source>Could not load the referenced library '{0}': {1}.
-		</source>
-        <target state="new">Could not load the referenced library '{0}': {1}.
-		</target>
-        <note>
-		</note>
+        <source>Could not load the referenced library '{0}': {1}.</source>
+        <target state="new">Could not load the referenced library '{0}': {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1105">
-        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</source>
-        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</target>
-        <note>
-		</note>
+        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</source>
+        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1106">
-        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</source>
-        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</target>
-        <note>
-		</note>
+        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</source>
+        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1107">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1108">
-        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</source>
-        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</source>
+        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1109">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1110">
-        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1111">
-        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</source>
-        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</target>
-        <note>
-		</note>
+        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</source>
+        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1112">
-        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</source>
-        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</target>
-        <note>
-		</note>
+        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</source>
+        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1113">
-        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</source>
-        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</target>
-        <note>
-		</note>
+        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</source>
+        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1114">
-        <source>Binding error: test unable to find property: {0} on {1}
-		</source>
-        <target state="new">Binding error: test unable to find property: {0} on {1}
-		</target>
-        <note>
-		</note>
+        <source>Binding error: test unable to find property: {0} on {1}</source>
+        <target state="new">Binding error: test unable to find property: {0} on {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1115">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1116">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1117">
-        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</source>
-        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</source>
+        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1118">
-        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</source>
-        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</target>
-        <note>
-		</note>
+        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</source>
+        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1119">
-        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="BI0000">
         <source>Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0001">
         <source>The .NET runtime could not load the {0} type. Message: {1}</source>
         <target state="new">The .NET runtime could not load the {0} type. Message: {1}</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0002">
         <source>Could not compile the API bindings.
@@ -21,72 +19,47 @@
         <target state="new">Could not compile the API bindings.
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0026">
-        <source>Could not parse the command line argument '--warnaserror': {0}
-		</source>
-        <target state="new">Could not parse the command line argument '--warnaserror': {0}
-		</target>
-        <note>
-		</note>
+        <source>Could not parse the command line argument '--warnaserror': {0}</source>
+        <target state="new">Could not parse the command line argument '--warnaserror': {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0068">
-        <source>Invalid value for target framework: {0}.
-		</source>
-        <target state="new">Invalid value for target framework: {0}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid value for target framework: {0}.</source>
+        <target state="new">Invalid value for target framework: {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0086">
-        <source>A target framework (--target-framework) must be specified.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified.
-		</target>
-        <note>
-		</note>
+        <source>A target framework (--target-framework) must be specified.</source>
+        <target state="new">A target framework (--target-framework) must be specified.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0087">
-        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</source>
-        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</target>
-        <note>
-		</note>
+        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</source>
+        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0088">
-        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0089">
-        <source>Internal error: property {0} doesn't have neither a getter nor a setter.
-		</source>
-        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: property {0} doesn't have neither a getter nor a setter.</source>
+        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0099">
-        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1000">
         <source>Could not compile the generated API bindings.	
@@ -95,270 +68,171 @@
         <target state="new">Could not compile the generated API bindings.	
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1001">
-        <source>Do not know how to make a trampoline for {0}
-		</source>
-        <target state="new">Do not know how to make a trampoline for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a trampoline for {0}</source>
+        <target state="new">Do not know how to make a trampoline for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1002">
-        <source>Unknown kind {0} in method '{1}.{2}'
-		</source>
-        <target state="new">Unknown kind {0} in method '{1}.{2}'
-		</target>
-        <note>
-		</note>
+        <source>Unknown kind {0} in method '{1}.{2}'</source>
+        <target state="new">Unknown kind {0} in method '{1}.{2}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1003">
-        <source>The delegate method {0}.{1} needs to take at least one parameter
-		</source>
-        <target state="new">The delegate method {0}.{1} needs to take at least one parameter
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} needs to take at least one parameter</source>
+        <target state="new">The delegate method {0}.{1} needs to take at least one parameter</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1004">
-        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1005">
-        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</source>
-        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</target>
-        <note>
-		</note>
+        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</source>
+        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1006">
-        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1007">
-        <source>Unknown attribute {0} on {1}.{2}
-		</source>
-        <target state="new">Unknown attribute {0} on {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unknown attribute {0} on {1}.{2}</source>
+        <target state="new">Unknown attribute {0} on {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1008">
-        <source>[IsThreadStatic] is only valid on properties that are also [Static]
-		</source>
-        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]
-		</target>
-        <note>
-		</note>
+        <source>[IsThreadStatic] is only valid on properties that are also [Static]</source>
+        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1009">
-        <source>No selector specified for method `{0}.{1}'
-		</source>
-        <target state="new">No selector specified for method `{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for method `{0}.{1}'</source>
+        <target state="new">No selector specified for method `{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1010">
-        <source>No Export attribute on {0}.{1} property
-		</source>
-        <target state="new">No Export attribute on {0}.{1} property
-		</target>
-        <note>
-		</note>
+        <source>No Export attribute on {0}.{1} property</source>
+        <target state="new">No Export attribute on {0}.{1} property</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1011">
-        <source>Do not know how to extract type {0}/{1} from an NSDictionary
-		</source>
-        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to extract type {0}/{1} from an NSDictionary</source>
+        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1012">
-        <source>No Export or Bind attribute defined on {0}.{1}
-		</source>
-        <target state="new">No Export or Bind attribute defined on {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No Export or Bind attribute defined on {0}.{1}</source>
+        <target state="new">No Export or Bind attribute defined on {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1013">
-        <source>Unsupported type for Fields (string), you probably meant NSString
-		</source>
-        <target state="new">Unsupported type for Fields (string), you probably meant NSString
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields (string), you probably meant NSString</source>
+        <target state="new">Unsupported type for Fields (string), you probably meant NSString</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1014">
-        <source>Unsupported type for Fields: {0} for '{1}'.
-		</source>
-        <target state="new">Unsupported type for Fields: {0} for '{1}'.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields: {0} for '{1}'.</source>
+        <target state="new">Unsupported type for Fields: {0} for '{1}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1015">
-        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</source>
-        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</target>
-        <note>
-		</note>
+        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates</source>
+        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1016">
-        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1017">
-        <source>Do not know how to make a signature for {0}
-		</source>
-        <target state="new">Do not know how to make a signature for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a signature for {0}</source>
+        <target state="new">Do not know how to make a signature for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1018">
-        <source>No [Export] attribute on property {0}.{1}
-		</source>
-        <target state="new">No [Export] attribute on property {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No [Export] attribute on property {0}.{1}</source>
+        <target state="new">No [Export] attribute on property {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1019">
-        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</source>
-        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'</source>
+        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1020">
-        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</source>
-        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</source>
+        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1021">
-        <source>Unsupported type for read/write Fields: {0} for {1}.{2}
-		</source>
-        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for read/write Fields: {0} for {1}.{2}</source>
+        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1022">
-        <source>Model classes can not be categories
-		</source>
-        <target state="new">Model classes can not be categories
-		</target>
-        <note>
-		</note>
+        <source>Model classes can not be categories</source>
+        <target state="new">Model classes can not be categories</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1023">
-        <source>The number of Events (Type) and Delegates (string) must match for `{0}`
-		</source>
-        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`
-		</target>
-        <note>
-		</note>
+        <source>The number of Events (Type) and Delegates (string) must match for `{0}`</source>
+        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1024">
-        <source>No selector specified for property '{0}.{1}'
-		</source>
-        <target state="new">No selector specified for property '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for property '{0}.{1}'</source>
+        <target state="new">No selector specified for property '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1025">
-        <source>[Static] and [Protocol] are mutually exclusive ({0})
-		</source>
-        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})
-		</target>
-        <note>
-		</note>
+        <source>[Static] and [Protocol] are mutually exclusive ({0})</source>
+        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1026">
-        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</source>
-        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</target>
-        <note>
-		</note>
+        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</source>
+        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1027">
-        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</source>
-        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</target>
-        <note>
-		</note>
+        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</source>
+        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1028">
-        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1029">
-        <source>Internal error: invalid enum mode for type '{0}'
-		</source>
-        <target state="new">Internal error: invalid enum mode for type '{0}'
-		</target>
-        <note>
-		</note>
+        <source>Internal error: invalid enum mode for type '{0}'</source>
+        <target state="new">Internal error: invalid enum mode for type '{0}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1030">
-        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</source>
-        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</target>
-        <note>
-		</note>
+        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</source>
+        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1031">
-        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</source>
-        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</target>
-        <note>
-		</note>
+        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</source>
+        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1032">
-        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</source>
-        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}</source>
+        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1033">
-        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</source>
-        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</target>
+        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</source>
+        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</target>
         <note>Generating a strongly typed dictionary for type '{0}' is not supported.
 {0} - the property type.
 {1} - the dictionary type.
@@ -366,538 +240,341 @@
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
-        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</source>
-        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</source>
+        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1035">
-        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</source>
-        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</target>
-        <note>
-		</note>
+        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</source>
+        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1036">
-        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</source>
-        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</target>
-        <note>
-		</note>
+        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</source>
+        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1037">
-        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1038">
-        <source>The selector {0} on type {1} is found multiple times with different return types.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different return types.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different return types.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different return types.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1039">
-        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1040">
-        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1041">
         <source>The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</source>
         <target state="new">The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1042">
-        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</source>
-        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</target>
-        <note>
-		</note>
+        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</source>
+        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1043">
-        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</source>
-        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</target>
-        <note>
-		</note>
+        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</source>
+        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1044">
-        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</source>
-        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</target>
-        <note>
-		</note>
+        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].</source>
+        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1045">
-        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</source>
-        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</target>
-        <note>
-		</note>
+        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</source>
+        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1046">
-        <source>The [Field] constant {0} cannot only be used once inside enum {1}.
-		</source>
-        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.
-		</target>
-        <note>
-		</note>
+        <source>The [Field] constant {0} cannot only be used once inside enum {1}.</source>
+        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1047">
-        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1048">
-        <source>Unsupported type {0} decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type {0} decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} decorated with [BindAs]</source>
+        <target state="new">Unsupported type {0} decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1049">
-        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</source>
-        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</target>
-        <note>
-		</note>
+        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</source>
+        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1050">
-        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</source>
-        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</target>
-        <note>
-		</note>
+        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}</source>
+        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1051">
-        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1052">
-        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1053">
-        <source>Internal error: unknown target framework '{0}'.
-		</source>
-        <target state="new">Internal error: unknown target framework '{0}'.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: unknown target framework '{0}'.</source>
+        <target state="new">Internal error: unknown target framework '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1054">
-        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1055">
-        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1056">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1057">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1058">
-        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
+        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
         <note />
       </trans-unit>
       <trans-unit id="BI1059">
-        <source>Found {0} {1} attributes on the member {2}. At most one was expected.
-		</source>
-        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.
-		</target>
-        <note>
-		</note>
+        <source>Found {0} {1} attributes on the member {2}. At most one was expected.</source>
+        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1060">
-        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</source>
-        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</target>
-        <note>
-		</note>
+        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</source>
+        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1061">
-        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</source>
-        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</target>
-        <note>
-		</note>
+        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</source>
+        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1062">
-        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</source>
-        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</source>
+        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1063">
-        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</source>
-        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</source>
+        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1064">
-        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1065">
-        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1066">
-        <source>Unsupported return type '{0}' in {1}.{2}.
-		</source>
-        <target state="new">Unsupported return type '{0}' in {1}.{2}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported return type '{0}' in {1}.{2}.</source>
+        <target state="new">Unsupported return type '{0}' in {1}.{2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1067">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1068">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1069">
-        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</source>
-        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</source>
+        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1070">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1071">
-        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</source>
-        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</source>
+        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1072">
-        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</source>
-        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</source>
+        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1073">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1074">
-        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</source>
-        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</target>
-        <note>
-		</note>
+        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}</source>
+        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1075">
-        <source>Unimplemented CoreImage property type {0}
-		</source>
-        <target state="new">Unimplemented CoreImage property type {0}
-		</target>
-        <note>
-		</note>
+        <source>Unimplemented CoreImage property type {0}</source>
+        <target state="new">Unimplemented CoreImage property type {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1076">
-        <source>Unable to find selector for {0} on {1} on self or base class
-		</source>
-        <target state="new">Unable to find selector for {0} on {1} on self or base class
-		</target>
-        <note>
-		</note>
+        <source>Unable to find selector for {0} on {1} on self or base class</source>
+        <target state="new">Unable to find selector for {0} on {1} on self or base class</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1077">
-        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</source>
-        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</target>
+        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</source>
+        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</target>
         <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
 {0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">
-        <source>{0} in method `{1}'
-		</source>
-        <target state="new">{0} in method `{1}'
-		</target>
-        <note>
-		</note>
+        <source>{0} in method `{1}'</source>
+        <target state="new">{0} in method `{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1079">
-        <source>{0} in parameter `{1}' from {2}.{3}
-		</source>
-        <target state="new">{0} in parameter `{1}' from {2}.{3}
-		</target>
-        <note>
-		</note>
+        <source>{0} in parameter `{1}' from {2}.{3}</source>
+        <target state="new">{0} in parameter `{1}' from {2}.{3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1080">
-        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]</source>
+        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1081">
-        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </source>
-        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </target>
-        <note>
-        </note>
+        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.</source>
+        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1101">
-        <source>Trying to use a string as a [Target]
-		</source>
-        <target state="new">Trying to use a string as a [Target]
-		</target>
-        <note>
-		</note>
+        <source>Trying to use a string as a [Target]</source>
+        <target state="new">Trying to use a string as a [Target]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1102">
-        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</source>
-        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</target>
-        <note>
-		</note>
+        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</source>
+        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1103">
-        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</source>
-        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</target>
-        <note>
-		</note>
+        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</source>
+        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1104">
-        <source>Could not load the referenced library '{0}': {1}.
-		</source>
-        <target state="new">Could not load the referenced library '{0}': {1}.
-		</target>
-        <note>
-		</note>
+        <source>Could not load the referenced library '{0}': {1}.</source>
+        <target state="new">Could not load the referenced library '{0}': {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1105">
-        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</source>
-        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</target>
-        <note>
-		</note>
+        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</source>
+        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1106">
-        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</source>
-        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</target>
-        <note>
-		</note>
+        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</source>
+        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1107">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1108">
-        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</source>
-        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</source>
+        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1109">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1110">
-        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1111">
-        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</source>
-        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</target>
-        <note>
-		</note>
+        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</source>
+        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1112">
-        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</source>
-        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</target>
-        <note>
-		</note>
+        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</source>
+        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1113">
-        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</source>
-        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</target>
-        <note>
-		</note>
+        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</source>
+        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1114">
-        <source>Binding error: test unable to find property: {0} on {1}
-		</source>
-        <target state="new">Binding error: test unable to find property: {0} on {1}
-		</target>
-        <note>
-		</note>
+        <source>Binding error: test unable to find property: {0} on {1}</source>
+        <target state="new">Binding error: test unable to find property: {0} on {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1115">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1116">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1117">
-        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</source>
-        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</source>
+        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1118">
-        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</source>
-        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</target>
-        <note>
-		</note>
+        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</source>
+        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1119">
-        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="BI0000">
         <source>Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0001">
         <source>The .NET runtime could not load the {0} type. Message: {1}</source>
         <target state="new">The .NET runtime could not load the {0} type. Message: {1}</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0002">
         <source>Could not compile the API bindings.
@@ -21,72 +19,47 @@
         <target state="new">Could not compile the API bindings.
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0026">
-        <source>Could not parse the command line argument '--warnaserror': {0}
-		</source>
-        <target state="new">Could not parse the command line argument '--warnaserror': {0}
-		</target>
-        <note>
-		</note>
+        <source>Could not parse the command line argument '--warnaserror': {0}</source>
+        <target state="new">Could not parse the command line argument '--warnaserror': {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0068">
-        <source>Invalid value for target framework: {0}.
-		</source>
-        <target state="new">Invalid value for target framework: {0}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid value for target framework: {0}.</source>
+        <target state="new">Invalid value for target framework: {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0086">
-        <source>A target framework (--target-framework) must be specified.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified.
-		</target>
-        <note>
-		</note>
+        <source>A target framework (--target-framework) must be specified.</source>
+        <target state="new">A target framework (--target-framework) must be specified.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0087">
-        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</source>
-        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</target>
-        <note>
-		</note>
+        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</source>
+        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0088">
-        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0089">
-        <source>Internal error: property {0} doesn't have neither a getter nor a setter.
-		</source>
-        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: property {0} doesn't have neither a getter nor a setter.</source>
+        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0099">
-        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1000">
         <source>Could not compile the generated API bindings.	
@@ -95,270 +68,171 @@
         <target state="new">Could not compile the generated API bindings.	
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1001">
-        <source>Do not know how to make a trampoline for {0}
-		</source>
-        <target state="new">Do not know how to make a trampoline for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a trampoline for {0}</source>
+        <target state="new">Do not know how to make a trampoline for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1002">
-        <source>Unknown kind {0} in method '{1}.{2}'
-		</source>
-        <target state="new">Unknown kind {0} in method '{1}.{2}'
-		</target>
-        <note>
-		</note>
+        <source>Unknown kind {0} in method '{1}.{2}'</source>
+        <target state="new">Unknown kind {0} in method '{1}.{2}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1003">
-        <source>The delegate method {0}.{1} needs to take at least one parameter
-		</source>
-        <target state="new">The delegate method {0}.{1} needs to take at least one parameter
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} needs to take at least one parameter</source>
+        <target state="new">The delegate method {0}.{1} needs to take at least one parameter</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1004">
-        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1005">
-        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</source>
-        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</target>
-        <note>
-		</note>
+        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</source>
+        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1006">
-        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1007">
-        <source>Unknown attribute {0} on {1}.{2}
-		</source>
-        <target state="new">Unknown attribute {0} on {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unknown attribute {0} on {1}.{2}</source>
+        <target state="new">Unknown attribute {0} on {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1008">
-        <source>[IsThreadStatic] is only valid on properties that are also [Static]
-		</source>
-        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]
-		</target>
-        <note>
-		</note>
+        <source>[IsThreadStatic] is only valid on properties that are also [Static]</source>
+        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1009">
-        <source>No selector specified for method `{0}.{1}'
-		</source>
-        <target state="new">No selector specified for method `{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for method `{0}.{1}'</source>
+        <target state="new">No selector specified for method `{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1010">
-        <source>No Export attribute on {0}.{1} property
-		</source>
-        <target state="new">No Export attribute on {0}.{1} property
-		</target>
-        <note>
-		</note>
+        <source>No Export attribute on {0}.{1} property</source>
+        <target state="new">No Export attribute on {0}.{1} property</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1011">
-        <source>Do not know how to extract type {0}/{1} from an NSDictionary
-		</source>
-        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to extract type {0}/{1} from an NSDictionary</source>
+        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1012">
-        <source>No Export or Bind attribute defined on {0}.{1}
-		</source>
-        <target state="new">No Export or Bind attribute defined on {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No Export or Bind attribute defined on {0}.{1}</source>
+        <target state="new">No Export or Bind attribute defined on {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1013">
-        <source>Unsupported type for Fields (string), you probably meant NSString
-		</source>
-        <target state="new">Unsupported type for Fields (string), you probably meant NSString
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields (string), you probably meant NSString</source>
+        <target state="new">Unsupported type for Fields (string), you probably meant NSString</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1014">
-        <source>Unsupported type for Fields: {0} for '{1}'.
-		</source>
-        <target state="new">Unsupported type for Fields: {0} for '{1}'.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields: {0} for '{1}'.</source>
+        <target state="new">Unsupported type for Fields: {0} for '{1}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1015">
-        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</source>
-        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</target>
-        <note>
-		</note>
+        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates</source>
+        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1016">
-        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1017">
-        <source>Do not know how to make a signature for {0}
-		</source>
-        <target state="new">Do not know how to make a signature for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a signature for {0}</source>
+        <target state="new">Do not know how to make a signature for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1018">
-        <source>No [Export] attribute on property {0}.{1}
-		</source>
-        <target state="new">No [Export] attribute on property {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No [Export] attribute on property {0}.{1}</source>
+        <target state="new">No [Export] attribute on property {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1019">
-        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</source>
-        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'</source>
+        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1020">
-        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</source>
-        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</source>
+        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1021">
-        <source>Unsupported type for read/write Fields: {0} for {1}.{2}
-		</source>
-        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for read/write Fields: {0} for {1}.{2}</source>
+        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1022">
-        <source>Model classes can not be categories
-		</source>
-        <target state="new">Model classes can not be categories
-		</target>
-        <note>
-		</note>
+        <source>Model classes can not be categories</source>
+        <target state="new">Model classes can not be categories</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1023">
-        <source>The number of Events (Type) and Delegates (string) must match for `{0}`
-		</source>
-        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`
-		</target>
-        <note>
-		</note>
+        <source>The number of Events (Type) and Delegates (string) must match for `{0}`</source>
+        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1024">
-        <source>No selector specified for property '{0}.{1}'
-		</source>
-        <target state="new">No selector specified for property '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for property '{0}.{1}'</source>
+        <target state="new">No selector specified for property '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1025">
-        <source>[Static] and [Protocol] are mutually exclusive ({0})
-		</source>
-        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})
-		</target>
-        <note>
-		</note>
+        <source>[Static] and [Protocol] are mutually exclusive ({0})</source>
+        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1026">
-        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</source>
-        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</target>
-        <note>
-		</note>
+        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</source>
+        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1027">
-        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</source>
-        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</target>
-        <note>
-		</note>
+        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</source>
+        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1028">
-        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1029">
-        <source>Internal error: invalid enum mode for type '{0}'
-		</source>
-        <target state="new">Internal error: invalid enum mode for type '{0}'
-		</target>
-        <note>
-		</note>
+        <source>Internal error: invalid enum mode for type '{0}'</source>
+        <target state="new">Internal error: invalid enum mode for type '{0}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1030">
-        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</source>
-        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</target>
-        <note>
-		</note>
+        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</source>
+        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1031">
-        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</source>
-        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</target>
-        <note>
-		</note>
+        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</source>
+        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1032">
-        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</source>
-        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}</source>
+        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1033">
-        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</source>
-        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</target>
+        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</source>
+        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</target>
         <note>Generating a strongly typed dictionary for type '{0}' is not supported.
 {0} - the property type.
 {1} - the dictionary type.
@@ -366,538 +240,341 @@
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
-        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</source>
-        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</source>
+        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1035">
-        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</source>
-        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</target>
-        <note>
-		</note>
+        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</source>
+        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1036">
-        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</source>
-        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</target>
-        <note>
-		</note>
+        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</source>
+        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1037">
-        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1038">
-        <source>The selector {0} on type {1} is found multiple times with different return types.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different return types.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different return types.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different return types.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1039">
-        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1040">
-        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1041">
         <source>The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</source>
         <target state="new">The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1042">
-        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</source>
-        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</target>
-        <note>
-		</note>
+        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</source>
+        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1043">
-        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</source>
-        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</target>
-        <note>
-		</note>
+        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</source>
+        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1044">
-        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</source>
-        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</target>
-        <note>
-		</note>
+        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].</source>
+        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1045">
-        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</source>
-        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</target>
-        <note>
-		</note>
+        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</source>
+        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1046">
-        <source>The [Field] constant {0} cannot only be used once inside enum {1}.
-		</source>
-        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.
-		</target>
-        <note>
-		</note>
+        <source>The [Field] constant {0} cannot only be used once inside enum {1}.</source>
+        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1047">
-        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1048">
-        <source>Unsupported type {0} decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type {0} decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} decorated with [BindAs]</source>
+        <target state="new">Unsupported type {0} decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1049">
-        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</source>
-        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</target>
-        <note>
-		</note>
+        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</source>
+        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1050">
-        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</source>
-        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</target>
-        <note>
-		</note>
+        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}</source>
+        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1051">
-        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1052">
-        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1053">
-        <source>Internal error: unknown target framework '{0}'.
-		</source>
-        <target state="new">Internal error: unknown target framework '{0}'.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: unknown target framework '{0}'.</source>
+        <target state="new">Internal error: unknown target framework '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1054">
-        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1055">
-        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1056">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1057">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1058">
-        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
+        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
         <note />
       </trans-unit>
       <trans-unit id="BI1059">
-        <source>Found {0} {1} attributes on the member {2}. At most one was expected.
-		</source>
-        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.
-		</target>
-        <note>
-		</note>
+        <source>Found {0} {1} attributes on the member {2}. At most one was expected.</source>
+        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1060">
-        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</source>
-        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</target>
-        <note>
-		</note>
+        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</source>
+        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1061">
-        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</source>
-        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</target>
-        <note>
-		</note>
+        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</source>
+        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1062">
-        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</source>
-        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</source>
+        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1063">
-        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</source>
-        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</source>
+        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1064">
-        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1065">
-        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1066">
-        <source>Unsupported return type '{0}' in {1}.{2}.
-		</source>
-        <target state="new">Unsupported return type '{0}' in {1}.{2}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported return type '{0}' in {1}.{2}.</source>
+        <target state="new">Unsupported return type '{0}' in {1}.{2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1067">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1068">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1069">
-        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</source>
-        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</source>
+        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1070">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1071">
-        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</source>
-        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</source>
+        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1072">
-        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</source>
-        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</source>
+        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1073">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1074">
-        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</source>
-        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</target>
-        <note>
-		</note>
+        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}</source>
+        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1075">
-        <source>Unimplemented CoreImage property type {0}
-		</source>
-        <target state="new">Unimplemented CoreImage property type {0}
-		</target>
-        <note>
-		</note>
+        <source>Unimplemented CoreImage property type {0}</source>
+        <target state="new">Unimplemented CoreImage property type {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1076">
-        <source>Unable to find selector for {0} on {1} on self or base class
-		</source>
-        <target state="new">Unable to find selector for {0} on {1} on self or base class
-		</target>
-        <note>
-		</note>
+        <source>Unable to find selector for {0} on {1} on self or base class</source>
+        <target state="new">Unable to find selector for {0} on {1} on self or base class</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1077">
-        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</source>
-        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</target>
+        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</source>
+        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</target>
         <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
 {0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">
-        <source>{0} in method `{1}'
-		</source>
-        <target state="new">{0} in method `{1}'
-		</target>
-        <note>
-		</note>
+        <source>{0} in method `{1}'</source>
+        <target state="new">{0} in method `{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1079">
-        <source>{0} in parameter `{1}' from {2}.{3}
-		</source>
-        <target state="new">{0} in parameter `{1}' from {2}.{3}
-		</target>
-        <note>
-		</note>
+        <source>{0} in parameter `{1}' from {2}.{3}</source>
+        <target state="new">{0} in parameter `{1}' from {2}.{3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1080">
-        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]</source>
+        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1081">
-        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </source>
-        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </target>
-        <note>
-        </note>
+        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.</source>
+        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1101">
-        <source>Trying to use a string as a [Target]
-		</source>
-        <target state="new">Trying to use a string as a [Target]
-		</target>
-        <note>
-		</note>
+        <source>Trying to use a string as a [Target]</source>
+        <target state="new">Trying to use a string as a [Target]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1102">
-        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</source>
-        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</target>
-        <note>
-		</note>
+        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</source>
+        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1103">
-        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</source>
-        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</target>
-        <note>
-		</note>
+        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</source>
+        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1104">
-        <source>Could not load the referenced library '{0}': {1}.
-		</source>
-        <target state="new">Could not load the referenced library '{0}': {1}.
-		</target>
-        <note>
-		</note>
+        <source>Could not load the referenced library '{0}': {1}.</source>
+        <target state="new">Could not load the referenced library '{0}': {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1105">
-        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</source>
-        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</target>
-        <note>
-		</note>
+        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</source>
+        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1106">
-        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</source>
-        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</target>
-        <note>
-		</note>
+        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</source>
+        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1107">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1108">
-        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</source>
-        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</source>
+        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1109">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1110">
-        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1111">
-        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</source>
-        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</target>
-        <note>
-		</note>
+        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</source>
+        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1112">
-        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</source>
-        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</target>
-        <note>
-		</note>
+        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</source>
+        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1113">
-        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</source>
-        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</target>
-        <note>
-		</note>
+        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</source>
+        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1114">
-        <source>Binding error: test unable to find property: {0} on {1}
-		</source>
-        <target state="new">Binding error: test unable to find property: {0} on {1}
-		</target>
-        <note>
-		</note>
+        <source>Binding error: test unable to find property: {0} on {1}</source>
+        <target state="new">Binding error: test unable to find property: {0} on {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1115">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1116">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1117">
-        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</source>
-        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</source>
+        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1118">
-        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</source>
-        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</target>
-        <note>
-		</note>
+        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</source>
+        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1119">
-        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="BI0000">
         <source>Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0001">
         <source>The .NET runtime could not load the {0} type. Message: {1}</source>
         <target state="new">The .NET runtime could not load the {0} type. Message: {1}</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0002">
         <source>Could not compile the API bindings.
@@ -21,72 +19,47 @@
         <target state="new">Could not compile the API bindings.
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0026">
-        <source>Could not parse the command line argument '--warnaserror': {0}
-		</source>
-        <target state="new">Could not parse the command line argument '--warnaserror': {0}
-		</target>
-        <note>
-		</note>
+        <source>Could not parse the command line argument '--warnaserror': {0}</source>
+        <target state="new">Could not parse the command line argument '--warnaserror': {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0068">
-        <source>Invalid value for target framework: {0}.
-		</source>
-        <target state="new">Invalid value for target framework: {0}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid value for target framework: {0}.</source>
+        <target state="new">Invalid value for target framework: {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0086">
-        <source>A target framework (--target-framework) must be specified.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified.
-		</target>
-        <note>
-		</note>
+        <source>A target framework (--target-framework) must be specified.</source>
+        <target state="new">A target framework (--target-framework) must be specified.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0087">
-        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</source>
-        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</target>
-        <note>
-		</note>
+        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</source>
+        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0088">
-        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0089">
-        <source>Internal error: property {0} doesn't have neither a getter nor a setter.
-		</source>
-        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: property {0} doesn't have neither a getter nor a setter.</source>
+        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0099">
-        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1000">
         <source>Could not compile the generated API bindings.	
@@ -95,270 +68,171 @@
         <target state="new">Could not compile the generated API bindings.	
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1001">
-        <source>Do not know how to make a trampoline for {0}
-		</source>
-        <target state="new">Do not know how to make a trampoline for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a trampoline for {0}</source>
+        <target state="new">Do not know how to make a trampoline for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1002">
-        <source>Unknown kind {0} in method '{1}.{2}'
-		</source>
-        <target state="new">Unknown kind {0} in method '{1}.{2}'
-		</target>
-        <note>
-		</note>
+        <source>Unknown kind {0} in method '{1}.{2}'</source>
+        <target state="new">Unknown kind {0} in method '{1}.{2}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1003">
-        <source>The delegate method {0}.{1} needs to take at least one parameter
-		</source>
-        <target state="new">The delegate method {0}.{1} needs to take at least one parameter
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} needs to take at least one parameter</source>
+        <target state="new">The delegate method {0}.{1} needs to take at least one parameter</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1004">
-        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1005">
-        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</source>
-        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</target>
-        <note>
-		</note>
+        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</source>
+        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1006">
-        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1007">
-        <source>Unknown attribute {0} on {1}.{2}
-		</source>
-        <target state="new">Unknown attribute {0} on {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unknown attribute {0} on {1}.{2}</source>
+        <target state="new">Unknown attribute {0} on {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1008">
-        <source>[IsThreadStatic] is only valid on properties that are also [Static]
-		</source>
-        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]
-		</target>
-        <note>
-		</note>
+        <source>[IsThreadStatic] is only valid on properties that are also [Static]</source>
+        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1009">
-        <source>No selector specified for method `{0}.{1}'
-		</source>
-        <target state="new">No selector specified for method `{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for method `{0}.{1}'</source>
+        <target state="new">No selector specified for method `{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1010">
-        <source>No Export attribute on {0}.{1} property
-		</source>
-        <target state="new">No Export attribute on {0}.{1} property
-		</target>
-        <note>
-		</note>
+        <source>No Export attribute on {0}.{1} property</source>
+        <target state="new">No Export attribute on {0}.{1} property</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1011">
-        <source>Do not know how to extract type {0}/{1} from an NSDictionary
-		</source>
-        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to extract type {0}/{1} from an NSDictionary</source>
+        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1012">
-        <source>No Export or Bind attribute defined on {0}.{1}
-		</source>
-        <target state="new">No Export or Bind attribute defined on {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No Export or Bind attribute defined on {0}.{1}</source>
+        <target state="new">No Export or Bind attribute defined on {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1013">
-        <source>Unsupported type for Fields (string), you probably meant NSString
-		</source>
-        <target state="new">Unsupported type for Fields (string), you probably meant NSString
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields (string), you probably meant NSString</source>
+        <target state="new">Unsupported type for Fields (string), you probably meant NSString</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1014">
-        <source>Unsupported type for Fields: {0} for '{1}'.
-		</source>
-        <target state="new">Unsupported type for Fields: {0} for '{1}'.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields: {0} for '{1}'.</source>
+        <target state="new">Unsupported type for Fields: {0} for '{1}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1015">
-        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</source>
-        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</target>
-        <note>
-		</note>
+        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates</source>
+        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1016">
-        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1017">
-        <source>Do not know how to make a signature for {0}
-		</source>
-        <target state="new">Do not know how to make a signature for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a signature for {0}</source>
+        <target state="new">Do not know how to make a signature for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1018">
-        <source>No [Export] attribute on property {0}.{1}
-		</source>
-        <target state="new">No [Export] attribute on property {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No [Export] attribute on property {0}.{1}</source>
+        <target state="new">No [Export] attribute on property {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1019">
-        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</source>
-        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'</source>
+        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1020">
-        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</source>
-        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</source>
+        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1021">
-        <source>Unsupported type for read/write Fields: {0} for {1}.{2}
-		</source>
-        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for read/write Fields: {0} for {1}.{2}</source>
+        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1022">
-        <source>Model classes can not be categories
-		</source>
-        <target state="new">Model classes can not be categories
-		</target>
-        <note>
-		</note>
+        <source>Model classes can not be categories</source>
+        <target state="new">Model classes can not be categories</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1023">
-        <source>The number of Events (Type) and Delegates (string) must match for `{0}`
-		</source>
-        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`
-		</target>
-        <note>
-		</note>
+        <source>The number of Events (Type) and Delegates (string) must match for `{0}`</source>
+        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1024">
-        <source>No selector specified for property '{0}.{1}'
-		</source>
-        <target state="new">No selector specified for property '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for property '{0}.{1}'</source>
+        <target state="new">No selector specified for property '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1025">
-        <source>[Static] and [Protocol] are mutually exclusive ({0})
-		</source>
-        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})
-		</target>
-        <note>
-		</note>
+        <source>[Static] and [Protocol] are mutually exclusive ({0})</source>
+        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1026">
-        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</source>
-        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</target>
-        <note>
-		</note>
+        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</source>
+        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1027">
-        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</source>
-        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</target>
-        <note>
-		</note>
+        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</source>
+        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1028">
-        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1029">
-        <source>Internal error: invalid enum mode for type '{0}'
-		</source>
-        <target state="new">Internal error: invalid enum mode for type '{0}'
-		</target>
-        <note>
-		</note>
+        <source>Internal error: invalid enum mode for type '{0}'</source>
+        <target state="new">Internal error: invalid enum mode for type '{0}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1030">
-        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</source>
-        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</target>
-        <note>
-		</note>
+        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</source>
+        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1031">
-        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</source>
-        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</target>
-        <note>
-		</note>
+        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</source>
+        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1032">
-        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</source>
-        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}</source>
+        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1033">
-        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</source>
-        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</target>
+        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</source>
+        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</target>
         <note>Generating a strongly typed dictionary for type '{0}' is not supported.
 {0} - the property type.
 {1} - the dictionary type.
@@ -366,538 +240,341 @@
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
-        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</source>
-        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</source>
+        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1035">
-        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</source>
-        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</target>
-        <note>
-		</note>
+        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</source>
+        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1036">
-        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</source>
-        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</target>
-        <note>
-		</note>
+        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</source>
+        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1037">
-        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1038">
-        <source>The selector {0} on type {1} is found multiple times with different return types.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different return types.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different return types.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different return types.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1039">
-        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1040">
-        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1041">
         <source>The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</source>
         <target state="new">The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1042">
-        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</source>
-        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</target>
-        <note>
-		</note>
+        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</source>
+        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1043">
-        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</source>
-        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</target>
-        <note>
-		</note>
+        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</source>
+        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1044">
-        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</source>
-        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</target>
-        <note>
-		</note>
+        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].</source>
+        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1045">
-        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</source>
-        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</target>
-        <note>
-		</note>
+        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</source>
+        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1046">
-        <source>The [Field] constant {0} cannot only be used once inside enum {1}.
-		</source>
-        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.
-		</target>
-        <note>
-		</note>
+        <source>The [Field] constant {0} cannot only be used once inside enum {1}.</source>
+        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1047">
-        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1048">
-        <source>Unsupported type {0} decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type {0} decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} decorated with [BindAs]</source>
+        <target state="new">Unsupported type {0} decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1049">
-        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</source>
-        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</target>
-        <note>
-		</note>
+        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</source>
+        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1050">
-        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</source>
-        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</target>
-        <note>
-		</note>
+        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}</source>
+        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1051">
-        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1052">
-        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1053">
-        <source>Internal error: unknown target framework '{0}'.
-		</source>
-        <target state="new">Internal error: unknown target framework '{0}'.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: unknown target framework '{0}'.</source>
+        <target state="new">Internal error: unknown target framework '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1054">
-        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1055">
-        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1056">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1057">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1058">
-        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
+        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
         <note />
       </trans-unit>
       <trans-unit id="BI1059">
-        <source>Found {0} {1} attributes on the member {2}. At most one was expected.
-		</source>
-        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.
-		</target>
-        <note>
-		</note>
+        <source>Found {0} {1} attributes on the member {2}. At most one was expected.</source>
+        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1060">
-        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</source>
-        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</target>
-        <note>
-		</note>
+        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</source>
+        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1061">
-        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</source>
-        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</target>
-        <note>
-		</note>
+        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</source>
+        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1062">
-        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</source>
-        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</source>
+        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1063">
-        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</source>
-        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</source>
+        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1064">
-        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1065">
-        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1066">
-        <source>Unsupported return type '{0}' in {1}.{2}.
-		</source>
-        <target state="new">Unsupported return type '{0}' in {1}.{2}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported return type '{0}' in {1}.{2}.</source>
+        <target state="new">Unsupported return type '{0}' in {1}.{2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1067">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1068">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1069">
-        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</source>
-        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</source>
+        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1070">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1071">
-        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</source>
-        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</source>
+        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1072">
-        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</source>
-        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</source>
+        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1073">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1074">
-        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</source>
-        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</target>
-        <note>
-		</note>
+        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}</source>
+        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1075">
-        <source>Unimplemented CoreImage property type {0}
-		</source>
-        <target state="new">Unimplemented CoreImage property type {0}
-		</target>
-        <note>
-		</note>
+        <source>Unimplemented CoreImage property type {0}</source>
+        <target state="new">Unimplemented CoreImage property type {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1076">
-        <source>Unable to find selector for {0} on {1} on self or base class
-		</source>
-        <target state="new">Unable to find selector for {0} on {1} on self or base class
-		</target>
-        <note>
-		</note>
+        <source>Unable to find selector for {0} on {1} on self or base class</source>
+        <target state="new">Unable to find selector for {0} on {1} on self or base class</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1077">
-        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</source>
-        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</target>
+        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</source>
+        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</target>
         <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
 {0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">
-        <source>{0} in method `{1}'
-		</source>
-        <target state="new">{0} in method `{1}'
-		</target>
-        <note>
-		</note>
+        <source>{0} in method `{1}'</source>
+        <target state="new">{0} in method `{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1079">
-        <source>{0} in parameter `{1}' from {2}.{3}
-		</source>
-        <target state="new">{0} in parameter `{1}' from {2}.{3}
-		</target>
-        <note>
-		</note>
+        <source>{0} in parameter `{1}' from {2}.{3}</source>
+        <target state="new">{0} in parameter `{1}' from {2}.{3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1080">
-        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]</source>
+        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1081">
-        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </source>
-        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </target>
-        <note>
-        </note>
+        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.</source>
+        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1101">
-        <source>Trying to use a string as a [Target]
-		</source>
-        <target state="new">Trying to use a string as a [Target]
-		</target>
-        <note>
-		</note>
+        <source>Trying to use a string as a [Target]</source>
+        <target state="new">Trying to use a string as a [Target]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1102">
-        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</source>
-        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</target>
-        <note>
-		</note>
+        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</source>
+        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1103">
-        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</source>
-        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</target>
-        <note>
-		</note>
+        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</source>
+        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1104">
-        <source>Could not load the referenced library '{0}': {1}.
-		</source>
-        <target state="new">Could not load the referenced library '{0}': {1}.
-		</target>
-        <note>
-		</note>
+        <source>Could not load the referenced library '{0}': {1}.</source>
+        <target state="new">Could not load the referenced library '{0}': {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1105">
-        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</source>
-        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</target>
-        <note>
-		</note>
+        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</source>
+        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1106">
-        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</source>
-        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</target>
-        <note>
-		</note>
+        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</source>
+        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1107">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1108">
-        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</source>
-        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</source>
+        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1109">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1110">
-        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1111">
-        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</source>
-        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</target>
-        <note>
-		</note>
+        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</source>
+        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1112">
-        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</source>
-        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</target>
-        <note>
-		</note>
+        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</source>
+        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1113">
-        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</source>
-        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</target>
-        <note>
-		</note>
+        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</source>
+        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1114">
-        <source>Binding error: test unable to find property: {0} on {1}
-		</source>
-        <target state="new">Binding error: test unable to find property: {0} on {1}
-		</target>
-        <note>
-		</note>
+        <source>Binding error: test unable to find property: {0} on {1}</source>
+        <target state="new">Binding error: test unable to find property: {0} on {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1115">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1116">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1117">
-        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</source>
-        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</source>
+        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1118">
-        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</source>
-        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</target>
-        <note>
-		</note>
+        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</source>
+        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1119">
-        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="BI0000">
         <source>Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0001">
         <source>The .NET runtime could not load the {0} type. Message: {1}</source>
         <target state="new">The .NET runtime could not load the {0} type. Message: {1}</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0002">
         <source>Could not compile the API bindings.
@@ -21,72 +19,47 @@
         <target state="new">Could not compile the API bindings.
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0026">
-        <source>Could not parse the command line argument '--warnaserror': {0}
-		</source>
-        <target state="new">Could not parse the command line argument '--warnaserror': {0}
-		</target>
-        <note>
-		</note>
+        <source>Could not parse the command line argument '--warnaserror': {0}</source>
+        <target state="new">Could not parse the command line argument '--warnaserror': {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0068">
-        <source>Invalid value for target framework: {0}.
-		</source>
-        <target state="new">Invalid value for target framework: {0}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid value for target framework: {0}.</source>
+        <target state="new">Invalid value for target framework: {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0086">
-        <source>A target framework (--target-framework) must be specified.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified.
-		</target>
-        <note>
-		</note>
+        <source>A target framework (--target-framework) must be specified.</source>
+        <target state="new">A target framework (--target-framework) must be specified.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0087">
-        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</source>
-        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</target>
-        <note>
-		</note>
+        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</source>
+        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0088">
-        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0089">
-        <source>Internal error: property {0} doesn't have neither a getter nor a setter.
-		</source>
-        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: property {0} doesn't have neither a getter nor a setter.</source>
+        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0099">
-        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1000">
         <source>Could not compile the generated API bindings.	
@@ -95,270 +68,171 @@
         <target state="new">Could not compile the generated API bindings.	
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1001">
-        <source>Do not know how to make a trampoline for {0}
-		</source>
-        <target state="new">Do not know how to make a trampoline for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a trampoline for {0}</source>
+        <target state="new">Do not know how to make a trampoline for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1002">
-        <source>Unknown kind {0} in method '{1}.{2}'
-		</source>
-        <target state="new">Unknown kind {0} in method '{1}.{2}'
-		</target>
-        <note>
-		</note>
+        <source>Unknown kind {0} in method '{1}.{2}'</source>
+        <target state="new">Unknown kind {0} in method '{1}.{2}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1003">
-        <source>The delegate method {0}.{1} needs to take at least one parameter
-		</source>
-        <target state="new">The delegate method {0}.{1} needs to take at least one parameter
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} needs to take at least one parameter</source>
+        <target state="new">The delegate method {0}.{1} needs to take at least one parameter</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1004">
-        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1005">
-        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</source>
-        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</target>
-        <note>
-		</note>
+        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</source>
+        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1006">
-        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1007">
-        <source>Unknown attribute {0} on {1}.{2}
-		</source>
-        <target state="new">Unknown attribute {0} on {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unknown attribute {0} on {1}.{2}</source>
+        <target state="new">Unknown attribute {0} on {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1008">
-        <source>[IsThreadStatic] is only valid on properties that are also [Static]
-		</source>
-        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]
-		</target>
-        <note>
-		</note>
+        <source>[IsThreadStatic] is only valid on properties that are also [Static]</source>
+        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1009">
-        <source>No selector specified for method `{0}.{1}'
-		</source>
-        <target state="new">No selector specified for method `{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for method `{0}.{1}'</source>
+        <target state="new">No selector specified for method `{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1010">
-        <source>No Export attribute on {0}.{1} property
-		</source>
-        <target state="new">No Export attribute on {0}.{1} property
-		</target>
-        <note>
-		</note>
+        <source>No Export attribute on {0}.{1} property</source>
+        <target state="new">No Export attribute on {0}.{1} property</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1011">
-        <source>Do not know how to extract type {0}/{1} from an NSDictionary
-		</source>
-        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to extract type {0}/{1} from an NSDictionary</source>
+        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1012">
-        <source>No Export or Bind attribute defined on {0}.{1}
-		</source>
-        <target state="new">No Export or Bind attribute defined on {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No Export or Bind attribute defined on {0}.{1}</source>
+        <target state="new">No Export or Bind attribute defined on {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1013">
-        <source>Unsupported type for Fields (string), you probably meant NSString
-		</source>
-        <target state="new">Unsupported type for Fields (string), you probably meant NSString
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields (string), you probably meant NSString</source>
+        <target state="new">Unsupported type for Fields (string), you probably meant NSString</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1014">
-        <source>Unsupported type for Fields: {0} for '{1}'.
-		</source>
-        <target state="new">Unsupported type for Fields: {0} for '{1}'.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields: {0} for '{1}'.</source>
+        <target state="new">Unsupported type for Fields: {0} for '{1}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1015">
-        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</source>
-        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</target>
-        <note>
-		</note>
+        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates</source>
+        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1016">
-        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1017">
-        <source>Do not know how to make a signature for {0}
-		</source>
-        <target state="new">Do not know how to make a signature for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a signature for {0}</source>
+        <target state="new">Do not know how to make a signature for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1018">
-        <source>No [Export] attribute on property {0}.{1}
-		</source>
-        <target state="new">No [Export] attribute on property {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No [Export] attribute on property {0}.{1}</source>
+        <target state="new">No [Export] attribute on property {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1019">
-        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</source>
-        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'</source>
+        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1020">
-        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</source>
-        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</source>
+        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1021">
-        <source>Unsupported type for read/write Fields: {0} for {1}.{2}
-		</source>
-        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for read/write Fields: {0} for {1}.{2}</source>
+        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1022">
-        <source>Model classes can not be categories
-		</source>
-        <target state="new">Model classes can not be categories
-		</target>
-        <note>
-		</note>
+        <source>Model classes can not be categories</source>
+        <target state="new">Model classes can not be categories</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1023">
-        <source>The number of Events (Type) and Delegates (string) must match for `{0}`
-		</source>
-        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`
-		</target>
-        <note>
-		</note>
+        <source>The number of Events (Type) and Delegates (string) must match for `{0}`</source>
+        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1024">
-        <source>No selector specified for property '{0}.{1}'
-		</source>
-        <target state="new">No selector specified for property '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for property '{0}.{1}'</source>
+        <target state="new">No selector specified for property '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1025">
-        <source>[Static] and [Protocol] are mutually exclusive ({0})
-		</source>
-        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})
-		</target>
-        <note>
-		</note>
+        <source>[Static] and [Protocol] are mutually exclusive ({0})</source>
+        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1026">
-        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</source>
-        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</target>
-        <note>
-		</note>
+        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</source>
+        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1027">
-        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</source>
-        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</target>
-        <note>
-		</note>
+        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</source>
+        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1028">
-        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1029">
-        <source>Internal error: invalid enum mode for type '{0}'
-		</source>
-        <target state="new">Internal error: invalid enum mode for type '{0}'
-		</target>
-        <note>
-		</note>
+        <source>Internal error: invalid enum mode for type '{0}'</source>
+        <target state="new">Internal error: invalid enum mode for type '{0}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1030">
-        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</source>
-        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</target>
-        <note>
-		</note>
+        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</source>
+        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1031">
-        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</source>
-        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</target>
-        <note>
-		</note>
+        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</source>
+        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1032">
-        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</source>
-        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}</source>
+        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1033">
-        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</source>
-        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</target>
+        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</source>
+        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</target>
         <note>Generating a strongly typed dictionary for type '{0}' is not supported.
 {0} - the property type.
 {1} - the dictionary type.
@@ -366,538 +240,341 @@
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
-        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</source>
-        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</source>
+        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1035">
-        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</source>
-        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</target>
-        <note>
-		</note>
+        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</source>
+        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1036">
-        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</source>
-        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</target>
-        <note>
-		</note>
+        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</source>
+        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1037">
-        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1038">
-        <source>The selector {0} on type {1} is found multiple times with different return types.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different return types.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different return types.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different return types.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1039">
-        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1040">
-        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1041">
         <source>The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</source>
         <target state="new">The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1042">
-        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</source>
-        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</target>
-        <note>
-		</note>
+        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</source>
+        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1043">
-        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</source>
-        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</target>
-        <note>
-		</note>
+        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</source>
+        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1044">
-        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</source>
-        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</target>
-        <note>
-		</note>
+        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].</source>
+        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1045">
-        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</source>
-        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</target>
-        <note>
-		</note>
+        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</source>
+        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1046">
-        <source>The [Field] constant {0} cannot only be used once inside enum {1}.
-		</source>
-        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.
-		</target>
-        <note>
-		</note>
+        <source>The [Field] constant {0} cannot only be used once inside enum {1}.</source>
+        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1047">
-        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1048">
-        <source>Unsupported type {0} decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type {0} decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} decorated with [BindAs]</source>
+        <target state="new">Unsupported type {0} decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1049">
-        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</source>
-        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</target>
-        <note>
-		</note>
+        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</source>
+        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1050">
-        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</source>
-        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</target>
-        <note>
-		</note>
+        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}</source>
+        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1051">
-        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1052">
-        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1053">
-        <source>Internal error: unknown target framework '{0}'.
-		</source>
-        <target state="new">Internal error: unknown target framework '{0}'.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: unknown target framework '{0}'.</source>
+        <target state="new">Internal error: unknown target framework '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1054">
-        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1055">
-        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1056">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1057">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1058">
-        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
+        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
         <note />
       </trans-unit>
       <trans-unit id="BI1059">
-        <source>Found {0} {1} attributes on the member {2}. At most one was expected.
-		</source>
-        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.
-		</target>
-        <note>
-		</note>
+        <source>Found {0} {1} attributes on the member {2}. At most one was expected.</source>
+        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1060">
-        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</source>
-        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</target>
-        <note>
-		</note>
+        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</source>
+        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1061">
-        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</source>
-        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</target>
-        <note>
-		</note>
+        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</source>
+        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1062">
-        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</source>
-        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</source>
+        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1063">
-        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</source>
-        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</source>
+        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1064">
-        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1065">
-        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1066">
-        <source>Unsupported return type '{0}' in {1}.{2}.
-		</source>
-        <target state="new">Unsupported return type '{0}' in {1}.{2}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported return type '{0}' in {1}.{2}.</source>
+        <target state="new">Unsupported return type '{0}' in {1}.{2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1067">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1068">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1069">
-        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</source>
-        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</source>
+        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1070">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1071">
-        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</source>
-        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</source>
+        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1072">
-        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</source>
-        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</source>
+        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1073">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1074">
-        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</source>
-        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</target>
-        <note>
-		</note>
+        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}</source>
+        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1075">
-        <source>Unimplemented CoreImage property type {0}
-		</source>
-        <target state="new">Unimplemented CoreImage property type {0}
-		</target>
-        <note>
-		</note>
+        <source>Unimplemented CoreImage property type {0}</source>
+        <target state="new">Unimplemented CoreImage property type {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1076">
-        <source>Unable to find selector for {0} on {1} on self or base class
-		</source>
-        <target state="new">Unable to find selector for {0} on {1} on self or base class
-		</target>
-        <note>
-		</note>
+        <source>Unable to find selector for {0} on {1} on self or base class</source>
+        <target state="new">Unable to find selector for {0} on {1} on self or base class</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1077">
-        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</source>
-        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</target>
+        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</source>
+        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</target>
         <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
 {0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">
-        <source>{0} in method `{1}'
-		</source>
-        <target state="new">{0} in method `{1}'
-		</target>
-        <note>
-		</note>
+        <source>{0} in method `{1}'</source>
+        <target state="new">{0} in method `{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1079">
-        <source>{0} in parameter `{1}' from {2}.{3}
-		</source>
-        <target state="new">{0} in parameter `{1}' from {2}.{3}
-		</target>
-        <note>
-		</note>
+        <source>{0} in parameter `{1}' from {2}.{3}</source>
+        <target state="new">{0} in parameter `{1}' from {2}.{3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1080">
-        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]</source>
+        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1081">
-        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </source>
-        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </target>
-        <note>
-        </note>
+        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.</source>
+        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1101">
-        <source>Trying to use a string as a [Target]
-		</source>
-        <target state="new">Trying to use a string as a [Target]
-		</target>
-        <note>
-		</note>
+        <source>Trying to use a string as a [Target]</source>
+        <target state="new">Trying to use a string as a [Target]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1102">
-        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</source>
-        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</target>
-        <note>
-		</note>
+        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</source>
+        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1103">
-        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</source>
-        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</target>
-        <note>
-		</note>
+        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</source>
+        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1104">
-        <source>Could not load the referenced library '{0}': {1}.
-		</source>
-        <target state="new">Could not load the referenced library '{0}': {1}.
-		</target>
-        <note>
-		</note>
+        <source>Could not load the referenced library '{0}': {1}.</source>
+        <target state="new">Could not load the referenced library '{0}': {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1105">
-        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</source>
-        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</target>
-        <note>
-		</note>
+        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</source>
+        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1106">
-        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</source>
-        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</target>
-        <note>
-		</note>
+        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</source>
+        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1107">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1108">
-        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</source>
-        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</source>
+        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1109">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1110">
-        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1111">
-        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</source>
-        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</target>
-        <note>
-		</note>
+        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</source>
+        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1112">
-        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</source>
-        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</target>
-        <note>
-		</note>
+        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</source>
+        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1113">
-        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</source>
-        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</target>
-        <note>
-		</note>
+        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</source>
+        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1114">
-        <source>Binding error: test unable to find property: {0} on {1}
-		</source>
-        <target state="new">Binding error: test unable to find property: {0} on {1}
-		</target>
-        <note>
-		</note>
+        <source>Binding error: test unable to find property: {0} on {1}</source>
+        <target state="new">Binding error: test unable to find property: {0} on {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1115">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1116">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1117">
-        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</source>
-        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</source>
+        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1118">
-        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</source>
-        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</target>
-        <note>
-		</note>
+        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</source>
+        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1119">
-        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="BI0000">
         <source>Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0001">
         <source>The .NET runtime could not load the {0} type. Message: {1}</source>
         <target state="new">The .NET runtime could not load the {0} type. Message: {1}</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0002">
         <source>Could not compile the API bindings.
@@ -21,72 +19,47 @@
         <target state="new">Could not compile the API bindings.
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0026">
-        <source>Could not parse the command line argument '--warnaserror': {0}
-		</source>
-        <target state="new">Could not parse the command line argument '--warnaserror': {0}
-		</target>
-        <note>
-		</note>
+        <source>Could not parse the command line argument '--warnaserror': {0}</source>
+        <target state="new">Could not parse the command line argument '--warnaserror': {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0068">
-        <source>Invalid value for target framework: {0}.
-		</source>
-        <target state="new">Invalid value for target framework: {0}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid value for target framework: {0}.</source>
+        <target state="new">Invalid value for target framework: {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0086">
-        <source>A target framework (--target-framework) must be specified.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified.
-		</target>
-        <note>
-		</note>
+        <source>A target framework (--target-framework) must be specified.</source>
+        <target state="new">A target framework (--target-framework) must be specified.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0087">
-        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</source>
-        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</target>
-        <note>
-		</note>
+        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</source>
+        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0088">
-        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0089">
-        <source>Internal error: property {0} doesn't have neither a getter nor a setter.
-		</source>
-        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: property {0} doesn't have neither a getter nor a setter.</source>
+        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0099">
-        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1000">
         <source>Could not compile the generated API bindings.	
@@ -95,270 +68,171 @@
         <target state="new">Could not compile the generated API bindings.	
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1001">
-        <source>Do not know how to make a trampoline for {0}
-		</source>
-        <target state="new">Do not know how to make a trampoline for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a trampoline for {0}</source>
+        <target state="new">Do not know how to make a trampoline for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1002">
-        <source>Unknown kind {0} in method '{1}.{2}'
-		</source>
-        <target state="new">Unknown kind {0} in method '{1}.{2}'
-		</target>
-        <note>
-		</note>
+        <source>Unknown kind {0} in method '{1}.{2}'</source>
+        <target state="new">Unknown kind {0} in method '{1}.{2}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1003">
-        <source>The delegate method {0}.{1} needs to take at least one parameter
-		</source>
-        <target state="new">The delegate method {0}.{1} needs to take at least one parameter
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} needs to take at least one parameter</source>
+        <target state="new">The delegate method {0}.{1} needs to take at least one parameter</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1004">
-        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1005">
-        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</source>
-        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</target>
-        <note>
-		</note>
+        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</source>
+        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1006">
-        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1007">
-        <source>Unknown attribute {0} on {1}.{2}
-		</source>
-        <target state="new">Unknown attribute {0} on {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unknown attribute {0} on {1}.{2}</source>
+        <target state="new">Unknown attribute {0} on {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1008">
-        <source>[IsThreadStatic] is only valid on properties that are also [Static]
-		</source>
-        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]
-		</target>
-        <note>
-		</note>
+        <source>[IsThreadStatic] is only valid on properties that are also [Static]</source>
+        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1009">
-        <source>No selector specified for method `{0}.{1}'
-		</source>
-        <target state="new">No selector specified for method `{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for method `{0}.{1}'</source>
+        <target state="new">No selector specified for method `{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1010">
-        <source>No Export attribute on {0}.{1} property
-		</source>
-        <target state="new">No Export attribute on {0}.{1} property
-		</target>
-        <note>
-		</note>
+        <source>No Export attribute on {0}.{1} property</source>
+        <target state="new">No Export attribute on {0}.{1} property</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1011">
-        <source>Do not know how to extract type {0}/{1} from an NSDictionary
-		</source>
-        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to extract type {0}/{1} from an NSDictionary</source>
+        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1012">
-        <source>No Export or Bind attribute defined on {0}.{1}
-		</source>
-        <target state="new">No Export or Bind attribute defined on {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No Export or Bind attribute defined on {0}.{1}</source>
+        <target state="new">No Export or Bind attribute defined on {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1013">
-        <source>Unsupported type for Fields (string), you probably meant NSString
-		</source>
-        <target state="new">Unsupported type for Fields (string), you probably meant NSString
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields (string), you probably meant NSString</source>
+        <target state="new">Unsupported type for Fields (string), you probably meant NSString</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1014">
-        <source>Unsupported type for Fields: {0} for '{1}'.
-		</source>
-        <target state="new">Unsupported type for Fields: {0} for '{1}'.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields: {0} for '{1}'.</source>
+        <target state="new">Unsupported type for Fields: {0} for '{1}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1015">
-        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</source>
-        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</target>
-        <note>
-		</note>
+        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates</source>
+        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1016">
-        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1017">
-        <source>Do not know how to make a signature for {0}
-		</source>
-        <target state="new">Do not know how to make a signature for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a signature for {0}</source>
+        <target state="new">Do not know how to make a signature for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1018">
-        <source>No [Export] attribute on property {0}.{1}
-		</source>
-        <target state="new">No [Export] attribute on property {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No [Export] attribute on property {0}.{1}</source>
+        <target state="new">No [Export] attribute on property {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1019">
-        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</source>
-        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'</source>
+        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1020">
-        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</source>
-        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</source>
+        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1021">
-        <source>Unsupported type for read/write Fields: {0} for {1}.{2}
-		</source>
-        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for read/write Fields: {0} for {1}.{2}</source>
+        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1022">
-        <source>Model classes can not be categories
-		</source>
-        <target state="new">Model classes can not be categories
-		</target>
-        <note>
-		</note>
+        <source>Model classes can not be categories</source>
+        <target state="new">Model classes can not be categories</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1023">
-        <source>The number of Events (Type) and Delegates (string) must match for `{0}`
-		</source>
-        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`
-		</target>
-        <note>
-		</note>
+        <source>The number of Events (Type) and Delegates (string) must match for `{0}`</source>
+        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1024">
-        <source>No selector specified for property '{0}.{1}'
-		</source>
-        <target state="new">No selector specified for property '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for property '{0}.{1}'</source>
+        <target state="new">No selector specified for property '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1025">
-        <source>[Static] and [Protocol] are mutually exclusive ({0})
-		</source>
-        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})
-		</target>
-        <note>
-		</note>
+        <source>[Static] and [Protocol] are mutually exclusive ({0})</source>
+        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1026">
-        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</source>
-        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</target>
-        <note>
-		</note>
+        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</source>
+        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1027">
-        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</source>
-        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</target>
-        <note>
-		</note>
+        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</source>
+        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1028">
-        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1029">
-        <source>Internal error: invalid enum mode for type '{0}'
-		</source>
-        <target state="new">Internal error: invalid enum mode for type '{0}'
-		</target>
-        <note>
-		</note>
+        <source>Internal error: invalid enum mode for type '{0}'</source>
+        <target state="new">Internal error: invalid enum mode for type '{0}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1030">
-        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</source>
-        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</target>
-        <note>
-		</note>
+        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</source>
+        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1031">
-        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</source>
-        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</target>
-        <note>
-		</note>
+        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</source>
+        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1032">
-        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</source>
-        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}</source>
+        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1033">
-        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</source>
-        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</target>
+        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</source>
+        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</target>
         <note>Generating a strongly typed dictionary for type '{0}' is not supported.
 {0} - the property type.
 {1} - the dictionary type.
@@ -366,538 +240,341 @@
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
-        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</source>
-        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</source>
+        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1035">
-        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</source>
-        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</target>
-        <note>
-		</note>
+        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</source>
+        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1036">
-        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</source>
-        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</target>
-        <note>
-		</note>
+        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</source>
+        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1037">
-        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1038">
-        <source>The selector {0} on type {1} is found multiple times with different return types.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different return types.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different return types.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different return types.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1039">
-        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1040">
-        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1041">
         <source>The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</source>
         <target state="new">The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1042">
-        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</source>
-        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</target>
-        <note>
-		</note>
+        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</source>
+        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1043">
-        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</source>
-        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</target>
-        <note>
-		</note>
+        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</source>
+        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1044">
-        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</source>
-        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</target>
-        <note>
-		</note>
+        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].</source>
+        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1045">
-        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</source>
-        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</target>
-        <note>
-		</note>
+        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</source>
+        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1046">
-        <source>The [Field] constant {0} cannot only be used once inside enum {1}.
-		</source>
-        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.
-		</target>
-        <note>
-		</note>
+        <source>The [Field] constant {0} cannot only be used once inside enum {1}.</source>
+        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1047">
-        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1048">
-        <source>Unsupported type {0} decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type {0} decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} decorated with [BindAs]</source>
+        <target state="new">Unsupported type {0} decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1049">
-        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</source>
-        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</target>
-        <note>
-		</note>
+        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</source>
+        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1050">
-        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</source>
-        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</target>
-        <note>
-		</note>
+        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}</source>
+        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1051">
-        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1052">
-        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1053">
-        <source>Internal error: unknown target framework '{0}'.
-		</source>
-        <target state="new">Internal error: unknown target framework '{0}'.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: unknown target framework '{0}'.</source>
+        <target state="new">Internal error: unknown target framework '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1054">
-        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1055">
-        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1056">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1057">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1058">
-        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
+        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
         <note />
       </trans-unit>
       <trans-unit id="BI1059">
-        <source>Found {0} {1} attributes on the member {2}. At most one was expected.
-		</source>
-        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.
-		</target>
-        <note>
-		</note>
+        <source>Found {0} {1} attributes on the member {2}. At most one was expected.</source>
+        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1060">
-        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</source>
-        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</target>
-        <note>
-		</note>
+        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</source>
+        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1061">
-        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</source>
-        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</target>
-        <note>
-		</note>
+        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</source>
+        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1062">
-        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</source>
-        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</source>
+        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1063">
-        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</source>
-        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</source>
+        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1064">
-        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1065">
-        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1066">
-        <source>Unsupported return type '{0}' in {1}.{2}.
-		</source>
-        <target state="new">Unsupported return type '{0}' in {1}.{2}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported return type '{0}' in {1}.{2}.</source>
+        <target state="new">Unsupported return type '{0}' in {1}.{2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1067">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1068">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1069">
-        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</source>
-        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</source>
+        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1070">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1071">
-        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</source>
-        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</source>
+        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1072">
-        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</source>
-        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</source>
+        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1073">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1074">
-        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</source>
-        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</target>
-        <note>
-		</note>
+        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}</source>
+        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1075">
-        <source>Unimplemented CoreImage property type {0}
-		</source>
-        <target state="new">Unimplemented CoreImage property type {0}
-		</target>
-        <note>
-		</note>
+        <source>Unimplemented CoreImage property type {0}</source>
+        <target state="new">Unimplemented CoreImage property type {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1076">
-        <source>Unable to find selector for {0} on {1} on self or base class
-		</source>
-        <target state="new">Unable to find selector for {0} on {1} on self or base class
-		</target>
-        <note>
-		</note>
+        <source>Unable to find selector for {0} on {1} on self or base class</source>
+        <target state="new">Unable to find selector for {0} on {1} on self or base class</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1077">
-        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</source>
-        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</target>
+        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</source>
+        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</target>
         <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
 {0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">
-        <source>{0} in method `{1}'
-		</source>
-        <target state="new">{0} in method `{1}'
-		</target>
-        <note>
-		</note>
+        <source>{0} in method `{1}'</source>
+        <target state="new">{0} in method `{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1079">
-        <source>{0} in parameter `{1}' from {2}.{3}
-		</source>
-        <target state="new">{0} in parameter `{1}' from {2}.{3}
-		</target>
-        <note>
-		</note>
+        <source>{0} in parameter `{1}' from {2}.{3}</source>
+        <target state="new">{0} in parameter `{1}' from {2}.{3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1080">
-        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]</source>
+        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1081">
-        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </source>
-        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </target>
-        <note>
-        </note>
+        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.</source>
+        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1101">
-        <source>Trying to use a string as a [Target]
-		</source>
-        <target state="new">Trying to use a string as a [Target]
-		</target>
-        <note>
-		</note>
+        <source>Trying to use a string as a [Target]</source>
+        <target state="new">Trying to use a string as a [Target]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1102">
-        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</source>
-        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</target>
-        <note>
-		</note>
+        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</source>
+        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1103">
-        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</source>
-        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</target>
-        <note>
-		</note>
+        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</source>
+        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1104">
-        <source>Could not load the referenced library '{0}': {1}.
-		</source>
-        <target state="new">Could not load the referenced library '{0}': {1}.
-		</target>
-        <note>
-		</note>
+        <source>Could not load the referenced library '{0}': {1}.</source>
+        <target state="new">Could not load the referenced library '{0}': {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1105">
-        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</source>
-        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</target>
-        <note>
-		</note>
+        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</source>
+        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1106">
-        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</source>
-        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</target>
-        <note>
-		</note>
+        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</source>
+        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1107">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1108">
-        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</source>
-        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</source>
+        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1109">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1110">
-        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1111">
-        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</source>
-        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</target>
-        <note>
-		</note>
+        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</source>
+        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1112">
-        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</source>
-        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</target>
-        <note>
-		</note>
+        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</source>
+        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1113">
-        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</source>
-        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</target>
-        <note>
-		</note>
+        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</source>
+        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1114">
-        <source>Binding error: test unable to find property: {0} on {1}
-		</source>
-        <target state="new">Binding error: test unable to find property: {0} on {1}
-		</target>
-        <note>
-		</note>
+        <source>Binding error: test unable to find property: {0} on {1}</source>
+        <target state="new">Binding error: test unable to find property: {0} on {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1115">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1116">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1117">
-        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</source>
-        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</source>
+        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1118">
-        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</source>
-        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</target>
-        <note>
-		</note>
+        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</source>
+        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1119">
-        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="BI0000">
         <source>Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</source>
         <target state="new">Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0001">
         <source>The .NET runtime could not load the {0} type. Message: {1}</source>
         <target state="new">The .NET runtime could not load the {0} type. Message: {1}</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0002">
         <source>Could not compile the API bindings.
@@ -21,72 +19,47 @@
         <target state="new">Could not compile the API bindings.
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI0026">
-        <source>Could not parse the command line argument '--warnaserror': {0}
-		</source>
-        <target state="new">Could not parse the command line argument '--warnaserror': {0}
-		</target>
-        <note>
-		</note>
+        <source>Could not parse the command line argument '--warnaserror': {0}</source>
+        <target state="new">Could not parse the command line argument '--warnaserror': {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0068">
-        <source>Invalid value for target framework: {0}.
-		</source>
-        <target state="new">Invalid value for target framework: {0}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid value for target framework: {0}.</source>
+        <target state="new">Invalid value for target framework: {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0070">
-        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</source>
-        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.
-		</target>
-        <note>
-		</note>
+        <source>Invalid target framework: {0}. Valid target frameworks are: {1}.</source>
+        <target state="new">Invalid target framework: {0}. Valid target frameworks are: {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0086">
-        <source>A target framework (--target-framework) must be specified.
-		</source>
-        <target state="new">A target framework (--target-framework) must be specified.
-		</target>
-        <note>
-		</note>
+        <source>A target framework (--target-framework) must be specified.</source>
+        <target state="new">A target framework (--target-framework) must be specified.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0087">
-        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</source>
-        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.
-		</target>
-        <note>
-		</note>
+        <source>Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</source>
+        <target state="new">Xamarin.Mac Classic binding projects are not supported anymore. Please upgrade the binding project to a Xamarin.Mac Unified binding project.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0088">
-        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error: don't know how to create ref/out (input) code for {0} in {1}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0089">
-        <source>Internal error: property {0} doesn't have neither a getter nor a setter.
-		</source>
-        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: property {0} doesn't have neither a getter nor a setter.</source>
+        <target state="new">Internal error: property {0} doesn't have neither a getter nor a setter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI0099">
-        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</source>
-        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
-		</target>
-        <note>
-		</note>
+        <source>Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</source>
+        <target state="new">Internal error {0}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1000">
         <source>Could not compile the generated API bindings.	
@@ -95,270 +68,171 @@
         <target state="new">Could not compile the generated API bindings.	
 		{0}
 		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1001">
-        <source>Do not know how to make a trampoline for {0}
-		</source>
-        <target state="new">Do not know how to make a trampoline for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a trampoline for {0}</source>
+        <target state="new">Do not know how to make a trampoline for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1002">
-        <source>Unknown kind {0} in method '{1}.{2}'
-		</source>
-        <target state="new">Unknown kind {0} in method '{1}.{2}'
-		</target>
-        <note>
-		</note>
+        <source>Unknown kind {0} in method '{1}.{2}'</source>
+        <target state="new">Unknown kind {0} in method '{1}.{2}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1003">
-        <source>The delegate method {0}.{1} needs to take at least one parameter
-		</source>
-        <target state="new">The delegate method {0}.{1} needs to take at least one parameter
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} needs to take at least one parameter</source>
+        <target state="new">The delegate method {0}.{1} needs to take at least one parameter</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1004">
-        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [EventArgs] attribute (has {2} parameters)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1005">
-        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</source>
-        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end
-		</target>
-        <note>
-		</note>
+        <source>EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</source>
+        <target state="new">EventArgs in {0}.{1} attribute should not include the text `EventArgs' at the end</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1006">
-        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DelegateName] attribute (or EventArgs)</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1007">
-        <source>Unknown attribute {0} on {1}.{2}
-		</source>
-        <target state="new">Unknown attribute {0} on {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unknown attribute {0} on {1}.{2}</source>
+        <target state="new">Unknown attribute {0} on {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1008">
-        <source>[IsThreadStatic] is only valid on properties that are also [Static]
-		</source>
-        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]
-		</target>
-        <note>
-		</note>
+        <source>[IsThreadStatic] is only valid on properties that are also [Static]</source>
+        <target state="new">[IsThreadStatic] is only valid on properties that are also [Static]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1009">
-        <source>No selector specified for method `{0}.{1}'
-		</source>
-        <target state="new">No selector specified for method `{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for method `{0}.{1}'</source>
+        <target state="new">No selector specified for method `{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1010">
-        <source>No Export attribute on {0}.{1} property
-		</source>
-        <target state="new">No Export attribute on {0}.{1} property
-		</target>
-        <note>
-		</note>
+        <source>No Export attribute on {0}.{1} property</source>
+        <target state="new">No Export attribute on {0}.{1} property</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1011">
-        <source>Do not know how to extract type {0}/{1} from an NSDictionary
-		</source>
-        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to extract type {0}/{1} from an NSDictionary</source>
+        <target state="new">Do not know how to extract type {0}/{1} from an NSDictionary</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1012">
-        <source>No Export or Bind attribute defined on {0}.{1}
-		</source>
-        <target state="new">No Export or Bind attribute defined on {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No Export or Bind attribute defined on {0}.{1}</source>
+        <target state="new">No Export or Bind attribute defined on {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1013">
-        <source>Unsupported type for Fields (string), you probably meant NSString
-		</source>
-        <target state="new">Unsupported type for Fields (string), you probably meant NSString
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields (string), you probably meant NSString</source>
+        <target state="new">Unsupported type for Fields (string), you probably meant NSString</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1014">
-        <source>Unsupported type for Fields: {0} for '{1}'.
-		</source>
-        <target state="new">Unsupported type for Fields: {0} for '{1}'.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for Fields: {0} for '{1}'.</source>
+        <target state="new">Unsupported type for Fields: {0} for '{1}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1015">
-        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</source>
-        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates
-		</target>
-        <note>
-		</note>
+        <source>In class {0} You specified the Events property, but did not bind those to names with Delegates</source>
+        <target state="new">In class {0} You specified the Events property, but did not bind those to names with Delegates</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1016">
-        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</source>
-        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute
-		</target>
-        <note>
-		</note>
+        <source>The delegate method {0}.{1} is missing the [DefaultValue] attribute</source>
+        <target state="new">The delegate method {0}.{1} is missing the [DefaultValue] attribute</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1017">
-        <source>Do not know how to make a signature for {0}
-		</source>
-        <target state="new">Do not know how to make a signature for {0}
-		</target>
-        <note>
-		</note>
+        <source>Do not know how to make a signature for {0}</source>
+        <target state="new">Do not know how to make a signature for {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1018">
-        <source>No [Export] attribute on property {0}.{1}
-		</source>
-        <target state="new">No [Export] attribute on property {0}.{1}
-		</target>
-        <note>
-		</note>
+        <source>No [Export] attribute on property {0}.{1}</source>
+        <target state="new">No [Export] attribute on property {0}.{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1019">
-        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</source>
-        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>Invalid [NoDefaultValue] attribute on method '{0}.{1}'</source>
+        <target state="new">Invalid [NoDefaultValue] attribute on method '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1020">
-        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</source>
-        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</source>
+        <target state="new">Unsupported type {0} used on exported method {1}.{2} -&gt; {3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1021">
-        <source>Unsupported type for read/write Fields: {0} for {1}.{2}
-		</source>
-        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type for read/write Fields: {0} for {1}.{2}</source>
+        <target state="new">Unsupported type for read/write Fields: {0} for {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1022">
-        <source>Model classes can not be categories
-		</source>
-        <target state="new">Model classes can not be categories
-		</target>
-        <note>
-		</note>
+        <source>Model classes can not be categories</source>
+        <target state="new">Model classes can not be categories</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1023">
-        <source>The number of Events (Type) and Delegates (string) must match for `{0}`
-		</source>
-        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`
-		</target>
-        <note>
-		</note>
+        <source>The number of Events (Type) and Delegates (string) must match for `{0}`</source>
+        <target state="new">The number of Events (Type) and Delegates (string) must match for `{0}`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1024">
-        <source>No selector specified for property '{0}.{1}'
-		</source>
-        <target state="new">No selector specified for property '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>No selector specified for property '{0}.{1}'</source>
+        <target state="new">No selector specified for property '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1025">
-        <source>[Static] and [Protocol] are mutually exclusive ({0})
-		</source>
-        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})
-		</target>
-        <note>
-		</note>
+        <source>[Static] and [Protocol] are mutually exclusive ({0})</source>
+        <target state="new">[Static] and [Protocol] are mutually exclusive ({0})</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1026">
-        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</source>
-        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`
-		</target>
-        <note>
-		</note>
+        <source>`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</source>
+        <target state="new">`{0}`: Enums attributed with [{1}] must have an underlying type of `long` or `ulong`</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1027">
-        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</source>
-        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.
-		</target>
-        <note>
-		</note>
+        <source>Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</source>
+        <target state="new">Support for ZeroCopy strings is not implemented. Strings will be marshalled as NSStrings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1028">
-        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal sanity check failed, please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1029">
-        <source>Internal error: invalid enum mode for type '{0}'
-		</source>
-        <target state="new">Internal error: invalid enum mode for type '{0}'
-		</target>
-        <note>
-		</note>
+        <source>Internal error: invalid enum mode for type '{0}'</source>
+        <target state="new">Internal error: invalid enum mode for type '{0}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1030">
-        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</source>
-        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency
-		</target>
-        <note>
-		</note>
+        <source>{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</source>
+        <target state="new">{0} cannot have [BaseType(typeof({1}))] as it creates a circular dependency</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1031">
-        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</source>
-        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.
-		</target>
-        <note>
-		</note>
+        <source>The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</source>
+        <target state="new">The [Target] attribute is not supported for the Unified API (found on the member '{0}.{1}'). For Objective-C categories, create an api definition interface with the [Category] attribute instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1032">
-        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</source>
-        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}
-		</target>
-        <note>
-		</note>
+        <source>No support for setters in StrongDictionary classes for type {0} in {1}.{2}</source>
+        <target state="new">No support for setters in StrongDictionary classes for type {0} in {1}.{2}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1033">
-        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</source>
-        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property
-		</target>
+        <source>Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</source>
+        <target state="new">Limitation: can not automatically create strongly typed dictionary for ({0}) the value type of the {1}.{2} property</target>
         <note>Generating a strongly typed dictionary for type '{0}' is not supported.
 {0} - the property type.
 {1} - the dictionary type.
@@ -366,538 +240,341 @@
 		</note>
       </trans-unit>
       <trans-unit id="BI1034">
-        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</source>
-        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</source>
+        <target state="new">The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1035">
-        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</source>
-        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.
-		</target>
-        <note>
-		</note>
+        <source>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</source>
+        <target state="new">The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1036">
-        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</source>
-        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').
-		</target>
-        <note>
-		</note>
+        <source>The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</source>
+        <target state="new">The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1037">
-        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with both read only and write only versions, with no read/write version.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1038">
-        <source>The selector {0} on type {1} is found multiple times with different return types.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different return types.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different return types.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different return types.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1039">
-        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1040">
-        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</source>
-        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
-		</target>
-        <note>
-		</note>
+        <source>The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</source>
+        <target state="new">The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1041">
         <source>The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</source>
         <target state="new">The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.		</target>
-        <note>
-		</note>
+        <note></note>
       </trans-unit>
       <trans-unit id="BI1042">
-        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</source>
-        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")
-		</target>
-        <note>
-		</note>
+        <source>Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</source>
+        <target state="new">Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal")</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1043">
-        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</source>
-        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.
-		</target>
-        <note>
-		</note>
+        <source>Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</source>
+        <target state="new">Repeated overload {0} and no [DelegateApiNameAttribute] provided to generate property name on host class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1044">
-        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</source>
-        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].
-		</target>
-        <note>
-		</note>
+        <source>Repeated name '{0}' provided in [DelegateApiNameAttribute].</source>
+        <target state="new">Repeated name '{0}' provided in [DelegateApiNameAttribute].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1045">
-        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</source>
-        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.
-		</target>
-        <note>
-		</note>
+        <source>Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</source>
+        <target state="new">Only a single [DefaultEnumValue] attribute can be used inside enum {0}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1046">
-        <source>The [Field] constant {0} cannot only be used once inside enum {1}.
-		</source>
-        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.
-		</target>
-        <note>
-		</note>
+        <source>The [Field] constant {0} cannot only be used once inside enum {1}.</source>
+        <target state="new">The [Field] constant {0} cannot only be used once inside enum {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1047">
-        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1048">
-        <source>Unsupported type {0} decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type {0} decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type {0} decorated with [BindAs]</source>
+        <target state="new">Unsupported type {0} decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1049">
-        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</source>
-        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].
-		</target>
-        <note>
-		</note>
+        <source>Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</source>
+        <target state="new">Could not {0} type {1} from {2} {3} used on member {4} decorated with [BindAs].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1050">
-        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</source>
-        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}
-		</target>
-        <note>
-		</note>
+        <source>[BindAs] cannot be used inside Protocol or Model types. Type: {0}</source>
+        <target state="new">[BindAs] cannot be used inside Protocol or Model types. Type: {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1051">
-        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Don't know how to get attributes for {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1052">
-        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1053">
-        <source>Internal error: unknown target framework '{0}'.
-		</source>
-        <target state="new">Internal error: unknown target framework '{0}'.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: unknown target framework '{0}'.</source>
+        <target state="new">Internal error: unknown target framework '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1054">
-        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: can't convert type '{0}' (unknown assembly). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1055">
-        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to convert type '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1056">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert type constructor argument #{1}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1057">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (could not convert constructor type #{1} ({2})). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1058">
-        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
+        <source>Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: could not find a constructor for the mock attribute '{0}'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
         <note />
       </trans-unit>
       <trans-unit id="BI1059">
-        <source>Found {0} {1} attributes on the member {2}. At most one was expected.
-		</source>
-        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.
-		</target>
-        <note>
-		</note>
+        <source>Found {0} {1} attributes on the member {2}. At most one was expected.</source>
+        <target state="new">Found {0} {1} attributes on the member {2}. At most one was expected.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1060">
-        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</source>
-        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
-		</target>
-        <note>
-		</note>
+        <source>The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</source>
+        <target state="new">The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1061">
-        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</source>
-        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.
-		</target>
-        <note>
-		</note>
+        <source>The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</source>
+        <target state="new">The attribute '{0}' found on '{1}' is not a valid binding attribute. Please remove this attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1062">
-        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</source>
-        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</source>
+        <target state="new">The member '{0}.{1}' contains ref/out parameters and must not be decorated with [Async].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1063">
-        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</source>
-        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'
-		</target>
-        <note>
-		</note>
+        <source>The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</source>
+        <target state="new">The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '{0}.{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1064">
-        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1065">
-        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</source>
-        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</source>
+        <target state="new">Unsupported parameter type '{0}' for the parameter '{1}' in {2}.{3}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1066">
-        <source>Unsupported return type '{0}' in {1}.{2}.
-		</source>
-        <target state="new">Unsupported return type '{0}' in {1}.{2}.
-		</target>
-        <note>
-		</note>
+        <source>Unsupported return type '{0}' in {1}.{2}.</source>
+        <target state="new">Unsupported return type '{0}' in {1}.{2}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1067">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties don't share the same accessors ('{4}' is read-only, while '${5}' is write-only).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1068">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', and the inlined properties use different selectors ({4}.{5} uses '{6}', and {7}.{8} uses '{9}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1069">
-        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</source>
-        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</source>
+        <target state="new">The type '{0}' is trying to inline the methods binding the selector '{1}' from the protocols '{2}' and '{3}', using methods with different signatures ('{4}' vs '{5}').</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1070">
-        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</source>
-        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).
-		</target>
-        <note>
-		</note>
+        <source>The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</source>
+        <target state="new">The type '{0}' is trying to inline the property '{1}' from the protocols '{2}' and '{3}', but the inlined properties are of different types ('{4}' is {5}, while '{6}' is {7}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1071">
-        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</source>
-        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</source>
+        <target state="new">The BindAs type for the member "{0}.{1}" must be an array when the member's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1072">
-        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</source>
-        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.
-		</target>
-        <note>
-		</note>
+        <source>The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</source>
+        <target state="new">The BindAs type for the parameter "{0}" in the method "{1}.{2}" must be an array when the parameter's type is an array.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1073">
-        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1074">
-        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</source>
-        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}
-		</target>
-        <note>
-		</note>
+        <source> Missing [CoreImageFilterProperty] attribute on {0} property {1}</source>
+        <target state="new"> Missing [CoreImageFilterProperty] attribute on {0} property {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1075">
-        <source>Unimplemented CoreImage property type {0}
-		</source>
-        <target state="new">Unimplemented CoreImage property type {0}
-		</target>
-        <note>
-		</note>
+        <source>Unimplemented CoreImage property type {0}</source>
+        <target state="new">Unimplemented CoreImage property type {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1076">
-        <source>Unable to find selector for {0} on {1} on self or base class
-		</source>
-        <target state="new">Unable to find selector for {0} on {1} on self or base class
-		</target>
-        <note>
-		</note>
+        <source>Unable to find selector for {0} on {1} on self or base class</source>
+        <target state="new">Unable to find selector for {0} on {1} on self or base class</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1077">
-        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</source>
-        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType
-		</target>
+        <source>Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</source>
+        <target state="new">Async method {0} with more than one result parameter in the callback by neither ResultTypeName or ResultType</target>
         <note>A message for an asynchronous method with more than one result parameter. The following are literal names and should not be translated: ResultTypeName, ResultType
 {0} - The method name.
 		</note>
       </trans-unit>
       <trans-unit id="BI1078">
-        <source>{0} in method `{1}'
-		</source>
-        <target state="new">{0} in method `{1}'
-		</target>
-        <note>
-		</note>
+        <source>{0} in method `{1}'</source>
+        <target state="new">{0} in method `{1}'</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1079">
-        <source>{0} in parameter `{1}' from {2}.{3}
-		</source>
-        <target state="new">{0} in parameter `{1}' from {2}.{3}
-		</target>
-        <note>
-		</note>
+        <source>{0} in parameter `{1}' from {2}.{3}</source>
+        <target state="new">{0} in parameter `{1}' from {2}.{3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1080">
-        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</source>
-        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]
-		</target>
-        <note>
-		</note>
+        <source>Unsupported type 'ref/out {0}' decorated with [BindAs]</source>
+        <target state="new">Unsupported type 'ref/out {0}' decorated with [BindAs]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1081">
-        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </source>
-        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.
-        </target>
-        <note>
-        </note>
+        <source>Unable to find the assembly '{0}'. Add it as a reference using its full path.</source>
+        <target state="new">Unable to find the assembly '{0}'. Add it as a reference using its full path.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1101">
-        <source>Trying to use a string as a [Target]
-		</source>
-        <target state="new">Trying to use a string as a [Target]
-		</target>
-        <note>
-		</note>
+        <source>Trying to use a string as a [Target]</source>
+        <target state="new">Trying to use a string as a [Target]</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1102">
-        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</source>
-        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.
-		</target>
-        <note>
-		</note>
+        <source>Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</source>
+        <target state="new">Using the deprecated 'EventArgs' for a delegate signature in {0}.{1}, please use 'DelegateName' instead.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1103">
-        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</source>
-        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice
-		</target>
-        <note>
-		</note>
+        <source>'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</source>
+        <target state="new">'{0}' does not live under a namespace; namespaces are a highly recommended .NET best practice</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1104">
-        <source>Could not load the referenced library '{0}': {1}.
-		</source>
-        <target state="new">Could not load the referenced library '{0}': {1}.
-		</target>
-        <note>
-		</note>
+        <source>Could not load the referenced library '{0}': {1}.</source>
+        <target state="new">Could not load the referenced library '{0}': {1}.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1105">
-        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</source>
-        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments
-		</target>
-        <note>
-		</note>
+        <source>Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</source>
+        <target state="new">Potential selector/argument mismatch [Export ("{0}")] has {1} arguments and {2} has {3} arguments</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1106">
-        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</source>
-        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).
-		</target>
-        <note>
-		</note>
+        <source>The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</source>
+        <target state="new">The parameter {2} in the method {0}.{1} exposes a model ({3}). Please expose the corresponding protocol type instead ({4}.I{5}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1107">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1108">
-        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</source>
-        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
-		</target>
-        <note>
-		</note>
+        <source>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</source>
+        <target state="new">The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1109">
-        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1110">
-        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</source>
-        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).
-		</target>
-        <note>
-		</note>
+        <source>The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</source>
+        <target state="new">The property {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1111">
-        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</source>
-        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?
-		</target>
-        <note>
-		</note>
+        <source>Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</source>
+        <target state="new">Interface '{0}' on '{1}' is being ignored as it is not a protocol. Did you mean '{2}' instead?</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1112">
-        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</source>
-        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.
-		</target>
-        <note>
-		</note>
+        <source>Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</source>
+        <target state="new">Property {0} should be renamed to 'Delegate' for BaseType.Events and BaseType.Delegates to work.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1113">
-        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</source>
-        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.
-		</target>
-        <note>
-		</note>
+        <source>BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</source>
+        <target state="new">BaseType.Delegates were set but no properties could be found. Do ensure that the WrapAttribute is used on the right properties.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1114">
-        <source>Binding error: test unable to find property: {0} on {1}
-		</source>
-        <target state="new">Binding error: test unable to find property: {0} on {1}
-		</target>
-        <note>
-		</note>
+        <source>Binding error: test unable to find property: {0} on {1}</source>
+        <target state="new">Binding error: test unable to find property: {0} on {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1115">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1116">
-        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</source>
-        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
-		</target>
-        <note>
-		</note>
+        <source>The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</source>
+        <target state="new">The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1117">
-        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</source>
-        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
-		</target>
-        <note>
-		</note>
+        <source>The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</source>
+        <target state="new">The member '{0}' is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1118">
-        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</source>
-        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.
-		</target>
-        <note>
-		</note>
+        <source>[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</source>
+        <target state="new">[NullAllowed] should not be used on methods, like '{0}', but only on properties, parameters and return values.</target>
+        <note />
       </trans-unit>
       <trans-unit id="BI1119">
-        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</source>
-        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
-		</target>
-        <note>
-		</note>
+        <source>Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</source>
+        <target state="new">Internal error: found the same type ({0}) in multiple assemblies ({1} and {2}). Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="default">
         <source>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/xamarin/xamarin-macios/issues/new</source>


### PR DESCRIPTION
This fixes an issue where a composed error message would show up in two lines:

    BTOUCH : error BI1079: bgen: Do not know how to make a signature for System.Boolean*
    		 in parameter `inventoryAbortResultCodeFound' from iOSBinding.Easy2ReadProtocolMessage.FromRawData

Leaving customers confused (https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1280923),
because they wouldn't see the second part of the error.

After the fix:

    BTOUCH : error BI1079: bgen: Do not know how to make a signature for System.Boolean* in parameter `inventoryAbortResultCodeFound' from iOSBinding.Easy2ReadProtocolMessage.FromRawData

---

Before:

<img width="1080" alt="Screen Shot 2021-02-23 at 09 16 27" src="https://user-images.githubusercontent.com/249268/108819345-064d5e80-75bb-11eb-9176-6ae3badada6e.png">

After:

<img width="1054" alt="Screen Shot 2021-02-23 at 09 20 54" src="https://user-images.githubusercontent.com/249268/108819336-051c3180-75bb-11eb-8674-04608dbc371b.png">

On another note, we should probably do this for all our other warning/error messages as well.