### PR TITLE
[CI] Add missing rule to generate the provisionator deps on older macs.

### DIFF
--- a/tools/devops/Makefile
+++ b/tools/devops/Makefile
@@ -19,6 +19,14 @@ build-provisioning.csx: build-provisioning.csx.in Makefile $(TOP)/Make.config
 		-e 's#@DOTNET_VERSION@#$(DOTNET_VERSION)#g' \
 		$< > $@;
 
+mac-tests-provisioning.csx: mac-tests-provisioning.csx.in Makefile $(TOP)/Make.config
+	$(Q_GEN) sed \
+		-e 's#@XM_PACKAGE@#$(XM_PACKAGE)#g' \
+		-e 's#@MONO_PACKAGE@#$(MIN_MONO_URL)#g' \
+		-e 's#@VS_PACKAGE@#$(MIN_VISUAL_STUDIO_URL)#g' \
+		-e 's#@DOTNET_VERSION@#$(DOTNET_VERSION)#g' \
+		$< > $@;
+
 provision-xcode.csx: provision-xcode.csx.in Makefile $(TOP)/Make.config
 	$(Q_GEN) sed \
 		-e 's#@XCODE_XIP_NAME@#$(notdir $(XCODE_URL))#g' \


### PR DESCRIPTION
The rule is needed to run the tests on older macs. 