### PR TITLE
[dotnet] Build the partial static registrar for CoreCLR.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -390,7 +390,8 @@
 			<_XamarinRefAssemblyDirectory>$(_XamarinRefPackageDirectory)/ref/net6.0/</_XamarinRefAssemblyDirectory>
 			<_XamarinRefAssemblyPath>$(_XamarinRefAssemblyDirectory)$(_PlatformAssemblyName).dll</_XamarinRefAssemblyPath>
 
-			<_LibPartialStaticRegistrar>$(_XamarinNativeLibraryDirectory)/Microsoft.$(_PlatformName).registrar.a</_LibPartialStaticRegistrar>
+			<_LibPartialStaticRegistrar Condition="'$(UseMonoRuntime)' == 'true'">$(_XamarinNativeLibraryDirectory)/Microsoft.$(_PlatformName).registrar.a</_LibPartialStaticRegistrar>
+			<_LibPartialStaticRegistrar Condition="'$(UseMonoRuntime)' != 'true'">$(_XamarinNativeLibraryDirectory)/Microsoft.$(_PlatformName).registrar.coreclr.a</_LibPartialStaticRegistrar>
 
 			<_MonoRuntimePackPath>%(_MonoFrameworkReference.RuntimePackPath)/runtimes/$(RuntimeIdentifier)/</_MonoRuntimePackPath>
 		</PropertyGroup>

--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -164,6 +164,12 @@ xamarin_mono_object_release (MonoReflectionType **mobj)
 	xamarin_mono_object_release ((MonoObject **) mobj);
 }
 
+void
+xamarin_mono_object_release (MonoString **mobj)
+{
+	xamarin_mono_object_release ((MonoObject **) mobj);
+}
+
 /* Implementation of the Mono Embedding API */
 
 // returns a retained MonoAssembly *

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -291,10 +291,11 @@ MonoObject *	xamarin_gchandle_unwrap (GCHandle handle); // Will get the target a
  */
 #if defined(CORECLR_RUNTIME)
 void			xamarin_mono_object_retain (MonoObject *mobj);
-// Use C++ linking to be able to use method overloading.
+// Use C++ linking to be able to use method overloading, so that callers don't have to cast their variables to 'MonoObject**' (which improves type safety a lot).
 extern "C++" void	xamarin_mono_object_release (MonoObject **mobj);
 extern "C++" void	xamarin_mono_object_release (MonoReflectionMethod **mobj);
 extern "C++" void	xamarin_mono_object_release (MonoReflectionType **mobj);
+extern "C++" void	xamarin_mono_object_release (MonoString **mobj);
 #else
 // Nothing to do here.
 #define			xamarin_mono_object_retain(x)

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -238,6 +238,13 @@ namespace Xamarin.Bundler {
 			options.Add ("warn-on-type-ref=", "Warn if any of the comma-separated types is referenced by assemblies - both before and after linking.", v => {
 				app.WarnOnTypeRef.AddRange (v.Split (new char [] { ',' }, StringSplitOptions.RemoveEmptyEntries));
 			});
+			options.Add ("xamarin-runtime=", "Which runtime to use (MonoVM or CoreCLR).", v => {
+				if (!Enum.TryParse<XamarinRuntime> (v, out var rv))
+					throw new InvalidOperationException ($"Invalid XamarinRuntime '{v}'");
+				app.XamarinRuntime = rv;
+			}, true /* hidden - this is only for build-time --runregistrar support */);
+
+
 			// Keep the ResponseFileSource option at the end.
 			options.Add (new Mono.Options.ResponseFileSource ());
 

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -21,6 +21,8 @@ $(MMP_DIR)/mmp.exe: $(mmp_dependencies)
 MMP_TARGETS_DOTNET = \
 	$(DOTNET_DESTDIR)/Microsoft.macOS.Runtime.osx-x64/runtimes/osx-x64/native/Microsoft.macOS.registrar.a \
 	$(DOTNET_DESTDIR)/Microsoft.macOS.Runtime.osx-arm64/runtimes/osx-arm64/native/Microsoft.macOS.registrar.a \
+	$(DOTNET_DESTDIR)/Microsoft.macOS.Runtime.osx-x64/runtimes/osx-x64/native/Microsoft.macOS.registrar.coreclr.a \
+	$(DOTNET_DESTDIR)/Microsoft.macOS.Runtime.osx-arm64/runtimes/osx-arm64/native/Microsoft.macOS.registrar.coreclr.a \
 
 MMP_TARGETS = \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/mmp \
@@ -51,7 +53,13 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/Xamarin.Mac.registrar.%.a: Xa
 $(DOTNET_DESTDIR)/Microsoft.macOS.Runtime.osx-x64/runtimes/osx-x64/native/Microsoft.macOS.registrar.a: Microsoft.macOS.registrar.x86_64.a | $(DOTNET_DESTDIR)/Microsoft.macOS.Runtime.osx-x64/runtimes/osx-x64/native
 	$(Q) $(CP) $< $@
 
+$(DOTNET_DESTDIR)/Microsoft.macOS.Runtime.osx-x64/runtimes/osx-x64/native/Microsoft.macOS.registrar.coreclr.a: Microsoft.macOS.registrar.coreclr.x86_64.a | $(DOTNET_DESTDIR)/Microsoft.macOS.Runtime.osx-x64/runtimes/osx-x64/native
+	$(Q) $(CP) $< $@
+
 $(DOTNET_DESTDIR)/Microsoft.macOS.Runtime.osx-arm64/runtimes/osx-arm64/native/Microsoft.macOS.registrar.a: Microsoft.macOS.registrar.arm64.a | $(DOTNET_DESTDIR)/Microsoft.macOS.Runtime.osx-arm64/runtimes/osx-arm64/native
+	$(Q) $(CP) $< $@
+
+$(DOTNET_DESTDIR)/Microsoft.macOS.Runtime.osx-arm64/runtimes/osx-arm64/native/Microsoft.macOS.registrar.coreclr.a: Microsoft.macOS.registrar.coreclr.arm64.a | $(DOTNET_DESTDIR)/Microsoft.macOS.Runtime.osx-arm64/runtimes/osx-arm64/native
 	$(Q) $(CP) $< $@
 
 $(MMP_DIRECTORIES):
@@ -75,6 +83,10 @@ Microsoft.macOS.registrar.x86_64.m: $(TOP)/src/build/dotnet/macos/64/Xamarin.Mac
 	$(GENERATE_PART_REGISTRAR) --arch=x86_64 --target-framework .NETCoreApp,Version=6.0,Profile=macos -a:$(DOTNET6_BCL_DIR)/System.Runtime.dll
 	$(Q) touch $@ $(basename $@).h
 
+Microsoft.macOS.registrar.coreclr.x86_64.m: $(TOP)/src/build/dotnet/macos/64/Xamarin.Mac.dll $(LOCAL_MMP)
+	$(GENERATE_PART_REGISTRAR) --arch=x86_64 --target-framework .NETCoreApp,Version=6.0,Profile=macos -a:$(DOTNET6_BCL_DIR)/System.Runtime.dll --xamarin-runtime CoreCLR
+	$(Q) touch $@ $(basename $@).h
+
 Xamarin.Mac.registrar.full.x86_64.m:   $(TOP)/src/build/mac/full-64/Xamarin.Mac.dll $(LOCAL_MMP)
 	$(GENERATE_PART_REGISTRAR) --arch=x86_64 --target-framework Xamarin.Mac,Version=v4.5,Profile=Full -a:$(FULL_BCL_DIR)/mscorlib.dll
 	$(Q) touch Xamarin.Mac.registrar.full.x86_64.m Xamarin.Mac.registrar.full.x86_64.h
@@ -83,15 +95,22 @@ Microsoft.macOS.registrar.arm64.m: $(TOP)/src/build/dotnet/macos/64/Xamarin.Mac.
 	$(GENERATE_PART_REGISTRAR) --arch=arm64 --target-framework .NETCoreApp,Version=6.0,Profile=macos -a:$(DOTNET6_BCL_DIR)/System.Runtime.dll
 	$(Q) touch $@ $(basename $@).h
 
+Microsoft.macOS.registrar.coreclr.arm64.m: $(TOP)/src/build/dotnet/macos/64/Xamarin.Mac.dll $(LOCAL_MMP)
+	$(GENERATE_PART_REGISTRAR) --arch=arm64 --target-framework .NETCoreApp,Version=6.0,Profile=macos -a:$(DOTNET6_BCL_DIR)/System.Runtime.dll --xamarin-runtime CoreCLR
+	$(Q) touch $@ $(basename $@).h
+
 Xamarin.Mac.registrar.full.arm64.m:   $(TOP)/src/build/mac/full-64/Xamarin.Mac.dll $(LOCAL_MMP)
 	$(GENERATE_PART_REGISTRAR) --arch=arm64 --target-framework Xamarin.Mac,Version=v4.5,Profile=Full -a:$(FULL_BCL_DIR)/mscorlib.dll
 	$(Q) touch Xamarin.Mac.registrar.full.arm64.m Xamarin.Mac.registrar.full.arm64.h
 
+%.coreclr.x86_64.a: export EXTRA_DEFINES=-DCORECLR_RUNTIME
+%.coreclr.arm64.a: export EXTRA_DEFINES=-DCORECLR_RUNTIME
+
 %.x86_64.a: %.x86_64.m
-	$(Q_CC) $(MAC_CC) -DDEBUG -g -gdwarf-2 -x objective-c++ -std=c++14 -o $@ -c -arch x86_64 $< -Wall -Wno-unguarded-availability-new -I$(TOP)/runtime -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx
+	$(Q_CC) $(MAC_CC) -DDEBUG -g -gdwarf-2 -x objective-c++ -std=c++14 -o $@ -c -arch x86_64 $< -Wall -Wno-unguarded-availability-new -I$(TOP)/runtime -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx $(EXTRA_DEFINES)
 
 %.arm64.a: %.arm64.m
-	$(Q_CC) $(MAC_CC) -DDEBUG -g -gdwarf-2 -x objective-c++ -std=c++14 -o $@ -c -arch arm64 $< -Wall -Wno-unguarded-availability-new -I$(TOP)/runtime -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx
+	$(Q_CC) $(MAC_CC) -DDEBUG -g -gdwarf-2 -x objective-c++ -std=c++14 -o $@ -c -arch arm64 $< -Wall -Wno-unguarded-availability-new -I$(TOP)/runtime -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx $(EXTRA_DEFINES)
 
 Xamarin.Mac.registrar.%.a: Xamarin.Mac.registrar.%.x86_64.a Xamarin.Mac.registrar.%.arm64.a
 	$(Q_LIPO) $(DEVICE_BIN_PATH)/lipo -create -output $@ $^


### PR DESCRIPTION
* The generated static registration code will eventually be different.
* The generated code has to be compiled with different compiler flags.

This also required adding a new overload of xamarin_mono_object_release for the generated
code to compile.