### PR TITLE
[tests][intro] Run availability tests on properties too

### DIFF
--- a/src/Security/SslContext.cs
+++ b/src/Security/SslContext.cs
@@ -532,13 +532,10 @@ namespace Security {
 		}
 
 #if !WATCH
-		[iOS(9,0)][Mac (10,11)]
 		// TODO: Headers say /* Deprecated, does nothing */ but we are not completly sure about it since there is no deprecation macro
 		// Plus they added new members to SslSessionStrengthPolicy enum opened radar://23379052 https://trello.com/c/NbdTLVD3
 		// Xcode 8 beta 1: the P/Invoke was removed completely.
-		[Deprecated (PlatformName.iOS, 9, 2)]
 		[Unavailable (PlatformName.iOS, message : "'SetSessionStrengthPolicy' is not available anymore.")]
-		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Unavailable (PlatformName.MacOSX, message : "'SetSessionStrengthPolicy' is not available anymore.")]
 		[Obsolete ("'SetSessionStrengthPolicy' is not available anymore.")]
 		public SslStatus SetSessionStrengthPolicy (SslSessionStrengthPolicy policyStrength)

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -46,12 +46,11 @@ namespace Introspection {
 #elif __WATCHOS__
 			Platform = PlatformName.WatchOS;
 			Minimum = Xamarin.SdkVersions.MinWatchOSVersion;
-#else
+#elif MONOMAC
 			Platform = PlatformName.MacOSX;
 			Minimum = Xamarin.SdkVersions.MinOSXVersion;
-			// Need to special case macOS 'Maximum' version for OS minor subversions (can't change Constants.SdkVersion)
-			// Please comment the code below if needed
-			Maximum = new Version (11,1,0);
+#else
+			#error No Platform Defined
 #endif
 			Filter = (AvailabilityBaseAttribute arg) => {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != Platform);
@@ -114,6 +113,52 @@ namespace Introspection {
 			return false;
 		}
 
+		void CheckIntroduced (Type t, AvailabilityBaseAttribute ta, MemberInfo m)
+		{
+			var ma = CheckAvailability (m);
+			if (ta == null || ma == null)
+				return;
+
+			// need to skip members that are copied to satisfy interfaces (protocol members)
+			if (FoundInProtocols (m, t))
+				return;
+
+			// Duplicate checks, e.g. same attribute on member and type (extranous metadata)
+			if (ma.Version == ta.Version) {
+				switch (t.FullName) {
+				case "AppKit.INSAccessibility":
+					// special case for [I]NSAccessibility type (10.9) / protocol (10.10) mix up
+					// https://github.com/xamarin/xamarin-macios/issues/10009
+					// better some dupes than being inaccurate when protocol members are inlined
+					break;
+				default:
+					AddErrorLine ($"[FAIL] {ma.Version} ({m}) == {ta.Version} ({t})");
+					break;
+				}
+			}
+			// Consistency checks, e.g. member lower than type
+			// note: that's valid in some cases, like a new base type being introduced
+			if (ma.Version < ta.Version) {
+				switch (t.FullName) {
+				case "CoreBluetooth.CBPeer":
+					switch (m.ToString ()) {
+					// type added later and existing property was moved
+					case "Foundation.NSUuid get_Identifier()":
+					case "Foundation.NSUuid Identifier":
+						return;
+					}
+					break;
+				case "MetricKit.MXUnitAveragePixelLuminance":
+				case "MetricKit.MXUnitSignalBars":
+					// design bug wrt generics leading to redefinition of some members in subclasses
+					if (m.ToString () == "System.String Symbol")
+						return;
+					break;
+				}
+				AddErrorLine ($"[FAIL] {ma.Version} ({m}) < {ta.Version} ({t})");
+			}
+		}
+
 		[Test]
 		public void Introduced ()
 		{
@@ -123,51 +168,18 @@ namespace Introspection {
 				if (LogProgress)
 					Console.WriteLine ($"T: {t}");
 				var ta = CheckAvailability (t);
+
+				foreach (var p in t.GetProperties (BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public)) {
+					if (LogProgress)
+						Console.WriteLine ($"P: {p}");
+					CheckIntroduced (t, ta, p);
+				}
+
+				// this checks getter and setters which have copies of availability attributes (in legacy)
 				foreach (var m in t.GetMembers (BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public)) {
 					if (LogProgress)
 						Console.WriteLine ($"M: {m}");
-					var ma = CheckAvailability (m);
-					if (ta == null || ma == null)
-						continue;
-
-					// need to skip members that are copied to satisfy interfaces (protocol members)
-					if (FoundInProtocols (m, t))
-						continue;
-
-					// Duplicate checks, e.g. same attribute on member and type (extranous metadata)
-					if (ma.Version == ta.Version) {
-						switch (t.FullName) {
-						case "AppKit.INSAccessibility":
-							// special case for [I]NSAccessibility type (10.9) / protocol (10.10) mix up
-							// https://github.com/xamarin/xamarin-macios/issues/10009
-							// better some dupes than being inaccurate when protocol members are inlined
-							break;
-						default:
-							AddErrorLine ($"[FAIL] {ma.Version} ({m}) == {ta.Version} ({t})");
-							break;
-						}
-					}
-					// Consistency checks, e.g. member lower than type
-					// note: that's valid in some cases, like a new base type being introduced
-					if (ma.Version < ta.Version) {
-						switch (t.FullName) {
-						case "CoreBluetooth.CBPeer":
-							switch (m.ToString ()) {
-							// type added later and existing property was moved
-							case "Foundation.NSUuid get_Identifier()":
-							case "Foundation.NSUuid Identifier":
-								continue;
-							}
-							break;
-						case "MetricKit.MXUnitAveragePixelLuminance":
-						case "MetricKit.MXUnitSignalBars":
-							// design bug wrt generics leading to redefinition of some members in subclasses
-							if (m.ToString () == "System.String Symbol")
-								continue;
-							break;
-						}
-						AddErrorLine ($"[FAIL] {ma.Version} ({m}) < {ta.Version} ({t})");
-					}
+					CheckIntroduced (t, ta, m);
 				}
 			}
 			AssertIfErrors ("{0} API with unneeded or incorrect version information", Errors);
@@ -232,6 +244,17 @@ namespace Introspection {
 			return null;
 		}
 
+		void CheckUnavailable (Type t, bool typeUnavailable, MemberInfo m)
+		{
+			var ma = GetAvailable (m);
+			if (typeUnavailable && (ma != null))
+				AddErrorLine ($"[FAIL] {m} is marked with {ma} but the type {t.FullName} is [Unavailable ({Platform})].");
+
+			var mu = IsUnavailable (m);
+			if (mu && (ma != null))
+				AddErrorLine ($"[FAIL] {m} is marked both [Unavailable ({Platform})] and {ma}.");
+		}
+
 		[Test]
 		public void Unavailable ()
 		{
@@ -245,17 +268,16 @@ namespace Introspection {
 				if (tu && (ta != null))
 					AddErrorLine ($"[FAIL] {t.FullName} is marked both [Unavailable ({Platform})] and {ta}.");
 
+				foreach (var p in t.GetProperties (BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public)) {
+					if (LogProgress)
+						Console.WriteLine ($"P: {p}");
+					CheckUnavailable (t, tu, p);
+				}
+
 				foreach (var m in t.GetMembers (BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public)) {
 					if (LogProgress)
 						Console.WriteLine ($"M: {m}");
-
-					var ma = GetAvailable (t);
-					if (tu && (ma != null))
-						AddErrorLine ($"[FAIL] {m} is marked with {ma} but the type {t.FullName} is [Unavailable ({Platform})].");
-
-					var mu = IsUnavailable (t);
-					if (mu && (ma != null))
-						AddErrorLine ($"[FAIL] {m} is marked both [Unavailable ({Platform})] and {ma}.");
+					CheckUnavailable (t, tu, m);
 				}
 			}
 			AssertIfErrors ("{0} API with mixed [Unavailable] and availability attributes", Errors);


### PR DESCRIPTION
and not just methods even if we are generating them on both [1]

That spotted a single error inside `src/Security/SslContext.cs`
which this PR also fix. IOW there's no point in saying the API
was (a long time ago) available since our code to call it was
removed.

[1] which is something we should not need to do on .net since
* the compiler-based tooling does not need it on the getter/setter
* other tools needs to be updated (so it won't break any existing
  use case)