### PR TITLE
[xcode12.5] [CI] There is no reason to need to run these tests on device bots.

### DIFF
--- a/tools/devops/automation/templates/devices/build.yml
+++ b/tools/devops/automation/templates/devices/build.yml
@@ -58,10 +58,6 @@ steps:
 - bash: cd $(System.DefaultWorkingDirectory)/xamarin-macios/ && git clean -xdf
   displayName: 'Clean workspace'
 
-# Run the pipeline script tests to ensure that we will have not have an unexpected behaviour.
-- bash: make -C $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts run-tests
-  displayName: 'Run pipeline script tests'
-
 - pwsh : |
     Write-Host "IsMacOS: ${IsMacOS}"
     Write-Host "IsWindows: ${IsWindows}"


### PR DESCRIPTION



Backport of #11214
