### PR TITLE
[xcode12.5] [Makefile] Why copy-paste when you can 'make fix-xcode-select'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,9 @@ fix-install-permissions:
 	sudo chown -R $(USER) /Library/Frameworks/Xamarin.iOS.framework
 	sudo chown -R $(USER) /Library/Frameworks/Xamarin.Mac.framework
 
+fix-xcode-select:
+	sudo xcode-select -s $(XCODE_DEVELOPER_ROOT)
+
 git-clean-all:
 	@echo "$(COLOR_RED)Cleaning and resetting all dependencies. This is a destructive operation.$(COLOR_CLEAR)"
 	@echo "$(COLOR_RED)You have 5 seconds to cancel (Ctrl-C) if you wish.$(COLOR_CLEAR)"


### PR DESCRIPTION
The name of the branch says it all.


Backport of #10692
