### PR TITLE
[d16-9] [CI] There is no reason to need to run these tests on device bots.

### DIFF
--- a/tools/devops/automation/templates/devices/build.yml
+++ b/tools/devops/automation/templates/devices/build.yml
@@ -60,10 +60,6 @@ steps:
 - bash: cd $(System.DefaultWorkingDirectory)/xamarin-macios/ && git clean -xdf
   displayName: 'Clean workspace'
 
-# Run the pipeline script tests to ensure that we will have not have an unexpected behaviour.
-- bash: make -C $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts run-tests
-  displayName: 'Run pipeline script tests'
-
 - pwsh : |
     gci env: | format-table -autosize -wrap
   displayName: 'Dump Environment'


### PR DESCRIPTION



Backport of #11214
