### PR TITLE
[dotnet] Call monovm_initialize before mono_jit_init

### DIFF
--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -402,11 +402,10 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 	xamarin_initialize_cocoa_threads (NULL);
 #endif
 
-	xamarin_bridge_initialize ();
-
 #if DOTNET
 	xamarin_vm_initialize ();
 #endif
+	xamarin_bridge_initialize ();
 
 	xamarin_initialize ();
 	DEBUG_LAUNCH_TIME_PRINT ("\tmonotouch init time");

--- a/tests/linker/CommonLinkAnyTest.cs
+++ b/tests/linker/CommonLinkAnyTest.cs
@@ -42,5 +42,14 @@ namespace LinkAnyTest {
 			Assert.IsNotNull (filePath, "CallerFilePath");
 		}
 
+#if NET
+		[Test]
+		public void AppContextGetData ()
+		{
+			// https://github.com/dotnet/runtime/issues/50290
+			Assert.IsNotNull (AppContext.GetData ("APP_PATHS"), "APP_PATHS");
+			Assert.IsNotNull (AppContext.GetData ("PINVOKE_OVERRIDE"), "PINVOKE_OVERRIDE");
+		}
+#endif
 	}
 }


### PR DESCRIPTION
Those are called respectively inside `xamarin_vm_initialize` and
`xamarin_bridge_initialize` functions.

This fix the **AppContext.GetData always return null for iOS** issue
https://github.com/dotnet/runtime/issues/50290

Thanks for @filipnavara for diagnosing this quicker than anyone else!

Added unit tests to ensure `AppContext.GetData` can read back the values
we're providing at startup.