### PR TITLE
[runtime] Remove dead code.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1102,15 +1102,6 @@ xamarin_add_registration_map (struct MTRegistrationMap *map, bool partial)
  * Exception handling
  */
 
-static XamarinUnhandledExceptionFunc unhandled_exception_func;
-
-void 
-xamarin_install_unhandled_exception_hook (XamarinUnhandledExceptionFunc func)
-{
-	// COOP: no managed memory access: any mode
-	unhandled_exception_func = func;	
-}
-
 static MonoObject *
 fetch_exception_property (MonoObject *obj, const char *name, bool is_virtual)
 {
@@ -1163,9 +1154,6 @@ print_exception (MonoObject *exc, bool is_inner, NSMutableString *msg)
 	[msg appendFormat: @"%s (%s)\n", message, type_name];
 	if (trace)
 		[msg appendFormat: @"%s\n", trace];
-
-	if (unhandled_exception_func && !is_inner)
-		unhandled_exception_func (exc, type_name, message, trace);
 
 	mono_free (trace);
 	mono_free (message);

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -237,8 +237,6 @@ void			xamarin_check_objc_type (id obj, Class expected_class, SEL sel, id self, 
 
 void			xamarin_set_gc_pump_enabled (bool value);
 
-typedef void  	(*XamarinUnhandledExceptionFunc)         (MonoObject *exc, const char *type_name, const char *message, const char *trace);
-void          	xamarin_install_unhandled_exception_hook (XamarinUnhandledExceptionFunc func);
 void			xamarin_process_nsexception (NSException *exc);
 void			xamarin_process_nsexception_using_mode (NSException *ns_exception, bool throwManagedAsDefault);
 void			xamarin_process_managed_exception (MonoObject *exc);


### PR DESCRIPTION
This seems to be a leftover from when we were implementing support for third-party crash reporters many, many moons ago.