### PR TITLE
[mlaunch] Don't ship for MacCatalyst.

### DIFF
--- a/tools/mlaunch/Makefile
+++ b/tools/mlaunch/Makefile
@@ -13,7 +13,7 @@ endif
 endif
 endif
 
-DOTNET_PLATFORMS_MOBILE=$(filter-out macOS,$(DOTNET_PLATFORMS))
+DOTNET_PLATFORMS_MOBILE=$(filter-out macOS MacCatalyst,$(DOTNET_PLATFORMS))
 
 ifdef ENABLE_MLAUNCH
 build-and-install:


### PR DESCRIPTION
We don't need mlaunch for MacCatalyst.