### PR TITLE
[dotnet] Fix device builds

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/LinkNativeCodeTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/LinkNativeCodeTaskBase.cs
@@ -61,7 +61,7 @@ namespace Xamarin.MacDev.Tasks {
 			var abi = abis [0].ToNativeArchitecture ();
 
 			var arguments = new List<string> ();
-			arguments.Add ("clang");
+			arguments.Add ("clang++");
 
 			switch (Platform) {
 			case ApplePlatform.iOS:

--- a/tests/common/TestProjects/MyXamarinFormsApp/MyXamarinFormsApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyXamarinFormsApp/MyXamarinFormsApp.dotnet.csproj
@@ -14,15 +14,6 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" GeneratePathProperty="true" />
     <PackageReference Include="Xamarin.Essentials" Version="1.1.0" />
-    <!-- The linker resolves some assembly references too eagerly, and fails when it can't find them, so work around this by referencing the missing assemblies-->
-    <!-- ref: https://github.com/mono/linker/issues/1139 -->
-    <PackageReference Include="System.Security.Permissions" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Threading.AccessControl" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.CodeDom" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.IO.Ports" Version="5.0.0-preview.2.20160.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnet/MyXamarinFormsApp/MyXamarinFormsApp.csproj
+++ b/tests/dotnet/MyXamarinFormsApp/MyXamarinFormsApp.csproj
@@ -14,15 +14,6 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" GeneratePathProperty="true" />
     <PackageReference Include="Xamarin.Essentials" Version="1.1.0" />
-    <!-- The linker resolves some assembly references too eagerly, and fails when it can't find them, so work around this by referencing the missing assemblies-->
-    <!-- ref: https://github.com/mono/linker/issues/1139 -->
-    <PackageReference Include="System.Security.Permissions" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Threading.AccessControl" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.CodeDom" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.IO.Ports" Version="5.0.0-preview.2.20160.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/introspection/ApiPInvokeTest.cs
+++ b/tests/introspection/ApiPInvokeTest.cs
@@ -299,6 +299,7 @@ namespace Introspection
 				Check (a);
 		}
 
+#if !NET
 		[Test]
 		public void SystemData ()
 		{
@@ -306,5 +307,6 @@ namespace Introspection
 			if (!SkipAssembly (a))
 				Check (a);
 		}
+#endif
 	}
 }

--- a/tests/introspection/dotnet/iOS/introspection.csproj
+++ b/tests/introspection/dotnet/iOS/introspection.csproj
@@ -21,16 +21,6 @@
     <ProjectReference Include="..\..\..\..\external\Touch.Unit\Touch.Client\dotnet\iOS\Touch.Client-iOS.dotnet.csproj" />
     <!-- MonoTouch.Dialog references System.Json, which isn't shipped with .NET5, so reference the NuGet instead -->
     <PackageReference Include="System.Json" Version="4.7.1" />
-    <!-- The linker resolves some assembly references too eagerly, and fails when it can't find them, so work around this by referencing the missing assemblies-->
-    <!-- ref: https://github.com/mono/linker/issues/1139 -->
-    <PackageReference Include="System.Security.Permissions" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Threading.AccessControl" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.CodeDom" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.IO.Ports" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Data.SqlClient" Version="5.0.0-alpha1.19523.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/introspection/dotnet/tvOS/introspection.csproj
+++ b/tests/introspection/dotnet/tvOS/introspection.csproj
@@ -18,16 +18,6 @@
     <ProjectReference Include="..\..\..\..\external\Touch.Unit\Touch.Client\dotnet\tvOS\Touch.Client-tvOS.dotnet.csproj" />
     <!-- MonoTouch.Dialog references System.Json, which isn't shipped with .NET5, so reference the NuGet instead -->
     <PackageReference Include="System.Json" Version="4.7.1" />
-    <!-- The linker resolves some assembly references too eagerly, and fails when it can't find them, so work around this by referencing the missing assemblies-->
-    <!-- ref: https://github.com/mono/linker/issues/1139 -->
-    <PackageReference Include="System.Security.Permissions" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Threading.AccessControl" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.CodeDom" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.IO.Ports" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Data.SqlClient" Version="5.0.0-alpha1.19523.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/linker/ios/dont link/DontLinkRegressionTests.cs
+++ b/tests/linker/ios/dont link/DontLinkRegressionTests.cs
@@ -24,6 +24,7 @@ using NUnit.Framework;
 
 namespace DontLink {
 
+#if !NET
 	[FileIOPermission (SecurityAction.LinkDemand, AllLocalFiles = FileIOPermissionAccess.AllAccess)]
 	public class SecurityDeclarationDecoratedUserCode {
 
@@ -33,6 +34,7 @@ namespace DontLink {
 			return true;
 		}
 	}
+#endif
 
 	[TestFixture]
 	public class DontLinkRegressionTests {
@@ -82,6 +84,7 @@ namespace DontLink {
 			}
 		}
 
+#if !NET
 		[Test]
 		public void SecurityDeclaration ()
 		{
@@ -92,6 +95,7 @@ namespace DontLink {
 			Assert.NotNull (Type.GetType ("System.Security.Permissions.FileIOPermissionAttribute, mscorlib"), "FileIOPermissionAttribute");
 			Assert.NotNull (Type.GetType ("System.Security.Permissions.FileIOPermissionAccess, mscorlib"), "FileIOPermissionAccess");
 		}
+#endif
 
 		[Test]
 		public void DefaultEncoding ()

--- a/tests/linker/ios/dont link/dotnet/iOS/dont link.csproj
+++ b/tests/linker/ios/dont link/dotnet/iOS/dont link.csproj
@@ -18,17 +18,6 @@
     <ProjectReference Include="..\..\..\..\..\..\external\Touch.Unit\Touch.Client\dotnet\iOS\Touch.Client-iOS.dotnet.csproj" />
     <!-- MonoTouch.Dialog references System.Json, which isn't shipped with .NET5, so reference the NuGet instead -->
     <PackageReference Include="System.Json" Version="4.7.1" />
-    <!-- The linker resolves some assembly references too eagerly, and fails when it can't find them, so work around this by referencing the missing assemblies-->
-    <!-- ref: https://github.com/mono/linker/issues/1139 -->
-    <PackageReference Include="System.Security.Permissions" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Threading.AccessControl" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.CodeDom" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.IO.Ports" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Data.SqlClient" Version="5.0.0-alpha1.19523.8" />
-
     <ProjectReference Include="..\..\..\..\..\BundledResources\dotnet\iOS\BundledResources.csproj" />
   </ItemGroup>
 

--- a/tests/linker/ios/link all/AttributeTest.cs
+++ b/tests/linker/ios/link all/AttributeTest.cs
@@ -106,6 +106,7 @@ namespace LinkAll.Attributes {
 	public class CustomTypeO {
 	}
 
+#if !NET
 	[FileIOPermission (SecurityAction.LinkDemand, AllLocalFiles = FileIOPermissionAccess.AllAccess)]
 	public class SecurityDeclarationDecoratedUserCode {
 
@@ -115,6 +116,7 @@ namespace LinkAll.Attributes {
 			return true;
 		}
 	}
+#endif
 
 	[TestFixture]
 	// we want the tests to be available because we use the linker
@@ -222,6 +224,7 @@ namespace LinkAll.Attributes {
 			//Assert.NotNull (Type.GetType ("LinkAll.Attributes.CustomTypeO"), "CustomTypeO");
 		}
 
+#if !NET
 		[Test]
 		public void SecurityDeclaration ()
 		{
@@ -232,5 +235,6 @@ namespace LinkAll.Attributes {
 			Assert.Null (Type.GetType ("System.Security.Permissions.FileIOPermissionAttribute, " + mscorlib), "FileIOPermissionAttribute");
 			Assert.Null (Type.GetType ("System.Security.Permissions.FileIOPermissionAccess, " + mscorlib), "FileIOPermissionAccess");
 		}
+#endif
 	}
 }

--- a/tests/linker/ios/link all/LinkAllTest.cs
+++ b/tests/linker/ios/link all/LinkAllTest.cs
@@ -299,6 +299,7 @@ namespace LinkAll {
 			Assert.NotNull (Assembly.ReflectionOnlyLoadFrom (filename), "1");
 		}
 
+#if !NET
 		[Test]
 		public void SystemDataSqlClient ()
 		{
@@ -313,6 +314,7 @@ namespace LinkAll {
 			}
 #endif
 		}
+#endif
 		
 #if !__TVOS__ && !__WATCHOS__
 		[Test]

--- a/tests/linker/ios/link all/dotnet/iOS/link all.csproj
+++ b/tests/linker/ios/link all/dotnet/iOS/link all.csproj
@@ -34,17 +34,6 @@
     <ProjectReference Include="..\..\..\..\..\..\external\Touch.Unit\Touch.Client\dotnet\iOS\Touch.Client-iOS.dotnet.csproj" />
     <!-- MonoTouch.Dialog references System.Json, which isn't shipped with .NET5, so reference the NuGet instead -->
     <PackageReference Include="System.Json" Version="4.7.1" />
-    <!-- The linker resolves some assembly references too eagerly, and fails when it can't find them, so work around this by referencing the missing assemblies-->
-    <!-- ref: https://github.com/mono/linker/issues/1139 -->
-    <PackageReference Include="System.Security.Permissions" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Threading.AccessControl" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.CodeDom" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.IO.Ports" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Data.SqlClient" Version="5.0.0-alpha1.19523.8" />
-
     <ProjectReference Include="..\..\..\..\..\BundledResources\dotnet\iOS\BundledResources.csproj" />
     <ProjectReference Include="..\..\..\..\..\bindings-test\dotnet\iOS\bindings-test.csproj" />
   </ItemGroup>

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -14,7 +14,9 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
+#if !NET
 using System.Security.Permissions;
+#endif
 using System.Security.Principal;
 using System.Threading;
 using System.Xml;
@@ -49,6 +51,7 @@ using MonoTests.System.Net.Http;
 
 namespace LinkSdk {
 
+#if !NET
 	[FileIOPermission (SecurityAction.LinkDemand, AllLocalFiles = FileIOPermissionAccess.AllAccess)]
 	public class SecurityDeclarationDecoratedUserCode {
 
@@ -58,6 +61,7 @@ namespace LinkSdk {
 			return true;
 		}
 	}
+#endif
 
 	[TestFixture]
 	// we want the test to be availble if we use the linker
@@ -1007,6 +1011,7 @@ namespace LinkSdk {
 		}
 #endif // !__WATCHOS__
 
+#if !NET
 		[Test]
 		public void SecurityDeclaration ()
 		{
@@ -1017,6 +1022,7 @@ namespace LinkSdk {
 			Assert.Null (GetTypeHelper ("System.Security.Permissions.FileIOPermissionAttribute, mscorlib"), "FileIOPermissionAttribute");
 			Assert.Null (GetTypeHelper ("System.Security.Permissions.FileIOPermissionAccess, mscorlib"), "FileIOPermissionAccess");
 		}
+#endif
 
 #if !__WATCHOS__
 		static Type type_uibutton = typeof (UIButton);

--- a/tests/linker/ios/link sdk/PclTest.cs
+++ b/tests/linker/ios/link sdk/PclTest.cs
@@ -2,7 +2,9 @@ using System;
 using System.IO;
 using System.Net;
 using System.ServiceModel;
+#if !NET
 using System.ServiceModel.Channels;
+#endif
 using System.Windows.Input;
 using System.Xml;
 using Foundation;
@@ -68,6 +70,7 @@ namespace LinkSdk {
 			}
 		}
 
+#if !NET
 		[Test]
 		public void ServiceModel ()
 		{
@@ -96,6 +99,7 @@ namespace LinkSdk {
 				throw new NotImplementedException ();
 			}
 		}
+#endif
 
 		[Test]
 		public void Xml ()

--- a/tests/linker/ios/link sdk/dotnet/iOS/link sdk.csproj
+++ b/tests/linker/ios/link sdk/dotnet/iOS/link sdk.csproj
@@ -25,18 +25,6 @@
     <ProjectReference Include="..\..\..\..\..\..\external\Touch.Unit\Touch.Client\dotnet\iOS\Touch.Client-iOS.dotnet.csproj" />
     <!-- MonoTouch.Dialog references System.Json, which isn't shipped with .NET5, so reference the NuGet instead -->
     <PackageReference Include="System.Json" Version="4.7.1" />
-    <!-- The linker resolves some assembly references too eagerly, and fails when it can't find them, so work around this by referencing the missing assemblies-->
-    <!-- ref: https://github.com/mono/linker/issues/1139 -->
-    <PackageReference Include="System.Security.Permissions" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Threading.AccessControl" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.CodeDom" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.IO.Ports" Version="5.0.0-preview.3.20209.5" />
-    <PackageReference Include="System.Data.SqlClient" Version="5.0.0-alpha1.19523.8" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="5.0.0-preview1.20104.1" />
-
     <ProjectReference Include="..\..\..\..\..\BundledResources\dotnet\iOS\BundledResources.csproj" />
     <ProjectReference Include="..\..\..\..\..\bindings-test\dotnet\iOS\bindings-test.csproj" />
   </ItemGroup>

--- a/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
@@ -25,16 +25,6 @@
     <ProjectReference Include="..\..\..\..\external\Touch.Unit\Touch.Client\dotnet\iOS\Touch.Client-iOS.dotnet.csproj" />
     <!-- MonoTouch.Dialog references System.Json, which isn't shipped with .NET5, so reference the NuGet instead -->
     <PackageReference Include="System.Json" Version="4.7.1" />
-    <!-- The linker resolves some assembly references too eagerly, and fails when it can't find them, so work around this by referencing the missing assemblies-->
-    <!-- ref: https://github.com/mono/linker/issues/1139 -->
-    <PackageReference Include="System.Security.Permissions" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Threading.AccessControl" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.CodeDom" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.IO.Ports" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Data.SqlClient" Version="5.0.0-alpha1.19523.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
@@ -23,16 +23,6 @@
     <ProjectReference Include="..\..\..\..\external\Touch.Unit\Touch.Client\dotnet\macOS\Touch.Client-macOS.dotnet.csproj" />
     <!-- MonoTouch.Dialog references System.Json, which isn't shipped with .NET5, so reference the NuGet instead -->
     <PackageReference Include="System.Json" Version="4.7.1" />
-    <!-- The linker resolves some assembly references too eagerly, and fails when it can't find them, so work around this by referencing the missing assemblies-->
-    <!-- ref: https://github.com/mono/linker/issues/1139 -->
-    <PackageReference Include="System.Security.Permissions" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Threading.AccessControl" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.CodeDom" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.IO.Ports" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Data.SqlClient" Version="5.0.0-alpha1.19523.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With P3 addition on ICU we must now link the native executable as C++.

Remove an old workaround, in many tests, referencing old (5.0/previews)
packages that caused native link time failures.

ref: https://github.com/mono/linker/issues/1139