### PR TITLE
[tests] Make the mtouch test project reference the actual mtouch project.

### DIFF
--- a/Xamarin.iOS.sln
+++ b/Xamarin.iOS.sln
@@ -15,7 +15,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "link sdk", "tests\linker\io
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dont link", "tests\linker\ios\dont link\dont link.csproj", "{839212D5-C25B-4284-AA96-59C3872B8184}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mtouch", "tests\mtouch\mtouch.csproj", "{9A1177F5-16E6-45DE-AA69-DC9924EC39B8}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mtouchtests", "tests\mtouch\mtouchtests.csproj", "{9A1177F5-16E6-45DE-AA69-DC9924EC39B8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "libmonotouch", "runtime\libmonotouch.csproj", "{8A5B637C-E4FF-4145-B887-9347020100F4}"
 EndProject

--- a/tests/mtouch/Makefile
+++ b/tests/mtouch/Makefile
@@ -18,7 +18,7 @@ all-local::
 # or multiple tests:
 #     make run-tests TEST_FIXTURE="-test=Xamarin.MTouch.MT1016,Xamarin.MTouch.MT1017"
 
-run-tests: bin/Debug/mtouch.dll test.config
+run-tests: bin/Debug/mtouchtests.dll test.config
 	rm -f .failed-stamp
 	$(TOP)/tools/nunit3-console-3.11.1 "$(abspath $<)" "--result=$(abspath $(CURDIR)/TestResult.xml);format=nunit2" $(TEST_FIXTURE) --labels=All --inprocess || touch $(CURDIR)/.failed-stamp
 	@# Create an html file and tell MonkeyWrench to upload it (if we're running there)
@@ -27,14 +27,14 @@ run-tests: bin/Debug/mtouch.dll test.config
 		echo "@MonkeyWrench: AddFile: $$PWD/index.html")
 	@[[ ! -e .failed-stamp ]] 
 
-# mtouch.csproj.inc contains the mtouch_dependencies variable used to determine if mtouch.dll needs to be rebuilt or not.
--include mtouch.csproj.inc
+# mtouchtests.csproj.inc contains the mtouch_dependencies variable used to determine if mtouchtests.dll needs to be rebuilt or not.
+-include mtouchtests.csproj.inc
 
-bin/Debug/mtouch.dll: $(mtouch_dependencies)
-	$(SYSTEM_XIBUILD) -- mtouch.csproj /r $(XBUILD_VERBOSITY)
+bin/Debug/mtouchtests.dll: $(mtouch_dependencies)
+	$(SYSTEM_XIBUILD) -- mtouchtests.csproj /r $(XBUILD_VERBOSITY)
 	$(Q) rm -f .failed-stamp
 
-build: bin/Debug/mtouch.dll
+build: bin/Debug/mtouchtests.dll
 
 test.config: $(TOP)/Make.config Makefile
 	@rm -f $@

--- a/tests/mtouch/SdkTest.cs
+++ b/tests/mtouch/SdkTest.cs
@@ -12,19 +12,20 @@ using NUnit.Framework;
 using Xamarin.Tests;
 
 namespace Xamarin.Linker {
-
-	public abstract class BaseProfile {
-
-		protected abstract bool IsSdk (string assemblyName);
-	}
-
 	public class ProfilePoker : MobileProfile {
 
 		static ProfilePoker p = new ProfilePoker ();
 
+		public override string ProductAssembly => throw new NotImplementedException ();
+
 		public static bool IsWellKnownSdk (string assemblyName)
 		{
 			return p.IsSdk (assemblyName);
+		}
+
+		protected override bool IsProduct (string assemblyName)
+		{
+			throw new NotImplementedException ();
 		}
 	}
 

--- a/tests/mtouch/mtouchtests.csproj
+++ b/tests/mtouch/mtouchtests.csproj
@@ -8,8 +8,8 @@
     <ProjectGuid>{9A1177F5-16E6-45DE-AA69-DC9924EC39B8}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>MTouchTests</RootNamespace>
-    <AssemblyName>mtouch</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <AssemblyName>mtouchtests</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,8 +27,13 @@
     <Reference Include="System.Xml" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
-    <PackageReference Include="Mono.Cecil" Version="0.11.1" />
     <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.404" />
+    <Reference Include="Mono.Cecil">
+      <HintPath>..\..\builds\mono-ios-sdk-destdir\ios-bcl\monotouch_tools\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb">
+      <HintPath>..\..\builds\mono-ios-sdk-destdir\ios-bcl\monotouch_tools\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MTouch.cs" />
@@ -43,9 +48,6 @@
       <Link>Configuration.cs</Link>
     </Compile>
     <Compile Include="MiscTests.cs" />
-    <Compile Include="..\..\tools\linker\MobileProfile.cs">
-      <Link>MobileProfile.cs</Link>
-    </Compile>
     <Compile Include="SdkTest.cs" />
     <Compile Include="MTouchTool.cs" />
     <Compile Include="TimingTests.cs" />
@@ -80,42 +82,12 @@
     <Compile Include="..\..\msbuild\Xamarin.Mac.Tasks\Tasks\MetalLib.cs">
       <Link>MetalLib.cs</Link>
     </Compile>
-    <Compile Include="..\..\tools\common\MachO.cs">
-      <Link>MachO.cs</Link>
-    </Compile>
-    <Compile Include="..\..\src\ObjCRuntime\ErrorHelper.cs">
-      <Link>ErrorHelper.cs</Link>
-    </Compile>
-    <Compile Include="..\..\tools\common\ErrorHelper.tools.cs">
-      <Link>tools\common\ErrorHelper.tools.cs</Link>
-    </Compile>
     <Compile Include="..\..\tools\common\SdkVersions.cs">
       <Link>SdkVersions.cs</Link>
     </Compile>
-    <Compile Include="..\..\tools\mtouch\Errors.Designer.cs">
-      <Link>Errors.Designer.cs</Link>
-    </Compile>
-    <Compile Include="..\..\tools\common\error.cs">
-      <Link>error.cs</Link>
-    </Compile>
     <Compile Include="ErrorTest.cs" />
-    <Compile Include="..\..\tools\common\ApplePlatform.cs">
-      <Link>tools\common\ApplePlatform.cs</Link>
-    </Compile>
     <Compile Include="Setup.cs" />
     <Compile Include="Compat.cs" />
-    <Compile Include="..\..\tools\common\Driver.execution.cs">
-      <Link>Driver.execution.cs</Link>
-    </Compile>
-    <Compile Include="..\..\tools\common\Execution.cs">
-      <Link>Execution.cs</Link>
-    </Compile>
-    <Compile Include="..\..\tools\common\TargetFramework.cs">
-      <Link>TargetFramework.cs</Link>
-    </Compile>
-    <Compile Include="..\..\tools\common\FileCopier.cs">
-      <Link>tools\common\FileCopier.cs</Link>
-    </Compile>
     <Compile Include="..\common\Tool.cs">
       <Link>Tool.cs</Link>
     </Compile>
@@ -124,9 +96,10 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\tools\mtouch\Errors.resx">
-      <Link>Errors.resx</Link>
-    </None>
+    <ProjectReference Include="..\..\tools\mtouch\mtouch.csproj">
+      <Project>{A737EFCC-4348-4EB1-9C14-4FDC0975388D}</Project>
+      <Name>mtouch</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tests/mtouch/mtouchtests.sln
+++ b/tests/mtouch/mtouchtests.sln
@@ -1,7 +1,9 @@
 
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mtouch", "mtouch.csproj", "{9A1177F5-16E6-45DE-AA69-DC9924EC39B8}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mtouchtests", "mtouchtests.csproj", "{9A1177F5-16E6-45DE-AA69-DC9924EC39B8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mtouch", "..\..\tools\mtouch\mtouch.csproj", "{A737EFCC-4348-4EB1-9C14-4FDC0975388D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,5 +33,21 @@ Global
 		{9A1177F5-16E6-45DE-AA69-DC9924EC39B8}.pcl_Release|Any CPU.Build.0 = Debug|Any CPU
 		{9A1177F5-16E6-45DE-AA69-DC9924EC39B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9A1177F5-16E6-45DE-AA69-DC9924EC39B8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.net_3_5_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.net_3_5_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.net_4_0_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.net_4_0_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.pcl_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.pcl_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.net_3_5_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.net_3_5_Release|Any CPU.Build.0 = Debug|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.net_4_0_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.net_4_0_Release|Any CPU.Build.0 = Debug|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.pcl_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.pcl_Release|Any CPU.Build.0 = Debug|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A737EFCC-4348-4EB1-9C14-4FDC0975388D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/tests/tests.sln
+++ b/tests/tests.sln
@@ -25,7 +25,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "link all", "linker\ios\link
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "link sdk", "linker\ios\link sdk\link sdk.csproj", "{C47F8F72-A7CA-4149-AA7D-BC4814803EF3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mtouch", "mtouch\mtouch.csproj", "{9A1177F5-16E6-45DE-AA69-DC9924EC39B8}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mtouchtests", "mtouch\mtouchtests.csproj", "{9A1177F5-16E6-45DE-AA69-DC9924EC39B8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "testgenerator", "test-libraries\testgenerator.csproj", "{CD430449-8E59-4ECD-ADD9-ACF79E9E660B}"
 EndProject

--- a/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
+++ b/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
@@ -82,7 +82,7 @@ namespace Xharness.Jenkins {
 			yield return nunitExecutionInstallSource;
 
 			var buildMTouch = new MakeTask (jenkins: jenkins, processManager: processManager) {
-				TestProject = new TestProject (Path.GetFullPath (Path.Combine (HarnessConfiguration.RootDirectory, "mtouch", "mtouch.sln"))),
+				TestProject = new TestProject (Path.GetFullPath (Path.Combine (HarnessConfiguration.RootDirectory, "mtouch", "mtouchtests.sln"))),
 				SpecifyPlatform = false,
 				SpecifyConfiguration = false,
 				Platform = TestPlatform.iOS,
@@ -90,8 +90,8 @@ namespace Xharness.Jenkins {
 				WorkingDirectory = Path.GetFullPath (Path.Combine (HarnessConfiguration.RootDirectory, "mtouch")),
 			};
 			var nunitExecutionMTouch = new NUnitExecuteTask (jenkins, buildMTouch, processManager) {
-				TestLibrary = Path.Combine (HarnessConfiguration.RootDirectory, "mtouch", "bin", "Debug", "mtouch.dll"),
-				TestProject = new TestProject (Path.GetFullPath (Path.Combine (HarnessConfiguration.RootDirectory, "mtouch", "mtouch.csproj"))),
+				TestLibrary = Path.Combine (HarnessConfiguration.RootDirectory, "mtouch", "bin", "Debug", "mtouchtests.dll"),
+				TestProject = new TestProject (Path.GetFullPath (Path.Combine (HarnessConfiguration.RootDirectory, "mtouch", "mtouchtests.csproj"))),
 				Platform = TestPlatform.iOS,
 				TestName = "MTouch tests",
 				Timeout = TimeSpan.FromMinutes (180),

--- a/tools/common/ErrorHelper.tools.cs
+++ b/tools/common/ErrorHelper.tools.cs
@@ -10,7 +10,7 @@ using Mono.Cecil.Cil;
 using Xamarin.Utils;
 
 namespace Xamarin.Bundler {
-	static partial class ErrorHelper {
+	public static partial class ErrorHelper {
 		public static ApplePlatform Platform;
 
 		internal static string Prefix {


### PR DESCRIPTION
This makes it easier to test localized strings used in mtouch, since we don't have
to replicate the build for all the resources.

This required a few changes to avoid including code in the mtouch tests that already
exists in the mtouch executable.

Also rename the mtouch test project to mtouchtests.csproj.

This way the test project can reference the actual mtouch.csproj without
causing conflicts due to having two projects with the same name.