### PR TITLE
[runtime] There's no need to attach/detach the current thread in CoreCLR.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -228,7 +228,9 @@
 
 		new Export ("MonoThread *", "mono_thread_attach",
 			"MonoDomain *", "domain"
-		),
+		) {
+			XamarinRuntime = RuntimeMode.MonoVM,
+		},
 
 		new Export ("mono_bool", "mono_thread_detach_if_exiting"),
 
@@ -355,7 +357,9 @@
 
 		new Export ("MonoClass *", "mono_get_exception_class"),
 
-		new Export ("MonoDomain *", "mono_get_root_domain"),
+		new Export ("MonoDomain *", "mono_get_root_domain") {
+			XamarinRuntime = RuntimeMode.MonoVM,
+		},
 
 		new Export ("void", "mono_domain_set_config", 
 			"MonoDomain *", "domain",
@@ -651,12 +655,16 @@
 		new Export (true, "void *", "mono_threads_attach_coop",
 			"MonoDomain *", "domain",
 			"gpointer*", "dummy"
-		),
+		) {
+			XamarinRuntime = RuntimeMode.MonoVM,
+		},
 
 		new Export (true, "void *", "mono_threads_detach_coop",
 			"gpointer", "cookie",
 			"gpointer*", "dummy"
-		),
+		) {
+			XamarinRuntime = RuntimeMode.MonoVM,
+		},
 
 		#endregion
 

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1220,7 +1220,9 @@ pump_gc (void *context)
 {
 	// COOP: this runs on a separate thread, so I'm not sure what happens here.
 	//       We can make sure we're in safe mode while sleeping though.
+#if !defined (CORECLR_RUNTIME)
 	mono_thread_attach (mono_get_root_domain ());
+#endif
 
 	while (xamarin_gc_pump) {
 		GCHandle exception_gchandle = INVALID_GCHANDLE;

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -391,10 +391,14 @@ public:
 
 #endif /* !TARGET_OS_WATCH */
 
+#if defined(CORECLR_RUNTIME)
+// this is not needed for CoreCLR
+#define MONO_THREAD_ATTACH
+#define MONO_THREAD_DETACH
 // Once we have one mono clone again the TARGET_OS_WATCH
 // condition should be removed (DYNAMIC_MONO_RUNTIME should still
 // be here though).
-#if TARGET_OS_WATCH && !defined (DYNAMIC_MONO_RUNTIME)
+#elif TARGET_OS_WATCH && !defined (DYNAMIC_MONO_RUNTIME)
 #define MONO_THREAD_ATTACH \
 	do { \
 		gpointer __thread_dummy; \


### PR DESCRIPTION
Next failure is now (with #11271 as well):

> monotouchtest[83025:8899609] Xamarin.Mac: The method mono_gchandle_get_target has not been implemented for CoreCLR.

```
3   com.xamarin.monotouch-test    	0x00000001030a56a8 xamarin_assertion_message + 408 (runtime.m:1503)
4   com.xamarin.monotouch-test    	0x0000000103074a80 mono_gchandle_get_target + 32 (mono-runtime.m:1982)
5   com.xamarin.monotouch-test    	0x00000001030a7cbf xamarin_gchandle_get_target + 47 (runtime.m:2721)
6   com.xamarin.monotouch-test    	0x00000001030aabe9 xamarin_switch_gchandle + 137 (runtime.m:1834)
7   com.xamarin.monotouch-test    	0x00000001030add4a xamarin_retain_trampoline + 42 (trampolines.m:701)
```