### PR TITLE
[linker] Obsolete 'LinkerSafeAttribute' in favor of `AssemblyMetadata`

### DIFF
--- a/src/Foundation/LinkerSafeAttribute.cs
+++ b/src/Foundation/LinkerSafeAttribute.cs
@@ -26,7 +26,7 @@ using System;
 
 namespace Foundation {
 	
-	[Obsolete ("Replace with '[assembly: System.Reflection.AssemblyMetadata (\"IsTrimmable\", \"True\")]'")]
+	[Obsolete ("Replace with '[assembly: System.Reflection.AssemblyMetadata (\"IsTrimmable\", \"True\")]'.")]
 	[AttributeUsage (AttributeTargets.Assembly)]
 	public sealed class LinkerSafeAttribute : Attribute {
 		

--- a/src/Foundation/LinkerSafeAttribute.cs
+++ b/src/Foundation/LinkerSafeAttribute.cs
@@ -26,6 +26,7 @@ using System;
 
 namespace Foundation {
 	
+	[Obsolete ("Replace with '[assembly: System.Reflection.AssemblyMetadata (\"IsTrimmable\", \"True\")]'")]
 	[AttributeUsage (AttributeTargets.Assembly)]
 	public sealed class LinkerSafeAttribute : Attribute {
 		

--- a/tools/mmp/Tuning.mmp.cs
+++ b/tools/mmp/Tuning.mmp.cs
@@ -200,7 +200,7 @@ namespace MonoMac.Tuner {
 	}
 
 
-	public class CustomizeMacActions : CustomizeActions
+	public class CustomizeMacActions : CustomizeCoreActions
 	{
 		LinkMode link_mode;
 

--- a/tools/mtouch/Tuning.mtouch.cs
+++ b/tools/mtouch/Tuning.mtouch.cs
@@ -224,7 +224,7 @@ namespace MonoTouch.Tuner {
 		}
 	}
 
-	public class CustomizeIOSActions : CustomizeActions
+	public class CustomizeIOSActions : CustomizeCoreActions
 	{
 		LinkMode link_mode;
 


### PR DESCRIPTION
In this case we can obsolete the attribute on both legacy and dotnet
since the replacement attribute is available on both. However this does
require a small update to the legacy linker (and is part of the PR).

Fix https://github.com/xamarin/xamarin-macios/issues/10674