### PR TITLE
[runtime] Simplify calls to xamarin_create_managed_ref.

### DIFF
--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -510,7 +510,6 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 		mono_runtime_invoke (method, retval, (void **) arg_ptrs, exception_ptr);
 		if (exception != NULL)
 			goto exception_handling;
-		xamarin_create_managed_ref (self, retval, true);
 	} else {
 		
 #ifdef TRACE

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -214,12 +214,8 @@ namespace Foundation {
 			IsDirectBinding = (this.GetType ().Assembly == PlatformAssembly);
 			Runtime.RegisterNSObject (this, handle);
 
-			// If the NativeRef bit is set, it means that this call was surfaced by
-			// monotouch_ctor_trampoline, which means we do not want to invoke Retain directly,
-			// it will be done by monotouch_ctor_trampoline on return.
 			bool native_ref = (flags & Flags.NativeRef) == Flags.NativeRef;
-			if (!native_ref)
-				CreateManagedRef (!alloced);
+			CreateManagedRef (!alloced || native_ref);
 		}
 
 		void CreateManagedRef (bool retain)

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3746,9 +3746,6 @@ namespace Registrar {
 			}
 
 			invoke.AppendLine ("mono_runtime_invoke (managed_method, {0}, arg_ptrs, {1});", isStatic ? "NULL" : "mthis", marshal_exception);
-		
-			if (isCtor)
-				invoke.AppendLine ("xamarin_create_managed_ref (self, mthis, true);");
 
 			body_setup.AppendLine ("GCHandle exception_gchandle = INVALID_GCHANDLE;");
 			// prepare the return value


### PR DESCRIPTION
I don't see why we should avoid calling xamarin_create_managed_ref from
NSObject's managed code, and then immediately call xamarin_create_managed_ref
upon return from NSObject's managed code.

This code is old ([1]), and from my reading of it, there's no specific reason
it was done this way.

So simplify the logic to call xamarin_create_managed_ref from a single place
(NSObject's managed code).

[1]: https://github.com/xamarin/maccore/commit/e59c45d3f9408d2b61f47ae90d126612fbb6351b