### PR TITLE
[d16-9] [CI] Group all API diff in a template to make things manageable.

### DIFF
--- a/tools/devops/automation/templates/build/api-diff.yml
+++ b/tools/devops/automation/templates/build/api-diff.yml
@@ -1,0 +1,43 @@
+# Contains all the different steps to generate the diff API diffs
+
+steps:
+- bash: |
+    report_error ()
+    {
+      MESSAGE=$(printf ":fire: Failed to create API Diff from stable (%s/console) :fire:")
+      echo "##vso[task.setvariable variable=APIDIFF_MESSAGE;isOutput=true]$MESSAGE"
+      echo "##vso[task.setvariable variable=APIDIFF_BUILT;isOutput=true]False"
+    }
+    trap report_error ERR
+
+    make -j8 -C $(Build.SourcesDirectory)/xamarin-macios/tools/apidiff jenkins-api-diff
+
+    # remove some files that do not need to be uploaded
+    cd $(Build.SourcesDirectory)/xamarin-macios/tools/apidiff/
+    rm -Rf *.exe *.pdb *.stamp *.zip *.sh ./references ./temp
+    MESSAGE=":white_check_mark: API Diff from stable"
+    echo "##vso[task.setvariable variable=APIDIFF_MESSAGE;isOutput=true]$MESSAGE"
+    echo "##vso[task.setvariable variable=APIDIFF_BUILT;isOutput=true]True"
+  displayName: 'API diff (from stable)'
+  name: apidiff
+  condition: and(succeeded(), contains(variables['configuration.SkipPublicJenkins'], 'False'))
+  continueOnError: true
+  env:
+    BUILD_REVISION: 'jenkins'
+
+- task: ArchiveFiles@1
+  displayName: 'Archive API diff (from stable)'
+  inputs:
+    rootFolder: $(Build.SourcesDirectory)/xamarin-macios/tools/apidiff
+    includeRootFolder: false
+    archiveFile: '$(Build.ArtifactStagingDirectory)/apidiff-stable.zip'
+  condition: and(succeeded(), contains(variables['configuration.SkipPublicJenkins'], 'False'))
+  continueOnError: true
+
+- task: PublishPipelineArtifact@1
+  displayName: 'Publish API diff (from stable)'
+  inputs:
+    targetPath: '$(Build.ArtifactStagingDirectory)/apidiff-stable.zip'
+    artifactName: apidiff-stable
+  condition: and(succeeded(), contains(variables['configuration.SkipPublicJenkins'], 'False'))
+  continueOnError: true

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -396,46 +396,7 @@ steps:
   condition: and(succeeded(), contains(variables['configuration.RunMacTests'], 'True'))
   continueOnError: true
 
-- bash: |
-    report_error ()
-    {
-      MESSAGE=$(printf ":fire: Failed to create API Diff from stable (%s/console) :fire:")
-      echo "##vso[task.setvariable variable=APIDIFF_MESSAGE;isOutput=true]$MESSAGE"
-      echo "##vso[task.setvariable variable=APIDIFF_BUILT;isOutput=true]False"
-    }
-    trap report_error ERR
-
-    make -j8 -C $(Build.SourcesDirectory)/xamarin-macios/tools/apidiff jenkins-api-diff
-
-    # remove some files that do not need to be uploaded
-    cd $(Build.SourcesDirectory)/xamarin-macios/tools/apidiff/
-    rm -Rf *.exe *.pdb *.stamp *.zip *.sh ./references ./temp
-    MESSAGE=":white_check_mark: API Diff from stable"
-    echo "##vso[task.setvariable variable=APIDIFF_MESSAGE;isOutput=true]$MESSAGE"
-    echo "##vso[task.setvariable variable=APIDIFF_BUILT;isOutput=true]True"
-  displayName: 'API diff (from stable)'
-  name: apidiff
-  condition: and(succeeded(), contains(variables['configuration.SkipPublicJenkins'], 'False'))
-  continueOnError: true
-  env:
-    BUILD_REVISION: 'jenkins'
-
-- task: ArchiveFiles@1
-  displayName: 'Archive API diff (from stable)'
-  inputs:
-    rootFolder: $(Build.SourcesDirectory)/xamarin-macios/tools/apidiff
-    includeRootFolder: false
-    archiveFile: '$(Build.ArtifactStagingDirectory)/apidiff-stable.zip'
-  condition: and(succeeded(), contains(variables['configuration.SkipPublicJenkins'], 'False'))
-  continueOnError: true
-
-- task: PublishPipelineArtifact@1
-  displayName: 'Publish API diff (from stable)'
-  inputs:
-    targetPath: '$(Build.ArtifactStagingDirectory)/apidiff-stable.zip'
-    artifactName: apidiff-stable
-  condition: and(succeeded(), contains(variables['configuration.SkipPublicJenkins'], 'False'))
-  continueOnError: true
+- template: api-diff.yml
 
 - bash: |
     set -x


### PR DESCRIPTION
Step fwd to group all API diff and get back the old generator and branch diffs.


Backport of #11112
