### PR TITLE
[6.0.1xx-preview3] [main] Update dependencies from dotnet/installer

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,8 +1,8 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="6.0.100-preview.3.21201.23">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="6.0.100-preview.3.21202.5">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>df3d6806ebff2480772a156c26b44e7fef992ced</Sha>
+      <Sha>aee38a6dd446b512b1ae510d80d2ed1c1f24e79a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink" Version="6.0.100-preview.2.21172.2">
       <Uri>https://github.com/mono/linker</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,7 @@
 <Project>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-preview.3.21201.23</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-preview.3.21202.5</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftNETILLinkPackageVersion>6.0.100-preview.2.21172.2</MicrosoftNETILLinkPackageVersion>
     <MicrosoftNETILLinkTasksPackageVersion>6.0.100-preview.2.21172.2</MicrosoftNETILLinkTasksPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
This pull request updates the following dependencies

[marker]: <> (Begin:df3e6147-3e41-4928-6775-08d8f479343c)
## From https://github.com/dotnet/installer
- **Subscription**: df3e6147-3e41-4928-6775-08d8f479343c
- **Build**: 20210402.5
- **Date Produced**: 4/2/2021 3:06 PM
- **Commit**: aee38a6dd446b512b1ae510d80d2ed1c1f24e79a
- **Branch**: refs/heads/release/6.0.1xx-preview3

[DependencyUpdate]: <> (Begin)

- **Updates**:
  - **Microsoft.Dotnet.Sdk.Internal**: [from 6.0.100-preview.3.21201.23 to 6.0.100-preview.3.21202.5][1]

[1]: https://github.com/dotnet/installer/compare/df3d680...aee38a6

[DependencyUpdate]: <> (End)


[marker]: <> (End:df3e6147-3e41-4928-6775-08d8f479343c)




Backport of #11106
