### PR TITLE
[Xcode12.5] Add missing TV availability. #10920

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -16084,7 +16084,7 @@ namespace UIKit {
 		[Export ("displayModeButtonItem")]
 		UIBarButtonItem DisplayModeButtonItem { get; }
 
-		[iOS (14,5)]
+		[iOS (14,5), TV (14,5)]
 		[Export ("displayModeButtonVisibility", ArgumentSemantic.Assign)]
 		UISplitViewControllerDisplayModeButtonVisibility DisplayModeButtonVisibility { get; set; }
 		


### PR DESCRIPTION
API was added in 14.5 not earlier.

fixes https://github.com/xamarin/xamarin-macios/issues/10920