### PR TITLE
[catalyst] Remove "unknown" API inside existing frameworks

### DIFF
--- a/src/AudioUnit/AudioComponent.cs
+++ b/src/AudioUnit/AudioComponent.cs
@@ -351,6 +351,7 @@ namespace AudioUnit
 		}
 
 #if !MONOMAC
+#if !__MACCATALYST__
 		[iOS (7,0)]
 		[Deprecated (PlatformName.iOS, 14,0)]
 		[DllImport(Constants.AudioUnitLibrary)]
@@ -362,6 +363,7 @@ namespace AudioUnit
 		{
 			return new UIKit.UIImage (AudioComponentGetIcon (handle, desiredPointSize));
 		}
+#endif // !__MACCATALYST__
 
 		[iOS (7,0)]
 		[Deprecated (PlatformName.iOS, 13,0)]

--- a/src/GameKit/GameKit.cs
+++ b/src/GameKit/GameKit.cs
@@ -304,6 +304,7 @@ namespace GameKit {
 	[iOS (11,3)][Deprecated (PlatformName.iOS, 14,0, message: "Do not use; this API was removed.")]
 	[Mac (10,13,4)][Deprecated (PlatformName.MacOSX, 11,0, message: "Do not use; this API was removed.")]
 	[TV (11,3)][Deprecated (PlatformName.TvOS, 14,0, message: "Do not use; this API was removed.")]
+	[NoMacCatalyst]
 	[Native]
 	public enum GKAuthenticationType : ulong {
 		WithoutUI = 0,

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -150,6 +150,7 @@ namespace AVFoundation {
 		[Deprecated (PlatformName.iOS, 12,0, message: "Always 'null'.")]
 		[Obsoleted (PlatformName.MacOSX, 10,8)]
 		[Deprecated (PlatformName.MacOSX, 10,14, message: "Always 'null'.")]
+		[NoMacCatalyst]
 		[Field ("AVMediaTypeTimedMetadata")] // last header where I can find this: iOS 5.1 SDK, 10.7 only on Mac
 		TimedMetadata = 6,
 
@@ -196,6 +197,7 @@ namespace AVFoundation {
 		[Field ("AVMediaTypeTimedMetadata")] // last header where I can find this: iOS 5.1 SDK, 10.7 only on Mac
 		[Availability (Obsoleted = Platform.iOS_6_0)]
 		[Availability (Obsoleted = Platform.Mac_10_8)]
+		[NoMacCatalyst]
 		NSString TimedMetadata { get; }
 
 		[Field ("AVMediaTypeMuxed")]

--- a/src/devicecheck.cs
+++ b/src/devicecheck.cs
@@ -49,6 +49,7 @@ namespace DeviceCheck {
 	}
 
 	[NoWatch, NoTV, NoMac]
+	[NoMacCatalyst]
 	[iOS (14,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -11643,11 +11643,13 @@ namespace Foundation
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
 	interface NSPortDelegate {
+		[NoMacCatalyst]
 		[Export ("handlePortMessage:")]
 		void MessageReceived (NSPortMessage message);
 	}
 
 	[BaseType (typeof (NSObject))]
+	[NoMacCatalyst]
 	interface NSPortMessage {
 #if MONOMAC
 		[DesignatedInitializer]

--- a/tests/monotouch-test/AVFoundation/CaptureDeviceTest.cs
+++ b/tests/monotouch-test/AVFoundation/CaptureDeviceTest.cs
@@ -34,16 +34,12 @@ namespace MonoTouchFixtures.AVFoundation {
 				Compare (AVMediaType.MetadataObject, AVMediaTypes.MetadataObject);
 
 			// obsoleted in iOS 6, removed in iOS12
-#if __MACCATALYST__
-			var removed = true;
-#else
-			var removed = TestRuntime.CheckSystemVersion (PlatformName.iOS, 12, 0);
-#endif
-
-			if (removed)
+#if !__MACCATALYST__
+			if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 12, 0))
 				Assert.Null (AVMediaType.TimedMetadata, "AVMediaTypeTimedMetadata");
 			else
 				Compare (AVMediaType.TimedMetadata, AVMediaTypes.TimedMetadata);
+#endif
 		}
 	}
 }

--- a/tests/xtro-sharpie/MacCatalyst-AVFoundation.todo
+++ b/tests/xtro-sharpie/MacCatalyst-AVFoundation.todo
@@ -98,4 +98,3 @@
 !missing-type! AVCaptureAudioPreviewOutput not bound
 !missing-type! AVCaptureDeviceInputSource not bound
 !missing-type! AVCaptureScreenInput not bound
-!unknown-field! AVMediaTypeTimedMetadata bound

--- a/tests/xtro-sharpie/MacCatalyst-AddressBook.ignore
+++ b/tests/xtro-sharpie/MacCatalyst-AddressBook.ignore
@@ -1,0 +1,3 @@
+## not directly used (as a type) by API but we need it for the generator
+## to support ABAddressBookErrorDomain and Libraries.AddressBookLibrary
+!unknown-native-enum! ABAddressBookError bound

--- a/tests/xtro-sharpie/MacCatalyst-AddressBook.todo
+++ b/tests/xtro-sharpie/MacCatalyst-AddressBook.todo
@@ -1,1 +1,0 @@
-!unknown-native-enum! ABAddressBookError bound

--- a/tests/xtro-sharpie/MacCatalyst-AudioToolbox.todo
+++ b/tests/xtro-sharpie/MacCatalyst-AudioToolbox.todo
@@ -39,4 +39,3 @@
 !missing-pinvoke! MusicSequenceSaveMIDIFile is not bound
 !missing-pinvoke! MusicSequenceSaveSMFData is not bound
 !missing-pinvoke! NewMusicTrackFrom is not bound
-!unknown-pinvoke! AudioComponentGetIcon bound

--- a/tests/xtro-sharpie/MacCatalyst-DeviceCheck.todo
+++ b/tests/xtro-sharpie/MacCatalyst-DeviceCheck.todo
@@ -1,1 +1,0 @@
-!unknown-type! DCAppAttestService bound

--- a/tests/xtro-sharpie/MacCatalyst-Foundation.ignore
+++ b/tests/xtro-sharpie/MacCatalyst-Foundation.ignore
@@ -1,0 +1,4 @@
+## NSPortMessage is not available (and is being rejected if used on iOS)
+## but this protocol member expose that type... we cannot remove the 
+## protocol itself since it's subclassed
+!missing-protocol-member! NSPortDelegate::handlePortMessage: not found

--- a/tests/xtro-sharpie/MacCatalyst-Foundation.todo
+++ b/tests/xtro-sharpie/MacCatalyst-Foundation.todo
@@ -387,4 +387,3 @@
 !missing-type! NSOrderedCollectionChange not bound
 !missing-type! NSOrderedCollectionDifference not bound
 !missing-type! NSURLHandle not bound
-!unknown-type! NSPortMessage bound

--- a/tests/xtro-sharpie/MacCatalyst-GameKit.todo
+++ b/tests/xtro-sharpie/MacCatalyst-GameKit.todo
@@ -4,4 +4,3 @@
 !incorrect-protocol-member! GKTurnBasedMatchmakerViewControllerDelegate::turnBasedMatchmakerViewController:playerQuitForMatch: is OPTIONAL and should NOT be abstract
 !missing-selector! GKAccessPoint::isFocused not bound
 !missing-selector! GKAccessPoint::setFocused: not bound
-!unknown-native-enum! GKAuthenticationType bound

--- a/tests/xtro-sharpie/MacCatalyst-MetalPerformanceShaders.todo
+++ b/tests/xtro-sharpie/MacCatalyst-MetalPerformanceShaders.todo
@@ -513,5 +513,4 @@
 !missing-type! MPSSVGFDefaultTextureAllocator not bound
 !missing-type! MPSSVGFDenoiser not bound
 !missing-type! MPSTemporalAA not bound
-!unknown-simd-type-mapping! The Simd type vector_uchar16 does not have a mapping to a managed type. Please add one in SimdCheck.cs
 !wrong-base-type! MPSTriangleAccelerationStructure expected MPSPolygonAccelerationStructure actual MPSAccelerationStructure

--- a/tests/xtro-sharpie/MacCatalyst-UIKit.todo
+++ b/tests/xtro-sharpie/MacCatalyst-UIKit.todo
@@ -619,5 +619,3 @@
 !missing-type! UISearchSuggestionItem not bound
 !missing-type! UITitlebar not bound
 !missing-type! UIWebView not bound
-!unknown-native-enum! UITextWritingDirection bound
-!unknown-native-enum! UIToolbarPosition bound

--- a/tests/xtro-sharpie/common-MetalPerformanceShaders.ignore
+++ b/tests/xtro-sharpie/common-MetalPerformanceShaders.ignore
@@ -51,3 +51,6 @@
 !missing-enum-value! MPSCnnReductionType native value MPSCNNReductionTypeCount = 4 not bound
 !missing-enum-value! MPSImageFeatureChannelFormat native value MPSImageFeatureChannelFormatCount = 6 not bound
 !missing-enum-value! MPSRnnMatrixId native value MPSRNNMatrixId_count = 29 not bound
+
+# unused (came along some API yet to be bound)
+!unknown-simd-type-mapping! The Simd type vector_uchar16 does not have a mapping to a managed type. Please add one in SimdCheck.cs

--- a/tests/xtro-sharpie/common-UIKit.ignore
+++ b/tests/xtro-sharpie/common-UIKit.ignore
@@ -166,6 +166,13 @@
 # Apple renamed it from UITextAlignment and we kept the old name for API compatibility
 !missing-enum! NSTextAlignment not bound
 
+## It got renamed from UITextWritingDirection to NSWritingDirection but it is a breaking change
+## Fixed in XAMCORE_4_0
+!unknown-native-enum! UITextWritingDirection bound
+
+## macro is used in UIBarCommon.h: #define UIToolbarPosition UIBarPosition
+!unknown-native-enum! UIToolbarPosition bound
+
 ## Protocol Inlined Maybe we want to change this in XAMCORE_4_0 since this predates our Category support
 !missing-protocol! UIResponderStandardEditActions not bound
 !missing-protocol-conformance! UIResponder should conform to UIResponderStandardEditActions

--- a/tests/xtro-sharpie/iOS-MetalPerformanceShaders.todo
+++ b/tests/xtro-sharpie/iOS-MetalPerformanceShaders.todo
@@ -504,5 +504,4 @@
 !missing-type! MPSSVGFDefaultTextureAllocator not bound
 !missing-type! MPSSVGFDenoiser not bound
 !missing-type! MPSTemporalAA not bound
-!unknown-simd-type-mapping! The Simd type vector_uchar16 does not have a mapping to a managed type. Please add one in SimdCheck.cs
 !wrong-base-type! MPSTriangleAccelerationStructure expected MPSPolygonAccelerationStructure actual MPSAccelerationStructure

--- a/tests/xtro-sharpie/iOS-UIKit.ignore
+++ b/tests/xtro-sharpie/iOS-UIKit.ignore
@@ -4,9 +4,6 @@
 !missing-selector! UIToolbar::setTintColor: not bound
 !missing-selector! UIToolbar::tintColor not bound
 
-## macro is used in UIBarCommon.h: #define UIToolbarPosition UIBarPosition
-!unknown-native-enum! UIToolbarPosition bound
-
 ### ARM ABI issue wrt variadic arguments
 !missing-selector! UIAlertView::initWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles: not bound
 
@@ -67,10 +64,6 @@
 ## Not really useful to have them exposed
 !missing-pinvoke! UIFontWeightForImageSymbolWeight is not bound
 !missing-pinvoke! UIImageSymbolWeightForFontWeight is not bound
-
-## It got renamed from UITextWritingDirection to NSWritingDirection but it is a breaking change
-## Fixed in XAMCORE_4_0
-!unknown-native-enum! UITextWritingDirection bound
 
 ## Introduced and deprecated in Xcode 11 and likely it will be removed in a future beta
 !missing-enum! UIDirectionalRectEdge not bound

--- a/tests/xtro-sharpie/macOS-MetalPerformanceShaders.todo
+++ b/tests/xtro-sharpie/macOS-MetalPerformanceShaders.todo
@@ -504,5 +504,4 @@
 !missing-type! MPSSVGFDefaultTextureAllocator not bound
 !missing-type! MPSSVGFDenoiser not bound
 !missing-type! MPSTemporalAA not bound
-!unknown-simd-type-mapping! The Simd type vector_uchar16 does not have a mapping to a managed type. Please add one in SimdCheck.cs
 !wrong-base-type! MPSTriangleAccelerationStructure expected MPSPolygonAccelerationStructure actual MPSAccelerationStructure

--- a/tests/xtro-sharpie/tvOS-MetalPerformanceShaders.todo
+++ b/tests/xtro-sharpie/tvOS-MetalPerformanceShaders.todo
@@ -504,5 +504,4 @@
 !missing-type! MPSSVGFDefaultTextureAllocator not bound
 !missing-type! MPSSVGFDenoiser not bound
 !missing-type! MPSTemporalAA not bound
-!unknown-simd-type-mapping! The Simd type vector_uchar16 does not have a mapping to a managed type. Please add one in SimdCheck.cs
 !wrong-base-type! MPSTriangleAccelerationStructure expected MPSPolygonAccelerationStructure actual MPSAccelerationStructure

--- a/tests/xtro-sharpie/tvOS-UIKit.ignore
+++ b/tests/xtro-sharpie/tvOS-UIKit.ignore
@@ -96,10 +96,6 @@
 ## It is deprecated and not of much use to expose it
 !missing-selector! +UIColor::groupTableViewBackgroundColor not bound
 
-## It got renamed from UITextWritingDirection to NSWritingDirection but it is a breaking change
-## Fixed in XAMCORE_4_0
-!unknown-native-enum! UITextWritingDirection bound
-
 ## Introduced and deprecated in Xcode 11 and likely it will be removed in a future beta
 !missing-enum! UIDirectionalRectEdge not bound
 !missing-selector! UIGestureRecognizer::initWithCoder: not bound


### PR DESCRIPTION
xtro tests are based on Apple's header files and report as _unknown_
bindings to API that are not found in headers - Catalyst in this case.

Removing them is required so the applications can be submitted to the
AppStore.