### PR TITLE
[generate-type-forwarders] Fix final properties

### DIFF
--- a/src/generate-type-forwarders/Program.cs
+++ b/src/generate-type-forwarders/Program.cs
@@ -484,7 +484,7 @@ namespace GenerateTypeForwarders {
 				} else if (!pd.DeclaringType.IsSealed) {
 					if (m.IsAbstract)
 						sb.Append ("abstract ");
-					else
+					else if (!m.IsFinal)
 						sb.Append ("virtual ");
 				}
 			}


### PR DESCRIPTION
The type implementation of an interface member does not need to be
`virtual` but, since it's done by _sealing_ the member.

Example

```diff
 public virtual ---final--- int Count { get; }
```