### PR TITLE
[tests] Revert manual preservation of InternalsVisibleToAttribute.ctor(string)

### DIFF
--- a/tests/linker/ios/link all/Main.cs
+++ b/tests/linker/ios/link all/Main.cs
@@ -16,16 +16,4 @@ namespace LinkAll
 		}
 #endif // !__WATCHOS__
 	}
-
-#if NET
-	// https://github.com/mono/linker/issues/1913
-	[Foundation.Preserve (AllMembers = true)]
-	class Preserver 
-	{
-		public Preserver ()
-		{
-			GC.KeepAlive (new System.Runtime.CompilerServices.InternalsVisibleToAttribute ("preserve this constructor"));
-		}
-	}
-#endif
 }


### PR DESCRIPTION
The issue https://github.com/mono/linker/issues/1913 was fixed a while ago.