### PR TITLE
[msbuild] Fix localization when the error code is shared with mtouch/mmp

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -47,8 +47,13 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\tools\mtouch\errors.resx">
-      <Link>errors.resx</Link>
-    </None>
+    <EmbeddedResource Include="..\..\tools\mtouch\errors.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <XlfSourceFormat>Resx</XlfSourceFormat>
+      <XlfOutputItem>EmbeddedResource</XlfOutputItem>
+      <LastGenOutput>Errors.Designer.cs</LastGenOutput>
+      <CustomToolNamespace>Xamarin.Bundler</CustomToolNamespace>
+      <LogicalName>Errors.mtouch.resources</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Code shared between msbuild and mtouch/mmp needs to share the
localization strings, otherwise the exception being thrown is of no help
to solve the issue.

THis happened if a wrong path was given for an `.xcframework` and
`FileCopier` reported an `MT1022` error.

Reference (not a fix for) https://github.com/xamarin/xamarin-macios/issues/10774