### PR TITLE
[CoreMedia] Store delegate in static variable to prevent premature garbage collection.

### DIFF
--- a/src/CoreMedia/CMSampleBuffer.cs
+++ b/src/CoreMedia/CMSampleBuffer.cs
@@ -599,6 +599,8 @@ namespace CoreMedia {
 		delegate void CMSampleBufferInvalidateCallback (/* CMSampleBufferRef */ IntPtr sbuf, 
 			/* uint64_t */ ulong invalidateRefCon);
 
+		static CMSampleBufferInvalidateCallback invalidate_handler = InvalidateHandler;
+
 #if !MONOMAC
 		[MonoPInvokeCallback (typeof (CMSampleBufferInvalidateCallback))]
 #endif
@@ -626,7 +628,7 @@ namespace CoreMedia {
 				return CMSampleBufferError.RequiredParameterMissing;
 
 			invalidate = GCHandle.Alloc (Tuple.Create (invalidateHandler, this));
-			return CMSampleBufferSetInvalidateCallback (handle, InvalidateHandler, (ulong)(IntPtr)invalidate);
+			return CMSampleBufferSetInvalidateCallback (handle, invalidate_handler, (ulong)(IntPtr)invalidate);
 		}
 							
 		[DllImport(Constants.CoreMediaLibrary)]


### PR DESCRIPTION
Fixes this crash in monotouch-test:

	Process terminated. A callback was made on a garbage collected delegate of type 'Xamarin.Mac!CoreMedia.CMSampleBuffer+CMSampleBufferInvalidateCallback::Invoke'.
	Repeat 2 times:
	--------------------------------
	   at CoreMedia.CMSampleBuffer.CMSampleBufferInvalidate(IntPtr)
	--------------------------------
	   at CoreMedia.CMSampleBuffer.Invalidate()
	   at MonoTouchFixtures.CoreMedia.SampleBufferTest.SetInvalidateCallback()
	   at System.RuntimeMethodHandle.InvokeMethod(System.Object, System.Object[], System.Signature, Boolean, Boolean)
	   at NUnit.Framework.Internal.Reflect.InvokeMethod(System.Reflection.MethodInfo, System.Object, System.Object[])
	   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(NUnit.Framework.Internal.TestExecutionContext)
	   at NUnit.Framework.Internal.Execution.SimpleWorkItem.PerformWork()
	   at NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()
	   at NUnit.Framework.Internal.Execution.CompositeWorkItem.RunChildren()
	   at NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()
	   at NUnit.Framework.Internal.Execution.CompositeWorkItem.RunChildren()
	   at NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()
	   at NUnit.Framework.Internal.Execution.CompositeWorkItem.RunChildren()
	   at NUnit.Framework.Internal.Execution.CompositeWorkItem.PerformWork()
	   at NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()
	   at NUnit.Framework.Internal.Execution.WorkItem.Execute()
	   at NUnit.Framework.Internal.Execution.MainThreadWorkItemDispatcher.Dispatch(NUnit.Framework.Internal.Execution.WorkItem)
	   at NUnit.Framework.Internal.Execution.CompositeWorkItem.RunChildren()
	   at NUnit.Framework.Internal.Execution.CompositeWorkItem.PerformWork()
	   at NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()
	   at NUnit.Framework.Internal.Execution.WorkItem.Execute()
	   at NUnit.Framework.Internal.Execution.MainThreadWorkItemDispatcher.Dispatch(NUnit.Framework.Internal.Execution.WorkItem)
	   at NUnit.Framework.Internal.Execution.MainThreadWorkItemDispatcher.Start(NUnit.Framework.Internal.Execution.WorkItem)
	   at NUnit.Framework.Api.NUnitTestAssemblyRunner.StartRun(NUnit.Framework.Interfaces.ITestListener)
	   at NUnit.Framework.Api.NUnitTestAssemblyRunner+<>c__DisplayClass38_0.<RunAsync>b__0()
	   at NUnit.Framework.Api.NUnitTestAssemblyRunner.WrapInNUnitCallContext(System.Action)
	   at NUnit.Framework.Api.NUnitTestAssemblyRunner.RunAsync(NUnit.Framework.Interfaces.ITestListener, NUnit.Framework.Interfaces.ITestFilter)
	   at NUnit.Framework.Api.NUnitTestAssemblyRunner.Run(NUnit.Framework.Interfaces.ITestListener, NUnit.Framework.Interfaces.ITestFilter)
	   at MonoTouch.NUnit.UI.BaseTouchRunner.Run(NUnit.Framework.Internal.Test)
	   at MonoTouch.NUnit.UI.BaseTouchRunner.Run()
	   at MonoTouch.NUnit.UI.BaseTouchRunner.RunAsync()
	   at MonoTouch.NUnit.UI.MacRunner+<RunTestsAsync>d__1.MoveNext()
	   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[[System.__Canon, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]](System.__Canon ByRef)
	   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[[System.Boolean, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].Start[[System.__Canon, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]](System.__Canon ByRef)
	   at MonoTouch.NUnit.UI.MacRunner.RunTestsAsync(MonoTouch.NUnit.UI.TouchOptions, System.Reflection.Assembly[])
	   at MonoTouch.NUnit.UI.MacRunner+<>c__DisplayClass0_0+<<MainAsync>b__0>d.MoveNext()
	   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[[System.__Canon, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]](System.__Canon ByRef)
	   at System.Runtime.CompilerServices.AsyncVoidMethodBuilder.Start[[System.__Canon, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]](System.__Canon ByRef)
	   at MonoTouch.NUnit.UI.MacRunner+<>c__DisplayClass0_0.<MainAsync>b__0()
	   at Foundation.NSActionDispatcher.Apply()
	   at System.RuntimeMethodHandle.InvokeMethod(System.Object, System.Object[], System.Signature, Boolean, Boolean)
	   at System.Reflection.RuntimeMethodInfo.Invoke(System.Object, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo)
	   at ObjCRuntime.Runtime.InvokeMethod(IntPtr, IntPtr, IntPtr)
	   at ObjCRuntime.Runtime.bridge_runtime_invoke_method(IntPtr, IntPtr, IntPtr, IntPtr ByRef)
	   at ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr_bool(IntPtr, IntPtr, IntPtr, IntPtr, Boolean)
	   at ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr_bool(IntPtr, IntPtr, IntPtr, IntPtr, Boolean)
	   at Foundation.NSObject.InvokeOnMainThread(System.Action)
	   at MonoTouch.NUnit.UI.MacRunner+<MainAsync>d__0.MoveNext()
	   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[[System.__Canon, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]](System.__Canon ByRef)
	   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[[System.Int32, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].Start[[System.__Canon, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]](System.__Canon ByRef)
	   at MonoTouch.NUnit.UI.MacRunner.MainAsync(System.Collections.Generic.IList`1<System.String>, Boolean, System.Action`1<Int32>, System.Reflection.Assembly[])
	   at Xamarin.Mac.Tests.MainClass+<Main>d__0.MoveNext()
	   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[[System.__Canon, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]](System.__Canon ByRef)
	   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[[System.Int32, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].Start[[System.__Canon, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]](System.__Canon ByRef)
	   at Xamarin.Mac.Tests.MainClass.Main(System.String[])
	   at Xamarin.Mac.Tests.MainClass.<Main>(System.String[])