### PR TITLE
Revert "[tests] Ignore LinkSdkRegressionTest.AsQueryable_Enumerable due to an issue in .NET"

### DIFF
--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -1138,9 +1138,6 @@ namespace LinkSdk {
 		}
 #endif
 
-#if NET
-		[Ignore ("https://github.com/mono/linker/issues/1453")]
-#endif
 		[Test]
 		// https://github.com/xamarin/xamarin-macios/issues/6346
 		public void AsQueryable_Enumerable ()


### PR DESCRIPTION
This reverts commit ae0649f4e59c0ea435429799eeeb5f4759a4195d.

Original issue https://github.com/dotnet/runtime/issues/41392 was fixed long ago