### PR TITLE
Add a MarshalAs attribute to all boolean return types and parameters in P/Invokes.

### DIFF
--- a/src/AddressBook/ABAddressBook.cs
+++ b/src/AddressBook/ABAddressBook.cs
@@ -218,6 +218,7 @@ namespace AddressBook {
 		}
 
 		[DllImport (Constants.AddressBookLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool ABAddressBookHasUnsavedChanges (IntPtr addressBook);
 		public bool HasUnsavedChanges {
 			get {
@@ -227,6 +228,7 @@ namespace AddressBook {
 		}
 
 		[DllImport (Constants.AddressBookLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool ABAddressBookSave (IntPtr addressBook, out IntPtr error);
 		public void Save ()
 		{
@@ -245,6 +247,7 @@ namespace AddressBook {
 		}
 
 		[DllImport (Constants.AddressBookLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool ABAddressBookAddRecord (IntPtr addressBook, IntPtr record, out IntPtr error);
 		public void Add (ABRecord record)
 		{
@@ -259,6 +262,7 @@ namespace AddressBook {
 		}
 
 		[DllImport (Constants.AddressBookLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool ABAddressBookRemoveRecord (IntPtr addressBook, IntPtr record, out IntPtr error);
 		public void Remove (ABRecord record)
 		{

--- a/src/AddressBook/ABGroup.cs
+++ b/src/AddressBook/ABGroup.cs
@@ -109,6 +109,7 @@ namespace AddressBook {
 		}
 
 		[DllImport (Constants.AddressBookLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool ABGroupAddMember (IntPtr group, IntPtr person, out IntPtr error);
 		public void Add (ABRecord person)
 		{
@@ -150,6 +151,7 @@ namespace AddressBook {
 		}
 
 		[DllImport (Constants.AddressBookLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool ABGroupRemoveMember (IntPtr group, IntPtr member, out IntPtr error);
 		public void Remove (ABRecord member)
 		{

--- a/src/AddressBook/ABMultiValue.cs
+++ b/src/AddressBook/ABMultiValue.cs
@@ -75,18 +75,23 @@ namespace AddressBook {
 		public static extern IntPtr CreateMutableCopy (IntPtr multiValue);
 
 		[DllImport (Constants.AddressBookLibrary, EntryPoint="ABMultiValueAddValueAndLabel")]
+		[return: MarshalAs (UnmanagedType.I1)]
 		public static extern bool AddValueAndLabel (IntPtr multiValue, IntPtr value, IntPtr label, out int /* int32_t */ outIdentifier);
 
 		[DllImport (Constants.AddressBookLibrary, EntryPoint="ABMultiValueReplaceValueAtIndex")]
+		[return: MarshalAs (UnmanagedType.I1)]
 		public static extern bool ReplaceValueAtIndex (IntPtr multiValue, IntPtr value, nint index);
 
 		[DllImport (Constants.AddressBookLibrary, EntryPoint="ABMultiValueReplaceLabelAtIndex")]
+		[return: MarshalAs (UnmanagedType.I1)]
 		public static extern bool ReplaceLabelAtIndex (IntPtr multiValue, IntPtr value, nint index);
 
 		[DllImport (Constants.AddressBookLibrary, EntryPoint="ABMultiValueInsertValueAndLabelAtIndex")]
+		[return: MarshalAs (UnmanagedType.I1)]
 		public static extern bool InsertValueAndLabelAtIndex (IntPtr multiValue, IntPtr value, IntPtr label, nint index, out int /* int32_t */ outIdentifier);
 
 		[DllImport (Constants.AddressBookLibrary, EntryPoint="ABMultiValueRemoveValueAndLabelAtIndex")]
+		[return: MarshalAs (UnmanagedType.I1)]
 		public static extern bool RemoveValueAndLabelAtIndex (IntPtr multiValue, nint index);
 
 		public static IntPtr ToIntPtr (NSObject value)

--- a/src/AddressBook/ABPerson.cs
+++ b/src/AddressBook/ABPerson.cs
@@ -525,6 +525,7 @@ namespace AddressBook {
 		}
 
 		[DllImport (Constants.AddressBookLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool ABPersonSetImageData (IntPtr person, IntPtr imageData, out IntPtr error);
 		[DllImport (Constants.AddressBookLibrary)]
 		extern static IntPtr ABPersonCopyImageData (IntPtr person);
@@ -539,12 +540,14 @@ namespace AddressBook {
 		}
 
 		[DllImport (Constants.AddressBookLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool ABPersonHasImageData (IntPtr person);
 		public bool HasImage {
 			get {return ABPersonHasImageData (Handle);}
 		}
 
 		[DllImport (Constants.AddressBookLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool ABPersonRemoveImageData (IntPtr person, out IntPtr error);
 		public void RemoveImage ()
 		{

--- a/src/AddressBook/ABRecord.cs
+++ b/src/AddressBook/ABRecord.cs
@@ -150,6 +150,7 @@ namespace AddressBook {
 		// TODO: Should SetValue/CopyValue/RemoveValue be public?
 
 		[DllImport (Constants.AddressBookLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool ABRecordSetValue (IntPtr record, int /* ABPropertyID = int32_t */ property, IntPtr value, out IntPtr error);
 		internal void SetValue (int property, IntPtr value)
 		{
@@ -177,6 +178,7 @@ namespace AddressBook {
 		}
 
 		[DllImport (Constants.AddressBookLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool ABRecordRemoveValue (IntPtr record, int /* ABPropertyID = int32_t */ property, out IntPtr error);
 		internal void RemoveValue (int property)
 		{

--- a/src/AddressBookUI/ABAddressFormatting.cs
+++ b/src/AddressBookUI/ABAddressFormatting.cs
@@ -20,7 +20,7 @@ namespace AddressBookUI {
 	static public class ABAddressFormatting {
 		
 		[DllImport (Constants.AddressBookUILibrary)]
-		static extern IntPtr /* NSString */ ABCreateStringWithAddressDictionary (IntPtr /* NSDictionary */ address, bool addCountryName);
+		static extern IntPtr /* NSString */ ABCreateStringWithAddressDictionary (IntPtr /* NSDictionary */ address, [MarshalAs (UnmanagedType.I1)] bool addCountryName);
 		
 		static public string ToString (NSDictionary address, bool addCountryName)
 		{

--- a/src/AppKit/NSAccessibility.cs
+++ b/src/AppKit/NSAccessibility.cs
@@ -222,7 +222,8 @@ namespace AppKit
 		}
 
 		[DllImport (Constants.AppKitLibrary)]
-		static extern bool NSAccessibilitySetMayContainProtectedContent (bool flag);
+		[return: MarshalAs (UnmanagedType.I1)]
+		static extern bool NSAccessibilitySetMayContainProtectedContent ([MarshalAs (UnmanagedType.I1)] bool flag);
 
 		public static bool SetMayContainProtectedContent (bool flag)
 		{

--- a/src/AppKit/NSCell.cs
+++ b/src/AppKit/NSCell.cs
@@ -37,7 +37,7 @@ namespace AppKit {
 		[DllImport (Constants.AppKitLibrary)]
 		extern static void NSDrawThreePartImage (CGRect rect,
 			IntPtr /* NSImage* */ startCap, IntPtr /* NSImage* */ centerFill, IntPtr /* NSImage* */ endCap,
-			bool vertial, nint op, nfloat alphaFraction, bool flipped);
+			[MarshalAs (UnmanagedType.I1)] bool vertial, nint op, nfloat alphaFraction, [MarshalAs (UnmanagedType.I1)] bool flipped);
 		
 		public void DrawThreePartImage (CGRect frame,
 			NSImage startCap, NSImage centerFill, NSImage endCap,
@@ -55,7 +55,7 @@ namespace AppKit {
 			IntPtr /* NSImage* */ topLeftCorner, IntPtr /* NSImage* */ topEdgeFill, IntPtr /* NSImage* */ topRightCorner,
 			IntPtr /* NSImage* */ leftEdgeFill, IntPtr /* NSImage* */ centerFill, IntPtr /* NSImage* */ rightEdgeFill,
 			IntPtr /* NSImage* */ bottomLeftCorner, IntPtr /* NSImage* */ bottomEdgeFill, IntPtr /* NSImage* */ bottomRightCnint,
-			nint op, nfloat alphaFraction, bool flipped);
+			nint op, nfloat alphaFraction, [MarshalAs (UnmanagedType.I1)] bool flipped);
 
 		public void DrawNinePartImage (CGRect frame,
 			NSImage topLeftCorner, NSImage topEdgeFill, NSImage topRightCorner,

--- a/src/AppKit/NSGraphics.cs
+++ b/src/AppKit/NSGraphics.cs
@@ -35,9 +35,9 @@ namespace AppKit {
 		public static readonly float DarkGray = (float) 1/3.0f;
 		
 		[DllImport (Constants.AppKitLibrary)]
-		extern static NSWindowDepth NSBestDepth (IntPtr colorspaceHandle, nint bitsPerSample, nint bitsPerPixel, bool planar, ref bool exactMatch);
+		extern static NSWindowDepth NSBestDepth (IntPtr colorspaceHandle, nint bitsPerSample, nint bitsPerPixel, [MarshalAs (UnmanagedType.I1)] bool planar, [MarshalAs (UnmanagedType.I1)] ref bool exactMatch);
 		
-		public static NSWindowDepth BestDepth (NSString colorspace, nint bitsPerSample, nint bitsPerPixel, bool planar, ref bool exactMatch)
+		public static NSWindowDepth BestDepth (NSString colorspace, nint bitsPerSample, nint bitsPerPixel, [MarshalAs (UnmanagedType.I1)] bool planar, [MarshalAs (UnmanagedType.I1)] ref bool exactMatch)
 		{
 			if (colorspace == null)
 				throw new ArgumentNullException ("colorspace");
@@ -46,6 +46,7 @@ namespace AppKit {
 		}
 
 		[DllImport (Constants.AppKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool NSPlanarFromDepth (NSWindowDepth depth);
 		
 		public static bool PlanarFromDepth (NSWindowDepth depth)

--- a/src/AudioToolbox/AudioConverter.cs
+++ b/src/AudioToolbox/AudioConverter.cs
@@ -737,7 +737,7 @@ namespace AudioToolbox
 
 		[DllImport (Constants.AudioToolboxLibrary)]
 		static extern AudioConverterError AudioConverterGetPropertyInfo (IntPtr inAudioConverter, AudioConverterPropertyID inPropertyID,
-			out int outSize, out bool outWritable);
+			out int outSize, [MarshalAs (UnmanagedType.I1)] out bool outWritable);
 
 		[DllImport (Constants.AudioToolboxLibrary)]
 		static extern AudioConverterError AudioConverterSetProperty (IntPtr inAudioConverter, AudioConverterPropertyID inPropertyID,

--- a/src/AudioToolbox/AudioFile.cs
+++ b/src/AudioToolbox/AudioFile.cs
@@ -688,7 +688,7 @@ namespace AudioToolbox {
 		}
 
 		[DllImport (Constants.AudioToolboxLibrary)]
-		extern static OSStatus AudioFileReadBytes (AudioFileID inAudioFile, bool useCache, long startingByte, ref int numBytes, IntPtr outBuffer);
+		extern static OSStatus AudioFileReadBytes (AudioFileID inAudioFile, [MarshalAs (UnmanagedType.I1)] bool useCache, long startingByte, ref int numBytes, IntPtr outBuffer);
 
 		public int Read (long startingByte, byte [] buffer, int offset, int count, bool useCache)
 		{
@@ -721,7 +721,7 @@ namespace AudioToolbox {
 		}
 		
 		[DllImport (Constants.AudioToolboxLibrary)]
-		extern static OSStatus AudioFileWriteBytes (AudioFileID audioFile, bool useCache, long startingByte, ref int numBytes, IntPtr buffer);
+		extern static OSStatus AudioFileWriteBytes (AudioFileID audioFile, [MarshalAs (UnmanagedType.I1)] bool useCache, long startingByte, ref int numBytes, IntPtr buffer);
 
 		public int Write (long startingByte, byte [] buffer, int offset, int count, bool useCache)
 		{
@@ -764,7 +764,7 @@ namespace AudioToolbox {
 		
 		[DllImport (Constants.AudioToolboxLibrary)]
 		unsafe extern static OSStatus AudioFileReadPacketData (
-			AudioFileID audioFile, bool useCache, ref int numBytes, 
+			AudioFileID audioFile, [MarshalAs (UnmanagedType.I1)] bool useCache, ref int numBytes, 
 			AudioStreamPacketDescription [] packetDescriptions, long inStartingPacket, ref int numPackets, IntPtr outBuffer);
 
 		public AudioStreamPacketDescription [] ReadPacketData (long inStartingPacket, int nPackets, byte [] buffer)
@@ -942,7 +942,7 @@ namespace AudioToolbox {
 
 		[DllImport (Constants.AudioToolboxLibrary)]
 		extern static AudioFileError AudioFileWritePackets (
-			AudioFileID audioFile, bool useCache, int inNumBytes, AudioStreamPacketDescription [] inPacketDescriptions,
+			AudioFileID audioFile, [MarshalAs (UnmanagedType.I1)] bool useCache, int inNumBytes, AudioStreamPacketDescription [] inPacketDescriptions,
                         long inStartingPacket, ref int numPackets, IntPtr buffer);
 
 		public int WritePackets (bool useCache, long startingPacket, int numPackets, IntPtr buffer, int byteCount)

--- a/src/AudioToolbox/AudioQueue.cs
+++ b/src/AudioToolbox/AudioQueue.cs
@@ -366,7 +366,7 @@ namespace AudioToolbox {
 		}
 		
 		[DllImport (Constants.AudioToolboxLibrary)]
-		extern static OSStatus AudioQueueDispose (IntPtr AQ, bool immediate);
+		extern static OSStatus AudioQueueDispose (IntPtr AQ, [MarshalAs (UnmanagedType.I1)] bool immediate);
 
 		protected virtual void Dispose (bool disposing)
 		{
@@ -423,7 +423,7 @@ namespace AudioToolbox {
 		}
 
 		[DllImport (Constants.AudioToolboxLibrary)]
-		extern static AudioQueueStatus AudioQueueStop (IntPtr aq, bool immediate);
+		extern static AudioQueueStatus AudioQueueStop (IntPtr aq, [MarshalAs (UnmanagedType.I1)] bool immediate);
 		public AudioQueueStatus Stop (bool immediate)
 		{
 			return AudioQueueStop (handle, immediate);
@@ -622,7 +622,7 @@ namespace AudioToolbox {
 		}
 		
 		[DllImport (Constants.AudioToolboxLibrary)]
-		extern static AudioQueueStatus AudioQueueGetCurrentTime (IntPtr AQ, IntPtr timelineHandle, ref AudioTimeStamp time, ref bool discontinuty);
+		extern static AudioQueueStatus AudioQueueGetCurrentTime (IntPtr AQ, IntPtr timelineHandle, ref AudioTimeStamp time, [MarshalAs (UnmanagedType.I1)] ref bool discontinuty);
 
 		public AudioQueueStatus GetCurrentTime (AudioQueueTimeline timeline, ref AudioTimeStamp time, ref bool timelineDiscontinuty)
 		{

--- a/src/AudioToolbox/MusicPlayer.cs
+++ b/src/AudioToolbox/MusicPlayer.cs
@@ -170,7 +170,7 @@ namespace AudioToolbox {
 		}
 
 		[DllImport (Constants.AudioToolboxLibrary)]
-		extern static /* OSStatus */ MusicPlayerStatus MusicPlayerIsPlaying (/* MusicPlayer */ IntPtr inPlayer, /* Boolean* */ out bool outIsPlaying);
+		extern static /* OSStatus */ MusicPlayerStatus MusicPlayerIsPlaying (/* MusicPlayer */ IntPtr inPlayer, /* Boolean* */ [MarshalAs (UnmanagedType.I1)] out bool outIsPlaying);
 
 		public bool IsPlaying {
 			get {

--- a/src/AudioUnit/AUGraph.cs
+++ b/src/AudioUnit/AUGraph.cs
@@ -465,13 +465,13 @@ namespace AudioUnit
 		static extern int /* OSStatus */ DisposeAUGraph(IntPtr inGraph);
 
 		[DllImport(Constants.AudioToolboxLibrary)]
-		static extern AUGraphError AUGraphIsOpen (IntPtr inGraph, out bool outIsOpen);
+		static extern AUGraphError AUGraphIsOpen (IntPtr inGraph, [MarshalAs (UnmanagedType.I1)] out bool outIsOpen);
 
 		[DllImport(Constants.AudioToolboxLibrary)]
-		static extern AUGraphError AUGraphIsInitialized (IntPtr inGraph, out bool outIsInitialized);
+		static extern AUGraphError AUGraphIsInitialized (IntPtr inGraph, [MarshalAs (UnmanagedType.I1)] out bool outIsInitialized);
 
 		[DllImport(Constants.AudioToolboxLibrary)]
-		static extern AUGraphError AUGraphIsRunning (IntPtr inGraph, out bool outIsRunning);
+		static extern AUGraphError AUGraphIsRunning (IntPtr inGraph, [MarshalAs (UnmanagedType.I1)] out bool outIsRunning);
 
 		[DllImport(Constants.AudioToolboxLibrary)]
 		static extern AUGraphError AUGraphGetCPULoad (IntPtr inGraph, out float /* Float32* */ outAverageCPULoad);
@@ -483,7 +483,7 @@ namespace AudioUnit
 		static extern AUGraphError AUGraphSetNodeInputCallback (IntPtr inGraph, int /* AUNode = SInt32 */ inDestNode, uint /* UInt32 */ inDestInputNumber, ref AURenderCallbackStruct inInputCallback);
 
 		[DllImport(Constants.AudioToolboxLibrary)]
-		static extern AUGraphError AUGraphUpdate (IntPtr inGraph, out bool outIsUpdated);
+		static extern AUGraphError AUGraphUpdate (IntPtr inGraph, [MarshalAs (UnmanagedType.I1)] out bool outIsUpdated);
 
 		[DllImport(Constants.AudioToolboxLibrary)]
 		static extern void CAShow (IntPtr handle);

--- a/src/AudioUnit/ExtAudioFile.cs
+++ b/src/AudioUnit/ExtAudioFile.cs
@@ -367,7 +367,7 @@ namespace AudioUnit
         static extern ExtAudioFileError ExtAudioFileOpenUrl (IntPtr inUrl, out IntPtr outExtAudioFile);
 
         [DllImport (Constants.AudioToolboxLibrary)]
-        static extern ExtAudioFileError ExtAudioFileWrapAudioFileID (IntPtr inFileID, bool inForWriting, IntPtr outExtAudioFile);    
+        static extern ExtAudioFileError ExtAudioFileWrapAudioFileID (IntPtr inFileID, [MarshalAs (UnmanagedType.I1)] bool inForWriting, IntPtr outExtAudioFile);    
 
         [DllImport(Constants.AudioToolboxLibrary)]
 		static extern ExtAudioFileError ExtAudioFileRead (IntPtr inExtAudioFile, ref uint /* UInt32* */ ioNumberFrames, IntPtr ioData);

--- a/src/CFNetwork/CFHTTPAuthentication.cs
+++ b/src/CFNetwork/CFHTTPAuthentication.cs
@@ -90,6 +90,7 @@ namespace CoreServices {
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CFHTTPAuthenticationIsValid (/* CFHTTPAuthenticationRef */ IntPtr auth, /* CFStreamError* */ IntPtr error);
 
 		public bool IsValid {
@@ -97,6 +98,7 @@ namespace CoreServices {
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CFHTTPAuthenticationAppliesToRequest (/* CFHTTPAuthenticationRef */ IntPtr auth, /* CFHTTPMessageRef */ IntPtr request);
 
 		public bool AppliesToRequest (CFHTTPMessage request)
@@ -111,6 +113,7 @@ namespace CoreServices {
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CFHTTPAuthenticationRequiresAccountDomain (/* CFHTTPAuthenticationRef */ IntPtr auth);
 
 		public bool RequiresAccountDomain {
@@ -118,6 +121,7 @@ namespace CoreServices {
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CFHTTPAuthenticationRequiresOrderedRequests (/* CFHTTPAuthenticationRef */ IntPtr auth);
 
 		public bool RequiresOrderedRequests {
@@ -125,6 +129,7 @@ namespace CoreServices {
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CFHTTPAuthenticationRequiresUserNameAndPassword (/* CFHTTPAuthenticationRef */ IntPtr auth);
 
 		public bool RequiresUserNameAndPassword {

--- a/src/CFNetwork/CFHTTPMessage.cs
+++ b/src/CFNetwork/CFHTTPMessage.cs
@@ -108,7 +108,7 @@ namespace CoreServices {
 
 		[DllImport (Constants.CFNetworkLibrary)]
 		extern static /* CFHTTPMessageRef __nonnull */ IntPtr CFHTTPMessageCreateEmpty (
-			/* CFAllocatorRef __nullable */ IntPtr alloc, /* Boolean */ bool isRequest);
+			/* CFAllocatorRef __nullable */ IntPtr alloc, /* Boolean */ [MarshalAs (UnmanagedType.I1)] bool isRequest);
 
 		public static CFHTTPMessage CreateEmpty (bool request)
 		{
@@ -164,6 +164,7 @@ namespace CoreServices {
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CFHTTPMessageIsRequest (/* CFHTTPMessageRef __nonnull */ IntPtr message);
 
 		public bool IsRequest {
@@ -224,6 +225,7 @@ namespace CoreServices {
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CFHTTPMessageIsHeaderComplete (
 			/* CFHTTPMessageRef __nonnull */ IntPtr message);
 
@@ -235,6 +237,7 @@ namespace CoreServices {
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CFHTTPMessageAppendBytes (
 			/* CFHTTPMessageRef __nonnull */ IntPtr message,
 			/* const UInt8* __nonnull */ byte[] newBytes, /* CFIndex */ nint numBytes);
@@ -295,6 +298,7 @@ namespace CoreServices {
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CFHTTPMessageApplyCredentials (/* CFHTTPMessageRef */ IntPtr request, 
 			/* CFHTTPAuthenticationRef */ IntPtr auth, /* CFString */ IntPtr username, /* CFString */ IntPtr password,
 			/* CFStreamError* */ out CFStreamError error);
@@ -365,13 +369,14 @@ namespace CoreServices {
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CFHTTPMessageAddAuthentication (
 			/* CFHTTPMessageRef __nonnull */ IntPtr request, 
 			/* CFHTTPMessageRef __nullable */ IntPtr authenticationFailureResponse,
 			/* CFStringRef __nonnull */ IntPtr username, 
 			/* CFStringRef __nonnull */ IntPtr password,
 			/* CFStringRef __nullable */ IntPtr authenticationScheme,
-			/* Boolean */ bool forProxy);
+			/* Boolean */ [MarshalAs (UnmanagedType.I1)] bool forProxy);
 
 		public bool AddAuthentication (CFHTTPMessage failureResponse, NSString username,
 		                               NSString password, AuthenticationScheme scheme,
@@ -388,6 +393,7 @@ namespace CoreServices {
 		}
 
 		[DllImport (Constants.CFNetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CFHTTPMessageApplyCredentialDictionary (/* CFHTTPMessageRef */ IntPtr request, 
 			/* CFHTTPAuthenticationRef */ IntPtr auth, /* CFDictionaryRef */ IntPtr dict, /* CFStreamError* */ out CFStreamError error);
 

--- a/src/CoreAnimation/CATransform3D.cs
+++ b/src/CoreAnimation/CATransform3D.cs
@@ -37,6 +37,7 @@ namespace CoreAnimation {
 		}
 		
 		[DllImport(Constants.QuartzLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CATransform3DIsIdentity (CATransform3D t);
 
 		public bool IsIdentity {
@@ -46,6 +47,7 @@ namespace CoreAnimation {
 		}
 
 		[DllImport(Constants.QuartzLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CATransform3DEqualToTransform (CATransform3D a, CATransform3D b);
 
 		public bool Equals (CATransform3D other)
@@ -160,6 +162,7 @@ namespace CoreAnimation {
 		
 
 		[DllImport(Constants.QuartzLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CATransform3DIsAffine (CATransform3D t);
 
 		public bool IsAffine {

--- a/src/CoreFoundation/CFBundle.cs
+++ b/src/CoreFoundation/CFBundle.cs
@@ -154,6 +154,7 @@ namespace CoreFoundation {
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CFBundleIsExecutableLoaded (IntPtr bundle);
 		
 		public bool HasLoadedExecutable {
@@ -161,6 +162,7 @@ namespace CoreFoundation {
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CFBundlePreflightExecutable (IntPtr bundle, out IntPtr error);
 		
 		public bool PreflightExecutable (out NSError error)
@@ -173,6 +175,7 @@ namespace CoreFoundation {
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CFBundleLoadExecutableAndReturnError (IntPtr bundle, out IntPtr error);
 		
 		public bool LoadExecutable (out NSError error)

--- a/src/CoreFoundation/CFDictionary.cs
+++ b/src/CoreFoundation/CFDictionary.cs
@@ -194,12 +194,15 @@ namespace CoreFoundation {
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		internal static extern bool CFNumberGetValue (IntPtr number, nint theType, out int value);
 
 		[DllImport (Constants.CoreFoundationLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		internal static extern bool CFNumberGetValue (IntPtr number, nint theType, out long value);
 
 		[DllImport (Constants.CoreFoundationLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CFDictionaryContainsKey (IntPtr theDict, IntPtr key);
 	}
 

--- a/src/CoreFoundation/CFMachPort.cs
+++ b/src/CoreFoundation/CFMachPort.cs
@@ -93,6 +93,7 @@ namespace CoreFoundation
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CFMachPortIsValid (IntPtr handle);
 		public bool IsValid { 
 			get {

--- a/src/CoreFoundation/CFPreferences.cs
+++ b/src/CoreFoundation/CFPreferences.cs
@@ -155,6 +155,7 @@ namespace CoreFoundation
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CFPreferencesGetAppBooleanValue (IntPtr key, IntPtr applicationId,
 			/*out bool*/ IntPtr keyExistsAndHasValidFormat);
 
@@ -285,6 +286,7 @@ namespace CoreFoundation
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CFPreferencesAppSynchronize (IntPtr applicationId);
 
 		public static bool AppSynchronize ()
@@ -313,6 +315,7 @@ namespace CoreFoundation
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CFPreferencesAppValueIsForced (IntPtr key, IntPtr applicationId);
 
 		public static bool AppValueIsForced (string key)

--- a/src/CoreFoundation/CFPropertyList.cs
+++ b/src/CoreFoundation/CFPropertyList.cs
@@ -88,6 +88,7 @@ namespace CoreFoundation
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CFPropertyListIsValid (IntPtr plist, nint format);
 
 		public bool IsValid (CFPropertyListFormat format)

--- a/src/CoreFoundation/CFType.cs
+++ b/src/CoreFoundation/CFType.cs
@@ -23,6 +23,7 @@ namespace CoreFoundation {
 		}
 		
 		[DllImport (Constants.CoreFoundationLibrary, EntryPoint="CFEqual")]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CFEqual (/*CFTypeRef*/ IntPtr cf1, /*CFTypeRef*/ IntPtr cf2);
 
 		public static bool Equal (IntPtr cf1, IntPtr cf2)

--- a/src/CoreGraphics/CGColor.cs
+++ b/src/CoreGraphics/CGColor.cs
@@ -169,6 +169,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport(Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGColorEqualToColor (/* CGColorRef */ IntPtr color1, /* CGColorRef */ IntPtr color2);
 
 		public static bool operator == (CGColor color1, CGColor color2)

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -486,6 +486,7 @@ namespace CoreGraphics {
 		[Watch (3,0)]
 		[TV (10,0)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CGColorSpaceIsWideGamutRGB (/* CGColorSpaceRef */ IntPtr space);
 
 		[iOS (10,0)][Mac (10,12)]
@@ -500,6 +501,7 @@ namespace CoreGraphics {
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10,0)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CGColorSpaceSupportsOutput (/* CGColorSpaceRef */ IntPtr space);
 
 		[iOS (10,0)][Mac (10,12)]
@@ -535,6 +537,7 @@ namespace CoreGraphics {
 		[Deprecated (PlatformName.TvOS, 13,4)]
 		[Deprecated (PlatformName.WatchOS, 6,2)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CGColorSpaceIsHDR (/* CGColorSpaceRef */ IntPtr space);
 
 		[Mac (10,15)][iOS(13,0)]
@@ -551,6 +554,7 @@ namespace CoreGraphics {
 
 		[iOS (14,0)][TV (14,0)][Watch (7,0)][Mac (11,0)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CGColorSpaceUsesExtendedRange (/* CGColorSpaceRef */ IntPtr space);
 
 		[iOS (14,0)][TV (14,0)][Watch (7,0)][Mac (11,0)]
@@ -562,6 +566,7 @@ namespace CoreGraphics {
 
 		[iOS (14,1), TV (14,2), Watch (7,1), Mac (11,0)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CGColorSpaceUsesITUR_2100TF (/* CGColorSpaceRef */ IntPtr space);
 
 		[iOS (14,1), TV (14,2), Watch (7,1), Mac (11,0)]

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -347,6 +347,7 @@ namespace CoreGraphics {
 
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGContextIsPathEmpty (/* CGContextRef */ IntPtr context);
 
 		public bool IsPathEmpty ()
@@ -371,6 +372,7 @@ namespace CoreGraphics {
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGContextPathContainsPoint (/* CGContextRef */ IntPtr context, CGPoint point, CGPathDrawingMode mode);
 
 		public bool PathContainsPoint (CGPoint point, CGPathDrawingMode mode)
@@ -1038,7 +1040,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextSetShouldAntialias (/* CGContextRef */ IntPtr context, bool shouldAntialias);
+		extern static void CGContextSetShouldAntialias (/* CGContextRef */ IntPtr context, [MarshalAs (UnmanagedType.I1)] bool shouldAntialias);
 
 		public void SetShouldAntialias (bool shouldAntialias)
 		{
@@ -1046,14 +1048,14 @@ namespace CoreGraphics {
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextSetAllowsAntialiasing (/* CGContextRef */ IntPtr context, bool allowsAntialiasing);
+		extern static void CGContextSetAllowsAntialiasing (/* CGContextRef */ IntPtr context, [MarshalAs (UnmanagedType.I1)] bool allowsAntialiasing);
 		public void SetAllowsAntialiasing (bool allowsAntialiasing)
 		{
 			CGContextSetAllowsAntialiasing (handle, allowsAntialiasing);
 		}
 			
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextSetShouldSmoothFonts (/* CGContextRef */ IntPtr context, bool shouldSmoothFonts);
+		extern static void CGContextSetShouldSmoothFonts (/* CGContextRef */ IntPtr context, [MarshalAs (UnmanagedType.I1)] bool shouldSmoothFonts);
 
 		public void SetShouldSmoothFonts (bool shouldSmoothFonts)
 		{
@@ -1147,7 +1149,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextSetAllowsFontSmoothing (/* CGContextRef */ IntPtr context, bool shouldSubpixelPositionFonts);
+		extern static void CGContextSetAllowsFontSmoothing (/* CGContextRef */ IntPtr context, [MarshalAs (UnmanagedType.I1)] bool shouldSubpixelPositionFonts);
 
 		public void SetAllowsFontSmoothing (bool allows)
 		{
@@ -1155,7 +1157,7 @@ namespace CoreGraphics {
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextSetAllowsFontSubpixelPositioning (/* CGContextRef */ IntPtr context, bool allowsFontSubpixelPositioning);
+		extern static void CGContextSetAllowsFontSubpixelPositioning (/* CGContextRef */ IntPtr context, [MarshalAs (UnmanagedType.I1)] bool allowsFontSubpixelPositioning);
 
 		public void SetAllowsSubpixelPositioning (bool allows)
 		{
@@ -1163,7 +1165,7 @@ namespace CoreGraphics {
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextSetAllowsFontSubpixelQuantization (/* CGContextRef */ IntPtr context, bool shouldSubpixelQuantizeFonts);
+		extern static void CGContextSetAllowsFontSubpixelQuantization (/* CGContextRef */ IntPtr context, [MarshalAs (UnmanagedType.I1)] bool shouldSubpixelQuantizeFonts);
 
 		public void SetAllowsFontSubpixelQuantization (bool allows)
 		{
@@ -1171,7 +1173,7 @@ namespace CoreGraphics {
 		}
 			
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextSetShouldSubpixelPositionFonts (/* CGContextRef */ IntPtr context, bool shouldSubpixelPositionFonts);
+		extern static void CGContextSetShouldSubpixelPositionFonts (/* CGContextRef */ IntPtr context, [MarshalAs (UnmanagedType.I1)] bool shouldSubpixelPositionFonts);
 
 		public void SetShouldSubpixelPositionFonts (bool shouldSubpixelPositionFonts)
 		{
@@ -1179,7 +1181,7 @@ namespace CoreGraphics {
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextSetShouldSubpixelQuantizeFonts (/* CGContextRef */ IntPtr context, bool shouldSubpixelQuantizeFonts);
+		extern static void CGContextSetShouldSubpixelQuantizeFonts (/* CGContextRef */ IntPtr context, [MarshalAs (UnmanagedType.I1)] bool shouldSubpixelQuantizeFonts);
 
 		public void ShouldSubpixelQuantizeFonts (bool shouldSubpixelQuantizeFonts)
 		{

--- a/src/CoreGraphics/CGDisplay.cs
+++ b/src/CoreGraphics/CGDisplay.cs
@@ -72,6 +72,7 @@ namespace CoreGraphics
 
 		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CGDisplayIsCaptured (uint display);
 
 		public static bool IsCaptured (int display)

--- a/src/CoreGraphics/CGEvent.cs
+++ b/src/CoreGraphics/CGEvent.cs
@@ -86,7 +86,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary)]
-		extern static IntPtr CGEventCreateKeyboardEvent (IntPtr source, ushort virtualKey, bool keyDown);
+		extern static IntPtr CGEventCreateKeyboardEvent (IntPtr source, ushort virtualKey, [MarshalAs (UnmanagedType.I1)] bool keyDown);
 
 		public CGEvent (CGEventSource source, ushort virtualKey, bool keyDown)
 		{
@@ -330,7 +330,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary)]
-		extern static void CGEventTapEnable (IntPtr machPort, bool enable);
+		extern static void CGEventTapEnable (IntPtr machPort, [MarshalAs (UnmanagedType.I1)] bool enable);
 
 		public static void TapEnable (CFMachPort machPort)
 		{
@@ -347,6 +347,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGEventTapIsEnabled (IntPtr machPort);
 
 		public static bool IsTapEnabled (CFMachPort machPort)
@@ -431,18 +432,22 @@ namespace CoreGraphics {
 
 		[Mac (11,0)]
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary, EntryPoint="CGPreflightListenEventAccess")]
+		[return: MarshalAs (UnmanagedType.I1)]
 		public static extern bool PreflightListenEventAccess ();
 
 		[Mac (11,0)]
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary, EntryPoint="CGRequestListenEventAccess")]
+		[return: MarshalAs (UnmanagedType.I1)]
 		public static extern bool RequestListenEventAccess ();
 
 		[Mac (11,0)]
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary, EntryPoint="CGPreflightPostEventAccess")]
+		[return: MarshalAs (UnmanagedType.I1)]
 		public static extern bool PreflightPostEventAccess ();
 
 		[Mac (11,0)]
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary, EntryPoint="CGRequestPostEventAccess")]
+		[return: MarshalAs (UnmanagedType.I1)]
 		public static extern bool RequestPostEventAccess ();
 
 	}

--- a/src/CoreGraphics/CGEventSource.cs
+++ b/src/CoreGraphics/CGEventSource.cs
@@ -109,9 +109,11 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary, EntryPoint="CGEventSourceButtonState")]
+		[return: MarshalAs (UnmanagedType.I1)]
 		public extern static bool GetButtonState (CGEventSourceStateID stateID, CGMouseButton button);
 
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary, EntryPoint="CGEventSourceKeyState")]
+		[return: MarshalAs (UnmanagedType.I1)]
 		public extern static bool GetKeyState (CGEventSourceStateID stateID, ushort keycode);
 
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary, EntryPoint="CGEventSourceFlagsState")]

--- a/src/CoreGraphics/CGGeometry.cs
+++ b/src/CoreGraphics/CGGeometry.cs
@@ -101,6 +101,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CGRectIsNull (CGRect rect);
 
 		public static bool IsNull (this CGRect self)
@@ -109,6 +110,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CGRectIsInfinite (CGRect rect);
 
 		public static bool IsInfinite (this CGRect self)

--- a/src/CoreGraphics/CGImage.cs
+++ b/src/CoreGraphics/CGImage.cs
@@ -169,7 +169,7 @@ namespace CoreGraphics {
 		extern static /* CGImageRef */ IntPtr CGImageCreate (/* size_t */ nint width, /* size_t */ nint height, 
 			/* size_t */ nint bitsPerComponent, /* size_t */ nint bitsPerPixel, /* size_t */ nint bytesPerRow,
 			/* CGColorSpaceRef */ IntPtr space, CGBitmapFlags bitmapInfo, /* CGDataProviderRef */ IntPtr provider,
-			/* CGFloat[] */ nfloat [] decode, bool shouldInterpolate, CGColorRenderingIntent intent);
+			/* CGFloat[] */ nfloat [] decode, [MarshalAs (UnmanagedType.I1)] bool shouldInterpolate, CGColorRenderingIntent intent);
 
 		public CGImage (int width, int height, int bitsPerComponent, int bitsPerPixel, int bytesPerRow,
 				CGColorSpace colorSpace, CGBitmapFlags bitmapFlags, CGDataProvider provider,
@@ -242,7 +242,7 @@ namespace CoreGraphics {
 	
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGImageRef */ IntPtr CGImageCreateWithJPEGDataProvider (/* CGDataProviderRef */ IntPtr source,
-			/* CGFloat[] */ nfloat [] decode, bool shouldInterpolate, CGColorRenderingIntent intent);
+			/* CGFloat[] */ nfloat [] decode, [MarshalAs (UnmanagedType.I1)] bool shouldInterpolate, CGColorRenderingIntent intent);
 
 		public static CGImage FromJPEG (CGDataProvider provider, nfloat [] decode, bool shouldInterpolate, CGColorRenderingIntent intent)
 		{
@@ -255,7 +255,7 @@ namespace CoreGraphics {
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGImageRef */ IntPtr CGImageCreateWithPNGDataProvider (/* CGDataProviderRef */ IntPtr source,
-			/* CGFloat[] */ nfloat [] decode, bool shouldInterpolate, CGColorRenderingIntent intent);
+			/* CGFloat[] */ nfloat [] decode, [MarshalAs (UnmanagedType.I1)] bool shouldInterpolate, CGColorRenderingIntent intent);
 
 		public static CGImage FromPNG (CGDataProvider provider, nfloat [] decode, bool shouldInterpolate, CGColorRenderingIntent intent)
 		{
@@ -269,7 +269,7 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGImageRef */ IntPtr CGImageMaskCreate (/* size */ nint width, /* size */ nint height, 
 			/* size */ nint bitsPerComponent, /* size */ nint bitsPerPixel, /* size */ nint bytesPerRow, 
-			/* CGDataProviderRef */ IntPtr provider, /* CGFloat[] */ nfloat [] decode, bool shouldInterpolate);
+			/* CGDataProviderRef */ IntPtr provider, /* CGFloat[] */ nfloat [] decode, [MarshalAs (UnmanagedType.I1)] bool shouldInterpolate);
 
 		public static CGImage CreateMask (int width, int height, int bitsPerComponent, int bitsPerPixel, int bytesPerRow, CGDataProvider provider, nfloat [] decode, bool shouldInterpolate)
 		{
@@ -337,6 +337,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGImageIsMask (/* CGImageRef */ IntPtr image);
 
 		public bool IsMask {
@@ -429,6 +430,7 @@ namespace CoreGraphics {
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGImageGetShouldInterpolate (/* CGImageRef */ IntPtr image);
 
 		public bool ShouldInterpolate {

--- a/src/CoreGraphics/CGPDFArray.cs
+++ b/src/CoreGraphics/CGPDFArray.cs
@@ -61,7 +61,8 @@ namespace CoreGraphics {
 		// CGPDFBoolean -> unsigned char -> CGPDFObject.h
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static bool CGPDFArrayGetBoolean (/* CGPDFArrayRef */ IntPtr array, /* size_t */ nint index, /* CGPDFBoolean* */ out bool value);
+		[return: MarshalAs (UnmanagedType.I1)]
+		extern static bool CGPDFArrayGetBoolean (/* CGPDFArrayRef */ IntPtr array, /* size_t */ nint index, /* CGPDFBoolean* */ [MarshalAs (UnmanagedType.I1)] out bool value);
 
 		public bool GetBoolean (nint idx, out bool result)
 		{
@@ -78,6 +79,7 @@ namespace CoreGraphics {
 		// CGPDFInteger -> long int 32/64 bits -> CGPDFObject.h
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFArrayGetInteger (/* CGPDFArrayRef */ IntPtr array, /* size_t */ nint index, /* CGPDFInteger* */ out nint value);
 
 		public bool GetInt (nint idx, out nint result)
@@ -95,6 +97,7 @@ namespace CoreGraphics {
 		// CGPDFReal -> CGFloat -> CGPDFObject.h
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFArrayGetNumber (/* CGPDFArrayRef */ IntPtr array, /* size_t */ nint index, /* CGPDFReal* */ out nfloat value);
 
 		public bool GetFloat (nint idx, out nfloat result)
@@ -110,6 +113,7 @@ namespace CoreGraphics {
 #endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFArrayGetName (/* CGPDFArrayRef */ IntPtr array, /* size_t */ nint index, /* const char** */ out IntPtr value);
 
 		public bool GetName (nint idx, out string result)
@@ -128,6 +132,7 @@ namespace CoreGraphics {
 #endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFArrayGetDictionary (/* CGPDFArrayRef */ IntPtr array, /* size_t */ nint index, /* CGPDFDictionaryRef* */ out IntPtr value);
 
 		public bool GetDictionary (nint idx, out CGPDFDictionary result)
@@ -146,6 +151,7 @@ namespace CoreGraphics {
 #endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFArrayGetStream (/* CGPDFArrayRef */ IntPtr array, /* size_t */ nint index, /* CGPDFStreamRef* */ out IntPtr value);
 
 		public bool GetStream (nint idx, out CGPDFStream result)
@@ -164,6 +170,7 @@ namespace CoreGraphics {
 #endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFArrayGetArray (/* CGPDFArrayRef */ IntPtr array, /* size_t */ nint index, /* CGPDFArrayRef* */ out IntPtr value);
 
 		public bool GetArray (nint idx, out CGPDFArray array)
@@ -182,6 +189,7 @@ namespace CoreGraphics {
 #endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFArrayGetString (/* CGPDFArrayRef */ IntPtr array, /* size_t */ nint index, /* CGPDFStringRef* */ out IntPtr value);
 
 		public bool GetString (nint idx, out string result)
@@ -218,6 +226,7 @@ namespace CoreGraphics {
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		[iOS (12, 0)][Mac (10, 14)][TV (12, 0)][Watch (5, 0)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFArrayApplyBlock (/* CGPDFArrayRef */ IntPtr array, /* CGPDFArrayApplierBlock */ ref BlockLiteral block, /* void* */ IntPtr info);
 
 		[iOS (12, 0)][Mac (10, 14)][TV (12, 0)][Watch (5, 0)]

--- a/src/CoreGraphics/CGPDFDictionary.cs
+++ b/src/CoreGraphics/CGPDFDictionary.cs
@@ -61,7 +61,8 @@ namespace CoreGraphics {
 		// CGPDFBoolean -> unsigned char -> CGPDFObject.h
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static bool CGPDFDictionaryGetBoolean (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFBoolean* */ out bool value);
+		[return: MarshalAs (UnmanagedType.I1)]
+		extern static bool CGPDFDictionaryGetBoolean (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFBoolean* */ [MarshalAs (UnmanagedType.I1)] out bool value);
 
 		public bool GetBoolean (string key, out bool result)
 		{
@@ -73,6 +74,7 @@ namespace CoreGraphics {
 		// CGPDFInteger -> long int so 32/64 bits -> CGPDFObject.h
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDictionaryGetInteger (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFInteger* */ out nint value);
 
 		public bool GetInt (string key, out nint result)
@@ -85,6 +87,7 @@ namespace CoreGraphics {
 		// CGPDFReal -> CGFloat -> CGPDFObject.h
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDictionaryGetNumber (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFReal* */ out nfloat value);
 
 		public bool GetFloat (string key, out nfloat result)
@@ -95,6 +98,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDictionaryGetName (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* const char ** */ out IntPtr value);
 
 		public bool GetName (string key, out string result)
@@ -108,6 +112,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDictionaryGetDictionary (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFDictionaryRef* */ out IntPtr result);
 
 		public bool GetDictionary (string key, out CGPDFDictionary result)
@@ -121,6 +126,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDictionaryGetStream (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFStreamRef* */ out IntPtr value);
 
 		public bool GetStream (string key, out CGPDFStream result)
@@ -134,6 +140,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDictionaryGetArray (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFArrayRef* */ out IntPtr value);
 
 		public bool GetArray (string key, out CGPDFArray array)
@@ -198,6 +205,7 @@ namespace CoreGraphics {
 		// CGPDFDictionary.h
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDictionaryGetString (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFStringRef* */ out IntPtr value);
 
 		public bool GetString (string key, out string result)

--- a/src/CoreGraphics/CGPDFDocument.cs
+++ b/src/CoreGraphics/CGPDFDocument.cs
@@ -150,6 +150,7 @@ namespace CoreGraphics {
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDocumentIsEncrypted (/* CGPDFDocumentRef */ IntPtr document);
 
 		public bool IsEncrypted {
@@ -159,6 +160,7 @@ namespace CoreGraphics {
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDocumentUnlockWithPassword (/* CGPDFDocumentRef */ IntPtr document, /* const char* */ string password);
 
 		public bool Unlock (string password)
@@ -167,6 +169,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDocumentIsUnlocked (/* CGPDFDocumentRef */ IntPtr document);
 
 		public bool IsUnlocked {
@@ -176,6 +179,7 @@ namespace CoreGraphics {
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDocumentAllowsPrinting (/* CGPDFDocumentRef */ IntPtr document);
 
 		public bool AllowsPrinting {
@@ -185,6 +189,7 @@ namespace CoreGraphics {
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDocumentAllowsCopying (/* CGPDFDocumentRef */ IntPtr document);
 
 		public bool AllowsCopying {

--- a/src/CoreGraphics/CGPDFObject.cs
+++ b/src/CoreGraphics/CGPDFObject.cs
@@ -50,15 +50,19 @@ namespace CoreGraphics {
 		extern static CGPDFObjectType CGPDFObjectGetType (/* CGPDFObjectRef */ IntPtr pdfobj);
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFObjectGetValue (/* CGPDFObjectRef */IntPtr pdfobj, CGPDFObjectType type, /* void* */ out byte value);
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFObjectGetValue (/* CGPDFObjectRef */IntPtr pdfobj, CGPDFObjectType type, /* void* */ out nint value);
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFObjectGetValue (/* CGPDFObjectRef */IntPtr pdfobj, CGPDFObjectType type, /* void* */ out nfloat value);
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFObjectGetValue (/* CGPDFObjectRef */IntPtr pdfobj, CGPDFObjectType type, /* void* */ out IntPtr value);
 
 		public CGPDFObjectType Type {

--- a/src/CoreGraphics/CGPDFPage-2.cs
+++ b/src/CoreGraphics/CGPDFPage-2.cs
@@ -89,7 +89,7 @@ namespace CoreGraphics {
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static CGAffineTransform CGPDFPageGetDrawingTransform (/* CGPDFPageRef */ IntPtr page, CGPDFBox box, CGRect rect, int rotate, bool preserveAspectRatio);
+		extern static CGAffineTransform CGPDFPageGetDrawingTransform (/* CGPDFPageRef */ IntPtr page, CGPDFBox box, CGRect rect, int rotate, [MarshalAs (UnmanagedType.I1)] bool preserveAspectRatio);
 
 		public CGAffineTransform GetDrawingTransform (CGPDFBox box, CGRect rect, int rotate, bool preserveAspectRatio)
 		{

--- a/src/CoreGraphics/CGPDFScanner.cs
+++ b/src/CoreGraphics/CGPDFScanner.cs
@@ -94,6 +94,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFScannerScan (/* CGPDFScannerRef */ IntPtr scanner);
 
 		public bool Scan ()
@@ -102,6 +103,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFScannerPopObject (/* CGPDFScannerRef */ IntPtr scanner, /* CGPDFObjectRef* */ out IntPtr value);
 
 		public bool TryPop (out CGPDFObject value)
@@ -117,7 +119,8 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static bool CGPDFScannerPopBoolean (/* CGPDFScannerRef */ IntPtr scanner, /* CGPDFBoolean* */ out bool value);
+		[return: MarshalAs (UnmanagedType.I1)]
+		extern static bool CGPDFScannerPopBoolean (/* CGPDFScannerRef */ IntPtr scanner, /* CGPDFBoolean* */ [MarshalAs (UnmanagedType.I1)] out bool value);
 
 		public bool TryPop (out bool value)
 		{
@@ -125,6 +128,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFScannerPopInteger (/* CGPDFScannerRef */ IntPtr scanner, /* CGPDFInteger* */ out nint value);
 
 		public bool TryPop (out nint value)
@@ -133,6 +137,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFScannerPopNumber (/* CGPDFScannerRef */ IntPtr scanner, /* CGPDFReal* */ out nfloat value);
 
 		public bool TryPop (out nfloat value)
@@ -141,6 +146,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFScannerPopName (/* CGPDFScannerRef */ IntPtr scanner, /* const char** */ out IntPtr value);
 		// note: that string is not ours to free
 
@@ -158,6 +164,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFScannerPopString (/* CGPDFScannerRef */ IntPtr scanner, /* CGPDFStringRef* */ out IntPtr value);
 
 		public bool TryPop (out string value)
@@ -173,6 +180,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFScannerPopArray (/* CGPDFScannerRef */ IntPtr scanner, /* CGPDFArrayRef* */ out IntPtr value);
 
 		public bool TryPop (out CGPDFArray value)
@@ -188,6 +196,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFScannerPopDictionary (/* CGPDFScannerRef */ IntPtr scanner, /* CGPDFDictionaryRef* */ out IntPtr value);
 
 		public bool TryPop (out CGPDFDictionary value)
@@ -203,6 +212,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFScannerPopStream (/* CGPDFScannerRef */ IntPtr scanner, /* CGPDFStreamRef* */ out IntPtr value);
 
 		public bool TryPop (out CGPDFStream value)

--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -143,6 +143,7 @@ namespace CoreGraphics {
 
 #if !COREBUILD
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPathEqualToPath (/* CGPathRef */ IntPtr path1, /* CGPathRef */ IntPtr path2);
 
 		public static bool operator == (CGPath path1, CGPath path2)
@@ -356,7 +357,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		unsafe extern static void CGPathAddArc (/* CGMutablePathRef */ IntPtr path, CGAffineTransform *m, /* CGFloat */ nfloat x, /* CGFloat */ nfloat y, /* CGFloat */ nfloat radius, /* CGFloat */ nfloat startAngle, /* CGFloat */ nfloat endAngle, bool clockwise);
+		unsafe extern static void CGPathAddArc (/* CGMutablePathRef */ IntPtr path, CGAffineTransform *m, /* CGFloat */ nfloat x, /* CGFloat */ nfloat y, /* CGFloat */ nfloat radius, /* CGFloat */ nfloat startAngle, /* CGFloat */ nfloat endAngle, [MarshalAs (UnmanagedType.I1)] bool clockwise);
 
 		public unsafe void AddArc (CGAffineTransform m, nfloat x, nfloat y, nfloat radius, nfloat startAngle, nfloat endAngle, bool clockwise)
 		{
@@ -412,6 +413,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPathIsEmpty (/* CGPathRef */ IntPtr path);
 
 		public bool IsEmpty {
@@ -421,6 +423,7 @@ namespace CoreGraphics {
 		}
 			
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPathIsRect (/* CGPathRef */ IntPtr path, out CGRect rect);
 
 		public bool IsRect (out CGRect rect)
@@ -456,7 +459,8 @@ namespace CoreGraphics {
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		unsafe extern static bool CGPathContainsPoint(IntPtr path, CGAffineTransform *m, CGPoint point, bool eoFill);
+		[return: MarshalAs (UnmanagedType.I1)]
+		unsafe extern static bool CGPathContainsPoint(IntPtr path, CGAffineTransform *m, CGPoint point, [MarshalAs (UnmanagedType.I1)] bool eoFill);
 
 		public unsafe bool ContainsPoint (CGAffineTransform m, CGPoint point, bool eoFill)
 		{

--- a/src/CoreGraphics/CGPattern.cs
+++ b/src/CoreGraphics/CGPattern.cs
@@ -76,7 +76,7 @@ namespace CoreGraphics {
 
 		[DllImport(Constants.CoreGraphicsLibrary)]
 		extern static IntPtr CGPatternCreate (/* void* */ IntPtr info, CGRect bounds, CGAffineTransform matrix,
-			/* CGFloat */ nfloat xStep, /* CGFloat */ nfloat yStep, CGPatternTiling tiling, bool isColored,
+			/* CGFloat */ nfloat xStep, /* CGFloat */ nfloat yStep, CGPatternTiling tiling, [MarshalAs (UnmanagedType.I1)] bool isColored,
 			/* const CGPatternCallbacks* */ ref CGPatternCallbacks callbacks);
 
 		static CGPatternCallbacks callbacks = new CGPatternCallbacks () {

--- a/src/CoreGraphics/CGShading.cs
+++ b/src/CoreGraphics/CGShading.cs
@@ -60,7 +60,7 @@ namespace CoreGraphics {
 
 		[DllImport(Constants.CoreGraphicsLibrary)]
 		extern static /* CGShadingRef */ IntPtr CGShadingCreateAxial (/* CGColorSpaceRef */ IntPtr space, 
-			CGPoint start, CGPoint end, /* CGFunctionRef */ IntPtr functionHandle, bool extendStart, bool extendEnd);
+			CGPoint start, CGPoint end, /* CGFunctionRef */ IntPtr functionHandle, [MarshalAs (UnmanagedType.I1)] bool extendStart, [MarshalAs (UnmanagedType.I1)] bool extendEnd);
 
 		public static CGShading CreateAxial (CGColorSpace colorspace, CGPoint start, CGPoint end, CGFunction function, bool extendStart, bool extendEnd)
 		{
@@ -79,7 +79,7 @@ namespace CoreGraphics {
 		[DllImport(Constants.CoreGraphicsLibrary)]
 		extern static /* CGShadingRef */ IntPtr CGShadingCreateRadial (/* CGColorSpaceRef */ IntPtr space, 
 			CGPoint start, /* CGFloat */ nfloat startRadius, CGPoint end, /* CGFloat */ nfloat endRadius,
-			/* CGFunctionRef */ IntPtr function, bool extendStart, bool extendEnd);
+			/* CGFunctionRef */ IntPtr function, [MarshalAs (UnmanagedType.I1)] bool extendStart, [MarshalAs (UnmanagedType.I1)] bool extendEnd);
 
 		public static CGShading CreateRadial (CGColorSpace colorspace, CGPoint start, nfloat startRadius, CGPoint end, nfloat endRadius,
 						      CGFunction function, bool extendStart, bool extendEnd)

--- a/src/CoreLocation/CoreLocation.cs
+++ b/src/CoreLocation/CoreLocation.cs
@@ -55,6 +55,7 @@ namespace CoreLocation {
 		}
 
 		[DllImport (Constants.CoreLocationLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern /* BOOL */ bool CLLocationCoordinate2DIsValid (CLLocationCoordinate2D cord);
 		
 		public bool IsValid ()

--- a/src/CoreMedia/CMBufferQueue.cs
+++ b/src/CoreMedia/CMBufferQueue.cs
@@ -46,6 +46,7 @@ namespace CoreMedia {
 		CMBufferGetSize getTotalSize;
 		
 		delegate CMTime BufferGetTimeCallback (/* CMBufferRef */ IntPtr buf, /* void* */ IntPtr refcon);
+		[return: MarshalAs (UnmanagedType.I1)]
 		delegate bool   BufferGetBooleanCallback (/* CMBufferRef */ IntPtr buf, /* void* */ IntPtr refcon);
 		delegate int    BufferCompareCallback (/* CMBufferRef */ IntPtr buf1, /* CMBufferRef */ IntPtr buf2, /* void* */ IntPtr refcon);
 		delegate nint   BufferGetSizeCallback (/* CMBufferRef */ IntPtr buffer, /* void* */ IntPtr refcon);

--- a/src/CoreMedia/CMFormatDescription.cs
+++ b/src/CoreMedia/CMFormatDescription.cs
@@ -295,15 +295,16 @@ namespace CoreMedia {
 		internal extern static CMVideoDimensions CMVideoFormatDescriptionGetDimensions (/* CMVideoFormatDescriptionRef */ IntPtr videoDesc);
 
 		[DllImport (Constants.CoreMediaLibrary)]
-		internal extern static CGRect CMVideoFormatDescriptionGetCleanAperture (/* CMVideoFormatDescriptionRef */ IntPtr videoDesc, /* Boolean */ bool originIsAtTopLeft);
+		internal extern static CGRect CMVideoFormatDescriptionGetCleanAperture (/* CMVideoFormatDescriptionRef */ IntPtr videoDesc, /* Boolean */ [MarshalAs (UnmanagedType.I1)] bool originIsAtTopLeft);
 
 		[DllImport (Constants.CoreMediaLibrary)]
 		internal extern static /* CFArrayRef */ IntPtr CMVideoFormatDescriptionGetExtensionKeysCommonWithImageBuffers ();
 
 		[DllImport (Constants.CoreMediaLibrary)]
-		internal extern static CGSize CMVideoFormatDescriptionGetPresentationDimensions (/* CMVideoFormatDescriptionRef */ IntPtr videoDesc, /* Boolean */ bool usePixelAspectRatio, /* Boolean */ bool useCleanAperture);
+		internal extern static CGSize CMVideoFormatDescriptionGetPresentationDimensions (/* CMVideoFormatDescriptionRef */ IntPtr videoDesc, /* Boolean */ [MarshalAs (UnmanagedType.I1)] bool usePixelAspectRatio, /* Boolean */ [MarshalAs (UnmanagedType.I1)] bool useCleanAperture);
 
 		[DllImport (Constants.CoreMediaLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		internal extern static /* Boolean */ bool CMVideoFormatDescriptionMatchesImageBuffer (/* CMVideoFormatDescriptionRef */ IntPtr videoDesc, /* CVImageBufferRef */ IntPtr imageBuffer);
 
 #endif

--- a/src/CoreMedia/CMSampleBuffer.cs
+++ b/src/CoreMedia/CMSampleBuffer.cs
@@ -82,7 +82,7 @@ namespace CoreMedia {
 		extern static CMSampleBufferError CMAudioSampleBufferCreateWithPacketDescriptions (
 			/* CFAllocatorRef */ IntPtr allocator,
 			/* CMBlockBufferRef */ IntPtr dataBuffer,
-			/* Boolean */ bool dataReady,
+			/* Boolean */ [MarshalAs (UnmanagedType.I1)] bool dataReady,
 			/* CMSampleBufferMakeDataReadyCallback */ IntPtr makeDataReadyCallback,
 			/* void */ IntPtr makeDataReadyRefcon,
 			/* CMFormatDescriptionRef */ IntPtr formatDescription,
@@ -217,7 +217,7 @@ namespace CoreMedia {
 		static extern /* OSStatus */ CMSampleBufferError CMSampleBufferCreateForImageBuffer (
 			/* CFAllocatorRef */ IntPtr allocator,
 			/* CVImageBufferRef */ IntPtr imageBuffer,
-			/* Boolean */ bool dataReady,
+			/* Boolean */ [MarshalAs (UnmanagedType.I1)] bool dataReady,
 			/* CMSampleBufferMakeDataReadyCallback */ IntPtr makeDataReadyCallback,
 			/* void* */ IntPtr makeDataReadyRefcon,
 			/* CMVideoFormatDescriptionRef */ IntPtr formatDescription,
@@ -247,6 +247,7 @@ namespace CoreMedia {
 		}
 
 		[DllImport(Constants.CoreMediaLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CMSampleBufferDataIsReady (/* CMSampleBufferRef */ IntPtr sbuf);
 		
 		public bool DataIsReady
@@ -428,7 +429,7 @@ namespace CoreMedia {
 		}
 
 		[DllImport(Constants.CoreMediaLibrary)]
-		extern static /* CFArrayRef */ IntPtr CMSampleBufferGetSampleAttachmentsArray (/* CMSampleBufferRef */ IntPtr sbuf, /* Boolean */ bool createIfNecessary);
+		extern static /* CFArrayRef */ IntPtr CMSampleBufferGetSampleAttachmentsArray (/* CMSampleBufferRef */ IntPtr sbuf, /* Boolean */ [MarshalAs (UnmanagedType.I1)] bool createIfNecessary);
 		
 		public CMSampleBufferAttachmentSettings [] GetSampleAttachments (bool createIfNecessary)
 		{
@@ -537,6 +538,7 @@ namespace CoreMedia {
 		}
 		
 		[DllImport(Constants.CoreMediaLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CMSampleBufferIsValid (/* CMSampleBufferRef */ IntPtr sbuf);
 		
 		public bool IsValid

--- a/src/CoreMedia/CMSync.cs
+++ b/src/CoreMedia/CMSync.cs
@@ -70,6 +70,7 @@ namespace CoreMedia {
 		}
 
 		[DllImport(Constants.CoreMediaLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CMClockMightDrift (/* CMClockRef */ IntPtr clock, /* CMClockRef */ IntPtr otherClock);
 
 		public bool MightDrift (CMClock otherClock)
@@ -584,6 +585,7 @@ namespace CoreMedia {
 		}
 
 		[DllImport(Constants.CoreMediaLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CMSyncMightDrift (/* CMClockOrTimebaseRef */ IntPtr clockOrTimebase1, /* CMClockOrTimebaseRef */ IntPtr clockOrTimebase2);
 
 		public static bool MightDrift (CMClockOrTimebase clockOrTimebaseA, CMClockOrTimebase clockOrTimebaseB)

--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -1405,7 +1405,7 @@ namespace CoreMidi {
 		[Deprecated (PlatformName.iOS, 14,0)]
 		[Deprecated (PlatformName.MacOSX, 11,0)]
 		[DllImport (Constants.CoreMidiLibrary)]
-		extern static int MIDIDeviceAddEntity (MidiDeviceRef device, /* CFString */ IntPtr name, bool embedded, nuint numSourceEndpoints, nuint numDestinationEndpoints, MidiEntityRef newEntity);
+		extern static int MIDIDeviceAddEntity (MidiDeviceRef device, /* CFString */ IntPtr name, [MarshalAs (UnmanagedType.U1)] bool embedded, nuint numSourceEndpoints, nuint numDestinationEndpoints, MidiEntityRef newEntity);
 
 		public MidiEntity GetEntity (nint entityIndex)
 		{

--- a/src/CoreServices/FSEvents.cs
+++ b/src/CoreServices/FSEvents.cs
@@ -111,6 +111,7 @@ namespace CoreServices
 		}
 
 		[DllImport (Constants.CoreServicesLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool FSEventsPurgeEventsForDeviceUpToEventId (ulong device, ulong eventId);
 
 		public static bool PurgeEventsForDeviceUpToEventId (ulong device, ulong eventId)
@@ -267,6 +268,7 @@ namespace CoreServices
 		}
 
 		[DllImport (Constants.CoreServicesLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool FSEventStreamStart (IntPtr handle);
 
 		public bool Start ()

--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -1847,6 +1847,7 @@ namespace CoreText {
 		}
 
 		[DllImport (Constants.CoreTextLibrary, CharSet = CharSet.Unicode)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CTFontGetGlyphsForCharacters (IntPtr font, char[] characters, CGGlyph[] glyphs, nint count);
 
 		public bool GetGlyphsForCharacters (char[] characters, CGGlyph[] glyphs, nint count)

--- a/src/CoreText/CTFontDescriptor.cs
+++ b/src/CoreText/CTFontDescriptor.cs
@@ -736,6 +736,7 @@ namespace CoreText {
 #endregion
 		[Mac (10,9)]
 		[DllImport (Constants.CoreTextLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CTFontDescriptorMatchFontDescriptorsWithProgressHandler (IntPtr descriptors, IntPtr mandatoryAttributes,
 			Func<CTFontDescriptorMatchingState, IntPtr, bool> progressHandler);
 

--- a/src/CoreText/CTFontManager.cs
+++ b/src/CoreText/CTFontManager.cs
@@ -65,6 +65,7 @@ namespace CoreText {
 
 #if MONOMAC
 		[DllImport (Constants.CoreTextLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CTFontManagerIsSupportedFont (IntPtr url);
 
 		[Deprecated (PlatformName.MacOSX, 10, 6)]
@@ -88,6 +89,7 @@ namespace CoreText {
 #endif
 
 		[DllImport (Constants.CoreTextLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CTFontManagerRegisterFontsForURL (IntPtr fontUrl, CTFontManagerScope scope, ref IntPtr error);
 		public static NSError RegisterFontsForUrl (NSUrl fontUrl, CTFontManagerScope scope)
 		{
@@ -137,6 +139,7 @@ namespace CoreText {
 		[Deprecated (PlatformName.WatchOS, 6,0)]
 		[Deprecated (PlatformName.TvOS, 13,0)]
 		[DllImport (Constants.CoreTextLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CTFontManagerRegisterFontsForURLs(IntPtr arrayRef, CTFontManagerScope scope, ref IntPtr error_array);
 
 		[Deprecated (PlatformName.MacOSX, 10,15, message: "Use 'RegisterFonts' instead.")]
@@ -168,11 +171,11 @@ namespace CoreText {
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.CoreTextLibrary)]
-		static extern void CTFontManagerRegisterFontURLs (/* CFArrayRef */ IntPtr fontUrls, CTFontManagerScope scope, bool enabled, IntPtr registrationHandler);
+		static extern void CTFontManagerRegisterFontURLs (/* CFArrayRef */ IntPtr fontUrls, CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled, IntPtr registrationHandler);
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.CoreTextLibrary)]
-		static extern void CTFontManagerRegisterFontURLs (/* CFArrayRef */ IntPtr fontUrls, CTFontManagerScope scope, bool enabled, ref BlockLiteral registrationHandler);
+		static extern void CTFontManagerRegisterFontURLs (/* CFArrayRef */ IntPtr fontUrls, CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled, ref BlockLiteral registrationHandler);
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[BindingImpl (BindingImplOptions.Optimizable)]
@@ -191,6 +194,7 @@ namespace CoreText {
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CTFontManagerUnregisterFontsForURL(IntPtr fotUrl, CTFontManagerScope scope, ref IntPtr error);
 
 		public static NSError UnregisterFontsForUrl (NSUrl fontUrl, CTFontManagerScope scope)
@@ -216,6 +220,7 @@ namespace CoreText {
 		[Deprecated (PlatformName.WatchOS, 6,0)]
 		[Deprecated (PlatformName.TvOS, 13,0)]
 		[DllImport (Constants.CoreTextLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CTFontManagerUnregisterFontsForURLs(IntPtr arrayRef, CTFontManagerScope scope, ref IntPtr error_array);
 
 		[Deprecated (PlatformName.MacOSX, 10,15, message : "Use 'UnregisterFonts' instead.")]
@@ -280,6 +285,7 @@ namespace CoreText {
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CTFontManagerRegisterGraphicsFont (IntPtr cgfont, out IntPtr error);
 
 		public static bool RegisterGraphicsFont (CGFont font, out NSError error)
@@ -302,6 +308,7 @@ namespace CoreText {
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CTFontManagerUnregisterGraphicsFont (IntPtr cgfont, out IntPtr error);
 
 		public static bool UnregisterGraphicsFont (CGFont font, out NSError error)
@@ -363,11 +370,11 @@ namespace CoreText {
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.CoreTextLibrary)]
-		static extern unsafe void CTFontManagerRegisterFontDescriptors (/* CFArrayRef */ IntPtr fontDescriptors, CTFontManagerScope scope, bool enabled, IntPtr registrationHandler);
+		static extern unsafe void CTFontManagerRegisterFontDescriptors (/* CFArrayRef */ IntPtr fontDescriptors, CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled, IntPtr registrationHandler);
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.CoreTextLibrary)]
-		static extern unsafe void CTFontManagerRegisterFontDescriptors (/* CFArrayRef */ IntPtr fontDescriptors, CTFontManagerScope scope, bool enabled, ref BlockLiteral registrationHandler);
+		static extern unsafe void CTFontManagerRegisterFontDescriptors (/* CFArrayRef */ IntPtr fontDescriptors, CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled, ref BlockLiteral registrationHandler);
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[BindingImpl (BindingImplOptions.Optimizable)]
@@ -412,7 +419,7 @@ namespace CoreText {
 #if __IOS__
 		[iOS (13,0)]
 		[DllImport (Constants.CoreTextLibrary)]
-		static extern /* CFArrayRef */ IntPtr CTFontManagerCopyRegisteredFontDescriptors (CTFontManagerScope scope, bool enabled);
+		static extern /* CFArrayRef */ IntPtr CTFontManagerCopyRegisteredFontDescriptors (CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled);
 
 		[iOS (13,0)]
 		[NoWatch][NoTV][NoMac]
@@ -458,11 +465,11 @@ namespace CoreText {
 #if __IOS__
 		[NoWatch, NoTV, NoMac, iOS (13,0)]
 		[DllImport (Constants.CoreTextLibrary)]
-		static extern unsafe void CTFontManagerRegisterFontsWithAssetNames (/* CFArrayRef */ IntPtr fontAssetNames, /* CFBundleRef _Nullable */ IntPtr bundle, CTFontManagerScope scope, bool enabled, IntPtr registrationHandler);
+		static extern unsafe void CTFontManagerRegisterFontsWithAssetNames (/* CFArrayRef */ IntPtr fontAssetNames, /* CFBundleRef _Nullable */ IntPtr bundle, CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled, IntPtr registrationHandler);
 
 		[NoWatch, NoTV, NoMac, iOS (13,0)]
 		[DllImport (Constants.CoreTextLibrary)]
-		static extern unsafe void CTFontManagerRegisterFontsWithAssetNames (/* CFArrayRef */ IntPtr fontAssetNames, /* CFBundleRef _Nullable */ IntPtr bundle, CTFontManagerScope scope, bool enabled, ref BlockLiteral registrationHandler);
+		static extern unsafe void CTFontManagerRegisterFontsWithAssetNames (/* CFArrayRef */ IntPtr fontAssetNames, /* CFBundleRef _Nullable */ IntPtr bundle, CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled, ref BlockLiteral registrationHandler);
 
 		// reminder that NSBundle and CFBundle are NOT toll-free bridged :(
 		[NoWatch, NoTV, NoMac, iOS (13,0)]

--- a/src/CoreText/CTParagraphStyle.cs
+++ b/src/CoreText/CTParagraphStyle.cs
@@ -403,6 +403,7 @@ namespace CoreText {
 
 #region Paragraph Style Access
 		[DllImport (Constants.CoreTextLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern unsafe bool CTParagraphStyleGetValueForSpecifier (IntPtr paragraphStyle, CTParagraphStyleSpecifier spec, nuint valueBufferSize, void* valueBuffer);
 
 		public unsafe CTTextTab[] GetTabStops ()

--- a/src/CoreVideo/CVDisplayLink.cs
+++ b/src/CoreVideo/CVDisplayLink.cs
@@ -162,6 +162,7 @@ namespace CoreVideo {
 		}
 			
 		[DllImport (Constants.CoreVideoLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CVDisplayLinkIsRunning (IntPtr displayLink);
 		public bool IsRunning {
 			get {

--- a/src/CoreVideo/CVImageBuffer.cs
+++ b/src/CoreVideo/CVImageBuffer.cs
@@ -77,6 +77,7 @@ namespace CoreVideo {
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CVImageBufferIsFlipped (/* CVImageBufferRef __nonnull */ IntPtr imageBuffer);
 		
 		public bool IsFlipped {

--- a/src/CoreVideo/CVMetalTexture.cs
+++ b/src/CoreVideo/CVMetalTexture.cs
@@ -59,6 +59,7 @@ namespace CoreVideo {
 			/* CVMetalTextureRef __nonnull */ IntPtr image);
 
 		[DllImport (Constants.CoreVideoLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CVMetalTextureIsFlipped (/* CVMetalTextureRef __nonnull */ IntPtr image);
 
 		[DllImport (Constants.CoreVideoLibrary)]

--- a/src/CoreVideo/CVPixelBuffer.cs
+++ b/src/CoreVideo/CVPixelBuffer.cs
@@ -326,6 +326,7 @@ namespace CoreVideo {
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CVPixelBufferIsPlanar (/* CVPixelBufferRef __nonnull */ IntPtr pixelBuffer);
 
 		public bool IsPlanar {

--- a/src/Foundation/NSSearchPath.cs
+++ b/src/Foundation/NSSearchPath.cs
@@ -41,6 +41,6 @@ namespace Foundation
 		}
 
 		[DllImport (Constants.FoundationLibrary)]
-		static extern IntPtr NSSearchPathForDirectoriesInDomains (nuint directory, nuint domainMask, bool expandTilde);
+		static extern IntPtr NSSearchPathForDirectoriesInDomains (nuint directory, nuint domainMask, [MarshalAs (UnmanagedType.I1)] bool expandTilde);
 	}
 }

--- a/src/Foundation/NSThread.cs
+++ b/src/Foundation/NSThread.cs
@@ -37,7 +37,7 @@ namespace Foundation {
 		}
 
 		[DllImport ("__Internal")]
-		static extern IntPtr xamarin_init_nsthread (IntPtr handle, bool is_direct_binding, IntPtr target, IntPtr selector, IntPtr argument);
+		static extern IntPtr xamarin_init_nsthread (IntPtr handle, [MarshalAs (UnmanagedType.I1)] bool is_direct_binding, IntPtr target, IntPtr selector, IntPtr argument);
 
 		IntPtr InitNSThread (NSObject target, Selector selector, NSObject argument)
 		{

--- a/src/GameController/GCExtendedGamepadSnapshot.cs
+++ b/src/GameController/GCExtendedGamepadSnapshot.cs
@@ -132,11 +132,13 @@ namespace GameController {
 		
 		// GCExtendedGamepadSnapshot.h
 		[DllImport (Constants.GameControllerLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool GCExtendedGamepadSnapShotDataV100FromNSData (
 			/* GCExtendedGamepadSnapShotDataV100 * __nullable */ out GCExtendedGamepadSnapShotDataV100 snapshotData, 
 			/* NSData * __nullable */ IntPtr data);
 		
 		[DllImport (Constants.GameControllerLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		[TV (12, 2), Mac (10, 14, 4), iOS (12, 2)]
 		static extern bool GCExtendedGamepadSnapshotDataFromNSData (
 			/* GCExtendedGamepadSnapshotData * __nullable */ out GCExtendedGamepadSnapshotData snapshotData, 

--- a/src/GameController/GCGamepadSnapshot.cs
+++ b/src/GameController/GCGamepadSnapshot.cs
@@ -55,6 +55,7 @@ namespace GameController {
 		
 		// GCGamepadSnapshot.h
 		[DllImport (Constants.GameControllerLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool GCGamepadSnapShotDataV100FromNSData (
 			/* GCGamepadSnapShotDataV100 * __nullable */ out GCGamepadSnapShotDataV100 snapshotData,
 			/* NSData * __nullable */ IntPtr data);

--- a/src/GameController/GCMicroGamepadSnapshot.cs
+++ b/src/GameController/GCMicroGamepadSnapshot.cs
@@ -88,6 +88,7 @@ namespace GameController {
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 		[DllImport (Constants.GameControllerLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool GCMicroGamepadSnapShotDataV100FromNSData (out GCMicroGamepadSnapShotDataV100 snapshotData, /* NSData */ IntPtr data);
 
 		[Deprecated (PlatformName.iOS, 12, 2, message: "Use 'TryGetSnapshotData (NSData, out GCMicroGamepadSnapshotData)' instead.")]
@@ -102,6 +103,7 @@ namespace GameController {
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 		[DllImport (Constants.GameControllerLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		[TV (12, 2), Mac (10, 14, 4), iOS (12, 2)]
 		static extern bool GCMicroGamepadSnapshotDataFromNSData (out GCMicroGamepadSnapshotData snapshotData, /* NSData */ IntPtr data);
 

--- a/src/ImageIO/CGImageMetadata.cs
+++ b/src/ImageIO/CGImageMetadata.cs
@@ -32,6 +32,7 @@ namespace ImageIO {
 		}
 	}
 
+	[return: MarshalAs (UnmanagedType.I1)]
 	public delegate bool CGImageMetadataTagBlock (NSString path, CGImageMetadataTag tag);
 
 	// CGImageMetadata.h

--- a/src/MapKit/MapKit.cs
+++ b/src/MapKit/MapKit.cs
@@ -313,7 +313,8 @@ namespace MapKit {
 		}
 		
 		[DllImport (Constants.MapKitLibrary, EntryPoint="MKMapRectContainsPoint")]
-		static extern bool MKMapRectContainsPoint (MKMapRect rect, MKMapPoint point);
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		static extern bool MKMapRectContainsPoint (MKMapRect rect, MKMapPoint point);
 		
 		public bool Contains (MKMapPoint point)
 		{
@@ -321,6 +322,7 @@ namespace MapKit {
 		}
 
 		[DllImport (Constants.MapKitLibrary, EntryPoint="MKMapRectContainsRect")]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool MKMapRectContainsRect (MKMapRect rect1, MKMapRect rect2);
 		
 		public bool Contains (MKMapRect rect)
@@ -335,6 +337,7 @@ namespace MapKit {
 		static public extern MKMapRect Intersection (MKMapRect rect1, MKMapRect rect2);
 		
 		[DllImport (Constants.MapKitLibrary, EntryPoint="MKMapRectIntersectsRect")]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static public extern bool Intersects (MKMapRect rect1, MKMapRect rect2);
 		
 		[DllImport (Constants.MapKitLibrary, EntryPoint="MKMapRectInset")]
@@ -364,6 +367,7 @@ namespace MapKit {
 		}
 		
 		[DllImport (Constants.MapKitLibrary, EntryPoint="MKMapRectSpans180thMeridian")]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool MKMapRectSpans180thMeridian (MKMapRect rect);
 		
 		public bool Spans180thMeridian {

--- a/src/MediaAccessibility/MediaAccessibility.cs
+++ b/src/MediaAccessibility/MediaAccessibility.cs
@@ -43,7 +43,8 @@ namespace MediaAccessibility {
 #endif
 
 		[DllImport (Constants.MediaAccessibilityLibrary)]
-		static extern bool MACaptionAppearanceAddSelectedLanguage (nint domain,
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		static extern bool MACaptionAppearanceAddSelectedLanguage (nint domain,
 			/* CFStringRef __nonnull */ IntPtr language);
 
 		public static bool AddSelectedLanguage (MACaptionAppearanceDomain domain, string language)

--- a/src/MetalPerformanceShaders/MPSKernel.cs
+++ b/src/MetalPerformanceShaders/MPSKernel.cs
@@ -12,6 +12,7 @@ namespace MetalPerformanceShaders {
 
 #if !COREBUILD
 		[DllImport (Constants.MetalPerformanceShadersLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool MPSSupportsMTLDevice (/* __nullable id <MTLDevice> */ IntPtr device);
 
 		public static bool Supports (IMTLDevice device)

--- a/src/NativeTypes/Drawing.tt
+++ b/src/NativeTypes/Drawing.tt
@@ -619,10 +619,13 @@ namespace CoreGraphics
 		internal const string CG = Constants.CoreGraphicsLibrary;
 #endif
 		[DllImport (CG)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		internal extern static bool CGRectMakeWithDictionaryRepresentation (IntPtr dict, out CGRect rect);
 		[DllImport (CG)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		internal extern static bool CGPointMakeWithDictionaryRepresentation (IntPtr dict, out CGPoint point);
 		[DllImport (CG)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		internal extern static bool CGSizeMakeWithDictionaryRepresentation (IntPtr dict, out CGSize point);
 
 		[DllImport (CG)]

--- a/src/Network/NWBrowserDescriptor.cs
+++ b/src/Network/NWBrowserDescriptor.cs
@@ -39,10 +39,11 @@ namespace Network {
 		public static NWBrowserDescriptor CreateBonjourService (string type) => CreateBonjourService (type, null);
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool nw_browse_descriptor_get_include_txt_record (OS_nw_browse_descriptor descriptor);
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_browse_descriptor_set_include_txt_record (OS_nw_browse_descriptor descriptor, bool include_txt_record);
+		static extern void nw_browse_descriptor_set_include_txt_record (OS_nw_browse_descriptor descriptor, [MarshalAs (UnmanagedType.I1)] bool include_txt_record);
 
 		public bool IncludeTxtRecord {
 			get => nw_browse_descriptor_get_include_txt_record (GetCheckedHandle ()); 

--- a/src/Network/NWConnectionGroup.cs
+++ b/src/Network/NWConnectionGroup.cs
@@ -188,7 +188,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		unsafe static extern void nw_connection_group_set_receive_handler (OS_nw_connection_group group, uint maximum_message_size, bool reject_oversized_messages, BlockLiteral *handler);
+		unsafe static extern void nw_connection_group_set_receive_handler (OS_nw_connection_group group, uint maximum_message_size, [MarshalAs (UnmanagedType.I1)] bool reject_oversized_messages, BlockLiteral *handler);
 
 		delegate void nw_connection_group_receive_handler_t (IntPtr block, IntPtr content, IntPtr context, bool isCompleted);
 		static nw_connection_group_receive_handler_t static_ReceiveHandler = TrampolineReceiveHandler;

--- a/src/Network/NWEstablishmentReport.cs
+++ b/src/Network/NWEstablishmentReport.cs
@@ -30,11 +30,13 @@ namespace Network {
 		internal NWEstablishmentReport (IntPtr handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool nw_establishment_report_get_used_proxy (OS_nw_establishment_report report);
 
 		public bool UsedProxy => nw_establishment_report_get_used_proxy (GetCheckedHandle ());
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool nw_establishment_report_get_proxy_configured (OS_nw_establishment_report report);
 
 		public bool ProxyConfigured => nw_establishment_report_get_proxy_configured (GetCheckedHandle ());

--- a/src/Network/NWFramer.cs
+++ b/src/Network/NWFramer.cs
@@ -26,7 +26,7 @@ using OS_nw_parameters=System.IntPtr;
 
 namespace Network {
 
-	public delegate nuint NWFramerParseCompletionDelegate (Memory<byte> buffer, bool isCompleted);
+	public delegate nuint NWFramerParseCompletionDelegate (Memory<byte> buffer, [MarshalAs (UnmanagedType.I1)] bool isCompleted);
 	public delegate nuint NWFramerInputDelegate (NWFramer framer); 
 
 	[TV (13,0), Mac (10,15), iOS (13,0), Watch (6,0)]
@@ -34,6 +34,7 @@ namespace Network {
 		internal NWFramer (IntPtr handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool nw_framer_write_output_no_copy (OS_nw_framer framer, nuint output_length);
 
 		public bool WriteOutputNoCopy (nuint outputLength) => nw_framer_write_output_no_copy (GetCheckedHandle (), outputLength);
@@ -253,6 +254,7 @@ namespace Network {
 			=> new NWFramerMessage (nw_framer_message_create (GetCheckedHandle ()), owns: true);
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool nw_framer_prepend_application_protocol (OS_nw_framer framer, OS_nw_protocol_options protocol_options);
 
 		public bool PrependApplicationProtocol (NWProtocolOptions options)
@@ -283,7 +285,8 @@ namespace Network {
 		public void MarkFailedWithError (int errorCode) => nw_framer_mark_failed_with_error (GetCheckedHandle (), errorCode); 
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern bool nw_framer_deliver_input_no_copy (OS_nw_framer framer, nuint input_length, OS_nw_protocol_metadata message, bool is_complete);
+		[return: MarshalAs (UnmanagedType.I1)]
+		static extern bool nw_framer_deliver_input_no_copy (OS_nw_framer framer, nuint input_length, OS_nw_protocol_metadata message, [MarshalAs (UnmanagedType.I1)] bool is_complete);
 
 		public bool DeliverInputNoCopy (nuint length, NWFramerMessage message, bool isComplete)
 		{
@@ -353,6 +356,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern unsafe bool nw_framer_parse_output (OS_nw_framer framer, nuint minimum_incomplete_length, nuint maximum_length, byte *temp_buffer, ref BlockLiteral parse);
 
 		delegate void nw_framer_parse_output_t (IntPtr block, IntPtr buffer, nuint buffer_length, bool is_complete);
@@ -388,6 +392,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern unsafe bool nw_framer_parse_input (OS_nw_framer framer, nuint minimum_incomplete_length, nuint maximum_length, byte *temp_buffer, ref BlockLiteral parse);
 
 		delegate nuint nw_framer_parse_input_t (IntPtr block, IntPtr buffer, nuint buffer_length, bool is_complete);
@@ -424,7 +429,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		unsafe static extern void nw_framer_deliver_input (OS_nw_framer framer, byte *input_buffer, nuint input_length, OS_nw_protocol_metadata message, bool is_complete);
+		unsafe static extern void nw_framer_deliver_input (OS_nw_framer framer, byte *input_buffer, nuint input_length, OS_nw_protocol_metadata message, [MarshalAs (UnmanagedType.I1)] bool is_complete);
 
 		public void DeliverInput (ReadOnlySpan<byte> buffer, NWFramerMessage message, bool isComplete)
 		{

--- a/src/Network/NWFramerMessage.cs
+++ b/src/Network/NWFramerMessage.cs
@@ -80,6 +80,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool nw_framer_message_access_value (OS_nw_protocol_metadata message, string key, ref BlockLiteral access_value);
 		delegate bool nw_framer_message_access_value_t (IntPtr block, IntPtr data);
 		static nw_framer_message_access_value_t static_AccessValueHandler = TrampolineAccessValueHandler;

--- a/src/Network/NWMulticastGroup.cs
+++ b/src/Network/NWMulticastGroup.cs
@@ -26,6 +26,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool nw_group_descriptor_add_endpoint (OS_nw_group_descriptor descriptor, OS_nw_endpoint endpoint);
 
 		public void AddEndpoint (NWEndpoint endpoint)
@@ -36,10 +37,11 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool nw_multicast_group_descriptor_get_disable_unicast_traffic (OS_nw_group_descriptor multicast_descriptor);
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_multicast_group_descriptor_set_disable_unicast_traffic (OS_nw_group_descriptor multicast_descriptor, bool disable_unicast_traffic);
+		static extern void nw_multicast_group_descriptor_set_disable_unicast_traffic (OS_nw_group_descriptor multicast_descriptor, [MarshalAs (UnmanagedType.I1)] bool disable_unicast_traffic);
 
 		public bool DisabledUnicastTraffic {
 			get => nw_multicast_group_descriptor_get_disable_unicast_traffic (GetCheckedHandle ());

--- a/src/Network/NWParameters.cs
+++ b/src/Network/NWParameters.cs
@@ -465,7 +465,7 @@ namespace Network {
 
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_parameters_set_include_peer_to_peer (IntPtr handle, bool includePeerToPeer);
+		static extern void nw_parameters_set_include_peer_to_peer (IntPtr handle, [MarshalAs (UnmanagedType.I1)] bool includePeerToPeer);
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
@@ -483,7 +483,7 @@ namespace Network {
 
 		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_parameters_set_prohibit_constrained (IntPtr parameters, bool prohibit_constrained);
+		static extern void nw_parameters_set_prohibit_constrained (IntPtr parameters, [MarshalAs (UnmanagedType.I1)] bool prohibit_constrained);
 
 		[TV (13,0), Mac (10,15), iOS (13,0)]
 		public bool ProhibitConstrained {

--- a/src/Network/NWPath.cs
+++ b/src/Network/NWPath.cs
@@ -126,6 +126,7 @@ namespace Network {
 
 		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool nw_path_is_constrained (IntPtr path);
 
 		[TV (13,0), Mac (10,15), iOS (13,0)]

--- a/src/Network/NWProtocolMetadata.cs
+++ b/src/Network/NWProtocolMetadata.cs
@@ -198,6 +198,7 @@ namespace Network {
 
 		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		internal static extern bool nw_protocol_metadata_is_framer_message (OS_nw_protocol_metadata metadata);
 
 		[TV (13,0), Mac (10,15), iOS (13,0)]
@@ -205,6 +206,7 @@ namespace Network {
 
 		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		internal static extern bool nw_protocol_metadata_is_ws (OS_nw_protocol_metadata metadata);
 
 		[TV (13,0), Mac (10,15), iOS (13,0)]

--- a/src/Network/NWProtocolOptions.cs
+++ b/src/Network/NWProtocolOptions.cs
@@ -98,7 +98,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		internal static extern void nw_ip_options_set_calculate_receive_time (IntPtr options, bool calculateReceiveTime);
+		internal static extern void nw_ip_options_set_calculate_receive_time (IntPtr options,[MarshalAs (UnmanagedType.I1)]  bool calculateReceiveTime);
 
 		[Obsolete ("Use the 'NWProtocolIPOptions' class instead.")]
 		public void IPSetCalculateReceiveTime (bool calculateReceiveTime)

--- a/src/Network/NWTxtRecord.cs
+++ b/src/Network/NWTxtRecord.cs
@@ -101,6 +101,7 @@ namespace Network {
 		public bool IsDictionary => nw_txt_record_is_dictionary (GetCheckedHandle ()) != 0;
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool nw_txt_record_is_equal (OS_nw_txt_record left, OS_nw_txt_record right);
 
 		public bool Equals (NWTxtRecord other)
@@ -111,6 +112,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		unsafe static extern bool nw_txt_record_apply (OS_nw_txt_record txt_record, ref BlockLiteral applier);
 
 		delegate bool nw_txt_record_apply_t (IntPtr block, string key, NWTxtRecordFindKey found, IntPtr value, nuint valueLen);
@@ -185,6 +187,7 @@ namespace Network {
 #endif
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern unsafe bool nw_txt_record_access_key (OS_nw_txt_record txt_record, string key, ref BlockLiteral access_value);
 
 		unsafe delegate void nw_txt_record_access_key_t (IntPtr block, string key, NWTxtRecordFindKey found, IntPtr value, nuint valueLen);
@@ -222,6 +225,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		unsafe static extern bool nw_txt_record_access_bytes (OS_nw_txt_record txt_record, ref BlockLiteral access_bytes);
 
 		unsafe delegate void nw_txt_record_access_bytes_t (IntPtr block, IntPtr value, nuint valueLen);

--- a/src/Network/NWWebSocketOptions.cs
+++ b/src/Network/NWWebSocketOptions.cs
@@ -55,7 +55,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_ws_options_set_auto_reply_ping (OS_nw_protocol_options options, bool auto_reply_ping);
+		static extern void nw_ws_options_set_auto_reply_ping (OS_nw_protocol_options options, [MarshalAs (UnmanagedType.I1)] bool auto_reply_ping);
 
 		public bool AutoReplyPing {
 			get { return autoReplyPing;}
@@ -77,7 +77,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_ws_options_set_skip_handshake (OS_nw_protocol_options options, bool skip_handshake);
+		static extern void nw_ws_options_set_skip_handshake (OS_nw_protocol_options options, [MarshalAs (UnmanagedType.I1)] bool skip_handshake);
 
 		public bool SkipHandShake {
 			get { return skipHandShake; }

--- a/src/Network/NWWebSocketRequest.cs
+++ b/src/Network/NWWebSocketRequest.cs
@@ -25,6 +25,7 @@ namespace Network {
 		internal NWWebSocketRequest (IntPtr handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		unsafe static extern bool nw_ws_request_enumerate_additional_headers (OS_nw_ws_request request, ref BlockLiteral enumerator);
 
 		delegate void nw_ws_request_enumerate_additional_headers_t (IntPtr block, string header, string value);
@@ -55,6 +56,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool nw_ws_request_enumerate_subprotocols (OS_nw_ws_request request, ref BlockLiteral enumerator);
 
 		delegate void nw_ws_request_enumerate_subprotocols_t (IntPtr block, string subprotocol);

--- a/src/Network/NWWebSocketResponse.cs
+++ b/src/Network/NWWebSocketResponse.cs
@@ -42,6 +42,7 @@ namespace Network {
 		public NWWebSocketResponseStatus Status => nw_ws_response_get_status (GetCheckedHandle ()); 
 
 		[DllImport (Constants.NetworkLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		unsafe static extern bool nw_ws_response_enumerate_additional_headers (OS_nw_ws_response response, ref BlockLiteral enumerator);
 
 		delegate void nw_ws_response_enumerate_additional_headers_t (IntPtr block, string header, string value);

--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -591,15 +591,19 @@ namespace ObjCRuntime {
 		internal static extern void objc_registerClassPair (IntPtr cls);
 
 		[DllImport ("/usr/lib/libobjc.dylib")]
+		[return: MarshalAs (UnmanagedType.U1)]
 		internal static extern bool class_addIvar (IntPtr cls, string name, IntPtr size, byte alignment, string types);
 
 		[DllImport ("/usr/lib/libobjc.dylib")]
+		[return: MarshalAs (UnmanagedType.U1)]
 		internal static extern bool class_addMethod (IntPtr cls, IntPtr name, IntPtr imp, string types);
 
 		[DllImport ("/usr/lib/libobjc.dylib")]
+		[return: MarshalAs (UnmanagedType.U1)]
 		internal extern static bool class_addMethod (IntPtr cls, IntPtr name, Delegate imp, string types);
 
 		[DllImport ("/usr/lib/libobjc.dylib")]
+		[return: MarshalAs (UnmanagedType.U1)]
 		internal extern static bool class_addProtocol (IntPtr cls, IntPtr protocol);
 
 		[DllImport ("/usr/lib/libobjc.dylib")]
@@ -618,6 +622,7 @@ namespace ObjCRuntime {
 		internal extern static IntPtr class_getInstanceVariable (IntPtr cls, string name);
 
 		[DllImport ("/usr/lib/libobjc.dylib", CharSet=CharSet.Ansi)]
+		[return: MarshalAs (UnmanagedType.U1)]
 		internal extern static bool class_addProperty (IntPtr cls, string name, objc_attribute_prop [] attributes, int count);
 
 		[StructLayout (LayoutKind.Sequential, CharSet=CharSet.Ansi)]

--- a/src/ObjCRuntime/Protocol.cs
+++ b/src/ObjCRuntime/Protocol.cs
@@ -67,10 +67,10 @@ namespace ObjCRuntime {
 		internal extern static void objc_registerProtocol (IntPtr protocol);
 
 		[DllImport ("/usr/lib/libobjc.dylib")]
-		internal extern static void protocol_addProperty (IntPtr protocol, string name, Class.objc_attribute_prop [] attributes, int count, bool isRequired, bool isInstance);
+		internal extern static void protocol_addProperty (IntPtr protocol, string name, Class.objc_attribute_prop [] attributes, int count, [MarshalAs (UnmanagedType.I1)] bool isRequired, [MarshalAs (UnmanagedType.I1)] bool isInstance);
 
 		[DllImport ("/usr/lib/libobjc.dylib")]
-		internal extern static void protocol_addMethodDescription (IntPtr protocol, IntPtr nameSelector, string signature, bool isRequired, bool isInstance);
+		internal extern static void protocol_addMethodDescription (IntPtr protocol, IntPtr nameSelector, string signature, [MarshalAs (UnmanagedType.I1)] bool isRequired, [MarshalAs (UnmanagedType.I1)] bool isInstance);
 
 		[DllImport ("/usr/lib/libobjc.dylib")]
 		internal extern static void protocol_addProtocol (IntPtr protocol, IntPtr addition);

--- a/src/ObjCRuntime/Selector.cs
+++ b/src/ObjCRuntime/Selector.cs
@@ -130,6 +130,7 @@ namespace ObjCRuntime {
 
 		// objc/objc.h
 		[DllImport ("/usr/lib/libobjc.dylib")]
+		[return: MarshalAs (UnmanagedType.U1)]
 		extern static /* BOOL */ bool sel_isMapped (/* SEL */ IntPtr sel);
 	}
 }

--- a/src/OpenGLES/OpenTK/Platform/MacOS/CarbonBindings/CoreFoundation.cs
+++ b/src/OpenGLES/OpenTK/Platform/MacOS/CarbonBindings/CoreFoundation.cs
@@ -88,8 +88,10 @@ namespace OpenTK.Platform.MacOS.Carbon
         }
 
         [DllImport(appServices)]
+		[return: MarshalAs (UnmanagedType.I1)]
         internal unsafe static extern bool CFNumberGetValue (IntPtr number, CFNumberType theType, int* valuePtr);
         [DllImport(appServices)]
+		[return: MarshalAs (UnmanagedType.I1)]
         internal unsafe static extern bool CFNumberGetValue(IntPtr number, CFNumberType theType, double* valuePtr);
 
         internal enum CFNumberType

--- a/src/SearchKit/SearchKit.cs
+++ b/src/SearchKit/SearchKit.cs
@@ -68,7 +68,8 @@ namespace SearchKit
 		}
 
 		[DllImport (Constants.SearchKitLibrary)]
-		extern static bool SKSearchFindMatches (IntPtr handle, nint maxCount, IntPtr ids, IntPtr scores, double time, out nint foundCount);
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		extern static bool SKSearchFindMatches (IntPtr handle, nint maxCount, IntPtr ids, IntPtr scores, double time, out nint foundCount);
 
 		public bool FindMatches (nint maxCount, ref nint [] ids, double waitTime, out nint foundCount)
 		{
@@ -240,7 +241,7 @@ namespace SearchKit
 		[DllImport (Constants.SearchKitLibrary)]
 		extern static IntPtr SKIndexCreateWithMutableData (IntPtr url, IntPtr str, SKIndexType type, IntPtr dict);
 		[DllImport (Constants.SearchKitLibrary)]
-		extern static IntPtr SKIndexOpenWithURL (IntPtr url, IntPtr str, bool writeAccess);
+		extern static IntPtr SKIndexOpenWithURL (IntPtr url, IntPtr str, [MarshalAs (UnmanagedType.I1)] bool writeAccess);
 		[DllImport (Constants.SearchKitLibrary)]
 		extern static IntPtr SKIndexOpenWithMutableData (IntPtr mutableData, IntPtr str);
 		[DllImport (Constants.SearchKitLibrary)]
@@ -349,7 +350,8 @@ namespace SearchKit
 
 
 		[DllImport (Constants.SearchKitLibrary)]
-		extern static bool SKIndexAddDocumentWithText (IntPtr h, IntPtr doc, IntPtr str, bool canreplace);
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		extern static bool SKIndexAddDocumentWithText (IntPtr h, IntPtr doc, IntPtr str, [MarshalAs (UnmanagedType.I1)] bool canreplace);
 
 		public bool AddDocumentWithText (SKDocument document, string text, bool canReplace)
 		{
@@ -365,7 +367,8 @@ namespace SearchKit
 		}
 
 		[DllImport (Constants.SearchKitLibrary)]
-		extern static bool SKIndexAddDocument (IntPtr h, IntPtr doc, IntPtr mimeHintStr, bool canReplace);
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		extern static bool SKIndexAddDocument (IntPtr h, IntPtr doc, IntPtr mimeHintStr, [MarshalAs (UnmanagedType.I1)] bool canReplace);
 
 		public bool AddDocument (SKDocument document, string mimeHint, bool canReplace)
 		{
@@ -379,13 +382,15 @@ namespace SearchKit
 		public extern static void LoadDefaultExtractorPlugIns ();
 
 		[DllImport (Constants.SearchKitLibrary)]
-		extern static bool SKIndexFlush (IntPtr h);
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		extern static bool SKIndexFlush (IntPtr h);
 		public bool Flush ()
 		{
 			return SKIndexFlush (handle);
 		}
 		[DllImport (Constants.SearchKitLibrary)]
-		extern static bool SKIndexCompact (IntPtr h);
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		extern static bool SKIndexCompact (IntPtr h);
 		public bool Compact ()
 		{
 			return SKIndexCompact (handle);
@@ -425,7 +430,8 @@ namespace SearchKit
 		}
 
 		[DllImport (Constants.SearchKitLibrary)]
-		extern static bool SKIndexMoveDocument (IntPtr h, IntPtr document, IntPtr newParent);
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		extern static bool SKIndexMoveDocument (IntPtr h, IntPtr document, IntPtr newParent);
 		public bool MoveDocument (SKDocument document, SKDocument newParent)
 		{
 			if (document == null)
@@ -437,7 +443,8 @@ namespace SearchKit
 
 
 		[DllImport (Constants.SearchKitLibrary)]
-		extern static bool SKIndexRemoveDocument (IntPtr h, IntPtr doc);
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		extern static bool SKIndexRemoveDocument (IntPtr h, IntPtr doc);
 
 		public bool RemoveDocument (SKDocument document)
 		{
@@ -448,7 +455,8 @@ namespace SearchKit
 
 
 		[DllImport (Constants.SearchKitLibrary)]
-		extern static bool SKIndexRenameDocument (IntPtr h, IntPtr doc, IntPtr newName);
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		extern static bool SKIndexRenameDocument (IntPtr h, IntPtr doc, IntPtr newName);
 		public bool RenameDocument (SKDocument document, string newName)
 		{
 			if (document == null)

--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -884,6 +884,7 @@ namespace Security {
 
 		[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 		[DllImport (Constants.SecurityLibrary)]
+		[return: MarshalAs (UnmanagedType.U1)]
 		static extern bool /* Boolean */ SecKeyIsAlgorithmSupported (IntPtr /* SecKeyRef* */ key, /* SecKeyOperationType */ nint operation, IntPtr /* SecKeyAlgorithm* */ algorithm);
 
 		[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -910,6 +911,7 @@ namespace Security {
 
 		[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 		[DllImport (Constants.SecurityLibrary)]
+		[return: MarshalAs (UnmanagedType.U1)]
 		static extern /* Boolean */ bool SecKeyVerifySignature (/* SecKeyRef */ IntPtr key, /* SecKeyAlgorithm */ IntPtr algorithm, /* CFDataRef */ IntPtr signedData, /* CFDataRef */ IntPtr signature, /* CFErrorRef* */ out IntPtr error);
 
 		[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]

--- a/src/Security/Policy.cs
+++ b/src/Security/Policy.cs
@@ -54,7 +54,7 @@ namespace Security {
 		}
 
 		[DllImport (Constants.SecurityLibrary)]
-		extern static IntPtr /* SecPolicyRef */ SecPolicyCreateSSL (bool server, IntPtr /* CFStringRef */ hostname);
+		extern static IntPtr /* SecPolicyRef */ SecPolicyCreateSSL ([MarshalAs (UnmanagedType.I1)] bool server, IntPtr /* CFStringRef */ hostname);
 
 		static public SecPolicy CreateSslPolicy (bool server, string hostName)
 		{

--- a/src/Security/SecIdentity2.cs
+++ b/src/Security/SecIdentity2.cs
@@ -72,7 +72,8 @@ namespace Security {
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.SecurityLibrary)]
-		static extern bool sec_identity_access_certificates (IntPtr identity, ref BlockLiteral block);
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		static extern bool sec_identity_access_certificates (IntPtr identity, ref BlockLiteral block);
 
 		internal delegate void AccessCertificatesHandler (IntPtr block, IntPtr cert);
 		static readonly AccessCertificatesHandler access = TrampolineAccessCertificates;

--- a/src/Security/SecProtocolMetadata.cs
+++ b/src/Security/SecProtocolMetadata.cs
@@ -285,6 +285,7 @@ namespace Security {
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.SecurityLibrary)]
+		[return: MarshalAs (UnmanagedType.U1)]
 		static extern bool sec_protocol_metadata_access_pre_shared_keys (IntPtr /* sec_protocol_metadata_t */ handle, ref BlockLiteral block);
 
 		public delegate void SecAccessPreSharedKeysHandler (DispatchData psk, DispatchData pskIdentity);

--- a/src/Security/SecProtocolOptions.cs
+++ b/src/Security/SecProtocolOptions.cs
@@ -256,7 +256,8 @@ namespace Security {
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[DllImport (Constants.SecurityLibrary)]
-		static extern bool sec_protocol_options_are_equal (sec_protocol_options_t optionsA, sec_protocol_options_t optionsB);
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		static extern bool sec_protocol_options_are_equal (sec_protocol_options_t optionsA, sec_protocol_options_t optionsB);
 
 		// Equatable would be nice but would fail on earlier OS versions
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]

--- a/src/Security/SecTrust.cs
+++ b/src/Security/SecTrust.cs
@@ -85,11 +85,11 @@ namespace Security {
 
 		[iOS (7,0)][Mac (10,9)]
 		[DllImport (Constants.SecurityLibrary)]
-		extern static SecStatusCode /* OSStatus */ SecTrustGetNetworkFetchAllowed (IntPtr /* SecTrustRef */ trust, out bool /* Boolean* */ allowFetch);
+		extern static SecStatusCode /* OSStatus */ SecTrustGetNetworkFetchAllowed (IntPtr /* SecTrustRef */ trust, [MarshalAs (UnmanagedType.I1)] out bool /* Boolean* */ allowFetch);
 
 		[iOS (7,0)][Mac (10,9)]
 		[DllImport (Constants.SecurityLibrary)]
-		extern static SecStatusCode /* OSStatus */ SecTrustSetNetworkFetchAllowed (IntPtr /* SecTrustRef */ trust, bool /* Boolean */ allowFetch);
+		extern static SecStatusCode /* OSStatus */ SecTrustSetNetworkFetchAllowed (IntPtr /* SecTrustRef */ trust, [MarshalAs (UnmanagedType.I1)] bool /* Boolean */ allowFetch);
 
 		[iOS (7,0)][Mac (10,9)]
 		public bool NetworkFetchAllowed {
@@ -221,6 +221,7 @@ namespace Security {
 
 		[Watch (5,0)][TV (12,0)][Mac (10,14)][iOS (12,0)]
 		[DllImport (Constants.SecurityLibrary)]
+		[return: MarshalAs (UnmanagedType.U1)]
 		static extern bool SecTrustEvaluateWithError (/* SecTrustRef */ IntPtr trust, out /* CFErrorRef** */ IntPtr error);
 
 		[Watch (5,0)][TV (12,0)][Mac (10,14)][iOS (12,0)]

--- a/src/Security/SslContext.cs
+++ b/src/Security/SslContext.cs
@@ -162,7 +162,7 @@ namespace Security {
 		}
 
 		[DllImport (Constants.SecurityLibrary)]
-		extern static /* OSStatus */ SslStatus SSLGetSessionOption (/* SSLContextRef */ IntPtr context, SslSessionOption option, out bool value);
+		extern static /* OSStatus */ SslStatus SSLGetSessionOption (/* SSLContextRef */ IntPtr context, SslSessionOption option, [MarshalAs (UnmanagedType.I1)] out bool value);
 
 		public SslStatus GetSessionOption (SslSessionOption option, out bool value)
 		{
@@ -171,7 +171,7 @@ namespace Security {
 		}
 
 		[DllImport (Constants.SecurityLibrary)]
-		extern static /* OSStatus */ SslStatus SSLSetSessionOption (/* SSLContextRef */ IntPtr context, SslSessionOption option, bool value);
+		extern static /* OSStatus */ SslStatus SSLSetSessionOption (/* SSLContextRef */ IntPtr context, SslSessionOption option, [MarshalAs (UnmanagedType.I1)] bool value);
 
 		public SslStatus SetSessionOption (SslSessionOption option, bool value)
 		{

--- a/src/Security/Trust.cs
+++ b/src/Security/Trust.cs
@@ -226,6 +226,7 @@ namespace Security {
 
 		[Mac (10,9)]
 		[DllImport (Constants.SecurityLibrary)]
+		[return: MarshalAs (UnmanagedType.U1)]
 		extern static bool SecTrustSetExceptions (IntPtr /* SecTrustRef */ trust, IntPtr /* __nullable CFDataRef */ exceptions);
 
 		[Mac (10,9)]
@@ -304,7 +305,7 @@ namespace Security {
 		}
 
 		[DllImport (Constants.SecurityLibrary)]
-		extern static SecStatusCode /* OSStatus */ SecTrustSetAnchorCertificatesOnly (IntPtr /* SecTrustRef */ trust, bool anchorCertificatesOnly);
+		extern static SecStatusCode /* OSStatus */ SecTrustSetAnchorCertificatesOnly (IntPtr /* SecTrustRef */ trust, [MarshalAs (UnmanagedType.I1)] bool anchorCertificatesOnly);
 
 		public SecStatusCode SetAnchorCertificatesOnly (bool anchorCertificatesOnly)
 		{

--- a/src/SystemConfiguration/CaptiveNetwork.cs
+++ b/src/SystemConfiguration/CaptiveNetwork.cs
@@ -103,10 +103,12 @@ namespace SystemConfiguration {
 
 		[Deprecated (PlatformName.iOS, 9,0)]
 		[DllImport (Constants.SystemConfigurationLibrary)]
+		[return: MarshalAs (UnmanagedType.U1)]
 		extern static bool CNMarkPortalOffline (IntPtr /* CFStringRef __nonnull */ interfaceName);
 
 		[Deprecated (PlatformName.iOS, 9,0)]
 		[DllImport (Constants.SystemConfigurationLibrary)]
+		[return: MarshalAs (UnmanagedType.U1)]
 		extern static bool CNMarkPortalOnline (IntPtr /* CFStringRef __nonnull */ interfaceName);
 
 		[Deprecated (PlatformName.iOS, 9,0)]
@@ -127,6 +129,7 @@ namespace SystemConfiguration {
 
 		[Deprecated (PlatformName.iOS, 9,0)]
 		[DllImport (Constants.SystemConfigurationLibrary)]
+		[return: MarshalAs (UnmanagedType.U1)]
 		extern static bool CNSetSupportedSSIDs (IntPtr /* CFArrayRef __nonnull */ ssidArray);
 
 		[Deprecated (PlatformName.iOS, 9,0)]

--- a/src/SystemConfiguration/NetworkReachability.cs
+++ b/src/SystemConfiguration/NetworkReachability.cs
@@ -209,12 +209,14 @@ namespace SystemConfiguration {
 		delegate void SCNetworkReachabilityCallBack (/* SCNetworkReachabilityRef */ IntPtr handle, /* SCNetworkReachabilityFlags */ NetworkReachabilityFlags flags, /* void* */ IntPtr info);
 
 		[DllImport (Constants.SystemConfigurationLibrary)]
+		[return: MarshalAs (UnmanagedType.U1)]
 		static extern /* Boolean */ bool SCNetworkReachabilitySetCallback (
 			/* SCNetworkReachabilityRef __nonnull */ IntPtr handle, 
 			/* __nullable */ SCNetworkReachabilityCallBack callout,
 			/* __nullable */ ref SCNetworkReachabilityContext context);
 		
 		[DllImport (Constants.SystemConfigurationLibrary)]
+		[return: MarshalAs (UnmanagedType.U1)]
 		static extern /* Boolean */ bool SCNetworkReachabilitySetCallback (
 			/* SCNetworkReachabilityRef __nullable */ IntPtr handle, 
 			/* __nullable */ SCNetworkReachabilityCallBack callout, 
@@ -268,6 +270,7 @@ namespace SystemConfiguration {
 		}
 
 		[DllImport (Constants.SystemConfigurationLibrary)]
+		[return: MarshalAs (UnmanagedType.U1)]
 		extern static /* Boolean */ bool SCNetworkReachabilityScheduleWithRunLoop (
 			/* SCNetworkReachabilityRef __nonnull */ IntPtr target, /* CFRunLoopRef __nonnull */ IntPtr runloop, 
 			/* CFStringRef __nonnull */ IntPtr runLoopMode);
@@ -310,6 +313,7 @@ namespace SystemConfiguration {
 		}
 
 		[DllImport (Constants.SystemConfigurationLibrary)]
+		[return: MarshalAs (UnmanagedType.U1)]
 		extern static /* Boolean */ bool SCNetworkReachabilitySetDispatchQueue (
 			/* SCNetworkReachabilityRef __nonnull */ IntPtr target,
 			/* dispatch_queue_t __nullable */ IntPtr queue);

--- a/src/UIKit/UIAccessibility.cs
+++ b/src/UIKit/UIAccessibility.cs
@@ -38,6 +38,7 @@ namespace UIKit {
 	public static partial class UIAccessibility {
 		// UIAccessibility.h
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* BOOL */ bool UIAccessibilityIsVoiceOverRunning ();
 
 		static public bool IsVoiceOverRunning {
@@ -48,6 +49,7 @@ namespace UIKit {
 		
 		// UIAccessibility.h
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* BOOL */ bool UIAccessibilityIsMonoAudioEnabled ();
 
 		static public bool IsMonoAudioEnabled {
@@ -72,6 +74,7 @@ namespace UIKit {
 		// UIAccessibility.h
 		[iOS (9,0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* BOOL */ bool UIAccessibilityIsShakeToUndoEnabled ();
 
 		[iOS (9,0)]
@@ -83,6 +86,7 @@ namespace UIKit {
 		
 		// UIAccessibility.h
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* BOOL */ bool UIAccessibilityIsClosedCaptioningEnabled ();
 
 		static public bool IsClosedCaptioningEnabled {
@@ -93,6 +97,7 @@ namespace UIKit {
 		
 		// UIAccessibility.h
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* BOOL */ bool UIAccessibilityIsInvertColorsEnabled ();
 
 		static public bool IsInvertColorsEnabled {
@@ -103,6 +108,7 @@ namespace UIKit {
 		
 		// UIAccessibility.h
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* BOOL */ bool UIAccessibilityIsGuidedAccessEnabled ();
 
 		static public bool IsGuidedAccessEnabled {
@@ -189,7 +195,7 @@ namespace UIKit {
 		// UIAccessibility.h
 		[iOS (7,0)]
 		[DllImport (Constants.UIKitLibrary)]
-		extern unsafe static void UIAccessibilityRequestGuidedAccessSession (/* BOOL */ bool enable, /* void(^completionHandler)(BOOL didSucceed) */ void * completionHandler);
+		extern unsafe static void UIAccessibilityRequestGuidedAccessSession (/* BOOL */ [MarshalAs (UnmanagedType.I1)] bool enable, /* void(^completionHandler)(BOOL didSucceed) */ void * completionHandler);
 
 		[iOS (7,0)]
 		[BindingImpl (BindingImplOptions.Optimizable)]
@@ -231,6 +237,7 @@ namespace UIKit {
 
 		[iOS (8,0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool UIAccessibilityDarkerSystemColorsEnabled ();
 
 		[iOS (8,0)]
@@ -252,6 +259,7 @@ namespace UIKit {
 
 		[iOS (8,0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool UIAccessibilityIsBoldTextEnabled ();
 
 		[iOS (8,0)]
@@ -263,6 +271,7 @@ namespace UIKit {
 
 		[TV (14,0), iOS (14,0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool UIAccessibilityButtonShapesEnabled ();
 
 		[TV (14,0), iOS (14,0)]
@@ -270,6 +279,7 @@ namespace UIKit {
 
 		[iOS (8,0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool UIAccessibilityIsGrayscaleEnabled ();
 
 		[iOS (8,0)]
@@ -281,6 +291,7 @@ namespace UIKit {
 
 		[iOS (8,0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool UIAccessibilityIsReduceMotionEnabled ();
 
 		[iOS (8,0)]
@@ -292,6 +303,7 @@ namespace UIKit {
 
 		[TV (14,0), iOS (14,0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool UIAccessibilityPrefersCrossFadeTransitions ();
 
 		[TV (14,0), iOS (14,0)]
@@ -299,6 +311,7 @@ namespace UIKit {
 
 		[iOS (13,0), TV (13,0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool UIAccessibilityIsVideoAutoplayEnabled ();
 
 		[iOS (13,0), TV (13,0)]
@@ -306,6 +319,7 @@ namespace UIKit {
 
 		[iOS (8,0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool UIAccessibilityIsReduceTransparencyEnabled ();
 
 		[iOS (8,0)]
@@ -317,6 +331,7 @@ namespace UIKit {
 
 		[iOS (8,0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool UIAccessibilityIsSwitchControlRunning ();
 
 		[iOS (8,0)]
@@ -328,6 +343,7 @@ namespace UIKit {
 
 		[iOS (8,0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool UIAccessibilityIsSpeakSelectionEnabled ();
 		[iOS (8,0)]
 		static public bool IsSpeakSelectionEnabled {
@@ -338,6 +354,7 @@ namespace UIKit {
 
 		[iOS (8,0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool UIAccessibilityIsSpeakScreenEnabled ();
 		[iOS (8,0)]
 		static public bool IsSpeakScreenEnabled {
@@ -348,6 +365,7 @@ namespace UIKit {
 
 		[iOS (10,0), TV (10,0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool UIAccessibilityIsAssistiveTouchRunning ();
 		[iOS (10,0), TV (10,0)]
 		public static bool IsAssistiveTouchRunning {
@@ -358,6 +376,7 @@ namespace UIKit {
 
 		[iOS (13,0), TV (13,0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool UIAccessibilityShouldDifferentiateWithoutColor ();
 
 		[iOS (13,0), TV (13,0)]
@@ -365,6 +384,7 @@ namespace UIKit {
 
 		[iOS (13,0), TV (13,0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool UIAccessibilityIsOnOffSwitchLabelsEnabled ();
 
 		[iOS (13,0), TV (13,0)]

--- a/src/UIKit/UIContentSizeCategory.cs
+++ b/src/UIKit/UIContentSizeCategory.cs
@@ -29,6 +29,7 @@ namespace UIKit {
 
 		[iOS (11, 0), TV (11, 0)]
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool UIContentSizeCategoryIsAccessibilityCategory (IntPtr /* NSString */ category);
 
 		[iOS (11, 0), TV (11, 0)]

--- a/src/UIKit/UIGraphics.cs
+++ b/src/UIKit/UIGraphics.cs
@@ -44,7 +44,7 @@ namespace UIKit {
 		public extern static void BeginImageContext (CGSize size);
 
 		[DllImport (Constants.UIKitLibrary, EntryPoint="UIGraphicsBeginImageContextWithOptions")]
-		public extern static void BeginImageContextWithOptions (CGSize size, bool opaque, nfloat scale);
+		public extern static void BeginImageContextWithOptions (CGSize size, [MarshalAs (UnmanagedType.I1)] bool opaque, nfloat scale);
 	
 		[DllImport (Constants.UIKitLibrary)]
 		static extern IntPtr UIGraphicsGetImageFromCurrentImageContext ();

--- a/src/UIKit/UIGuidedAccessRestriction.cs
+++ b/src/UIKit/UIGuidedAccessRestriction.cs
@@ -36,7 +36,7 @@ namespace UIKit {
 #if IOS
 		[iOS (12,2)]
 		[DllImport (Constants.UIKitLibrary)]
-		static extern void UIGuidedAccessConfigureAccessibilityFeatures (/* UIGuidedAccessAccessibilityFeature */ nuint features, bool enabled, IntPtr completion);
+		static extern void UIGuidedAccessConfigureAccessibilityFeatures (/* UIGuidedAccessAccessibilityFeature */ nuint features, [MarshalAs (UnmanagedType.I1)] bool enabled, IntPtr completion);
 
 		[iOS (12,2)]
 		public delegate void UIGuidedAccessConfigureAccessibilityFeaturesCompletionHandler (bool success, NSError error);

--- a/src/UIKit/UITypes.cs
+++ b/src/UIKit/UITypes.cs
@@ -116,6 +116,7 @@ namespace UIKit {
 		}
 
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool UIFloatRangeIsInfinite (UIFloatRange range);
 
 		public bool IsInfinite {

--- a/src/UIKit/UIVideo.cs
+++ b/src/UIKit/UIVideo.cs
@@ -43,6 +43,7 @@ namespace UIKit {
 		public delegate void SaveStatus (string path, NSError error);
 		
 		[DllImport (Constants.UIKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* BOOL */ bool UIVideoAtPathIsCompatibleWithSavedPhotosAlbum (/* NSString* */ IntPtr videoPath);
 		
 		public static bool IsCompatibleWithSavedPhotosAlbum (string path)

--- a/src/VideoToolbox/VTDecompressionSession.cs
+++ b/src/VideoToolbox/VTDecompressionSession.cs
@@ -340,6 +340,7 @@ namespace VideoToolbox {
 
 		[Mac (10,13), iOS (11,0), TV (11,0)]
 		[DllImport (Constants.VideoToolboxLibrary)]
+		[return: MarshalAs (UnmanagedType.U1)]
 		extern static bool VTIsHardwareDecodeSupported (CMVideoCodecType codecType);
 
 		[Mac (10,13), iOS (11,0), TV (11,0)]

--- a/src/Vision/VNUtils.cs
+++ b/src/Vision/VNUtils.cs
@@ -24,6 +24,7 @@ namespace Vision {
 		public static CGRect NormalizedIdentityRect { get; } = Dlfcn.GetCGRect (Libraries.Vision.Handle, "VNNormalizedIdentityRect");
 
 		[DllImport (Constants.VisionLibrary, EntryPoint = "VNNormalizedRectIsIdentityRect")]
+		[return: MarshalAs (UnmanagedType.U1)]
 		public static extern bool IsIdentityRect (CGRect rect);
 
 		[DllImport (Constants.VisionLibrary, EntryPoint = "VNImagePointForNormalizedPoint")]

--- a/src/WatchKit/WKAccessibility.cs
+++ b/src/WatchKit/WKAccessibility.cs
@@ -10,6 +10,7 @@ namespace WatchKit {
 	public partial class WKAccessibility {
 
 		[DllImport (Constants.WatchKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool WKAccessibilityIsVoiceOverRunning ();
 
 		static public bool IsVoiceOverRunning {
@@ -18,6 +19,7 @@ namespace WatchKit {
 
 		[Watch (4,0)]
 		[DllImport (Constants.WatchKitLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool WKAccessibilityIsReduceMotionEnabled ();
 
 		[Watch (4,0)]

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -2031,7 +2031,10 @@ public partial class Generator : IMemberGatherer {
 			b.Append (", ");
 
 			try {
-				b.Append (ParameterGetMarshalType (new MarshalInfo (this, mi, pi) { EnumMode = enum_mode }, true));
+				var parameterType = ParameterGetMarshalType (new MarshalInfo (this, mi, pi) { EnumMode = enum_mode }, true);
+				if (parameterType == "bool" || parameterType == "out bool" || parameterType == "ref bool")
+					b.Append ("[MarshalAs (UnmanagedType.I1)] ");
+				b.Append (parameterType);
 			} catch (BindingException ex) {
 				throw new BindingException (1079, ex.Error, ex, ex.Message, pi.Name.GetSafeParamName (), mi.DeclaringType, mi.Name);
 			}
@@ -2054,8 +2057,12 @@ public partial class Generator : IMemberGatherer {
 			print (m, "\t\t[DllImport (LIBOBJC_DYLIB, EntryPoint=\"{0}\")]", entry_point);
 		}
 
+		var returnType = need_stret ? "void" : ParameterGetMarshalType (new MarshalInfo (this, mi) { EnumMode = enum_mode }, true);
+		if (returnType == "bool")
+			print (m, "\t\t[return: MarshalAs (UnmanagedType.I1)]");
+
 		print (m, "\t\tpublic extern static {0} {1} ({3}IntPtr receiver, IntPtr selector{2});",
-		       need_stret ? "void" : ParameterGetMarshalType (new MarshalInfo (this, mi) { EnumMode = enum_mode }, true), method_name, b.ToString (),
+		       returnType, method_name, b.ToString (),
 		       need_stret ? (aligned ? "IntPtr" : "out " + FormatTypeUsedIn ("ObjCRuntime", mi.ReturnType)) + " retval, " : "");
 	}
 

--- a/tests/cecil-tests/Helper.cs
+++ b/tests/cecil-tests/Helper.cs
@@ -24,10 +24,14 @@ namespace Cecil.Tests {
 				return null;
 			if (!cache.TryGetValue (assembly, out var ad)) {
 				if (parameters == null) {
-					ad = AssemblyDefinition.ReadAssembly (assembly);
-				} else {
-					ad = AssemblyDefinition.ReadAssembly (assembly, parameters);
+					var resolver = new DefaultAssemblyResolver ();
+					resolver.AddSearchDirectory (GetBCLDirectory (assembly));
+					parameters = new ReaderParameters () {
+						AssemblyResolver = resolver,
+					};
 				}
+
+				ad = AssemblyDefinition.ReadAssembly (assembly, parameters);
 				cache.Add (assembly, ad);
 			}
 			return ad;
@@ -59,6 +63,30 @@ namespace Cecil.Tests {
 				}
 			}
 			yield break;
+		}
+
+		public static string GetBCLDirectory (string assembly)
+		{
+			var rv = string.Empty;
+
+			switch (Path.GetFileName (assembly)) {
+			case "Xamarin.iOS.dll":
+				rv = Path.GetDirectoryName (Configuration.XamarinIOSDll);
+				break;
+			case "Xamarin.WatchOS.dll":
+				rv = Path.GetDirectoryName (Configuration.XamarinWatchOSDll);
+				break;
+			case "Xamarin.TVOS.dll":
+				rv = Path.GetDirectoryName (Configuration.XamarinTVOSDll);
+				break;
+			case "Xamarin.Mac.dll":
+				rv = Path.GetDirectoryName (assembly);
+				break;
+			default:
+				throw new NotImplementedException (assembly);
+			}
+
+			return rv;
 		}
 
 		public static IEnumerable PlatformAssemblies {

--- a/tests/cecil-tests/MarshalAsBooleanTest.cs
+++ b/tests/cecil-tests/MarshalAsBooleanTest.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using NUnit.Framework;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+#nullable enable
+
+namespace Cecil.Tests {
+
+	[TestFixture]
+	public class MarshalAsBooleanTest {
+		[TestCaseSource (typeof (Helper), "PlatformAssemblies")]
+		public void MarshalAsBoolean (string assemblyPath)
+		{
+			var assembly = Helper.GetAssembly (assemblyPath);
+			if (assembly == null)
+				Assert.Ignore ($"{assemblyPath} could not be found (might be disabled in build)");
+
+			var failedMethods = new List<string> ();
+			List<string>? failures = null;
+			var checkedTypes = new List<TypeReference> ();
+			foreach (var m in Helper.FilterMethods (assembly!, (m) => m.HasPInvokeInfo)) {
+				failures = null;
+				if (!CheckMarshalAs (checkedTypes, m, ref failures)) {
+					failedMethods.Add ($"Found {failures!.Count} issues with {m.FullName}:\n\t{string.Join ("\n\t", failures)}");
+				}
+			}
+
+			Assert.That (failedMethods, Is.Empty, "Methods with bool return type / parameters and no MarshalAs attribute.");
+		}
+
+		static void AddFailure (ref List<string>? failures, string failure)
+		{
+			if (failures == null)
+				failures = new List<string> ();
+
+			failures.Add (failure);
+			Console.WriteLine (failure);
+		}
+
+		bool CheckMarshalAs (List<TypeReference> checkedTypes, MethodDefinition method, ref List<string>? failures)
+		{
+			var rv = true;
+
+			if (!CheckMarshalAs (checkedTypes, method, method.MethodReturnType.ReturnType, method.MethodReturnType, ref failures)) {
+				AddFailure (ref failures, $"The boolean return type does not have a MarshalAs attribute: {method.FullName}");
+				rv = false;
+			}
+
+			if (method.HasParameters) {
+				for (var i = 0; i < method.Parameters.Count; i++) {
+					var param = method.Parameters [i];
+					var paramType = param.ParameterType;
+					if (paramType.IsByReference)
+						paramType = paramType.GetElementType ();
+					if (!CheckMarshalAs (checkedTypes, method, paramType, param, ref failures)) {
+						AddFailure (ref failures, $"The boolean parameter #{i + 1} ({param.Name}) does not have a MarshalAs attribute: {method.FullName}");
+						rv = false;
+					}
+				}
+			}
+
+			return rv;
+		}
+
+		bool CheckMarshalAsDelegate (List<TypeReference> checkedTypes, MethodDefinition method, TypeReference type, IMarshalInfoProvider provider, ref List<string>? failures)
+		{
+			var invokeMethod = type.Resolve ().Methods.Single (v => v.Name == "Invoke");
+			if (!CheckMarshalAs (checkedTypes, invokeMethod, ref failures)) {
+				AddFailure (ref failures, $"For the delegate type {type.FullName}");
+				return false;
+			}
+			return true;
+		}
+
+		bool CheckValueType (List<TypeReference> checkedTypes, MethodDefinition method, TypeReference tr, ref List<string>? failures)
+		{
+			var rv = true;
+
+			var type = tr.Resolve ();
+			if (type.IsEnum)
+				return true;
+
+			foreach (var field in type.Fields) {
+				if (field.IsStatic)
+					continue;
+
+				if (!CheckMarshalAs (checkedTypes, method, field.FieldType, field, ref failures)) {
+					AddFailure (ref failures, $"The boolean field '{field.Name}' in {tr.FullName} does not have a MarshalAs attribute. Original method: {method.FullName}");
+					rv = false;
+				}
+			}
+			return rv;
+		}
+
+		static bool IsDelegate (TypeReference tr)
+		{
+			var t = tr.Resolve ();
+			if (t == null)
+				return false;
+
+			var baseType = t.BaseType;
+			return baseType.Namespace == "System" && baseType.Name == "MulticastDelegate";
+		}
+
+		bool CheckMarshalAs (List<TypeReference> checkedTypes, MethodDefinition method, TypeReference type, IMarshalInfoProvider provider, ref List<string>? failures)
+		{
+			if (checkedTypes.Contains (type))
+				return true;
+			checkedTypes.Add (type);
+
+			if (type.IsValueType && !type.IsPrimitive)
+				return CheckValueType (checkedTypes, method, type, ref failures);
+
+			if (IsDelegate (type))
+				return CheckMarshalAsDelegate (checkedTypes, method, type, provider, ref failures);
+
+			if (provider.HasMarshalInfo)
+				return true;
+
+			if (type.Namespace != "System" || type.Name != "Boolean")
+				return true;
+
+			// boolean type without MarshalAs directive.
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
There is a mismatch between the size of booleans for managed and native code:
in most cases native bools are 1 byte, but the default marshalling behavior is
to marshal 4 bytes. This difference hasn't come up often with Mono, but with
CoreCLR numerous tests fail due to this (and presumably many more are randomly
succeeding).

So add a MarshalAs attribute to all boolean return types and parameters for
P/Invokes (including delegates passed to P/Invokes), and also add a test to
make sure we'll never forget to add the attribute when needed.

Ref: https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1414?view=vs-2019