### PR TITLE
[build] Add installer dependency to linker packs

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,11 +4,7 @@
       <Uri>https://github.com/dotnet/installer</Uri>
       <Sha>2455d34cebebfa62772f57be93b2cf99d14dbad2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink" Version="6.0.100-preview.2.21212.1">
-      <Uri>https://github.com/mono/linker</Uri>
-      <Sha>6bfa2c0657d2dcfd6dce684ab34b470ce567631a</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.100-preview.2.21212.1">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.100-preview.2.21212.1" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>6bfa2c0657d2dcfd6dce684ab34b470ce567631a</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,6 @@
   <!--Package versions-->
   <PropertyGroup>
     <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-preview.4.21218.6</MicrosoftDotnetSdkInternalPackageVersion>
-    <MicrosoftNETILLinkPackageVersion>6.0.100-preview.2.21212.1</MicrosoftNETILLinkPackageVersion>
     <MicrosoftNETILLinkTasksPackageVersion>6.0.100-preview.2.21212.1</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
   </PropertyGroup>

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="XliffTasks" Version="1.0.0-beta.20154.1" />
-    <PackageReference Include="Microsoft.NET.ILLink" Version="$(MicrosoftNETILLinkPackageVersion)" />
+    <PackageReference Include="Microsoft.NET.ILLink" Version="$(MicrosoftNETILLinkTasksPackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\common\ApplePlatform.cs">


### PR DESCRIPTION
Adds a coherent parent dependency to `Microsoft.NET.ILLink.Tasks`, which
ensures that it will not be updated past the version included in
`Microsoft.Dotnet.Sdk.Internal`.

These changes allow us to remove our mono/linker darc subscriptions, as
`Microsoft.Dotnet.Sdk.Internal` updates will also bring in the latest
`Microsoft.NET.ILLink.Tasks` that the SDK references.  This will reduce
the number of dependency update PRs created by maestro.

Since the `Microsoft.NET.ILLink.Tasks` and `Microsoft.NET.ILLink` NuGet
packages are created by the same build, we only need to track one of
these package IDs in eng/Version* files.