### PR TITLE
[CI] Circumvent login keychain with envvars

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -143,6 +143,7 @@ stages:
     iOSDeviceDemand: 'xismoke-32'
     vsdropsPrefix: ${{ variables.vsdropsPrefix }}
     keyringPass: $(xma-password)
+    gitHubToken: ${{ variables["GitHub.Token"] }}
 
 - template: templates/devices/stage.yml
   parameters:
@@ -156,6 +157,7 @@ stages:
     iOSDeviceDemand: 'ios'
     vsdropsPrefix: ${{ variables.vsdropsPrefix }}
     keyringPass: $(xma-password)
+    gitHubToken: ${{ variables["GitHub.Token"] }}
 
 - template: templates/devices/stage.yml
   parameters:
@@ -169,6 +171,7 @@ stages:
     iOSDeviceDemand: 'tvos'
     vsdropsPrefix: ${{ variables.vsdropsPrefix }}
     keyringPass: $(xma-password)
+    gitHubToken: ${{ variables["GitHub.Token"] }}
 
 - template: templates/mac/stage.yml
   parameters:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -144,6 +144,7 @@ stages:
     vsdropsPrefix: ${{ variables.vsdropsPrefix }}
     keyringPass: $(xma-password)
     gitHubToken: ${{ variables['GitHub.Token'] }}
+    xqaCertPass: $(xqa--certificates--password)
 
 - template: templates/devices/stage.yml
   parameters:
@@ -158,6 +159,7 @@ stages:
     vsdropsPrefix: ${{ variables.vsdropsPrefix }}
     keyringPass: $(xma-password)
     gitHubToken: ${{ variables['GitHub.Token'] }}
+    xqaCertPass: $(xqa--certificates--password)
 
 - template: templates/devices/stage.yml
   parameters:
@@ -172,6 +174,7 @@ stages:
     vsdropsPrefix: ${{ variables.vsdropsPrefix }}
     keyringPass: $(xma-password)
     gitHubToken: ${{ variables['GitHub.Token'] }}
+    xqaCertPass: $(xqa--certificates--password)
 
 - template: templates/mac/stage.yml
   parameters:
@@ -192,7 +195,7 @@ stages:
   displayName: 'Sample testing'
   dependsOn:
   - build_packages
-  condition: and(succeeded(), contains (stageDependencies.build_packages.build.outputs['configuration.RunSampleTests'], 'True')) 
+  condition: and(succeeded(), contains (stageDependencies.build_packages.build.outputs['configuration.RunSampleTests'], 'True'))
   jobs:
   - job: sample_testing
     pool:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -143,7 +143,7 @@ stages:
     iOSDeviceDemand: 'xismoke-32'
     vsdropsPrefix: ${{ variables.vsdropsPrefix }}
     keyringPass: $(xma-password)
-    gitHubToken: ${{ variables["GitHub.Token"] }}
+    gitHubToken: ${{ variables['GitHub.Token'] }}
 
 - template: templates/devices/stage.yml
   parameters:
@@ -157,7 +157,7 @@ stages:
     iOSDeviceDemand: 'ios'
     vsdropsPrefix: ${{ variables.vsdropsPrefix }}
     keyringPass: $(xma-password)
-    gitHubToken: ${{ variables["GitHub.Token"] }}
+    gitHubToken: ${{ variables['GitHub.Token'] }}
 
 - template: templates/devices/stage.yml
   parameters:
@@ -171,7 +171,7 @@ stages:
     iOSDeviceDemand: 'tvos'
     vsdropsPrefix: ${{ variables.vsdropsPrefix }}
     keyringPass: $(xma-password)
-    gitHubToken: ${{ variables["GitHub.Token"] }}
+    gitHubToken: ${{ variables['GitHub.Token'] }}
 
 - template: templates/mac/stage.yml
   parameters:

--- a/tools/devops/automation/templates/devices/build.yml
+++ b/tools/devops/automation/templates/devices/build.yml
@@ -7,12 +7,12 @@
 parameters:
 
 - name: statusContext
-  type: string 
-  default: 'iOS Device Tests' # default context, since we started dealing with iOS devices. 
+  type: string
+  default: 'iOS Device Tests' # default context, since we started dealing with iOS devices.
 
 - name: testsLabels
-  type: string 
-  default: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests' # default context, since we started dealing with iOS devices. 
+  type: string
+  default: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests' # default context, since we started dealing with iOS devices.
 
 - name: disableProvisionatorCache
   type: boolean
@@ -23,7 +23,7 @@ parameters:
   default: false
 
 - name: useXamarinStorage
-  type: boolean 
+  type: boolean
   default: false  # xamarin-storage will disappear, so by default do not use it
 
 - name: vsdropsPrefix
@@ -34,10 +34,13 @@ parameters:
   type: string
 
 - name: devicePrefix
-  type: string 
+  type: string
   default: 'ios' # default context, since we started dealing with iOS devices.
-  
+
 - name: gitHubToken
+  type: string
+
+- name: xqaCertPass
   type: string
 
 steps:
@@ -123,11 +126,16 @@ steps:
     set -e
     rm -f ~/Library/Caches/com.xamarin.provisionator/Provisions/*p12
     rm -f ~/Library/Caches/com.xamarin.provisionator/Provisions/*mobileprovision
-    ./maccore/tools/install-qa-provisioning-profiles.sh -v 
+    ./maccore/tools/install-qa-provisioning-profiles.sh -v
   displayName: 'Add provisioning profiles'
   timeoutInMinutes: 30
   env:
     AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}
+    AUTH_TOKEN_LA_DEV_APPLE_P12: ${{ parameters.xqaCertPass }}
+    AUTH_TOKEN_LA_DISTR_APPLE_P12: ${{ parameters.xqaCertPass }}
+    AUTH_TOKEN_LA_MAC_INSTALLER_DISTR_P12: ${{ parameters.xqaCertPass }}
+    AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_P12: ${{ parameters.xqaCertPass }}
+    AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_2_P12: ${{ parameters.xqaCertPass }}
     LOGIN_KEYCHAIN_PASSWORD: ${{ parameters.keyringPass }}
 
 # download the artifacts.json, which will use to find the URI of the built pkg to later be installed by provisionator
@@ -174,7 +182,7 @@ steps:
 # remove any old processes that might have been left behind.
 - pwsh : |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/automation/scripts/System.psm1
-    Clear-XamarinProcesses 
+    Clear-XamarinProcesses
   displayName: 'Process cleanup'
 
 # Increase mlaunch verbosity. Will step on the old setting present.
@@ -182,19 +190,19 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/automation/scripts/MLaunch.psm1
     Set-MLaunchVerbosity -Verbosity 10
   displayName: 'Make mlaunch verbose'
-  condition: succeededOrFailed() # we do not care about the previous step 
+  condition: succeededOrFailed() # we do not care about the previous step
 
 # Re-start the daemon used to find the devices in the bot.
 - pwsh : |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/automation/scripts/MLaunch.psm1
-    Optimize-DeviceDiscovery 
+    Optimize-DeviceDiscovery
   displayName: 'Fix device discovery (reset launchctl)'
   condition: succeededOrFailed() # making mlaunch verbose should be a non blocker
 
-# Update the status to pending, that way the monitoring person knows that we started running the tests. Up to this 
+# Update the status to pending, that way the monitoring person knows that we started running the tests. Up to this
 # point we were just setting up the agent.
 - pwsh: |
-    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/automation/scripts/GitHub.psm1 
+    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/automation/scripts/GitHub.psm1
     Set-GitHubStatus -Status "pending" -Context "$Env:CONTEXT" -Description "Running device tests on $Env:CONTEXT"
   env:
     BUILD_REVISION: $(Build.SourceVersion)
@@ -226,7 +234,7 @@ steps:
       echo '##vso[task.setvariable variable=TESTS_JOBSTATUS;isOutput=true]Failed'
     fi
   env:
-    WORKING_DIR: $(System.DefaultWorkingDirectory) 
+    WORKING_DIR: $(System.DefaultWorkingDirectory)
     TESTS_EXTRA_ARGUMENTS: ${{ parameters.testsLabels }}
     USE_XAMARIN_STORAGE: ${{ parameters.useXamarinStorage }}
     VSDROPS_URI: '${{ parameters.vsdropsPrefix }}/$(Build.BuildNumber)/$(Build.BuildId)/${{ parameters.devicePrefix }};/tests/' # uri used to create the vsdrops index using full uri

--- a/tools/devops/automation/templates/devices/build.yml
+++ b/tools/devops/automation/templates/devices/build.yml
@@ -35,7 +35,10 @@ parameters:
 
 - name: devicePrefix
   type: string 
-  default: 'ios' # default context, since we started dealing with iOS devices. 
+  default: 'ios' # default context, since we started dealing with iOS devices.
+  
+- name: gitHubToken
+  type: string
 
 steps:
 
@@ -124,6 +127,7 @@ steps:
   displayName: 'Add provisioning profiles'
   timeoutInMinutes: 30
   env:
+    AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}
     LOGIN_KEYCHAIN_PASSWORD: ${{ parameters.keyringPass }}
 
 # download the artifacts.json, which will use to find the URI of the built pkg to later be installed by provisionator

--- a/tools/devops/automation/templates/devices/stage.yml
+++ b/tools/devops/automation/templates/devices/stage.yml
@@ -1,7 +1,7 @@
 # Main template that contains all the jobs that are required to run the device tests.
 #
 # The stage contains two different jobs
-# 
+#
 # tests: Runs the tests on a pool that contains devices that are capable to run them.
 # publish_html: Because vsdrop is not supported on macOS we have an extra job that
 #   will run on a pool with Windows devices that will publish the results on VSDrop to
@@ -11,13 +11,13 @@ parameters:
 
 # string that is used to identify the status to be used to expose the result on GitHub
 - name: statusContext
-  type: string 
-  default: 'iOS Device Tests' # default context, since we started dealing with iOS devices. 
+  type: string
+  default: 'iOS Device Tests' # default context, since we started dealing with iOS devices.
 
 # string that contains the extra labels to pass to xharness to select the tests to execute.
 - name: testsLabels
-  type: string 
-  default: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests' # default context, since we started dealing with iOS devices. 
+  type: string
+  default: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests' # default context, since we started dealing with iOS devices.
 
 # name of the pool that contains the iOS devices
 - name: iOSDevicePool
@@ -27,16 +27,16 @@ parameters:
 # demand that has to be matched by a bot to be able to run the tests.
 - name: iOSDeviceDemand
   type: string
-  default: 'xismoke' 
+  default: 'xismoke'
 
 - name: useXamarinStorage
   type: boolean
   default: false
 
-- name: vsdropsPrefix 
+- name: vsdropsPrefix
   type: string
 
-- name: stageName 
+- name: stageName
   type: string
 
 - name: keyringPass
@@ -48,8 +48,11 @@ parameters:
 - name: devicePrefix
   type: string
   default: 'ios' # default context, since we started dealing with iOS devices.
-  
+
 - name: gitHubToken
+  type: string
+
+- name: xqaCertPass
   type: string
 
 stages:
@@ -74,10 +77,11 @@ stages:
         testsLabels: ${{ parameters.testsLabels }}
         statusContext: ${{ parameters.statusContext }}
         useXamarinStorage: ${{ parameters.useXamarinStorage }}
-        vsdropsPrefix: ${{ parameters.vsdropsPrefix }} 
-        keyringPass: ${{ parameters.keyringPass }} 
+        vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
+        keyringPass: ${{ parameters.keyringPass }}
         devicePrefix: ${{ parameters.devicePrefix }}
         gitHubToken: ${{ parameters.gitHubToken }}
+        xqaCertPass: ${{ parameters.xqaCertPass }}
 
   - job: upload_vsdrops
     displayName: 'Upload report to vsdrops'
@@ -90,7 +94,7 @@ stages:
         clean: all
     steps:
     - template: ../common/upload-vsdrops.yml
-      parameters: 
+      parameters:
         devicePrefix: ${{ parameters.devicePrefix }}
 
   - job: upload_vsts_tests
@@ -104,7 +108,7 @@ stages:
         clean: all
     steps:
     - template: ../common/upload-vsts-tests.yml
-      parameters: 
+      parameters:
         devicePrefix: ${{ parameters.devicePrefix }}
 
   - job: publish_html
@@ -113,7 +117,7 @@ stages:
     dependsOn: # has to wait for the tests to be done AND the data to be uploaded
     - tests
     - upload_vsdrops
-    - upload_vsts_tests 
+    - upload_vsts_tests
     condition: succeededOrFailed()
     variables:
       # Define the variable FOO from the previous job
@@ -128,5 +132,5 @@ stages:
     - template: ../common/publish-html.yml
       parameters:
         statusContext: ${{ parameters.statusContext }}
-        vsdropsPrefix: ${{ parameters.vsdropsPrefix }} 
+        vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
         devicePrefix: ${{ parameters.devicePrefix }}

--- a/tools/devops/automation/templates/devices/stage.yml
+++ b/tools/devops/automation/templates/devices/stage.yml
@@ -47,7 +47,10 @@ parameters:
 
 - name: devicePrefix
   type: string
-  default: 'ios' # default context, since we started dealing with iOS devices. 
+  default: 'ios' # default context, since we started dealing with iOS devices.
+  
+- name: gitHubToken
+  type: string
 
 stages:
 - stage:
@@ -74,6 +77,7 @@ stages:
         vsdropsPrefix: ${{ parameters.vsdropsPrefix }} 
         keyringPass: ${{ parameters.keyringPass }} 
         devicePrefix: ${{ parameters.devicePrefix }}
+        gitHubToken: ${{ parameters.gitHubToken }}
 
   - job: upload_vsdrops
     displayName: 'Upload report to vsdrops'


### PR DESCRIPTION
Provisionator hits the login.keychain when looking for the github token credential used to download the provisioning profiles from dl.internalx.com during CI.

Provisionator first checks the environment before asking the keychain for the credential, so this change introduces the credential (backed by keyvault) as an envvar before invoking provisionator. 