### PR TITLE
Revert "[dotnet] Force the GC mode to be preemptive. (#10667)"

### DIFF
--- a/tools/dotnet-linker/Steps/GenerateMainStep.cs
+++ b/tools/dotnet-linker/Steps/GenerateMainStep.cs
@@ -32,7 +32,6 @@ namespace Xamarin {
 				contents.AppendLine ("static void xamarin_initialize_dotnet ()");
 				contents.AppendLine ("{");
 				contents.AppendLine ("\tsetenv (\"DOTNET_SYSTEM_GLOBALIZATION_INVARIANT\", \"1\", 1); // https://github.com/xamarin/xamarin-macios/issues/8906");
-				contents.AppendLine ("\tsetenv (\"MONO_THREADS_SUSPEND\", \"preemptive\", 1); // https://github.com/dotnet/runtime/issues/47121");
 				contents.AppendLine ("}");
 				contents.AppendLine ();
 


### PR DESCRIPTION
This reverts commit abc3616873988ebaa11bf88cd304eeb0f0f0bc98.

The issue https://github.com/dotnet/runtime/issues/47121 was fixed recently.