### PR TITLE
[runtime] Make xamarin_release_managed_ref a normal P/Invoke.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -342,6 +342,14 @@ void xamarin_framework_peer_lock ()
 	MONO_EXIT_GC_SAFE;
 }
 
+// Same as xamarin_framework_peer_lock, except the current mode should be GC Safe.
+void xamarin_framework_peer_lock_safe ()
+{
+	MONO_ASSERT_GC_SAFE_OR_DETACHED;
+
+	pthread_mutex_lock (&framework_peer_release_lock);
+}
+
 void xamarin_framework_peer_unlock ()
 {
 	pthread_mutex_unlock (&framework_peer_release_lock);
@@ -555,15 +563,13 @@ get_flags (id self)
 }
 
 static inline void
-set_flags (id self, enum XamarinGCHandleFlags flags)
+set_flags_safe (id self, enum XamarinGCHandleFlags flags)
 {
 	// COOP: we call a selector, and that must only be done in SAFE mode.
-	MONO_ASSERT_GC_UNSAFE;
+	MONO_ASSERT_GC_SAFE_OR_DETACHED;
 
-	MONO_ENTER_GC_SAFE;
 	id<XamarinExtendedObject> xself = self;
 	[xself xamarinSetFlags: flags];
-	MONO_EXIT_GC_SAFE;
 }
 
 static inline enum XamarinGCHandleFlags
@@ -1377,7 +1383,6 @@ xamarin_initialize ()
 	nsvalue_class = get_class_from_name (platform_image, foundation, "NSValue", true);
 	nsstring_class = get_class_from_name (platform_image, foundation, "NSString", true);
 
-	xamarin_add_internal_call ("Foundation.NSObject::xamarin_release_managed_ref", (const void *) xamarin_release_managed_ref);
 	xamarin_add_internal_call ("Foundation.NSObject::xamarin_create_managed_ref", (const void *) xamarin_create_managed_ref);
 
 	runtime_initialize = mono_class_get_method_from_name (runtime_class, "Initialize", 1);
@@ -1930,10 +1935,9 @@ get_safe_retainCount (id self)
 void
 xamarin_release_managed_ref (id self, bool user_type)
 {
-	// COOP: This is an icall, so at entry we're in unsafe mode.
-	// COOP: we stay in unsafe mode (since we write to the managed memory) unless calling a selector (which must be done in safe mode)
-	MONO_ASSERT_GC_UNSAFE;
-	
+	// COOP: This is a P/Invoke, so at entry we're in safe mode.
+	MONO_ASSERT_GC_SAFE_OR_DETACHED;
+
 #if defined(DEBUG_REF_COUNTING)
 	PRINT ("monotouch_release_managed_ref (%s Handle=%p) retainCount=%d; HasManagedRef=%i GCHandle=%p IsUserType=%i managed_obj=%p\n", 
 		class_getName (object_getClass (self)), self, (int32_t) [self retainCount], user_type ? xamarin_has_managed_ref (self) : 666, user_type ? get_gchandle_without_flags (self) : (void*) 666, user_type, managed_obj);
@@ -1941,7 +1945,7 @@ xamarin_release_managed_ref (id self, bool user_type)
 
 	if (user_type) {
 		/* clear MANAGED_REF_BIT */
-		set_flags (self, (enum XamarinGCHandleFlags) (get_flags (self) & ~XamarinGCHandleFlags_HasManagedRef));
+		set_flags_safe (self, (enum XamarinGCHandleFlags) (get_flags_safe (self) & ~XamarinGCHandleFlags_HasManagedRef));
 	} else {
 		//
 		// This lock is needed so that we can safely call retainCount in the
@@ -2009,13 +2013,11 @@ xamarin_release_managed_ref (id self, bool user_type)
 		//
 		//    This is https://github.com/xamarin/xamarin-macios/issues/3943
 		//
-		xamarin_framework_peer_lock ();
+		xamarin_framework_peer_lock_safe ();
 		xamarin_framework_peer_unlock ();
 	}
 
-	MONO_ENTER_GC_SAFE;
 	[self release];
-	MONO_EXIT_GC_SAFE;
 }
 
 void

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -197,6 +197,7 @@ void			xamarin_free (void *ptr);
 MonoMethod *	xamarin_get_reflection_method_method (MonoReflectionMethod *method);
 MonoMethod *	xamarin_get_managed_method_for_token (guint32 token_ref, GCHandle *exception_gchandle);
 void			xamarin_framework_peer_lock ();
+void			xamarin_framework_peer_lock_safe ();
 void			xamarin_framework_peer_unlock ();
 bool			xamarin_file_exists (const char *path);
 MonoAssembly *	xamarin_open_and_register (const char *path, GCHandle *exception_gchandle);

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -153,7 +153,7 @@ namespace Foundation {
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		extern static void RegisterToggleRef (NSObject obj, IntPtr handle, bool isCustomType);
 
-		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		[DllImport ("__Internal")]
 		static extern void xamarin_release_managed_ref (IntPtr handle, bool user_type);
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]


### PR DESCRIPTION
* We already switch to GC Safe mode anyway, so there were no benefits from
  entering native code in a GC unsafe mode. In fact we used to switch to GC
  Safe mode for every statement in xamarin_release_managed_ref, and now we can
  execute everything in GC Safe mode without switching back and forth. This
  also means there should be no difference in behavior.

* All parameters are blittable, so there's no extra marshalling cost.

* Easier for CoreCLR.