### PR TITLE
[d16-9] [apidiff] Bump api-diff with xcode12.4 release as it's new reference

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -36,7 +36,7 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 
 include $(TOP)/Make.versions
 
-APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode12.3/c51fabee8aa096e83f7a781aecba68113613b71d/26/package/bundle.zip
+APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/xcode12.4/5a05865f660ccfa5c56b4be7fedb9090f875c01c/4417458/package/bundle.zip
 
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 


### PR DESCRIPTION



Backport of #10745
