### PR TITLE
[CoreCLR] Implement mono_assembly_get_object.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -167,4 +167,15 @@ mono_domain_get (void)
 	return NULL;
 }
 
+// returns a retained MonoReflectionAssembly *
+MonoReflectionAssembly *
+mono_assembly_get_object (MonoDomain * domain, MonoAssembly * assembly)
+{
+	// MonoAssembly and MonoReflectionAssembly are identical in CoreCLR (both are actually MonoObjects).
+	// However, we're returning a retained object, so we need to retain here.
+	xamarin_mono_object_retain (assembly);
+	LOG_CORECLR (stderr, "mono_assembly_get_object (%p, %p): rv: %p\n", domain, assembly, assembly);
+	return assembly;
+}
+
 #endif // CORECLR_RUNTIME

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -366,7 +366,9 @@
 		new Export ("MonoReflectionAssembly *", "mono_assembly_get_object",
 			"MonoDomain *", "domain",
 			"MonoAssembly *", "assembly"
-		),
+		) {
+			HasCoreCLRBridgeFunction = true,
+		},
 
 		new Export ("MonoReflectionMethod *", "mono_method_get_object",
 			"MonoDomain *", "domain",

--- a/runtime/mono-runtime.h.t4
+++ b/runtime/mono-runtime.h.t4
@@ -97,7 +97,12 @@ typedef struct _MonoClassField MonoClassField;
 typedef struct _MonoString MonoString;
 typedef struct _MonoArray MonoArray;
 typedef struct _MonoReflectionMethod MonoReflectionMethod;
+#if defined (CORECLR_RUNTIME)
+// In Mono, MonoReflectionAssembly is a substruct of MonoObject, but for the CoreCLR bridge we use the same struct representation for both types.
+typedef struct _MonoObject MonoReflectionAssembly;
+#else
 typedef struct _MonoReflectionAssembly MonoReflectionAssembly;
+#endif
 typedef struct _MonoReflectionType MonoReflectionType;
 typedef struct _MonoException MonoException;
 typedef struct _MonoThread MonoThread;

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -433,7 +433,9 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 	}
 
 	if (xamarin_supports_dynamic_registration) {
-		xamarin_register_entry_assembly (mono_assembly_get_object (mono_domain_get (), assembly), &exception_gchandle);
+		MonoReflectionAssembly *rassembly = mono_assembly_get_object (mono_domain_get (), assembly);
+		xamarin_register_entry_assembly (rassembly, &exception_gchandle);
+		xamarin_mono_object_release (&rassembly);
 		if (exception_gchandle != NULL)
 			xamarin_process_managed_exception_gchandle (exception_gchandle);
 	}

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -994,7 +994,9 @@ xamarin_register_monoassembly (MonoAssembly *assembly, GCHandle *exception_gchan
 		LOG (PRODUCT ": Skipping assembly registration for %s since it's not needed (dynamic registration is not supported)", mono_assembly_name_get_name (mono_assembly_get_name (assembly)));
 		return true;
 	}
-	xamarin_register_assembly (mono_assembly_get_object (mono_domain_get (), assembly), exception_gchandle);
+	MonoReflectionAssembly *rassembly = mono_assembly_get_object (mono_domain_get (), assembly);
+	xamarin_register_assembly (rassembly, exception_gchandle);
+	xamarin_mono_object_release (&rassembly);
 	return *exception_gchandle == INVALID_GCHANDLE;
 }
 


### PR DESCRIPTION
Next failure is now:

> monotouchtest[27142:4675921] Xamarin.Mac: The method mono_profiler_install has not been implemented for CoreCLR.