### PR TITLE
[Xcode12.5][CI] Workaround misconfig pools. (#11323)

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -69,19 +69,22 @@ parameters:
       stageName: 'Mac Catalina (10.15)',
       macPool: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Trusted',
       osVersion: '10.15',
-      statusContext: 'Mac Catalina (10.15)'
+      statusContext: 'Mac Catalina (10.15)',
+      checkDemands: true
     },
     {
       stageName: 'Mac Mojave (10.14)',
       macPool: 'Hosted Mac Internal Mojave',
       osVersion: '10.14',
-      statusContext: 'Mac Mojave (10.14)'
+      statusContext: 'Mac Mojave (10.14)',
+      checkDemands: false
     },
     {
       stageName: 'Mac High Sierra (10.13)',
       macPool: 'Hosted Mac Internal',
       osVersion: '10.13',
-      statusContext: 'Mac High Sierra (10.13)'
+      statusContext: 'Mac High Sierra (10.13)',
+      checkDemands: false
     }]
 
 resources:
@@ -216,8 +219,10 @@ stages:
       parameters:
         stageName: ${{ config['stageName'] }}
         macPool: ${{ config['macPool'] }}
+        osVersion: ${{ config['osVersion'] }}
         statusContext: ${{ config['statusContext'] }}
         keyringPass: $(xma-password)
+        checkDemands: ${{ config['checkDemands'] }}
 
   # TODO: Not the real step
   - stage: sample_testing

--- a/tools/devops/automation/templates/mac/stage.yml
+++ b/tools/devops/automation/templates/mac/stage.yml
@@ -13,6 +13,13 @@ parameters:
 - name: keyringPass
   type: string
 
+- name: osVersion
+  type: string
+
+- name: checkDemands
+  type: boolean
+  default: true
+
 stages:
 - stage:
   displayName: ${{ parameters.stageName }}
@@ -30,8 +37,10 @@ stages:
 
     pool:
       name: ${{ parameters.macPool }}
-      demands: 
-      - Agent.OS -equals Darwin
+      ${{ if eq(parameters.checkDemands, true) }}:
+        demands: 
+        - Agent.OS -equals Darwin
+        - Agent.OSVersion -equals ${{ parameters.osVersion }}
 
     steps:
     - template: build.yml


### PR DESCRIPTION
For some reason, some of the internal hosted pools have been set without
the OS version (WRONG WRONG). The simples way is to allow to skip this
check in those pools over re-configuring all bots.

'We can lick gravity, but sometimes the paperwork is overwhelming.'