### PR TITLE
[dotnet][msbuild] Stop publishing dylibs in release builds

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -696,7 +696,7 @@
 			<ResolvedFileToPublish
 				Update="@(ResolvedFileToPublish)"
 				RelativePath="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_DylibPublishDir)))\%(Filename)%(Extension)"
-				Condition="'%(Extension)' == '.dylib'" />
+				Condition="'$(_SdkIsSimulator)' != 'false' And '%(Extension)' == '.dylib'" />
 			<ResolvedFileToPublish
 				Update="@(ResolvedFileToPublish)"
 				RelativePath="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_AssemblyPublishDir)))%(Filename)%(Extension)"


### PR DESCRIPTION
With https://github.com/xamarin/xamarin-macios/pull/11158 we do not
load symbols from the dylibs - so we do not have to ship them.

This makes the size comparison, between legacy and dotnet, more accurate
since the dylibs were large binaries.

https://gist.github.com/spouliot/9cad974b73b982404421e634f2a3a2b7