### PR TITLE
[dotnet] Fixes builds for iOS physical devices from Windows

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.2.111</MessagingVersion>
+		<MessagingVersion>1.2.114</MessagingVersion>
 	</PropertyGroup>
 </Project>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompile.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompile.cs
@@ -1,9 +1,12 @@
+using System.Collections.Generic;
+using System.IO;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 using Xamarin.Messaging.Build.Client;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public class AOTCompile : AOTCompileTaskBase, ICancelableTask
+	public class AOTCompile : AOTCompileTaskBase, ITaskCallback, ICancelableTask
 	{
 		public override bool Execute ()
 		{
@@ -11,6 +14,18 @@ namespace Xamarin.MacDev.Tasks
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
+		}
+
+		public bool ShouldCopyToBuildServer (ITaskItem item) => false;
+
+		public bool ShouldCreateOutputFile (ITaskItem item) => true;
+
+		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied ()
+		{
+			var compiler = new TaskItem (AOTCompilerPath);
+			compiler.SetMetadata ("IsUnixExecutable", "true");
+
+			yield return compiler;
 		}
 
 		public void Cancel ()

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
@@ -30,11 +30,13 @@ namespace Xamarin.MacDev.Tasks
 
 		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied ()
 		{
-			foreach (var dir in IncludeDirectories)
-			{
-				foreach (var file in Directory.EnumerateFiles(dir.ItemSpec, "*.*", SearchOption.AllDirectories))
+			if (IncludeDirectories != null) {
+				foreach (var dir in IncludeDirectories) 
 				{
-					yield return new TaskItem(file);
+					foreach (var file in Directory.EnumerateFiles(dir.ItemSpec, "*.*", SearchOption.AllDirectories)) 
+					{
+						yield return new TaskItem(file);
+					}
 				}
 			}
 		}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/EmbedProvisionProfile.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/EmbedProvisionProfile.cs
@@ -1,6 +1,15 @@
-﻿namespace Xamarin.MacDev.Tasks
+﻿using Xamarin.Messaging.Build.Client;
+
+namespace Xamarin.MacDev.Tasks
 {
 	public class EmbedProvisionProfile : EmbedProvisionProfileTaskBase
 	{
+		public override bool Execute ()
+		{
+			if (!string.IsNullOrEmpty (SessionId))
+				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
+
+			return base.Execute ();
+		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCode.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCode.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
@@ -7,15 +8,22 @@ namespace Xamarin.MacDev.Tasks
 {
 	public class LinkNativeCode : LinkNativeCodeTaskBase, ITaskCallback
 	{
+		string outputPath;
+
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (!string.IsNullOrEmpty (SessionId)) {
+				outputPath = Path.GetDirectoryName (OutputFile);
+
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
+			}
 
 			return base.Execute ();
 		}
 
-		public bool ShouldCopyToBuildServer (ITaskItem item) => false;
+		// We should avoid copying files from the output path because those already exist on the Mac
+		// and the ones on Windows are empty, so we will break the build
+		public bool ShouldCopyToBuildServer (ITaskItem item) => Path.GetDirectoryName(item.ItemSpec) != outputPath;
 
 		public bool ShouldCreateOutputFile (ITaskItem item) => false;
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCode.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCode.cs
@@ -23,7 +23,7 @@ namespace Xamarin.MacDev.Tasks
 
 		// We should avoid copying files from the output path because those already exist on the Mac
 		// and the ones on Windows are empty, so we will break the build
-		public bool ShouldCopyToBuildServer (ITaskItem item) => Path.GetDirectoryName(item.ItemSpec) != outputPath;
+		public bool ShouldCopyToBuildServer (ITaskItem item) => Path.GetDirectoryName (item.ItemSpec) != outputPath;
 
 		public bool ShouldCreateOutputFile (ITaskItem item) => false;
 


### PR DESCRIPTION
- We need to create output files for the AOTCompile task on Windows and copy the AOT Compiler to the Mac since it is part of a NuGet package that will not exist on the Mac
- The EmbedProvisionProfile task needs to be run remotely so the embedded.mobileprovision file is included in the app bundle
- When copying input files to the Mac for LinkNativeCode we should skip files that already exist on the Mac because those on Windows are empty. If we copy those we are essentially replacing the real files by the empty ones from Windows.