### PR TITLE
Target new xamarin-macios multi-OS agent pools

### DIFF
--- a/tools/devops/automation/templates/agent-pool-selector.yml
+++ b/tools/devops/automation/templates/agent-pool-selector.yml
@@ -2,10 +2,10 @@
 # Selects appropriate agent pool based on trigger type (PR or CI)
 #
 parameters:
-  agentPoolPR: 'VSEng-Xamarin-RedmondMacCatalinaBuildPool-iOS-Untrusted'
-  agentPoolPRUrl: 'https://devdiv.visualstudio.com/DevDiv/_settings/agentqueues?queueId=2734&view=agents'
-  agentPoolCI: 'VSEng-Xamarin-RedmondMacCatalinaBuildPool-iOS-Trusted'
-  agentPoolCIUrl: 'https://devdiv.visualstudio.com/DevDiv/_settings/agentqueues?queueId=2748&view=agents'
+  agentPoolPR: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Untrusted'
+  agentPoolPRUrl: 'https://devdiv.visualstudio.com/_settings/agentpools?poolId=366&view=agents'
+  agentPoolCI: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Trusted'
+  agentPoolCIUrl: 'https://devdiv.visualstudio.com/_settings/agentpools?poolId=367&view=agents'
   condition: succeeded()
 
 steps:

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -74,8 +74,8 @@ steps:
     Write-Host "Python3 location"
     which python3
 
-    Write-Host "Pip version"
-    pip -V
+    Write-Host "Pip3 version"
+    pip3 -V
   displayName: 'Show Python information'
 
 - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/clean-bot.sh


### PR DESCRIPTION
Plan is to abandon the old pools and shift all jobs (Big Sur and Catalina) for main, XCode12.5, d16-9, etc. to the new pools

Note: Bot capacity in the new PR & CI pools is sufficient to merge this PR