### PR TITLE
[msbuild] Rename $(_UsingXamarinSdk) to $(UsingAppleNETSdk)

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -9,6 +9,8 @@
 	<Import Project="Xamarin.Shared.Sdk.TargetFrameworkInference.props" />
 
 	<PropertyGroup>
+		<!-- Set to true when using the Microsoft.<platform>.Sdk NuGet. This is used by pre-existing/shared targets to tweak behavior depending on build system -->
+		<UsingAppleNETSdk>true</UsingAppleNETSdk>
 		<SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' ">true</SuppressTrimAnalysisWarnings>
 		<AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(MSBuildThisFileDirectory)Microsoft.$(_PlatformName).Sdk.targets</AfterMicrosoftNETSdkTargets>
 	</PropertyGroup>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -2,8 +2,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 	<PropertyGroup>
-		<!-- Set to true when using the Microsoft.<platform>.Sdk NuGet. This is used by pre-existing/shared targets to tweak behavior depending on build system -->
-		<_UsingXamarinSdk>true</_UsingXamarinSdk>
 		<!-- This is the location of the Microsoft.<platform>.Sdk NuGet (/usr/local/share/dotnet/sdk/<version>/Sdks/Microsoft.[iOS/tvOS/watchOS/macOS].Sdk) -->
 		<_XamarinSdkRootDirectory>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..'))\</_XamarinSdkRootDirectory>
 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.AppExtension.CSharp.targets
@@ -26,7 +26,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(_UsingXamarinSdk)' != 'true'" />
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.Mac.AppExtension.Common.targets" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.CSharp.targets
@@ -23,7 +23,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkIdentifier)' == '' And '$(TargetFrameworkVersion)' == ''">v4.5</TargetFrameworkVersion>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(_UsingXamarinSdk)' != 'true'" />
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 
 	<Import Project="Xamarin.Mac.Common.targets" />
 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -39,7 +39,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<_AppBundleName>$(AssemblyName)</_AppBundleName>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(_UsingXamarinSdk)' != 'true'">
+	<PropertyGroup Condition="'$(UsingAppleNETSdk)' != 'true'">
 		<BuildDependsOn>
 			BuildOnlySettings;
 			_CollectBundleResources;
@@ -55,7 +55,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<CreateAppBundleDependsOn Condition="'$(_UsingXamarinSdk)' != 'true'">
+		<CreateAppBundleDependsOn Condition="'$(UsingAppleNETSdk)' != 'true'">
 			_DetectSigningIdentity;
 			_CopyResourcesToBundle;
 			_SmeltMetal;
@@ -84,7 +84,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		</_CodesignAppBundleDependsOn>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(_UsingXamarinSdk)' != 'true'">
+	<PropertyGroup Condition="'$(UsingAppleNETSdk)' != 'true'">
 		<CleanDependsOn>
 			$(CleanDependsOn);
 			_CleanAppBundle;
@@ -203,7 +203,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	</PropertyGroup>
 
 	<Target Name="_CompileToNative" DependsOnTargets="$(CompileToNativeDependsOn)"
-		Condition = "'$(_UsingXamarinSdk)' != 'true'"
+		Condition = "'$(UsingAppleNETSdk)' != 'true'"
 		Inputs="@(_CompileToNativeInput);@(_FileNativeReference);@(BundleDependentFiles)"
 		Outputs="$(_AppBundlePath)Contents\MacOS\$(_AppBundleName);$(DeviceSpecificOutputPath)bundler.stamp">
 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -29,13 +29,13 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 	import Microsoft.CSharp.targets. However, we can't do most of Xamarin.Mac.ObjCBinding.CSharp.props before it. -->
 
 	<Choose>
-		<When Condition=" '$(UseXamMacFullFramework)' == '' And ( '$(TargetFrameworkVersion)' == 'v2.0' Or '$(TargetFrameworkVersion)' == '' ) And '$(_UsingXamarinSdk)' != 'true'">
+		<When Condition=" '$(UseXamMacFullFramework)' == '' And ( '$(TargetFrameworkVersion)' == 'v2.0' Or '$(TargetFrameworkVersion)' == '' ) And '$(UsingAppleNETSdk)' != 'true'">
 			<PropertyGroup>
 				<TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
 				<TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
 			</PropertyGroup>
 		</When>
-		<When Condition="'$(_UsingXamarinSdk)' != 'true'">
+		<When Condition="'$(UsingAppleNETSdk)' != 'true'">
 			<PropertyGroup>
 				<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
 				<UseXamMacFullFramework>true</UseXamMacFullFramework>
@@ -44,7 +44,7 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 		</When>
 	</Choose>
 
-	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(_UsingXamarinSdk)' != 'true'" />
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.ObjCBinding.CSharp.props"/>
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.ObjCBinding.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.ObjCBinding.targets
@@ -19,7 +19,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 	<!-- Add our own pre-build steps -->
-	<PropertyGroup Condition="'$(_UsingXamarinSdk)' != 'true'">
+	<PropertyGroup Condition="'$(UsingAppleNETSdk)' != 'true'">
 		<BuildDependsOn>
 			BuildOnlySettings;
 			_CreateGeneratedSourcesDir;
@@ -29,7 +29,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 	</PropertyGroup>
 
 	<!-- Add our own Clean steps -->
-	<PropertyGroup Condition="'$(_UsingXamarinSdk)' != 'true'">
+	<PropertyGroup Condition="'$(UsingAppleNETSdk)' != 'true'">
 		<CleanDependsOn>
 			_CleanGeneratedSources;
 			$(CleanDependsOn)

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -184,7 +184,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<RemoveDir Directories="$(BindingResourcePath);" />  
 	</Target>
 	
-	<Target Name="_AddExtraReferences" BeforeTargets="ResolveAssemblyReferences" Condition="'$(DisableExtraReferences)' != 'true' And '$(_UsingXamarinSdk)' != 'true'">
+	<Target Name="_AddExtraReferences" BeforeTargets="ResolveAssemblyReferences" Condition="'$(DisableExtraReferences)' != 'true' And '$(UsingAppleNETSdk)' != 'true'">
 		<ItemGroup>
 			<!-- https://github.com/mono/mono/issues/13483 -->
 			<Reference Include="System.Drawing.Common.dll" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.MacCatalyst.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.MacCatalyst.CSharp.targets
@@ -23,7 +23,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(_UsingXamarinSdk)' != 'true'" />
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 
 	<Import Project="Xamarin.MacCatalyst.Common.targets" />
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.CSharp.targets
@@ -27,7 +27,7 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(_UsingXamarinSdk)' != 'true'" />
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.TVOS.AppExtension.Common.targets" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.CSharp.targets
@@ -23,7 +23,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(_UsingXamarinSdk)' != 'true'" />
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.TVOS.Common.targets" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.CSharp.targets
@@ -22,7 +22,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 	</PropertyGroup>
-	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(_UsingXamarinSdk)' != 'true'" />
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.WatchOS.App.Common.targets" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.CSharp.targets
@@ -26,7 +26,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- See Xamarin.iOS.AppExtension.CSharp.targets for a detailed explanation of this variable -->
 		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 	</PropertyGroup>
-	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(_UsingXamarinSdk)' != 'true'" />
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.WatchOS.AppExtension.Common.targets" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.CSharp.targets
@@ -22,7 +22,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 	</PropertyGroup>
-	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(_UsingXamarinSdk)' != 'true'" />
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.WatchOS.Common.targets" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.CSharp.targets
@@ -39,7 +39,7 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		-->
 		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 	</PropertyGroup>
-	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(_UsingXamarinSdk)' != 'true'" />
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.iOS.AppExtension.Common.targets" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.CSharp.targets
@@ -22,7 +22,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 	</PropertyGroup>
-	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(_UsingXamarinSdk)' != 'true'" />
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.iOS.Common.targets" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
@@ -63,7 +63,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</ItemGroup>
 
 	<!-- Do not resolve from the GAC under any circumstances in Mobile -->
-	<PropertyGroup Condition="'$(_UsingXamarinSdk)' != 'true'">
+	<PropertyGroup Condition="'$(UsingAppleNETSdk)' != 'true'">
 		<AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}',''))</AssemblySearchPaths>
 		<AssemblySearchPaths Condition="'$(MSBuildRuntimeVersion)' != ''">$(AssemblySearchPaths.Split(';'))</AssemblySearchPaths>
 	</PropertyGroup>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -65,7 +65,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</ItemDefinitionGroup>
 
 	<!-- Insert our app bundle generation step -->
-	<PropertyGroup Condition="'$(_UsingXamarinSdk)' != 'true'">
+	<PropertyGroup Condition="'$(UsingAppleNETSdk)' != 'true'">
 		<BuildDependsOn>
 			BuildOnlySettings;
 			PrepareForBuild;
@@ -131,7 +131,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<Target Name="_OptimizeLocalizationFiles" DependsOnTargets="$(OptimizeLocalizationFilesDependsOn)" />
 
-	<PropertyGroup Condition="'$(_UsingXamarinSdk)' != 'true'">
+	<PropertyGroup Condition="'$(UsingAppleNETSdk)' != 'true'">
 		<CreateAppBundleDependsOn>
 			_DetectAppManifest;
 			_DetectSigningIdentity;
@@ -373,7 +373,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</PropertyGroup>
 
 	<Target Name="_CompileToNative" DependsOnTargets="$(_CompileToNativeDependsOn)"
-		Condition = "'$(IsAppDistribution)' != 'true' And '$(_UsingXamarinSdk)' != 'true'"
+		Condition = "'$(IsAppDistribution)' != 'true' And '$(UsingAppleNETSdk)' != 'true'"
 		Inputs="@(_CompileToNativeInput);@(_FileNativeReference);@(BundleDependentFiles)"
 		Outputs="$(_NativeExecutable);$(DeviceSpecificOutputPath)bundler.stamp">
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
@@ -20,7 +20,7 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 
 	<Import Project="Xamarin.iOS.ObjCBinding.CSharp.props"/>
 
-	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(_UsingXamarinSdk)' != 'true'" />
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.iOS.ObjCBinding.Common.targets" />
 	<Import Project="Xamarin.Shared.targets"/>
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.CSharp.targets
@@ -22,7 +22,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 	</PropertyGroup>
-	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(_UsingXamarinSdk)' != 'true'" />
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.iOS.WatchApp.Common.targets" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"


### PR DESCRIPTION
The `$(_UsingXamarinSdk)` property has been renamed to help improve
external usability.  This change increases parity with the Android SDK,
which currently defines `$(UsingAndroidNETSdk)` for internal and
external use.  The property has also been moved so that it will be
set as early as possible, before the .NET Sdk targets are imported.