### PR TITLE
[registrar] Remove redundant call to xamarin_register_nsobject from the dynamic registrar.

### DIFF
--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -6,18 +6,6 @@
 <#@ import namespace="System.Collections.Generic" #>
 <#
 	var delegates = new XDelegates {
-		new XDelegate ("void", "void", "xamarin_register_nsobject",
-			// Do not automatically convert the 'managed_obj' parameter, the
-			// automatic conversion doesn't support neither the GCHandle type
-			// RegisterNSObject expects (tracking resurrection), nor the fact
-			// that the called method takes ownership of the GCHandle.
-			"GCHandle", "IntPtr", "managed_obj",
-			"id", "IntPtr", "native_obj"
-		) {
-			WrappedManagedFunction = "RegisterNSObject",
-			OnlyDynamicUsage = true,
-		},
-
 		new XDelegate ("void", "void", "xamarin_register_assembly",
 			"GCHandle->MonoReflectionAssembly *", "IntPtr", "assembly"
 		) {

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -511,10 +511,6 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 		if (exception != NULL)
 			goto exception_handling;
 		xamarin_create_managed_ref (self, retval, true);
-
-		xamarin_register_nsobject (xamarin_gchandle_new_weakref (retval, false), self, &exception_gchandle);
-		if (exception_gchandle != INVALID_GCHANDLE)
-			goto exception_handling;
 	} else {
 		
 #ifdef TRACE

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -386,11 +386,6 @@ namespace ObjCRuntime {
 		}
 
 #region Wrappers for delegate callbacks
-		static void RegisterNSObject (IntPtr managed_obj, IntPtr native_obj)
-		{
-			RegisterNSObject (GCHandle.FromIntPtr (managed_obj), native_obj, null);
-		}
-
 		static void RegisterAssembly (IntPtr a)
 		{
 			RegisterAssembly ((Assembly) GetGCHandleTarget (a));
@@ -1010,15 +1005,7 @@ namespace ObjCRuntime {
 		}
 		
 		internal static void RegisterNSObject (NSObject obj, IntPtr ptr) {
-			RegisterNSObject (GCHandle.Alloc (obj, GCHandleType.WeakTrackResurrection), ptr, obj);
-		}
-
-		// 'obj' can be provided if the caller has it, otherwise we'll fetch it from the GCHandle
-		// The GCHandle must be a WeakTracResurrection GCHandle, and the caller must not free it
-		internal static void RegisterNSObject (GCHandle handle, IntPtr ptr, NSObject obj)
-		{
-			if (obj == null)
-				obj = (NSObject) handle.Target;
+			var handle = GCHandle.Alloc (obj, GCHandleType.WeakTrackResurrection);
 			lock (lock_obj) {
 				object_map [ptr] = handle;
 				obj.Handle = ptr;


### PR DESCRIPTION
The ctor we just called called it already.

Also, the static registrar doesn't have this call, so the dynamic registrar
shouldn't need it either.