### PR TITLE
[release/6.0.1xx-preview4] [CI] Enable setting provisionator channel as parameter

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -17,6 +17,10 @@ parameters:
 - name: runSamples
   type: boolean
   default: false
+  
+- name: provisionatorChannel
+  type: string
+  default: 'latest'
 
 # We are doing some black magic. We have several templates that 
 # are executed with different parameters. 
@@ -136,7 +140,8 @@ variables:
 - name: TeamName
   value: 'xamarin-macios'
 - name: PROVISIONATOR_CHANNEL
-  value: 'pr/mandel-macaque/401'
+  value: ${{ parameters.provisionatorChannel }}
+  
 
 trigger:
   branches:


### PR DESCRIPTION
This also brings in the latest changes for provisionator; specifically https://github.com/xamarin/provisionator/pull/402 to unblock builds.


Backport of #11377
