### PR TITLE
[Localization] Temporarily Stop OneLocBuild from making PRs

### DIFF
--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -116,7 +116,7 @@ steps:
   inputs:
     locProj: '$(Build.SourcesDirectory)\Localize\LocProject.json'
     outDir: '$(Build.ArtifactStagingDirectory)'
-    isCreatePrSelected: true
+    isCreatePrSelected: false
     isAutoCompletePrSelected: false
     prSourceBranchPrefix: 'locfiles'
     repoType: gitHub


### PR DESCRIPTION
The 'isCreatePRSelected' is responsible for creating the PR. 
Turning it to false should stop OneLocBuild from creating PRs.

The only thing I am not sure of and would like to know from reviewers is:
the rest of the inputs are used for creating the PRs. If we are not creating a PR, 
I am not sure if Yaml will complain about these additional unused inputs
```isAutoCompletePrSelected: false
    prSourceBranchPrefix: 'locfiles'
    repoType: gitHub
    gitHubPatVariable: '$(GitHub.Token)'
    packageSourceAuth: patAuth
    patVariable: '$(OneLocBuild--PAT)'