### PR TITLE
[runtime] Call into managed code to call GC.Collect instead of using embedding API.

### DIFF
--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -6,6 +6,10 @@
 <#@ import namespace="System.Collections.Generic" #>
 <#
 	var delegates = new XDelegates {
+		new XDelegate ("void", "void", "xamarin_gc_collect") {
+			WrappedManagedFunction = "GCCollect",
+		},
+
 		new XDelegate ("void", "void", "xamarin_register_assembly",
 			"GCHandle->MonoReflectionAssembly *", "IntPtr", "assembly"
 		) {
@@ -341,9 +345,6 @@
 			ReturnType = new Arg (cReturnType, mReturnType, string.Empty);
 			EntryPoint = entryPoint;
 
-			if (arguments == null || arguments.Length == 0)
-				return;
-
 			if (arguments.Length % 3 != 0)
 				throw new Exception (string.Format ("Export arguments params must be a multiple of 3 to form a set of (c type, managed name, name) triples for {0}", entryPoint));
 
@@ -416,8 +417,11 @@
 				sb.Append (EntryPoint.Substring ("xamarin_".Length));
 				sb.Append (" (");
 				sb.Append (invoke_args);
-				if (ExceptionHandling)
-					sb.Append (", exception_gchandle");
+				if (ExceptionHandling) {
+					if (Arguments.Count > 0)
+						sb.Append (", ");
+					sb.Append ("exception_gchandle");
+				}
 
 				if (ReturnType.IsGCHandleConversion)
 					sb.Append (")");
@@ -454,9 +458,6 @@
 
 		string CFormatArgs (string empty, bool nameOnly, bool exposed = false)
 		{
-			if (Arguments == null || Arguments.Count == 0)
-				return empty;
-
 			var builder = new StringBuilder ();
 
 			foreach (var arg in Arguments) {
@@ -469,13 +470,16 @@
 				builder.Append (", ");
 			}
 
-			builder.Length -= 2;
+			if (Arguments.Count > 0)
+				builder.Length -= 2;
 
 			if (ExceptionHandling) {
+				if (Arguments.Count > 0)
+					builder.Append (", ");
 				if (nameOnly) {
-					builder.Append (", exception_gchandle");
+					builder.Append ("exception_gchandle");
 				} else {
-					builder.Append (", GCHandle *exception_gchandle");
+					builder.Append ("GCHandle *exception_gchandle");
 				}
 			}
 
@@ -484,9 +488,6 @@
 
 		string MFormatArgs (string empty, bool nameOnly)
 		{
-			if (Arguments == null || Arguments.Count == 0)
-				return empty;
-
 			var builder = new StringBuilder ();
 
 			foreach (var arg in Arguments) {
@@ -503,13 +504,16 @@
 				builder.Append (", ");
 			}
 
-			builder.Length -= 2;
+			if (Arguments.Count > 0)
+				builder.Length -= 2;
 
 			if (ExceptionHandling) {
 				if (nameOnly) {
 					// nothing to do
 				} else {
-					builder.Append (", out IntPtr exception_gchandle");
+					if (Arguments.Count > 0)
+						builder.Append (", ");
+					builder.Append ("out IntPtr exception_gchandle");
 				}
 			}
 

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -410,10 +410,6 @@
 			"MonoDebugFormat", "format"
 		),
 
-		new Export ("void", "mono_gc_collect",
-			"int", "generation"
-		),
-
 		new Export ("mono_bool", "mono_is_debugger_attached"),
 
 		#endregion

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -223,7 +223,9 @@ extern void mono_gc_init_finalizer_thread (void);
 - (void) memoryWarning: (NSNotification *) sender
 {
 	// COOP: ?
-	mono_gc_collect (mono_gc_max_generation ());
+	GCHandle exception_gchandle = INVALID_GCHANDLE;
+	xamarin_gc_collect (&exception_gchandle);
+	xamarin_process_managed_exception_gchandle (exception_gchandle);
 }
 
 @end

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1233,7 +1233,9 @@ pump_gc (void *context)
 	mono_thread_attach (mono_get_root_domain ());
 
 	while (xamarin_gc_pump) {
-		mono_gc_collect (mono_gc_max_generation ());
+		GCHandle exception_gchandle = INVALID_GCHANDLE;
+		xamarin_gc_collect (&exception_gchandle);
+		xamarin_process_managed_exception_gchandle (exception_gchandle);
 		MONO_ENTER_GC_SAFE;
 		usleep (1000000);
 		MONO_EXIT_GC_SAFE;

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1706,6 +1706,11 @@ namespace ObjCRuntime {
 			throw ErrorHelper.CreateError (8003, "Failed to find the closed generic method '{0}' on the type '{1}'.", open_method.Name, closed_type.FullName);
 		}
 
+		static void GCCollect ()
+		{
+			GC.Collect ();
+		}
+
 		[EditorBrowsable (EditorBrowsableState.Never)]
 #if MONOMAC
 		public static void ReleaseBlockOnMainThread (IntPtr block)


### PR DESCRIPTION
Any performance difference will be neglible compared to running the GC, so
there's no compelling reason to use the embedding API.

This makes things a bit easier with CoreCLR, since the new code works there too.

This also required a few changes in delegates.t4 to make code generation for
functions without arguments work correctly.