### PR TITLE
[xcode12.5][webkit] Disable WKDownload init (default ctor)

### DIFF
--- a/src/wkwebkit.cs
+++ b/src/wkwebkit.cs
@@ -1173,6 +1173,7 @@ namespace WebKit
 
 	[Mac (11,3)][iOS (14,5)]
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor]
 	interface WKDownload : NSProgressReporting {
 
 		[NullAllowed, Export ("originalRequest")]


### PR DESCRIPTION
It hangs at `dealloc` time. THere's no documentation about the class
but it seems it might not be user-createable (even if that's uncommon
on classes where you can assign your own delegate)