### PR TITLE
[ObjCRuntime] Print to stderr if using xamarin_log fails. Fixes #11239.

### DIFF
--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -27,7 +27,7 @@ namespace ObjCRuntime {
 		[System.Diagnostics.Conditional ("UNDEFINED")]
 		static void log_coreclr (string message)
 		{
-			xamarin_log (message);
+			NSLog (message);
 		}
 
 		// Returns a retained MonoObject. Caller must release.

--- a/tests/xtro-sharpie/common-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/common-CoreFoundation.ignore
@@ -981,6 +981,7 @@
 !unknown-pinvoke! dispatch_walltime bound
 !unknown-pinvoke! dispatch_write bound
 !unknown-pinvoke! open bound
+!unknown-pinvoke! write bound
 !missing-field! kCFStreamErrorDomainSOCKS not bound
 !missing-field! kCFStreamErrorDomainSSL not bound
 !missing-field! kCFStreamPropertyShouldCloseNativeSocket not bound


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/11239.