### PR TITLE
[dotnet] move WorkloadManifest.* files to /data/ folder

### DIFF
--- a/dotnet/package/microsoft.workloads.csproj
+++ b/dotnet/package/microsoft.workloads.csproj
@@ -5,4 +5,8 @@
     <_packagePath>$(MSBuildThisFileDirectory)..\Microsoft.NET.Workload.$(_PlatformName)\</_packagePath>
   </PropertyGroup>
   <Import Project="common.csproj" />
+  <ItemGroup>
+    <!-- workload .nupkg contents should go in /data/ -->
+    <Content Update="$(_packagePath)WorkloadManifest.*" PackagePath="data" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Context: https://github.com/dotnet/designs/pull/188/files#diff-8fcaa29d8e6f00b34b3cb1830d93f33e75f04424780a66a3c658c7021048e74fR125

The future `dotnet workload install` commands will be expecting that
the `.nupkg` for a workload will contain:

* `data/WorkloadManifest.json`
* `data/WorkloadManifest.targets`

This was done so that we don't interfere with NuGet's spec for layout
of a `.nupkg` file. You are allowed to put whatever you like in a
`/data/` folder.

The layout on disk in `/usr/local/share/dotnet`, etc. is unchanged, so
we don't need any changes to our installers, etc.

Android side:

https://github.com/xamarin/xamarin-android/pull/5843