### PR TITLE
[release/6.0.1xx-preview4] [Tests] Update xamarin domain to make tests not fail.

### DIFF
--- a/tests/monotouch-test/System.Net.Http/NetworkResources.cs
+++ b/tests/monotouch-test/System.Net.Http/NetworkResources.cs
@@ -9,7 +9,7 @@ namespace MonoTests.System.Net.Http
 	{
 		public static readonly string MicrosoftUrl = "https://www.microsoft.com";
 		public static readonly Uri MicrosoftUri = new Uri (MicrosoftUrl);
-		public static readonly string XamarinUrl = "https://xamarin.com";
+		public static readonly string XamarinUrl = "https://dotnet.microsoft.com/apps/xamarin";
 		public static readonly Uri XamarinUri = new Uri (XamarinUrl);
 		public static readonly string StatsUrl = "https://api.imgur.com/2/stats";
 

--- a/tests/monotouch-test/example.pac
+++ b/tests/monotouch-test/example.pac
@@ -1,7 +1,7 @@
 ﻿// Example PAC file that returns a proxy for the urls that have the
 // xamarin domain name.
 function FindProxyForURL(url, host) {
-	if (dnsDomainIs(host, "xamarin.com"))
+	if (dnsDomainIs(host, "dotnet.microsoft.com"))
 		return "PROXY example.com:8080";
 	 
 	if (dnsDomainIs(host, "microsoft.com"))


### PR DESCRIPTION
A wrong implementation of a redirect was added and returns a 403 and not
a 302 resulting in an error. Update to the final destination of the
redirect and be happy.

fixes https://github.com/xamarin/maccore/issues/2432


Backport of #11408
