### PR TITLE
[d16-10] [CI] Workaround misconfig pools.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -73,19 +73,22 @@ parameters:
       stageName: 'Mac Catalina (10.15)',
       macPool: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Trusted',
       osVersion: '10.15',
-      statusContext: 'Mac Catalina (10.15)'
+      statusContext: 'Mac Catalina (10.15)',
+      checkDemands: true
     },
     {
       stageName: 'Mac Mojave (10.14)',
       macPool: 'Hosted Mac Internal Mojave',
       osVersion: '10.14',
-      statusContext: 'Mac Mojave (10.14)'
+      statusContext: 'Mac Mojave (10.14)',
+      checkDemands: false
     },
     {
       stageName: 'Mac High Sierra (10.13)',
       macPool: 'Hosted Mac Internal',
       osVersion: '10.13',
-      statusContext: 'Mac High Sierra (10.13)'
+      statusContext: 'Mac High Sierra (10.13)',
+      checkDemands: false
     }]
 
 resources:
@@ -235,6 +238,7 @@ stages:
           osVersion: ${{ config['osVersion'] }}
           statusContext: ${{ config['statusContext'] }}
           keyringPass: $(xma-password)
+          checkDemands: ${{ config['checkDemands'] }}
 
 - ${{ if eq(parameters.runSamples, true) }}:
   # TODO: Not the real step

--- a/tools/devops/automation/templates/mac/stage.yml
+++ b/tools/devops/automation/templates/mac/stage.yml
@@ -16,6 +16,10 @@ parameters:
 - name: osVersion
   type: string
 
+- name: checkDemands
+  type: boolean
+  default: true
+
 stages:
 - stage:
   displayName: ${{ parameters.stageName }}
@@ -33,9 +37,10 @@ stages:
 
     pool:
       name: ${{ parameters.macPool }}
-      demands: 
-      - Agent.OS -equals Darwin
-      - Agent.OSVersion -equals ${{ parameters.osVersion }}
+      ${{ if eq(parameters.checkDemands, true) }}:
+        demands: 
+        - Agent.OS -equals Darwin
+        - Agent.OSVersion -equals ${{ parameters.osVersion }}
 
     steps:
     - template: build.yml


### PR DESCRIPTION
For some reason, some of the internal hosted pools have been set without
the OS version (WRONG WRONG). The simples way is to allow to skip this
check in those pools over re-configuring all bots.

Example of tests starting: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4684353&view=logs&j=ac718a0d-597a-528b-5222-a379ea9341a1

The commit does not fix the tests, just makes sure they run.

'We can lick gravity, but sometimes the paperwork is overwhelming.'


Backport of #11323
