### PR TITLE
[release/6.0.1xx-preview4] [msbuild] Accept 'UseInterpreter' as an alternative for 'MtouchInterpreter'. Fixes #11138.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -219,6 +219,9 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<AppBundleExtension Condition="'$(AppBundleExtension)' == '' And '$(IsAppExtension)' == 'true' And '$(IsXpcService)' == 'true'">.xpc</AppBundleExtension>
 		<AppBundleExtension Condition="'$(AppBundleExtension)' == '' And '$(IsAppExtension)' == 'true'">.appex</AppBundleExtension>
 		<AppBundleExtension Condition="'$(AppBundleExtension)' == ''">.app</AppBundleExtension>
+
+		<!-- Accept 'UseInterpreter' as an alternative for 'MtouchInterpreter', so that we have the same variable name as Android -->
+		<MtouchInterpreter Condition="'$(MtouchInterpreter)' == '' And '$(UseInterpreter)' == 'True'">all</MtouchInterpreter>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(IsBindingProject)' == 'true'">


### PR DESCRIPTION
Accept 'UseInterpreter' as an alternative for 'MtouchInterpreter', so that we
support the same variable name between iOS and Android.

Fixes https://github.com/xamarin/xamarin-macios/issues/11138.


Backport of #11252
