### PR TITLE
[runtime] Don't install any logging/printing handlers for CoreCLR, there's no equivalent.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -576,15 +576,21 @@
 		new Export ("void", "mono_trace_set_log_handler",
 			"MonoLogCallback", "callback",
 			"void *", "user_data"
-		),
+		) {
+			XamarinRuntime = RuntimeMode.MonoVM,
+		},
 
 		new Export ("void", "mono_trace_set_print_handler",
 			"MonoPrintCallback", "callback"
-		),
+		) {
+			XamarinRuntime = RuntimeMode.MonoVM,
+		},
 
 		new Export ("void", "mono_trace_set_printerr_handler",
 			"MonoPrintCallback", "callback"
-		),
+		) {
+			XamarinRuntime = RuntimeMode.MonoVM,
+		},
 
 		#endregion
 
@@ -681,6 +687,12 @@
 		OnlyLegacy = 2,
 	}
 
+	enum RuntimeMode {
+		Both = 0,
+		MonoVM = 1,
+		CoreCLR = 2,
+	}
+
 	class Export
 	{
 		public string ReturnType;
@@ -689,6 +701,7 @@
 		public List<Arg> Arguments;
 		public bool Optional;
 		public DotNetMode Mode;
+		public RuntimeMode XamarinRuntime;
 
 		public Export (string returnType, string entryPoint, params string [] arguments)
 			: this (false, returnType, entryPoint, arguments)
@@ -718,6 +731,28 @@
 			}
 		}
 
+		public string RuntimeIf {
+			get {
+				switch (XamarinRuntime) {
+				case RuntimeMode.CoreCLR:
+					return "#if defined (CORECLR_RUNTIME)\n";
+				case RuntimeMode.MonoVM:
+					return "#if !defined (CORECLR_RUNTIME)\n";
+				}
+				return string.Empty;
+			}
+		}
+
+		public string RuntimeEndIf {
+			get {
+				switch (XamarinRuntime) {
+				case RuntimeMode.CoreCLR:
+				case RuntimeMode.MonoVM:
+					return "#endif\n";
+				}
+				return string.Empty;
+			}
+		}
 		public Export (bool optional, string returnType, string entryPoint, params string [] arguments)
 		{
 			ReturnType = returnType;

--- a/runtime/mono-runtime.m.t4
+++ b/runtime/mono-runtime.m.t4
@@ -75,13 +75,13 @@ xamarin_initialize_dynamic_runtime (const char *mono_runtime_prefix)
 
 
 <# foreach (var export in exports) { #>
-<#= export.DotNetIf #>	<#= export.EntryPoint #>_func = (<#= export.EntryPoint #>_def) dlsym (libmono, "<#= export.EntryPoint #>");
+<#= export.DotNetIf #><#= export.RuntimeIf #>	<#= export.EntryPoint #>_func = (<#= export.EntryPoint #>_def) dlsym (libmono, "<#= export.EntryPoint #>");
 <# if (!export.Optional) { #>
 	if (<#= export.EntryPoint #>_func == NULL) {
 		fprintf (stderr, "Could not load <#= export.EntryPoint #>\n");
 		errmsg = "Failed to load the Mono framework.";
 	}
-<#= export.DotNetEndIf #><# } #>
+<#= export.DotNetEndIf #><#= export.RuntimeEndIf #><# } #>
 
 <# } #>
 	xamarin_dynamic_runtime_initialized = 1;
@@ -123,7 +123,10 @@ int xamarin_fix_ranlib_warning_about_no_symbols;
 #if defined (CORECLR_RUNTIME)
 #include "xamarin/runtime.h"
 
-<# foreach (var export in exports) { #>
+<# foreach (var export in exports) {
+	if (export.XamarinRuntime == RuntimeMode.MonoVM)
+		continue;
+#>
 MONO_API <#= export.ReturnType #>
 <#= export.EntryPoint #> (<#= export.ArgumentSignature #>)
 {

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1249,6 +1249,7 @@ pump_gc (void *context)
 }
 #endif /* DEBUG */
 
+#if !defined (CORECLR_RUNTIME)
 static void
 log_callback (const char *log_domain, const char *log_level, const char *message, mono_bool fatal, void *user_data)
 {
@@ -1265,6 +1266,7 @@ print_callback (const char *string, mono_bool is_stdout)
 	// COOP: Not accessing managed memory: any mode
 	PRINT ("%s", string);
 }
+#endif // !defined (CORECLR_RUNTIME)
 
 static int
 xamarin_compare_ints (const void *a, const void *b)
@@ -1323,9 +1325,11 @@ xamarin_initialize_embedded ()
 void
 xamarin_install_log_callbacks ()
 {
+#if !defined (CORECLR_RUNTIME)
 	mono_trace_set_log_handler (log_callback, NULL);
 	mono_trace_set_print_handler (print_callback);
 	mono_trace_set_printerr_handler (print_callback);
+#endif
 }
 
 void


### PR DESCRIPTION
This also means that we don't have to generate CoreCLR wrappers for the corresponding
embedding API, so adjust the generated code accordingly.