### PR TITLE
[Localization] Using PrBuild Variable

### DIFF
--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -90,7 +90,7 @@ steps:
   workingDirectory: $(Build.SourcesDirectory)\tools\devops 
 
 - task: OneLocBuild@2
-  condition: contains(variables['labels.prBuild'], 'False')
+  condition: and (contains(variables['labels.prBuild'], 'False'), eq('$(Build.SourceBranchName), 'main'))
   continueOnError: true
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -106,7 +106,7 @@ steps:
     patVariable: '$(OneLocBuild--PAT)'
 
 - task: PublishBuildArtifacts@1
-  condition: contains(variables['labels.prBuild'], 'False')
+  condition: and (contains(variables['labels.prBuild'], 'False'), eq('$(Build.SourceBranchName), 'main'))
   continueOnError: true
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'

--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -90,10 +90,11 @@ steps:
   workingDirectory: $(Build.SourcesDirectory)\tools\devops 
 
 - task: OneLocBuild@2
-  condition: eq('$(Build.SourceBranchName)', 'merge')
+  condition: eq('$[PrBuild]', 'True')
   continueOnError: true
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    PrBuild: $(labels.prBuild)
   inputs:
     locProj: '$(Build.SourcesDirectory)\Localize\LocProject.json'
     outDir: '$(Build.ArtifactStagingDirectory)'
@@ -106,9 +107,11 @@ steps:
     patVariable: '$(OneLocBuild--PAT)'
 
 - task: PublishBuildArtifacts@1
-  condition: eq('$(Build.SourceBranchName)', 'merge')
+  condition: eq('$[PrBuild]', 'True')
   continueOnError: true
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'
     ArtifactName: 'localizationDrop'
     publishLocation: 'Container'
+  env:
+    PrBuild: $(labels.prBuild)

--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -90,7 +90,7 @@ steps:
   workingDirectory: $(Build.SourcesDirectory)\tools\devops 
 
 - task: OneLocBuild@2
-  condition: and (contains(variables['labels.prBuild'], 'False'), eq('$(Build.SourceBranchName), 'main'))
+  condition: and (contains(variables['labels.prBuild'], 'False'), eq('$(Build.SourceBranchName)', 'main'))
   continueOnError: true
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -106,7 +106,7 @@ steps:
     patVariable: '$(OneLocBuild--PAT)'
 
 - task: PublishBuildArtifacts@1
-  condition: and (contains(variables['labels.prBuild'], 'False'), eq('$(Build.SourceBranchName), 'main'))
+  condition: and (contains(variables['labels.prBuild'], 'False'), eq('$(Build.SourceBranchName)', 'main'))
   continueOnError: true
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'

--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -90,11 +90,10 @@ steps:
   workingDirectory: $(Build.SourcesDirectory)\tools\devops 
 
 - task: OneLocBuild@2
-  condition: eq('$[PrBuild]', 'True')
+  condition: contains(variables['labels.prBuild'], 'False')
   continueOnError: true
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    PrBuild: $(labels.prBuild)
   inputs:
     locProj: '$(Build.SourcesDirectory)\Localize\LocProject.json'
     outDir: '$(Build.ArtifactStagingDirectory)'
@@ -107,11 +106,9 @@ steps:
     patVariable: '$(OneLocBuild--PAT)'
 
 - task: PublishBuildArtifacts@1
-  condition: eq('$[PrBuild]', 'True')
+  condition: contains(variables['labels.prBuild'], 'False')
   continueOnError: true
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'
     ArtifactName: 'localizationDrop'
     publishLocation: 'Container'
-  env:
-    PrBuild: $(labels.prBuild)


### PR DESCRIPTION
Changes to use PrBuild variable as check for running OneLocBuild task instead of checking if Build.SourceBranchName is set to 'merge'.