### PR TITLE
Revert "[tests] Ignore CommonLinkSdkTest.TypeDescriptor_A7793 in .NET due to a linker bug."

### DIFF
--- a/tests/linker/CommonLinkSdkTest.cs
+++ b/tests/linker/CommonLinkSdkTest.cs
@@ -13,9 +13,6 @@ namespace LinkSdk {
 	[TestFixture]
 	// we want the test to be availble if we use the linker
 	[Preserve (AllMembers = true)]
-#if NET
-	[Ignore ("Type converters are linked away: https://github.com/mono/linker/issues/1451")]
-#endif
 	public class CommonLinkSdkTest {
 
 		[Test]


### PR DESCRIPTION
This reverts commit dea6580c7855a747314d7008fdf1327a52010224.

This was fixed a while ago https://github.com/mono/linker/issues/1451 -> https://github.com/dotnet/runtime/issues/41390