### PR TITLE
Use our [OBJC_]CFLAGS when compiling code for macOS.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -361,8 +361,8 @@ DEVICETV_OBJC_CFLAGS       = $(DEVICETV_CFLAGS) $(DEVICE_OBJC_CFLAGS)
 
 XAMARIN_MACOS_SDK = $(MAC_FRAMEWORK_CURRENT_DIR)/SDKs/Xamarin.macOS.sdk
 
-MAC_OBJC_CFLAGS=-ObjC++ -std=c++14 -fno-exceptions -Wall -DMONOMAC -DMIN_XM_MONO_VERSION=\"$(MIN_XM_MONO_VERSION)\"
-MAC_CFLAGS = -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -Wall -DMONOMAC -g -DMIN_XM_MONO_VERSION=\"$(MIN_XM_MONO_VERSION)\"
+MAC_OBJC_CFLAGS= -DMONOMAC -DMIN_XM_MONO_VERSION=\"$(MIN_XM_MONO_VERSION)\" $(CFLAGS) $(OBJC_CFLAGS)
+MAC_CFLAGS = -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -DMONOMAC -g -DMIN_XM_MONO_VERSION=\"$(MIN_XM_MONO_VERSION)\" $(CFLAGS)
 MAC_LDFLAGS = -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -framework AppKit
 
 # paths to the modules we depend on, as variables, so people can put

--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -185,7 +185,7 @@ get_mono_env_options (int *count)
 	if (n == 0)
 		return NULL;
 
-	argv = (char **) malloc (sizeof (char *) * (n + 1));
+	argv = (char **) malloc (sizeof (char *) * ((unsigned long) n + 1));
 	i = 0;
 
 	while (list != NULL) {
@@ -606,7 +606,7 @@ int xamarin_main (int argc, char **argv, enum XamarinLaunchMode launch_mode)
 		if (xamarin_mac_modern)
 			new_argc += 1;
 
-		char **new_argv = (char **) malloc (sizeof (char *) * (new_argc + 1 /* null terminated */));
+		char **new_argv = (char **) malloc (sizeof (char *) * ((unsigned long) new_argc + 1 /* null terminated */));
 		const char **ptr = (const char **) new_argv;
 		// binary
 		*ptr++ = argv [0];


### PR DESCRIPTION
This required fixing a couple of compiler warnings in code that's now compiled
with more warnings + warnings-as-errors enabled:

    launcher.m:188:48: error: implicit conversion changes signedness: 'int' to 'unsigned long' [-Werror,-Wsign-conversion]
            argv = (char **) malloc (sizeof (char *) * (n + 1));
                                                     ~  ~~^~~
    launcher.m:609:67: error: implicit conversion changes signedness: 'int' to 'unsigned long' [-Werror,-Wsign-conversion]
                    char **new_argv = (char **) malloc (sizeof (char *) * (new_argc + 1 /* null terminated */));
                                                                        ~  ~~~~~~~~~^~~

CFLAGS will:

* Enable all warnings (`-Wall`).
* Make all warnings errors.
* Enable a few more warnings not enabled with -Wall (`-Wconversion -Wdeprecated -Wuninitialized`).
* Enable strong stack protection (`-fstack-protector-strong`).
* Make it possible to use anonymous struct members (`-fms-extensions`). This is required to compile our ARM64-specific code for macOS (in a later PR).