### PR TITLE
[dotnet] produce .nupkg files for Workload packs

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -44,6 +44,7 @@ DIRECTORIES += \
 	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/Sdk) \
 	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets) \
 	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Templates) \
+	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.NET.Workload.$(platform)) \
 	$(DOTNET_MANIFESTS_PATH) \
 	$(DOTNET_PACKS_PATH) \
 	$(DOTNET_TEMPLATE_PACKS_PATH) \
@@ -169,6 +170,7 @@ $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplate,Microso
 $(eval $(call CreateWindowsNuGetTemplate,Microsoft.iOS.Windows.Sdk,$(IOS_WINDOWS_NUGET_VERSION_NO_METADATA),$(IOS_WINDOWS_NUGET_TARGETS)))
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Ref,$($(platform)_NUGET_VERSION_NO_METADATA))))
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Templates,$($(platform)_NUGET_VERSION_NO_METADATA))))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.NET.Workload.$(platform),$($(platform)_NUGET_VERSION_NO_METADATA))))
 $(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Runtime.$(rid),$($(platform)_NUGET_VERSION_NO_METADATA)))))
 
 # Copy the nuget from the temporary directory into the final directory
@@ -191,11 +193,13 @@ SDK_PACKS_$(1) = $(DOTNET_NUPKG_DIR)/$($(1)_NUGET).Sdk.$($(1)_NUGET_VERSION_FULL
 SDK_PACKS += $$(SDK_PACKS_$(1))
 TEMPLATE_PACKS_$(1) = $(DOTNET_NUPKG_DIR)/$($(1)_NUGET).Templates.$($(1)_NUGET_VERSION_FULL).nupkg
 TEMPLATE_PACKS += $$(TEMPLATE_PACKS_$(1))
-pack-$(shell echo $(1) | tr A-Z a-z): $$(RUNTIME_PACKS_$(1)) $$(REF_PACKS_$(1)) $$(SDK_PACKS_$(1)) $$(TEMPLATE_PACKS_$(1))
+WORKLOAD_PACKS_$(1) = $(DOTNET_NUPKG_DIR)/$(subst Microsoft.,Microsoft.NET.Workload.,$($(1)_NUGET)).$($(1)_NUGET_VERSION_FULL).nupkg
+WORKLOAD_PACKS += $$(WORKLOAD_PACKS_$(1))
+pack-$(shell echo $(1) | tr A-Z a-z): $$(RUNTIME_PACKS_$(1)) $$(REF_PACKS_$(1)) $$(SDK_PACKS_$(1)) $$(TEMPLATE_PACKS_$(1)) $$(WORKLOAD_PACKS_$(1))
 endef
 $(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(eval $(call PacksDefinitions,$(platform))))
 
-TARGETS += $(RUNTIME_PACKS) $(REF_PACKS) $(SDK_PACKS) $(TEMPLATE_PACKS)
+TARGETS += $(RUNTIME_PACKS) $(REF_PACKS) $(SDK_PACKS) $(TEMPLATE_PACKS) $(WORKLOAD_PACKS)
 
 define InstallWorkload
 $(DOTNET_MANIFESTS_PATH)/Microsoft.NET.Workload.$1: | $(DOTNET_MANIFESTS_PATH)

--- a/dotnet/package/Microsoft.NET.Workload.MacCatalyst/package.csproj
+++ b/dotnet/package/Microsoft.NET.Workload.MacCatalyst/package.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <_PlatformName>MacCatalyst</_PlatformName>
+  </PropertyGroup>
+
+  <Import Project="../microsoft.workloads.csproj" />
+</Project>

--- a/dotnet/package/Microsoft.NET.Workload.iOS/package.csproj
+++ b/dotnet/package/Microsoft.NET.Workload.iOS/package.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <_PlatformName>iOS</_PlatformName>
+  </PropertyGroup>
+
+  <Import Project="../microsoft.workloads.csproj" />
+</Project>

--- a/dotnet/package/Microsoft.NET.Workload.macOS/package.csproj
+++ b/dotnet/package/Microsoft.NET.Workload.macOS/package.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <_PlatformName>macOS</_PlatformName>
+  </PropertyGroup>
+
+  <Import Project="../microsoft.workloads.csproj" />
+</Project>

--- a/dotnet/package/Microsoft.NET.Workload.tvOS/package.csproj
+++ b/dotnet/package/Microsoft.NET.Workload.tvOS/package.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <_PlatformName>tvOS</_PlatformName>
+  </PropertyGroup>
+
+  <Import Project="../microsoft.workloads.csproj" />
+</Project>

--- a/dotnet/package/microsoft.workloads.csproj
+++ b/dotnet/package/microsoft.workloads.csproj
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <PackageId>Microsoft.NET.Workload.$(_PlatformName)</PackageId>
+    <Description>.NET Workload for $(_PlatformName) platforms</Description>
+    <_packagePath>$(MSBuildThisFileDirectory)..\Microsoft.NET.Workload.$(_PlatformName)\</_packagePath>
+  </PropertyGroup>
+  <Import Project="common.csproj" />
+</Project>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-macios/issues/10620

I have a prototype where I figured out how Maui would consume the iOS &
Android workloads:

https://github.com/jonathanpeppers/maui-workload

One issue I ran into was there isn't a `Microsoft.NET.Workload.iOS`
package on the NuGet feed:

    <add key="xamarin" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />

We will also need these packages to insert them in the dotnet/installer
repo, when they are ready for us to do "real" insertions for .NET 6.

To make this work, I mostly had to create a `package.csproj` for the
workload packs and fix up the `Makefile`.

Now I get additional `.nupkg` files produced in:

    % ls _build/nupkgs | grep Microsoft.NET.Workload
    Microsoft.NET.Workload.MacCatalyst.14.3.100-ci.workload-nupkgs.299+sha.692087e74.nupkg
    Microsoft.NET.Workload.iOS.14.4.100-ci.workload-nupkgs.1154+sha.692087e74.nupkg
    Microsoft.NET.Workload.macOS.11.1.100-ci.workload-nupkgs.1207+sha.692087e74.nupkg
    Microsoft.NET.Workload.tvOS.14.3.100-ci.workload-nupkgs.1207+sha.692087e74.nupkg