### PR TITLE
Bump MSBuild.StructuredLogger to 2.1.404

### DIFF
--- a/tests/bgen/bgen-tests.csproj
+++ b/tests/bgen/bgen-tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.2" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.364" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.404" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnet/UnitTests/DotNetUnitTests.csproj
+++ b/tests/dotnet/UnitTests/DotNetUnitTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.2" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.364" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.404" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <PackageReference Include="Mono.Cecil" Version="0.11.1" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.364" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.404" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ErrorTests.cs" />

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -40,7 +40,7 @@
       <HintPath>..\..\_mac-build\Library\Frameworks\Xamarin.Mac.framework\Versions\git\lib\mmp\mmp.exe</HintPath>
     </Reference>
     <PackageReference Include="Mono.Cecil" Version="0.11.1" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.364" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.404" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />

--- a/tests/msbuild/Xamarin.MacDev.Tests/Xamarin.MacDev.Tests.csproj
+++ b/tests/msbuild/Xamarin.MacDev.Tests/Xamarin.MacDev.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.6.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.1" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.364" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.404" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\mtouch\Cache.cs">

--- a/tests/mtouch/mtouch.csproj
+++ b/tests/mtouch/mtouch.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <PackageReference Include="Mono.Cecil" Version="0.11.1" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.364" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.404" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MTouch.cs" />


### PR DESCRIPTION
Required to bump dotnet runtime to preview 4 as the binary log format
was updated (and this affects our ability to run some tests)

https://vsdrop.corp.microsoft.com/file/v1/xamarin-macios/device-tests/20210407.33/4632319/sim/;/tests/vsdrops_index.html