### PR TITLE
[tests] Adjust Assembly.GetType calls to find nested types due to different behavior in CoreCLR.

### DIFF
--- a/tests/monotouch-test/CoreMedia/BlockBufferTest.cs
+++ b/tests/monotouch-test/CoreMedia/BlockBufferTest.cs
@@ -33,7 +33,7 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void CMBlockBufferCustomBlockSource ()
 		{
-			var type = Type.GetType ("CoreMedia.CMCustomBlockAllocator/CMBlockBufferCustomBlockSource, " + typeof (NSObject).Assembly.GetName ().Name);
+			var type = Type.GetType ("CoreMedia.CMCustomBlockAllocator+CMBlockBufferCustomBlockSource, " + typeof (NSObject).Assembly.GetName ().Name);
 			Assert.NotNull (type, "CMBlockBufferCustomBlockSource");
 			// it's 28 (not 32) bytes when executed on 64bits iOS, which implies it's packed to 4 bytes
 			Assert.That (Marshal.SizeOf (type), Is.EqualTo (4 + 3 * IntPtr.Size), "Size");

--- a/tests/monotouch-test/Photos/LivePhotoEditingContextTest.cs
+++ b/tests/monotouch-test/Photos/LivePhotoEditingContextTest.cs
@@ -50,7 +50,7 @@ namespace MonoTouchFixtures.Photos {
 			if (!Runtime.DynamicRegistrationSupported)
 				Assert.Ignore ("This test requires support for the dynamic registrar to setup the block");
 
-			var t = typeof (NSObject).Assembly.GetType ("ObjCRuntime.Trampolines/SDPHLivePhotoFrameProcessingBlock2");
+			var t = typeof (NSObject).Assembly.GetType ("ObjCRuntime.Trampolines+SDPHLivePhotoFrameProcessingBlock2");
 			Assert.NotNull (t, "SDPHLivePhotoFrameProcessingBlock2");
 
 			var m = t.GetMethod ("Invoke", BindingFlags.Static | BindingFlags.NonPublic);


### PR DESCRIPTION
Assembly.GetType works differently between CoreCLR and Mono for nested types:
Mono accepts both '/' and '+' as the character separating the declaring type
from the nested type, while CoreCLR only accepts '+'.

So just switch to '+', since that works everywhere.