### PR TITLE
Target new xamarin-macios agent pools

### DIFF
--- a/tools/devops/automation/templates/agent-pool-selector.yml
+++ b/tools/devops/automation/templates/agent-pool-selector.yml
@@ -4,8 +4,8 @@
 parameters:
   agentPoolPR: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Untrusted'
   agentPoolPRUrl: 'https://devdiv.visualstudio.com/_settings/agentpools?poolId=366&view=agents'
-  agentPoolCI: 'VSEng-Xamarin-RedmondMacCatalinaBuildPool-iOS-Trusted'
-  agentPoolCIUrl: 'https://devdiv.visualstudio.com/DevDiv/_settings/agentqueues?queueId=2748&view=agents'
+  agentPoolCI: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Trusted'
+  agentPoolCIUrl: 'https://devdiv.visualstudio.com/_settings/agentpools?poolId=367&view=agents'
   condition: succeeded()
 
 steps:

--- a/tools/devops/automation/templates/agent-pool-selector.yml
+++ b/tools/devops/automation/templates/agent-pool-selector.yml
@@ -2,8 +2,8 @@
 # Selects appropriate agent pool based on trigger type (PR or CI)
 #
 parameters:
-  agentPoolPR: 'VSEng-Xamarin-RedmondMacCatalinaBuildPool-iOS-Untrusted'
-  agentPoolPRUrl: 'https://devdiv.visualstudio.com/DevDiv/_settings/agentqueues?queueId=2734&view=agents'
+  agentPoolPR: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Untrusted'
+  agentPoolPRUrl: 'https://devdiv.visualstudio.com/_settings/agentpools?poolId=366&view=agents'
   agentPoolCI: 'VSEng-Xamarin-RedmondMacCatalinaBuildPool-iOS-Trusted'
   agentPoolCIUrl: 'https://devdiv.visualstudio.com/DevDiv/_settings/agentqueues?queueId=2748&view=agents'
   condition: succeeded()

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -74,8 +74,8 @@ steps:
     Write-Host "Python3 location"
     which python3
 
-    Write-Host "Pip version"
-    pip -V
+    Write-Host "Pip3 version"
+    pip3 -V
   displayName: 'Show Python information'
 
 - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/clean-bot.sh

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -75,9 +75,7 @@ jobs:
     name: $(AgentPoolComputed)
     demands:
     - Agent.OS -equals Darwin
-    - Agent.OSVersion -equals 10.16
-    - macios_image -equals v2
-    - XcodeChannel -equals Beta
+    - macios_image -equals v2.1     # Big Sur image with Xcode 12.4 and 12.5 installed
   workspace:
     clean: all
 


### PR DESCRIPTION
Since agent pools can contain a mix of OSes, stop targeting pools with Catalina in the name and instead target pools with more generic names that will become the production pools going forward

Pool migration:
VSEng-Xamarin-RedmondMacCatalinaBuildPool-iOS-Untrusted -> VSEng-Xamarin-RedmondMacBuildPool-iOS-Untrusted
VSEng-Xamarin-RedmondMacCatalinaBuildPool-iOS-Trusted -> VSEng-Xamarin-RedmondMacBuildPool-iOS-Trusted

