### PR TITLE
[generate-type-forwarders] Fix missing `protected internal` methods stubs

### DIFF
--- a/src/generate-type-forwarders/Program.cs
+++ b/src/generate-type-forwarders/Program.cs
@@ -38,7 +38,7 @@ namespace GenerateTypeForwarders {
 		{
 			if (method is null)
 				return false;
-			return method.IsPublic || method.IsFamily;
+			return method.IsPublic || method.IsFamily || method.IsFamilyOrAssembly;
 		}
 
 		static bool IsVisible (this PropertyDefinition property)


### PR DESCRIPTION
Example:

```diff
-protected virtual void OnNewPersonComplete (ABNewPersonCompleteEventArgs e);
```