### PR TITLE
[generate-type-forwarders] Fix const/readonly fields

### DIFF
--- a/src/generate-type-forwarders/Program.cs
+++ b/src/generate-type-forwarders/Program.cs
@@ -320,11 +320,24 @@ namespace GenerateTypeForwarders {
 			} else {
 				sb.Append ('\t', indent);
 				sb.Append ("public ");
-				if (fd.IsStatic)
+				if (fd.IsLiteral)
+					sb.Append ("const ");
+				else if (fd.IsStatic)
 					sb.Append ("static ");
+				if (fd.IsInitOnly)
+					sb.Append ("readonly ");
 				EmitTypeName (sb, fd.FieldType);
 				sb.Append (' ');
 				sb.Append (fd.Name);
+				if (fd.HasConstant) {
+					sb.Append (" = ");
+					bool is_string = fd.Constant is string;
+					if (is_string)
+						sb.Append ('"');
+					sb.Append (fd.Constant);
+					if (is_string)
+						sb.Append ('"');
+				}
 				sb.Append (';');
 			}
 			sb.AppendLine ();


### PR DESCRIPTION
Examples:

```diff
-public double MinimumDuration = 5---null---;
+public const double MinimumDuration = null;
```

```diff
 public ---readonly--- Foundation.NSString RGB565;
```

Also handle `string` constants (quotes).