### PR TITLE
[runtime] Move setting the NSObject flags in xamarin_create_managed_ref from native to managed code.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2040,8 +2040,6 @@ xamarin_create_managed_ref (id self, gpointer managed_object, bool retain, bool 
 	PRINT ("monotouch_create_managed_ref (%s Handle=%p) retainCount=%d; HasManagedRef=%i GCHandle=%i IsUserType=%i managed_object=%p\n", 
 		class_getName ([self class]), self, get_safe_retainCount (self), user_type ? xamarin_has_managed_ref (self) : 666, user_type ? get_gchandle_without_flags (self) : (void*) 666, user_type, managed_object);
 #endif
-	
-	xamarin_set_nsobject_flags ((MonoObject *) managed_object, xamarin_get_nsobject_flags ((MonoObject *) managed_object) | NSObjectFlagsHasManagedRef);
 
 	if (user_type) {
 		gchandle = get_gchandle_without_flags (self);

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -220,6 +220,7 @@ namespace Foundation {
 
 		void CreateManagedRef (bool retain)
 		{
+			flags |= Flags.HasManagedRef;
 			xamarin_create_managed_ref (handle, this, retain, Runtime.IsUserType (handle));
 		}
 


### PR DESCRIPTION
* Less poking into managed memory from native code.
* Makes things easier for CoreCLR support.