### PR TITLE
[runtime] Move a few mono function declaration to the generated logic for mono function declarations instead of doing it manually.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -654,6 +654,21 @@
 		),
 
 		#endregion
+
+		#region mini/debugger-agent.h
+
+		new Export ("void", "mono_debugger_agent_parse_options",
+			"const char *", "options"
+		),
+
+		new Export ("gboolean", "mono_debugger_agent_transport_handshake"),
+
+		new Export ("void", "mono_debugger_agent_register_transport",
+			"DebuggerTransport *", "trans"
+		),
+
+		#endregion
+
 	};
 #><#+
 	class Arg

--- a/runtime/mono-runtime.h.t4
+++ b/runtime/mono-runtime.h.t4
@@ -173,6 +173,17 @@ typedef enum {
 	MONO_DEBUG_FORMAT_DEBUGGER
 } MonoDebugFormat;
 
+/* mini/debugger-agent.h */
+
+typedef struct {
+	const char *name;
+	void (*connect) (const char *address);
+	void (*close1) (void);
+	void (*close2) (void);
+	gboolean (*send) (void *buf, size_t len);
+	ssize_t (*recv) (void *buf, size_t len);
+} DebuggerTransport;
+
 /* metadata/mini.h */
 typedef gboolean (*MonoExceptionFrameWalk)      (MonoMethod *method, gpointer ip, size_t native_offset, gboolean managed, gpointer user_data);
 typedef void  (*MonoUnhandledExceptionFunc)         (MonoObject *exc, gpointer user_data);

--- a/runtime/monotouch-debug.h
+++ b/runtime/monotouch-debug.h
@@ -25,19 +25,6 @@ void monotouch_start_profiling ();
 void monotouch_set_connection_mode (const char *mode);
 void monotouch_set_monodevelop_port (int port);
 
-
-typedef struct {
-	const char *name;
-	void (*connect) (const char *address);
-	void (*close1) (void);
-	void (*close2) (void);
-	gboolean (*send) (void *buf, size_t len);
-	ssize_t (*recv) (void *buf, size_t len);
-} DebuggerTransport;
-
-void mono_debugger_agent_parse_options (const char *options); 
-gboolean mono_debugger_agent_transport_handshake (void);
-void mono_debugger_agent_register_transport (DebuggerTransport *trans);
 bool xamarin_is_native_debugger_attached ();
 
 #ifdef __cplusplus


### PR DESCRIPTION
This makes things a little bit easier to when starting work with CoreCLR.