### PR TITLE
[runtime] Move some code from native to managed for xamarin_release_managed_ref.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1979,8 +1979,6 @@ xamarin_release_managed_ref (id self, MonoObject *managed_obj)
 		class_getName (object_getClass (self)), self, (int32_t) [self retainCount], user_type ? xamarin_has_managed_ref (self) : 666, user_type ? get_gchandle_without_flags (self) : (void*) 666, user_type, managed_obj);
 #endif
 
-	xamarin_set_nsobject_flags (managed_obj, xamarin_get_nsobject_flags (managed_obj) & ~NSObjectFlagsHasManagedRef);
-
 	if (user_type) {
 		/* clear MANAGED_REF_BIT */
 		set_flags (self, (enum XamarinGCHandleFlags) (get_flags (self) & ~XamarinGCHandleFlags_HasManagedRef));

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -229,6 +229,7 @@ namespace Foundation {
 
 		void ReleaseManagedRef ()
 		{
+			flags &= ~Flags.HasManagedRef;
 			xamarin_release_managed_ref (handle, this);
 		}
 


### PR DESCRIPTION
* Avoids one usage of xamarin_set_nsobject_flags (which pokes into managed
  memory from native code, which won't be possible with CoreCLR).

* Makes it possible to move more code from native to managed for
  xamarin_release_managed_ref in the future.

* Since the code order is exactly the same, it shouldn't have any other side
  effects.