### PR TITLE
[d16-9] [CI] Set status as error if one or more tests failed.

### DIFF
--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -109,6 +109,7 @@ steps:
     if($Env:TESTS_JOBSTATUS -ne "Succeeded")
     {
       Set-PipelineResult -Status partiallySucceeded
+      Set-GitHubStatus -Status "error" -Description "Some tests failed." -Context "$(Build.DefinitionName)"
     }
   env:
     BUILD_REVISION: $(Build.SourceVersion)

--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -109,7 +109,9 @@ steps:
     if($Env:TESTS_JOBSTATUS -ne "Succeeded")
     {
       Set-PipelineResult -Status partiallySucceeded
-      Set-GitHubStatus -Status "error" -Description "Some tests failed." -Context "$(Build.DefinitionName)"
+      Set-GitHubStatus -Status "error" -Description "Some tests failed." -Context "$(Build.DefinitionName) (Test run)"
+    } else {
+      Set-GitHubStatus -Status "success" -Description "All tests passed." -Context "$(Build.DefinitionName) (Test run)"
     }
   env:
     BUILD_REVISION: $(Build.SourceVersion)


### PR DESCRIPTION
We set the pipeline as a partial success BUT the github status as an error. We did fail.


Backport of #11170
