### PR TITLE
[runtime] Implement mono_object_isinst for CoreCLR.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -247,4 +247,12 @@ mono_object_get_class (MonoObject * obj)
 	return rv;
 }
 
+MonoObject *
+mono_object_isinst (MonoObject * obj, MonoClass * klass)
+{
+	bool rv = xamarin_bridge_isinstance (obj, klass);
+	LOG_CORECLR (stderr, "%s (%p, %p) => %i\n", __func__, obj, klass, rv);
+	return rv ? obj : NULL;
+}
+
 #endif // CORECLR_RUNTIME

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -373,6 +373,15 @@
 			OnlyDynamicUsage = false,
 			OnlyCoreCLR = true,
 		},
+
+		new XDelegate ("bool", "bool", "xamarin_bridge_isinstance",
+			"GCHandle", "IntPtr", "gchandle",
+			"GCHandle", "IntPtr", "type"
+		) {
+			WrappedManagedFunction = "IsInstance",
+			OnlyDynamicUsage = false,
+			OnlyCoreCLR = true,
+		},
 	};
 	delegates.CalculateLengths ();
 #><#+

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -157,7 +157,9 @@
 		new Export ("MonoObject *", "mono_object_isinst",
 			"MonoObject *", "obj",
 			"MonoClass *", "klass"
-		),
+		) {
+			HasCoreCLRBridgeFunction = true,
+		},
 
 		new Export ("MonoClass *", "mono_object_get_class",
 			"MonoObject *", "obj"

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -169,6 +169,19 @@ namespace ObjCRuntime {
 			return GetMonoObject (obj.GetType ());
 		}
 
+		static bool IsInstance (MonoObjectPtr mobj, MonoObjectPtr mtype)
+		{
+			var obj = GetMonoObjectTarget (mobj);
+			if (obj == null)
+				return false;
+
+			var type = (Type) GetMonoObjectTarget (mtype);
+			var rv = type.IsAssignableFrom (obj.GetType ());
+
+			log_coreclr ($"IsInstance ({obj.GetType ()}, {type})");
+
+			return rv;
+		}
 	}
 }
 


### PR DESCRIPTION
Next failure is:

> monotouchtest[8307:20722735] Xamarin.Mac: The method mono_runtime_invoke has not been implemented for CoreCLR.

```
* frame #0: 0x00007fff2059b462 libsystem_kernel.dylib`__pthread_kill + 10
  frame #1: 0x00007fff205c9610 libsystem_pthread.dylib`pthread_kill + 263
  frame #2: 0x00007fff2051c720 libsystem_c.dylib`abort + 120
  frame #3: 0x0000000100044ab8 monotouchtest`xamarin_assertion_message(msg="The method %s has not been implemented for CoreCLR.\n") at runtime.m:1474:2
  frame #4: 0x0000000100013f0d monotouchtest`mono_runtime_invoke(method=0x0000000100e5afe0, obj=0x0000000100e5afd0, params=0x00007ffeefbfdd28, exc=0x0000000000000000) at mono-runtime.m:1946:2
  frame #5: 0x00000001000a1a69 monotouchtest`native_to_managed_trampoline_30(self=0x0000000100e5bad0, _cmd="xamarinApplySelector", managed_method_ptr=0x00000001001d5028, token_ref=12113) at Microsoft.macOS.registrar.coreclr.x86_64.m:1371:2
  frame #6: 0x00000001000a1bcc monotouchtest`-[__MonoMac_NSActionDispatcher xamarinApplySelector](self=0x0000000100e5bad0, _cmd="xamarinApplySelector") at Microsoft.macOS.registrar.coreclr.x86_64.m:38540:3
  frame #7: 0x00007fff2143bba9 Foundation`-[NSObject(NSThreadPerformAdditions) performSelector:onThread:withObject:waitUntilDone:modes:] + 935
  frame #8: 0x00007fff2143b6a1 Foundation`-[NSObject(NSThreadPerformAdditions) performSelectorOnMainThread:withObject:waitUntilDone:] + 124
  frame #9: 0x000000010005cc89 monotouchtest`xamarin_dyn_objc_msgSend at trampolines-x86_64-objc_msgSend.s:15
```