### PR TITLE
[CI] Fix pool selector

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -147,7 +147,7 @@ MIN_XM_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/
 # Minimum Visual Studio version
 MIN_VISUAL_STUDIO_URL=https://bosstoragemirror.blob.core.windows.net/vsmac/3425624/release-8.4/88f89d49594ac101891944e2a6b9a0b607a6fb52/VisualStudioForMac-8.4.4.8.dmg
 MIN_VISUAL_STUDIO_VERSION=8.4.4.8
-MAX_VISUAL_STUDIO_VERSION=8.8.99
+MAX_VISUAL_STUDIO_VERSION=8.9.99
 
 # Minimum CMake version
 MIN_CMAKE_URL=https://cmake.org/files/v3.6/cmake-3.6.2-Darwin-x86_64.dmg

--- a/tools/devops/automation/templates/agent-pool-selector.yml
+++ b/tools/devops/automation/templates/agent-pool-selector.yml
@@ -30,7 +30,6 @@ steps:
 
       [bool] $isTopicBranch = $False
       [bool] $isPullRequest = $False
-      [bool] $isManualBuild = $False
 
       if (-not ($buildSourceBranchName -eq 'main' -or $buildSourceBranchName -eq 'master' -or $buildSourceBranchName.StartsWith('d16-'))) {
         $isTopicBranch = $True
@@ -44,8 +43,6 @@ steps:
       } else {
           $targetBranch = $buildSourceBranchName
       }
-
-      $isManualBuild = $buildReason -eq 'Manual' 
 
       Write-Host "Settings:"
       Write-Host "  targetBranch: ${targetBranch}"

--- a/tools/devops/automation/templates/agent-pool-selector.yml
+++ b/tools/devops/automation/templates/agent-pool-selector.yml
@@ -30,6 +30,7 @@ steps:
 
       [bool] $isTopicBranch = $False
       [bool] $isPullRequest = $False
+      [bool] $isManualBuild = $False
 
       if (-not ($buildSourceBranchName -eq 'main' -or $buildSourceBranchName -eq 'master' -or $buildSourceBranchName.StartsWith('d16-'))) {
         $isTopicBranch = $True
@@ -44,12 +45,14 @@ steps:
           $targetBranch = $buildSourceBranchName
       }
 
+      $isManualBuild = $buildReason -eq 'Manual' 
+
       Write-Host "Settings:"
       Write-Host "  targetBranch: ${targetBranch}"
       Write-Host "  isTopicBranch: ${isTopicBranch}"
       Write-Host "  isPullRequest: ${isPullRequest}"
 
-      if ($isTopicBranch -or $isPullRequest) {
+      if ($isPullRequest) {
         $agentPool = $agentPoolPR      # Untrusted on-prem iOS pool used for all PRs (including those from forks) and feature/topic branch commits not targeting main or d16-x branches
         $agentPoolUrl = $agentPoolPRUrl
       } else {


### PR DESCRIPTION
Use the untrusted pool only when is a PR, use the trusted one in all other cases (we push to origin to build pkgs in some cases and we want to use the trusted pool).