### PR TITLE
[dotnet] Update `Min*` constants and fix builds for tests

### DIFF
--- a/tests/common/TestProjects/My Spaced App/Info.plist
+++ b/tests/common/TestProjects/My Spaced App/Info.plist
@@ -15,7 +15,7 @@
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>
 	<key>MinimumOSVersion</key>
-	<string>7.0</string>
+	<string>10.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>ApplicationName</string>
 	<key>CFBundleIdentifier</key>

--- a/tests/common/TestProjects/MyActionExtension/Info.plist
+++ b/tests/common/TestProjects/MyActionExtension/Info.plist
@@ -48,6 +48,6 @@
 		<string>com.apple.ui-services</string>
 	</dict>
 	<key>MinimumOSVersion</key>
-	<string>9.3</string>
+	<string>10.0</string>
 </dict>
 </plist>

--- a/tests/common/TestProjects/MyAppWithPackageReference/Info.plist
+++ b/tests/common/TestProjects/MyAppWithPackageReference/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>9.3</string>
+	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/tests/common/TestProjects/MyDocumentPickerExtension/Info.plist
+++ b/tests/common/TestProjects/MyDocumentPickerExtension/Info.plist
@@ -42,6 +42,6 @@
 		<string>com.apple.fileprovider-ui</string>
 	</dict>
 	<key>MinimumOSVersion</key>
-	<string>9.3</string>
+	<string>10.0</string>
 </dict>
 </plist>

--- a/tests/common/TestProjects/MyExtensionWithPackageReference/Info.plist
+++ b/tests/common/TestProjects/MyExtensionWithPackageReference/Info.plist
@@ -48,6 +48,6 @@
 		<string>com.apple.ui-services</string>
 	</dict>
 	<key>MinimumOSVersion</key>
-	<string>9.3</string>
+	<string>10.0</string>
 </dict>
 </plist>

--- a/tests/common/TestProjects/MyIBToolLinkTest/Info.plist
+++ b/tests/common/TestProjects/MyIBToolLinkTest/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>7.0</string>
+	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/tests/common/TestProjects/MyMasterDetailApp/Info.plist
+++ b/tests/common/TestProjects/MyMasterDetailApp/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>8.0</string>
+	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/tests/common/TestProjects/MyMetalGame/Info.plist
+++ b/tests/common/TestProjects/MyMetalGame/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>8.0</string>
+	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/tests/common/TestProjects/MyPhotoEditingExtension/Info.plist
+++ b/tests/common/TestProjects/MyPhotoEditingExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>MinimumOSVersion</key>
-	<string>8.0</string>
+	<string>10.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/tests/common/TestProjects/MyShareExtension/Info.plist
+++ b/tests/common/TestProjects/MyShareExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>MinimumOSVersion</key>
-	<string>8.0</string>
+	<string>10.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/tests/common/TestProjects/MySingleView/Info.plist
+++ b/tests/common/TestProjects/MySingleView/Info.plist
@@ -15,7 +15,7 @@
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>
 	<key>MinimumOSVersion</key>
-	<string>7.0</string>
+	<string>10.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>ApplicationName</string>
 	<key>CFBundleIdentifier</key>

--- a/tests/common/TestProjects/MySpriteKitGame/Info.plist
+++ b/tests/common/TestProjects/MySpriteKitGame/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>8.0</string>
+	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/tests/common/TestProjects/MyTVApp/Info.plist
+++ b/tests/common/TestProjects/MyTVApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>
 	<key>MinimumOSVersion</key>
-	<string>9.0</string>
+	<string>10.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>MyTVApp</string>
 	<key>CFBundleIdentifier</key>

--- a/tests/common/TestProjects/MyTVServicesExtension/Info.plist
+++ b/tests/common/TestProjects/MyTVServicesExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>MinimumOSVersion</key>
-	<string>9.2</string>
+	<string>10.0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/tests/common/TestProjects/MyTabbedApplication/Info.plist
+++ b/tests/common/TestProjects/MyTabbedApplication/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>9.3</string>
+	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/tests/common/TestProjects/MyWebViewApp/Info.plist
+++ b/tests/common/TestProjects/MyWebViewApp/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>8.0</string>
+	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/tests/common/TestProjects/MyXamarinFormsApp/Info.plist
+++ b/tests/common/TestProjects/MyXamarinFormsApp/Info.plist
@@ -21,7 +21,7 @@
         <string>UIInterfaceOrientationLandscapeRight</string>
     </array>
     <key>MinimumOSVersion</key>
-    <string>8.0</string>
+    <string>10.0</string>
     <key>CFBundleDisplayName</key>
     <string>MyXamarinFormsApp</string>
     <key>CFBundleIdentifier</key>

--- a/tests/common/TestProjects/MyiOSAppWithBinding/Info.plist
+++ b/tests/common/TestProjects/MyiOSAppWithBinding/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>9.0</string>
+	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/tests/dotnet/MyCocoaApp/Info.plist
+++ b/tests/dotnet/MyCocoaApp/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.13</string>
+	<string>10.14</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/tests/dotnet/MyInterpretedApp/Info.plist
+++ b/tests/dotnet/MyInterpretedApp/Info.plist
@@ -13,7 +13,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>MinimumOSVersion</key>
-	<string>7.0</string>
+	<string>10.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>ApplicationName</string>
 	<key>CFBundleIdentifier</key>

--- a/tests/dotnet/MySingleView/Info.plist
+++ b/tests/dotnet/MySingleView/Info.plist
@@ -13,7 +13,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>MinimumOSVersion</key>
-	<string>7.0</string>
+	<string>10.0</string>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
 	<key>XSLaunchImageAssets</key>

--- a/tests/dotnet/MyTVApp/Info.plist
+++ b/tests/dotnet/MyTVApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>
 	<key>MinimumOSVersion</key>
-	<string>9.0</string>
+	<string>10.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>MyTVApp</string>
 	<key>CFBundleIdentifier</key>

--- a/tests/dotnet/MyXamarinFormsApp/Info.plist
+++ b/tests/dotnet/MyXamarinFormsApp/Info.plist
@@ -21,7 +21,7 @@
         <string>UIInterfaceOrientationLandscapeRight</string>
     </array>
     <key>MinimumOSVersion</key>
-    <string>8.0</string>
+    <string>10.0</string>
     <key>CFBundleDisplayName</key>
     <string>MyXamarinFormsApp</string>
     <key>CFBundleIdentifier</key>

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -91,6 +91,7 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
+		[Ignore ("watchOS not supported on net6")]
 		public void BuildMyWatchApp ()
 		{
 			Configuration.IgnoreIfIgnoredPlatform (ApplePlatform.WatchOS);
@@ -125,7 +126,7 @@ namespace Xamarin.Tests {
 
 		[TestCase ("iOS")]
 		[TestCase ("tvOS")]
-		[TestCase ("watchOS")]
+		// not supported on net6 [TestCase ("watchOS")]
 		[TestCase ("macOS")]
 		[TestCase ("MacCatalyst")]
 		public void BuildMyClassLibrary (string platform)
@@ -139,7 +140,7 @@ namespace Xamarin.Tests {
 
 		[TestCase ("iOS")]
 		[TestCase ("tvOS")]
-		[TestCase ("watchOS")]
+		// not supported on net6 [TestCase ("watchOS")]
 		[TestCase ("macOS")]
 		[TestCase ("MacCatalyst")]
 		public void BuildEmbeddedResourcesTest (string platform)
@@ -173,7 +174,7 @@ namespace Xamarin.Tests {
 
 		[TestCase ("iOS")]
 		[TestCase ("tvOS")]
-		[TestCase ("watchOS")]
+		// not supported on net6 [TestCase ("watchOS")]
 		[TestCase ("macOS")]
 		[TestCase ("MacCatalyst")]
 		public void BuildFSharpLibraryTest (string platform)
@@ -201,7 +202,7 @@ namespace Xamarin.Tests {
 
 		[TestCase ("iOS")]
 		[TestCase ("tvOS")]
-		[TestCase ("watchOS")]
+		// not supported on net6 [TestCase ("watchOS")]
 		[TestCase ("macOS")]
 		[TestCase ("MacCatalyst")]
 		public void BuildBindingsTest (string platform)
@@ -233,7 +234,7 @@ namespace Xamarin.Tests {
 
 		[TestCase ("iOS")]
 		[TestCase ("tvOS")]
-		[TestCase ("watchOS")]
+		// not supported on net6 [TestCase ("watchOS")]
 		[TestCase ("macOS")]
 		[TestCase ("MacCatalyst")]
 		public void BuildBindingsTest2 (string platform)
@@ -264,7 +265,7 @@ namespace Xamarin.Tests {
 
 		[TestCase ("iOS", "monotouch")]
 		[TestCase ("tvOS", "monotouch")]
-		[TestCase ("watchOS", "monotouch")]
+		// not supported on net6 [TestCase ("watchOS")]
 		[TestCase ("macOS", "xammac")]
 		[TestCase ("MacCatalyst", "monotouch")]
 		public void BuildBundledResources (string platform, string prefix)
@@ -298,7 +299,7 @@ namespace Xamarin.Tests {
 
 		[TestCase ("iOS")]
 		[TestCase ("tvOS")]
-		// [TestCase ("watchOS")] // No watchOS Touch.Client project for .NET yet
+		// not supported on net6 [TestCase ("watchOS")]
 		// [TestCase ("macOS")] // No macOS Touch.Client project for .NET yet
 		[TestCase ("MacCatalyst")]
 		public void BuildInterdependentBindingProjects (string platform)

--- a/tests/interdependent-binding-projects/dotnet/iOS/Info.plist
+++ b/tests/interdependent-binding-projects/dotnet/iOS/Info.plist
@@ -9,7 +9,7 @@
 		<key>CFBundleName</key>
 		<string>InterdependentBindingProject</string>
 		<key>MinimumOSVersion</key>
-		<string>7.0</string>
+		<string>10.0</string>
 		<key>UIDeviceFamily</key>
 		<array>
 			<integer>1</integer>

--- a/tests/interdependent-binding-projects/dotnet/macOS/Info.plist
+++ b/tests/interdependent-binding-projects/dotnet/macOS/Info.plist
@@ -9,6 +9,6 @@
 		<key>CFBundleName</key>
 		<string>CFBundleIdentifier</string>
 		<key>LSMinimumSystemVersion</key>
-		<string>10.9</string>
+		<string>10.14</string>
 	</dict>
 </plist>

--- a/tests/interdependent-binding-projects/dotnet/tvOS/Info.plist
+++ b/tests/interdependent-binding-projects/dotnet/tvOS/Info.plist
@@ -9,7 +9,7 @@
 		<key>CFBundleName</key>
 		<string>InterdependentBindingProject</string>
 		<key>MinimumOSVersion</key>
-		<string>9.0</string>
+		<string>10.0</string>
 		<key>UIDeviceFamily</key>
 		<array>
 			<integer>3</integer>

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -160,6 +160,9 @@ namespace Introspection {
 		}
 
 		[Test]
+#if NET
+		[Ignore ("Requires attributes update - see status in ...")]
+#endif
 		public void Introduced ()
 		{
 			//LogProgress = true;

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -161,7 +161,7 @@ namespace Introspection {
 
 		[Test]
 #if NET
-		[Ignore ("Requires attributes update - see status in ...")]
+		[Ignore ("Requires attributes update - see status in https://github.com/xamarin/xamarin-macios/issues/10834")]
 #endif
 		public void Introduced ()
 		{

--- a/tests/introspection/dotnet/iOS/Info.plist
+++ b/tests/introspection/dotnet/iOS/Info.plist
@@ -20,7 +20,8 @@
 	<string>Testing lens</string>
 	<key>UIDeviceFamily</key>
 	<array>
-		<integer>3</integer>
+		<integer>1</integer>
+		<integer>2</integer>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/tests/introspection/dotnet/iOS/introspection.csproj
+++ b/tests/introspection/dotnet/iOS/introspection.csproj
@@ -120,9 +120,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\iOS\Info.plist">
-      <LogicalName>Info.plist</LogicalName>
-    </None>
+    <None Include="Info.plist" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="..\..\iOS\LaunchScreen.storyboard" Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" />

--- a/tests/linker/ios/dont link/dotnet/iOS/Info.plist
+++ b/tests/linker/ios/dont link/dotnet/iOS/Info.plist
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"[]>
+<plist version="1.0">
+  <dict>
+    <key>CFBundleDisplayName</key>
+    <string>DontLinkTest</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.xamarin.dontlink</string>
+    <key>MinimumOSVersion</key>
+    <string>10.0</string>
+    <key>UIDeviceFamily</key>
+    <array>
+      <integer>1</integer>
+      <integer>2</integer>
+    </array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+      <string>UIInterfaceOrientationPortrait</string>
+      <string>UIInterfaceOrientationLandscapeLeft</string>
+      <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+      <string>UIInterfaceOrientationPortrait</string>
+      <string>UIInterfaceOrientationPortraitUpsideDown</string>
+      <string>UIInterfaceOrientationLandscapeLeft</string>
+      <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>XSAppIconAssets</key>
+    <string>Assets.xcassets/AppIcons.appiconset</string>
+    <key>UILaunchStoryboardName</key>
+    <string>LaunchScreen</string>
+  </dict>
+</plist>

--- a/tests/linker/ios/dont link/dotnet/iOS/dont link.csproj
+++ b/tests/linker/ios/dont link/dotnet/iOS/dont link.csproj
@@ -33,9 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\Info.plist">
-      <LogicalName>Info.plist</LogicalName>
-    </None>
+    <None Include="Info.plist" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Main.cs" />

--- a/tests/linker/ios/link all/dotnet/iOS/Info.plist
+++ b/tests/linker/ios/link all/dotnet/iOS/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>LinkAll</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.xamarin.linkall</string>
+	<key>CFBundleName</key>
+	<string>LinkAll</string>
+	<key>MinimumOSVersion</key>
+	<string>10.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>XSAppIconAssets</key>
+	<string>Assets.xcassets/AppIcons.appiconset</string>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+</dict>
+</plist>

--- a/tests/linker/ios/link all/dotnet/iOS/link all.csproj
+++ b/tests/linker/ios/link all/dotnet/iOS/link all.csproj
@@ -50,9 +50,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\Info.plist">
-      <LogicalName>Info.plist</LogicalName>
-    </None>
+    <None Include="Info.plist" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Main.cs" />

--- a/tests/linker/ios/link sdk/dotnet/iOS/Info.plist
+++ b/tests/linker/ios/link sdk/dotnet/iOS/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>LinkSdkTest</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.xamarin.linksdk</string>
+	<key>MinimumOSVersion</key>
+	<string>10.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>XSAppIconAssets</key>
+	<string>Assets.xcassets/AppIcons.appiconset</string>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+</dict>
+</plist>

--- a/tests/linker/ios/link sdk/dotnet/iOS/link sdk.csproj
+++ b/tests/linker/ios/link sdk/dotnet/iOS/link sdk.csproj
@@ -42,9 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\Info.plist">
-      <LogicalName>Info.plist</LogicalName>
-    </None>
+    <None Include="Info.plist" />
     <LinkDescription Include="$(RootTestsDirectory)\linker\ios\link sdk\dotnet\extra-linker-defs.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/monotouch-test/dotnet/iOS/Info.plist
+++ b/tests/monotouch-test/dotnet/iOS/Info.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>MonoTouchTest</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.xamarin.monotouch-test</string>
+	<key>CFBundleName</key>
+	<string>MonoTouchTest</string>
+	<key>MinimumOSVersion</key>
+	<string>10.0</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>Testing tastes</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Smile!</string>
+	<key>NSContactsUsageDescription</key>
+	<string>Testing friends</string>
+	<key>NSHomeKitUsageDescription</key>
+	<string>Testing roofs</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Testing mike</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Testing lens</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Testing world domination through blue teeth coloring</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiresFullScreen</key>
+	<true/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>XSAppIconAssets</key>
+	<string>Assets.xcassets/AppIcons.appiconset</string>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.xamarin.monotouch-test.TesgBackgroundTask</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>processing</string>
+	</array>
+</dict>
+</plist>

--- a/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
@@ -38,9 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\Info.plist">
-      <LogicalName>Info.plist</LogicalName>
-    </None>
+    <None Include="Info.plist" />
     <None Include="..\..\Entitlements.plist" />
     <None Include="..\..\app.config" />
     <None Include="..\..\EmptyNib.xib" />

--- a/tests/monotouch-test/dotnet/macOS/Info.plist
+++ b/tests/monotouch-test/dotnet/macOS/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.9</string>
+	<string>10.14</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>LSUIElement</key>

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/IBToolTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/IBToolTaskTests.cs
@@ -81,23 +81,11 @@ namespace Xamarin.iOS.Tasks
 			}
 
 			string [] expected = {
-					"LaunchScreen~ipad.nib/runtime.nib",
-					"LaunchScreen~ipad.nib/objects-8.0+.nib",
-					"Main~ipad.storyboardc/Info-8.0+.plist",
-					"Main~ipad.storyboardc/Info.plist",
-					"Main.storyboardc/UIViewController-BYZ-38-t0r~ipad.nib/runtime.nib",
-					"Main.storyboardc/UIViewController-BYZ-38-t0r~ipad.nib/objects-8.0+.nib",
-					"Main.storyboardc/BYZ-38-t0r-view-8bC-Xf-vdC~iphone.nib/runtime.nib",
-					"Main.storyboardc/BYZ-38-t0r-view-8bC-Xf-vdC~iphone.nib/objects-8.0+.nib",
-					"Main.storyboardc/UIViewController-BYZ-38-t0r~iphone.nib/runtime.nib",
-					"Main.storyboardc/UIViewController-BYZ-38-t0r~iphone.nib/objects-8.0+.nib",
-					"Main.storyboardc/BYZ-38-t0r-view-8bC-Xf-vdC~ipad.nib/runtime.nib",
-					"Main.storyboardc/BYZ-38-t0r-view-8bC-Xf-vdC~ipad.nib/objects-8.0+.nib",
-					"LaunchScreen~iphone.nib/runtime.nib",
-					"LaunchScreen~iphone.nib/objects-8.0+.nib",
-					"Main~iphone.storyboardc/Info-8.0+.plist",
-					"Main~iphone.storyboardc/Info.plist",
-				};
+				"LaunchScreen.nib",
+				"Main.storyboardc/UIViewController-BYZ-38-t0r.nib",
+				"Main.storyboardc/BYZ-38-t0r-view-8bC-Xf-vdC.nib",
+				"Main.storyboardc/Info.plist",
+			};
 
 			var inexistentResource = bundleResources.Except (expected).ToArray ();
 			var unexpectedResource = expected.Except (bundleResources).ToArray ();

--- a/tools/common/SdkVersions.cs.in
+++ b/tools/common/SdkVersions.cs.in
@@ -18,11 +18,19 @@ namespace Xamarin {
 		public const string TVOS = "@TVOS_SDK_VERSION@";
 		public const string MacCatalyst = "@MACCATALYST_SDK_VERSION@";
 
+#if NET
+		public const string MinOSX = "@DOTNET_MIN_OSX_SDK_VERSION@";
+		public const string MiniOS = "@DOTNET_MIN_IOS_SDK_VERSION@";
+		public const string MinWatchOS = "99.99"; // TODO not supported, many changes required to remove it
+		public const string MinTVOS = "@DOTNET_MIN_TVOS_SDK_VERSION@";
+		public const string MinMacCatalyst = "@DOTNET_MIN_MACCATALYST_SDK_VERSION@";
+#else
 		public const string MinOSX = "@MIN_OSX_SDK_VERSION@";
 		public const string MiniOS = "@MIN_IOS_SDK_VERSION@";
 		public const string MinWatchOS = "@MIN_WATCHOS_SDK_VERSION@";
 		public const string MinTVOS = "@MIN_TVOS_SDK_VERSION@";
 		public const string MinMacCatalyst = "@MIN_MACCATALYST_SDK_VERSION@";
+#endif
 
 		public const string MiniOSSimulator = "@MIN_IOS_SIMULATOR_VERSION@";
 		public const string MinWatchOSSimulator = "@MIN_WATCHOS_SIMULATOR_VERSION@";


### PR DESCRIPTION
We're bumping the minimum OS versions for all supported platforms
https://github.com/dotnet/core/blob/master/release-notes/6.0/6.0-supported-os.md

Intro's `Introduced` test is ignored as it require (a lot of) changes. This
will be fixed in separate PRs and gradually re-enabled.

iOS
```
[FAIL] Introduced : 7573 API with unneeded or incorrect version information
```

tvOS
```
[FAIL] Introduced : 299 API with unneeded or incorrect version information
```

Tracking progress in https://github.com/xamarin/xamarin-macios/issues/10834