### PR TITLE
[runtime] Redirect to our objc_msgSend wrapper functions when needed for .NET code.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -323,7 +323,9 @@
 			"const char *", "func",
 			"const char *", "tdll",
 			"const char *", "tfunc"
-		),
+		) {
+			Mode = DotNetMode.OnlyLegacy,
+		},
 
 		#endregion
 

--- a/runtime/runtime-internal.h
+++ b/runtime/runtime-internal.h
@@ -31,6 +31,11 @@ extern "C" {
 
 void *xamarin_marshal_return_value (SEL sel, MonoType *mtype, const char *type, MonoObject *retval, bool retain, MonoMethod *method, MethodDescription *desc, GCHandle *exception_gchandle);
 
+void xamarin_dyn_objc_msgSend ();
+void xamarin_dyn_objc_msgSendSuper ();
+void xamarin_dyn_objc_msgSend_stret ();
+void xamarin_dyn_objc_msgSendSuper_stret ();
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2503,7 +2503,9 @@ xamarin_pinvoke_override (const char *libraryName, const char *entrypointName)
 	void* symbol = NULL;
 
 	if (!strcmp (libraryName, "__Internal")) {
+		symbol = dlsym (RTLD_DEFAULT, entrypointName);
 #if defined (__i386__) || defined (__x86_64__)
+	} else if (!strcmp (libraryName, "/usr/lib/libobjc.dylib")) {
 		if (xamarin_marshal_objectivec_exception_mode != MarshalObjectiveCExceptionModeDisable) {
 			if (!strcmp (entrypointName, "objc_msgSend")) {
 				symbol = (void *) &xamarin_dyn_objc_msgSend;
@@ -2516,9 +2518,6 @@ xamarin_pinvoke_override (const char *libraryName, const char *entrypointName)
 			}
 		}
 #endif // defined (__i386__) || defined (__x86_64__)
-
-		if (symbol == NULL)
-			symbol = dlsym (RTLD_DEFAULT, entrypointName);
 	}
 
 	return symbol;

--- a/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
@@ -96,10 +96,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			Assert.Ignore ("This test only works in debug mode in the simulator.");
 #endif
 
-#if NET && (__MACOS__ || __MACCATALYST__)
-			Assert.Ignore ("Exception marshalling hasn't been completely implemented on macOS/Mac Catalyst yet, due to removal of the dllmap support");
-#endif
-
 			InstallHandlers ();
 
 			try {
@@ -148,10 +144,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			Assert.Ignore ("This test only works in debug mode in the simulator.");
 #endif
 			var hasDebugger = global::System.Diagnostics.Debugger.IsAttached;
-
-#if NET && (__MACOS__ || __MACCATALYST__)
-			Assert.Ignore ("Exception marshalling hasn't been completely implemented on macOS/Mac Catalyst yet, due to removal of the dllmap support");
-#endif
 
 			InstallHandlers ();
 			try {

--- a/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
@@ -15,7 +15,6 @@
     <DefineConstants>$(DefineConstants);MONOMAC;XAMMAC_TESTS</DefineConstants>
     <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);DEBUG;DYNAMIC_REGISTRAR</DefineConstants>
     <RootTestsDirectory>..\..\..</RootTestsDirectory>
-    <MonoBundlingExtraArgs>--marshal-objectivec-exceptions:disable</MonoBundlingExtraArgs>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -1359,14 +1359,7 @@ namespace Xamarin.Bundler {
 						break;
 					case ApplePlatform.MacOSX:
 					case ApplePlatform.MacCatalyst:
-#if NET
-						// Mono doesn't support dllmaps for Mac Catalyst / macOS in .NET for now:
-						// macOS: https://github.com/dotnet/runtime/issues/43204
-						// Mac Catalyst: https://github.com/dotnet/runtime/issues/48110
-						MarshalObjectiveCExceptions = MarshalObjectiveCExceptionMode.Disable;
-#else
 						MarshalObjectiveCExceptions = EnableDebug ? MarshalObjectiveCExceptionMode.ThrowManagedException : MarshalObjectiveCExceptionMode.Disable;
-#endif
 						break;
 					default:
 						throw ErrorHelper.CreateError (71, Errors.MX0071 /* Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new with a test case. */, Platform, ProductName);

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -613,12 +613,7 @@ namespace Xamarin.Bundler {
 			sw.WriteLine ("\txamarin_executable_name = \"{0}\";", App.AssemblyName);
 			if (!App.IsDefaultMarshalManagedExceptionMode)
 				sw.WriteLine ("\txamarin_marshal_managed_exception_mode = MarshalManagedExceptionMode{0};", App.MarshalManagedExceptions);
-#if NET
-			// We require support for dllmap, which isn't in .NET/macOS yet (https://github.com/dotnet/runtime/issues/43204), so disable
-			sw.WriteLine ("\txamarin_marshal_objectivec_exception_mode = MarshalObjectiveCExceptionModeDisable;");
-#else
 			sw.WriteLine ("\txamarin_marshal_objectivec_exception_mode = MarshalObjectiveCExceptionMode{0};", App.MarshalObjectiveCExceptions);
-#endif
 			if (App.DisableLldbAttach.HasValue ? App.DisableLldbAttach.Value : !App.EnableDebug)
 				sw.WriteLine ("\txamarin_disable_lldb_attach = true;");
 			if (App.DisableOmitFramePointer ?? App.EnableDebug)


### PR DESCRIPTION
This makes the mono_dllmap_insert function unnecessary for .NET, so remove it.

Ref: https://github.com/dotnet/runtime/issues/48110
Ref: https://github.com/dotnet/runtime/issues/43204
Ref: #10504