### PR TITLE
[dotnet] Sets missing ILLink parameter from Windows

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -358,6 +358,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 				ReferenceAssemblyPaths="@(ReferencePath)"
 				RootAssemblyNames="@(TrimmerRootAssembly)"
 				TrimMode="$(TrimMode)"
+				DefaultAction="$(_TrimmerDefaultAction)"
 				RemoveSymbols="$(TrimmerRemoveSymbols)"
 				FeatureSettings="@(_TrimmerFeatureSettings)"
 				CustomData="@(_TrimmerCustomData)"


### PR DESCRIPTION
This was making the linker to not behave correctly, and apps were crashing on the simulator.