### PR TITLE
[runtime/dotnet] Call coreclr_initialize/monovm_initialize at startup.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -11,6 +11,11 @@
 #include "xamarin/xamarin.h"
 #include "xamarin/coreclr-bridge.h"
 
+#include "coreclrhost.h"
+
+unsigned int coreclr_domainId = 0;
+void *coreclr_handle = NULL;
+
 void
 xamarin_bridge_setup ()
 {
@@ -19,6 +24,27 @@ xamarin_bridge_setup ()
 void
 xamarin_bridge_initialize ()
 {
+}
+
+bool
+xamarin_bridge_vm_initialize (int propertyCount, const char **propertyKeys, const char **propertyValues)
+{
+	int rv;
+
+	const char *executablePath = [[[[NSBundle mainBundle] executableURL] path] UTF8String];
+	rv = coreclr_initialize (
+		executablePath,
+		xamarin_executable_name,
+		propertyCount,
+		propertyKeys,
+		propertyValues,
+		&coreclr_handle,
+		&coreclr_domainId
+		);
+
+	LOG_CORECLR (stderr, "xamarin_vm_initialize (%i, %p, %p): rv: %i domainId: %i handle: %p\n", propertyCount, propertyKeys, propertyValues, rv, coreclr_domainId, coreclr_handle);
+
+	return rv == 0;
 }
 
 #endif // CORECLR_RUNTIME

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -656,12 +656,29 @@
 
 		#endregion
 
+		#region mini/mono-private-unstable.
+
+		new Export ("int", "monovm_initialize",
+			"int", "propertyCount",
+			"const char **", "propertyKeys",
+			"const char **", "propertyValues"
+		) {
+			Mode = DotNetMode.OnlyDotNet,
+		},
+
+		#endregion
 	};
 #><#+
 	class Arg
 	{
 		public string Type;
 		public string Name;
+	}
+
+	enum DotNetMode {
+		Both = 0,
+		OnlyDotNet = 1,
+		OnlyLegacy = 2,
 	}
 
 	class Export
@@ -671,12 +688,35 @@
 		public string AlternativeExpression;
 		public List<Arg> Arguments;
 		public bool Optional;
+		public DotNetMode Mode;
 
 		public Export (string returnType, string entryPoint, params string [] arguments)
 			: this (false, returnType, entryPoint, arguments)
 		{
 		}
 
+		public string DotNetIf {
+			get {
+				switch (Mode) {
+				case DotNetMode.OnlyLegacy:
+					return "#if !DOTNET\n";
+				case DotNetMode.OnlyDotNet:
+					return "#if DOTNET\n";
+				}
+				return string.Empty;
+			}
+		}
+
+		public string DotNetEndIf {
+			get {
+				switch (Mode) {
+				case DotNetMode.OnlyLegacy:
+				case DotNetMode.OnlyDotNet:
+					return "#endif\n";
+				}
+				return string.Empty;
+			}
+		}
 
 		public Export (bool optional, string returnType, string entryPoint, params string [] arguments)
 		{

--- a/runtime/mono-runtime.h.t4
+++ b/runtime/mono-runtime.h.t4
@@ -54,8 +54,8 @@ char *xamarin_get_mono_runtime_build_info (); // returns NULL if libmono couldn'
 
 #ifdef DYNAMIC_MONO_RUNTIME
 <# foreach (var export in exports) { #>
-#define <#= export.EntryPoint #> <#= export.EntryPoint #>_impl
-<# } #>
+<#= export.DotNetIf #>#define <#= export.EntryPoint #> <#= export.EntryPoint #>_impl
+<#= export.DotNetEndIf #><# } #>
 #endif
 
 /* This is copied from mono's header files */
@@ -305,15 +305,16 @@ void mono_gc_init_finalizer_thread ();
 
 <# foreach (var export in exports) { #>
 
-MONO_API <#= export.ReturnType #>
+<#= export.DotNetIf #>MONO_API <#= export.ReturnType #>
 <#= export.EntryPoint #> (<#= export.ArgumentSignature #>);
-<# } #>
+<#= export.DotNetEndIf #><# } #>
 
 <# foreach (var export in exports) {
 	if (!export.Optional)
 		continue; #>
-bool
+<#= export.DotNetIf #>bool
 <#= export.EntryPoint #>_exists ();
+<#= export.DotNetEndIf #>
 
 <# } #>
 

--- a/runtime/mono-runtime.m.t4
+++ b/runtime/mono-runtime.m.t4
@@ -26,12 +26,12 @@
 #include "runtime-internal.h"
 
 <# foreach (var export in exports) { #>
-typedef <#= export.ReturnType #> (* <#= export.EntryPoint #>_def) (<#= export.ArgumentSignature #>);
-<# } #>
+<#= export.DotNetIf #>typedef <#= export.ReturnType #> (* <#= export.EntryPoint #>_def) (<#= export.ArgumentSignature #>);
+<#= export.DotNetEndIf #><# } #>
 
 <# foreach (var export in exports) { #>
-<#= export.EntryPoint #>_def <#= export.EntryPoint #>_func = NULL;
-<# } #>
+<#= export.DotNetIf #><#= export.EntryPoint #>_def <#= export.EntryPoint #>_func = NULL;
+<#= export.DotNetEndIf #><# } #>
 
 char *
 xamarin_get_mono_runtime_build_info ()
@@ -75,13 +75,13 @@ xamarin_initialize_dynamic_runtime (const char *mono_runtime_prefix)
 
 
 <# foreach (var export in exports) { #>
-	<#= export.EntryPoint #>_func = (<#= export.EntryPoint #>_def) dlsym (libmono, "<#= export.EntryPoint #>");
+<#= export.DotNetIf #>	<#= export.EntryPoint #>_func = (<#= export.EntryPoint #>_def) dlsym (libmono, "<#= export.EntryPoint #>");
 <# if (!export.Optional) { #>
 	if (<#= export.EntryPoint #>_func == NULL) {
 		fprintf (stderr, "Could not load <#= export.EntryPoint #>\n");
 		errmsg = "Failed to load the Mono framework.";
 	}
-<# } #>
+<#= export.DotNetEndIf #><# } #>
 
 <# } #>
 	xamarin_dynamic_runtime_initialized = 1;
@@ -90,7 +90,7 @@ xamarin_initialize_dynamic_runtime (const char *mono_runtime_prefix)
 }
 
 <# foreach (var export in exports) { #>
-MONO_API <#= export.ReturnType #>
+<#= export.DotNetIf #>MONO_API <#= export.ReturnType #>
 <#= export.EntryPoint #> (<#= export.ArgumentSignature #>)
 {
 <# if (export.Optional) { #>
@@ -104,7 +104,7 @@ MONO_API <#= export.ReturnType #>
 <# } #>
 	return <#= export.EntryPoint #>_func (<#= export.ArgumentNames #>);
 }
-<# } #>
+<#= export.DotNetEndIf #><# } #>
 
 <# foreach (var export in exports) {
 	if (!export.Optional)

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -400,6 +400,10 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 
 	xamarin_bridge_initialize ();
 
+#if DOTNET
+	xamarin_vm_initialize ();
+#endif
+
 	xamarin_initialize ();
 	DEBUG_LAUNCH_TIME_PRINT ("\tmonotouch init time");
 

--- a/runtime/monovm-bridge.m
+++ b/runtime/monovm-bridge.m
@@ -81,5 +81,28 @@ xamarin_bridge_initialize ()
 }
 #endif // !LEGACY_XAMARIN_MAC
 
+#if DOTNET
+
+bool
+xamarin_bridge_vm_initialize (int propertyCount, const char **propertyKeys, const char **propertyValues)
+{
+	int rv;
+
+#if TARGET_OS_TV
+	rv = 0;
+	// Due to https://github.com/dotnet/runtime/issues/48508, we can't link with the .NET version of libmonosgen-2.0.dylib,
+	// which means that we can't call monovm_initialize here (libxamarin.dylib fails native linking). Just ignore it for now.
+	fprintf (stderr, "xamarin_vm_initialize (%i, %p, %p): Ignored due to https://github.com/dotnet/runtime/issues/48508.\n", propertyCount, propertyKeys, propertyValues);
+#else
+
+	rv = monovm_initialize (propertyCount, propertyKeys, propertyValues);
+
+	LOG_MONOVM (stderr, "xamarin_vm_initialize (%i, %p, %p): rv: %i\n", propertyCount, propertyKeys, propertyValues, rv);
+#endif
+
+	return rv == 0;
+}
+
+#endif // DOTNET
 
 #endif // !CORECLR_RUNTIME

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2455,6 +2455,43 @@ xamarin_insert_dllmap ()
 #endif // defined (__i386__) || defined (__x86_64__)
 }
 
+#if DOTNET
+void
+xamarin_vm_initialize ()
+{
+	char *pinvokeOverride = xamarin_strdup_printf ("%p", &xamarin_pinvoke_override);
+	const char *propertyKeys[] = {
+		"APP_PATHS",
+		"PINVOKE_OVERRIDE",
+	};
+	const char *propertyValues[] = {
+		xamarin_get_bundle_path (),
+		pinvokeOverride,
+	};
+	static_assert (sizeof (propertyKeys) == sizeof (propertyValues), "The number of keys and values must be the same.");
+
+	int propertyCount = sizeof (propertyValues) / sizeof (propertyValues [0]);
+	bool rv = xamarin_bridge_vm_initialize (propertyCount, propertyKeys, propertyValues);
+	xamarin_free (pinvokeOverride);
+
+	if (!rv)
+		xamarin_assertion_message ("Failed to initialize the VM");
+}
+
+void*
+xamarin_pinvoke_override (const char *libraryName, const char *entrypointName)
+{
+
+	void* symbol = NULL;
+
+	if (!strcmp (libraryName, "__Internal")) {
+		symbol = dlsym (RTLD_DEFAULT, entrypointName);
+	}
+
+	return symbol;
+}
+#endif
+
 void
 xamarin_printf (const char *format, ...)
 {

--- a/runtime/xamarin/coreclr-bridge.h
+++ b/runtime/xamarin/coreclr-bridge.h
@@ -6,6 +6,9 @@
 #ifndef __CORECLR_BRIDGE__
 #define __CORECLR_BRIDGE__
 
+//#define LOG_CORECLR(...)
+#define LOG_CORECLR(...) fprintf (__VA_ARGS__)
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/runtime/xamarin/monovm-bridge.h
+++ b/runtime/xamarin/monovm-bridge.h
@@ -13,6 +13,9 @@
 #ifndef __MONOVM_BRIDGE__
 #define __MONOVM_BRIDGE__
 
+//#define LOG_MONOVM(...)
+#define LOG_MONOVM(...) fprintf (__VA_ARGS__)
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -200,6 +200,9 @@ void			xamarin_bridge_initialize (); // this is called a bit later, after parsin
 unsigned char *	xamarin_load_aot_data (MonoAssembly *assembly, int size, gpointer user_data, void **out_handle);
 void			xamarin_free_aot_data (MonoAssembly *assembly, int size, gpointer user_data, void *handle);
 MonoAssembly*	xamarin_assembly_preload_hook (MonoAssemblyName *aname, char **assemblies_path, void* user_data);
+void			xamarin_vm_initialize ();
+bool			xamarin_bridge_vm_initialize (int propertyCount, const char **propertyKeys, const char **propertyValues);
+void*			xamarin_pinvoke_override (const char *libraryName, const char *entrypointName);
 
 MonoObject *	xamarin_new_nsobject (id self, MonoClass *klass, GCHandle *exception_gchandle);
 bool			xamarin_has_managed_ref (id self);


### PR DESCRIPTION
We need to call coreclr_initialize/monovm_initialize at startup, so do that.
This is a partial implementation, in that we're not setting all the properties
that we should, and also the PINVOKE_OVERRIDE callback is not doing everything
it should either yet.

Ref: #10504.