### PR TITLE
[dotnet] Fixes Xamarin.Messaging HintPath

### DIFF
--- a/msbuild/Messaging/Xamarin.Messaging.Build.Contracts/Xamarin.Messaging.Build.Contracts.csproj
+++ b/msbuild/Messaging/Xamarin.Messaging.Build.Contracts/Xamarin.Messaging.Build.Contracts.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Messaging">
-      <HintPath>..\Xamarin.Messaging\bin\$(Configuration)\netstandard2.0\Xamarin.Messaging.dll</HintPath>
+      <HintPath>..\Xamarin.Messaging\$(OutputPath)\Xamarin.Messaging.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Messaging">
-      <HintPath>..\Messaging\Xamarin.Messaging\bin\$(Configuration)\netstandard2.0\Xamarin.Messaging.dll</HintPath>
+      <HintPath>..\Messaging\Xamarin.Messaging\$(OutputPath)\Xamarin.Messaging.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Messaging">
-      <HintPath>..\Messaging\Xamarin.Messaging\bin\$(Configuration)\netstandard2.0\Xamarin.Messaging.dll</HintPath>
+      <HintPath>..\Messaging\Xamarin.Messaging\$(OutputPath)\Xamarin.Messaging.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <Reference Include="Xamarin.Messaging">
-      <HintPath>..\Messaging\Xamarin.Messaging\bin\$(Configuration)\netstandard2.0\Xamarin.Messaging.dll</HintPath>
+      <HintPath>..\Messaging\Xamarin.Messaging\$(OutputPath)\Xamarin.Messaging.dll</HintPath>
     </Reference>
     <!-- We need the net472 implementation, otherwise the Build agent needs to be a net5.0 app -->
     <Reference Include="ILLink.Tasks">


### PR DESCRIPTION
Changes the HintPath to the Messaging assembly to use OutputPath instead, otherwise the build fails when that property is different than `bin\$(Configuration)\netstandard2.0`