### PR TITLE
[xcode12.5] [CI][VSTS] VSDrops urls are case-sensitive.

### DIFF
--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -64,7 +64,7 @@ steps:
     $gists["index"] = $url
 
     # similar dict but for the html links from vsdrops
-    $apiDiffRoot="$Env:VSDROPSPREFIX/$Env:BUILD_BUILDNUMBER/$Env:BUILD_BUILDID/APIDiff/;/"
+    $apiDiffRoot="$Env:VSDROPSPREFIX/$Env:BUILD_BUILDNUMBER/$Env:BUILD_BUILDID/apidiff/;/"
     $html =  @{
       "iOS" = $apiDiffRoot + "ios-api-diff.html"; 
       "macOS" = $apiDiffRoot + "mac-api-diff.html";


### PR DESCRIPTION
Example:

* Wrong - https://vsdrop.corp.microsoft.com/file/v1/xamarin-macios/device-tests/20210226.4/4505964/APIDiff/;/mac-api-diff.html
* Correct - https://vsdrop.corp.microsoft.com/file/v1/xamarin-macios/device-tests/20210226.4/4505964/apidiff/;/mac-api-diff.html


Backport of #10740
