### PR TITLE
[mmp] Use the resolver (and configure it correctly) when using --runregistrar.

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -912,6 +912,7 @@ namespace Xamarin.Bundler {
 				CommandLineAssemblies = RootAssemblies,
 #endif
 			};
+			resolver.Configure ();
 
 			if (Platform == ApplePlatform.iOS && !Driver.IsDotNet) {
 				if (Is32Build) {
@@ -974,7 +975,7 @@ namespace Xamarin.Bundler {
 			if (RootAssemblies.Count == 1)
 				registrar.GenerateSingleAssembly (resolver, resolvedAssemblies.Values, Path.ChangeExtension (registrar_m, "h"), registrar_m, Path.GetFileNameWithoutExtension (RootAssembly));
 			else
-				registrar.Generate (resolvedAssemblies.Values, Path.ChangeExtension (registrar_m, "h"), registrar_m);
+				registrar.Generate (resolver, resolvedAssemblies.Values, Path.ChangeExtension (registrar_m, "h"), registrar_m);
 		}
 
 		public IEnumerable<Abi> Abis {

--- a/tools/common/CoreResolver.cs
+++ b/tools/common/CoreResolver.cs
@@ -136,5 +136,9 @@ namespace Xamarin.Bundler {
 
 			return String.Empty;
 		}
+
+		public virtual void Configure ()
+		{
+		}
 	}
 }

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -977,7 +977,7 @@ namespace Registrar {
 			// find corlib
 			var corlib_name = Driver.CorlibName;
 			AssemblyDefinition corlib = null;
-			IEnumerable<AssemblyDefinition> candidates = null;
+			var candidates = new List<AssemblyDefinition> ();
 
 			foreach (var assembly in input_assemblies) {
 				if (corlib_name == assembly.Name.Name) {
@@ -989,18 +989,16 @@ namespace Registrar {
 			if (corlib == null)
 				corlib = Resolver.Resolve (AssemblyNameReference.Parse (corlib_name), new ReaderParameters ());
 
-			if (corlib != null) {
-				candidates = new AssemblyDefinition [] { corlib };
-			} else if (Resolver != null) {
-				candidates = Resolver.ToResolverCache ().Values.Cast<AssemblyDefinition> ();
-			}
+			if (corlib != null)
+				candidates.Add (corlib);
 
-			if (candidates != null) {
-				foreach (var candidate in candidates) {
-					foreach (var type in candidate.MainModule.Types) {
-						if (type.Namespace == "System" && type.Name == "Void")
-							return system_void = type;
-					}
+			if (Resolver != null)
+				candidates.AddRange (Resolver.ToResolverCache ().Values.Cast<AssemblyDefinition> ());
+
+			foreach (var candidate in candidates) {
+				foreach (var type in candidate.MainModule.Types) {
+					if (type.Namespace == "System" && type.Name == "Void")
+						return system_void = type;
 				}
 			}
 
@@ -4764,12 +4762,18 @@ namespace Registrar {
 		public void GenerateSingleAssembly (PlatformResolver resolver, IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, string assembly)
 		{
 			single_assembly = assembly;
-			this.resolver = resolver;
-			Generate (assemblies, header_path, source_path);
+			Generate (resolver, assemblies, header_path, source_path);
 		}
 
 		public void Generate (IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path)
 		{
+			Generate (null, assemblies, header_path, source_path);
+		}
+
+		public void Generate (PlatformResolver resolver, IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path)
+		{
+			this.resolver = resolver;
+
 			if (Target?.CachedLink == true)
 				throw ErrorHelper.CreateError (99, Errors.MX0099, "the static registrar should not execute unless the linker also executed (or was disabled). A potential workaround is to pass '-f' as an additional " + Driver.NAME + " argument to force a full build");
 

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -508,20 +508,7 @@ namespace Xamarin.Bundler {
 
 				App.References.Add (root_assembly);
 				BuildTarget.Resolver.CommandLineAssemblies = App.References;
-
-				if (!UseLegacyAssemblyResolution && (IsUnifiedFullSystemFramework || IsUnifiedFullXamMacFramework)) {
-					// We need to look in the GAC/System mono for both FullSystem and FullXamMac, because that's
-					// how we've been resolving assemblies in the past (Cecil has a fall-back mode where it looks
-					// in the GAC, and we never disabled that, meaning that we always looked in the GAC if failing
-					// to resolve from somewhere else). This makes it explicit that we look in the GAC, and we
-					// now also warn when using FullXamMac and finding assemblies in the GAC.
-					BuildTarget.Resolver.GlobalAssemblyCache = Path.Combine (SystemMonoDirectory, "lib", "mono", "gac");
-					var framework_dir = Path.GetDirectoryName (typeof (object).Module.FullyQualifiedName);
-					BuildTarget.Resolver.SystemFrameworkDirectories = new [] {
-						framework_dir,
-						Path.Combine (framework_dir, "Facades")
-					};
-				}
+				BuildTarget.Resolver.Configure ();
 
 				if (string.IsNullOrEmpty (app_name))
 					app_name = root_wo_ext;
@@ -670,7 +657,7 @@ namespace Xamarin.Bundler {
 		}
 
 		static string system_mono_directory;
-		static string SystemMonoDirectory {
+		public static string SystemMonoDirectory {
 			get {
 				if (system_mono_directory == null)
 					system_mono_directory = RunPkgConfig ("--variable=prefix", force_system_mono: true);

--- a/tools/mmp/resolver.cs
+++ b/tools/mmp/resolver.cs
@@ -110,6 +110,24 @@ namespace Xamarin.Bundler {
 			return null;
 		}
 
+		public override void Configure ()
+		{
+			base.Configure ();
+
+			if (!Driver.UseLegacyAssemblyResolution && (Driver.IsUnifiedFullSystemFramework || Driver.IsUnifiedFullXamMacFramework)) {
+				// We need to look in the GAC/System mono for both FullSystem and FullXamMac, because that's
+				// how we've been resolving assemblies in the past (Cecil has a fall-back mode where it looks
+				// in the GAC, and we never disabled that, meaning that we always looked in the GAC if failing
+				// to resolve from somewhere else). This makes it explicit that we look in the GAC, and we
+				// now also warn when using FullXamMac and finding assemblies in the GAC.
+				GlobalAssemblyCache = Path.Combine (Driver.SystemMonoDirectory, "lib", "mono", "gac");
+				var framework_dir = Path.GetDirectoryName (typeof (object).Module.FullyQualifiedName);
+				SystemFrameworkDirectories = new [] {
+						framework_dir,
+						Path.Combine (framework_dir, "Facades")
+					};
+			}
+		}
 	}
 
 	public class MonoMacAssemblyResolver : AssemblyResolver {


### PR DESCRIPTION
* Extract the code we use to configure the assembly resolver during a normal
  mmp run to make it usable for --runregistrar.
* Configure the assembly resolver we use for --runregistrar.
* Pass the assembly resolver to the registrar so that it's actually used.
* Adjust the System.Void lookup to look everywhere even if we find a corlib,
  since behavior changes a bit now that we're using an assembly resolver:
	* Previous behavior:
		1. In .NET mode, look for a corlib named System.Private.CoreLib, and fail to find it.
		2. Look in all the loaded assemblies for System.Void (and find it in System.Runtime.dll).
	* Broken behavior as a result of the resolver changes:
		1. Find corlib as System.Private.CoreLib.dll
		2. Fail to find System.Void in System.Private.CoreLib.dll, since we'd only look in corlib.
	* New behavior
		1. Find corlib as System.Private.CoreLib.dll
		2. Fail to find System.Void in System.Private.CoreLib.dll, but find it in System.Runtime.dll,
		   since we're now looking in all the loaded assemblies.

This is required to make VSMac's usage of --runregistrar