### PR TITLE
[xcode12.5] [CI] Add a tag to identify those auto-scheduled builds. fixes #11191

### DIFF
--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -21,6 +21,10 @@ steps:
     # the following list will be used to track the tags and set them in VSTS to make the monitoring person life easier
     [System.Collections.Generic.List[string]]$tags = @()
 
+    if ($buildReason -eq "Schedule") {
+        $tags.Add("cronjob")
+    }
+
     if ($buildReason -eq "PullRequest" -or (($buildReason -eq "Manual") -and ($buildSourceBranchName -eq "merge")) ) {
       Write-Host "Configuring build from PR."
       # This is an interesting step, we do know we are dealing with a PR, but we need the PR id to


### PR DESCRIPTION



Backport of #11204
