### PR TITLE
[tests][link all] Fix nunit silent exception causing some tests not to be enabled

### DIFF
--- a/src/ObjCRuntime/PlatformAvailability.cs
+++ b/src/ObjCRuntime/PlatformAvailability.cs
@@ -351,7 +351,7 @@ namespace ObjCRuntime
 		static void Check (string property, Platform existing, Platform updated)
 		{
 			if (!PlatformHelper.IsValid (updated)){
-				throw new Exception (String.Format ("Platform setting deteremined invalid, cannot set '{0}' to '{1}' " +
+				throw new Exception (String.Format ("Platform setting determined invalid, cannot set '{0}' to '{1}' " +
 					"as it is already set for the same platform to '{2}'",
 					property, updated, existing));
 			}

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -328,7 +328,6 @@ partial class TestRuntime
 			default:
 				throw new NotImplementedException ();
 			}
-			break;
 		case 11:
 			switch (minor) {
 			case 0:

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -425,8 +425,7 @@ namespace Xharness {
 				IgnoreMacCatalystVariation = false,
 			});
 			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "linker", "ios", "link all", "dotnet", "iOS", "link all.csproj"))) { Configurations = new string [] { "Debug", "Release" }, IsDotNetProject = true, SkipiOSVariation = false, SkiptvOSVariation = true, SkipwatchOSVariation = true, SkipTodayExtensionVariation = true, SkipDeviceVariations = false, SkipiOS32Variation = true });
-			// https://github.com/xamarin/xamarin-macios/issues/11243
-			// IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "linker", "ios", "link all", "dotnet", "tvOS", "link all.csproj"))) { Configurations = new string [] { "Debug", "Release" }, IsDotNetProject = true, SkipiOSVariation = true, SkiptvOSVariation = true, SkipwatchOSVariation = true, SkipTodayExtensionVariation = true, SkipDeviceVariations = false, SkipiOS32Variation = true, GenerateVariations = false, TestPlatform = TestPlatform.tvOS, });
+			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "linker", "ios", "link all", "dotnet", "tvOS", "link all.csproj"))) { Configurations = new string [] { "Debug", "Release" }, IsDotNetProject = true, SkipiOSVariation = true, SkiptvOSVariation = true, SkipwatchOSVariation = true, SkipTodayExtensionVariation = true, SkipDeviceVariations = false, SkipiOS32Variation = true, GenerateVariations = false, TestPlatform = TestPlatform.tvOS, });
 			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "linker", "ios", "link sdk", "link sdk.csproj"))) {
 				Configurations = new string [] { "Debug", "Release" },
 				IgnoreMacCatalystVariation = false,


### PR DESCRIPTION
This exposed a few tests that are failing on dotnet (adjusted or fixed)
Also fix a typo in an exception message in `src/ObjCRuntime/PlatformAvailability.cs`
and a build warning in `tests/common/TestRuntime.cs`

Fix part of https://github.com/xamarin/xamarin-macios/issues/11243
And allows enabling the tvOS/dotnet link all tests