### PR TITLE
[CI] Do not clutter the nuget feed with PR build nugets.

### DIFF
--- a/tools/devops/automation/templates/build/build-nugets.yml
+++ b/tools/devops/automation/templates/build/build-nugets.yml
@@ -22,15 +22,17 @@ steps:
     artifactName: build-binlogs
   condition: and(succeededOrFailed(), contains(variables['configuration.BuildNugets'], 'True'))
 
-- task: NuGetCommand@2
-  displayName: 'Publish Nugets'
-  inputs:
-    command: push
-    packagesToPush: $(Build.SourcesDirectory)/package/*.nupkg
-    nuGetFeedType: external
-    publishFeedCredentials: xamarin-impl public feed
-  condition: and(succeeded(), eq(variables['configuration.BuildNugets'], 'True'))
-  continueOnError: true # should not stop the build since is not official just yet.
+# do not publish on pull requets
+- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - task: NuGetCommand@2
+    displayName: 'Publish Nugets'
+    inputs:
+      command: push
+      packagesToPush: $(Build.SourcesDirectory)/package/*.nupkg
+      nuGetFeedType: external
+      publishFeedCredentials: xamarin-impl public feed
+    condition: and(succeeded(), eq(variables['configuration.BuildNugets'], 'True'))
+    continueOnError: true # should not stop the build since is not official just yet.
 
 # Only executed when the publshing of the nugets failed.
 - bash: |


### PR DESCRIPTION
Do not publish the nugets that have been created in a PR build. The
build results can be accessed from the comment once completed. This way
we make sure that next builds do not have conflicts when publishing the
nugets.