### PR TITLE
[runtime] Move the call to Runtime.UnregisterNSObject from native to managed code.

### DIFF
--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -218,7 +218,7 @@ GCHandle		xamarin_get_gchandle_with_flags (id self, enum XamarinGCHandleFlags *f
 void			xamarin_set_gchandle_with_flags (id self, GCHandle gchandle, enum XamarinGCHandleFlags flags);
 void			xamarin_create_gchandle (id self, void *managed_object, enum XamarinGCHandleFlags flags, bool force_weak);
 void			xamarin_create_managed_ref (id self, void * managed_object, bool retain, bool user_type);
-void            xamarin_release_managed_ref (id self, MonoObject *managed_obj, bool user_type);
+void            xamarin_release_managed_ref (id self, bool user_type);
 void			xamarin_notify_dealloc (id self, GCHandle gchandle);
 
 int				xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode);

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -990,7 +990,7 @@ namespace ObjCRuntime {
 			}
 		}
 					
-		static void NativeObjectHasDied (IntPtr ptr, NSObject managed_obj)
+		internal static void NativeObjectHasDied (IntPtr ptr, NSObject managed_obj)
 		{
 			lock (lock_obj) {
 				if (object_map.TryGetValue (ptr, out var wr)) {


### PR DESCRIPTION
* Avoids a native->managed transition
* Avoids creating/destroying a GCHandle.
* Makes it possible to remove an argument from the call to
  xamarin_release_managed_ref.
* Makes things easier for CoreCLR.