### PR TITLE
[ObjCRuntime] Simplify Runtime.NSLog to always call xamarin_log.

### DIFF
--- a/src/ObjCRuntime/Dlfcn.cs
+++ b/src/ObjCRuntime/Dlfcn.cs
@@ -108,8 +108,12 @@ namespace ObjCRuntime {
 			// "no cache image with name (<top>)"
 			if (path.IndexOf ('/') == -1){
 				if (!warningShown){
-					Runtime.NSLog ("You are using dlopen without a full path, retrying by prepending /usr/lib");
-					warningShown = true;
+					try {
+						Runtime.NSLog ("You are using dlopen without a full path, retrying by prepending /usr/lib");
+						warningShown = true;
+					} catch {
+						// Ignore any failures to show the warning.
+					}
 				}
 				
 				x = _dlopen ("/usr/lib/" + path, mode);

--- a/src/ObjCRuntime/Dlfcn.cs
+++ b/src/ObjCRuntime/Dlfcn.cs
@@ -96,8 +96,13 @@ namespace ObjCRuntime {
 		[DllImport (Constants.libSystemLibrary, EntryPoint="dlopen")]
 		internal static extern IntPtr _dlopen (string path, int mode /* this is int32, not nint */);
 
-		static bool warningShown;
 		public static IntPtr dlopen (string path, int mode)
+		{
+			return dlopen (path, mode, true);
+		}
+
+		static bool warningShown;
+		internal static IntPtr dlopen (string path, int mode, bool showWarning)
 		{
 			var x = _dlopen (path, mode);
 			if (x != IntPtr.Zero)
@@ -107,13 +112,9 @@ namespace ObjCRuntime {
 			// In iOS >= 9, this fails with:
 			// "no cache image with name (<top>)"
 			if (path.IndexOf ('/') == -1){
-				if (!warningShown){
-					try {
-						Runtime.NSLog ("You are using dlopen without a full path, retrying by prepending /usr/lib");
-						warningShown = true;
-					} catch {
-						// Ignore any failures to show the warning.
-					}
+				if (!warningShown && showWarning) {
+					Runtime.NSLog ("You are using dlopen without a full path, retrying by prepending /usr/lib");
+					warningShown = true;
 				}
 				
 				x = _dlopen ("/usr/lib/" + path, mode);

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1614,55 +1614,17 @@ namespace ObjCRuntime {
 			ConnectMethod (method.DeclaringType, method, selector);
 		}
 
-#if MONOMAC
-		[DllImport (Constants.FoundationLibrary, EntryPoint = "NSLog")]
-		extern static void NSLog_impl (IntPtr format, [MarshalAs (UnmanagedType.LPStr)] string s);
-		static void NSLog (IntPtr format, string s)
+		[DllImport ("__Internal", CharSet = CharSet.Unicode)]
+		internal extern static void xamarin_log (string s);
+
+		internal static void NSLog (string value)
 		{
-			if (PlatformHelper.CheckSystemVersion (10, 12)) {
-				Console.WriteLine (s);
-			} else {
-				NSLog_impl (format, s);
-			}
+			xamarin_log (value);
 		}
-#else
-		[DllImport (Constants.FoundationLibrary)]
-		extern static void NSLog (IntPtr format, [MarshalAs (UnmanagedType.LPStr)] string s);
-#endif
 
-#if MONOMAC
-		[DllImport ("__Internal")]
-		extern static void xamarin_log (string s);
-		internal static void NSLog (string s)
-		{
-			if (PlatformHelper.CheckSystemVersion (10, 12)) {
-				Console.WriteLine (s);
-			} else {
-				xamarin_log (s);
-			}
-		}
-#else
-		[DllImport ("__Internal", EntryPoint="xamarin_log", CharSet=CharSet.Unicode)]
-		internal extern static void NSLog (string s);
-#endif
-
-#if !MONOMAC
-		[DllImport (Constants.FoundationLibrary, EntryPoint = "NSLog")]
-		extern static void NSLog_arm64 (IntPtr format, IntPtr p2, IntPtr p3, IntPtr p4, IntPtr p5, IntPtr p6, IntPtr p7, IntPtr p8, [MarshalAs (UnmanagedType.LPStr)] string s);
-#endif
-
-		[BindingImpl (BindingImplOptions.Optimizable)]
 		internal static void NSLog (string format, params object[] args)
 		{
-			var fmt = NSString.CreateNative ("%s");
-			var val = (args == null || args.Length == 0) ? format : string.Format (format, args);
-#if !MONOMAC
-			if (IsARM64CallingConvention)
-				NSLog_arm64 (fmt, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, val);
-			else
-#endif
-				NSLog (fmt, val);
-			NSString.ReleaseNative (fmt);
+			xamarin_log (string.Format (format, args));
 		}
 #endif // !COREBUILD
 

--- a/src/ObjCRuntime/Runtime.mac.cs
+++ b/src/ObjCRuntime/Runtime.mac.cs
@@ -85,9 +85,9 @@ namespace ObjCRuntime {
 				runtime_library = new IntPtr (-2 /* RTLD_DEFAULT */);
 				rv = Dlfcn.dlsym (runtime_library, name);
 				if (rv == IntPtr.Zero) {
-					runtime_library = Dlfcn.dlopen ("libxammac.dylib", 0);
+					runtime_library = Dlfcn.dlopen ("libxammac.dylib", 0, false);
 					if (runtime_library == IntPtr.Zero)
-						runtime_library = Dlfcn.dlopen (Path.Combine (Path.GetDirectoryName (typeof (NSApplication).Assembly.Location), "libxammac.dylib"), 0);
+						runtime_library = Dlfcn.dlopen (Path.Combine (Path.GetDirectoryName (typeof (NSApplication).Assembly.Location), "libxammac.dylib"), 0, false);
 					if (runtime_library == IntPtr.Zero)
 						throw new DllNotFoundException ("Could not find the runtime library libxammac.dylib");
 					rv = Dlfcn.dlsym (runtime_library, name);


### PR DESCRIPTION
This also fixes a couple of bugs:

* We wouldn't use the arm64 version of NSLog on Xamarin.Mac.
* We would use a wrong xamarin_log declaration on Xamarin.Mac on older macOS
  (the string argument would be UTF8 as opposed to Unicode, which is what the
  native function expects).