### PR TITLE
[tests] Add a bluetooth usage description to monotouch-test/macOS.

### DIFF
--- a/tests/monotouch-test/dotnet/macOS/Info.plist
+++ b/tests/monotouch-test/dotnet/macOS/Info.plist
@@ -23,5 +23,7 @@
 	</dict>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Testing world domination through blue teeth coloring</string>
 </dict>
 </plist>


### PR DESCRIPTION
This seems to be required when running monotouch-test with lldb (!) - no idea
why it doesn't fail otherwise.