### PR TITLE
[runtime] Move parts of NSObject creation from native to managed.

### DIFF
--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -277,6 +277,15 @@
 			WrappedManagedFunction = "CreateRuntimeException",
 			OnlyDynamicUsage = false,
 		},
+
+		new XDelegate ("GCHandle", "IntPtr", "xamarin_create_nsobject",
+			"GCHandle->MonoReflectionType *", "IntPtr", "type_gchandle",
+			"id", "IntPtr", "native_obj",
+			"enum NSObjectFlags", "NSObject.Flags", "flags"
+		) {
+			WrappedManagedFunction = "CreateNSObject",
+			OnlyDynamicUsage = false,
+		},
 	};
 	delegates.CalculateLengths ();
 #><#+

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -153,11 +153,6 @@
 			"MonoString *", "string_obj"
 		),
 
-		new Export ("MonoObject *", "mono_object_new",
-			"MonoDomain *", "domain",
-			"MonoClass *", "klass"
-		),
-
 		new Export ("uintptr_t", "mono_array_length",
 			"MonoArray *", "array"
 		),

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -221,16 +221,6 @@ xamarin_get_nsobject_handle (MonoObject *obj)
 	return mobj->handle;
 }
 
-void
-xamarin_set_nsobject_handle (MonoObject *obj, id handle)
-{
-	// COOP: Writing managed data, must be in UNSAFE mode
-	MONO_ASSERT_GC_UNSAFE;
-	
-	struct Managed_NSObject *mobj = (struct Managed_NSObject *) obj;
-	mobj->handle  = handle;
-}
-
 uint8_t
 xamarin_get_nsobject_flags (MonoObject *obj)
 {
@@ -353,6 +343,16 @@ void xamarin_framework_peer_lock_safe ()
 void xamarin_framework_peer_unlock ()
 {
 	pthread_mutex_unlock (&framework_peer_release_lock);
+}
+
+MonoObject *
+xamarin_new_nsobject (id self, MonoClass *klass, GCHandle *exception_gchandle)
+{
+	MonoType *type = mono_class_get_type (klass);
+	MonoReflectionType *rtype = mono_type_get_object (mono_domain_get (), type);
+
+	GCHandle obj = xamarin_create_nsobject (rtype, self, NSObjectFlagsNativeRef, exception_gchandle);
+	return xamarin_gchandle_unwrap (obj);
 }
 
 MonoClass *

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -503,10 +503,10 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 		 * This problem is documented in the following bug:
 		 * https://bugzilla.xamarin.com/show_bug.cgi?id=6556
 		 */
-		retval = mono_object_new (domain, mono_method_get_class (method));
+		retval = xamarin_new_nsobject (self, mono_method_get_class (method), &exception_gchandle);
+		if (exception_gchandle != INVALID_GCHANDLE)
+			goto exception_handling;
 
-		xamarin_set_nsobject_handle (retval, self);
-		xamarin_set_nsobject_flags (retval, NSObjectFlagsNativeRef);
 		mono_runtime_invoke (method, retval, (void **) arg_ptrs, exception_ptr);
 		if (exception != NULL)
 			goto exception_handling;

--- a/runtime/xamarin/main.h
+++ b/runtime/xamarin/main.h
@@ -44,6 +44,18 @@ enum XamarinLaunchMode {
 	XamarinLaunchModeEmbedded = 2,
 };
 
+// This has a managed equivalent in NSObject2.cs
+enum NSObjectFlags {
+	NSObjectFlagsDisposed = 1,
+	NSObjectFlagsNativeRef = 2,
+	NSObjectFlagsIsDirectBinding = 4,
+	NSObjectFlagsRegisteredToggleRef = 8,
+	NSObjectFlagsInFinalizerQueue = 16,
+	NSObjectFlagsHasManagedRef = 32,
+	// 64, // Used by SoM
+	NSObjectFlagsIsCustomType = 128,
+};
+
 extern bool mono_use_llvm; // this is defined inside mono
 
 #if DEBUG

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -138,18 +138,6 @@ typedef struct {
 	BindAsData bindas[];
 } MethodDescription;
 
-// This has a managed equivalent in NSObject2.cs
-enum NSObjectFlags {
-	NSObjectFlagsDisposed = 1,
-	NSObjectFlagsNativeRef = 2,
-	NSObjectFlagsIsDirectBinding = 4,
-	NSObjectFlagsRegisteredToggleRef = 8,
-	NSObjectFlagsInFinalizerQueue = 16,
-	NSObjectFlagsHasManagedRef = 32,
-	// 64, // Used by SoM
-	NSObjectFlagsIsCustomType = 128,
-};
-
 struct AssemblyLocation {
 	const char *assembly_name; // base name (without extension) of the assembly
 	const char *location; // the directory where the assembly is
@@ -184,7 +172,6 @@ MonoObject *	xamarin_get_nsobject_with_type_for_ptr_created (id self, bool owns,
 MonoObject *	xamarin_get_delegate_for_block_parameter (MonoMethod *method, guint32 token_ref, int par, void *nativeBlock, GCHandle *exception_gchandle);
 id              xamarin_get_block_for_delegate (MonoMethod *method, MonoObject *delegate, const char *signature /* NULL allowed, but requires the dynamic registrar at runtime to compute */, guint32 token_ref /* INVALID_TOKEN_REF allowed, but requires the dynamic registrar at runtime */, GCHandle *exception_gchandle);
 id				xamarin_get_nsobject_handle (MonoObject *obj);
-void			xamarin_set_nsobject_handle (MonoObject *obj, id handle);
 uint8_t         xamarin_get_nsobject_flags (MonoObject *obj);
 void			xamarin_set_nsobject_flags (MonoObject *obj, uint8_t flags);
 void			xamarin_throw_nsexception (MonoException *exc);
@@ -209,6 +196,7 @@ void			xamarin_add_registration_map (struct MTRegistrationMap *map, bool partial
 uint32_t		xamarin_find_protocol_wrapper_type (uint32_t token_ref);
 void			xamarin_release_block_on_main_thread (void *obj);
 
+MonoObject *	xamarin_new_nsobject (id self, MonoClass *klass, GCHandle *exception_gchandle);
 bool			xamarin_has_managed_ref (id self);
 bool			xamarin_has_managed_ref_safe (id self);
 void			xamarin_switch_gchandle (id self, bool to_weak);

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -72,7 +72,7 @@ namespace Foundation {
 
 		// This enum has a native counterpart in runtime.h
 		[Flags]
-		enum Flags : byte {
+		internal enum Flags : byte {
 			Disposed = 1,
 			NativeRef = 2,
 			IsDirectBinding = 4,
@@ -143,6 +143,16 @@ namespace Foundation {
 		public void Dispose () {
 			Dispose (true);
 			GC.SuppressFinalize (this);
+		}
+
+		internal static IntPtr CreateNSObject (IntPtr type_gchandle, IntPtr handle, Flags flags)
+		{
+			// This function is called from native code before any constructors have executed.
+			var type = (Type) Runtime.GetGCHandleTarget (type_gchandle);
+			var obj = (NSObject) RuntimeHelpers.GetUninitializedObject (type);
+			obj.handle = handle;
+			obj.flags = flags;
+			return Runtime.AllocGCHandle (obj);
 		}
 
 		internal static IntPtr Initialize ()

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1127,6 +1127,11 @@ namespace ObjCRuntime {
 			return (T) ctor.Invoke (new object[] { ptr, owns});
 		}
 
+		static IntPtr CreateNSObject (IntPtr type_gchandle, IntPtr handle, NSObject.Flags flags)
+		{
+			return NSObject.CreateNSObject (type_gchandle, handle, flags);
+		}
+
 		static ConstructorInfo GetIntPtrConstructor (Type type)
 		{
 			lock (intptr_ctor_cache) {

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3723,10 +3723,8 @@ namespace Registrar {
 			
 			// the actual invoke
 			if (isCtor) {
-				invoke.AppendLine ("mthis = mono_object_new (mono_domain_get (), mono_method_get_class (managed_method));");
-				body_setup.AppendLine ("uint8_t flags = NSObjectFlagsNativeRef;");
-				invoke.AppendLine ("xamarin_set_nsobject_handle (mthis, self);");
-				invoke.AppendLine ("xamarin_set_nsobject_flags (mthis, flags);");
+				invoke.AppendLine ("mthis = xamarin_new_nsobject (self, mono_method_get_class (managed_method), &exception_gchandle);");
+				invoke.AppendLine ("if (exception_gchandle != INVALID_GCHANDLE) goto exception_handling;");
 			}
 
 			var marshal_exception = "NULL";


### PR DESCRIPTION
Move the creation of an uninitialized NSObject from native to managed, which:

* Removes the need for the mono_object_new Embedding API.
* Removes one location where we write to managed memory from native code (to
  write the handle + flags in the uninitialized NSObject).
* Makes things easier for CoreCLR.