### PR TITLE
[dotnet] Add ICU support for iOS builds

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -137,8 +137,8 @@
 		<EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
 		<EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
 		<HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
-		<!-- .NET only supports invariant globalization for Apple platforms for now: https://github.com/xamarin/xamarin-macios/issues/8906 -->
-		<InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">true</InvariantGlobalization>
+		<!-- tvOS support was not added in P3 -> https://github.com/dotnet/runtime/issues/50912 -->
+		<InvariantGlobalization Condition="'$(_PlatformName)' == 'tvOS' And '$(InvariantGlobalization)' == ''">true</InvariantGlobalization>
 		<StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
 		<UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
 		<UseNativeHttpHandler Condition="'$(_PlatformName)' != 'macOS' And '$(UseNativeHttpHandler)' == ''">true</UseNativeHttpHandler>
@@ -245,6 +245,7 @@
 				@(_XamarinFrameworkAssemblies -> 'FrameworkAssembly=%(Filename)')
 				Interpreter=$(MtouchInterpreter)
 				IntermediateLinkDir=$(IntermediateLinkDir)
+				InvariantGlobalization=$(InvariantGlobalization)
 				ItemsDirectory=$(_LinkerItemsDirectory)
 				IsSimulatorBuild=$(_SdkIsSimulator)
 				LinkMode=$(_LinkMode)
@@ -695,6 +696,10 @@
 				Update="@(ResolvedFileToPublish)"
 				RelativePath="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_DylibPublishDir)))%(Filename)%(Extension)"
 				Condition="'%(Extension)' == '.dylib'" />
+			<ResolvedFileToPublish
+				Update="@(ResolvedFileToPublish)"
+				RelativePath="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_AssemblyPublishDir)))%(Filename)%(Extension)"
+				Condition="'$(_PlatformName)' != 'macOS' And '$(InvariantGlobalization)' != 'true' And '%(Filename)%(Extension)' == 'icudt.dat'" />
 		</ItemGroup>
 	</Target>
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -137,7 +137,7 @@
 		<EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
 		<EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
 		<HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
-		<!-- tvOS support was not added in P3 -> https://github.com/dotnet/runtime/issues/50912 -->
+		<!-- tvOS support blocked by https://github.com/dotnet/runtime/issues/48508 (see xamarin_bridge_vm_initialize in monovm-bridge.m) -->
 		<InvariantGlobalization Condition="'$(_PlatformName)' == 'tvOS' And '$(InvariantGlobalization)' == ''">true</InvariantGlobalization>
 		<StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
 		<UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2437,10 +2437,12 @@ xamarin_vm_initialize ()
 	const char *propertyKeys[] = {
 		"APP_PATHS",
 		"PINVOKE_OVERRIDE",
+		"ICU_DAT_FILE_PATH",
 	};
 	const char *propertyValues[] = {
 		xamarin_get_bundle_path (),
 		pinvokeOverride,
+		"icudt.dat",
 	};
 	static_assert (sizeof (propertyKeys) == sizeof (propertyValues), "The number of keys and values must be the same.");
 

--- a/tests/EmbeddedResources/ResourcesTest.cs
+++ b/tests/EmbeddedResources/ResourcesTest.cs
@@ -44,14 +44,10 @@ namespace EmbeddedResources {
 			Assert.AreEqual ("Welcome", manager.GetString ("String1", new CultureInfo ("en")), "en");
 			Assert.AreEqual ("G'day", manager.GetString ("String1", new CultureInfo ("en-AU")), "en-AU");
 			Assert.AreEqual ("Willkommen", manager.GetString ("String1", new CultureInfo ("de")), "de");
-#if !NET // https://github.com/xamarin/xamarin-macios/issues/8906
 			Assert.AreEqual ("Willkommen", manager.GetString ("String1", new CultureInfo ("de-DE")), "de-DE");
-#endif
 			Assert.AreEqual ("Bienvenido", manager.GetString ("String1", new CultureInfo ("es")), "es");
-#if !NET // https://github.com/xamarin/xamarin-macios/issues/8906
 			Assert.AreEqual ("Bienvenido", manager.GetString ("String1", new CultureInfo ("es-AR")), "es-AR");
 			Assert.AreEqual ("Bienvenido", manager.GetString ("String1", new CultureInfo ("es-ES")), "es-ES");
-#endif
 		}
 	}
 }

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -102,6 +102,8 @@ namespace Xamarin.Tests {
 
 					var filename = Path.GetFileName (v);
 					switch (filename) {
+					case "icudt.dat":
+						return false; // ICU data file only present on .NET
 					case "runtime-options.plist":
 						return false; // the .NET runtime will deal with selecting the http handler, no need for us to do anything
 					}

--- a/tests/monotouch-test/Foundation/LocaleTest.cs
+++ b/tests/monotouch-test/Foundation/LocaleTest.cs
@@ -38,9 +38,6 @@ namespace MonoTouchFixtures.Foundation {
 			Assert.That (NSLocale.FromLocaleIdentifier (ident).Identifier, Is.EqualTo (ident), "FromLocaleIdentifier");
 		}
 		
-#if NET
-		[Ignore ("No globalization data yet - https://github.com/xamarin/xamarin-macios/issues/8906")]
-#endif
 		[Test]
 		public void InitRegionInfo ()
 		{

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Linker {
 		public Version DeploymentTarget { get; private set; }
 		public HashSet<string> FrameworkAssemblies { get; private set; } = new HashSet<string> ();
 		public string IntermediateLinkDir { get; private set; }
+		public bool InvariantGlobalization { get; private set; }
 		public string ItemsDirectory { get; private set; }
 		public bool IsSimulatorBuild { get; private set; }
 		public LinkMode LinkMode => Application.LinkMode;
@@ -227,6 +228,9 @@ namespace Xamarin.Linker {
 					if (!Enum.TryParse<XamarinRuntime> (value, out var rv))
 						throw new InvalidOperationException ($"Invalid XamarinRuntime '{value}' in {linker_file}");
 					Application.XamarinRuntime = rv;
+					break;
+				case "InvariantGlobalization":
+					InvariantGlobalization = string.Equals ("true", value, StringComparison.OrdinalIgnoreCase);
 					break;
 				default:
 					throw new InvalidOperationException ($"Unknown key '{key}' in {linker_file}");

--- a/tools/dotnet-linker/Steps/GenerateMainStep.cs
+++ b/tools/dotnet-linker/Steps/GenerateMainStep.cs
@@ -31,7 +31,9 @@ namespace Xamarin {
 				contents.AppendLine ("#include <stdlib.h>");
 				contents.AppendLine ("static void xamarin_initialize_dotnet ()");
 				contents.AppendLine ("{");
-				contents.AppendLine ("\tsetenv (\"DOTNET_SYSTEM_GLOBALIZATION_INVARIANT\", \"1\", 1); // https://github.com/xamarin/xamarin-macios/issues/8906");
+				if (Configuration.InvariantGlobalization) {
+					contents.AppendLine ("\tsetenv (\"DOTNET_SYSTEM_GLOBALIZATION_INVARIANT\", \"1\", 1);");
+				}
 				contents.AppendLine ("}");
 				contents.AppendLine ();
 


### PR DESCRIPTION
and re-enable some tests for dotnet

Part of the fix for https://github.com/xamarin/xamarin-macios/issues/8906

Known Issues
* [some Calendar are not the expected ones](https://github.com/dotnet/runtime/issues/50859)
* [No support for tvOS](https://github.com/dotnet/runtime/issues/50912)