### PR TITLE
Avoids to remove the launch profiles capability when the _KeepLaunchProfiles property is true

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -101,9 +101,7 @@
 		<ProjectCapability Include="MacCatalystBinding" Condition="'$(_ProjectType)' == 'MacCatalystBindingProject'" />
 		<ProjectCapability Include="MacCatalystClassLibrary" Condition="'$(_ProjectType)' == 'MacCatalystClassLibrary'" />
 
-		<!-- See https://work.azdo.io/1112733 -->
-		<!-- Conflicts with our targets generator in VS+CPS -->
-		<ProjectCapability Remove="LaunchProfiles" />
+		<ProjectCapability Condition="'$(_KeepLaunchProfiles)' != 'true'" Remove="LaunchProfiles" />
 	</ItemGroup>
 	
 	<PropertyGroup>


### PR DESCRIPTION
- this property will be defined on single projects to use launch profiles capability required on VisualStudio
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1291515

When a single-project is loaded on VisualStudio, to enable the switch between target frameworks the LaunchProfiles capability need to be enabled. 

By default, it is enabled but this capability is removed by our SDKs because the HEAD projects (Android and iOS) does not use this IDE feature to display devices on the start button.

The _KeepLaunchProfiles property avoids that removal in order to have LaunchProfiles enabled on VisualStudio.

MAUI targets adds _KeepLaunchProfiles with the value true to enable it for single-project.
