### PR TITLE
[dotnet] Add support for specifying the VM with the _XamarinRuntime property.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -89,7 +89,7 @@
        The problem is that by default we get the 'Microsoft.NETCore.App.Runtime.osx-x64' runtime pack (the core clr version), when we want the 'Microsoft.NETCore.App.Mono.Runtime.osx-x64' runtime pack.
        This works around that by declaring a new known framework for mono's runtime pack, removing the default 'Microsoft.NETCore.App' framework reference, and adding the mono one.
    -->
-  <ItemGroup Condition="'$(_PlatformName)' == 'macOS'">
+  <ItemGroup Condition="'$(_PlatformName)' == 'macOS' And '$(_XamarinRuntime)' != 'CoreCLR'">
     <KnownFrameworkReference Include="Microsoft.NETCore.App.Mono"
                               TargetFramework="net6.0"
                               RuntimeFrameworkName="Microsoft.NETCore.App.Mono"

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -260,6 +260,7 @@
 				TargetArchitectures=$(TargetArchitectures)
 				TargetFramework=$(_ComputedTargetFrameworkMoniker)
 				Verbosity=$(_BundlerVerbosity)
+				XamarinRuntime=$(_XamarinRuntime)
 			</_CustomLinkerOptions>
 			<_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --custom-data "LinkerOptionsFile=$(_CustomLinkerOptionsFile)"</_ExtraTrimmerArgs>
 
@@ -379,8 +380,9 @@
 
 	<Target Name="_ComputeFrameworkVariables" DependsOnTargets="ResolveRuntimePackAssets">
 		<PropertyGroup>
-			<_MonoNugetPackageId Condition="'$(_PlatformName)' != 'macOS'">Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)</_MonoNugetPackageId>
-			<_MonoNugetPackageId Condition="'$(_PlatformName)' == 'macOS'">Microsoft.NETCore.App.Runtime.Mono.$(RuntimeIdentifier)</_MonoNugetPackageId>
+			<_PackageIdInfix Condition="'$(_XamarinRuntime)' != 'CoreCLR' And '$(_PlatformName)' == 'macOS'">Mono.</_PackageIdInfix>
+
+			<_MonoNugetPackageId>Microsoft.NETCore.App.Runtime.$(_PackageIdInfix)$(RuntimeIdentifier)</_MonoNugetPackageId>
 		</PropertyGroup>
 		<ItemGroup>
 			<!-- Look in the ResolvedFrameworkReference for our Microsoft.* package. This should only find a single package. -->
@@ -428,8 +430,9 @@
 			<_LibXamarinLinkMode Condition="'$(_LibXamarinLinkMode)' == ''">static</_LibXamarinLinkMode>
 			<_LibXamarinExtension Condition="'$(_LibXamarinLinkMode)' == 'dylib'">dylib</_LibXamarinExtension>
 			<_LibXamarinExtension Condition="'$(_LibXamarinLinkMode)' == 'static'">a</_LibXamarinExtension>
+			<_LibXamarinRuntime Condition="'$(_XamarinRuntime)' == 'CoreCLR'">-coreclr</_LibXamarinRuntime>
 			<_LibXamarinDebug Condition="'$(_BundlerDebug)' == 'true'">-debug</_LibXamarinDebug>
-			<_LibXamarinName Condition="'$(_LibXamarinName)' == ''">libxamarin-dotnet$(_LibXamarinDebug).$(_LibXamarinExtension)</_LibXamarinName>
+			<_LibXamarinName Condition="'$(_LibXamarinName)' == ''">libxamarin-dotnet$(_LibXamarinRuntime)$(_LibXamarinDebug).$(_LibXamarinExtension)</_LibXamarinName>
 
 		</PropertyGroup>
 

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -293,6 +293,7 @@ namespace Xharness {
 				Name = "monotouch-test",
 				IsDotNetProject = true,
 				TargetFrameworkFlavors = MacFlavors.DotNet,
+				Platform = "AnyCPU",
 			});
 
 			foreach (var flavor in new MonoNativeFlavor [] { MonoNativeFlavor.Compat, MonoNativeFlavor.Unified }) {

--- a/tests/xharness/Jenkins/TestData.cs
+++ b/tests/xharness/Jenkins/TestData.cs
@@ -18,6 +18,7 @@ namespace Xharness.Jenkins {
 		public bool? Ignored;
 		public bool EnableSGenConc;
 		public bool UseThumb;
+		public string XamarinRuntime;
 		public MonoNativeLinkMode MonoNativeLinkMode;
 		public IEnumerable<IDevice> Candidates;
 	}

--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -115,6 +115,10 @@ namespace Xharness.Jenkins {
 			case "AnyCPU":
 			case "x86":
 				switch (test.TestName) {
+				case "monotouch-test":
+					if (test.TestProject.IsDotNetProject)
+						yield return new TestData { Variation = "Debug (CoreCLR)", Debug = true, XamarinRuntime = "CoreCLR", Ignored = true, };
+					break;
 				case "xammac tests":
 					switch (test.ProjectConfiguration) {
 					case "Release":
@@ -157,6 +161,7 @@ namespace Xharness.Jenkins {
 					var ignored = test_data.Ignored;
 					var known_failure = test_data.KnownFailure;
 					var candidates = test_data.Candidates;
+					var xamarin_runtime = test_data.XamarinRuntime;
 
 					if (task.TestProject.IsDotNetProject)
 						variation += " [dotnet]";
@@ -210,6 +215,8 @@ namespace Xharness.Jenkins {
 
 						if (!debug && !isMac)
 							clone.Xml.SetMtouchUseLlvm (true, task.ProjectPlatform, configuration);
+						if (!string.IsNullOrEmpty (xamarin_runtime))
+							clone.Xml.SetTopLevelPropertyGroupValue ("_XamarinRuntime", xamarin_runtime);
 						clone.Xml.Save (clone.Path);
 					});
 

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -131,6 +131,7 @@ namespace Xamarin.Bundler {
 		public bool? DisableOmitFramePointer = null; // Only applicable to Xamarin.Mac
 		public string CustomBundleName = "MonoBundle"; // Only applicable to Xamarin.Mac and Mac Catalyst
 
+		public XamarinRuntime XamarinRuntime;
 		public bool? UseMonoFramework;
 
 		// The bitcode mode to compile to.

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -785,7 +785,8 @@ namespace Xamarin.Bundler {
 				sw.WriteLine ("\txamarin_gc_pump = {0};", app.DebugTrack.Value ? "TRUE" : "FALSE");
 			sw.WriteLine ("\txamarin_init_mono_debug = {0};", app.PackageManagedDebugSymbols ? "TRUE" : "FALSE");
 			sw.WriteLine ("\txamarin_executable_name = \"{0}\";", assembly_name);
-			sw.WriteLine ("\tmono_use_llvm = {0};", enable_llvm ? "TRUE" : "FALSE");
+			if (app.XamarinRuntime == XamarinRuntime.MonoVM)
+				sw.WriteLine ("\tmono_use_llvm = {0};", enable_llvm ? "TRUE" : "FALSE");
 			sw.WriteLine ("\txamarin_log_level = {0};", Driver.Verbosity.ToString (CultureInfo.InvariantCulture));
 			sw.WriteLine ("\txamarin_arch_name = \"{0}\";", abi.AsArchString ());
 			if (!app.IsDefaultMarshalManagedExceptionMode)

--- a/tools/common/XamarinRuntime.cs
+++ b/tools/common/XamarinRuntime.cs
@@ -1,0 +1,6 @@
+namespace Xamarin.Bundler {
+	public enum XamarinRuntime {
+		MonoVM,
+		CoreCLR,
+	}
+}

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -216,6 +216,11 @@ namespace Xamarin.Linker {
 						throw new InvalidOperationException ($"Invalid Verbosity '{value}' in {linker_file}");
 					Driver.Verbosity += verbosity;
 					break;
+				case "XamarinRuntime":
+					if (!Enum.TryParse<XamarinRuntime> (value, out var rv))
+						throw new InvalidOperationException ($"Invalid XamarinRuntime '{value}' in {linker_file}");
+					Application.XamarinRuntime = rv;
+					break;
 				default:
 					throw new InvalidOperationException ($"Unknown key '{key}' in {linker_file}");
 				}
@@ -291,6 +296,7 @@ namespace Xamarin.Linker {
 				Console.WriteLine ($"    SdkVersion: {SdkVersion}");
 				Console.WriteLine ($"    UseInterpreter: {Application.UseInterpreter}");
 				Console.WriteLine ($"    Verbosity: {Verbosity}");
+				Console.WriteLine ($"    XamarinRuntime: {Application.XamarinRuntime}");
 			}
 		}
 

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -191,6 +191,9 @@
     <Compile Include="..\common\DlsymOptions.cs">
       <Link>external\tools\common\DlsymOptions.cs</Link>
     </Compile>
+    <Compile Include="..\common\XamarinRuntime.cs">
+      <Link>tools\common\XamarinRuntime.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\mtouch\Errors.resx">

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -467,6 +467,9 @@
     <Compile Include="..\common\DlsymOptions.cs">
       <Link>tools\common\DlsymOptions.cs</Link>
     </Compile>
+    <Compile Include="..\common\XamarinRuntime.cs">
+      <Link>tools\common\XamarinRuntime.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -481,6 +481,9 @@
     <Compile Include="..\common\DlsymOptions.cs">
       <Link>tools\common\DlsymOptions.cs</Link>
     </Compile>
+    <Compile Include="..\common\XamarinRuntime.cs">
+      <Link>tools\common\XamarinRuntime.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Core" />


### PR DESCRIPTION
Use a private property (prefixed with underscore) for now, until we can decide
on a better/general name.

Also add a variation to xharness to build monotouch-test with CoreCLR
(building works fine, but it crashes at startup, which is expected at this
point).