### PR TITLE
[d16-9][CI] Allow to enable or disable the dotnet builds. 

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -14,6 +14,10 @@ parameters:
   type: boolean
   default: true
 
+- name: enableDotnet
+  type: boolean
+  default: true
+
 # We are doing some black magic. We have several templates that 
 # are executed with different parameters. 
 #
@@ -191,7 +195,7 @@ stages:
         runTests: ${{ parameters.runTests }}
         runDeviceTests: ${{ parameters.runDeviceTests }}
         keyringPass: $(xma-password)
-
+        enableDotnet: ${{ parameters.enableDotnet }}
 
 - ${{ if or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual')) }}:
   - ${{ each config in parameters.deviceTestsConfigurations }}:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -16,7 +16,7 @@ parameters:
 
 - name: enableDotnet
   type: boolean
-  default: true
+  default: false
 
 # We are doing some black magic. We have several templates that 
 # are executed with different parameters. 

--- a/tools/devops/automation/templates/build/build-nugets.yml
+++ b/tools/devops/automation/templates/build/build-nugets.yml
@@ -1,0 +1,17 @@
+steps:
+- bash:  $(Build.SourcesDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/build-nugets.sh
+  displayName: 'Build Nugets'
+  condition: and(succeeded(), contains(variables['configuration.BuildNugets'], 'True'))
+  continueOnError: true # should not stop the build since is not official just yet.
+  timeoutInMinutes: 180
+
+- task: NuGetCommand@2
+  displayName: 'Publish Nugets'
+  inputs:
+    command: push
+    packagesToPush: $(Build.SourcesDirectory)/package/*.nupkg
+    nuGetFeedType: external
+    publishFeedCredentials: xamarin-impl public feed
+  condition: and(succeeded(), eq(variables['configuration.BuildNugets'], 'True'))
+  continueOnError: true # should not stop the build since is not official just yet.
+  timeoutInMinutes: 180

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -17,6 +17,10 @@ parameters:
 - name: keyringPass
   type: string
 
+- name: enableDotnet
+  type: boolean
+  default: false
+
 steps:
 - checkout: self          # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
   clean: true             # Executes: git clean -ffdx && git reset --hard HEAD
@@ -258,13 +262,21 @@ steps:
       CONFIGURE_FLAGS="--enable-xamarin"
     fi
 
-    CONFIGURE_FLAGS="$CONFIGURE_FLAGS --enable-dotnet --enable-install-source"
+    if [[ "$EnableDotNet" == "True" ]]; then
+      echo "Enabling dotnet builds."
+      CONFIGURE_FLAGS="$CONFIGURE_FLAGS --enable-dotnet --enable-dotnet-windows"
+    fi
+
+    CONFIGURE_FLAGS="$CONFIGURE_FLAGS --enable-install-source"
+    echo "Configuration falgs are '$CONFIGURE_FLAGS'"
 
     cd $(Build.SourcesDirectory)/xamarin-macios/
     ./configure $CONFIGURE_FLAGS
     echo $(cat $(Build.SourcesDirectory)/xamarin-macios/configure.inc)
   env:
     IsPR: $(configuration.IsPR)
+    ${{ if eq(parameters.enableDotnet, true) }}:
+      EnableDotNet: 'True'
   displayName: "Configure build"
   timeoutInMinutes: 5
 
@@ -291,26 +303,14 @@ steps:
   timeoutInMinutes: 180
 
 # build nugets
-- bash:  $(Build.SourcesDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/build-nugets.sh
-  displayName: 'Build Nugets'
-  condition: and(succeeded(), contains(variables['configuration.BuildNugets'], 'True'))
-  continueOnError: true # should not stop the build since is not official just yet.
-  timeoutInMinutes: 180
-
-- task: NuGetCommand@2
-  displayName: 'Publish Nugets'
-  inputs:
-    command: push
-    packagesToPush: $(Build.SourcesDirectory)/package/*.nupkg
-    nuGetFeedType: external
-    publishFeedCredentials: xamarin-impl public feed
-  condition: and(succeeded(), eq(variables['configuration.BuildNugets'], 'True'))
-  continueOnError: true # should not stop the build since is not official just yet.
-  timeoutInMinutes: 180
+- ${{ if eq(parameters.enableDotnet, true) }}:
+  - template: build-nugets.yml
 
 # only sign an notarize in no PR executions
 - ${{ if ne(parameters.isPR, 'True') }}:
   - template: sign-and-notarized.yml
+    parameters:
+      enableDotnet: ${{ parameters.enableDotnet }}
 
 - template: generate-workspace-info.yml@templates
   parameters:

--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -1,6 +1,12 @@
 # This job will parse all the labels present in a PR, will set
 # the tags for the build AND will set a number of configuration
 # variables to be used by the rest of the projects
+parameters:
+
+- name: enableDotnet
+  type: boolean
+  default: false
+
 steps:
 - checkout: self          # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
   clean: true             # Executes: git clean -ffdx && git reset --hard HEAD
@@ -24,6 +30,12 @@ steps:
     if ($buildReason -eq "Schedule") {
         $tags.Add("cronjob")
     }
+    if ($Env:ENABLE_DOTNET -eq "True") {
+      Write-Host "dotnet will be enabled for the build because ENABLE_DOTNET was '$Env:ENABLE_DOTNET'"
+    } else {
+      Write-Host "dotnet will be disabled for the build because ENABLE_DOTNET was '$Env:ENABLE_DOTNET'"
+    }
+
 
     if ($buildReason -eq "PullRequest" -or (($buildReason -eq "Manual") -and ($buildSourceBranchName -eq "merge")) ) {
       Write-Host "Configuring build from PR."
@@ -57,7 +69,8 @@ steps:
       # decide if we add the run-dotnet-tests label (if not present) this is done only for main
       # we can use $ref for that :)
       $xharnessLabels = $tags -join ","
-      if ($ref -eq "main" -and -not ("run-dotnet-tests" -in $xharnessLabels)) {
+      if ($Env:ENABLE_DOTNET -eq "True" -and -not ("run-dotnet-tests" -in $xharnessLabels)) {
+        Write-Host "Adding label run-dotnet-tests to xharness."
         $tags.Add("run-dotnet-tests")
         if ($xharnessLabels -eq "") {
           $xharnessLabels = "run-dotnet-tests"
@@ -102,5 +115,7 @@ steps:
     BUILD_REVISION: $(Build.SourceVersion)
     GITHUB_TOKEN: $(GitHub.Token)
     ACCESSTOKEN: $(AzDoBuildAccess.Token)
+    ${{ if eq(parameters.enableDotnet, true) }}:
+      ENABLE_DOTNET: "True"
   name: labels
   displayName: 'Configure build'

--- a/tools/devops/automation/templates/build/sign-and-notarized.yml
+++ b/tools/devops/automation/templates/build/sign-and-notarized.yml
@@ -5,6 +5,10 @@ parameters:
   type: string
   default: 'Real'
 
+- name: enableDotnet
+  type: boolean
+  default: false
+
 steps:
 
 - bash: |
@@ -41,36 +45,37 @@ steps:
     zipSources: false  # we do not use the feature and makes the installation to last 10/12 mins instead of < 1 min
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+ 
+- ${{ if eq(parameters.enableDotnet, true) }}:
+  - pwsh : |
+      # Get the list of files to sign
+      $msiFiles = Get-ChildItem -Path $(Build.SourcesDirectory)/package/ -Filter "*.msi"
 
-- pwsh : |
-    # Get the list of files to sign
-    $msiFiles = Get-ChildItem -Path $(Build.SourcesDirectory)/package/ -Filter "*.msi"
-
-    # Add those files to an array
-    $SignFiles = @()
-    foreach($msi in $msiFiles) {
-        Write-Host "$($msi.FullName)"
-        $SignFiles += @{ "SrcPath"="$($msi.FullName)"}
-    }
-
-    Write-Host "$msiFiles"
-
-    # array of dicts
-    $SignFileRecord = @(
-      @{
-        "Certs" = "400";
-        "SignFileList" = $SignFiles;
+      # Add those files to an array
+      $SignFiles = @()
+      foreach($msi in $msiFiles) {
+          Write-Host "$($msi.FullName)"
+          $SignFiles += @{ "SrcPath"="$($msi.FullName)"}
       }
-    )
 
-    $SignFileList = @{
-        "SignFileRecordList" = $SignFileRecord
-    }
+      Write-Host "$msiFiles"
 
-    # Write the json to a file
-    ConvertTo-Json -InputObject $SignFileList -Depth 5 | Out-File -FilePath $(Build.ArtifactStagingDirectory)/MsiFiles2Notarize.json -Force
-    dotnet $Env:MBSIGN_APPFOLDER/ddsignfiles.dll /filelist:$(Build.ArtifactStagingDirectory)/MsiFiles2Notarize.json
-  displayName: 'Sign .msi'
+      # array of dicts
+      $SignFileRecord = @(
+        @{
+          "Certs" = "400";
+          "SignFileList" = $SignFiles;
+        }
+      )
+
+      $SignFileList = @{
+          "SignFileRecordList" = $SignFileRecord
+      }
+
+      # Write the json to a file
+      ConvertTo-Json -InputObject $SignFileList -Depth 5 | Out-File -FilePath $(Build.ArtifactStagingDirectory)/MsiFiles2Notarize.json -Force
+      dotnet $Env:MBSIGN_APPFOLDER/ddsignfiles.dll /filelist:$(Build.ArtifactStagingDirectory)/MsiFiles2Notarize.json
+    displayName: 'Sign .msi'
 
 - bash: |
     security unlock-keychain -p $PRODUCTSIGN_KEYCHAIN_PASSWORD builder.keychain

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -15,6 +15,10 @@ parameters:
 - name: keyringPass
   type: string
 
+- name: enableDotnet
+  type: boolean
+  default: false
+
 jobs:
 - job: configure
   displayName: 'Configure build'
@@ -85,6 +89,7 @@ jobs:
       runDeviceTests: ${{ parameters.runDeviceTests }}
       vsdropsPrefix: ${{ parameters.vsdropsPrefix }} 
       keyringPass: ${{ parameters.keyringPass }} 
+      enableDotnet: ${{ parameters.enableDotnet }}
 
 - job: upload_azure_blob
   displayName: 'Upload packages to Azure'
@@ -101,6 +106,8 @@ jobs:
       clean: all
   steps:
   - template: upload-azure.yml
+    parameters:
+      enableDotnet: ${{ parameters.enableDotnet }}
 
 - job: upload_vsdrops
   displayName: 'Upload test results to VSDrops'

--- a/tools/devops/automation/templates/build/upload-azure.yml
+++ b/tools/devops/automation/templates/build/upload-azure.yml
@@ -1,3 +1,8 @@
+parameters:
+- name: enableDotnet
+  type: boolean
+  default: false
+
 steps:
 
 - checkout: self
@@ -164,10 +169,25 @@ steps:
        Set-GitHubStatus -Status "error" -Description "msbuild.zip not found." -Context "msbuild.zip"
     }
 
-    $nugets =  $files = Get-ChildItem -Path $pkgsPath -Filter *.nupkg -File -Name
+    if ($Env:ENABLE_DOTNET -eq "True" -and  $Env:SkipNugets -ne "True") {
+      $nugets = Get-ChildItem -Path $pkgsPath -Filter *.nupkg -File -Name
+      Write-Host $nugets 
+      Write-Host "nuget count is $($nugets.Count)"
 
-    foreach ($n in $nugets) {
-      Set-GitHubStatus -Status "success" -Description "$n" -TargetUrl "$pkgsVirtualUrl/$n" -Context "$n"
+      if ($nugets.Count -gt 0) {
+        Write-Host "Setting status to success."
+        Set-GitHubStatus -Status "success" -Description "Nugets built." -TargetUrl "$pkgsVirtualUrl/$n" -Context "$(Build.DefinitionName) (Nugets built)"
+        Write-Host "Publishing result is $Env:NUGETS_PUBLISHED"
+        if ($Env:NUGETS_PUBLISHED -ne "Failed") {
+          Set-GitHubStatus -Status "success" -Description "Nugets published." -TargetUrl "$pkgsVirtualUrl/$n" -Context "$(Build.DefinitionName) (Nugets published)"
+        } else {
+          Set-GitHubStatus -Status "error" -Description "Error when publishing nugets." -TargetUrl "$pkgsVirtualUrl/$n" -Context "$(Build.DefinitionName) (Nugets published)"
+        }
+      } else {
+        Write-Host "Setting nuget status to failure." 
+        Set-GitHubStatus -Status "error" -Description "No nugets were built." -TargetUrl "$pkgsVirtualUrl/$n" -Context "$(Build.DefinitionName) (Nugets built)"
+        Set-GitHubStatus -Status "error" -Description "No nugets were published." -TargetUrl "$pkgsVirtualUrl/$n" -Context "$(Build.DefinitionName) (Nugets published)"
+      }
     }
 
     $msi =  $files = Get-ChildItem -Path $pkgsPath -Filter *.msi -File -Name
@@ -180,4 +200,6 @@ steps:
     GITHUB_TOKEN: $(GitHub.Token)
     ACCESSTOKEN: $(System.AccessToken)
     STORAGE_URI: $(Parameters.outputStorageUri)
+    ${{ if eq(parameters.enableDotnet, true) }}:
+      ENABLE_DOTNET: "True"
   displayName: 'Set GithubStatus'


### PR DESCRIPTION
Create a new parameter that can be used to decide if we build or not the
dotnet parts of the project. If we do not, we make sure that we do not
have any errors in all the other steps.

cherry-pick + disable the dotnet build in the branch.