### PR TITLE
[generate-type-forwarders] Silence build warnings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1375,14 +1375,14 @@ $(MACCATALYST_BUILD_DIR)/reference/Xamarin.iOS.cs: $(MACCATALYST_BUILD_DIR)/refe
 	$(Q) mv $@.tmp $@
 
 $(MACCATALYST_BUILD_DIR)/reference/Xamarin.iOS.dll: $(MACCATALYST_BUILD_DIR)/reference/Xamarin.iOS.cs
-	$(Q) $(MACCATALYST_CSC) $< -out:$@ -r:$(MACCATALYST_BUILD_DIR)/reference/Xamarin.MacCatalyst.dll -target:library -deterministic -publicsign -keyfile:$(PRODUCT_KEY_PATH) -nologo -nowarn:618 -unsafe
+	$(Q) $(MACCATALYST_CSC) $< -out:$@ -r:$(MACCATALYST_BUILD_DIR)/reference/Xamarin.MacCatalyst.dll -target:library -deterministic -publicsign -keyfile:$(PRODUCT_KEY_PATH) -nologo -nowarn:108,114,618 -unsafe
 
 $(MACCATALYST_DOTNET_BUILD_DIR)/ref/Xamarin.iOS.cs: $(MACCATALYST_DOTNET_BUILD_DIR)/ref/Xamarin.MacCatalyst.dll $(IOS_DOTNET_BUILD_DIR)/ref/Xamarin.iOS.dll Makefile $(GENERATE_TYPE_FORWARDERS)
 	$(Q) mono $(GENERATE_TYPE_FORWARDERS) $(IOS_DOTNET_BUILD_DIR)/ref/Xamarin.iOS.dll $(MACCATALYST_DOTNET_BUILD_DIR)/ref/Xamarin.MacCatalyst.dll $@.tmp
 	$(Q) mv $@.tmp $@
 
 $(MACCATALYST_DOTNET_BUILD_DIR)/ref/Xamarin.iOS.dll: $(MACCATALYST_DOTNET_BUILD_DIR)/ref/Xamarin.iOS.cs
-	$(Q) $(DOTNET6_CSC) $(DOTNET_FLAGS) $< -out:$@ -r:$(MACCATALYST_DOTNET_BUILD_DIR)/ref/Xamarin.MacCatalyst.dll -target:library -deterministic -publicsign -keyfile:$(PRODUCT_KEY_PATH) -nologo -nowarn:618 -unsafe
+	$(Q) $(DOTNET6_CSC) $(DOTNET_FLAGS) $< -out:$@ -r:$(MACCATALYST_DOTNET_BUILD_DIR)/ref/Xamarin.MacCatalyst.dll -target:library -deterministic -publicsign -keyfile:$(PRODUCT_KEY_PATH) -nologo -nowarn:108,114,618 -unsafe
 
 $(MACCATALYST_BUILD_DIR)/reference/OpenTK-1.0.cs: $(MACCATALYST_BUILD_DIR)/reference/Xamarin.MacCatalyst.dll $(IOS_BUILD_DIR)/reference/OpenTK-1.0.dll Makefile $(GENERATE_TYPE_FORWARDERS)
 	$(Q) mono $(GENERATE_TYPE_FORWARDERS) $(IOS_BUILD_DIR)/reference/OpenTK-1.0.dll $(MACCATALYST_BUILD_DIR)/reference/Xamarin.MacCatalyst.dll $@.tmp


### PR DESCRIPTION
Silence warnings for both legacy and dotnet builds
```
build/maccatalyst/reference/Xamarin.iOS.cs(8014,68): warning CS0108: 'ABPeoplePickerNavigationController.Delegate' hides inherited member 'UINavigationController.Delegate'. Use the new keyword if hiding was intended.
build/maccatalyst/reference/Xamarin.iOS.cs(29868,37): warning CS0114: 'HKWorkoutType.Identifier' hides inherited member 'HKObjectType.Identifier'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
build/maccatalyst/reference/Xamarin.iOS.cs(17769,54): warning CS0108: 'CPTemplateApplicationScene.Delegate' hides inherited member 'UIScene.Delegate'. Use the new keyword if hiding was intended.
build/maccatalyst/reference/Xamarin.iOS.cs(17626,63): warning CS0108: 'CPTemplateApplicationDashboardScene.Delegate' hides inherited member 'UIScene.Delegate'. Use the new keyword if hiding was intended.
build/maccatalyst/reference/Xamarin.iOS.cs(38414,25): warning CS0108: 'MFMessageComposeViewController.Notifications' hides inherited member 'UIViewController.Notifications'. Use the new keyword if hiding was intended.
```