### PR TITLE
[6.0.1xx-preview3] [Make.config] Hardcode preview.3 on our versioning

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -57,7 +57,7 @@ CURRENT_BRANCH_SED_ESCAPED:=$(subst |,\|,$(subst &,\&,$(subst $$,\$$,$(subst /,\
 # The branch name in the nuget version has to be alphanumeric, and we follow the semantic versioning spec,
 # which defines "alphanumeric" as the letters, numbers and the dash character (and nothing else).
 # So here we replace all non-alphanumeric characters in the branch name with a dash.
-CURRENT_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%s" "$(CURRENT_BRANCH)" | tr -c '[a-zA-Z0-9-.]' '-')
+CURRENT_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%s" "$(CURRENT_BRANCH)" | tr -c '[a-zA-Z0-9-]' '-')
 
 # Get the current hash
 CURRENT_HASH:=$(shell git log -1 --pretty=%h)
@@ -77,7 +77,7 @@ endif
 ifneq ($(PULL_REQUEST_ID),)
 NUGET_PRERELEASE_IDENTIFIER=ci.pr.gh$(PULL_REQUEST_ID).
 else
-NUGET_PRERELEASE_IDENTIFIER=ci.$(CURRENT_BRANCH_ALPHANUMERIC).
+NUGET_PRERELEASE_IDENTIFIER=preview.3.
 endif
 NUGET_BUILD_METADATA=sha.$(CURRENT_HASH)
 

--- a/Make.config
+++ b/Make.config
@@ -57,7 +57,7 @@ CURRENT_BRANCH_SED_ESCAPED:=$(subst |,\|,$(subst &,\&,$(subst $$,\$$,$(subst /,\
 # The branch name in the nuget version has to be alphanumeric, and we follow the semantic versioning spec,
 # which defines "alphanumeric" as the letters, numbers and the dash character (and nothing else).
 # So here we replace all non-alphanumeric characters in the branch name with a dash.
-CURRENT_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%s" "$(CURRENT_BRANCH)" | tr -c '[a-zA-Z0-9-]' '-')
+CURRENT_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%s" "$(CURRENT_BRANCH)" | tr -c '[a-zA-Z0-9-.]' '-')
 
 # Get the current hash
 CURRENT_HASH:=$(shell git log -1 --pretty=%h)


### PR DESCRIPTION
~Backport of #11108~

Hardcode preview 3 branch name and revert dot on CURRENT_BRANCH_ALPHANUMERIC

This is to follow suit on versioning found in dotnet/maui#598