### PR TITLE
[msbuild] Show tool output with high importance if the tool fails.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
@@ -115,8 +115,12 @@ namespace Xamarin.MacDev.Tasks {
 					output += Environment.NewLine;
 				output += rv.StandardError.ToString ();
 			}
-			if (output.Length > 0)
-				Log.LogMessage (rv.ExitCode == 0 ? MessageImportance.Low : MessageImportance.Normal, output);
+			if (output.Length > 0) {
+				var importance = MessageImportance.Low;
+				if (rv.ExitCode != 0)
+					importance = showErrorIfFailure ? MessageImportance.High : MessageImportance.Normal;
+				Log.LogMessage (importance, output);
+			}
 
 			if (showErrorIfFailure && rv.ExitCode != 0)
 				Log.LogError (MSBStrings.E0117, /* {0} exited with code {1} */ fileName == "xcrun" ? arguments [0] : fileName, rv.ExitCode);


### PR DESCRIPTION
Build failures will now include things like this for quiet builds:

    Tool xcrun execution finished (exit code = 1).

    Undefined symbols for architecture x86_64:
      "_GlobalizationNative_LoadICUData", referenced from:
         -u command line option
    ld: symbol(s) not found for architecture x86_64
    clang: error: linker command failed with exit code 1 (use -v to see invocation)