### PR TITLE
[d16-9] [CI] Unify both failing statuses.

### DIFF
--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -520,18 +520,17 @@ function New-GitHubSummaryComment {
     $headerLinks = $sb.ToString()
     $request = $null
 
+    # set the context to be "pipeline name (Test run)", example xamarin-macios (Test run)
+    $statusContext = "$Env:BUILD_DEFINITIONNAME (Test run)"
+    if ($Context -ne "Build") { #special case when we deal with the device tests
+        $statusContext = "$Contex - $Env:BUILD_DEFINITIONNAME) (Test run)"
+    }
+
     if (-not (Test-Path $TestSummaryPath -PathType Leaf)) {
         Write-Host "No test summary found"
-        Set-GitHubStatus -Status "failure" -Description "Tests failed catastrophically on $Context (no summary found)." -Context "$Context"
+        Set-GitHubStatus -Status "failure" -Description "Tests failed catastrophically on $Context (no summary found)." -Context $statusContext
         $request = New-GitHubComment -Header "Tests failed catastrophically on $Context (no summary found)." -Emoji ":fire:" -Description "Result file $TestSummaryPath not found. $headerLinks"
     } else {
-
-        # set the context to be "pipeline name (Test run)", example xamarin-macios (Test run)
-        $statusContext = "$Env:BUILD_DEFINITIONNAME (Test run)"
-        if ($Context -ne "Build") { #special case when we deal with the device tests
-            $statusContext = "$Contex - $Env:BUILD_DEFINITIONNAME) (Test run)"
-        }
-
         if (Test-JobSuccess -Status $Env:TESTS_JOBSTATUS) {
             Set-GitHubStatus -Status "success" -Description "All tests passed on $Context." -Context $statusContext
             $request = New-GitHubCommentFromFile -Header "Tests passed on $Context." -Description "Tests passed on $Context. $headerLinks"  -Emoji ":white_check_mark:" -Path $TestSummaryPath


### PR DESCRIPTION
Move logic one level up and re-use it in the other status.


Backport of #11311
