### PR TITLE
[runtime] Simplify the various print_all_exceptions methods a bit.

### DIFF
--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -640,7 +640,7 @@ exception_handling:
 					// If we already have an exception, don't overwrite it with an exception from disposing something.
 					// However we don't want to silently ignore it, so print it.
 					NSLog (@PRODUCT ": An exception occurred while disposing the object %p:", list->data);
-					NSLog (@"%@", xamarin_print_all_exceptions (xamarin_gchandle_get_target (dispose_exception_gchandle)));
+					NSLog (@"%@", xamarin_print_all_exceptions (dispose_exception_gchandle));
 				}
 			}
 			list = list->next;

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -242,7 +242,7 @@ void			xamarin_process_managed_exception_gchandle (GCHandle gchandle);
 void			xamarin_throw_product_exception (int code, const char *message);
 GCHandle		xamarin_create_product_exception (int code, const char *message);
 GCHandle		xamarin_create_product_exception_with_inner_exception (int code, GCHandle inner_exception_gchandle /* will be freed */, const char *message);
-NSString *		xamarin_print_all_exceptions (MonoObject *exc);
+NSString *		xamarin_print_all_exceptions (GCHandle handle);
 
 id				xamarin_invoke_objc_method_implementation (id self, SEL sel, IMP xamarin_impl);
 MonoClass *		xamarin_get_nsnumber_class ();


### PR DESCRIPTION
Unify them into a single one (xamarin_print_all_exceptions), which takes the
GCHandle of the exception to create an NSString representation of.

This makes it easier to make this code work with CoreCLR.