### PR TITLE
[runtime] Always enable debugging in .NET/macOS and .NET/Mac Catalyst in debug versions of libxamarin.

### DIFF
--- a/runtime/monotouch-debug.m
+++ b/runtime/monotouch-debug.m
@@ -519,7 +519,7 @@ void monotouch_configure_debugging ()
 	NSDictionary *settings = [NSDictionary dictionaryWithContentsOfFile: root_plist];
 	NSArray *preferences = [settings objectForKey:@"PreferenceSpecifiers"];
 	NSMutableArray *hosts = [NSMutableArray array];
-	bool debug_enabled;
+	bool debug_enabled = true;
 	NSString *monodevelop_host;
 	NSString *monotouch_debug_enabled;
 
@@ -537,13 +537,15 @@ void monotouch_configure_debugging ()
 		return;
 	}
  
-	// If debugging is enabled
+ #if !(TARGET_OS_MACCATALYST || TARGET_OS_OSX)
+	// If debugging is enabled (only check for mobile builds - for macOS / Mac Catalyst debugging is always enabled in debug versions of libxamarin)
 	monotouch_debug_enabled = get_preference (preferences, NULL, @"__monotouch_debug_enabled"); 
 	if (monotouch_debug_enabled != nil) {
 		debug_enabled = [monotouch_debug_enabled isEqualToString:@"1"];
 	} else {
 		debug_enabled = [defaults boolForKey:@"__monotouch_debug_enabled"];
 	}
+#endif // !(TARGET_OS_MACCATALYST || TARGET_OS_OSX)
 
 #if TARGET_OS_WATCH && !TARGET_OS_SIMULATOR
 	if (debug_enabled) {


### PR DESCRIPTION
This makes it so that it's possible to attach to the debugger by setting the
\_\_XAMARIN_DEBUG_HOSTS\_\_/\_\_XAMARIN_DEBUG_PORT\_\_ environment variables, without
the need for enabling a setting somewhere else (like in
Settings.bundle/Root.plist on mobile devices).