### PR TITLE
Revert "[tests] Ignore the XmlSerializationTest.Bug1820_GenericList test in .NET due to a linker bug."

### DIFF
--- a/tests/linker/ios/link sdk/Bug1820Test.cs
+++ b/tests/linker/ios/link sdk/Bug1820Test.cs
@@ -148,9 +148,6 @@ namespace LinkSdk.Serialization {
 			}
 		}
 		
-#if NET
-		[Ignore ("https://github.com/mono/linker/issues/1454")]
-#endif
 		[Test]
 		// http://bugzilla.xamarin.com/show_bug.cgi?id=1820
 		// note: this also test the linker (5.1+) ability not to remove 'unused' XML setters and .ctors used for serialization


### PR DESCRIPTION
This reverts commit 9cbf14500b3182a076bcffa3e308d1d708c1ba86.

The original issue https://github.com/mono/linker/issues/1454 -> https://github.com/dotnet/runtime/issues/41389 was fixed a while ago.