### PR TITLE
[runtime] Move the code to wrap every managed thread with an NSAutoreleasePool to the MonoVM bridge.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -49,6 +49,13 @@ xamarin_bridge_vm_initialize (int propertyCount, const char **propertyKeys, cons
 }
 
 void
+xamarin_install_nsautoreleasepool_hooks ()
+{
+	// https://github.com/xamarin/xamarin-macios/issues/11256
+	fprintf (stderr, "TODO: add support for wrapping all threads with NSAutoreleasePools.\n");
+}
+
+void
 xamarin_handle_bridge_exception (GCHandle gchandle, const char *method)
 {
 	if (gchandle == INVALID_GCHANDLE)

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -201,7 +201,9 @@
 		new Export ("void", "mono_profiler_install_thread",
 			"MonoProfileThreadFunc", "start",
 			"MonoProfileThreadFunc", "end"
-		),
+		) {
+			XamarinRuntime = RuntimeMode.MonoVM,
+		},
 
 		new Export ("void", "mono_profiler_install_gc",
 			"MonoProfileGCFunc", "callback",
@@ -218,7 +220,9 @@
 
 		new Export ("mono_bool", "mono_thread_is_foreign",
 			"MonoThread *", "thread"
-		),
+		) {
+			XamarinRuntime = RuntimeMode.MonoVM,
+		},
 
 		new Export ("MonoThread * ", "mono_thread_current"),
 

--- a/runtime/monovm-bridge.m
+++ b/runtime/monovm-bridge.m
@@ -11,6 +11,7 @@
 #if !defined (CORECLR_RUNTIME)
 
 #include <TargetConditionals.h>
+#include <pthread.h>
 
 #if !DOTNET && TARGET_OS_OSX
 #define LEGACY_XAMARIN_MAC 1
@@ -193,6 +194,86 @@ xamarin_get_runtime_class ()
 	if (runtime_class == NULL)
 		xamarin_assertion_message ("Internal consistency error, please file a bug (https://github.com/xamarin/xamarin-macios/issues/new). Additional data: can't get the %s class because it's been linked away.\n", "Runtime");
 	return runtime_class;
+}
+
+/* Wrapping threads with NSAutoreleasePool
+ *
+ * We must create an NSAutoreleasePool for each thread, so users
+ * don't have to do it manually.
+ *
+ * Use mono's profiling API to get notified for thread start/stop,
+ * and create a pool that spans the thread's entire lifetime.
+ */
+
+static CFMutableDictionaryRef xamarin_thread_hash = NULL;
+static pthread_mutex_t thread_hash_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static void
+xamarin_thread_start (void *user_data)
+{
+	// COOP: no managed memory access: any mode. Switching to safe mode since we're locking a mutex.
+	NSAutoreleasePool *pool;
+
+	if (mono_thread_is_foreign (mono_thread_current ()))
+		return;
+
+	MONO_ENTER_GC_SAFE;
+
+	pool = [[NSAutoreleasePool alloc] init];
+
+	pthread_mutex_lock (&thread_hash_lock);
+
+	CFDictionarySetValue (xamarin_thread_hash, GINT_TO_POINTER (pthread_self ()), pool);
+
+	pthread_mutex_unlock (&thread_hash_lock);
+
+	MONO_EXIT_GC_SAFE;
+}
+
+static void
+xamarin_thread_finish (void *user_data)
+{
+	// COOP: no managed memory access: any mode. Switching to safe mode since we're locking a mutex.
+	NSAutoreleasePool *pool;
+
+	MONO_ENTER_GC_SAFE;
+
+	/* Don't drain the pool while holding the thread hash lock. */
+	pthread_mutex_lock (&thread_hash_lock);
+
+	pool = (NSAutoreleasePool *) CFDictionaryGetValue (xamarin_thread_hash, GINT_TO_POINTER (pthread_self ()));
+	if (pool)
+		CFDictionaryRemoveValue (xamarin_thread_hash, GINT_TO_POINTER (pthread_self ()));
+
+	pthread_mutex_unlock (&thread_hash_lock);
+
+	if (pool)
+		[pool drain];
+
+	MONO_EXIT_GC_SAFE;
+}
+
+static void
+thread_start (MonoProfiler *prof, uintptr_t tid)
+{
+	// COOP: no managed memory access: any mode.
+	xamarin_thread_start (NULL);
+}
+
+static void
+thread_end (MonoProfiler *prof, uintptr_t tid)
+{
+	// COOP: no managed memory access: any mode.
+	xamarin_thread_finish (NULL);
+}
+
+void
+xamarin_install_nsautoreleasepool_hooks ()
+{
+	// COOP: executed at startup (and no managed memory access): any mode.
+	xamarin_thread_hash = CFDictionaryCreateMutable (kCFAllocatorDefault, 0, NULL, NULL);
+
+	mono_profiler_install_thread (thread_start, thread_end);
 }
 
 #if DOTNET

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -921,6 +921,7 @@ gc_enable_new_refcount (void)
 }
 #endif // !CORECLR_RUNTIME
 
+#if !defined (CORECLR_RUNTIME)
 struct _MonoProfiler {
 	int dummy;
 };
@@ -933,6 +934,7 @@ xamarin_install_mono_profiler ()
 	// (currently gc_enable_new_refcount and xamarin_install_nsautoreleasepool_hooks).
 	mono_profiler_install (&profiler, NULL);
 }
+#endif
 
 bool
 xamarin_file_exists (const char *path)
@@ -1381,7 +1383,9 @@ xamarin_initialize ()
 	xamarin_bridge_register_product_assembly (&exception_gchandle);
 	xamarin_process_managed_exception_gchandle (exception_gchandle);
 
+#if !defined (CORECLR_RUNTIME)
 	xamarin_install_mono_profiler (); // must be called before xamarin_install_nsautoreleasepool_hooks or gc_enable_new_refcount
+#endif
 
 	xamarin_install_nsautoreleasepool_hooks ();
 

--- a/runtime/shared.h
+++ b/runtime/shared.h
@@ -23,7 +23,6 @@ extern "C" {
 typedef void (init_cocoa_func) (void);
 void xamarin_initialize_cocoa_threads (init_cocoa_func *func);
 
-void xamarin_install_nsautoreleasepool_hooks ();
 id xamarin_init_nsthread (id obj, bool is_direct, id target, SEL sel, id arg);
 void xamarin_insert_dllmap ();
 

--- a/runtime/shared.m
+++ b/runtime/shared.m
@@ -11,7 +11,6 @@
 #include <objc/objc.h>
 #include <objc/runtime.h>
 #include <objc/message.h>
-#include <pthread.h>
 
 #import <Foundation/Foundation.h>
 
@@ -149,86 +148,6 @@ xamarin_initialize_cocoa_threads (init_cocoa_func *func)
 	[[[XamarinCocoaThreadInitializer alloc] initWithFunc: func] autorelease];
 }
 
-/* Wrapping threads with NSAutoreleasePool
- *
- * We must create an NSAutoreleasePool for each thread, so users
- * don't have to do it manually.
- * 
- * Use mono's profiling API to get notified for thread start/stop,
- * and create a pool that spans the thread's entire lifetime.
- */
-
-static CFMutableDictionaryRef xamarin_thread_hash = NULL;
-static pthread_mutex_t thread_hash_lock = PTHREAD_MUTEX_INITIALIZER;
-
-static void
-xamarin_thread_start (void *user_data)
-{
-	// COOP: no managed memory access: any mode. Switching to safe mode since we're locking a mutex.
-	NSAutoreleasePool *pool;
-
-	if (mono_thread_is_foreign (mono_thread_current ()))
-		return;
-
-	MONO_ENTER_GC_SAFE;
-
-	pool = [[NSAutoreleasePool alloc] init];
-
-	pthread_mutex_lock (&thread_hash_lock);
-
-	CFDictionarySetValue (xamarin_thread_hash, GINT_TO_POINTER (pthread_self ()), pool);
-
-	pthread_mutex_unlock (&thread_hash_lock);
-
-	MONO_EXIT_GC_SAFE;
-}
-	
-static void
-xamarin_thread_finish (void *user_data)
-{
-	// COOP: no managed memory access: any mode. Switching to safe mode since we're locking a mutex.
-	NSAutoreleasePool *pool;
-
-	MONO_ENTER_GC_SAFE;
-
-	/* Don't drain the pool while holding the thread hash lock. */
-	pthread_mutex_lock (&thread_hash_lock);
-
-	pool = (NSAutoreleasePool *) CFDictionaryGetValue (xamarin_thread_hash, GINT_TO_POINTER (pthread_self ()));
-	if (pool)
-		CFDictionaryRemoveValue (xamarin_thread_hash, GINT_TO_POINTER (pthread_self ()));
-
-	pthread_mutex_unlock (&thread_hash_lock);
-
-	if (pool)
-		[pool drain];
-		
-	MONO_EXIT_GC_SAFE;
-}
-
-static void
-thread_start (MonoProfiler *prof, uintptr_t tid)
-{
-	// COOP: no managed memory access: any mode.
-	xamarin_thread_start (NULL);
-}
-
-static void
-thread_end (MonoProfiler *prof, uintptr_t tid)
-{
-	// COOP: no managed memory access: any mode.
-	xamarin_thread_finish (NULL);
-}
-
-void
-xamarin_install_nsautoreleasepool_hooks ()
-{
-	// COOP: executed at startup (and no managed memory access): any mode.
-	xamarin_thread_hash = CFDictionaryCreateMutable (kCFAllocatorDefault, 0, NULL, NULL);
-
-	mono_profiler_install_thread (thread_start, thread_end);
-}
-	
 /* Threads & Blocks
  * 
  * At the moment we can't execute managed code in the dispose method for a block (the process may deadlock,

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -209,6 +209,7 @@ void*			xamarin_pinvoke_override (const char *libraryName, const char *entrypoin
 void			xamarin_bridge_call_runtime_initialize (struct InitializationOptions* options, GCHandle* exception_gchandle);
 void			xamarin_bridge_register_product_assembly (GCHandle* exception_gchandle);
 bool			xamarin_register_monoassembly (MonoAssembly *assembly, GCHandle *exception_gchandle);
+void			xamarin_install_nsautoreleasepool_hooks ();
 
 MonoObject *	xamarin_new_nsobject (id self, MonoClass *klass, GCHandle *exception_gchandle);
 bool			xamarin_has_managed_ref (id self);


### PR DESCRIPTION
The current implementation is MonoVM-specific, and won't work with CoreCLR
(something else will have to be implemented for CoreCLR, which is tracked
here: https://github.com/xamarin/xamarin-macios/issues/11256).

Next failure is now (after #11254 is merged as well):

> monotouchtest[50744:5001174] Xamarin.Mac: The method mono_jit_exec has not been implemented for CoreCLR.