### PR TITLE
[Xcode12.5] Fix regression test not to crash. fixes #10918

### DIFF
--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -1043,14 +1043,16 @@ namespace LinkSdk {
 		public void Github5024 ()
 		{
 			TestRuntime.AssertXcodeVersion (6,0);
-			var sc = new UISearchController ((UIViewController) null);
-			sc.SetSearchResultsUpdater ((vc) => { });
+			using (var controller = new UISplitViewController ()) {
+				var sc = new UISearchController ((UIViewController)controller);
+				sc.SetSearchResultsUpdater ((vc) => { });
 
-			var a = typeof (UISearchController).AssemblyQualifiedName;
-			var n = a.Replace ("UIKit.UISearchController", "UIKit.UISearchController+__Xamarin_UISearchResultsUpdating");
-			var t = Type.GetType (n);
-			Assert.NotNull (t, "private inner type");
-			Assert.IsNotNull (t.GetMethod ("UpdateSearchResultsForSearchController"), "preserved");
+				var a = typeof (UISearchController).AssemblyQualifiedName;
+				var n = a.Replace ("UIKit.UISearchController", "UIKit.UISearchController+__Xamarin_UISearchResultsUpdating");
+				var t = Type.GetType (n);
+				Assert.NotNull (t, "private inner type");
+				Assert.IsNotNull (t.GetMethod ("UpdateSearchResultsForSearchController"), "preserved");
+			}
 		}
 #endif // !__WATCHOS__
 


### PR DESCRIPTION
The api does not longer allow you to pass a null ptr. Create a dummy
controller:

fixes https://github.com/xamarin/xamarin-macios/issues/10918