### PR TITLE
Turns out we need MarshalAs for characters as well.

### DIFF
--- a/src/generator-typemanager.cs
+++ b/src/generator-typemanager.cs
@@ -10,6 +10,7 @@ public class TypeManager {
 	public Type System_Attribute;
 	public Type System_Boolean;
 	public Type System_Byte;
+	public Type System_Char;
 	public Type System_Delegate;
 	public Type System_Double;
 	public Type System_Float;
@@ -172,6 +173,7 @@ public class TypeManager {
 		System_Attribute = Lookup (corlib_assembly, "System", "Attribute");
 		System_Boolean = Lookup (corlib_assembly, "System", "Boolean");
 		System_Byte = Lookup (corlib_assembly, "System", "Byte");
+		System_Char = Lookup (corlib_assembly, "System", "Char");
 		System_Delegate = Lookup (corlib_assembly, "System", "Delegate");
 		System_Double = Lookup (corlib_assembly, "System", "Double");
 		System_Float = Lookup (corlib_assembly, "System", "Single");

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1127,6 +1127,8 @@ public partial class Generator : IMemberGatherer {
 			return "float";
 		if (t == TypeManager.System_Boolean)
 			return "bool";
+		if (t == TypeManager.System_Char)
+			return "char";
 
 		return formatted ? FormatType (null, t) : t.Name;
 	}
@@ -2034,6 +2036,8 @@ public partial class Generator : IMemberGatherer {
 				var parameterType = ParameterGetMarshalType (new MarshalInfo (this, mi, pi) { EnumMode = enum_mode }, true);
 				if (parameterType == "bool" || parameterType == "out bool" || parameterType == "ref bool")
 					b.Append ("[MarshalAs (UnmanagedType.I1)] ");
+				else if (parameterType == "char" || parameterType == "out char" || parameterType == "ref char")
+					b.Append ("[MarshalAs (UnmanagedType.U2)] ");
 				b.Append (parameterType);
 			} catch (BindingException ex) {
 				throw new BindingException (1079, ex.Error, ex, ex.Message, pi.Name.GetSafeParamName (), mi.DeclaringType, mi.Name);
@@ -2060,6 +2064,8 @@ public partial class Generator : IMemberGatherer {
 		var returnType = need_stret ? "void" : ParameterGetMarshalType (new MarshalInfo (this, mi) { EnumMode = enum_mode }, true);
 		if (returnType == "bool")
 			print (m, "\t\t[return: MarshalAs (UnmanagedType.I1)]");
+		else if (returnType == "char")
+			print (m, "\t\t[return: MarshalAs (UnmanagedType.U2)]");
 
 		print (m, "\t\tpublic extern static {0} {1} ({3}IntPtr receiver, IntPtr selector{2});",
 		       returnType, method_name, b.ToString (),
@@ -3454,8 +3460,8 @@ public partial class Generator : IMemberGatherer {
 			return "nint";
 		if (type == TypeManager.System_nuint)
 			return "nuint";
-		if (type == TypeManager.System_Boolean)
-			return "bool";
+		if (type == TypeManager.System_Char)
+			return "char";
 
 		if (type.IsArray)
 			return FormatTypeUsedIn (usedInNamespace, type.GetElementType ()) + "[" + new string (',', type.GetArrayRank () - 1) + "]";


### PR DESCRIPTION
The default marshalling size for characters in .NET is a single byte, and that
is potentially lossy (and causes tests to fail for non-ascii characters when using CoreCLR).