### PR TITLE
[generate-type-forwarders] Fix parameter arrays used by-reference

### DIFF
--- a/src/generate-type-forwarders/Program.cs
+++ b/src/generate-type-forwarders/Program.cs
@@ -166,10 +166,10 @@ namespace GenerateTypeForwarders {
 				if (param.IsOut) {
 					sb.Append ("out ");
 					if (paramType.IsByReference)
-						paramType = paramType.GetElementType ();
+						paramType = (paramType as TypeSpecification).ElementType;
 				} else if (paramType.IsByReference) {
 					sb.Append ("ref ");
-					paramType = paramType.GetElementType ();
+					paramType = (paramType as TypeSpecification).ElementType;
 				}
 
 				EmitTypeName (sb, paramType);


### PR DESCRIPTION
Removed method:

```csharp
public static GLKMesh[] FromAsset (ModelIO.MDLAsset asset, out ModelIO.MDLMesh[] sourceMeshes, out Foundation.NSError error);
```

Added method:

```csharp
public static GLKMesh[] FromAsset (ModelIO.MDLAsset asset, out ModelIO.MDLMesh sourceMeshes, out Foundation.NSError error);
```