### PR TITLE
[CI] Remove Mac OS devices that will not happen.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -70,6 +70,12 @@ parameters:
   type: object
   default: [
     {
+      stageName: 'Mac Catalina (10.15)',
+      macPool: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Trusted',
+      osVersion: '10.15',
+      statusContext: 'Mac Catalina (10.15)'
+    },
+    {
       stageName: 'Mac Mojave (10.14)',
       macPool: 'Hosted Mac Internal Mojave',
       osVersion: '10.14',
@@ -80,12 +86,6 @@ parameters:
       macPool: 'Hosted Mac Internal',
       osVersion: '10.13',
       statusContext: 'Mac High Sierra (10.13)'
-    },
-    {
-      stageName: 'Mac Sierra (10.12)',
-      macPool: 'VSEng-Xamarin-RedmondMacTestPool-iOS',
-      osVersion: '10.12',
-      statusContext: 'Mac Sierra (10.12)'
     }]
 
 resources:


### PR DESCRIPTION
Remove those devices of Mac OS X that will not happen because we cannot
run the agent in such and old device. This is due to the fact that the
agent runs using c# and we do not support such and old OS.

Also add a new stage to run tests on catalina. ATM older OS as not
working, but Catalina should work with our trusted pool.