### PR TITLE
[d16-10] [CI] Fix mac tests provisioning.

### DIFF
--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -134,6 +134,8 @@ steps:
     ls -Rla $(Build.SourcesDirectory)/artifacts
     $(Build.SourcesDirectory)/artifacts/mac-test-package/test-dependencies.sh
   displayName: Install dependencies.
+  env:
+    IGNORE_DOTNET: 1  # Not needed for the tests.
 
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\GitHub.psm1 


### PR DESCRIPTION
We should not try to use donet.config because that file is generated. Make.config contains the same info.


Backport of #11324
