### PR TITLE
[xcode12.5] [CI][VSTS] continueOnError is the correct way.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -439,7 +439,6 @@ steps:
   displayName: 'Run tests'
   name: runTests # not to be confused with the displayName, this is used to later use the name of the step to access the output variables from an other job
   timeoutInMinutes: 600
-  condition: succeededOrFailed() # we do not care about the previous process cleanup
   enabled: ${{ parameters.runTests }}
   env:
     BUILD_REVISION: jenkins


### PR DESCRIPTION
We do have continueOnError in the required steps, is enough to ensure tests are ran when they should.


Backport of #10693
