### PR TITLE
[msbuild] Use System.Net.Mqtt instead of Server

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="$(MicrosoftNETILLinkTasksPackageVersion)" />
     <PackageReference Include="Xamarin.Messaging.Build.Client" Version="$(MessagingVersion)" />
     <!-- Needed from Xamarin.Messaging.Build -->
-    <PackageReference Include="System.Net.Mqtt.Server" Version="0.6.7-beta" />
+    <PackageReference Include="System.Net.Mqtt" Version="0.6.7-beta" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Messaging actually depends on `System.Net.Mqtt`, which is also a dependency of `System.Net.Mqtt.Server`, that's why it worked but we don't really need the extra assemblies provided by the latter.