### PR TITLE
[release/6.0.1xx-preview4] [bgen] Ship all files published by 'dotnet publish' for bgen. Fixes #11269.

### DIFF
--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -14,8 +14,8 @@ $(BUILD_DIR)/common/bgen.exe: $(generator_dependencies) Makefile.generator $(BUI
 	$(Q_GEN) $(SYSTEM_MSBUILD) $(XBUILD_VERBOSITY) /p:Configuration=Debug generator.csproj /p:IntermediateOutputPath=$(BUILD_DIR)/IDE/obj/common/ /p:OutputPath=$(BUILD_DIR)/common
 
 $(DOTNET_BUILD_DIR)/bgen/bgen:  $(generator_dependencies) Makefile.generator $(BUILD_DIR)/generator-frameworks.g.cs global.json | $(DOTNET_BUILD_DIR)/bgen
-	$(Q_DOTNET_BUILD) $(DOTNET6) publish bgen/bgen.csproj $(DOTNET_BUILD_VERBOSITY) /p:Configuration=Debug /p:IntermediateOutputPath=$(abspath $(DOTNET_BUILD_DIR)/IDE/obj/common)/ /p:OutputPath=$(abspath $(DOTNET_BUILD_DIR)/IDE/bin/common)/
-	$(Q) $(CP) $(DOTNET_BUILD_DIR)/IDE/bin/common/bgen* $(dir $@)
+	$(Q_DOTNET_BUILD) $(DOTNET6) publish bgen/bgen.csproj $(DOTNET_BUILD_VERBOSITY) /p:Configuration=Debug /p:IntermediateOutputPath=$(abspath $(DOTNET_BUILD_DIR)/IDE/obj/common/bgen)/ /p:OutputPath=$(abspath $(DOTNET_BUILD_DIR)/IDE/bin/common/bgen/)/
+	$(Q) $(CP) $(DOTNET_BUILD_DIR)/IDE/bin/common/bgen/publish/* $(dir $@)
 	$(Q) printf 'exec $(DOTNET6) "$$(dirname "$$0")"/bgen.dll $$@\n' > $@
 	$(Q) chmod +x $@
 

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -21,8 +21,8 @@ $(DOTNET_BUILD_DIR)/bgen/bgen:  $(generator_dependencies) Makefile.generator $(B
 
 
 $(DOTNET_DESTDIR)/%.Sdk/tools/lib/bgen/bgen: $(DOTNET_BUILD_DIR)/bgen/bgen | $(DOTNET_DESTDIR)/%.Sdk/tools/lib/bgen
-	$(Q) rm -f $(dir $@)/bgen*
-	$(Q) $(CP) $<* $(dir $@)
+	$(Q) rm -Rf "$(dir $@)"
+	$(Q) $(CP) -r "$(dir $<)" "$(dir $@)"
 
 $(DOTNET_DESTDIR)/%.Sdk/tools/bin/bgen: bgen/bgen.dotnet | $(DOTNET_DESTDIR)/%.Sdk/tools/bin
 	$(Q) $(CP) $< $@


### PR DESCRIPTION
Ship all files published by 'dotnet publish' for bgen, not only files prefixed
by 'bgen*'. This way we ship Mono.Options.dll too (and we won't crash at
launch trying to look for it).

Fixes https://github.com/xamarin/xamarin-macios/issues/11269.


Backport of #11362
