### PR TITLE
[msbuild] Fix ItemName vs PropertyName confusion in task output.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -951,7 +951,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			NoSymbolStrip="$(_NoSymbolStrip)"
 			NoDSymUtil="$(_NoDSymUtil)"
 			>
-			<Output TaskParameter="CustomBundleName" ItemName="_CustomBundleName" />
+			<Output TaskParameter="CustomBundleName" PropertyName="_CustomBundleName" />
 			<Output TaskParameter="EnvironmentVariables" ItemName="_BundlerEnvironmentVariables" />
 			<Output TaskParameter="MarshalManagedExceptionMode" PropertyName="_MarshalManagedExceptionMode" />
 			<Output TaskParameter="MarshalObjectiveCExceptionMode" PropertyName="_MarshalObjectiveCExceptionMode" />


### PR DESCRIPTION
There doesn't seem to have been any ill effects from the confusion, but it's
better done the right way.