### PR TITLE
Reenable HotRestart targets for the legacy Sdk

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Windows.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Windows.After.targets
@@ -27,5 +27,5 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)' == 'true'" Directories="$(OutputPath);$(IntermediateOutputPath)" RemoveAppDir="$(RemoveAppDir)" ContinueOnError="true" />
 	</Target>
 
-	<!-- <Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.Local.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.iOS.Local.targets')" /> -->
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.Local.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.iOS.Local.targets')" />
 </Project>


### PR DESCRIPTION
There's no Hot Restart support for net6 yet, but we should still import those targets if the file exist, because are needed on the legacy iOS Sdk on Windows.