### PR TITLE
[generate-type-forwarders] Add interfaces to types

### DIFF
--- a/src/generate-type-forwarders/Program.cs
+++ b/src/generate-type-forwarders/Program.cs
@@ -51,6 +51,55 @@ namespace GenerateTypeForwarders {
 			return field.IsPublic || field.IsFamily;
 		}
 
+		static bool SatisfyAnyInterface (this MethodDefinition method)
+		{
+			return SatisfyInterface (method, method.DeclaringType);
+		}
+
+		static bool SatisfyInterface (MethodDefinition method, TypeDefinition type)
+		{
+			if (!type.HasInterfaces)
+				return false;
+			foreach (var intf in type.Interfaces) {
+				var it = intf.InterfaceType.Resolve ();
+				if (!it.HasMethods)
+					continue;
+				var m = method.FullName.Replace (method.DeclaringType.FullName + "::" + it.FullName + ".", it.FullName + "::");
+				foreach (var im in it.Methods) {
+					if (m == im.FullName)
+						return true;
+				}
+				if (SatisfyInterface (method, it))
+					return true;
+			}
+			return false;
+		}
+
+		static bool SatisfyAnyInterface (this PropertyDefinition property)
+		{
+			return SatisfyInterface (property, property.DeclaringType);
+		}
+
+		static bool SatisfyInterface (PropertyDefinition property, TypeDefinition type)
+		{
+			if (!type.HasInterfaces)
+				return false;
+			// remove the implicit (interface) part of the name
+			var pname = property.Name.Substring (property.Name.LastIndexOf ('.') + 1);
+			foreach (var intf in type.Interfaces) {
+				var it = intf.InterfaceType.Resolve ();
+				if (!it.HasProperties)
+					continue;
+				foreach (var ip in it.Properties) {
+					if ((pname == ip.Name) && (property.PropertyType.FullName == ip.PropertyType.FullName))
+						return true;
+				}
+				if (SatisfyInterface (property, it))
+					return true;
+			}
+			return false;
+		}
+
 		static void EmitTypeName (StringBuilder sb, TypeReference type)
 		{
 			if (type.FullName == "System.Void") {
@@ -131,10 +180,9 @@ namespace GenerateTypeForwarders {
 
 		static void EmitPNSE (StringBuilder sb, MethodDefinition method, int indent, bool nsobject)
 		{
-			if (method.IsPrivate)
-				return;
-
 			if (method.IsConstructor) {
+				if (method.IsStatic)
+					return;
 				// we can have an internal ctor using internal types that are not generated leading to uncompilable code
 				// e.g. `internal DisplayedPropertiesCollection (ABFunc<NSNumber[]> g, Action<NSNumber[]> s)`
 				if (method.IsAssembly && method.HasParameters) {
@@ -411,15 +459,16 @@ namespace GenerateTypeForwarders {
 			var gm = pd.GetMethod;
 			var sm = pd.SetMethod;
 			var m = gm ?? sm;
+			var implicit_interface = pd.Name.IndexOf ('.') != -1;
 			if (m.IsPublic)
 				sb.Append ("public ");
-			else
+			else if (m.IsFamily)
 				sb.Append ("protected ");
 			if (m.IsStatic) {
 				sb.Append ("static ");
 				if (HasPropertyInTypeHierarchy (pd.DeclaringType, m, out var _))
 					sb.Append ("new ");
-			} else if (m.IsVirtual) {
+			} else if (m.IsVirtual && !implicit_interface) {
 				if (HasPropertyInTypeHierarchy (pd.DeclaringType, m, out var valid)) {
 					if (valid) {
 						sb.Append ("override ");
@@ -437,14 +486,14 @@ namespace GenerateTypeForwarders {
 			sb.Append (' ');
 			sb.Append (pd.Name);
 			sb.AppendLine (" {");
-			if (gm.IsVisible ()) {
+			if (gm.IsVisible () || ((gm != null) && implicit_interface)) {
 				sb.Append ('\t', indent + 1);
 				if (gm.IsAbstract)
 					sb.AppendLine ("get;");
 				else
 					sb.AppendLine ("get { throw new global::System.PlatformNotSupportedException (global::Constants.UnavailableOnMacCatalyst); }");
 			}
-			if (pd.SetMethod.IsVisible ()) {
+			if (sm.IsVisible () || ((sm != null) && implicit_interface)) {
 				sb.Append ('\t', indent + 1);
 				if (sm.IsAbstract)
 					sb.AppendLine ("set;");
@@ -522,6 +571,7 @@ namespace GenerateTypeForwarders {
 					sb.Append (type.Name);
 				}
 
+				bool first = true;
 				if (type.IsEnum) {
 					sb.Append (" : ");
 					var enumType = type.Fields.First (v => v.Name == "value__").FieldType;
@@ -552,7 +602,23 @@ namespace GenerateTypeForwarders {
 				} else if (type.BaseType != null && type.BaseType.FullName != "System.Object") {
 					sb.Append (" : ");
 					EmitTypeName (sb, type.BaseType);
+					first = false;
 				}
+
+				if (type.HasInterfaces) {
+					foreach (var intf in type.Interfaces) {
+						var it = intf.InterfaceType.Resolve ();
+						if (!it.IsVisible ())
+							continue;
+						if (first)
+							sb.Append (" : ");
+						else
+							sb.Append (", ");
+						EmitTypeName (sb, intf.InterfaceType);
+						first = false;
+					}
+				}
+
 				sb.Append (" {");
 				sb.AppendLine ();
 				foreach (var nestedType in type.NestedTypes) {
@@ -571,7 +637,7 @@ namespace GenerateTypeForwarders {
 				}
 				foreach (var method in type.Methods) {
 					// need .ctor(IntPtr) for chaining
-					if (!method.IsVisible () && !method.IsConstructor)
+					if (!method.IsVisible () && !method.IsConstructor && !method.SatisfyAnyInterface ())
 						continue;
 					EmitPNSE (sb, method, indent + 1, nsobject);
 				}
@@ -583,7 +649,7 @@ namespace GenerateTypeForwarders {
 				}
 
 				foreach (var prop in type.Properties) {
-					if (!prop.IsVisible ())
+					if (!prop.IsVisible () && !prop.SatisfyAnyInterface ())
 						continue;
 					EmitProperty (sb, prop, indent + 1);
 				}


### PR DESCRIPTION
and that requires ensuring all (implicit/explicit) interface members are
generated...

**Example**

Removed interfaces:

```csharp
IARAnchorCopying
Foundation.INSCoding
Foundation.INSCopying
Foundation.INSSecureCoding
```