### PR TITLE
[Localization] Setting 'configure' to use Windows Build Agent

### DIFF
--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -19,7 +19,7 @@ jobs:
 - job: configure
   displayName: 'Configure build'
   pool:
-    vmImage: ubuntu-latest
+    vmImage: windows-latest
 
   steps:
   - template: configure.yml


### PR DESCRIPTION
The OneLocBuild requires a windows build agent. @mandel-macaque suggested that we change the configure build agent from ubuntu to windows since it should not need to be ubuntu. If the build does not complain, this will give us a great place to add the OneLocBuild task.