### PR TITLE
[runtime] Move MonoVM-specific initialization to MonoVM-specific code.

### DIFF
--- a/mk/quiet.mk
+++ b/mk/quiet.mk
@@ -33,6 +33,7 @@ Q_SN=   $(if $(V),,@echo "SN       $(@F)";)
 Q_XBUILD=$(if $(V),,@echo "XBUILD  $(@F)";)
 Q_TT=   $(if $(V),,@echo "TT       $(@F)";)
 Q_BUILD=$(if $(V),,@echo "BUILD    $(@F)";)
+Q_CURL=$(if $(V),,@echo "CURL     $(@F)";)
 
 Q_DOTNET_BUILD=$(if $(V),,@echo "CSC      [dotnet] $(@F)";)
 Q_DOTNET_GEN  =$(if $(V),,@echo "GEN      [dotnet] $(@F)";)

--- a/runtime/.gitignore
+++ b/runtime/.gitignore
@@ -11,3 +11,4 @@ tvextension-main.m
 bindings-generated.m
 *.dylib
 *.o
+coreclrhost.h

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -19,8 +19,10 @@ SHIPPED_HEADERS +=         \
 	xamarin/trampolines.h  \
 	xamarin/runtime.h      \
 	xamarin/runtime-generated.h \
+	xamarin/monovm-bridge.h \
+	xamarin/coreclr-bridge.h \
 
-SHARED_SOURCES += mono-runtime.m bindings.m bindings-generated.m shared.m runtime.m trampolines.m trampolines-invoke.m xamarin-support.m nsstring-localization.m trampolines-varargs.m
+SHARED_SOURCES += mono-runtime.m bindings.m bindings-generated.m shared.m runtime.m trampolines.m trampolines-invoke.m xamarin-support.m nsstring-localization.m trampolines-varargs.m monovm-bridge.m coreclr-bridge.m
 SHARED_I386_SOURCES += trampolines-i386.m trampolines-i386-asm.s trampolines-i386-objc_msgSend.s trampolines-i386-objc_msgSendSuper.s trampolines-i386-objc_msgSend_stret.s trampolines-i386-objc_msgSendSuper_stret.s
 SHARED_X86_64_SOURCES += trampolines-x86_64.m trampolines-x86_64-asm.s trampolines-x86_64-objc_msgSend.s trampolines-x86_64-objc_msgSendSuper.s trampolines-x86_64-objc_msgSend_stret.s trampolines-x86_64-objc_msgSendSuper_stret.s
 SHARED_ARM64_SOURCES += trampolines-arm64.m trampolines-arm64-asm.s

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -30,6 +30,11 @@ SHARED_FILES = $(SHARED_SOURCES) $(SHARED_HEADERS) $(SHARED_I386_SOURCES) $(SHAR
 
 EXTRA_DEPENDENCIES = $(SHARED_HEADERS) $(TOP)/Make.config $(TOP)/mk/mono.mk
 
+coreclrhost.h: Makefile
+	$(Q_CURL) curl -L --output "$@" https://raw.githubusercontent.com/dotnet/runtime/6c8f9fff6adcf6c661072646dbdafabed5267ec5/src/coreclr/hosts/inc/coreclrhost.h
+
+coreclr-bridge.m: coreclrhost.h
+
 xamarin/mono-runtime.h: mono-runtime.h.t4 exports.t4
 	$(Q_GEN) $(TT) $< -o $@
 

--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -11,4 +11,14 @@
 #include "xamarin/xamarin.h"
 #include "xamarin/coreclr-bridge.h"
 
+void
+xamarin_bridge_setup ()
+{
+}
+
+void
+xamarin_bridge_initialize ()
+{
+}
+
 #endif // CORECLR_RUNTIME

--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -1,0 +1,14 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*- */
+/*
+*  Authors: Rolf Bjarne Kvinge
+*
+*  Copyright (C) 2021 Microsoft Corp.
+*
+*/
+
+#if defined (CORECLR_RUNTIME)
+
+#include "xamarin/xamarin.h"
+#include "xamarin/coreclr-bridge.h"
+
+#endif // CORECLR_RUNTIME

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -31,7 +31,7 @@
 #include "../tools/mtouch/monotouch-fixes.c"
 #endif
 
-static unsigned char *
+unsigned char *
 xamarin_load_aot_data (MonoAssembly *assembly, int size, gpointer user_data, void **out_handle)
 {
 	// COOP: This is a callback called by the AOT runtime, I believe we don't have to change the GC mode here (even though it accesses managed memory).
@@ -76,7 +76,7 @@ xamarin_load_aot_data (MonoAssembly *assembly, int size, gpointer user_data, voi
 	return (unsigned char *) ptr;
 }
 
-static void
+void
 xamarin_free_aot_data (MonoAssembly *assembly, int size, gpointer user_data, void *handle)
 {
 	// COOP: This is a callback called by the AOT runtime, I belive we don't have to change the GC mode here.
@@ -86,8 +86,8 @@ xamarin_free_aot_data (MonoAssembly *assembly, int size, gpointer user_data, voi
 /*
 This hook avoids the gazillion of filesystem probes we do as part of assembly loading.
 */
-static MonoAssembly*
-assembly_preload_hook (MonoAssemblyName *aname, char **assemblies_path, void* user_data)
+MonoAssembly*
+xamarin_assembly_preload_hook (MonoAssemblyName *aname, char **assemblies_path, void* user_data)
 {
 	// COOP: This is a callback called by the AOT runtime, I belive we don't have to change the GC mode here.
 	char filename [1024];
@@ -261,15 +261,11 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 
 	MonoAssembly *assembly;
 	GCHandle exception_gchandle = NULL;
-	
 	const char *c_bundle_path = xamarin_get_bundle_path ();
 
 	chdir (c_bundle_path);
-	setenv ("MONO_PATH", c_bundle_path, 1);
 
-	setenv ("MONO_XMLSERIALIZER_THS", "no", 1);
 	setenv ("DYLD_BIND_AT_LAUNCH", "1", 1);
-	setenv ("MONO_REFLECTION_SERIALIZER", "yes", 1);
 
 #if TARGET_OS_WATCH
 	// watchOS can raise signals just fine...
@@ -277,12 +273,7 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 	signal (SIGPIPE, SIG_IGN);
 #endif
 
-#if TARGET_OS_WATCH || TARGET_OS_TV
-	mini_parse_debug_option ("explicit-null-checks");
-#endif
-	// see http://bugzilla.xamarin.com/show_bug.cgi?id=820
-	// take this line out once the bug is fixed
-	mini_parse_debug_option ("no-gdb-backtrace");
+	xamarin_bridge_setup ();
 
 	DEBUG_LAUNCH_TIME_PRINT ("Spin-up time");
 
@@ -407,39 +398,7 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 	xamarin_initialize_cocoa_threads (NULL);
 #endif
 
-#if defined (__arm__) || defined(__aarch64__)
-	xamarin_register_modules ();
-#endif
-	DEBUG_LAUNCH_TIME_PRINT ("\tAOT register time");
-
-#ifdef DEBUG
-	monotouch_start_debugging ();
-	DEBUG_LAUNCH_TIME_PRINT ("\tDebug init time");
-#endif
-	
-	if (xamarin_init_mono_debug)
-		mono_debug_init (MONO_DEBUG_FORMAT_MONO);
-	
-	mono_install_assembly_preload_hook (assembly_preload_hook, NULL);
-	mono_install_load_aot_data_hook (xamarin_load_aot_data, xamarin_free_aot_data, NULL);
-
-#ifdef DEBUG
-	monotouch_start_profiling ();
-	DEBUG_LAUNCH_TIME_PRINT ("\tProfiler config time");
-#endif
-
-	mono_set_signal_chaining (TRUE);
-	mono_set_crash_chaining (TRUE);
-	mono_install_unhandled_exception_hook (xamarin_unhandled_exception_handler, NULL);
-	mono_install_ftnptr_eh_callback (xamarin_ftnptr_exception_handler);
-
-	mono_jit_init_version ("MonoTouch", "mobile");
-	/*
-	  As part of mono initialization a preload hook is added that overrides ours, so we need to re-instate it here.
-	  This is wasteful, but there's no way to manipulate the preload hook list except by adding to it.
-	*/
-	mono_install_assembly_preload_hook (assembly_preload_hook, NULL);
-	DEBUG_LAUNCH_TIME_PRINT ("\tJIT init time");
+	xamarin_bridge_initialize ();
 
 	xamarin_initialize ();
 	DEBUG_LAUNCH_TIME_PRINT ("\tmonotouch init time");

--- a/runtime/monovm-bridge.m
+++ b/runtime/monovm-bridge.m
@@ -10,8 +10,76 @@
 
 #if !defined (CORECLR_RUNTIME)
 
+#include <TargetConditionals.h>
+
+#if !DOTNET && TARGET_OS_OSX
+#define LEGACY_XAMARIN_MAC 1
+#else
+#define LEGACY_XAMARIN_MAC 0
+#endif
+
+#include "monotouch-debug.h"
+#include "runtime-internal.h"
 #include "xamarin/xamarin.h"
 #include "xamarin/monovm-bridge.h"
+
+#if !LEGACY_XAMARIN_MAC
+void
+xamarin_bridge_setup ()
+{
+	const char *c_bundle_path = xamarin_get_bundle_path ();
+
+	setenv ("MONO_PATH", c_bundle_path, 1);
+
+	setenv ("MONO_XMLSERIALIZER_THS", "no", 1);
+	setenv ("MONO_REFLECTION_SERIALIZER", "yes", 1);
+
+#if TARGET_OS_WATCH || TARGET_OS_TV
+	mini_parse_debug_option ("explicit-null-checks");
+#endif
+	// see http://bugzilla.xamarin.com/show_bug.cgi?id=820
+	// take this line out once the bug is fixed
+	mini_parse_debug_option ("no-gdb-backtrace");
+}
+
+void
+xamarin_bridge_initialize ()
+{
+#if defined (__arm__) || defined(__aarch64__)
+	xamarin_register_modules ();
+#endif
+	DEBUG_LAUNCH_TIME_PRINT ("\tAOT register time");
+
+#ifdef DEBUG
+	monotouch_start_debugging ();
+	DEBUG_LAUNCH_TIME_PRINT ("\tDebug init time");
+#endif
+	
+	if (xamarin_init_mono_debug)
+		mono_debug_init (MONO_DEBUG_FORMAT_MONO);
+	
+	mono_install_assembly_preload_hook (xamarin_assembly_preload_hook, NULL);
+	mono_install_load_aot_data_hook (xamarin_load_aot_data, xamarin_free_aot_data, NULL);
+
+#ifdef DEBUG
+	monotouch_start_profiling ();
+	DEBUG_LAUNCH_TIME_PRINT ("\tProfiler config time");
+#endif
+
+	mono_set_signal_chaining (TRUE);
+	mono_set_crash_chaining (TRUE);
+	mono_install_unhandled_exception_hook (xamarin_unhandled_exception_handler, NULL);
+	mono_install_ftnptr_eh_callback (xamarin_ftnptr_exception_handler);
+
+	mono_jit_init_version ("MonoTouch", "mobile");
+	/*
+	  As part of mono initialization a preload hook is added that overrides ours, so we need to re-instate it here.
+	  This is wasteful, but there's no way to manipulate the preload hook list except by adding to it.
+	*/
+	mono_install_assembly_preload_hook (xamarin_assembly_preload_hook, NULL);
+	DEBUG_LAUNCH_TIME_PRINT ("\tJIT init time");
+}
+#endif // !LEGACY_XAMARIN_MAC
 
 
 #endif // !CORECLR_RUNTIME

--- a/runtime/monovm-bridge.m
+++ b/runtime/monovm-bridge.m
@@ -1,0 +1,17 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*- */
+/*
+*  Authors: Rolf Bjarne Kvinge
+*
+*  Copyright (C) 2021 Microsoft Corp.
+*
+*/
+
+/* Support code for using MonoVM */
+
+#if !defined (CORECLR_RUNTIME)
+
+#include "xamarin/xamarin.h"
+#include "xamarin/monovm-bridge.h"
+
+
+#endif // !CORECLR_RUNTIME

--- a/runtime/xamarin/coreclr-bridge.h
+++ b/runtime/xamarin/coreclr-bridge.h
@@ -1,0 +1,19 @@
+
+/* Support for using CoreCLR */
+
+#if defined (CORECLR_RUNTIME)
+
+#ifndef __CORECLR_BRIDGE__
+#define __CORECLR_BRIDGE__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* __CORECLR_BRIDGE__ */
+
+#endif // CORECLR_RUNTIME

--- a/runtime/xamarin/monovm-bridge.h
+++ b/runtime/xamarin/monovm-bridge.h
@@ -17,7 +17,6 @@
 extern "C" {
 #endif
 
-
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/runtime/xamarin/monovm-bridge.h
+++ b/runtime/xamarin/monovm-bridge.h
@@ -1,0 +1,27 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*- */
+/*
+*  Authors: Rolf Bjarne Kvinge
+*
+*  Copyright (C) 2021 Microsoft Corp.
+*
+*/
+
+/* Support code for using MonoVM */
+
+#if !defined (CORECLR_RUNTIME)
+
+#ifndef __MONOVM_BRIDGE__
+#define __MONOVM_BRIDGE__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* __MONOVM_BRIDGE__ */
+
+#endif // !CORECLR_RUNTIME

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -195,6 +195,11 @@ const char *	xamarin_skip_encoding_flags (const char *encoding);
 void			xamarin_add_registration_map (struct MTRegistrationMap *map, bool partial);
 uint32_t		xamarin_find_protocol_wrapper_type (uint32_t token_ref);
 void			xamarin_release_block_on_main_thread (void *obj);
+void			xamarin_bridge_setup (); // this is called very early, before parsing the command line arguments
+void			xamarin_bridge_initialize (); // this is called a bit later, after parsing the command line arguments.
+unsigned char *	xamarin_load_aot_data (MonoAssembly *assembly, int size, gpointer user_data, void **out_handle);
+void			xamarin_free_aot_data (MonoAssembly *assembly, int size, gpointer user_data, void *handle);
+MonoAssembly*	xamarin_assembly_preload_hook (MonoAssemblyName *aname, char **assemblies_path, void* user_data);
 
 MonoObject *	xamarin_new_nsobject (id self, MonoClass *klass, GCHandle *exception_gchandle);
 bool			xamarin_has_managed_ref (id self);


### PR DESCRIPTION
This makes the CoreCLR launch sequence reach the xamarin_initialize method
before it runs into Mono Embedding API (and aborts).