### PR TITLE
[d16-9] [CI][Xharness] If we are use the tcp tunnel do not try to get IPs.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -242,7 +242,7 @@ namespace Xharness {
 			if (isSimulator) {
 				args.Add (new SetAppArgumentArgument ("-hostname:127.0.0.1", true));
 				args.Add (new SetEnvVariableArgument ("NUNIT_HOSTNAME", "127.0.0.1"));
-			} else {
+			} else if (!listenerFactory.UseTunnel) {  // if is not simulator AND we are not using the tunnel, if we use the tunnel this is not needed
 				var ips = new StringBuilder ();
 				var ipAddresses = System.Net.Dns.GetHostEntry (System.Net.Dns.GetHostName ()).AddressList;
 				for (int i = 0; i < ipAddresses.Length; i++) {


### PR DESCRIPTION
The main reason why we use the Tcp Tunnel is because we do have
networking issues, one of them is related to the DNS server. If we use
the tunnel we have made a choice and we are sure we will not need the
IPs.

This solves a case in which we have a network failure when we try
to retrieve the IP address using the DNS lookup.


Backport of #11027
