### PR TITLE
[tests][introspection] Report error if no version is present in [SupportedOSPlatformAttribute]

### DIFF
--- a/tests/common/PlatformInfo.cs
+++ b/tests/common/PlatformInfo.cs
@@ -125,8 +125,11 @@ namespace Xamarin.Tests
 			}
 			bool versioned = Version.TryParse (a.PlatformName [n..], out var v);
 
-			if (a is SupportedOSPlatformAttribute)
+			if (a is SupportedOSPlatformAttribute) {
+				if (!versioned)
+					throw new FormatException (a.PlatformName);
 				return new IntroducedAttribute (p, v.Major, v.Minor);
+			}
 			if (a is UnsupportedOSPlatformAttribute) {
 				// if a version is provided then it means it was deprecated
 				// if no version is provided then it means it's unavailable


### PR DESCRIPTION
Otherwise a `[SupportedOSPlatformAttribute ("ios12,3")]` (should be a
dot, not a comma) would throw a `NullReferenceException` making it
harder to track down the error