### PR TITLE
[CI] Reduce the number of statuses when we build nugets.

### DIFF
--- a/tools/devops/automation/templates/build/build-nugets.yml
+++ b/tools/devops/automation/templates/build/build-nugets.yml
@@ -1,0 +1,39 @@
+# all steps that are required to build the nugets and publish them
+
+steps:
+
+- bash:  $(Build.SourcesDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/build-nugets.sh
+  displayName: 'Build Nugets'
+  condition: and(succeeded(), contains(variables['configuration.BuildNugets'], 'True'))
+  continueOnError: true # should not stop the build since is not official just yet.
+  timeoutInMinutes: 180
+
+- script: >-
+    dotnet build -t:GenerateBuildAssetRegistryManifest /v:n
+    $(Build.SourcesDirectory)/xamarin-macios/dotnet/package/Microsoft.iOS.Ref/package.csproj
+    -bl:$(Build.ArtifactStagingDirectory)/build-binlogs/generate-bar-manifest.binlog
+  displayName: Generate and Upload Build Asset Registry Manifest
+  condition: and(succeeded(), contains(variables['configuration.BuildNugets'], 'True'))
+
+- task: PublishPipelineArtifact@1
+  displayName: 'Publish Artifact: build-binlogs'
+  inputs:
+    targetPath: $(Build.ArtifactStagingDirectory)/build-binlogs
+    artifactName: build-binlogs
+  condition: and(succeededOrFailed(), contains(variables['configuration.BuildNugets'], 'True'))
+
+- task: NuGetCommand@2
+  displayName: 'Publish Nugets'
+  inputs:
+    command: push
+    packagesToPush: $(Build.SourcesDirectory)/package/*.nupkg
+    nuGetFeedType: external
+    publishFeedCredentials: xamarin-impl public feed
+  condition: and(succeeded(), eq(variables['configuration.BuildNugets'], 'True'))
+
+# Only executed when the publshing of the nugets failed.
+- bash: |
+    echo "##vso[task.setvariable variable=NUGETS_PUBLISHED;isOutput=true]Failed"
+  name: nugetPublishing
+  displayName: 'On tests timeout'
+  condition: failed()

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -300,35 +300,7 @@ steps:
   timeoutInMinutes: 180
 
 # build nugets
-- bash:  $(Build.SourcesDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/build-nugets.sh
-  displayName: 'Build Nugets'
-  condition: and(succeeded(), contains(variables['configuration.BuildNugets'], 'True'))
-  continueOnError: true # should not stop the build since is not official just yet.
-  timeoutInMinutes: 180
-
-- script: >-
-    dotnet build -t:GenerateBuildAssetRegistryManifest /v:n
-    $(Build.SourcesDirectory)/xamarin-macios/dotnet/package/Microsoft.iOS.Ref/package.csproj
-    -bl:$(Build.ArtifactStagingDirectory)/build-binlogs/generate-bar-manifest.binlog
-  displayName: Generate and Upload Build Asset Registry Manifest
-  condition: and(succeeded(), contains(variables['configuration.BuildNugets'], 'True'))
-
-- task: PublishPipelineArtifact@1
-  displayName: 'Publish Artifact: build-binlogs'
-  inputs:
-    targetPath: $(Build.ArtifactStagingDirectory)/build-binlogs
-    artifactName: build-binlogs
-  condition: and(succeededOrFailed(), contains(variables['configuration.BuildNugets'], 'True'))
-
-- task: NuGetCommand@2
-  displayName: 'Publish Nugets'
-  inputs:
-    command: push
-    packagesToPush: $(Build.SourcesDirectory)/package/*.nupkg
-    nuGetFeedType: external
-    publishFeedCredentials: xamarin-impl public feed
-  condition: and(succeeded(), eq(variables['configuration.BuildNugets'], 'True'))
-  continueOnError: true # should not stop the build since is not official just yet.
+- template: build-nugets.yml
 
 # only sign an notarize in no PR executions
 - ${{ if ne(parameters.isPR, 'True') }}:

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -99,11 +99,15 @@ jobs:
 - job: upload_azure_blob
   displayName: 'Upload packages to Azure'
   timeoutInMinutes: 1000
-  dependsOn: build # can start as soon as the packages are available
+  dependsOn:
+  - configure
+  - build # can start as soon as the packages are available
   condition: and(succeeded(), contains (dependencies.build.outputs['configuration.BuildPkgs'], 'True')) # only run when we do have pkgs
 
   variables:
     Parameters.outputStorageUri: ''
+    NUGETS_PUBLISHED: $[ dependencies.build.outputs['nugetPublishing.NUGETS_PUBLISHED'] ]
+    SKIP_NUGETS: $[ dependencies.configure.outputs['labels.skip-nugets'] ]
 
   pool:
     vmImage: 'windows-latest'

--- a/tools/devops/automation/templates/build/upload-azure.yml
+++ b/tools/devops/automation/templates/build/upload-azure.yml
@@ -164,13 +164,24 @@ steps:
        Set-GitHubStatus -Status "error" -Description "msbuild.zip not found." -Context "msbuild.zip"
     }
 
-    $nugets =  $files = Get-ChildItem -Path $pkgsPath -Filter *.nupkg -File -Name
+    if ($Env:SkipNugets -ne "True") {
+      $nugets = Get-ChildItem -Path $pkgsPath -Filter *.nupkg -File -Name
 
-    foreach ($n in $nugets) {
-      Set-GitHubStatus -Status "success" -Description "$n" -TargetUrl "$pkgsVirtualUrl/$n" -Context "$n"
+      if ($nugets.Count > 0)
+        Set-GitHubStatus -Status "success" -Description "Nugets built." -TargetUrl "$pkgsVirtualUrl/$n" -Context "$(Build.DefinitionName) (Nugets built)"
+        if ($Env:NUGETS_PUBLISHED -ne "Failed") {
+          Set-GitHubStatus -Status "success" -Description "Nugets published." -TargetUrl "$pkgsVirtualUrl/$n" -Context "$(Build.DefinitionName) (Nugets published)"
+        } else {
+          Set-GitHubStatus -Status "error" -Description "Error when publishing nugets." -TargetUrl "$pkgsVirtualUrl/$n" -Context "$(Build.DefinitionName) (Nugets published)"
+        }
+      } else {
+        Set-GitHubStatus -Status "error" -Description "No nugets were built." -TargetUrl "$pkgsVirtualUrl/$n" -Context "$(Build.DefinitionName) (Nugets built)"
+        Set-GitHubStatus -Status "error" -Description "No nugets were published." -TargetUrl "$pkgsVirtualUrl/$n" -Context "$(Build.DefinitionName) (Nugets published)"
+      }
     }
 
-    $msi =  $files = Get-ChildItem -Path $pkgsPath -Filter *.msi -File -Name
+
+    $msi = Get-ChildItem -Path $pkgsPath -Filter *.msi -File -Name
 
     foreach ($n in $msi) {
       Set-GitHubStatus -Status "success" -Description "$n" -TargetUrl "$pkgsVirtualUrl/$n" -Context "$n"


### PR DESCRIPTION
We move from having a status per nugets to two statues:

1. xamarin-macios (Nugets built) -  to let us know that we did build
   nugets.
2. xamarin-macios (Nuvets published) - to let us know tat we did pubish
   the nugets.