### PR TITLE
[CI] Re-enable CI on maestro branches.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -138,7 +138,6 @@ trigger:
     - '*'
     exclude:
     - refs/heads/locfiles/*
-    - refs/heads/darc-*
   paths:
     exclude:
     - docs


### PR DESCRIPTION
Because the maestro bot is not a team memeber AND cannot be added as
one, it will not trigger a PR build, but it will trigger an CI build. WE
make the changes to take those as PR builds and do them in the CI.