### PR TITLE
[dotnet] We shouldn't need the workaround for mono_config_parse_memory anymore.

### DIFF
--- a/tools/dotnet-linker/Steps/GenerateMainStep.cs
+++ b/tools/dotnet-linker/Steps/GenerateMainStep.cs
@@ -36,21 +36,6 @@ namespace Xamarin {
 				contents.AppendLine ("}");
 				contents.AppendLine ();
 
-				if (Configuration.Platform == ApplePlatform.MacOSX) {
-					// mono_config_parse_memory was removed in .NET: https://github.com/dotnet/runtime/pull/48007
-					// however, we still use this function in our libxamarin code, and we can't remove it without affecting
-					// legacy Xamarin.Mac, so just add a dummy implementation of mono_config_parse_memory so that the
-					// native linker doesn't complain. This is a temporary solution: we'll soon build a .NET-specific
-					// libxamarin, in which case we can #ifdef out the call to mono_config_parse_memory for .NET only.
-					contents.AppendLine ("#include <stdio.h>");
-					contents.AppendLine ("extern \"C\" void mono_config_parse_memory (const char *buffer);");
-					contents.AppendLine ("void mono_config_parse_memory (const char *buffer)");
-					contents.AppendLine ("{");
-					contents.AppendLine ("\tfprintf (stderr, \"mono_config_parse_memory has been removed\\n\");");
-					contents.AppendLine ("}");
-					contents.AppendLine ();
-				}
-
 				Configuration.Target.GenerateMain (contents, app.Platform, abi, file, registration_methods);
 
 				var item = new MSBuildItem {


### PR DESCRIPTION
We're now building the .NET version of libxamarin referencing the .NET version
of libmono, which means we don't need this workaround anymore.