### PR TITLE
[tests] Preserve all test fixtures.

### DIFF
--- a/tests/api-shared/ObjCRuntime/RegistrarTest.cs
+++ b/tests/api-shared/ObjCRuntime/RegistrarTest.cs
@@ -17,6 +17,7 @@ using NUnit.Framework;
 
 namespace XamarinTests.ObjCRuntime {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class RegistrarSharedTest {
 		public static Registrars CurrentRegistrar {
 			get {

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1150,4 +1150,3 @@ partial class TestRuntime
 		}
 	}
 }
-

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1150,3 +1150,4 @@ partial class TestRuntime
 		}
 	}
 }
+

--- a/tests/monotouch-test/AVFoundation/AVAudioIONode.cs
+++ b/tests/monotouch-test/AVFoundation/AVAudioIONode.cs
@@ -11,6 +11,7 @@ using AVFoundation;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class AVAudioIONodeTests
 	{
 		[Test]

--- a/tests/monotouch-test/AVFoundation/AVPlayerLayerTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVPlayerLayerTest.cs
@@ -11,6 +11,7 @@ using AUUnit = AudioUnit.AudioUnit;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class AVPlayerLayerTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/DerivedEventTest.cs
+++ b/tests/monotouch-test/AppKit/DerivedEventTest.cs
@@ -13,6 +13,7 @@ using CoreGraphics;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class DerivedEventTest
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSAppearance.cs
+++ b/tests/monotouch-test/AppKit/NSAppearance.cs
@@ -9,6 +9,7 @@ using Foundation;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSAppearanceTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSApplication.cs
+++ b/tests/monotouch-test/AppKit/NSApplication.cs
@@ -9,6 +9,7 @@ using Foundation;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSApplicationTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSCellTest.cs
+++ b/tests/monotouch-test/AppKit/NSCellTest.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 namespace MonoMacFixtures.AppKit
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class CellTest
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSClipView.cs
+++ b/tests/monotouch-test/AppKit/NSClipView.cs
@@ -4,11 +4,13 @@ using System;
 
 using AppKit;
 using CoreGraphics;
+using Foundation;
 using ObjCRuntime;
 
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSClipViewTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSColor.cs
+++ b/tests/monotouch-test/AppKit/NSColor.cs
@@ -4,10 +4,12 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 
 using AppKit;
+using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSColorTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSControl.cs
+++ b/tests/monotouch-test/AppKit/NSControl.cs
@@ -3,11 +3,13 @@ using NUnit.Framework;
 using System;
 
 using AppKit;
+using Foundation;
 using ObjCRuntime;
 
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSControlTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSDraggingItem.cs
+++ b/tests/monotouch-test/AppKit/NSDraggingItem.cs
@@ -9,6 +9,7 @@ using Foundation;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSDraggingItemTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSFont.cs
+++ b/tests/monotouch-test/AppKit/NSFont.cs
@@ -11,6 +11,7 @@ using CoreText;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSFontTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSGradient.cs
+++ b/tests/monotouch-test/AppKit/NSGradient.cs
@@ -3,11 +3,13 @@ using System;
 using NUnit.Framework;
 
 using AppKit;
+using Foundation;
 using ObjCRuntime;
 
 namespace Xamarin.Mac.Tests  
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSGradientTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSImage.cs
+++ b/tests/monotouch-test/AppKit/NSImage.cs
@@ -4,11 +4,13 @@ using System;
 
 using AppKit;
 using CoreGraphics;
+using Foundation;
 using ObjCRuntime;
 
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSImageTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSLayoutManagerTests.cs
+++ b/tests/monotouch-test/AppKit/NSLayoutManagerTests.cs
@@ -10,6 +10,7 @@ using CoreGraphics;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSLayoutManagerTests
 	{
 		NSLayoutManager manager;

--- a/tests/monotouch-test/AppKit/NSOpenGLPixelFormat.cs
+++ b/tests/monotouch-test/AppKit/NSOpenGLPixelFormat.cs
@@ -3,9 +3,11 @@ using System;
 using NUnit.Framework;
 
 using AppKit;
+using Foundation;
 
 namespace Xamarin.Mac.Tests {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSOpenGLPixelFormatTests {
 		[Test]
 		public void NSOpenGLPixelFormatAttributesShouldPassWith0Terminate ()

--- a/tests/monotouch-test/AppKit/NSOutlineView.cs
+++ b/tests/monotouch-test/AppKit/NSOutlineView.cs
@@ -9,6 +9,7 @@ using Foundation;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSOutlineViewTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSPasteboard.cs
+++ b/tests/monotouch-test/AppKit/NSPasteboard.cs
@@ -9,6 +9,7 @@ using Foundation;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSPasteboardTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSPathControl.cs
+++ b/tests/monotouch-test/AppKit/NSPathControl.cs
@@ -9,6 +9,7 @@ using Foundation;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSPathControlTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSPathControlItem.cs
+++ b/tests/monotouch-test/AppKit/NSPathControlItem.cs
@@ -8,6 +8,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSPathControlItemTests
 	{
 		[SetUp]

--- a/tests/monotouch-test/AppKit/NSScreen.cs
+++ b/tests/monotouch-test/AppKit/NSScreen.cs
@@ -10,6 +10,7 @@ using Foundation;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSSCreenTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSSearchField.cs
+++ b/tests/monotouch-test/AppKit/NSSearchField.cs
@@ -8,6 +8,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSSearchFieldTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSSlider.cs
+++ b/tests/monotouch-test/AppKit/NSSlider.cs
@@ -9,6 +9,7 @@ using Foundation;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSSliderTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSSplitViewController.cs
+++ b/tests/monotouch-test/AppKit/NSSplitViewController.cs
@@ -9,6 +9,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSSplitViewControllerTests
 	{
 		NSSplitViewController controller;

--- a/tests/monotouch-test/AppKit/NSSplitViewItem.cs
+++ b/tests/monotouch-test/AppKit/NSSplitViewItem.cs
@@ -9,6 +9,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSSplitViewItemTests
 	{
 		NSSplitViewItem item;

--- a/tests/monotouch-test/AppKit/NSStackView.cs
+++ b/tests/monotouch-test/AppKit/NSStackView.cs
@@ -8,6 +8,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSStackViewTests
 	{
 		NSStackView view;

--- a/tests/monotouch-test/AppKit/NSStepperCell.cs
+++ b/tests/monotouch-test/AppKit/NSStepperCell.cs
@@ -3,10 +3,12 @@ using System;
 using NUnit.Framework;
 
 using AppKit;
+using Foundation;
 
 namespace apitest
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSStepperCellTests
 	{
 		NSStepperCell cell;

--- a/tests/monotouch-test/AppKit/NSStoryboardSegue.cs
+++ b/tests/monotouch-test/AppKit/NSStoryboardSegue.cs
@@ -8,6 +8,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSStoryboardSegueTests
 	{
 		NSStoryboardSegue segue;

--- a/tests/monotouch-test/AppKit/NSTabViewController.cs
+++ b/tests/monotouch-test/AppKit/NSTabViewController.cs
@@ -9,6 +9,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSTabViewControllerTests
 	{
 		NSTabViewController controller;

--- a/tests/monotouch-test/AppKit/NSTabViewItem.cs
+++ b/tests/monotouch-test/AppKit/NSTabViewItem.cs
@@ -8,6 +8,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSTabViewItemTests
 	{
 		NSTabViewItem item;

--- a/tests/monotouch-test/AppKit/NSTableColumn.cs
+++ b/tests/monotouch-test/AppKit/NSTableColumn.cs
@@ -8,6 +8,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSTableColumnTests
 	{
 		NSTableColumn column;

--- a/tests/monotouch-test/AppKit/NSTableRowView.cs
+++ b/tests/monotouch-test/AppKit/NSTableRowView.cs
@@ -8,6 +8,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSTableRowViewTests
 	{
 		NSTableRowView view;

--- a/tests/monotouch-test/AppKit/NSTableView.cs
+++ b/tests/monotouch-test/AppKit/NSTableView.cs
@@ -9,6 +9,7 @@ using Foundation;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSTableViewTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSTextField.cs
+++ b/tests/monotouch-test/AppKit/NSTextField.cs
@@ -8,6 +8,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSTextFieldTests
 	{
 		NSTextField textField;

--- a/tests/monotouch-test/AppKit/NSTextFinder.cs
+++ b/tests/monotouch-test/AppKit/NSTextFinder.cs
@@ -11,6 +11,7 @@ using Foundation;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSTextFinderTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSTextInputClient.cs
+++ b/tests/monotouch-test/AppKit/NSTextInputClient.cs
@@ -9,6 +9,7 @@ using Foundation;
 namespace apitest
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSTextInputClient
 	{
 		NSTextView textView;

--- a/tests/monotouch-test/AppKit/NSTextView.cs
+++ b/tests/monotouch-test/AppKit/NSTextView.cs
@@ -8,6 +8,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSTextViewTests
 	{
 		NSTextView view;

--- a/tests/monotouch-test/AppKit/NSToolbar.cs
+++ b/tests/monotouch-test/AppKit/NSToolbar.cs
@@ -8,6 +8,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSToolbarTests
 	{
 		NSToolbar toolbar;

--- a/tests/monotouch-test/AppKit/NSToolbarItem.cs
+++ b/tests/monotouch-test/AppKit/NSToolbarItem.cs
@@ -8,6 +8,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSToolbarItemTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSUserDefaultsController.cs
+++ b/tests/monotouch-test/AppKit/NSUserDefaultsController.cs
@@ -8,6 +8,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSUserDefaultsControllerTests
 	{
 		NSUserDefaultsController controller;

--- a/tests/monotouch-test/AppKit/NSViewController.cs
+++ b/tests/monotouch-test/AppKit/NSViewController.cs
@@ -8,6 +8,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSViewControllerTests
 	{
 		NSViewController controller;

--- a/tests/monotouch-test/AppKit/NSVisualEffectView.cs
+++ b/tests/monotouch-test/AppKit/NSVisualEffectView.cs
@@ -8,6 +8,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSVisualEffectViewTests
 	{
 		NSVisualEffectView view;

--- a/tests/monotouch-test/AppKit/NSWindowController.cs
+++ b/tests/monotouch-test/AppKit/NSWindowController.cs
@@ -10,6 +10,7 @@ using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
+	[Preserve (AllMembers = true)]
 	public class NSWindowControllerTests
 	{
 		[Test]

--- a/tests/monotouch-test/AppKit/NSWorkspace.cs
+++ b/tests/monotouch-test/AppKit/NSWorkspace.cs
@@ -3,11 +3,13 @@ using NUnit.Framework;
 using System;
 
 using AppKit;
+using Foundation;
 using ObjCRuntime;
 
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSWorkspaceTests
 	{
 		[Test]

--- a/tests/monotouch-test/AudioUnit/AUGraphTestMac.cs
+++ b/tests/monotouch-test/AudioUnit/AUGraphTestMac.cs
@@ -6,10 +6,12 @@ using NUnit.Framework;
 using AppKit;
 using AudioUnit;
 using AudioToolbox;
+using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class AUGraphTests
 	{
 		int graphRenderCallbackCount = 0;

--- a/tests/monotouch-test/AudioUnit/AudioUnit.cs
+++ b/tests/monotouch-test/AudioUnit/AudioUnit.cs
@@ -6,10 +6,12 @@ using NUnit.Framework;
 using AppKit;
 using AudioUnit;
 using theUnit = AudioUnit.AudioUnit;
+using Foundation;
 
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class AudioUnitTests
 	{
 		theUnit GetAudioUnitForTest ()

--- a/tests/monotouch-test/CoreAnimation/CABasicAnimation.cs
+++ b/tests/monotouch-test/CoreAnimation/CABasicAnimation.cs
@@ -11,6 +11,7 @@ using Foundation;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class CABasicAnimationTests
 	{
 		[Test]

--- a/tests/monotouch-test/CoreAnimation/CAKeyFrameAnimation.cs
+++ b/tests/monotouch-test/CoreAnimation/CAKeyFrameAnimation.cs
@@ -11,6 +11,7 @@ using Foundation;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class CAKeyFrameAnimationTests
 	{
 		[Test]

--- a/tests/monotouch-test/CoreAnimation/CALayer.cs
+++ b/tests/monotouch-test/CoreAnimation/CALayer.cs
@@ -11,6 +11,7 @@ using Foundation;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class CALayerTests
 	{
 		[Test]

--- a/tests/monotouch-test/CoreAnimation/CAOpenGLLayer.cs
+++ b/tests/monotouch-test/CoreAnimation/CAOpenGLLayer.cs
@@ -11,6 +11,7 @@ using ObjCRuntime;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class CAOpenGLLayerTest
 	{		
 #if !DYNAMIC_REGISTRAR

--- a/tests/monotouch-test/CoreGraphics/ColorConversionInfoTest.cs
+++ b/tests/monotouch-test/CoreGraphics/ColorConversionInfoTest.cs
@@ -18,6 +18,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.CoreGraphics {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class ColorConversionInfoTest {
 
 		[Test]

--- a/tests/monotouch-test/CoreImage/CIFilter.cs
+++ b/tests/monotouch-test/CoreImage/CIFilter.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using System;
 
 using AppKit;
+using Foundation;
 using ObjCRuntime;
 using CoreImage;
 using CoreGraphics;
@@ -10,6 +11,7 @@ using CoreGraphics;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class CIFilterTests
 	{
 		[Test]

--- a/tests/monotouch-test/Darwin/KernelNotificationTest.cs
+++ b/tests/monotouch-test/Darwin/KernelNotificationTest.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Diagnostics;
 
+using Foundation;
 using Darwin;
 
 using NUnit.Framework;
@@ -9,6 +10,7 @@ using NUnit.Framework;
 namespace apitest
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class KernelNotificationTest
 	{
 		KernelEvent [] CreateEvents (Process process)

--- a/tests/monotouch-test/Foundation/AppleScript.cs
+++ b/tests/monotouch-test/Foundation/AppleScript.cs
@@ -8,6 +8,7 @@ using Foundation;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class AppleScriptTests
 	{		
 		[Test]

--- a/tests/monotouch-test/Foundation/AttributedStringTest.cs
+++ b/tests/monotouch-test/Foundation/AttributedStringTest.cs
@@ -16,6 +16,7 @@ using CoreText;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class AttributedStringTest {
 
 		CGColor red, yellow;

--- a/tests/monotouch-test/Foundation/FileHandleTest.cs
+++ b/tests/monotouch-test/Foundation/FileHandleTest.cs
@@ -14,6 +14,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class FileHandleTest {
 
 		[Test]

--- a/tests/monotouch-test/Foundation/IndexPathTest.cs
+++ b/tests/monotouch-test/Foundation/IndexPathTest.cs
@@ -14,6 +14,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class IndexPathTest {
 		[Test]
 		public void FromIndex ()

--- a/tests/monotouch-test/Foundation/MutableAttributedStringTest.cs
+++ b/tests/monotouch-test/Foundation/MutableAttributedStringTest.cs
@@ -14,6 +14,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MutableSAttributedStringTest {
 
 		[Test]

--- a/tests/monotouch-test/Foundation/NSArray1Test.cs
+++ b/tests/monotouch-test/Foundation/NSArray1Test.cs
@@ -18,6 +18,7 @@ using Foundation;
 
 namespace MonoTouchFixtures.Foundation {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSArray1Test {
 		[Test]
 		public void Ctor ()

--- a/tests/monotouch-test/Foundation/NSDictionary2Test.cs
+++ b/tests/monotouch-test/Foundation/NSDictionary2Test.cs
@@ -11,6 +11,7 @@ using ObjCRuntime;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSDictionary2Test {
 
 		[Test]

--- a/tests/monotouch-test/Foundation/NSDictionaryTest.cs
+++ b/tests/monotouch-test/Foundation/NSDictionaryTest.cs
@@ -9,6 +9,7 @@ using ObjCRuntime;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSDictionaryTest {
 
 		//

--- a/tests/monotouch-test/Foundation/NSFormatter.cs
+++ b/tests/monotouch-test/Foundation/NSFormatter.cs
@@ -8,6 +8,7 @@ using AppKit;
 namespace apitest
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSFormatterTests
 	{
 		NSNumberFormatter formatter;

--- a/tests/monotouch-test/Foundation/NSIndexSet.cs
+++ b/tests/monotouch-test/Foundation/NSIndexSet.cs
@@ -11,6 +11,7 @@ using CoreGraphics;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSIndexSetTests
 	{
 		[Test]

--- a/tests/monotouch-test/Foundation/NSInputStreamTest.cs
+++ b/tests/monotouch-test/Foundation/NSInputStreamTest.cs
@@ -5,6 +5,7 @@ using Foundation;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSInputStreamTest
 	{
 		[Test]

--- a/tests/monotouch-test/Foundation/NSLayoutConstraint.cs
+++ b/tests/monotouch-test/Foundation/NSLayoutConstraint.cs
@@ -1,10 +1,12 @@
 #if __MACOS__
 using AppKit;
+using Foundation;
 using NUnit.Framework;
 
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSLayoutConstraintTest
 	{
 		[Test]

--- a/tests/monotouch-test/Foundation/NSLayoutConstraintTest.cs
+++ b/tests/monotouch-test/Foundation/NSLayoutConstraintTest.cs
@@ -8,12 +8,14 @@
 //
 #if !MONOMAC
 using UIKit;
+using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
 
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSLayoutConstraintTest {
 
 #if !__WATCHOS__ // FIXME: it looks like this test can be rewritten to not use UIViewController, so that it can run on WatchOS as well.

--- a/tests/monotouch-test/Foundation/NSMetadataItem.cs
+++ b/tests/monotouch-test/Foundation/NSMetadataItem.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 namespace Xamarin.Mac.Tests {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSMetadataItemTest {
 		
 		[Test]

--- a/tests/monotouch-test/Foundation/NSMutableArray1Test.cs
+++ b/tests/monotouch-test/Foundation/NSMutableArray1Test.cs
@@ -9,6 +9,7 @@ using Foundation;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSMutableArray1Test {
 
 		[Test]

--- a/tests/monotouch-test/Foundation/NSMutableDictionary2Test.cs
+++ b/tests/monotouch-test/Foundation/NSMutableDictionary2Test.cs
@@ -11,6 +11,7 @@ using ObjCRuntime;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSMutableDictionary2Test {
 
 		[Test]

--- a/tests/monotouch-test/Foundation/NSMutableDictionaryTest.cs
+++ b/tests/monotouch-test/Foundation/NSMutableDictionaryTest.cs
@@ -9,6 +9,7 @@ using ObjCRuntime;
 namespace monotouchtest
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSMutableDictionaryTest {
 		
 		[Test]

--- a/tests/monotouch-test/Foundation/NSMutableOrderedSet1Test.cs
+++ b/tests/monotouch-test/Foundation/NSMutableOrderedSet1Test.cs
@@ -19,6 +19,7 @@ using Foundation;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSMutableOrderedSet1Test {
 
 		[Test]

--- a/tests/monotouch-test/Foundation/NSMutableOrderedSetTest.cs
+++ b/tests/monotouch-test/Foundation/NSMutableOrderedSetTest.cs
@@ -16,6 +16,7 @@ using Foundation;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSMutableOrderedSetTest {
 		
 		[Test]

--- a/tests/monotouch-test/Foundation/NSMutableSet1Test.cs
+++ b/tests/monotouch-test/Foundation/NSMutableSet1Test.cs
@@ -9,6 +9,7 @@ using Foundation;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSMutableSet1Test {
 
 		[Test]

--- a/tests/monotouch-test/Foundation/NSMutableSetTest.cs
+++ b/tests/monotouch-test/Foundation/NSMutableSetTest.cs
@@ -16,6 +16,7 @@ using Foundation;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSMutableSetTest {
 
 		[Test]

--- a/tests/monotouch-test/Foundation/NSObject.cs
+++ b/tests/monotouch-test/Foundation/NSObject.cs
@@ -11,6 +11,7 @@ using CoreGraphics;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSObjectTests
 	{
 		[Test]

--- a/tests/monotouch-test/Foundation/NSOrderedSet1Test.cs
+++ b/tests/monotouch-test/Foundation/NSOrderedSet1Test.cs
@@ -19,6 +19,7 @@ using Foundation;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSOrderedSet1Test {
 
 		[Test]

--- a/tests/monotouch-test/Foundation/NSOrderedSetTest.cs
+++ b/tests/monotouch-test/Foundation/NSOrderedSetTest.cs
@@ -16,6 +16,7 @@ using Foundation;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSOrderedSetTest {
 
 		[Test]

--- a/tests/monotouch-test/Foundation/NSSet1Test.cs
+++ b/tests/monotouch-test/Foundation/NSSet1Test.cs
@@ -9,6 +9,7 @@ using Foundation;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSSet1Test {
 
 		[Test]

--- a/tests/monotouch-test/Foundation/NSSetTest.cs
+++ b/tests/monotouch-test/Foundation/NSSetTest.cs
@@ -7,6 +7,7 @@ using Foundation;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSSetTest
 	{
 		[Test]

--- a/tests/monotouch-test/Foundation/NSStreamTest.cs
+++ b/tests/monotouch-test/Foundation/NSStreamTest.cs
@@ -11,6 +11,7 @@ using Foundation;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSStreamTest 
 	{
 		[Test]

--- a/tests/monotouch-test/Foundation/NSString.cs
+++ b/tests/monotouch-test/Foundation/NSString.cs
@@ -10,6 +10,7 @@ using CoreGraphics;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSStringTests
 	{
 		[Test]
@@ -65,6 +66,7 @@ namespace Xamarin.Mac.Tests
 	}
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSAttributedStringTests
 	{
 		[Test]

--- a/tests/monotouch-test/Foundation/NSThread.cs
+++ b/tests/monotouch-test/Foundation/NSThread.cs
@@ -11,6 +11,7 @@ using CoreGraphics;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSThreadTests
 	{
 		[Test]

--- a/tests/monotouch-test/Foundation/NSUrlSessionConfiguration.cs
+++ b/tests/monotouch-test/Foundation/NSUrlSessionConfiguration.cs
@@ -8,6 +8,7 @@ using ObjCRuntime;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NSUrlSessionConfigurationTest {
 
 		[Test]

--- a/tests/monotouch-test/Foundation/OutputStreamTest.cs
+++ b/tests/monotouch-test/Foundation/OutputStreamTest.cs
@@ -17,6 +17,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Foundation {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class OutputStreamTest {
 
 		[Test]

--- a/tests/monotouch-test/HttpClient/HttpClientTest.cs
+++ b/tests/monotouch-test/HttpClient/HttpClientTest.cs
@@ -12,6 +12,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.HttpClientTests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class HttpClientTest
 	{
 		const int WaitTimeout = 5000;

--- a/tests/monotouch-test/Metal/ClearValueTest.cs
+++ b/tests/monotouch-test/Metal/ClearValueTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class ClearValueTest
 	{
 		[Test]

--- a/tests/monotouch-test/Metal/DeviceTest.cs
+++ b/tests/monotouch-test/Metal/DeviceTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 	
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class DeviceTest {
 		
 		[Test]

--- a/tests/monotouch-test/Metal/HeapDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/HeapDescriptorTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 
+using Foundation;
 using ObjCRuntime;
 using Metal;
 
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class HeapDescriptorTest {
 		MTLHeapDescriptor hd = null;
 

--- a/tests/monotouch-test/Metal/MTLArgumentDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLArgumentDescriptorTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -9,6 +10,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLArgumentDescriptorTest {
 		MTLArgumentDescriptor descriptor = null;
 

--- a/tests/monotouch-test/Metal/MTLArgumentEncoderTest.cs
+++ b/tests/monotouch-test/Metal/MTLArgumentEncoderTest.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLArgumentEncoderTest {
 		IMTLDevice device;
 		IMTLLibrary library;

--- a/tests/monotouch-test/Metal/MTLAttributeDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLAttributeDescriptorTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -9,6 +10,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 	
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLAttributeDescriptorTest {
 		MTLAttributeDescriptor descriptor = null;
 		

--- a/tests/monotouch-test/Metal/MTLAttributeTest.cs
+++ b/tests/monotouch-test/Metal/MTLAttributeTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -9,6 +10,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 	
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLAttributeTest {
 		MTLAttribute attr = null;
 		

--- a/tests/monotouch-test/Metal/MTLBlitPassDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLBlitPassDescriptorTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -11,6 +12,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLBlitPassDescriptorTest { 
 
 		[SetUp]

--- a/tests/monotouch-test/Metal/MTLBlitPassSampleBufferAttachmentDescriptorArrayTest.cs
+++ b/tests/monotouch-test/Metal/MTLBlitPassSampleBufferAttachmentDescriptorArrayTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLBlitPassSampleBufferAttachmentDescriptorArrayTest {
 		MTLBlitPassSampleBufferAttachmentDescriptorArray array;
 

--- a/tests/monotouch-test/Metal/MTLBlitPassSampleBufferAttachmentDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLBlitPassSampleBufferAttachmentDescriptorTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -11,6 +12,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLBlitPassSampleBufferAttachmentDescriptorTest {
 		MTLBlitPassSampleBufferAttachmentDescriptor descriptor;
 

--- a/tests/monotouch-test/Metal/MTLBufferLayoutDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLBufferLayoutDescriptorTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -9,6 +10,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 	
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLBufferLayoutDescriptorTest {
 
 		[SetUp]

--- a/tests/monotouch-test/Metal/MTLComputeCommandEncoderTest.cs
+++ b/tests/monotouch-test/Metal/MTLComputeCommandEncoderTest.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLComputeCommandEncoderTest {
 		IMTLDevice device;
 		IMTLCommandQueue commandQ;

--- a/tests/monotouch-test/Metal/MTLComputePassDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLComputePassDescriptorTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLComputePassDescriptorTest {
 		MTLComputePassDescriptor descriptor;
 

--- a/tests/monotouch-test/Metal/MTLComputePassSampleBufferAttachmentDescriptorArrayTest.cs
+++ b/tests/monotouch-test/Metal/MTLComputePassSampleBufferAttachmentDescriptorArrayTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLComputePassSampleBufferAttachmentDescriptorArrayTest {
 		MTLComputePassSampleBufferAttachmentDescriptorArray array;
 

--- a/tests/monotouch-test/Metal/MTLComputePassSampleBufferAttachmentDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLComputePassSampleBufferAttachmentDescriptorTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLComputePassSampleBufferAttachmentDescriptorTest {
 		MTLComputePassSampleBufferAttachmentDescriptor descriptor;
 

--- a/tests/monotouch-test/Metal/MTLCounterSampleBufferDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLCounterSampleBufferDescriptorTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLCounterSampleBufferDescriptorTest {
 		MTLCounterSampleBufferDescriptor descriptor;
 

--- a/tests/monotouch-test/Metal/MTLFunctionConstantTest.cs
+++ b/tests/monotouch-test/Metal/MTLFunctionConstantTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -9,6 +10,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 	
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLFunctionConstantTest {
 		
 		[SetUp]

--- a/tests/monotouch-test/Metal/MTLIndirectCommandBufferDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLIndirectCommandBufferDescriptorTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -9,6 +10,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLIndirectCommandBufferDescriptorTest {
 		MTLIndirectCommandBufferDescriptor descriptor = null;
 

--- a/tests/monotouch-test/Metal/MTLIntersectionFunctionTableDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLIntersectionFunctionTableDescriptorTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLIntersectionFunctionTableDescriptorTest {
 
 		[SetUp]

--- a/tests/monotouch-test/Metal/MTLIntersectionFunctionTableTests.cs
+++ b/tests/monotouch-test/Metal/MTLIntersectionFunctionTableTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 	
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLIntersectionFunctionTableTests {
 		IMTLDevice device;
 		IMTLIntersectionFunctionTable functionTable;

--- a/tests/monotouch-test/Metal/MTLLinkedFunctionsTest.cs
+++ b/tests/monotouch-test/Metal/MTLLinkedFunctionsTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLLinkedFunctionsTest {
 		MTLLinkedFunctions functions;
 

--- a/tests/monotouch-test/Metal/MTLPipelineBufferDescriptorTests.cs
+++ b/tests/monotouch-test/Metal/MTLPipelineBufferDescriptorTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -9,6 +10,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLPipelineBufferDescriptorTest {
 		MTLPipelineBufferDescriptor descriptor = null;
 

--- a/tests/monotouch-test/Metal/MTLPointerTypeTests.cs
+++ b/tests/monotouch-test/Metal/MTLPointerTypeTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -9,6 +10,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLPointerTypeTests {
 		MTLPointerType ptrType = null;
 

--- a/tests/monotouch-test/Metal/MTLRenderPassSampleBufferAttachmentDescriptorArrayTest.cs
+++ b/tests/monotouch-test/Metal/MTLRenderPassSampleBufferAttachmentDescriptorArrayTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLRenderPassSampleBufferAttachmentDescriptorArrayTest {
 		MTLRenderPassSampleBufferAttachmentDescriptorArray array;
 

--- a/tests/monotouch-test/Metal/MTLRenderPassSampleBufferAttachmentDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLRenderPassSampleBufferAttachmentDescriptorTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLRenderPassSampleBufferAttachmentDescriptorTest {
 		MTLRenderPassSampleBufferAttachmentDescriptor descriptor;
 

--- a/tests/monotouch-test/Metal/MTLResourceStatePassDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLResourceStatePassDescriptorTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLResourceStatePassDescriptorTest {
 		MTLResourceStatePassDescriptor descriptor;
 

--- a/tests/monotouch-test/Metal/MTLResourceStatePassSampleBufferAttachmentDescriptorArrayTest.cs
+++ b/tests/monotouch-test/Metal/MTLResourceStatePassSampleBufferAttachmentDescriptorArrayTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLResourceStatePassSampleBufferAttachmentDescriptorArrayTest {
 		MTLResourceStatePassSampleBufferAttachmentDescriptorArray array;
 

--- a/tests/monotouch-test/Metal/MTLResourceStatePassSampleBufferAttachmentDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLResourceStatePassSampleBufferAttachmentDescriptorTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLResourceStatePassSampleBufferAttachmentDescriptorTest {
 
 		MTLResourceStatePassSampleBufferAttachmentDescriptor descriptor;

--- a/tests/monotouch-test/Metal/MTLSharedEventListenerTest.cs
+++ b/tests/monotouch-test/Metal/MTLSharedEventListenerTest.cs
@@ -3,6 +3,7 @@
 using System;
 
 using CoreFoundation;
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLSharedEventListenerTest {
 		MTLSharedEventListener listener = null;
 		DispatchQueue queue = null;

--- a/tests/monotouch-test/Metal/MTLStageInRegionIndirectArgumentsTest.cs
+++ b/tests/monotouch-test/Metal/MTLStageInRegionIndirectArgumentsTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -9,6 +10,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLStageInRegionIndirectArgumentsTest {
 
 		[SetUp]

--- a/tests/monotouch-test/Metal/MTLStageInputOutputDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLStageInputOutputDescriptorTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -9,6 +10,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 	
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLStageInputOutputDescriptorTest {
 		MTLStageInputOutputDescriptor descriptor  = null;
 		

--- a/tests/monotouch-test/Metal/MTLTextureReferenceType.cs
+++ b/tests/monotouch-test/Metal/MTLTextureReferenceType.cs
@@ -2,6 +2,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -9,6 +10,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLTextureReferenceTypeTests {
 		MTLTextureReferenceType reference = null;
 

--- a/tests/monotouch-test/Metal/MTLTileRenderPipelineColorAttachmentDescriptorTests.cs
+++ b/tests/monotouch-test/Metal/MTLTileRenderPipelineColorAttachmentDescriptorTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 using ObjCRuntime;
 
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLTileRenderPipelineColorAttachmentDescriptorTests {
 		MTLTileRenderPipelineColorAttachmentDescriptor descriptor = null;
 

--- a/tests/monotouch-test/Metal/MTLTileRenderPipelineDescriptor.cs
+++ b/tests/monotouch-test/Metal/MTLTileRenderPipelineDescriptor.cs
@@ -2,6 +2,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 using ObjCRuntime;
 
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLTileRenderPipelineDescriptorTests {
 		MTLTileRenderPipelineDescriptor descriptor = null;
 

--- a/tests/monotouch-test/Metal/MTLTileRenderPipelineDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLTileRenderPipelineDescriptorTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLTileRenderPipelineDescriptorTest {
 
 		MTLTileRenderPipelineDescriptor descriptor;

--- a/tests/monotouch-test/Metal/MTLVisibleFunctionTableDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLVisibleFunctionTableDescriptorTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MTLVisibleFunctionTableDescriptorTest {
 
 		MTLVisibleFunctionTableDescriptor descriptor;

--- a/tests/monotouch-test/Metal/StructTest.cs
+++ b/tests/monotouch-test/Metal/StructTest.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Runtime.InteropServices;
 
+using Foundation;
 using Metal;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.Metal {
 	
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class StructTest {
 		
 		[Test]

--- a/tests/monotouch-test/MetalPerformanceShaders/ImageScaleTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/ImageScaleTest.cs
@@ -12,6 +12,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.MetalPerformanceShaders {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class ImageScaleTest {
 
 		IMTLDevice device;

--- a/tests/monotouch-test/MetalPerformanceShaders/KernelTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/KernelTest.cs
@@ -14,6 +14,7 @@ using NUnit.Framework;
 namespace MonoTouchFixtures.MetalPerformanceShaders {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class KernelTest {
 
 		IMTLDevice device;

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSAccelerationStructureTests.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSAccelerationStructureTests.cs
@@ -22,6 +22,7 @@ using OpenTK;
 
 namespace MonoTouchFixtures.MetalPerformanceShaders {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MPSAccelerationStructureTests {
 
 		IMTLDevice device;

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageBatchTests.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageBatchTests.cs
@@ -20,6 +20,7 @@ using NUnit.Framework;
 
 namespace MonoTouchFixtures.MetalPerformanceShaders {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MPSImageBatchTests {
 
 		IMTLDevice device;

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramEqualizationTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramEqualizationTest.cs
@@ -3,6 +3,7 @@
 #if !__WATCHOS__
 
 using System;
+using Foundation;
 using ObjCRuntime;
 
 using Metal;
@@ -14,6 +15,7 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MPSImageHistogramEqualizationTest
 	{
 		IMTLDevice device;

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramSpecificationTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramSpecificationTest.cs
@@ -3,6 +3,7 @@
 #if !__WATCHOS__
 
 using System;
+using Foundation;
 using ObjCRuntime;
 
 using Metal;
@@ -14,6 +15,7 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MPSImageHistogramSpecificationTest
 	{
 		IMTLDevice device;

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramTest.cs
@@ -3,6 +3,7 @@
 #if !__WATCHOS__
 
 using System;
+using Foundation;
 using ObjCRuntime;
 
 using Metal;
@@ -14,6 +15,7 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MPSImageHistogramTest
 	{
 		IMTLDevice device;

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageNormalizedHistogramTests.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageNormalizedHistogramTests.cs
@@ -12,6 +12,7 @@
 
 using System;
 
+using Foundation;
 using Metal;
 using MetalPerformanceShaders;
 using ObjCRuntime;
@@ -20,6 +21,7 @@ using NUnit.Framework;
 
 namespace MonoTouchFixtures.MetalPerformanceShaders {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MPSImageNormalizedHistogramTests {
 		IMTLDevice device;
 

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSStateBatchTests.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSStateBatchTests.cs
@@ -20,6 +20,7 @@ using NUnit.Framework;
 
 namespace MonoTouchFixtures.MetalPerformanceShaders {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MPSStateBatchTests {
 
 		IMTLDevice device;

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSStateResourceListTests.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSStateResourceListTests.cs
@@ -20,6 +20,7 @@ using NUnit.Framework;
 
 namespace MonoTouchFixtures.MetalPerformanceShaders {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MPSStateResourceListTests {
 
 		IMTLDevice device;

--- a/tests/monotouch-test/MonoMac/AssemblyTest.cs
+++ b/tests/monotouch-test/MonoMac/AssemblyTest.cs
@@ -16,6 +16,7 @@ using NUnit.Framework;
 namespace MonoMacFixtures {
 	
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class AssemblyTest {
 
 		static byte[] pkt = { 0x84, 0xe0, 0x4f, 0xf9, 0xcf, 0xb7, 0x90, 0x65 };

--- a/tests/monotouch-test/MonoMac/CBUUID.cs
+++ b/tests/monotouch-test/MonoMac/CBUUID.cs
@@ -20,6 +20,7 @@ using Xamarin.Mac.Tests;
 namespace MonoMacFixtures.CoreBluetooth
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class CBUUIDTest
 	{
 		[SetUp]

--- a/tests/monotouch-test/ObjCRuntime/DelegateAndDataSourceTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/DelegateAndDataSourceTest.cs
@@ -26,6 +26,7 @@ namespace Xamarin.Mac.Tests
 	}
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class DelegateAndDataSourceTest
 	{
 		[Test]

--- a/tests/monotouch-test/ObjCRuntime/EveryFrameworkSmokeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/EveryFrameworkSmokeTest.cs
@@ -15,6 +15,7 @@ using ObjCRuntime;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class EveryFrameworkSmokeTests
 	{
 		enum LoadStatus { FailTest, Acceptable };

--- a/tests/monotouch-test/ObjCRuntime/SimpleRegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/SimpleRegistrarTest.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Mac.Tests
 	}
 	
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class SimpleRegistrarTest
 	{
 		[DllImport ("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]

--- a/tests/monotouch-test/ObjCRuntime/TestPreservation.cs
+++ b/tests/monotouch-test/ObjCRuntime/TestPreservation.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Foundation;
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures {
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class VerifyAllTestsArePreserved {
+		[Test]
+		public void Test ()
+		{
+			if (TestRuntime.IsLinkAll) {
+				// The linker will remove the Preserve attribute, so this test doesn't make sense when the linker is enabled.
+				// Also it wouldn't find tests without the Preserve attribute reliably anyway, since the linker would link those tests away.
+				Assert.Ignore ("This test does not make sense to run with the linker enabled for all assemblies.");
+			}
+			TestAssembly (typeof (TestRuntime).Assembly);
+		}
+
+		void TestAssembly (Assembly asm)
+		{
+			var failedTypes = new List<string> ();
+			foreach (var type in asm.GetTypes ()) {
+				if (!IsTestFixture (type))
+					continue;
+
+				if (type.IsDefined (typeof (PreserveAttribute)))
+					continue;
+
+				if (Skip (type))
+					continue;
+
+				failedTypes.Add (type.FullName);
+			}
+
+			Assert.That (failedTypes, Is.Empty, "Failed types");
+		}
+
+		bool Skip (Type type)
+		{
+			switch (type.FullName) {
+			// We get the System.Drawing tests from source from mono, so we can't fix them (easily).
+			case "MonoTests.System.Drawing.PointTest":
+			case "MonoTests.System.Drawing.PointFTest":
+			case "MonoTests.System.Drawing.TestRectangle":
+			case "MonoTests.System.Drawing.TestRectangleF":
+			case "MonoTests.System.Drawing.SizeTest":
+			case "MonoTests.System.Drawing.SizeFTest":
+				return true;
+			}
+
+			return false;
+		}
+
+		bool IsTestFixture (Type type)
+		{
+			// what's a test fixture: https://docs.nunit.org/articles/nunit/writing-tests/attributes/testfixture.html
+			if (type == null || type == typeof (object))
+				return false;
+
+			if (type.IsDefined (typeof (TestFixtureAttribute)))
+				return true;
+
+			if (IsTestFixture (type.BaseType))
+				return true;
+
+			// "So long as the class contains at least one method marked with the Test, TestCase or TestCaseSource attribute, it will be treated as a test fixture."
+			foreach (var method in type.GetMethods (BindingFlags.Public | BindingFlags.Instance)) {
+				if (method.IsDefined (typeof (TestAttribute)))
+					return true;
+
+				if (method.IsDefined (typeof (TestCaseAttribute)))
+					return true;
+
+				if (method.IsDefined (typeof (TestCaseSourceAttribute)))
+					return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/tests/monotouch-test/OpenGL/CGLContext.cs
+++ b/tests/monotouch-test/OpenGL/CGLContext.cs
@@ -1,10 +1,12 @@
 #if __MACOS__
 using System;
 using NUnit.Framework;
+using Foundation;
 using OpenGL;
 
 namespace Xamarin.Mac.Tests {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class CGLContextTests {
 		[Test]
 		public void CurrentContextAllowsNull ()

--- a/tests/monotouch-test/SceneKit/SCNGeometrySource.cs
+++ b/tests/monotouch-test/SceneKit/SCNGeometrySource.cs
@@ -9,6 +9,7 @@ using SceneKit;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class SCNGeometrySourceTests
 	{
 		[SetUp]

--- a/tests/monotouch-test/SceneKit/SCNMaterial.cs
+++ b/tests/monotouch-test/SceneKit/SCNMaterial.cs
@@ -10,6 +10,7 @@ using SceneKit;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class SCNMaterialTests
 	{
 		[SetUp]

--- a/tests/monotouch-test/SceneKit/SCNNode.cs
+++ b/tests/monotouch-test/SceneKit/SCNNode.cs
@@ -11,6 +11,7 @@ using SceneKit;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class SCNNodeTests
 	{
 		[SetUp]

--- a/tests/monotouch-test/SceneKit/SCNScene.cs
+++ b/tests/monotouch-test/SceneKit/SCNScene.cs
@@ -9,6 +9,7 @@ using SceneKit;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class SCNSceneTests
 	{
 		[SetUp]

--- a/tests/monotouch-test/SceneKit/SCNView.cs
+++ b/tests/monotouch-test/SceneKit/SCNView.cs
@@ -12,6 +12,7 @@ using SceneKit;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class SCNViewTests
 	{
 		[SetUp]

--- a/tests/monotouch-test/SceneKit/SCNWorld.cs
+++ b/tests/monotouch-test/SceneKit/SCNWorld.cs
@@ -11,6 +11,7 @@ using SceneKit;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class SCNWorldTests
 	{
 		[SetUp]

--- a/tests/monotouch-test/SceneKit/SceneKit.cs
+++ b/tests/monotouch-test/SceneKit/SceneKit.cs
@@ -12,6 +12,7 @@ using SceneKit;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class SceneKitTests // Generic one off tests
 	{
 		[SetUp]

--- a/tests/monotouch-test/ScriptingBridge/SBApplicationTest.cs
+++ b/tests/monotouch-test/ScriptingBridge/SBApplicationTest.cs
@@ -26,6 +26,7 @@ namespace Xamarin.Mac.Tests {
 	}
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class SBApplicationTest {
 
 		[Test]

--- a/tests/monotouch-test/SearchKit/SearchKitTest.cs
+++ b/tests/monotouch-test/SearchKit/SearchKitTest.cs
@@ -11,6 +11,7 @@ using SearchKit;
 namespace apitest {
 
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class SearchKitTests {
 		string path = $"/tmp/mmptest-my-{System.Diagnostics.Process.GetCurrentProcess ().Id}.index";
 

--- a/tests/monotouch-test/SpriteKit/SKPaymentTests.cs
+++ b/tests/monotouch-test/SpriteKit/SKPaymentTests.cs
@@ -10,6 +10,7 @@ using StoreKit;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class SKPaymentTests
 	{
 		[Test]

--- a/tests/monotouch-test/SpriteKit/SKScene.cs
+++ b/tests/monotouch-test/SpriteKit/SKScene.cs
@@ -12,6 +12,7 @@ using SpriteKit;
 namespace Xamarin.Mac.Tests
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class SKSceneTests
 	{
 		[SetUp]

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -18,14 +18,12 @@ using System.Net.Http.Headers;
 using System.Security.Authentication;
 using System.Text;
 using Foundation;
-#if MONOMAC
-using Foundation;
-#endif
 using ObjCRuntime;
 
 namespace MonoTests.System.Net.Http
 {
 	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class MessageHandlerTest
 	{
 		public MessageHandlerTest ()


### PR DESCRIPTION
This fixes the wildly diffetent number of tests when running xammac tests with and without linking.

Without linking:

> Tests run: 2446 Passed: 2321 Inconclusive: 9 Failed: 0 Ignored: 125

vs with linking:

> Tests run: 1885 Passed: 1802 Inconclusive: 4 Failed: 0 Ignored: 83

Now we run the same tests either with or without linking.

One test was updated to not fail when linking is enabled.

Also add a test to ensure all future test fixtures are preserved.