### PR TITLE
[runtime] Implement calling the managed Runtime.Initialize method from the CoreCLR bridge.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -8,6 +8,7 @@
 
 #if defined (CORECLR_RUNTIME)
 
+#include "product.h"
 #include "xamarin/xamarin.h"
 #include "xamarin/coreclr-bridge.h"
 
@@ -58,6 +59,61 @@ xamarin_handle_bridge_exception (GCHandle gchandle, const char *method)
 
 	fprintf (stderr, "%s threw an exception: %p\n", method, gchandle);
 	xamarin_assertion_message ("%s threw an exception: %p", method, gchandle);
+}
+
+typedef void (*xamarin_runtime_initialize_decl)(struct InitializationOptions* options);
+void
+xamarin_bridge_call_runtime_initialize (struct InitializationOptions* options, GCHandle* exception_gchandle)
+{
+	void *del = NULL;
+	int rv = coreclr_create_delegate (coreclr_handle, coreclr_domainId, PRODUCT ", Version=0.0.0.0", "ObjCRuntime.Runtime", "Initialize", &del);
+	if (rv != 0)
+		xamarin_assertion_message ("xamarin_bridge_call_runtime_initialize: failed to create delegate: %i\n", rv);
+
+	xamarin_runtime_initialize_decl runtime_initialize = (xamarin_runtime_initialize_decl) del;
+	runtime_initialize (options);
+}
+
+void
+xamarin_bridge_register_product_assembly (GCHandle* exception_gchandle)
+{
+	xamarin_open_and_register (PRODUCT_DUAL_ASSEMBLY, exception_gchandle);
+}
+
+MonoClass *
+xamarin_get_nsnumber_class ()
+{
+	xamarin_assertion_message ("The method %s it not implemented yet for CoreCLR", __func__);
+}
+
+MonoClass *
+xamarin_get_nsvalue_class ()
+{
+	xamarin_assertion_message ("The method %s it not implemented yet for CoreCLR", __func__);
+}
+
+MonoClass *
+xamarin_get_inativeobject_class ()
+{
+	xamarin_assertion_message ("The method %s it not implemented yet for CoreCLR", __func__);
+}
+
+MonoClass *
+xamarin_get_nsobject_class ()
+{
+	xamarin_assertion_message ("The method %s it not implemented yet for CoreCLR", __func__);
+}
+
+MonoClass *
+xamarin_get_nsstring_class ()
+{
+	xamarin_assertion_message ("The method %s it not implemented yet for CoreCLR", __func__);
+}
+
+MonoClass *
+xamarin_get_runtime_class ()
+{
+	xamarin_assertion_message ("The method %s it not implemented yet for CoreCLR", __func__);
 }
 
 #endif // CORECLR_RUNTIME

--- a/runtime/monovm-bridge.m
+++ b/runtime/monovm-bridge.m
@@ -18,10 +18,19 @@
 #define LEGACY_XAMARIN_MAC 0
 #endif
 
+#include "product.h"
 #include "monotouch-debug.h"
 #include "runtime-internal.h"
 #include "xamarin/xamarin.h"
 #include "xamarin/monovm-bridge.h"
+
+static MonoAssembly* entry_assembly = NULL;
+static MonoClass* inativeobject_class = NULL;
+static MonoClass* nsobject_class = NULL;
+static MonoClass* nsvalue_class = NULL;
+static MonoClass* nsnumber_class = NULL;
+static MonoClass* nsstring_class = NULL;
+static MonoClass* runtime_class = NULL;
 
 #if !LEGACY_XAMARIN_MAC
 void
@@ -80,6 +89,109 @@ xamarin_bridge_initialize ()
 	DEBUG_LAUNCH_TIME_PRINT ("\tJIT init time");
 }
 #endif // !LEGACY_XAMARIN_MAC
+
+static MonoClass *
+get_class_from_name (MonoImage* image, const char *nmspace, const char *name, bool optional = false)
+{
+	// COOP: this is a convenience function executed only at startup, I believe the mode here doesn't matter.	
+	MonoClass *rv = mono_class_from_name (image, nmspace, name);
+	if (!rv && !optional)
+		xamarin_assertion_message ("Fatal error: failed to load the class '%s.%s'\n.", nmspace, name);
+	return rv;
+}
+
+void
+xamarin_bridge_call_runtime_initialize (struct InitializationOptions* options, GCHandle* exception_gchandle)
+{
+	MonoMethod *runtime_initialize;
+	void* params[2];
+	MonoObject *exc = NULL;
+	MonoImage* platform_image = NULL;
+
+	entry_assembly = xamarin_open_assembly (PRODUCT_DUAL_ASSEMBLY);
+
+	if (!entry_assembly)
+		xamarin_assertion_message ("Failed to load %s.", PRODUCT_DUAL_ASSEMBLY);
+	platform_image = mono_assembly_get_image (entry_assembly);
+
+	const char *objcruntime = "ObjCRuntime";
+	const char *foundation = "Foundation";
+
+	runtime_class = get_class_from_name (platform_image, objcruntime, "Runtime");
+	inativeobject_class = get_class_from_name (platform_image, objcruntime, "INativeObject");
+	nsobject_class = get_class_from_name (platform_image, foundation, "NSObject");
+	nsnumber_class = get_class_from_name (platform_image, foundation, "NSNumber", true);
+	nsvalue_class = get_class_from_name (platform_image, foundation, "NSValue", true);
+	nsstring_class = get_class_from_name (platform_image, foundation, "NSString", true);
+
+	xamarin_add_internal_call ("Foundation.NSObject::xamarin_create_managed_ref", (const void *) xamarin_create_managed_ref);
+
+	runtime_initialize = mono_class_get_method_from_name (runtime_class, "Initialize", 1);
+
+	if (runtime_initialize == NULL)
+		xamarin_assertion_message ("Fatal error: failed to load the %s.%s method", "Runtime", "Initialize");
+
+	params [0] = options;
+
+	mono_runtime_invoke (runtime_initialize, NULL, params, &exc);
+
+	if (exc)
+		*exception_gchandle = xamarin_gchandle_new (exc, false);
+}
+
+void
+xamarin_bridge_register_product_assembly (GCHandle* exception_gchandle)
+{
+	xamarin_register_monoassembly (entry_assembly, exception_gchandle);
+}
+
+MonoClass *
+xamarin_get_inativeobject_class ()
+{
+	if (inativeobject_class == NULL)
+		xamarin_assertion_message ("Internal consistency error, please file a bug (https://github.com/xamarin/xamarin-macios/issues/new). Additional data: can't get the %s class because it's been linked away.\n", "INativeObject");
+	return inativeobject_class;
+}
+
+MonoClass *
+xamarin_get_nsobject_class ()
+{
+	if (nsobject_class == NULL)
+		xamarin_assertion_message ("Internal consistency error, please file a bug (https://github.com/xamarin/xamarin-macios/issues/new). Additional data: can't get the %s class because it's been linked away.\n", "NSObject");
+	return nsobject_class;
+}
+
+MonoClass *
+xamarin_get_nsvalue_class ()
+{
+	if (nsvalue_class == NULL)
+		xamarin_assertion_message ("Internal consistency error, please file a bug (https://github.com/xamarin/xamarin-macios/issues/new). Additional data: can't get the %s class because it's been linked away.\n", "NSValue");
+	return nsvalue_class;
+}
+
+MonoClass *
+xamarin_get_nsnumber_class ()
+{
+	if (nsnumber_class == NULL)
+		xamarin_assertion_message ("Internal consistency error, please file a bug (https://github.com/xamarin/xamarin-macios/issues/new). Additional data: can't get the %s class because it's been linked away.\n", "NSNumber");
+	return nsnumber_class;
+}
+
+MonoClass *
+xamarin_get_nsstring_class ()
+{
+	if (nsstring_class == NULL)
+		xamarin_assertion_message ("Internal consistency error, please file a bug (https://github.com/xamarin/xamarin-macios/issues/new). Additional data: can't get the %s class because it's been linked away.\n", "NSString");
+	return nsstring_class;
+}
+
+MonoClass *
+xamarin_get_runtime_class ()
+{
+	if (runtime_class == NULL)
+		xamarin_assertion_message ("Internal consistency error, please file a bug (https://github.com/xamarin/xamarin-macios/issues/new). Additional data: can't get the %s class because it's been linked away.\n", "Runtime");
+	return runtime_class;
+}
 
 #if DOTNET
 

--- a/runtime/runtime-internal.h
+++ b/runtime/runtime-internal.h
@@ -35,6 +35,7 @@ void xamarin_dyn_objc_msgSend ();
 void xamarin_dyn_objc_msgSendSuper ();
 void xamarin_dyn_objc_msgSend_stret ();
 void xamarin_dyn_objc_msgSendSuper_stret ();
+void xamarin_add_internal_call (const char *name, const void *method);
 
 #ifdef __cplusplus
 }

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -83,14 +83,6 @@ xamarin_extension_main_callback xamarin_extension_main = NULL;
 
 /* Local variable */
 
-static MonoImage      *platform_image;
-static MonoClass      *inativeobject_class;
-static MonoClass      *nsobject_class;
-static MonoClass      *nsvalue_class;
-static MonoClass      *nsnumber_class;
-static MonoClass      *nsstring_class;
-static MonoClass      *runtime_class;
-
 static pthread_mutex_t framework_peer_release_lock;
 static MonoGHashTable *xamarin_wrapper_hash;
 
@@ -193,7 +185,7 @@ struct Managed_NSObject {
 	uint8_t flags;
 };
 
-static void
+void
 xamarin_add_internal_call (const char *name, const void *method)
 {
 	/* COOP: With cooperative GC, icalls will run, like managed methods,
@@ -356,29 +348,13 @@ xamarin_new_nsobject (id self, MonoClass *klass, GCHandle *exception_gchandle)
 	return xamarin_gchandle_unwrap (obj);
 }
 
-MonoClass *
-xamarin_get_nsvalue_class ()
-{
-	if (nsvalue_class == NULL)
-		xamarin_assertion_message ("Internal consistency error, please file a bug (https://github.com/xamarin/xamarin-macios/issues/new). Additional data: can't get the %s class because it's been linked away.\n", "NSValue");
-	return nsvalue_class;
-}
-
-MonoClass *
-xamarin_get_nsnumber_class ()
-{
-	if (nsnumber_class == NULL)
-		xamarin_assertion_message ("Internal consistency error, please file a bug (https://github.com/xamarin/xamarin-macios/issues/new). Additional data: can't get the %s class because it's been linked away.\n", "NSNumber");
-	return nsnumber_class;
-}
-
 bool
 xamarin_is_class_nsobject (MonoClass *cls)
 {
 	// COOP: Reading managed data, must be in UNSAFE mode
 	MONO_ASSERT_GC_UNSAFE;
 	
-	return mono_class_is_subclass_of (cls, nsobject_class, false);
+	return mono_class_is_subclass_of (cls, xamarin_get_nsobject_class (), false);
 }
 
 bool
@@ -387,7 +363,7 @@ xamarin_is_class_inativeobject (MonoClass *cls)
 	// COOP: Reading managed data, must be in UNSAFE mode
 	MONO_ASSERT_GC_UNSAFE;
 	
-	return mono_class_is_subclass_of (cls, inativeobject_class, true);
+	return mono_class_is_subclass_of (cls, xamarin_get_inativeobject_class (), true);
 }
 
 bool
@@ -405,6 +381,7 @@ xamarin_is_class_nsnumber (MonoClass *cls)
 	// COOP: Reading managed data, must be in UNSAFE mode
 	MONO_ASSERT_GC_UNSAFE;
 
+	MonoClass *nsnumber_class = xamarin_get_nsnumber_class ();
 	if (nsnumber_class == NULL)
 		return false;
 
@@ -417,6 +394,7 @@ xamarin_is_class_nsvalue (MonoClass *cls)
 	// COOP: Reading managed data, must be in UNSAFE mode
 	MONO_ASSERT_GC_UNSAFE;
 
+	MonoClass *nsvalue_class = xamarin_get_nsvalue_class ();
 	if (nsvalue_class == NULL)
 		return false;
 
@@ -429,6 +407,7 @@ xamarin_is_class_nsstring (MonoClass *cls)
 	// COOP: Reading managed data, must be in UNSAFE mode
 	MONO_ASSERT_GC_UNSAFE;
 
+	MonoClass *nsstring_class = xamarin_get_nsstring_class ();
 	if (nsstring_class == NULL)
 		return false;
 
@@ -451,7 +430,7 @@ xamarin_is_class_nullable (MonoClass *cls, MonoClass **element_type, GCHandle *e
 		static MonoMethod *get_nullable_type = NULL;
 
 		if (get_nullable_type == NULL)
-			get_nullable_type = mono_class_get_method_from_name (runtime_class, "GetNullableType", 1);
+			get_nullable_type = mono_class_get_method_from_name (xamarin_get_runtime_class (), "GetNullableType", 1);
 
 		GCHandle type_handle = xamarin_gchandle_new ((MonoObject *) mono_type_get_object (mono_domain_get (), mono_class_get_type (cls)), false);
 		void *args [1] { type_handle };
@@ -935,16 +914,6 @@ gc_enable_new_refcount (void)
 	mono_profiler_install_gc (gc_event_callback, NULL);
 }
 
-static MonoClass *
-get_class_from_name (MonoImage* image, const char *nmspace, const char *name, bool optional = false)
-{
-	// COOP: this is a convenience function executed only at startup, I believe the mode here doesn't matter.	
-	MonoClass *rv = mono_class_from_name (image, nmspace, name);
-	if (!rv && !optional)
-		xamarin_assertion_message ("Fatal error: failed to load the class '%s.%s'\n.", nmspace, name);
-	return rv;
-}
-
 struct _MonoProfiler {
 	int dummy;
 };
@@ -1009,8 +978,8 @@ xamarin_open_assembly (const char *name)
 	return assembly;
 }
 
-static bool
-register_assembly (MonoAssembly *assembly, GCHandle *exception_gchandle)
+bool
+xamarin_register_monoassembly (MonoAssembly *assembly, GCHandle *exception_gchandle)
 {
 	// COOP: this is a function executed only at startup, I believe the mode here doesn't matter.
 	if (!xamarin_supports_dynamic_registration) {
@@ -1029,7 +998,7 @@ xamarin_open_and_register (const char *aname, GCHandle *exception_gchandle)
 
 	assembly = xamarin_open_assembly (aname);
 
-	register_assembly (assembly, exception_gchandle);
+	xamarin_register_monoassembly (assembly, exception_gchandle);
 	
 	return assembly;
 }
@@ -1041,6 +1010,7 @@ is_class_finalization_aware (MonoClass *cls)
 	// COOP: This is a callback called by the GC, I believe the mode here doesn't matter.
 	gboolean rv = false;
 
+	MonoClass *nsobject_class = xamarin_get_nsobject_class ();
 	if (nsobject_class)
 		rv = cls == nsobject_class || mono_class_is_assignable_from (nsobject_class, cls);
 
@@ -1340,11 +1310,7 @@ xamarin_initialize ()
 	// COOP: accessing managed memory: UNSAFE mode
 	MONO_ASSERT_GC_UNSAFE;
 	
-	MonoAssembly *assembly = NULL;
-	MonoMethod *runtime_initialize;
-	void* params[2];
 	GCHandle exception_gchandle = INVALID_GCHANDLE;
-	MonoObject *exc = NULL;
 
 	initialize_started = TRUE;
 
@@ -1378,29 +1344,6 @@ xamarin_initialize ()
 		NSSetUncaughtExceptionHandler (exception_handler);
 	}
 
-	assembly = xamarin_open_assembly (PRODUCT_DUAL_ASSEMBLY);
-
-	if (!assembly)
-		xamarin_assertion_message ("Failed to load %s.", PRODUCT_DUAL_ASSEMBLY);
-	platform_image = mono_assembly_get_image (assembly);
-
-	const char *objcruntime = "ObjCRuntime";
-	const char *foundation = "Foundation";
-
-	runtime_class = get_class_from_name (platform_image, objcruntime, "Runtime");
-	inativeobject_class = get_class_from_name (platform_image, objcruntime, "INativeObject");
-	nsobject_class = get_class_from_name (platform_image, foundation, "NSObject");
-	nsnumber_class = get_class_from_name (platform_image, foundation, "NSNumber", true);
-	nsvalue_class = get_class_from_name (platform_image, foundation, "NSValue", true);
-	nsstring_class = get_class_from_name (platform_image, foundation, "NSString", true);
-
-	xamarin_add_internal_call ("Foundation.NSObject::xamarin_create_managed_ref", (const void *) xamarin_create_managed_ref);
-
-	runtime_initialize = mono_class_get_method_from_name (runtime_class, "Initialize", 1);
-
-	if (runtime_initialize == NULL)
-		xamarin_assertion_message ("Fatal error: failed to load the %s.%s method", "Runtime", "Initialize");
-
 	options.size = sizeof (options);
 #if MONOTOUCH && (defined(__i386__) || defined (__x86_64__))
 	options.flags = (enum InitializationFlags) (options.flags | InitializationFlagsIsSimulator);
@@ -1419,19 +1362,15 @@ xamarin_initialize ()
 	options.EntryAssemblyPath = xamarin_entry_assembly_path;
 #endif
 
-	params [0] = &options;
-
-	mono_runtime_invoke (runtime_initialize, NULL, params, &exc);
-
-	if (exc) {
-		exception_gchandle = xamarin_gchandle_new (exc, false);
+	xamarin_bridge_call_runtime_initialize (&options, &exception_gchandle);
+	if (exception_gchandle != INVALID_GCHANDLE) {
 		NSLog (@PRODUCT ": An exception occurred when calling Runtime.Initialize:\n%@", xamarin_print_all_exceptions (exception_gchandle));
 		xamarin_process_managed_exception_gchandle (exception_gchandle);
 		xamarin_assertion_message ("Can't continue if Runtime.Initialize fails.");
 	}
 
-	if (!register_assembly (assembly, &exception_gchandle))
-		xamarin_process_managed_exception_gchandle (exception_gchandle);
+	xamarin_bridge_register_product_assembly (&exception_gchandle);
+	xamarin_process_managed_exception_gchandle (exception_gchandle);
 
 	xamarin_install_mono_profiler (); // must be called before xamarin_install_nsautoreleasepool_hooks or gc_enable_new_refcount
 

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -25,6 +25,8 @@
 extern "C" {
 #endif
 
+struct InitializationOptions;
+
 typedef struct {
 	const char *name;
 	const char *type;
@@ -204,6 +206,9 @@ void			xamarin_handle_bridge_exception (GCHandle gchandle, const char *method);
 void			xamarin_vm_initialize ();
 bool			xamarin_bridge_vm_initialize (int propertyCount, const char **propertyKeys, const char **propertyValues);
 void*			xamarin_pinvoke_override (const char *libraryName, const char *entrypointName);
+void			xamarin_bridge_call_runtime_initialize (struct InitializationOptions* options, GCHandle* exception_gchandle);
+void			xamarin_bridge_register_product_assembly (GCHandle* exception_gchandle);
+bool			xamarin_register_monoassembly (MonoAssembly *assembly, GCHandle *exception_gchandle);
 
 MonoObject *	xamarin_new_nsobject (id self, MonoClass *klass, GCHandle *exception_gchandle);
 bool			xamarin_has_managed_ref (id self);
@@ -245,6 +250,10 @@ NSString *		xamarin_print_all_exceptions (GCHandle handle);
 id				xamarin_invoke_objc_method_implementation (id self, SEL sel, IMP xamarin_impl);
 MonoClass *		xamarin_get_nsnumber_class ();
 MonoClass *		xamarin_get_nsvalue_class ();
+MonoClass *		xamarin_get_inativeobject_class ();
+MonoClass *		xamarin_get_nsobject_class ();
+MonoClass *		xamarin_get_nsstring_class ();
+MonoClass *		xamarin_get_runtime_class ();
 
 bool			xamarin_is_managed_exception_marshaling_disabled ();
 


### PR DESCRIPTION
* Move the existing logic to call Runtime.Initialize into the MonoVM code.
* Implement calling the managed Runtime.Initialize method from the CoreCLR bridge.

The call to Runtime.Initialize succeeds, which means we're now executing
managed code with CoreCLR for the first time.