### PR TITLE
[dotnet] Add `[Uns|S]upportedOSPlatformAttribute` to manual bindings (part 1)

### DIFF
--- a/src/Compression/Compression.cs
+++ b/src/Compression/Compression.cs
@@ -16,7 +16,9 @@ using ObjCRuntime;
 
 namespace Compression
 {
+#if !NET
 	[iOS (9,0), Mac (10,11)]
+#endif
 	public partial class CompressionStream : Stream
 	{
 		private const int DefaultBufferSize = 8192;

--- a/src/Compression/CompressionStreamStruct.cs
+++ b/src/Compression/CompressionStreamStruct.cs
@@ -6,8 +6,9 @@ using ObjCRuntime;
 
 namespace Compression
 {
-
+#if !NET
 		[iOS (9,0), Mac (10,11)]
+#endif
 		[StructLayout(LayoutKind.Sequential)]
 		struct CompressionStreamStruct {
 			public IntPtr Destination; // uint8_t * dst_ptr

--- a/src/Compression/Enums.cs
+++ b/src/Compression/Enums.cs
@@ -4,8 +4,10 @@ using ObjCRuntime;
 
 namespace Compression {
 
-	// this enum as per the headers is an int NOT an NSInterger
+	// this enum as per the headers is an int NOT an NSInteger
+#if !NET
 	[iOS (9,0), TV (9,0), Mac (10,11)]
+#endif
 	public enum CompressionAlgorithm {
 		LZ4 = 0x100,
 		LZ4Raw = 0x101,

--- a/src/CoreData/NSEntityDescription.cs
+++ b/src/CoreData/NSEntityDescription.cs
@@ -15,7 +15,9 @@ namespace CoreData
 {
 	public partial class NSEntityDescription
 	{
+#if !NET
 		[iOS (9,0), Mac (10,11)]
+#endif
 		public NSObject[][] UniquenessConstraints {
 			get { return NSArray.FromArrayOfArray (_UniquenessConstraints); }
 			set { _UniquenessConstraints = NSArray.From (value); }

--- a/src/CoreImage/CIContext.cs
+++ b/src/CoreImage/CIContext.cs
@@ -24,6 +24,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+using System.Runtime.Versioning;
+
 using Foundation;
 using CoreGraphics;
 using CoreFoundation;
@@ -86,7 +89,9 @@ namespace CoreImage {
 			}
 		}
 
+#if !NET
 		[Mac (10,12)]
+#endif
 		public bool? PriorityRequestLow {
 			get {
 				return GetBoolValue (CIContext.PriorityRequestLow);
@@ -105,7 +110,9 @@ namespace CoreImage {
 			}
 		}
 
+#if !NET
 		[iOS (7,0)]
+#endif
 		public bool? OutputPremultiplied {
 			get {
 				return GetBoolValue (CIContext.OutputPremultiplied);
@@ -115,7 +122,9 @@ namespace CoreImage {
 			}
 		}
 
+#if !NET
 		[iOS (10,0)][Mac (10,12)]
+#endif
 		public bool? CacheIntermediates {
 			get {
 				return GetBoolValue (CIContext.CacheIntermediates);
@@ -125,7 +134,13 @@ namespace CoreImage {
 			}
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios13.0")]
+		[SupportedOSPlatform ("tvos13.0")]
+		[SupportedOSPlatform ("macos10.15")]
+#else
 		[iOS (13,0)][TV (13,0)][Mac (10,15)]
+#endif
 		public bool? AllowLowPower {
 			get {
 				return GetBoolValue (CIContext.AllowLowPower);
@@ -135,7 +150,13 @@ namespace CoreImage {
 			}
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios14.0")]
+		[SupportedOSPlatform ("tvos14.0")]
+		[SupportedOSPlatform ("macos11.0")]
+#else
 		[iOS (14,0)][TV (14,0)][Mac (11,0)]
+#endif
 		public string? Name {
 			get {
 				return GetStringValue (CIContext.Name);
@@ -148,7 +169,9 @@ namespace CoreImage {
 	
 	public partial class CIContext {
 
+#if !NET
 		[iOS (8,0)]
+#endif
 		public CIContext (CIContextOptions options) :
 			this (options?.Dictionary)
 		{
@@ -183,7 +206,11 @@ namespace CoreImage {
 #endif
 
 #if MONOMAC
+#if NET
+		[UnsupportedOSPlatform ("macos10.11")]
+#else
 		[Deprecated (PlatformName.MacOSX, 10, 11)]
+#endif
 		public CGLayer? CreateCGLayer (CGSize size)
 		{
 			return CreateCGLayer (size, null);

--- a/src/CoreImage/CIDetectorOptions.cs
+++ b/src/CoreImage/CIDetectorOptions.cs
@@ -19,7 +19,9 @@ namespace CoreImage {
 		public FaceDetectorAccuracy? Accuracy { get; set; }
 		public float? MinFeatureSize { get; set; }
 
+#if !NET
 		[iOS (10,0)][Mac (10,12)]
+#endif
 		public int? MaxFeatureCount { get; set; }
 
 		public bool? TrackingEnabled { get; set; }

--- a/src/CoreImage/CIFilter.cs
+++ b/src/CoreImage/CIFilter.cs
@@ -119,7 +119,10 @@ using UIKit;
 
 namespace CoreImage {
 	public partial class CIFilter {
+
+#if !NET
 		[iOS (8,0)]
+#endif
 		protected CIFilter () : base ()
 		{
 		}

--- a/src/CoreImage/CIImage.cs
+++ b/src/CoreImage/CIImage.cs
@@ -47,9 +47,13 @@ namespace CoreImage {
 
 		public CIImageOrientation? ImageOrientation;
 
+#if !NET
 		[iOS (8,0)]
+#endif
 		public bool? AutoAdjustCrop;
+#if !NET
 		[iOS (8,0)]
+#endif
 		public bool? AutoAdjustLevel;
 		
 		internal NSDictionary? ToDictionary ()

--- a/src/CoreImage/Enums.cs
+++ b/src/CoreImage/Enums.cs
@@ -22,6 +22,7 @@
 //
 
 using System;
+using System.Runtime.Versioning;
 using ObjCRuntime;
 
 #nullable enable
@@ -76,9 +77,14 @@ namespace CoreImage {
 		RGf = 22
 	}
 
+#if NET
+	[SupportedOSPlatform ("ios11.0")]
+	[SupportedOSPlatform ("tvos11.0")]
+#else
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
+#endif
 	[Native]
 	public enum CIQRCodeErrorCorrectionLevel : long {
 		L = 76,
@@ -87,9 +93,14 @@ namespace CoreImage {
 		H = 72,
 	}
 
+#if NET
+	[SupportedOSPlatform ("ios11.0")]
+	[SupportedOSPlatform ("tvos11.0")]
+#else
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
+#endif
 	[Native]
 	public enum CIDataMatrixCodeEccVersion : long {
 		V000 = 0,
@@ -100,9 +111,14 @@ namespace CoreImage {
 		V200 = 200,
 	}
 
+#if NET
+	[SupportedOSPlatform ("ios11.0")]
+	[SupportedOSPlatform ("tvos11.0")]
+#else
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
+#endif
 	[Native]
 	public enum CIRenderDestinationAlphaMode : ulong {
 		None = 0,

--- a/src/CoreMedia/CMBufferQueue.cs
+++ b/src/CoreMedia/CMBufferQueue.cs
@@ -26,7 +26,9 @@ namespace CoreMedia {
 	public delegate bool   CMBufferGetBool (INativeObject buffer);
 	public delegate int    CMBufferCompare (INativeObject first, INativeObject second);
 
+#if !NET
 	[iOS (7,1), Watch (6,0)]
+#endif
 	public delegate nint   CMBufferGetSize (INativeObject buffer);
 
 	public class CMBufferQueue : INativeObject
@@ -294,12 +296,16 @@ namespace CoreMedia {
 			}
 		}
 		
+#if !NET
 		[iOS (7,1)][Mac (10,10)]
+#endif
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* size_t */ nint CMBufferQueueGetTotalSize (/* CMBufferQueueRef */ IntPtr queue);
 
+#if !NET
 		[iOS (7,1)]
 		[Mac (10, 10)]
+#endif
 		public nint GetTotalSize ()
 		{
 			return CMBufferQueueGetTotalSize (handle);
@@ -367,7 +373,9 @@ namespace CoreMedia {
 		}
 #endif // !COREBUILD
 
+#if !NET
 		[Watch (6,0)]
+#endif
 		public enum TriggerCondition {
 			WhenDurationBecomesLessThan = 1,
 			WhenDurationBecomesLessThanOrEqualTo = 2,

--- a/src/CoreMidi/MidiCIDeviceIdentification.cs
+++ b/src/CoreMidi/MidiCIDeviceIdentification.cs
@@ -1,13 +1,19 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using ObjCRuntime;
 using CoreFoundation;
 using Foundation;
 
 namespace CoreMidi {
 
+#if NET
+	[SupportedOSPlatform ("ios12.0")]
+	[UnsupportedOSPlatform ("tvos")]
+#else
 	[NoWatch, NoTV, Mac (10,14), iOS (12,0)]
+#endif
 	[StructLayout (LayoutKind.Sequential)]
 	public struct MidiCIDeviceIdentification {
 		[MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]

--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -38,6 +38,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using ObjCRuntime;
 using CoreFoundation;
 using Foundation;
@@ -507,8 +508,13 @@ namespace CoreMidi {
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static int /* OSStatus = SInt32 */ MIDIClientDispose (MidiObjectRef handle);
 
+#if NET
+		[UnsupportedOSPlatform ("ios14.0")]
+		[UnsupportedOSPlatform ("macos11.0")]
+#else
 		[Deprecated (PlatformName.iOS, 14,0)]
 		[Deprecated (PlatformName.MacOSX, 11,0)]
+#endif
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static int /* OSStatus = SInt32 */ MIDISourceCreate (MidiObjectRef handle, IntPtr name, out MidiObjectRef endpoint);
 			
@@ -545,8 +551,13 @@ namespace CoreMidi {
 			return Name;
 		}
 
+#if NET
+		[UnsupportedOSPlatform ("ios14.0")]
+		[UnsupportedOSPlatform ("macos11.0")]
+#else
 		[Deprecated (PlatformName.iOS, 14,0)]
 		[Deprecated (PlatformName.MacOSX, 11,0)]
+#endif
 		public MidiEndpoint CreateVirtualSource (string name, out MidiError statusCode)
 		{
 			using (var nsstr = new NSString (name)){
@@ -561,8 +572,13 @@ namespace CoreMidi {
 			}			
 		}
 
+#if NET
+		[UnsupportedOSPlatform ("ios14.0")]
+		[UnsupportedOSPlatform ("macos11.0")]
+#else
 		[Deprecated (PlatformName.iOS, 14,0)]
 		[Deprecated (PlatformName.MacOSX, 11,0)]
+#endif
 		public MidiEndpoint CreateVirtualDestination (string name, out MidiError status)
 		{
 			var m = new MidiEndpoint (this, name, out status);
@@ -877,8 +893,14 @@ namespace CoreMidi {
 	
 	public class MidiPort : MidiObject {
 #if !COREBUILD
+
+#if NET
+		[UnsupportedOSPlatform ("ios14.0")]
+		[UnsupportedOSPlatform ("macos11.0")]
+#else
 		[Deprecated (PlatformName.iOS, 14,0)]
 		[Deprecated (PlatformName.MacOSX, 11,0)]
+#endif
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static int /* OSStatus = SInt32 */ MIDIInputPortCreate (MidiClientRef client, IntPtr /* CFStringRef */ portName, MidiReadProc readProc, IntPtr context, out MidiPortRef midiPort);
 
@@ -976,13 +998,23 @@ namespace CoreMidi {
 			return (input ? "[input:" : "[output:") + Client + ":" + PortName + "]";
 		}
 
+#if NET
+		[UnsupportedOSPlatform ("ios14.0")]
+		[UnsupportedOSPlatform ("macos11.0")]
+#else
 		[Deprecated (PlatformName.iOS, 14,0)]
 		[Deprecated (PlatformName.MacOSX, 11,0)]
+#endif
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static MidiError /* OSStatus = SInt32 */ MIDISend (MidiPortRef port, MidiEndpointRef endpoint, IntPtr packets);
 
+#if NET
+		[UnsupportedOSPlatform ("ios14.0")]
+		[UnsupportedOSPlatform ("macos11.0")]
+#else
 		[Deprecated (PlatformName.iOS, 14,0)]
 		[Deprecated (PlatformName.MacOSX, 11,0)]
+#endif
 		public MidiError Send (MidiEndpoint endpoint, MidiPacket [] packets)
 		{
 			if (endpoint == null)
@@ -1402,8 +1434,13 @@ namespace CoreMidi {
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static MidiEntityRef MIDIDeviceGetEntity (MidiDeviceRef handle, nint item);
 
+#if NET
+		[UnsupportedOSPlatform ("ios14.0")]
+		[UnsupportedOSPlatform ("macos11.0")]
+#else
 		[Deprecated (PlatformName.iOS, 14,0)]
 		[Deprecated (PlatformName.MacOSX, 11,0)]
+#endif
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static int MIDIDeviceAddEntity (MidiDeviceRef device, /* CFString */ IntPtr name, [MarshalAs (UnmanagedType.U1)] bool embedded, nuint numSourceEndpoints, nuint numDestinationEndpoints, MidiEntityRef newEntity);
 
@@ -1417,7 +1454,11 @@ namespace CoreMidi {
 			return new MidiEntity (h);
 		}
 
+#if NET
+		[UnsupportedOSPlatform ("ios14.0")]
+#else
 		[Deprecated (PlatformName.iOS, 14,0)]
+#endif
 		public int Add (string name, bool embedded, nuint numSourceEndpoints, nuint numDestinationEndpoints, MidiEntity newEntity)
 		{
 			if (handle == MidiObject.InvalidRef)
@@ -1496,7 +1537,12 @@ namespace CoreMidi {
 			}
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios13.0")]
+		[SupportedOSPlatform ("macos10.15")]
+#else
 		[Mac (10,15), iOS (13,0)]
+#endif
 		public string NameConfigurationDictionary {
 			get {
 				return GetString (kMIDIPropertyNameConfigurationDictionary);
@@ -1915,8 +1961,13 @@ namespace CoreMidi {
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static int /* OSStatus = SInt32 */ MIDIEndpointDispose (MidiEndpointRef handle);
 		
+#if NET
+		[UnsupportedOSPlatform ("ios14.0")]
+		[UnsupportedOSPlatform ("macos11.0")]
+#else
 		[Deprecated (PlatformName.iOS, 14,0)]
 		[Deprecated (PlatformName.MacOSX, 11,0)]
+#endif
 		[DllImport (Constants.CoreMidiLibrary)]
 		extern static MidiError /* OSStatus = SInt32 */ MIDIDestinationCreate (MidiClientRef client, IntPtr /* CFStringRef */ name, MidiReadProc readProc, IntPtr context, out MidiEndpointRef midiEndpoint);
 
@@ -1924,8 +1975,13 @@ namespace CoreMidi {
 		extern static int /* OSStatus = SInt32 */ MIDIFlushOutput (MidiEndpointRef handle);
 
 		[DllImport (Constants.CoreMidiLibrary)]
+#if NET
+		[UnsupportedOSPlatform ("ios14.0")]
+		[UnsupportedOSPlatform ("macos11.0")]
+#else
 		[Deprecated (PlatformName.iOS, 14,0)]
 		[Deprecated (PlatformName.MacOSX, 11,0)]
+#endif
 		extern static MidiError /* OSStatus = SInt32 */ MIDIReceived (MidiEndpointRef handle, IntPtr /* MIDIPacketList* */ packetList);
 		
 		[DllImport (Constants.CoreMidiLibrary)]
@@ -2014,8 +2070,13 @@ namespace CoreMidi {
 			MIDIFlushOutput (handle);
 		}
 
+#if NET
+		[UnsupportedOSPlatform ("ios14.0")]
+		[UnsupportedOSPlatform ("macos11.0")]
+#else
 		[Deprecated (PlatformName.iOS, 14,0)]
 		[Deprecated (PlatformName.MacOSX, 11,0)]
+#endif
 		public MidiError Received (MidiPacket [] packets)
 		{
 			if (packets == null)

--- a/src/GameKit/GKLocalPlayerListener.cs
+++ b/src/GameKit/GKLocalPlayerListener.cs
@@ -10,10 +10,6 @@ namespace GameKit {
 
 		// GKInviteEventListener and GKTurnBasedEventListener both export same selector
 		// but generator changes now catch this. Stub it out to prevent API break
-		[Unavailable (PlatformName.TvOS, PlatformArchitecture.All)]
-		[Deprecated (PlatformName.iOS, 8,0, message: "Use 'DidRequestMatchWithOtherPlayers' instead.")]
-		[iOS (7,0)]
-		[Mac (10,10)]
 		[Obsolete ("Use 'DidRequestMatch (GKPlayer player, GKPlayer[] recipientPlayers)' instead.")]
 		public virtual void DidRequestMatchWithPlayers (GKPlayer player, string[] playerIDsToInvite)
 		{

--- a/src/Intents/INIntentResolutionResult.cs
+++ b/src/Intents/INIntentResolutionResult.cs
@@ -8,14 +8,20 @@
 //
 
 using System;
+using System.Runtime.Versioning;
 using Foundation;
 using ObjCRuntime;
 
 namespace Intents {
+
+#if NET
+	[SupportedOSPlatform ("tvos14.0")]
+#else
 	[iOS (10, 0)]
 	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[TV (14,0)]
+#endif
 	[Register ("INIntentResolutionResult", SkipRegistration = true)]
 	public sealed partial class INIntentResolutionResult<ObjectType> : INIntentResolutionResult
 		where ObjectType : class, INativeObject 
@@ -45,10 +51,20 @@ namespace Intents {
 			}
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios13.0")]
+		[SupportedOSPlatform ("macos11.0")]
+#else
 		[Watch (6,0), iOS (13,0), Mac (11,0)]
+#endif
 		public static INIntentResolutionResult GetUnsupported (nint reason) => throw new NotImplementedException ("All subclasses of INIntentResolutionResult must re-implement this method");
 
+#if NET
+		[SupportedOSPlatform ("ios13.0")]
+		[SupportedOSPlatform ("macos11.0")]
+#else
 		[Watch (6,0), iOS (13,0), Mac (11,0)]
+#endif
 		public static INIntentResolutionResult GetConfirmationRequired (NSObject itemToConfirm, nint reason) => throw new NotImplementedException ("All subclasses of INIntentResolutionResult must re-implement this method");
 
 	}

--- a/src/Intents/INSetClimateSettingsInCarIntent.cs
+++ b/src/Intents/INSetClimateSettingsInCarIntent.cs
@@ -1,5 +1,6 @@
 #if IOS
 
+using System.Runtime.Versioning;
 using Foundation;
 using Intents;
 using ObjCRuntime;
@@ -8,7 +9,11 @@ namespace Intents {
 
 	public partial class INSetClimateSettingsInCarIntent {
 
+#if NET
+		[UnsupportedOSPlatform ("ios12.0")]
+#else
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Use the overload that takes 'INSpeakableString carName'.")]
+#endif
 		public INSetClimateSettingsInCarIntent (bool? enableFan, bool? enableAirConditioner, bool? enableClimateControl, bool? enableAutoMode, INCarAirCirculationMode airCirculationMode, NSNumber fanSpeedIndex, NSNumber fanSpeedPercentage, INRelativeSetting relativeFanSpeedSetting, NSMeasurement<NSUnitTemperature> temperature, INRelativeSetting relativeTemperatureSetting, INCarSeat climateZone) :
 			this (enableFan.HasValue ? new NSNumber (enableFan.Value) : null, enableAirConditioner.HasValue ? new NSNumber (enableAirConditioner.Value) : null, 
 				enableClimateControl.HasValue ? new NSNumber (enableClimateControl.Value) : null, enableAutoMode.HasValue ? new NSNumber (enableAutoMode.Value) : null,

--- a/src/Intents/INSetDefrosterSettingsInCarIntent.cs
+++ b/src/Intents/INSetDefrosterSettingsInCarIntent.cs
@@ -1,5 +1,6 @@
 #if IOS
 
+using System.Runtime.Versioning;
 using Foundation;
 using Intents;
 using ObjCRuntime;
@@ -8,7 +9,11 @@ namespace Intents {
 
 	public partial class INSetDefrosterSettingsInCarIntent {
 
+#if NET
+		[UnsupportedOSPlatform ("ios12.0")]
+#else
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Use the overload that takes 'INSpeakableString carName'.")]
+#endif
 		public INSetDefrosterSettingsInCarIntent (bool? enable, INCarDefroster defroster) :
 			this (enable.HasValue ? new NSNumber (enable.Value) : null, defroster)
 		{

--- a/src/Intents/INSetProfileInCarIntent.cs
+++ b/src/Intents/INSetProfileInCarIntent.cs
@@ -1,5 +1,6 @@
 #if IOS
 
+using System.Runtime.Versioning;
 using Foundation;
 using Intents;
 using ObjCRuntime;
@@ -9,13 +10,21 @@ namespace Intents {
 
 	public partial class INSetProfileInCarIntent {
 
+#if NET
+		[UnsupportedOSPlatform ("ios12.0")]
+#else
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Use the overload that takes 'INSpeakableString carName'.")]
+#endif
 		public INSetProfileInCarIntent (NSNumber profileNumber, string profileLabel, bool? defaultProfile) :
 			this (profileNumber, profileLabel, defaultProfile.HasValue ? new NSNumber (defaultProfile.Value) : null)
 		{
 		}
 
+#if NET
+		[UnsupportedOSPlatform ("ios12.0")]
+#else
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Use the overload that takes 'INSpeakableString carName'.")]
+#endif
 		protected INSetProfileInCarIntent (NSNumber profileNumber, string profileLabel, NSNumber defaultProfile)
 		{
 			// Apple created this change in 10,2

--- a/src/Intents/INSetSeatSettingsInCarIntent.cs
+++ b/src/Intents/INSetSeatSettingsInCarIntent.cs
@@ -1,5 +1,6 @@
 #if IOS
 
+using System.Runtime.Versioning;
 using Foundation;
 using Intents;
 using ObjCRuntime;
@@ -8,7 +9,11 @@ namespace Intents {
 
 	public partial class INSetSeatSettingsInCarIntent {
 
+#if NET
+		[UnsupportedOSPlatform ("ios12.0")]
+#else
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Use the overload that takes 'INSpeakableString carName'.")]
+#endif
 		public INSetSeatSettingsInCarIntent (bool? enableHeating, bool? enableCooling, bool? enableMassage, INCarSeat seat, NSNumber level, INRelativeSetting relativeLevelSetting) :
 			this (enableHeating.HasValue ? new NSNumber (enableHeating.Value) : null, enableCooling.HasValue ? new NSNumber (enableCooling.Value) : null, enableMassage.HasValue ? new NSNumber (enableMassage.Value) : null, seat, level, relativeLevelSetting)
 		{

--- a/src/MLCompute/MLHelpers.cs
+++ b/src/MLCompute/MLHelpers.cs
@@ -218,11 +218,11 @@ namespace MLCompute {
 	}
 
 #if NET
-	[SupportedOSPlatform ("ios14.0")]
-	[SupportedOSPlatform ("tvos14.0")]
-	[SupportedOSPlatform ("macos11.0")]
+	[SupportedOSPlatform ("ios14.5")]
+	[SupportedOSPlatform ("tvos14.5")]
+	[SupportedOSPlatform ("macos11.3")]
 #else
-	[iOS (14,0)][TV (14,0)][Mac (11,0)]
+	[TV (14,5)][Mac (11,3)][iOS (14,5)]
 	[NoWatch]
 #endif
 	public static class MLCComparisonOperationExtensions {

--- a/src/MLCompute/MLHelpers.cs
+++ b/src/MLCompute/MLHelpers.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 using CoreFoundation;
 using Foundation;
@@ -7,8 +8,14 @@ using ObjCRuntime;
 
 namespace MLCompute {
 
-	[iOS (14,0)][TV (14,0)][Mac (10,16)]
+#if NET
+	[SupportedOSPlatform ("ios14.0")]
+	[SupportedOSPlatform ("tvos14.0")]
+	[SupportedOSPlatform ("macos11.0")]
+#else
+	[iOS (14,0)][TV (14,0)][Mac (11,0)]
 	[NoWatch]
+#endif
 	public static class MLCActivationTypeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
@@ -20,8 +27,14 @@ namespace MLCompute {
 		}
 	}
 
-	[iOS (14,0)][TV (14,0)][Mac (10,16)]
+#if NET
+	[SupportedOSPlatform ("ios14.0")]
+	[SupportedOSPlatform ("tvos14.0")]
+	[SupportedOSPlatform ("macos11.0")]
+#else
+	[iOS (14,0)][TV (14,0)][Mac (11,0)]
 	[NoWatch]
+#endif
 	public static class MLCArithmeticOperationExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
@@ -33,8 +46,14 @@ namespace MLCompute {
 		}
 	}
 
-	[iOS (14,0)][TV (14,0)][Mac (10,16)]
+#if NET
+	[SupportedOSPlatform ("ios14.0")]
+	[SupportedOSPlatform ("tvos14.0")]
+	[SupportedOSPlatform ("macos11.0")]
+#else
+	[iOS (14,0)][TV (14,0)][Mac (11,0)]
 	[NoWatch]
+#endif
 	public static class MLCPaddingPolicyExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
@@ -46,8 +65,14 @@ namespace MLCompute {
 		}
 	}
 
-	[iOS (14,0)][TV (14,0)][Mac (10,16)]
+#if NET
+	[SupportedOSPlatform ("ios14.0")]
+	[SupportedOSPlatform ("tvos14.0")]
+	[SupportedOSPlatform ("macos11.0")]
+#else
+	[iOS (14,0)][TV (14,0)][Mac (11,0)]
 	[NoWatch]
+#endif
 	public static class MLCLossTypeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
@@ -59,8 +84,14 @@ namespace MLCompute {
 		}
 	}
 
-	[iOS (14,0)][TV (14,0)][Mac (10,16)]
+#if NET
+	[SupportedOSPlatform ("ios14.0")]
+	[SupportedOSPlatform ("tvos14.0")]
+	[SupportedOSPlatform ("macos11.0")]
+#else
+	[iOS (14,0)][TV (14,0)][Mac (11,0)]
 	[NoWatch]
+#endif
 	public static class MLCReductionTypeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
@@ -72,8 +103,14 @@ namespace MLCompute {
 		}
 	}
 
-	[iOS (14,0)][TV (14,0)][Mac (10,16)]
+#if NET
+	[SupportedOSPlatform ("ios14.0")]
+	[SupportedOSPlatform ("tvos14.0")]
+	[SupportedOSPlatform ("macos11.0")]
+#else
+	[iOS (14,0)][TV (14,0)][Mac (11,0)]
 	[NoWatch]
+#endif
 	public static class MLCPaddingTypeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
@@ -85,8 +122,14 @@ namespace MLCompute {
 		}
 	}
 
-	[iOS (14,0)][TV (14,0)][Mac (10,16)]
+#if NET
+	[SupportedOSPlatform ("ios14.0")]
+	[SupportedOSPlatform ("tvos14.0")]
+	[SupportedOSPlatform ("macos11.0")]
+#else
+	[iOS (14,0)][TV (14,0)][Mac (11,0)]
 	[NoWatch]
+#endif
 	public static class MLCConvolutionTypeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
@@ -98,8 +141,14 @@ namespace MLCompute {
 		}
 	}
 
-	[iOS (14,0)][TV (14,0)][Mac (10,16)]
+#if NET
+	[SupportedOSPlatform ("ios14.0")]
+	[SupportedOSPlatform ("tvos14.0")]
+	[SupportedOSPlatform ("macos11.0")]
+#else
+	[iOS (14,0)][TV (14,0)][Mac (11,0)]
 	[NoWatch]
+#endif
 	public static class MLCPoolingTypeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
@@ -111,8 +160,14 @@ namespace MLCompute {
 		}
 	}
 
-	[iOS (14,0)][TV (14,0)][Mac (10,16)]
+#if NET
+	[SupportedOSPlatform ("ios14.0")]
+	[SupportedOSPlatform ("tvos14.0")]
+	[SupportedOSPlatform ("macos11.0")]
+#else
+	[iOS (14,0)][TV (14,0)][Mac (11,0)]
 	[NoWatch]
+#endif
 	public static class MLCSoftmaxOperationExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
@@ -124,8 +179,14 @@ namespace MLCompute {
 		}
 	}
 
-	[iOS (14,0)][TV (14,0)][Mac (10,16)]
+#if NET
+	[SupportedOSPlatform ("ios14.0")]
+	[SupportedOSPlatform ("tvos14.0")]
+	[SupportedOSPlatform ("macos11.0")]
+#else
+	[iOS (14,0)][TV (14,0)][Mac (11,0)]
 	[NoWatch]
+#endif
 	public static class MLCSampleModeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
@@ -137,8 +198,14 @@ namespace MLCompute {
 		}
 	}
 
-	[iOS (14,0)][TV (14,0)][Mac (10,16)]
+#if NET
+	[SupportedOSPlatform ("ios14.0")]
+	[SupportedOSPlatform ("tvos14.0")]
+	[SupportedOSPlatform ("macos11.0")]
+#else
+	[iOS (14,0)][TV (14,0)][Mac (11,0)]
 	[NoWatch]
+#endif
 	public static class MLCLstmResultModeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
@@ -150,8 +217,14 @@ namespace MLCompute {
 		}
 	}
 
-	[TV (14,5)][Mac (11,3)][iOS (14,5)]
+#if NET
+	[SupportedOSPlatform ("ios14.0")]
+	[SupportedOSPlatform ("tvos14.0")]
+	[SupportedOSPlatform ("macos11.0")]
+#else
+	[iOS (14,0)][TV (14,0)][Mac (11,0)]
 	[NoWatch]
+#endif
 	public static class MLCComparisonOperationExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]

--- a/src/MapKit/MKFeatureDisplayPriority.cs
+++ b/src/MapKit/MKFeatureDisplayPriority.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Versioning;
 using ObjCRuntime;
 
 #nullable enable
@@ -7,11 +8,16 @@ namespace MapKit {
 
 #if !WATCH || (WATCH && !XAMCORE_4_0)
 
-	// .net does not allow float-based enumerations
+#if NET
+	[SupportedOSPlatform ("ios11.0")]
+	[SupportedOSPlatform ("tvos11.0")]
+#else
 	[TV (11,0)][NoWatch][iOS (11,0)][Mac (10,13)]
+#endif
 #if WATCH && !XAMCORE_4_0
 	[Obsolete ("This API is not available on this platform.")]
 #endif
+	// .net does not allow float-based enumerations
 	public static class MKFeatureDisplayPriority {
 		public const float Required = 1000f;
 		public const float DefaultHigh = 750f;

--- a/src/MapKit/MKMapItem.cs
+++ b/src/MapKit/MKMapItem.cs
@@ -7,6 +7,8 @@
 
 #if !TVOS
 
+using System.Runtime.Versioning;
+
 using Foundation;
 using CoreLocation;
 using ObjCRuntime;
@@ -19,7 +21,11 @@ namespace MapKit {
 	// to replace NSString fields
 	public enum MKDirectionsMode {
 		Driving, Walking, Transit,
+#if NET
+		[UnsupportedOSPlatform ("tvos")]
+#else
 		[iOS (10,0)][NoTV][Watch (3,0)][Mac (10,12)]
+#endif
 		Default
 	}
 	
@@ -36,7 +42,10 @@ namespace MapKit {
 #endif
 
 #if !WATCH // The corresponding key (MKLaunchOptionsCameraKey) is allowed in WatchOS, but there's no MKMapCamera type.
+
+#if !NET
 		[iOS (7,0)]
+#endif
 		public MKMapCamera? Camera { get; set; }
 #endif
 

--- a/src/MapKit/MapKit.cs
+++ b/src/MapKit/MapKit.cs
@@ -53,7 +53,9 @@ namespace MapKit {
 
 	// MKGeometry.h
 	[StructLayout (LayoutKind.Sequential)]
+#if !NET
 	[Mac (10,9)]
+#endif
 	public struct MKCoordinateRegion {
 		public CLLocationCoordinate2D Center;
 		public MKCoordinateSpan Span;
@@ -80,7 +82,9 @@ namespace MapKit {
 
 	// MKGeometry.h
 	[StructLayout (LayoutKind.Sequential)]
+#if !NET
 	[Mac (10,9)]
+#endif
 	public struct MKMapPoint {
 		public double X, Y;
 
@@ -392,7 +396,9 @@ namespace MapKit {
 	}
 
 	// MKGeometry.h
+#if !NET
 	[Mac (10,9)]
+#endif
 	public static class MKGeometry {
 		
 		[DllImport (Constants.MapKitLibrary, EntryPoint="MKMapPointsPerMeterAtLatitude")]

--- a/src/MediaAccessibility/MAImageCaptioning.cs
+++ b/src/MediaAccessibility/MAImageCaptioning.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 using ObjCRuntime;
 using CoreFoundation;
@@ -9,7 +10,13 @@ using Foundation;
 
 namespace MediaAccessibility {
 
+#if NET
+	[SupportedOSPlatform ("ios13.0")]
+	[SupportedOSPlatform ("tvos13.0")]
+	[SupportedOSPlatform ("macos10.15")]
+#else
 	[TV (13,0), Mac (10,15), iOS (13,0)]
+#endif
 	public static partial class MAImageCaptioning {
 
 		[DllImport (Constants.MediaAccessibilityLibrary)]

--- a/src/MediaAccessibility/MediaAccessibility.cs
+++ b/src/MediaAccessibility/MediaAccessibility.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 using ObjCRuntime;
 using CoreFoundation;
@@ -17,7 +18,9 @@ using Foundation;
 
 namespace MediaAccessibility {
 
+#if !NET
 	[iOS (7,0)][Mac (10,9)]
+#endif
 	public static partial class MACaptionAppearance {
 
 #if !XAMCORE_4_0
@@ -218,11 +221,23 @@ namespace MediaAccessibility {
 			return (MACaptionAppearanceTextEdgeStyle) (int) rv;
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios13.0")]
+		[SupportedOSPlatform ("tvos13.0")]
+		[SupportedOSPlatform ("macos10.15")]
+#else
 		[TV (13,0), Mac (10,15), iOS (13,0)]
+#endif
 		[DllImport (Constants.MediaAccessibilityLibrary)]
 		static extern void MACaptionAppearanceDidDisplayCaptions (IntPtr /* CFArratRef */ strings);
 
+#if NET
+		[SupportedOSPlatform ("ios13.0")]
+		[SupportedOSPlatform ("tvos13.0")]
+		[SupportedOSPlatform ("macos10.15")]
+#else
 		[TV (13,0), Mac (10,15), iOS (13,0)]
+#endif
 		public static void DidDisplayCaptions (string[] strings)
 		{
 			if ((strings == null) || (strings.Length == 0))
@@ -233,7 +248,13 @@ namespace MediaAccessibility {
 			}
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios13.0")]
+		[SupportedOSPlatform ("tvos13.0")]
+		[SupportedOSPlatform ("macos10.15")]
+#else
 		[TV (13,0), Mac (10,15), iOS (13,0)]
+#endif
 		public static void DidDisplayCaptions (NSAttributedString[] strings)
 		{
 			// CFAttributedString is “toll-free bridged” with its Foundation counterpart, NSAttributedString.
@@ -248,7 +269,9 @@ namespace MediaAccessibility {
 	}
 
 	static partial class MAAudibleMedia {
+#if !NET
 		[iOS (8,0)][Mac (10,10)]
+#endif
 		[DllImport (Constants.MediaAccessibilityLibrary)]
 		static extern unsafe IntPtr /* CFArrayRef __nonnull */ MAAudibleMediaCopyPreferredCharacteristics ();
 

--- a/src/MediaToolbox/MTFormatNames.cs
+++ b/src/MediaToolbox/MTFormatNames.cs
@@ -11,23 +11,31 @@ namespace MediaToolbox {
 
 	static public class MTFormatNames {
 
+#if !NET
 		[iOS (9,0)][Mac (10,11)]
+#endif
 		[DllImport (Constants.MediaToolboxLibrary)]
 		static extern /* CFStringRef CM_NULLABLE */ IntPtr MTCopyLocalizedNameForMediaType (
 			CMMediaType mediaType);
 
+#if !NET
 		[iOS (9,0)][Mac (10,11)]
+#endif
 		static public string GetLocalizedName (this CMMediaType mediaType)
 		{
 			return CFString.FetchString (MTCopyLocalizedNameForMediaType (mediaType), releaseHandle: true);
 		}
 
+#if !NET
 		[iOS (9,0)][Mac (10,11)]
+#endif
 		[DllImport (Constants.MediaToolboxLibrary)]
 		static extern /* CFStringRef CM_NULLABLE */ IntPtr MTCopyLocalizedNameForMediaSubType (
 			CMMediaType mediaType, uint mediaSubType);
 
+#if !NET
 		[iOS (9,0)][Mac (10,11)]
+#endif
 		static public string GetLocalizedName (this CMMediaType mediaType, uint mediaSubType)
 		{
 			return CFString.FetchString (MTCopyLocalizedNameForMediaSubType (mediaType, mediaSubType), releaseHandle: true);

--- a/src/Metal/Defs.cs
+++ b/src/Metal/Defs.cs
@@ -9,6 +9,7 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 using Foundation;
 using ModelIO;
@@ -231,7 +232,12 @@ namespace Metal {
 		public uint ThreadGroupsPerGrid3;
 	}
 
+#if NET
+	[SupportedOSPlatform ("ios12.0")]
+	[SupportedOSPlatform ("tvos12.0")]
+#else
 	[Mac (10,14), iOS (12,0), TV (12,0)]
+#endif
 	[StructLayout (LayoutKind.Sequential)]
 	public struct MTLStageInRegionIndirectArguments {
 		public uint StageInOrigin1;
@@ -356,7 +362,13 @@ namespace Metal {
 	}
 #endif // MONOMAC
 
+#if NET
+	[SupportedOSPlatform ("ios13.0")]
+	[SupportedOSPlatform ("tvos13.0")]
+	[SupportedOSPlatform ("macos10.15")]
+#else
 	[Mac (10,15), iOS (13,0), TV (13,0)]
+#endif
 	[StructLayout (LayoutKind.Sequential)]
 	public struct MTLTextureSwizzleChannels {
 #if COREBUILD
@@ -374,9 +386,16 @@ namespace Metal {
 	}
 
 #if IOS || MONOMAC || COREBUILD
+
+#if NET
+	[SupportedOSPlatform ("ios13.0")]
+	[SupportedOSPlatform ("macos10.15.4")]
+	[SupportedOSPlatform ("maccatalyst13.4")]
+#else
 	[Introduced (PlatformName.iOS, 13,0, PlatformArchitecture.All)]
 	[Introduced (PlatformName.MacCatalyst, 13, 4)]
 	[Introduced (PlatformName.MacOSX, 10, 15, 4)]
+#endif
 	[StructLayout (LayoutKind.Sequential)]
 	public struct MTLVertexAmplificationViewMapping {
 		public uint ViewportArrayIndexOffset;
@@ -384,9 +403,15 @@ namespace Metal {
 		public uint RenderTargetArrayIndexOffset;
 	}
 
+#if NET
+	[SupportedOSPlatform ("ios13.0")]
+	[SupportedOSPlatform ("macos10.15.4")]
+	[SupportedOSPlatform ("maccatalyst13.4")]
+#else
 	[Introduced (PlatformName.iOS, 13,0, PlatformArchitecture.All)]
 	[Introduced (PlatformName.MacCatalyst, 13, 4)]
 	[Introduced (PlatformName.MacOSX, 10, 15, 4)]
+#endif
 	[StructLayout (LayoutKind.Sequential)]
 	public struct MTLCoordinate2D {
 		public float X;
@@ -396,8 +421,15 @@ namespace Metal {
 #endif
 
 #if !TVOS || !XAMCORE_4_0
+
+#if NET
+	[SupportedOSPlatform ("ios14.0")]
+	[SupportedOSPlatform ("macos11.0")]
+	[SupportedOSPlatform ("maccatalyst14.0")]
+#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[Mac (11,0), iOS (14,0), NoTV]
+#endif
 #if TVOS && !XAMCORE_4_0
 	[Obsolete ("This API is not available on this platform.")]
 #endif

--- a/src/Metal/MTLDevice.cs
+++ b/src/Metal/MTLDevice.cs
@@ -10,6 +10,7 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 using Foundation;
 using ObjCRuntime;
@@ -22,7 +23,9 @@ namespace Metal {
 	public delegate void MTLDeviceNotificationHandler (IMTLDevice device, NSString notifyName);
 #endif
 
+#if !NET
 	[iOS (8,0)][Mac (10,11)]
+#endif
 	public static partial class MTLDevice {
 		[DllImport (Constants.MetalLibrary)]
 		extern static IntPtr MTLCreateSystemDefaultDevice ();
@@ -160,7 +163,13 @@ namespace Metal {
 		}
 #if IOS
 
+#if NET
+		[SupportedOSPlatform ("ios13.0")]
+		[UnsupportedOSPlatform ("tvos")]
+		[UnsupportedOSPlatform ("macos")]
+#else
 		[NoMac, NoTV, iOS (13,0)]
+#endif
 		public static void ConvertSparseTileRegions (this IMTLDevice This, MTLRegion [] tileRegions, MTLRegion [] pixelRegions, MTLSize tileSize, nuint numRegions)
 		{
 			if (tileRegions == null)
@@ -180,7 +189,13 @@ namespace Metal {
 			}
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios13.0")]
+		[UnsupportedOSPlatform ("tvos")]
+		[UnsupportedOSPlatform ("macos")]
+#else
 		[NoMac, NoTV, iOS (13,0)]
+#endif
 		public static void ConvertSparsePixelRegions (this IMTLDevice This, MTLRegion [] pixelRegions, MTLRegion [] tileRegions, MTLSize tileSize, MTLSparseTextureRegionAlignmentMode mode, nuint numRegions)
 		{
 			if (tileRegions == null)

--- a/src/Metal/MTLIntersectionFunctionTable.cs
+++ b/src/Metal/MTLIntersectionFunctionTable.cs
@@ -1,6 +1,7 @@
 #if !TVOS
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Foundation;
 using ObjCRuntime;
 
@@ -11,7 +12,14 @@ namespace Metal {
 	// add some extension methods to make the API of the protocol nicer
 	public static class MTLIntersectionFunctionTableExtensions {
 
+#if NET
+		[SupportedOSPlatform ("ios14.0")]
+		[SupportedOSPlatform ("macos11.0")]
+		[SupportedOSPlatform ("maccatalyst14.0")]
+		[UnsupportedOSPlatform ("tvos")]
+#else
 		[Mac (11,0), iOS (14,0), NoTV]
+#endif
 		public static void SetBuffers (this IMTLIntersectionFunctionTable table, IMTLBuffer[] buffers, nuint[] offsets, NSRange range)
 		{
 			if (buffers == null)

--- a/src/Metal/MTLRasterizationRateLayerDescriptor.cs
+++ b/src/Metal/MTLRasterizationRateLayerDescriptor.cs
@@ -2,6 +2,7 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 using Foundation;
 using ObjCRuntime;
@@ -32,7 +33,11 @@ namespace Metal {
 			}
 		}
 */
+#if NET
+		[UnsupportedOSPlatform ("macos")]
+#else
 		[NoMac]
+#endif
 		static public MTLRasterizationRateLayerDescriptor Create (MTLSize sampleCount, float[] horizontal, float[] vertical)
 		{
 			if (horizontal == null)

--- a/src/Metal/MTLResourceStateCommandEncoder.cs
+++ b/src/Metal/MTLResourceStateCommandEncoder.cs
@@ -8,6 +8,7 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 using Foundation;
 using ObjCRuntime;
@@ -18,7 +19,12 @@ namespace Metal {
 
 	public static partial class MTLResourceStateCommandEncoder_Extensions {
 
+#if NET
+		[UnsupportedOSPlatform ("macos")]
+		[UnsupportedOSPlatform ("tvos")]
+#else
 		[NoMac, NoTV]
+#endif
 		public static void Update (this IMTLResourceStateCommandEncoder This, IMTLTexture texture, MTLSparseTextureMappingMode mode, MTLRegion[] regions, nuint[] mipLevels, nuint[] slices)
 		{
 			if (texture == null)

--- a/src/MetalKit/MTKTextureLoaderOptions.cs
+++ b/src/MetalKit/MTKTextureLoaderOptions.cs
@@ -14,7 +14,10 @@ using ObjCRuntime;
 
 namespace MetalKit {
 #if !COREBUILD
+
+#if !NET
 	[iOS (9,0)][Mac (10,11)]
+#endif
 	public partial class MTKTextureLoaderOptions : DictionaryContainer {
 
 		public MTLTextureUsage? TextureUsage {
@@ -47,7 +50,9 @@ namespace MetalKit {
 			}
 		}
 
+#if !NET
 		[iOS (10,0)][Mac (10,12)]
+#endif
 		public MTLStorageMode? TextureStorageMode {
 			get {
 				var val = GetNUIntValue (MTKTextureLoaderKeys.TextureStorageModeKey);
@@ -63,7 +68,9 @@ namespace MetalKit {
 			}
 		}
 
+#if !NET
 		[iOS (10,0)][Mac (10,12)]
+#endif
 		public MTKTextureLoaderCubeLayout? CubeLayout {
 			get {
 				var val = GetNSStringValue (MTKTextureLoaderKeys.CubeLayoutKey);
@@ -79,7 +86,9 @@ namespace MetalKit {
 			}
 		}
 
+#if !NET
 		[iOS (10,0)][Mac (10,12)]
+#endif
 		public MTKTextureLoaderOrigin? Origin {
 			get {
 				var val = GetNSStringValue (MTKTextureLoaderKeys.OriginKey);

--- a/src/MobileCoreServices/UTType.cs
+++ b/src/MobileCoreServices/UTType.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using ObjCRuntime;
 using CoreFoundation;
 using Foundation;
@@ -35,15 +36,21 @@ namespace MobileCoreServices {
 
 	public static partial class UTType {
 
+#if !NET
 		[iOS (8,0)][Mac (10,10)]
+#endif
 		[DllImport (Constants.CoreServicesLibrary)]
 		extern static int /* Boolean */ UTTypeIsDynamic (IntPtr /* CFStringRef */ handle);
 		
+#if !NET
 		[iOS (8,0)][Mac (10,10)]
+#endif
 		[DllImport (Constants.CoreServicesLibrary)]
 		extern static int /* Boolean */ UTTypeIsDeclared (IntPtr /* CFStringRef */ handle);
 
+#if !NET
 		[iOS (8,0)][Mac (10,10)]
+#endif
 		public static bool IsDynamic (string utType)
 		{
 			if (utType == null)
@@ -53,7 +60,9 @@ namespace MobileCoreServices {
 				return UTTypeIsDynamic (x.Handle) != 0;
 		}
 
+#if !NET
 		[iOS (8,0)][Mac (10,10)]
+#endif
 		public static bool IsDeclared (string utType)
 		{
 			if (utType == null)
@@ -98,11 +107,15 @@ namespace MobileCoreServices {
 			return ret;
 		}
 		
+#if !NET
 		[iOS (8,0)][Mac (10,10)]
+#endif
 		[DllImport (Constants.CoreServicesLibrary)]
 		extern static IntPtr /* NSString Array */ UTTypeCopyAllTagsWithClass (IntPtr /* CFStringRef */ utiStr, IntPtr /* CFStringRef */ tagClassStr);
 		
+#if !NET
 		[iOS (8,0)][Mac (10,10)]
+#endif
 		public static string [] CopyAllTags (string uti, string tagClass)
 		{
 			if (uti == null)
@@ -200,7 +213,12 @@ namespace MobileCoreServices {
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern unsafe bool /* Boolean */ UTTypeEqual (/* CFStringRef */ IntPtr inUTI1, /* CFStringRef */ IntPtr inUTI2);
 
+#if NET
+		[SupportedOSPlatform ("ios12.0")]
+		[SupportedOSPlatform ("tvos12.0")]
+#else
 		[iOS (12,0)][TV (12,0)][Watch (5,0)]
+#endif
 		public static bool Equals (NSString uti1, NSString uti2)
 		{
 			if (uti1 == null)

--- a/src/ModelIO/MDLNoiseTexture.cs
+++ b/src/ModelIO/MDLNoiseTexture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Versioning;
 using ObjCRuntime;
 using Vector2i = global::OpenTK.Vector2i;
 
@@ -12,7 +13,11 @@ namespace ModelIO {
 		{
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios10.2")]
+#else
 		[iOS (10,2), Mac (10,12)]
+#endif
 		public MDLNoiseTexture (float input, string name, Vector2i textureDimensions, MDLTextureChannelEncoding channelEncoding, MDLNoiseTextureType type)
 		{
 			// two different `init*` would share the same C# signature

--- a/src/ModelIO/MDLStructs.cs
+++ b/src/ModelIO/MDLStructs.cs
@@ -9,6 +9,7 @@
 //
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Foundation;
 using CoreFoundation;
 using CoreGraphics;
@@ -32,11 +33,15 @@ namespace ModelIO {
 #if !COREBUILD
 	public static class MDLVertexFormatExtensions {
 		
+#if !NET
 		[iOS (9,0)][Mac (10,11)]
+#endif
 		[DllImport (Constants.MetalKitLibrary)]
 		static extern /* MTLVertexFormat */ nuint MTKMetalVertexFormatFromModelIO (/* MTLVertexFormat */ nuint vertexFormat);
 
+#if !NET
 		[iOS (9,0)][Mac (10,11)]
+#endif
 		public static MTLVertexFormat ToMetalVertexFormat (this MDLVertexFormat vertexFormat)
 		{
 			nuint mtlVertexFormat = MTKMetalVertexFormatFromModelIO ((nuint)(ulong)vertexFormat);

--- a/src/NaturalLanguage/NLModel.cs
+++ b/src/NaturalLanguage/NLModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 
 using Foundation;
 using ObjCRuntime;
@@ -8,16 +9,30 @@ namespace NaturalLanguage {
 
 	public partial class NLModel {
 
+#if NET
+		[SupportedOSPlatform ("ios14.0")]
+		[SupportedOSPlatform ("tvos14.0")]
+		[SupportedOSPlatform ("maccatalyst14.0")]
+		[SupportedOSPlatform ("macos11.0")]
+#else
 		[Watch (7,0), TV (14,0), Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
+#endif
 		public Dictionary<NLLanguage, double> GetPredictedLabelHypotheses (string @string, nuint maximumCount)
 		{
 			using (var hypo = GetNativePredictedLabelHypotheses (@string, maximumCount))
 				return NLLanguageExtensions.Convert (hypo);
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios14.0")]
+		[SupportedOSPlatform ("tvos14.0")]
+		[SupportedOSPlatform ("maccatalyst14.0")]
+		[SupportedOSPlatform ("macos11.0")]
+#else
 		[Watch (7,0), TV (14,0), Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
+#endif
 		public Dictionary<NLLanguage, double>[] GetPredictedLabelHypotheses (string[] tokens, nuint maximumCount)
 		{
 			var hypos = GetNativePredictedLabelHypotheses (tokens, maximumCount);

--- a/src/NetworkExtension/NEHotspotConfiguration.cs
+++ b/src/NetworkExtension/NEHotspotConfiguration.cs
@@ -2,6 +2,7 @@
 
 #if !MONOMAC
 
+using System.Runtime.Versioning;
 using Foundation;
 
 namespace NetworkExtension {
@@ -18,14 +19,22 @@ namespace NetworkExtension {
 			InitializeHandle (initWithSsid (ssid, passphrase, isWep));
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios13.0")]
+#else
 		[iOS (13,0)]
+#endif
 		public NEHotspotConfiguration (string ssid, bool ssidIsPrefix)
 		{
 			var h = ssidIsPrefix ? initWithSsidPrefix (ssid) : initWithSsid (ssid);
 			InitializeHandle (h);
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios13.0")]
+#else
 		[iOS (13,0)]
+#endif
 		public NEHotspotConfiguration (string ssid, string passphrase, bool isWep, bool ssidIsPrefix)
 		{
 			var h = ssidIsPrefix ? initWithSsidPrefix (ssid, passphrase, isWep) : initWithSsid (ssid, passphrase, isWep);

--- a/src/OpenGLES/EAGLConsts.cs
+++ b/src/OpenGLES/EAGLConsts.cs
@@ -6,14 +6,20 @@
 //
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 using Foundation;
 using ObjCRuntime;
 
 namespace OpenGLES {
 
+#if NET
+	[UnsupportedOSPlatform ("ios12.0")]
+	[UnsupportedOSPlatform ("tvos12.0")]
+#else
 	[Deprecated (PlatformName.iOS, 12,0, message: "Use 'Metal' instead.")]
 	[Deprecated (PlatformName.TvOS, 12,0, message: "Use 'Metal' instead.")]
+#endif
 	public static class EAGLDrawableProperty {
 		public static readonly NSString ColorFormat;
 		public static readonly NSString RetainedBacking;
@@ -28,8 +34,13 @@ namespace OpenGLES {
 		}
 	}
 
+#if NET
+	[UnsupportedOSPlatform ("ios12.0")]
+	[UnsupportedOSPlatform ("tvos12.0")]
+#else
 	[Deprecated (PlatformName.iOS, 12,0, message: "Use 'Metal' instead.")]
 	[Deprecated (PlatformName.TvOS, 12,0, message: "Use 'Metal' instead.")]
+#endif
 	public static class EAGLColorFormat {
 		public static readonly NSString RGB565;
 		public static readonly NSString RGBA8;

--- a/src/OpenGLES/EAGLContext.cs
+++ b/src/OpenGLES/EAGLContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using ObjCRuntime;
 
 namespace OpenGLES
@@ -30,8 +31,13 @@ namespace OpenGLES
 			return _PresentRenderbufferAtTime (target, presentationTime);
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios10.3")]
+		[SupportedOSPlatform ("tvos10.2")]
+#else
 		[iOS (10,3)]
 		[TV (10,2)]
+#endif
 		public virtual bool PresentRenderBuffer (nuint target, double presentationTime, PresentationMode mode)
 		{
 			switch (mode) {

--- a/src/PassKit/PKPaymentRequest.cs
+++ b/src/PassKit/PKPaymentRequest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Versioning;
 using Foundation;
 using ObjCRuntime;
 
@@ -41,13 +42,21 @@ namespace PassKit {
 
 	public partial class PKPaymentRequest {
 
+#if NET
+		[SupportedOSPlatform ("ios11.0")]
+#else
 		[Watch (4,0)][iOS (11,0)]
+#endif
 		public PKContactFields RequiredBillingContactFields {
 			get { return PKContactFieldsExtensions.GetValue (WeakRequiredBillingContactFields); }
 			set { WeakRequiredBillingContactFields = PKContactFieldsExtensions.GetSet (value); }
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios11.0")]
+#else
 		[Watch (4,0)][iOS (11,0)]
+#endif
 		public PKContactFields RequiredShippingContactFields {
 			get { return PKContactFieldsExtensions.GetValue (WeakRequiredShippingContactFields); }
 			set { WeakRequiredShippingContactFields = PKContactFieldsExtensions.GetSet (value); }

--- a/src/PdfKit/PdfAnnotation.cs
+++ b/src/PdfKit/PdfAnnotation.cs
@@ -8,6 +8,8 @@
 //
 
 using System;
+using System.Runtime.Versioning;
+
 using CoreGraphics;
 using Foundation;
 using ObjCRuntime;
@@ -17,7 +19,9 @@ using ObjCRuntime;
 namespace PdfKit {
 	public partial class PdfAnnotation {
 
+#if !NET
 		[Mac (10,12)]
+#endif
 		public bool SetValue<T> (T value, PdfAnnotationKey key) where T : class, INativeObject
 		{
 			if (value == null)
@@ -26,7 +30,9 @@ namespace PdfKit {
 			return _SetValue (value.Handle, key.GetConstant ()!);
 		}
 
+#if !NET
 		[Mac (10,12)]
+#endif
 		public bool SetValue (string str, PdfAnnotationKey key)
 		{
 			var nstr = NSString.CreateNative (str);
@@ -37,7 +43,9 @@ namespace PdfKit {
 			}
 		}
 
+#if !NET
 		[Mac (10,12)]
+#endif
 		public T GetValue<T> (PdfAnnotationKey key) where T : class, INativeObject
 		{
 			return Runtime.GetINativeObject<T> (_GetValue (key.GetConstant ()!), true);
@@ -48,7 +56,9 @@ namespace PdfKit {
 			set { Type = value.GetConstant (); }
 		}
 
+#if !NET
 		[Mac (10,13)]
+#endif
 		public CGPoint[] QuadrilateralPoints {
 			get {
 				return NSArray.ArrayFromHandleFunc<CGPoint> (_QuadrilateralPoints, (v) =>

--- a/src/SensorKit/SRAbsoluteTime.cs
+++ b/src/SensorKit/SRAbsoluteTime.cs
@@ -1,14 +1,21 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using ObjCRuntime;
 
 #nullable enable
 
 namespace SensorKit {
 
+#if NET
+	[SupportedOSPlatform ("ios14.0")]
+	[UnsupportedOSPlatform ("tvos")]
+	[UnsupportedOSPlatform ("macos")]
+#else
 	[NoWatch, NoTV, NoMac]
 	[iOS (14,0)]
 	[MacCatalyst (14,0)]
+#endif
 	public static class SRAbsoluteTime {
 
 		[DllImport (Constants.SensorKitLibrary, EntryPoint = "SRAbsoluteTimeGetCurrent")]

--- a/src/SensorKit/SRAmbientLightChromaticity.cs
+++ b/src/SensorKit/SRAmbientLightChromaticity.cs
@@ -1,13 +1,20 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using ObjCRuntime;
 
 #nullable enable
 
 namespace SensorKit {
 
+#if NET
+	[SupportedOSPlatform ("ios14.0")]
+	[UnsupportedOSPlatform ("tvos")]
+	[UnsupportedOSPlatform ("macos")]
+#else
 	[NoWatch, NoTV, NoMac]
 	[iOS (14,0)]
+#endif
 	[StructLayout (LayoutKind.Sequential)]
 	public struct SRAmbientLightChromaticity {
 		public float X;

--- a/src/SpriteKit/SKNode.cs
+++ b/src/SpriteKit/SKNode.cs
@@ -10,6 +10,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 using Foundation;
 using ObjCRuntime;
 
@@ -19,7 +20,9 @@ namespace SpriteKit
 {
 	public partial class SKNode : IEnumerable, IEnumerable<SKNode>
 	{
+#if !NET
 		[iOS (8,0), Mac (10,10)]
+#endif
 		public static T FromFile<T> (string file) where T : SKNode
 		{
 			IntPtr handle;
@@ -52,7 +55,12 @@ namespace SpriteKit
 			return GetEnumerator ();
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios12.0")]
+		[SupportedOSPlatform ("tvos12.0")]
+#else
 		[Watch (5,0), TV (12,0), Mac (10,14), iOS (12,0)]
+#endif
 		public static SKNode? Create (string filename, Type [] types, out NSError error)
 		{
 			// Let's fail early.
@@ -70,7 +78,12 @@ namespace SpriteKit
 			}
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios12.0")]
+		[SupportedOSPlatform ("tvos12.0")]
+#else
 		[Watch (5,0), TV (12,0), Mac (10,14), iOS (12,0)]
+#endif
 		public static SKNode? Create (string filename, NSSet<Class> classes, out NSError error)
 		{
 			// `filename` will be checked by `Create` later

--- a/src/SpriteKit/SKShapeNode.cs
+++ b/src/SpriteKit/SKShapeNode.cs
@@ -16,8 +16,10 @@ using ObjCRuntime;
 namespace SpriteKit {
 	public partial class SKShapeNode : SKNode {
 
+#if !NET
 		[iOS (8, 0)]
 		[Mac (10, 10)]
+#endif
 		public static SKShapeNode FromPoints (CGPoint [] points)
 		{
 			if (points == null)
@@ -26,8 +28,10 @@ namespace SpriteKit {
 			return FromPoints (ref points[0], (nuint) points.Length);
 		}
 
+#if !NET
 		[iOS (8, 0)]
 		[Mac (10, 10)]
+#endif
 		public static SKShapeNode FromPoints (CGPoint [] points, int offset, int length)
 		{
 			if (points == null)
@@ -38,8 +42,10 @@ namespace SpriteKit {
 			return FromPoints (ref points [offset], (nuint) length);
 		}
 
+#if !NET
 		[iOS (8, 0)]
 		[Mac (10, 10)]
+#endif
 		public static SKShapeNode FromSplinePoints (CGPoint [] points)
 		{
 			if (points == null)
@@ -48,8 +54,10 @@ namespace SpriteKit {
 			return FromSplinePoints (ref points[0], (nuint) points.Length);
 		}
 
+#if !NET
 		[iOS (8, 0)]
 		[Mac (10, 10)]
+#endif
 		public static SKShapeNode FromSplinePoints (CGPoint [] points, int offset, int length)
 		{
 			if (points == null)

--- a/src/StoreKit/NativeMethods.cs
+++ b/src/StoreKit/NativeMethods.cs
@@ -5,7 +5,9 @@ using ObjCRuntime;
 namespace StoreKit {
 
 	partial class SKReceiptRefreshRequest {
+#if !NET
 		[iOS (7,1), Mac (10,14)]
+#endif
 		[DllImport (Constants.StoreKitLibrary, EntryPoint = "SKTerminateForInvalidReceipt")]
 		static extern public void TerminateForInvalidReceipt ();
 	}

--- a/src/SystemConfiguration/CaptiveNetwork.cs
+++ b/src/SystemConfiguration/CaptiveNetwork.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
@@ -25,47 +26,87 @@ namespace SystemConfiguration {
 		// in Xcode 10 the CaptiveNetwork API are marked as prohibited on tvOS
 #if !XAMCORE_4_0
 		[Obsolete ("Always return 'null'.")]
+#if NET
+		[UnsupportedOSPlatform ("tvos")]
+#else
 		[Unavailable (PlatformName.TvOS)]
+#endif
 		public static Foundation.NSString NetworkInfoKeyBSSID => null;
 
 		[Obsolete ("Always return 'null'.")]
+#if NET
+		[UnsupportedOSPlatform ("tvos")]
+#else
 		[Unavailable (PlatformName.TvOS)]
+#endif
 		public static Foundation.NSString NetworkInfoKeySSID => null;
 
 		[Obsolete ("Always return 'null'.")]
+#if NET
+		[UnsupportedOSPlatform ("tvos")]
+#else
 		[Unavailable (PlatformName.TvOS)]
+#endif
 		public static Foundation.NSString NetworkInfoKeySSIDData => null;
 
 		[Obsolete ("Throw a 'NotSupportedException'.")]
+#if NET
+		[UnsupportedOSPlatform ("tvos")]
+#else
 		[Unavailable (PlatformName.TvOS)]
+#endif
 		public static bool MarkPortalOffline (string iface) => throw new NotSupportedException ();
 
 		[Obsolete ("Throw a 'NotSupportedException'.")]
+#if NET
+		[UnsupportedOSPlatform ("tvos")]
+#else
 		[Unavailable (PlatformName.TvOS)]
+#endif
 		public static bool MarkPortalOnline (string iface)  => throw new NotSupportedException ();
 
 		[Obsolete ("Throw a 'NotSupportedException'.")]
+#if NET
+		[UnsupportedOSPlatform ("tvos")]
+#else
 		[Unavailable (PlatformName.TvOS)]
+#endif
 		public static bool SetSupportedSSIDs (string[] ssids) => throw new NotSupportedException ();
 
 		[Obsolete ("Throw a 'NotSupportedException'.")]
+#if NET
+		[UnsupportedOSPlatform ("tvos")]
+#else
 		[Unavailable (PlatformName.TvOS)]
+#endif
 		public static StatusCode TryCopyCurrentNetworkInfo (string interfaceName, out Foundation.NSDictionary currentNetworkInfo)  => throw new NotSupportedException ();
 
 		[Obsolete ("Throw a 'NotSupportedException'.")]
+#if NET
+		[UnsupportedOSPlatform ("tvos")]
+#else
 		[Unavailable (PlatformName.TvOS)]
+#endif
 		public static StatusCode TryGetSupportedInterfaces (out string[] supportedInterfaces)  => throw new NotSupportedException ();
 #endif
 #else
 		
 #if !MONOMAC
 
+#if NET
+		[UnsupportedOSPlatform ("ios14.0")]
+#else
 		[Deprecated (PlatformName.iOS, 14,0)]
+#endif
 		[DllImport (Constants.SystemConfigurationLibrary)]
 		extern static IntPtr /* CFDictionaryRef __nullable */  CNCopyCurrentNetworkInfo (
 			/* CFStringRef __nonnull */ IntPtr interfaceName);
 
+#if NET
+		[UnsupportedOSPlatform ("ios14.0")]
+#else
 		[Deprecated (PlatformName.iOS, 14,0)]
+#endif
 		static public StatusCode TryCopyCurrentNetworkInfo (string interfaceName, out NSDictionary currentNetworkInfo)
 		{
 			using (var nss = new NSString (interfaceName)) {
@@ -87,7 +128,11 @@ namespace SystemConfiguration {
 		[DllImport (Constants.SystemConfigurationLibrary)]
 		extern static IntPtr /* CFArrayRef __nullable */ CNCopySupportedInterfaces ();
 
+#if NET
+		[UnsupportedOSPlatform ("ios14.0")]
+#else
 		[Deprecated (PlatformName.iOS, 14,0, message: "Use 'NEHotspotNetwork.FetchCurrent' instead.")]
+#endif
 		static public StatusCode TryGetSupportedInterfaces (out string[] supportedInterfaces)
 		{
 			IntPtr array = CNCopySupportedInterfaces ();
@@ -101,17 +146,29 @@ namespace SystemConfiguration {
 			return StatusCode.OK;
 		}
 
+#if NET
+		[UnsupportedOSPlatform ("ios9.0")]
+#else
 		[Deprecated (PlatformName.iOS, 9,0)]
+#endif
 		[DllImport (Constants.SystemConfigurationLibrary)]
 		[return: MarshalAs (UnmanagedType.U1)]
 		extern static bool CNMarkPortalOffline (IntPtr /* CFStringRef __nonnull */ interfaceName);
 
+#if NET
+		[UnsupportedOSPlatform ("ios9.0")]
+#else
 		[Deprecated (PlatformName.iOS, 9,0)]
+#endif
 		[DllImport (Constants.SystemConfigurationLibrary)]
 		[return: MarshalAs (UnmanagedType.U1)]
 		extern static bool CNMarkPortalOnline (IntPtr /* CFStringRef __nonnull */ interfaceName);
 
+#if NET
+		[UnsupportedOSPlatform ("ios9.0")]
+#else
 		[Deprecated (PlatformName.iOS, 9,0)]
+#endif
 		static public bool MarkPortalOnline (string iface)
 		{
 			using (var nss = new NSString (iface)) {
@@ -119,7 +176,11 @@ namespace SystemConfiguration {
 			}
 		}
 
+#if NET
+		[UnsupportedOSPlatform ("ios9.0")]
+#else
 		[Deprecated (PlatformName.iOS, 9,0)]
+#endif
 		static public bool MarkPortalOffline (string iface)
 		{
 			using (var nss = new NSString (iface)) {
@@ -127,12 +188,20 @@ namespace SystemConfiguration {
 			}
 		}
 
+#if NET
+		[UnsupportedOSPlatform ("ios9.0")]
+#else
 		[Deprecated (PlatformName.iOS, 9,0)]
+#endif
 		[DllImport (Constants.SystemConfigurationLibrary)]
 		[return: MarshalAs (UnmanagedType.U1)]
 		extern static bool CNSetSupportedSSIDs (IntPtr /* CFArrayRef __nonnull */ ssidArray);
 
+#if NET
+		[UnsupportedOSPlatform ("ios9.0")]
+#else
 		[Deprecated (PlatformName.iOS, 9,0)]
+#endif
 		static public bool SetSupportedSSIDs (string [] ssids)
 		{
 			using (var arr = NSArray.FromStrings (ssids)) {

--- a/src/SystemConfiguration/NetworkReachability.cs
+++ b/src/SystemConfiguration/NetworkReachability.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using ObjCRuntime;
 using CoreFoundation;
 using Foundation;
@@ -30,7 +31,11 @@ namespace SystemConfiguration {
 		ConnectionOnDemand = 1<<5,
 		IsLocalAddress = 1<<16,
 		IsDirect = 1<<17,
+#if NET
+		[UnsupportedOSPlatform ("macos")]
+#else
 		[Unavailable (PlatformName.MacOSX)]
+#endif
 		IsWWAN = 1<<18,
 		ConnectionAutomatic = ConnectionOnTraffic
 	}

--- a/src/VideoSubscriberAccount/VSAccountMetadataRequest.cs
+++ b/src/VideoSubscriberAccount/VSAccountMetadataRequest.cs
@@ -1,5 +1,6 @@
 #if !__MACCATALYST__
 using System;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using ObjCRuntime;
 
@@ -7,7 +8,12 @@ namespace VideoSubscriberAccount {
 
 	public partial class VSAccountMetadataRequest {
 
+#if NET
+		[SupportedOSPlatform ("ios10.2")]
+		[SupportedOSPlatform ("tvos10.1")]
+#else
 		[TV (10,1)][iOS (10,2)]
+#endif
 		public VSAccountProviderAuthenticationScheme[] SupportedAuthenticationSchemes {
 			get {
 				return VSAccountProviderAuthenticationSchemeExtensions.GetValues (SupportedAuthenticationSchemesString);

--- a/src/Vision/VNUtils.cs
+++ b/src/Vision/VNUtils.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using CoreGraphics;
 using ObjCRuntime;
 using Foundation;
@@ -16,7 +17,13 @@ using Foundation;
 using Vector2 = global::OpenTK.Vector2;
 
 namespace Vision {
+
+#if NET
+	[SupportedOSPlatform ("ios11.0")]
+	[SupportedOSPlatform ("tvos11.0")]
+#else
 	[TV (11,0), Mac (10,13), iOS (11,0)]
+#endif
 	public static partial class VNUtils {
 	
 		// initialized only once (see tests/cecil-tests/)
@@ -30,8 +37,14 @@ namespace Vision {
 		[DllImport (Constants.VisionLibrary, EntryPoint = "VNImagePointForNormalizedPoint")]
 		public static extern CGPoint GetImagePoint (CGPoint normalizedPoint, nuint imageWidth, nuint imageHeight);
 
+#if NET
+		[SupportedOSPlatform ("ios14.0")]
+		[SupportedOSPlatform ("tvos14.0")]
+		[SupportedOSPlatform ("macos11.0")]
+#else
 		[TV (14,0), Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
+#endif
 		[DllImport (Constants.VisionLibrary, EntryPoint = "VNNormalizedPointForImagePoint")]
 		public static extern CGPoint GetNormalizedPoint (CGPoint imagePoint, nuint imageWidth, nuint imageHeight);
 
@@ -67,11 +80,23 @@ namespace Vision {
 			return result;
 		}
 
+#if NET
+		[SupportedOSPlatform ("ios13.0")]
+		[SupportedOSPlatform ("tvos13.0")]
+		[SupportedOSPlatform ("macos10.15")]
+#else
 		[TV (13,0), Mac (10,15), iOS (13,0)]
+#endif
 		[DllImport (Constants.VisionLibrary)]
 		static extern nuint VNElementTypeSize (nuint elementType);
 
+#if NET
+		[SupportedOSPlatform ("ios13.0")]
+		[SupportedOSPlatform ("tvos13.0")]
+		[SupportedOSPlatform ("macos10.15")]
+#else
 		[TV (13,0), Mac (10,15), iOS (13,0)]
+#endif
 		public static nuint GetElementTypeSize (VNElementType elementType) => VNElementTypeSize ((nuint) (ulong) elementType);
 	}
 

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1023,8 +1023,10 @@ ITUNESLIBRARY_SOURCES = \
 
 # JavaScriptCore
 
-JAVASCRIPTCORE_SOURCES = \
+JAVASCRIPTCORE_API_SOURCES = \
 	JavaScriptCore/Enums.cs \
+
+JAVASCRIPTCORE_SOURCES = \
 	JavaScriptCore/Extensions.cs \
 
 # LocalAuthentication


### PR DESCRIPTION
Once complete the `LegacyAttributes` can be enabled in introspection to
ensure no old attributes are introduced.