### PR TITLE
[d16-9] [CI] Exclude builds for certain paths.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -69,6 +69,16 @@ trigger:
     exclude:
     - refs/heads/locfiles/*
     - refs/heads/darc-*
+  paths:
+    exclude:
+    - docs
+    - CODEOWNERS
+    - ISSUE_TEMPLATE.md
+    - LICENSE
+    - NOTICE.txt
+    - README.md
+    - SECURITY.MD
+    - src/README.md
 
 pr:
   autoCancel: true
@@ -77,6 +87,16 @@ pr:
     - main
     - d16-*
     - xcode*
+  paths:
+    exclude:
+    - docs
+    - CODEOWNERS
+    - ISSUE_TEMPLATE.md
+    - LICENSE
+    - NOTICE.txt
+    - README.md
+    - SECURITY.MD
+    - src/README.md
 
 stages:
 


### PR DESCRIPTION
Lets not trigger builds for readmes and other docs.


Backport of #11104
