### PR TITLE
[xcode12.5] [ObjCRuntime] Fix a GCHandle leak.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -997,8 +997,10 @@ namespace ObjCRuntime {
 		{
 			lock (lock_obj) {
 				if (object_map.TryGetValue (ptr, out var wr)) {
-					if (managed_obj == null || wr.Target == (object) managed_obj)
+					if (managed_obj == null || wr.Target == (object) managed_obj) {
 						object_map.Remove (ptr);
+						wr.Free ();
+					}
 
 				}
 


### PR DESCRIPTION
Make sure to free the weak GCHandles we create to track NSObjects, just
removing them from our dictionary doesn't cut it.


Backport of #10967
