### PR TITLE
[CI] Adding ContinueOnError to unblock the CI

### DIFF
--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -83,6 +83,7 @@ steps:
   displayName: 'Configure build'
 
 - task: OneLocBuild@2
+  continueOnError: true
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
   inputs:
@@ -92,6 +93,7 @@ steps:
     prSourceBranchPrefix: 'locfiles'
 
 - task: PublishBuildArtifacts@1
+  continueOnError: true
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'
     ArtifactName: 'localizationDrop'


### PR DESCRIPTION
My recent PR added some things to the configure yaml that are incomplete and are breaking the CI.
I am adding the ContinueOnError to unblock the the CI.