### PR TITLE
[runtime] Don't start the toggle ref machinery in CoreCLR.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -304,12 +304,16 @@
 		new Export ("void", "mono_add_internal_call",
 			"const char *", "name",
 			"const void *", "method"
-		),
+		) {
+			XamarinRuntime = RuntimeMode.MonoVM,
+		},
 
 		new Export (true, "void", "mono_dangerous_add_raw_internal_call",
 			"const char *", "name",
 			"const void *", "method"
-		),
+		) {
+			XamarinRuntime = RuntimeMode.MonoVM,
+		},
 
 		new Export ("MonoMethodSignature *", "mono_method_signature",
 			"MonoMethod *", "method"

--- a/runtime/mono-runtime.m.t4
+++ b/runtime/mono-runtime.m.t4
@@ -81,8 +81,8 @@ xamarin_initialize_dynamic_runtime (const char *mono_runtime_prefix)
 		fprintf (stderr, "Could not load <#= export.EntryPoint #>\n");
 		errmsg = "Failed to load the Mono framework.";
 	}
-<#= export.DotNetEndIf #><#= export.RuntimeEndIf #><# } #>
-
+<# } #>
+<#= export.DotNetEndIf #><#= export.RuntimeEndIf #>
 <# } #>
 	xamarin_dynamic_runtime_initialized = 1;
 


### PR DESCRIPTION
The implementation will be completely different, where the hook into CoreCLR
is in managed code.

We still need to initialize the framework_peer_release_lock mutex, so move
that code out of gc_enable_new_refcount.