### PR TITLE
Fixes on iOS.Windows targets

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.ObjCBinding.CSharp.After.props
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.ObjCBinding.CSharp.After.props
@@ -1,20 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.Windows.props" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.iOS.Windows.props')" />
-	
-	<UsingTask TaskName="Xamarin.iOS.Tasks.PrepareObjCBindingNativeFrameworks" AssemblyFile="$(CoreiOSSdkDirectory)Xamarin.iOS.Tasks.dll" />
-	
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Messaging.Build.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Messaging.Build.targets') And '$(MessagingBuildTargetsImported)' != 'true'" />
-	
-	<Target Name="CopyCompressedNativeFrameworkResources" Condition="'@(_NativeFrameworkResource)' != ''" AfterTargets="_CompressNativeFrameworkResources">
-		<CopyFileFromBuildServer SessionId="$(BuildSessionId)" File="$(IntermediateOutputPath)%(_NativeFramework.Filename)%(_NativeFramework.Extension)" />
-	</Target>
-	
-	<!-- This target copies the ObjCBindingNativeFrameworks to the Mac -->
-	<Target Name="PrepareObjCBindingNativeFrameworks" BeforeTargets="_CompressObjCBindingNativeFrameworkResources">
-		<PrepareObjCBindingNativeFrameworks SessionId="$(BuildSessionId)" ObjCBindingNativeFrameworks="@(ObjCBindingNativeFramework)" />
-	</Target>
-	
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">	
 	<!-- Allows providing SDK-specific property overrides -->
 	<PropertyGroup>
 		<XamarinAppleSdkProps>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Xamarin.Apple.Sdk.props'))\Xamarin.Apple.Sdk.props</XamarinAppleSdkProps>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.ObjCBinding.CSharp.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.ObjCBinding.CSharp.After.targets
@@ -15,7 +15,10 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 ***********************************************************************************************
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.Windows.props" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.iOS.Windows.props')" />
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.Windows.After.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.iOS.Windows.After.targets')" />
+
+	<UsingTask TaskName="Xamarin.iOS.Tasks.PrepareObjCBindingNativeFrameworks" AssemblyFile="$(CoreiOSSdkDirectory)Xamarin.iOS.Tasks.dll" />
 	
 	<PropertyGroup Condition="'$(DesignTimeBuild)' != 'true'">
 		<CompileDependsOn>
@@ -38,5 +41,13 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 		<PropertyGroup>
 			<DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">false</DesignTimeBuild>
 		</PropertyGroup>
+	</Target>
+
+	<Target Name="CopyCompressedNativeFrameworkResources" Condition="'@(_NativeFrameworkResource)' != ''" AfterTargets="_CompressNativeFrameworkResources">
+		<CopyFileFromBuildServer SessionId="$(BuildSessionId)" File="$(IntermediateOutputPath)%(_NativeFramework.Filename)%(_NativeFramework.Extension)" />
+	</Target>
+
+	<Target Name="PrepareObjCBindingNativeFrameworks" BeforeTargets="_CompressObjCBindingNativeFrameworkResources">
+		<PrepareObjCBindingNativeFrameworks SessionId="$(BuildSessionId)" ObjCBindingNativeFrameworks="@(ObjCBindingNativeFramework)" />
 	</Target>
 </Project>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Windows.props
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Windows.props
@@ -13,8 +13,9 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<!-- Naming convention that relies on the fact that the Microsoft.iOS.Sdk pack exists with the same version that the Windows SDK -->
-		<CoreiOSSdkDirectory>$(MSBuildThisFileDirectory.Replace('Microsoft.iOS.Windows.Sdk', 'Microsoft.iOS.Sdk'))</CoreiOSSdkDirectory>
+		<CoreiOSSdkDirectory>$(MSBuildThisFileDirectory)</CoreiOSSdkDirectory>
+		<!-- Naming convention that relies on the fact that the Microsoft.iOS.Sdk pack exists with the same version that the Windows SDK (.net6 only) -->
+		<CoreiOSSdkDirectory Condition="$(MSBuildThisFileDirectory.Contains('Microsoft.iOS.Windows.Sdk'))">$(MSBuildThisFileDirectory.Replace('Microsoft.iOS.Windows.Sdk', 'Microsoft.iOS.Sdk'))</CoreiOSSdkDirectory>
 		<!-- Property originally defined in Xamarin.Messaging.Build.targets, from Xamarin.Messaging.Build.Client package -->
 		<MessagingBuildClientAssemblyFile>$(CoreiOSSdkDirectory)Xamarin.iOS.Tasks.dll</MessagingBuildClientAssemblyFile>
 		<MessagingAgentsDirectory>$(MSBuildThisFileDirectory)</MessagingAgentsDirectory>


### PR DESCRIPTION
- Fixed iOS Binding projects build in Windows 
- Fixing CoreiOSSdkDirectory definition for legacy project system