### PR TITLE
[generate-type-forwarders] Fix `new virtual` properties

### DIFF
--- a/src/generate-type-forwarders/Program.cs
+++ b/src/generate-type-forwarders/Program.cs
@@ -424,7 +424,7 @@ namespace GenerateTypeForwarders {
 					if (valid) {
 						sb.Append ("override ");
 					} else {
-						sb.Append ("new ");
+						sb.Append ("new virtual ");
 					}
 				} else if (!pd.DeclaringType.IsSealed) {
 					if (m.IsAbstract)


### PR DESCRIPTION
```diff
-public virtual FPUIActionExtensionContext ExtensionContext { get; }
+public FPUIActionExtensionContext ExtensionContext { get; }
```