### PR TITLE
[dotnet] Fix release builds on devices

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -127,7 +127,6 @@
 		<EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
 		<HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
 		<HttpNativeHandler Condition="'$(_PlatformName)' != 'macOS' And '$(HttpNativeHandler)' == ''">true</HttpNativeHandler>
-		<InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
 		<StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
 		<UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
 	</PropertyGroup>

--- a/tests/dotnet/Makefile
+++ b/tests/dotnet/Makefile
@@ -58,5 +58,5 @@ build-oldnet:
 build-dotnet: $(TARGETS)
 	$(DOTNET6) build size-comparison/MySingleView/dotnet/MySingleView.csproj --runtime ios-arm64 $(COMMON_ARGS) /bl:$@.binlog
 
-run-dotnet: build-dotnet
-	$(DOTNET6) build -t:Run size-comparison/MySingleView/dotnet/MySingleView.csproj
+run-dotnet: $(TARGETS)
+	$(DOTNET6) build -t:Run size-comparison/MySingleView/dotnet/MySingleView.csproj --runtime ios-arm64 $(COMMON_ARGS)


### PR DESCRIPTION
Fixed by removal of
```
<InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
```
which is (should be) the default.

All our local usage compare with it with `true` so this likely comes from
somewhere else (sdk / runtime).

It does not really have a huge impact on build size (and the small diff
is probably the source of the crash)

* fails (17,479,981): https://gist.github.com/spouliot/6f8defb8f940e68314ba167ea76dc9bf
* works (17,502,741): https://gist.github.com/spouliot/d06f0b1b95e114fe469ce49081c70e33

Also fix target to run a release (no debug) build, which is more helpful
"out of the box" :)

Tracking issue with: https://github.com/xamarin/xamarin-macios/issues/11366