### PR TITLE
Make NSWindow appearanceSource null allowed

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -20963,6 +20963,7 @@ namespace AppKit {
 		CGPoint ConvertPointFromBacking (CGPoint point);
 
 		[Mac (10, 14)]
+		[NullAllowed]
 		[Export ("appearanceSource", ArgumentSemantic.Weak)]
 		INSAppearanceCustomization AppearanceSource { get; set; }
 

--- a/tests/xtro-sharpie/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/macOS-AppKit.ignore
@@ -2208,7 +2208,6 @@
 !missing-null-allowed! 'System.Void AppKit.NSWindow::BeginCriticalSheet(AppKit.NSWindow,System.Action`1<System.nint>)' is missing an [NullAllowed] on parameter #1
 !missing-null-allowed! 'System.Void AppKit.NSWindow::BeginSheet(AppKit.NSWindow,System.Action`1<System.nint>)' is missing an [NullAllowed] on parameter #1
 !missing-null-allowed! 'System.Void AppKit.NSWindow::RunToolbarCustomizationPalette(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void AppKit.NSWindow::set_AppearanceSource(AppKit.INSAppearanceCustomization)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSWindow::set_BackgroundColor(AppKit.NSColor)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSWindow::set_ColorSpace(AppKit.NSColorSpace)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSWindow::set_ContentView(AppKit.NSView)' is missing an [NullAllowed] on parameter #0


### PR DESCRIPTION
Native headers show it's null_resettable.

```objc
/// If set, the receiver will inherit the appearance of that object, as well as use KVO to observe its effectiveAppearance for changes. Typically this is used for child windows that are shown from a parent window or specific view. Defaults to NSApp.
@property (weak, null_resettable) NSObject<NSAppearanceCustomization> *appearanceSource API_AVAILABLE(macos(10.14));
```