### PR TITLE
[dotnet] Add an IsCoreCLR initialization flag.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -132,6 +132,7 @@ enum InitializationFlags : int {
 	InitializationFlagsDynamicRegistrar			= 0x04,
 	/* unused									= 0x08,*/
 	InitializationFlagsIsSimulator				= 0x10,
+	InitializationFlagsIsCoreCLR                = 0x20,
 };
 
 struct InitializationOptions {
@@ -1393,6 +1394,10 @@ xamarin_initialize ()
 	options.size = sizeof (options);
 #if MONOTOUCH && (defined(__i386__) || defined (__x86_64__))
 	options.flags = (enum InitializationFlags) (options.flags | InitializationFlagsIsSimulator);
+#endif
+
+#if defined (CORECLR_RUNTIME)
+	options.flags = (enum InitializationFlags) (options.flags | InitializationFlagsIsCoreCLR);
 #endif
 
 	options.Delegates = &delegates;

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -127,6 +127,9 @@ namespace ObjCRuntime {
 			DynamicRegistrar		= 0x04,
 			/* unused				= 0x08,*/
 			IsSimulator				= 0x10,
+#if NET
+			IsCoreCLR				= 0x20,
+#endif
 		}
 
 #if MONOMAC
@@ -158,6 +161,15 @@ namespace ObjCRuntime {
 					return (Flags & InitializationFlags.IsSimulator) == InitializationFlags.IsSimulator;
 				}
 			}
+
+#if NET
+			// Future optimization potential: make the linker change this into a constant.
+			internal bool IsCoreCLR {
+				get {
+					return (Flags & InitializationFlags.IsCoreCLR) == InitializationFlags.IsCoreCLR;
+				}
+			}
+#endif
 		}
 
 		internal static unsafe InitializationOptions* options;


### PR DESCRIPTION
So that we can detect in managed code whether we're running with CoreCLR or
MonoVM.