### PR TITLE
[xcode12.5] [CI][VSTS] Remove redundant status.

### DIFF
--- a/tools/devops/automation/templates/governance-checks.yml
+++ b/tools/devops/automation/templates/governance-checks.yml
@@ -54,24 +54,3 @@ steps:
   displayName: "WhiteSource Bolt analysis"
   inputs:
     cwd: $(System.DefaultWorkingDirectory)
-
-- powershell: echo "##vso[task.setvariable variable=CHECKS_FAILED]True"
-  condition: failed() # we failed running the tests, therefore stop the pipeline
-
-- powershell: |
-    Import-Module "$(System.DefaultWorkingDirectory)\xamarin-macios\tools\devops\automation\scripts\GitHub.psm1"
-    Import-Module "$(System.DefaultWorkingDirectory)\xamarin-macios\tools\devops\automation\scripts\VSTS.psm1"
-    $context = "Governance"
-
-    Write-Host "Checks failed: '$Env:CHECKS_FAILED'"
-    if ($Env:CHECKS_FAILED -eq "True") {
-        Set-GitHubStatus -Status "error" -Description "Governance checks failed" -Context "$context"
-    } else {
-        Set-GitHubStatus -Status "success" -Description "Governance checks passed" -Context "$context"
-    }
-  env:
-    BUILD_REVISION: $(Build.SourceVersion)
-    GITHUB_TOKEN: $(GitHub.Token)
-    ACCESSTOKEN: $(System.AccessToken)
-  displayName: "Set Github status"
-  condition: succeededOrFailed()


### PR DESCRIPTION
VSTS already provides a status per job, since the governance tests do
not give much feedback in the comments and just set a status, we can use
the default provided by the VSTS app.

The two statuses are:

<img width="442" alt="Screenshot 2021-04-21 at 09 50 26" src="https://user-images.githubusercontent.com/2190086/115565099-14e88700-a287-11eb-9a0d-4fc7644771cb.png">

<img width="526" alt="Screenshot 2021-04-21 at 09 50 18" src="https://user-images.githubusercontent.com/2190086/115565105-16b24a80-a287-11eb-9f84-2d16fa3c6807.png">

It is also driving me crazy that we have two diff logos for the statuses.... but that is my problem :) 



Backport of #11267
