### PR TITLE
[runtime] Implement mono_object_get_class for CoreCLR.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -239,4 +239,12 @@ mono_method_get_class (MonoMethod * method)
 	return rv;
 }
 
+MonoClass *
+mono_object_get_class (MonoObject * obj)
+{
+	MonoClass *rv = xamarin_bridge_object_get_type (obj);
+	LOG_CORECLR (stderr, "%s (%p) => %p\n", __func__, obj, rv);
+	return rv;
+}
+
 #endif // CORECLR_RUNTIME

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -348,6 +348,14 @@
 			OnlyDynamicUsage = false,
 			OnlyCoreCLR = true,
 		},
+
+		new XDelegate ("MonoObject *", "IntPtr", "xamarin_bridge_object_get_type",
+			"MonoObject *", "IntPtr", "gchandle"
+		) {
+			WrappedManagedFunction = "ObjectGetType",
+			OnlyDynamicUsage = false,
+			OnlyCoreCLR = true,
+		},
 	};
 	delegates.CalculateLengths ();
 #><#+

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -166,7 +166,9 @@
 
 		new Export ("MonoClass *", "mono_object_get_class",
 			"MonoObject *", "obj"
-		),
+		) {
+			HasCoreCLRBridgeFunction = true,
+		},
 
 		new Export ("MonoMethod *", "mono_object_get_virtual_method",
 			"MonoObject *", "obj",

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -159,6 +159,16 @@ namespace ObjCRuntime {
 			return GetMonoObject (method.DeclaringType);
 		}
 
+		static IntPtr ObjectGetType (MonoObjectPtr mobj)
+		{
+			var obj = GetMonoObjectTarget (mobj);
+			if (obj == null) {
+				log_coreclr ($"ObjectGetType (0x{mobj.ToString ("x")}) => null object");
+				return IntPtr.Zero;
+			}
+			return GetMonoObject (obj.GetType ());
+		}
+
 	}
 }
 


### PR DESCRIPTION
Next failure is:

> monotouchtest[54859:22963055] Xamarin.Mac: The method mono_object_isinst has not been implemented for CoreCLR.

```
3   com.xamarin.monotouch-test    	0x0000000101777e78 xamarin_assertion_message + 408 (runtime.m:1516)
4   com.xamarin.monotouch-test    	0x0000000101747435 mono_object_isinst + 37 (mono-runtime.m:2038)
5   com.xamarin.monotouch-test    	0x000000010177b4de verify_cast(_MonoObject*, _MonoObject*, objc_class*, objc_selector*, _MonoObject*, void**) + 78 (runtime.m:694)
6   com.xamarin.monotouch-test    	0x000000010177b35d xamarin_check_for_gced_object + 125 (runtime.m:723)
7   com.xamarin.monotouch-test    	0x00000001017d4c84 native_to_managed_trampoline_30(objc_object*, objc_selector*, _MonoObject**, unsigned int) + 212 (Microsoft.macOS.registrar.coreclr.x86_64.m:1369)
8   com.xamarin.monotouch-test    	0x00000001017d4e0c -[__MonoMac_NSActionDispatcher xamarinApplySelector] + 44 (Microsoft.macOS.registrar.coreclr.x86_64.m:38540)
9   com.apple.Foundation          	0x00007fff2143bba9 -[NSObject(NSThreadPerformAdditions) performSelector:onThread:withObject:waitUntilDone:modes:] + 935
10  com.apple.Foundation          	0x00007fff2143b6a1 -[NSObject(NSThreadPerformAdditions) performSelectorOnMainThread:withObject:waitUntilDone:] + 124
11  com.xamarin.monotouch-test    	0x000000010178feb9 xamarin_dyn_objc_msgSend + 217 (trampolines-x86_64-objc_msgSend.s:15)
```