### PR TITLE
[dotnet] Use `[AssemblyMetadata ("IsTrimmable", "True")]` in platforms assemblies

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -78,7 +78,6 @@
                             RuntimePackNamePatterns="Microsoft.$(_PlatformName).Runtime.**RID**"
                             RuntimePackRuntimeIdentifiers="$(_RuntimePackRuntimeIdentifiers)"
                             Profile="$(_PlatformName)"
-                            IsTrimmable="true"
                             />
   </ItemGroup>
 

--- a/src/AssemblyInfo.cs.in
+++ b/src/AssemblyInfo.cs.in
@@ -16,4 +16,6 @@ using System.Runtime.CompilerServices;
 // [assembly: AssemblyCopyright ("Copyright 2011-2014 Xamarin Inc.")]
 [assembly: AssemblyCompany ("Xamarin Inc.")]
 
+[assembly: AssemblyMetadata ("IsTrimmable", "True")]
+
 [assembly: InternalsVisibleTo ("System.Net.Http,PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]


### PR DESCRIPTION
Fix https://github.com/xamarin/xamarin-macios/issues/10673