### PR TITLE
[release/6.0.1xx-preview4] [dotnet] Fixes _RunILLink from Windows for Preview 4

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -357,6 +357,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 				ReferenceAssemblyPaths="@(ReferencePath)"
 				RootAssemblyNames="@(TrimmerRootAssembly)"
 				TrimMode="$(TrimMode)"
+				DefaultAction="$(_TrimmerDefaultAction)"
 				RemoveSymbols="$(TrimmerRemoveSymbols)"
 				FeatureSettings="@(_TrimmerFeatureSettings)"
 				CustomData="@(_TrimmerCustomData)"

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -357,7 +357,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 				ReferenceAssemblyPaths="@(ReferencePath)"
 				RootAssemblyNames="@(TrimmerRootAssembly)"
 				TrimMode="$(TrimMode)"
-				DefaultAction="$(_TrimmerDefaultAction)"
+				DefaultAction="$(TrimmerDefaultAction)"
 				RemoveSymbols="$(TrimmerRemoveSymbols)"
 				FeatureSettings="@(_TrimmerFeatureSettings)"
 				CustomData="@(_TrimmerCustomData)"
@@ -374,6 +374,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 				TreatWarningsAsErrors="$(ILLinkTreatWarningsAsErrors)"
 				WarningsAsErrors="$(WarningsAsErrors)"
 				WarningsNotAsErrors="$(WarningsNotAsErrors)"
+				SingleWarn="$(TrimmerSingleWarn)"
 
 				CustomSteps="@(_TrimmerCustomSteps)"
 				RootDescriptorFiles="@(TrimmerRootDescriptor)"


### PR DESCRIPTION
Backport:

* [dotnet] Fixes _RunILLink from Windows for Preview 4 (#11390)

    There were some changes on the original target.

* [dotnet] Sets missing ILLink parameter from Windows (#11319)

    This was making the linker to not behave correctly, and apps were crashing
    on the simulator.