### PR TITLE
[build] Fix incorrect warning about CoreSimulator.framework version

### DIFF
--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -453,7 +453,7 @@ function install_coresimulator ()
 	local CURRENT_CORESIMULATOR_PATH=/Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator
 	local CURRENT_CORESIMULATOR_VERSION=0.0
 	if test -f "$CURRENT_CORESIMULATOR_PATH"; then
-		CURRENT_CORESIMULATOR_VERSION=$(otool -L $CURRENT_CORESIMULATOR_PATH | grep "$CURRENT_CORESIMULATOR_PATH.*current version" | sed -e 's/.*current version//' -e 's/)//' -e 's/[[:space:]]//g')
+		CURRENT_CORESIMULATOR_VERSION=$(otool -L $CURRENT_CORESIMULATOR_PATH | grep "$CURRENT_CORESIMULATOR_PATH.*current version" | sed -e 's/.*current version//' -e 's/)//' -e 's/[[:space:]]//g' | uniq)
 	fi
 
 	# Either version may be composed of either 2 or 3 numbers.


### PR DESCRIPTION
Avoid this warning when checking for required tools/dependencies

```
    You should have exactly CoreSimulator.framework version 732.18 (found 732.18
732.18). Execute './system-dependencies.sh --provision-xcode' to install the expected version.
```

Right version, but found two times ?

Because we're looking at a (now) fat framework so we get things twice

```
lipo -info /Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator
Architectures in the fat file: /Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator are: x86_64 arm64e
```

Solution ? make it uniq