### PR TITLE
[d16-10-preview2] [CI][XHarness] Ensure we filter the tests to run. (#11035)

### DIFF
--- a/tests/xharness/GitHub.cs
+++ b/tests/xharness/GitHub.cs
@@ -41,9 +41,9 @@ namespace Xharness {
 		{
 			var client = new WebClient ();
 			client.Headers.Add (HttpRequestHeader.UserAgent, "xamarin");
-			var xharness_github_token_file = Environment.GetEnvironmentVariable ("XHARNESS_GITHUB_TOKEN_FILE");
-			if (!string.IsNullOrEmpty (xharness_github_token_file) && File.Exists (xharness_github_token_file))
-				client.Headers.Add (HttpRequestHeader.Authorization, File.ReadAllText (xharness_github_token_file));
+			var xharness_github_token = Environment.GetEnvironmentVariable ("GITHUB_TOKEN");
+			if (!string.IsNullOrEmpty (xharness_github_token))
+				client.Headers.Add (HttpRequestHeader.Authorization, xharness_github_token);
 			return client;
 		}
 

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -571,6 +571,14 @@ steps:
     echo "##vso[task.setvariable variable=TESTS_RAN;isOutput=true]True"
     rm -rf ~/.config/.mono/keypairs/
 
+    if [[ "$IsPR" == "True" ]]; then
+      TARGET='jenkins'
+    else
+      TARGET='wrench-jenkins'
+    fi
+
+    echo "Using target '$TARGET'"
+
     RC=0
     make -C $(Build.SourcesDirectory)/xamarin-macios/tests "$TARGET" || RC=$?
 
@@ -590,8 +598,9 @@ steps:
   timeoutInMinutes: 600
   enabled: ${{ parameters.runTests }}
   env:
+    IsPR: $(configuration.IsPR)
+    GITHUB_TOKEN: $(GitHub.Token)  # used to filter the tests to be ran
     BUILD_REVISION: jenkins
-    TARGET: 'wrench-jenkins'
     VSDROPS_URI: '${{ parameters.vsdropsPrefix }}/$(Build.BuildNumber)/$(Build.BuildId)/sim;/tests/' # uri used to create the vsdrops index using full uri
 
 # Only executed when the tests failed, that means that we did have a timeout, and we could not set the status, this


### PR DESCRIPTION
VSTS does not longer have a file with the pat yet it does allow to use
an env variable with the pat provided by the keyvault. Before this
change we have been running all the tests which results in several extra
hours when we do not need to. For example, if nothing was changed in
msbuild, do not run its tests which are 45 mins long.

Changes are:

* provide pat in the env.
* update xharness to use an env var, do not longer read from a file.

fixes: https://github.com/xamarin/xamarin-macios/issues/10923


Backport of #11047
