### PR TITLE
[dotnet][msbuild] Fix RelativePath inside ResolvedFileToPublish

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -684,17 +684,17 @@
 			<!-- include .dll, .exe and, for debugging only, .pdb files inside the .app -->
 			<ResolvedFileToPublish
 				Update="@(ResolvedFileToPublish)"
-				RelativePath="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_AssemblyPublishDir)))%(ResolvedFileToPublish.DestinationSubDirectory)%(Filename)%(Extension)"
+				RelativePath="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_AssemblyPublishDir)))%(ResolvedFileToPublish.DestinationSubDirectory)\%(Filename)%(Extension)"
 				Condition="'%(Extension)' == '.dll' Or ('$(_BundlerDebug)' == 'true' And '%(Extension)' == '.pdb') Or '%(Extension)' == '.exe'" />
 			<!-- Copy the app.config file to the app bundle -->
 			<ResolvedFileToPublish
 				Update="@(ResolvedFileToPublish)"
-				RelativePath="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_AssemblyPublishDir)))%(ResolvedFileToPublish.DestinationSubDirectory)%(ResolvedFileToPublish.TargetPath)"
+				RelativePath="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_AssemblyPublishDir)))%(ResolvedFileToPublish.DestinationSubDirectory)\%(ResolvedFileToPublish.TargetPath)"
 				Condition="'$(AppConfig)' != '' And '%(ResolvedFileToPublish.OriginalItemSpec)' == '$(AppConfig)' And '%(ResolvedFileToPublish.Link)' == 'app.config' And '%(ResolvedFileToPublish.TargetPath)' != ''" />
 			<!-- .dylib are never needed (nor allowed) for fully AOT'ed applications FIXME https://github.com/xamarin/xamarin-macios/issues/11145 -->
 			<ResolvedFileToPublish
 				Update="@(ResolvedFileToPublish)"
-				RelativePath="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_DylibPublishDir)))%(Filename)%(Extension)"
+				RelativePath="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_DylibPublishDir)))\%(Filename)%(Extension)"
 				Condition="'%(Extension)' == '.dylib'" />
 		</ItemGroup>
 	</Target>


### PR DESCRIPTION
This worked fine up to P3 but failed with an early bump [1] to P4
where paths became invalid (missing a `/`) like:

`bin/iPhoneSimulator/Debug/net6.0-ios/iossimulator-x64/publish/../dont link.applibxamarin-dotnet-debug.dylib`

and did not copy the required `.dylib` [2] (and other stuff) inside the
app bundle.

[1] https://github.com/xamarin/xamarin-macios/pull/11127
[2] .dylib where the first thing to crash at startup

```
Termination Reason:    DYLD, [0x1] Library missing

Application Specific Information:
dyld: launch, loading dependent libraries
DYLD_SHARED_CACHE_DIR=/Users/builder/Library/Developer/CoreSimulator/Caches/dyld/19G2021/com.apple.CoreSimulator.SimRuntime.iOS-14-4.18D46
DYLD_ROOT_PATH=/Applications/Xcode_12.4.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot
DYLD_FALLBACK_FRAMEWORK_PATH=/Applications/Xcode_12.4.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks
DYLD_FALLBACK_LIBRARY_PATH=/Applications/Xcode_12.4.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib

Dyld Error Message:
  dyld: Using shared cache: C11E5D38-A0B0-37FA-AECD-28B337F6C0CA
Library not loaded: @rpath/libxamarin-dotnet-debug.dylib
  Referenced from: /Users/USER/Library/Developer/CoreSimulator/Devices/B3F9E3AC-227F-4B66-9F12-76C5B2CE4E34/data/Containers/Bundle/Application/379106D5-912C-47CC-A0E5-446C7C524706/dont link.app/dont link
  Reason: image not found
```