### PR TITLE
[runtime] Make the exception_gchandle argument optional for callbacks to managed code in CoreCLR.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -47,4 +47,17 @@ xamarin_bridge_vm_initialize (int propertyCount, const char **propertyKeys, cons
 	return rv == 0;
 }
 
+void
+xamarin_handle_bridge_exception (GCHandle gchandle, const char *method)
+{
+	if (gchandle == INVALID_GCHANDLE)
+		return;
+
+	if (method == NULL)
+		method = "<unknown method";
+
+	fprintf (stderr, "%s threw an exception: %p\n", method, gchandle);
+	xamarin_assertion_message ("%s threw an exception: %p", method, gchandle);
+}
+
 #endif // CORECLR_RUNTIME

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -414,6 +414,9 @@
 					}
 				}
 
+				if (ExceptionHandling)
+					sb.AppendLine ("\tGCHandle exception_gchandle_tmp = INVALID_GCHANDLE;");
+
 				sb.Append ("\t");
 				if (!ReturnType.IsVoid) {
 					sb.Append ($"{ReturnType.ExposedCType} rv = ");
@@ -426,10 +429,11 @@
 				sb.Append (EntryPoint.Substring ("xamarin_".Length));
 				sb.Append (" (");
 				sb.Append (invoke_args);
+
 				if (ExceptionHandling) {
 					if (Arguments.Count > 0)
 						sb.Append (", ");
-					sb.Append ("exception_gchandle");
+					sb.Append ("&exception_gchandle_tmp");
 				}
 
 				if (ReturnType.IsGCHandleConversion)
@@ -438,6 +442,19 @@
 				sb.AppendLine (");");
 
 				sb.Append (post_invoke);
+
+				if (ExceptionHandling) {
+					sb.AppendLine ("#if defined (CORECLR_RUNTIME)");
+					sb.AppendLine ("\tif (exception_gchandle == NULL) {");
+					sb.AppendLine ("\t\tif (exception_gchandle_tmp != INVALID_GCHANDLE)");
+					sb.AppendLine ("\t\t\txamarin_handle_bridge_exception (exception_gchandle_tmp, __func__);");
+					sb.AppendLine ("\t} else {");
+					sb.AppendLine ("\t\t*exception_gchandle = exception_gchandle_tmp;");
+					sb.AppendLine ("\t}");
+					sb.AppendLine ("#else");
+					sb.AppendLine ("\t*exception_gchandle = exception_gchandle_tmp;");
+					sb.AppendLine ("#endif");
+				}
 
 				if (!ReturnType.IsVoid)
 					sb.AppendLine ("\treturn rv;");
@@ -465,7 +482,7 @@
 			}
 		}
 
-		string CFormatArgs (string empty, bool nameOnly, bool exposed = false)
+		string CFormatArgs (string empty, bool nameOnly, bool exposed = false, bool functionDeclaration = false)
 		{
 			var builder = new StringBuilder ();
 
@@ -487,6 +504,8 @@
 					builder.Append (", ");
 				if (nameOnly) {
 					builder.Append ("exception_gchandle");
+				} else if (functionDeclaration) {
+					builder.Append ("GCHandle *exception_gchandle = NULL");
 				} else {
 					builder.Append ("GCHandle *exception_gchandle");
 				}
@@ -535,6 +554,10 @@
 
 		public string CArgumentSignatureExposed {
 			get { return CFormatArgs ("void", nameOnly: false, exposed: true); }
+		}
+
+		public string CArgumentSignatureFunctionDeclaration {
+			get { return CFormatArgs ("void", nameOnly: false, exposed: true, functionDeclaration: true); }
 		}
 
 		public string CArgumentNames {

--- a/runtime/runtime-generated.h.t4
+++ b/runtime/runtime-generated.h.t4
@@ -26,7 +26,7 @@ extern "C" {
 			continue;
 #>
 <#= d.ReturnType.ExposedCType #>
-<#= d.EntryPoint #> (<#= d.CArgumentSignatureExposed #>);
+<#= d.EntryPoint #> (<#= d.CArgumentSignatureFunctionDeclaration #>);
 
 <# } #>
 

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -200,6 +200,7 @@ void			xamarin_bridge_initialize (); // this is called a bit later, after parsin
 unsigned char *	xamarin_load_aot_data (MonoAssembly *assembly, int size, gpointer user_data, void **out_handle);
 void			xamarin_free_aot_data (MonoAssembly *assembly, int size, gpointer user_data, void *handle);
 MonoAssembly*	xamarin_assembly_preload_hook (MonoAssemblyName *aname, char **assemblies_path, void* user_data);
+void			xamarin_handle_bridge_exception (GCHandle gchandle, const char *method);
 void			xamarin_vm_initialize ();
 bool			xamarin_bridge_vm_initialize (int propertyCount, const char **propertyKeys, const char **propertyValues);
 void*			xamarin_pinvoke_override (const char *libraryName, const char *entrypointName);


### PR DESCRIPTION
If no exception handling is provided when calling a managed delegate from native
code, and the managed code throws, then we'll abort.

It's not entirely clear how we'll handle managed exceptions that go through native
code yet, so this makes the initial implementation easier. By making the exception
handling optional, it'll be easy to find all cases where we need to fix it later,
by making it non-optional. The alternative is to add exception handling code all
over the place that would potentially have to be updated when we figure out exactly
what needs to be done.