### PR TITLE
[NSObject] Don't call into Objective-C (the Description property) for disposed objects.

### DIFF
--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -763,6 +763,8 @@ namespace Foundation {
 
 		public override string ToString ()
 		{
+			if (disposed)
+				return base.ToString ();
 			return Description ?? base.ToString ();
 		}
 


### PR DESCRIPTION
Calling into Objective-C for disposed objects may crash, and calling ToString
shouldn't crash.