### PR TITLE
[generator] Improve performance for the printing inner loop.

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3191,25 +3191,26 @@ public partial class Generator : IMemberGatherer {
 		print (sw, format, args);
 	}
 
+	static char [] newlineCharacters = new char [] { '\n' };
+
 	public void print (StreamWriter w, string format)
 	{
 		if (indent < 0)
 			throw new InvalidOperationException ("Indent is a negative value.");
 
-		string[] lines = format.Split (new char [] { '\n' });
-		string lwsp = new string ('\t', indent);
-		
-		for (int i = 0; i < lines.Length; i++)
-			w.WriteLine (lwsp + lines[i]);
+		var lines = format.Split (newlineCharacters);
+
+		for (int i = 0; i < lines.Length; i++) {
+			if (lines [i].Length == 0)
+				continue;
+			w.Write ('\t', indent);
+			w.WriteLine (lines [i]);
+		}
 	}
 
 	public void print (StreamWriter w, string format, params object [] args)
 	{
-		string[] lines = String.Format (format, args).Split (new char [] { '\n' });
-		string lwsp = new string ('\t', indent);
-		
-		for (int i = 0; i < lines.Length; i++)
-			w.WriteLine (lwsp + lines[i]);
+		print (w, string.Format (format, args));
 	}
 
 	public void print (StreamWriter w, IEnumerable e)


### PR DESCRIPTION
* Remove 1 array allocation per print statement.
* Remove 2 string concatenations per print statement.
* Don't indent empty lines.

For the generated code for watchOS, this is the difference (time-wise I wasn't
able to measure anything significant, although the memory savings are
significant):

Before:

    Allocation summary
           Bytes        Count  Average Type name
     535.485.544    7.115.025       75 System.String
     145.340.480    2.270.945       64 IKVM.Reflection.CustomAttributeData
     110.149.624    1.238.394       88 System.Char[]
    ...
    Total memory allocated: 1.793.323.536 bytes in 28.827.325d objects

After:

    Allocation summary
           Bytes        Count  Average Type name
     494.592.328    6.624.441       74 System.String
     145.340.480    2.270.945       64 IKVM.Reflection.CustomAttributeData
      99.345.984      968.303      102 System.Char[]
    ...
    Total memory allocated: 1.741.626.784 bytes in 28.066.650d objects

Difference:

    Allocation summary
           Bytes       Count  Average Type name
     -40.893.216    -490.584       -1 System.String
               0           0       64 IKVM.Reflection.CustomAttributeData
     -10.803.640    -270.091      +14 System.Char[]
    ...
    Total memory allocated: -51.696.752 bytes in -760.675 objects

This was measured by executing the following in an already built working copy:

    /Library/Frameworks/Mono.framework/Versions/Current/bin/mono --profile=log:nocalls,alloc --debug build/common/bgen.exe @build/watchos.rsp