### PR TITLE
Revert "[tests] Ignore linkall's DataContractTest in .NET due to a linker bug."

### DIFF
--- a/tests/linker/ios/link all/DataContractTest.cs
+++ b/tests/linker/ios/link all/DataContractTest.cs
@@ -19,9 +19,6 @@ using NUnit.Framework;
 
 namespace LinkAll.Serialization.DataContract {
 
-#if NET
-	[Ignore ("https://github.com/mono/linker/issues/1460")]
-#endif
 	[TestFixture]
 	// we want the tests to be available because we use the linker
 	[Preserve (AllMembers = true)]


### PR DESCRIPTION
This reverts commit bc668916e7197ba5f9e0a6ea7f55df28234a183a.

Original issue https://github.com/dotnet/runtime/issues/41525 was solved a while ago.