### PR TITLE
Revert "[Make.config] Allow '.' on CURRENT_BRANCH_ALPHANUMERIC to match android package names"

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -57,7 +57,7 @@ CURRENT_BRANCH_SED_ESCAPED:=$(subst |,\|,$(subst &,\&,$(subst $$,\$$,$(subst /,\
 # The branch name in the nuget version has to be alphanumeric, and we follow the semantic versioning spec,
 # which defines "alphanumeric" as the letters, numbers and the dash character (and nothing else).
 # So here we replace all non-alphanumeric characters in the branch name with a dash.
-CURRENT_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%s" "$(CURRENT_BRANCH)" | tr -c '[a-zA-Z0-9-.]' '-')
+CURRENT_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%s" "$(CURRENT_BRANCH)" | tr -c '[a-zA-Z0-9-]' '-')
 
 # Get the current hash
 CURRENT_HASH:=$(shell git log -1 --pretty=%h)


### PR DESCRIPTION
Reverts xamarin/xamarin-macios#11108

Not needed since we will only do this for previews and we will be hardcoding the branch name at branching time.