### PR TITLE
[dotnet] suppress IL2026 linker warning

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -9,6 +9,7 @@
 	<Import Project="Xamarin.Shared.Sdk.TargetFrameworkInference.props" />
 
 	<PropertyGroup>
+		<SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' ">true</SuppressTrimAnalysisWarnings>
 		<AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(MSBuildThisFileDirectory)Microsoft.$(_PlatformName).Sdk.targets</AfterMicrosoftNETSdkTargets>
 	</PropertyGroup>
 </Project>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -142,7 +142,6 @@
 		<StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
 		<UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
 		<UseNativeHttpHandler Condition="'$(_PlatformName)' != 'macOS' And '$(UseNativeHttpHandler)' == ''">true</UseNativeHttpHandler>
-		<SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' ">true</SuppressTrimAnalysisWarnings>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
We started using `$(SuppressTrimAnalysisWarnings)` by default, because
ILLink started emitting warnings by default in .NET 6 Preview 3.

7bf3e8d8 fixed *most* of these warnings except for `IL2026`:

https://github.com/dotnet/sdk/blob/16aedd6e72bd2f8dea01918478fc1368bc017fe9/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets#L52-L57

I get around 20 instances of this warning when building dotnet/maui.

`IL2026` occurs because this logic is evaluated much earlier than the
`PrepareForILLink` MSBuild target:

https://github.com/dotnet/sdk/blob/16aedd6e72bd2f8dea01918478fc1368bc017fe9/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets#L202

The MSBuild evaluation order right now is:

* Sdk/Sdk.props
* Microsoft.[platform].Sdk.props
* Xamarin.Shared.Sdk.props
* Microsoft.NET.ILLink.targets
* Microsoft.[platform].Sdk.targets
* Xamarin.Shared.Sdk.targets

We need to set `$(SuppressTrimAnalysisWarnings)` earlier in
`Xamarin.Shared.Sdk.props` to solve the issue here.

On the Android side I got lucky, and it worked first try without
thinking too much. We import a `*.DefaultProperties.targets` before
`Microsoft.NET.ILLink.targets`, and that is why it worked.