### PR TITLE
[xtro] Update MacCatalyst todos.

### DIFF
--- a/tests/xtro-sharpie/MacCatalyst-AVKit.ignore
+++ b/tests/xtro-sharpie/MacCatalyst-AVKit.ignore
@@ -1,3 +1,6 @@
+## OSX-only enums (removed in XAMCORE_3_0)
+!unknown-native-enum! AVPlayerViewControlsStyle bound
+
 ## extra error values are fine and helps sharing code across platforms
 !extra-enum-value! Managed value -1100 for AVKitError.ContentRatingUnknown not found in native headers
 !extra-enum-value! Managed value -1101 for AVKitError.ContentDisallowedByPasscode not found in native headers

--- a/tests/xtro-sharpie/MacCatalyst-AudioToolbox.todo
+++ b/tests/xtro-sharpie/MacCatalyst-AudioToolbox.todo
@@ -24,14 +24,7 @@
 !missing-field! kAudioSessionOutputRoute_USBAudio not bound
 !missing-pinvoke! AudioComponentCopyConfigurationInfo is not bound
 !missing-pinvoke! AudioComponentValidate is not bound
-!missing-pinvoke! AudioSessionAddPropertyListener is not bound
-!missing-pinvoke! AudioSessionGetProperty is not bound
-!missing-pinvoke! AudioSessionGetPropertySize is not bound
-!missing-pinvoke! AudioSessionInitialize is not bound
 !missing-pinvoke! AudioSessionRemovePropertyListenerWithUserData is not bound
-!missing-pinvoke! AudioSessionSetActive is not bound
-!missing-pinvoke! AudioSessionSetActiveWithFlags is not bound
-!missing-pinvoke! AudioSessionSetProperty is not bound
 !missing-pinvoke! MusicDevicePrepareInstrument is not bound
 !missing-pinvoke! MusicDeviceReleaseInstrument is not bound
 !missing-pinvoke! MusicSequenceLoadSMFDataWithFlags is not bound

--- a/tests/xtro-sharpie/MacCatalyst-UIKit.ignore
+++ b/tests/xtro-sharpie/MacCatalyst-UIKit.ignore
@@ -1,3 +1,12 @@
+# Apple docs: Deprecated in iOS 3.2
+!unknown-field! UIKeyboardBoundsUserInfoKey bound
+!unknown-field! UIKeyboardCenterBeginUserInfoKey bound
+!unknown-field! UIKeyboardCenterEndUserInfoKey bound
+
+## Obsoleted selectors in very early versions of iOS (3.0) and removed in XAMCORE_3_0
+!extra-protocol-member! unexpected selector UITableViewDelegate::tableView:accessoryTypeForRowWithIndexPath: found
+!extra-protocol-member! unexpected selector UIImagePickerControllerDelegate::imagePickerController:didFinishPickingImage:editingInfo: found
+
 # deprecated types, not working at runtime
 !missing-protocol! UISearchDisplayDelegate not bound
 !missing-selector! NSStringDrawingContext::minimumTrackingAdjustment not bound

--- a/tests/xtro-sharpie/MacCatalyst-UIKit.todo
+++ b/tests/xtro-sharpie/MacCatalyst-UIKit.todo
@@ -49,7 +49,6 @@
 !incorrect-protocol-member! UIFocusItem::frame is REQUIRED and should be abstract
 !incorrect-protocol-member! UITextDocumentProxy::setMarkedText:selectedRange: is REQUIRED and should be abstract
 !incorrect-protocol-member! UITextDocumentProxy::unmarkText is REQUIRED and should be abstract
-!missing-enum! NSTextWritingDirection not bound
 !missing-enum! UIDirectionalRectEdge not bound
 !missing-enum! UITitlebarTitleVisibility not bound
 !missing-enum! UITitlebarToolbarStyle not bound


### PR DESCRIPTION
Fixes:

    ?fixed-todo? Entry '!missing-pinvoke! AudioSessionAddPropertyListener is not bound' in 'MacCatalyst-AudioToolbox.todo' is not found in corresponding 'MacCatalyst-AudioToolbox.raw' file
    ?fixed-todo? Entry '!missing-pinvoke! AudioSessionGetProperty is not bound' in 'MacCatalyst-AudioToolbox.todo' is not found in corresponding 'MacCatalyst-AudioToolbox.raw' file
    ?fixed-todo? Entry '!missing-pinvoke! AudioSessionGetPropertySize is not bound' in 'MacCatalyst-AudioToolbox.todo' is not found in corresponding 'MacCatalyst-AudioToolbox.raw' file
    ?fixed-todo? Entry '!missing-pinvoke! AudioSessionInitialize is not bound' in 'MacCatalyst-AudioToolbox.todo' is not found in corresponding 'MacCatalyst-AudioToolbox.raw' file
    ?fixed-todo? Entry '!missing-pinvoke! AudioSessionSetActive is not bound' in 'MacCatalyst-AudioToolbox.todo' is not found in corresponding 'MacCatalyst-AudioToolbox.raw' file
    ?fixed-todo? Entry '!missing-pinvoke! AudioSessionSetActiveWithFlags is not bound' in 'MacCatalyst-AudioToolbox.todo' is not found in corresponding 'MacCatalyst-AudioToolbox.raw' file
    ?fixed-todo? Entry '!missing-pinvoke! AudioSessionSetProperty is not bound' in 'MacCatalyst-AudioToolbox.todo' is not found in corresponding 'MacCatalyst-AudioToolbox.raw' file
    ?fixed-todo? Entry '!missing-enum! NSTextWritingDirection not bound' in 'MacCatalyst-UIKit.todo' is not found in corresponding 'MacCatalyst-UIKit.raw' file
    Sanity check failed (8)
    make: *** [classify] Error 8