### PR TITLE
[runtime] Port the is_user_type function from native to managed code.

### DIFF
--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -217,8 +217,8 @@ void			xamarin_clear_gchandle (id self);
 GCHandle		xamarin_get_gchandle_with_flags (id self, enum XamarinGCHandleFlags *flags);
 void			xamarin_set_gchandle_with_flags (id self, GCHandle gchandle, enum XamarinGCHandleFlags flags);
 void			xamarin_create_gchandle (id self, void *managed_object, enum XamarinGCHandleFlags flags, bool force_weak);
-void			xamarin_create_managed_ref (id self, void * managed_object, bool retain);
-void            xamarin_release_managed_ref (id self, MonoObject *managed_obj);
+void			xamarin_create_managed_ref (id self, void * managed_object, bool retain, bool user_type);
+void            xamarin_release_managed_ref (id self, MonoObject *managed_obj, bool user_type);
 void			xamarin_notify_dealloc (id self, GCHandle gchandle);
 
 int				xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode);

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -154,10 +154,10 @@ namespace Foundation {
 		extern static void RegisterToggleRef (NSObject obj, IntPtr handle, bool isCustomType);
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		static extern void xamarin_release_managed_ref (IntPtr handle, NSObject managed_obj);
+		static extern void xamarin_release_managed_ref (IntPtr handle, NSObject managed_obj, bool user_type);
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		static extern void xamarin_create_managed_ref (IntPtr handle, NSObject obj, bool retain);
+		static extern void xamarin_create_managed_ref (IntPtr handle, NSObject obj, bool retain, bool user_type);
 
 #if !XAMCORE_3_0
 		public static bool IsNewRefcountEnabled ()
@@ -220,13 +220,13 @@ namespace Foundation {
 
 		void CreateManagedRef (bool retain)
 		{
-			xamarin_create_managed_ref (handle, this, retain);
+			xamarin_create_managed_ref (handle, this, retain, Runtime.IsUserType (handle));
 		}
 
 		void ReleaseManagedRef ()
 		{
 			flags &= ~Flags.HasManagedRef;
-			xamarin_release_managed_ref (handle, this);
+			xamarin_release_managed_ref (handle, this, Runtime.IsUserType (handle));
 		}
 
 		static bool IsProtocol (Type type, IntPtr protocol)

--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -621,6 +621,9 @@ namespace ObjCRuntime {
 		[DllImport ("/usr/lib/libobjc.dylib")]
 		internal extern static IntPtr class_getInstanceVariable (IntPtr cls, string name);
 
+		[DllImport ("/usr/lib/libobjc.dylib")]
+		internal extern static IntPtr class_getInstanceMethod (IntPtr cls, IntPtr sel);
+
 		[DllImport ("/usr/lib/libobjc.dylib", CharSet=CharSet.Ansi)]
 		[return: MarshalAs (UnmanagedType.U1)]
 		internal extern static bool class_addProperty (IntPtr cls, string name, objc_attribute_prop [] attributes, int count);

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1526,6 +1526,43 @@ namespace ObjCRuntime {
 			throw new ArgumentException (string.Format ("'{0}' is an unknown protocol", type.FullName));
 		}
 
+		internal static bool IsUserType (IntPtr self)
+		{
+			var cls = Class.object_getClass (self);
+
+			unsafe {
+				if (options->RegistrationMap != null && options->RegistrationMap->map_count > 0) {
+					var map = options->RegistrationMap->map;
+					var idx = FindUserTypeIndex (map, 0, options->RegistrationMap->map_count - 1, cls);
+					if (idx >= 0)
+						return (map [idx].flags & MTTypeFlags.UserType) == MTTypeFlags.UserType;
+					// If using the partial static registrar, we need to continue
+					// If full static registrar, we can return false
+					if ((options->Flags & InitializationFlags.IsPartialStaticRegistrar) != InitializationFlags.IsPartialStaticRegistrar)
+						return false;
+				}
+			}
+
+			return Class.class_getInstanceMethod (cls, Selector.GetHandle ("xamarinSetGCHandle:flags:")) != IntPtr.Zero;
+		}
+
+		static unsafe int FindUserTypeIndex (MTClassMap* map, int lo, int hi, IntPtr cls)
+		{
+			if (hi >= lo) {
+				int mid = lo + (hi - lo) / 2;
+
+				if (map [mid].handle == cls)
+					return mid;
+
+				if ((long) map [mid].handle > (long) cls)
+					return FindUserTypeIndex (map, lo, mid - 1, cls);
+
+				return FindUserTypeIndex (map, mid + 1, hi, cls);
+			}
+
+			return -1;
+		}
+
 		public static void ConnectMethod (Type type, MethodInfo method, Selector selector)
 		{
 			if (selector == null)

--- a/tests/xtro-sharpie/common-ObjCRuntime.ignore
+++ b/tests/xtro-sharpie/common-ObjCRuntime.ignore
@@ -4,6 +4,7 @@
 !unknown-pinvoke! class_addMethod bound
 !unknown-pinvoke! class_addProperty bound
 !unknown-pinvoke! class_addProtocol bound
+!unknown-pinvoke! class_getInstanceMethod bound
 !unknown-pinvoke! class_getInstanceVariable bound
 !unknown-pinvoke! class_getMethodImplementation bound
 !unknown-pinvoke! class_getName bound


### PR DESCRIPTION
* This is a straight forward port of native code to managed code, and
  shouldn't have any significant side effects.

* Makes it possible to move more code from native to managed for
  xamarin_create_managed_ref and xamarin_release_managed_ref in the future.