### PR TITLE
Revert "[dotnet-linker] Make PreserveSmartEnumConversionsStep active for type as well to work around a linker bug."

### DIFF
--- a/tools/linker/MonoTouch.Tuner/PreserveSmartEnumConversionsSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/PreserveSmartEnumConversionsSubStep.cs
@@ -25,10 +25,7 @@ namespace Xamarin.Linker.Steps
 
 		public override SubStepTargets Targets {
 			get {
-				return
-					SubStepTargets.Method
-					| SubStepTargets.Type // SubStepTargets.Type is only needed to work around a linker bug: https://github.com/mono/linker/issues/1458
-					| SubStepTargets.Property;
+				return SubStepTargets.Method | SubStepTargets.Property;
 			}
 		}
 


### PR DESCRIPTION
This reverts commit 482151eea71da3c06749d34c129548ec6c822894.

This issue https://github.com/mono/linker/issues/1458 has been fixed a while ago.