### PR TITLE
[CI] Create post pipelines that will publish html results.

### DIFF
--- a/tools/devops/automation/publish-ci-html-results.yml
+++ b/tools/devops/automation/publish-ci-html-results.yml
@@ -1,0 +1,50 @@
+# YAML pipeline for publishing the test results as a static gitbub page in a different 
+# repository:
+# This pipeline will trigger in a succesful build of a build with a ciBuild tag.
+
+trigger: none
+pr: none
+
+resources:
+  repositories:
+  - repository: self
+    checkoutOptions:
+      submodules: false  # no need
+
+  - repository: macios.ci
+    type: github
+    name: xamarin/macios.ci
+    ref: refs/heads/main # get main and create the branch from main
+    endpoint: xamarin
+
+  pipelines:
+  - pipeline: macios
+    source: xamarin-macios
+    trigger: true # always do trigger
+    tags:
+      - ciBuild # used to identify builds for PRS, this is a workaround to get it working within vsts limits
+
+variables:
+- group: xamops-azdev-secrets
+- group: Xamarin-Secrets
+- group: Xamarin Release
+- name: GitHub.Token                                          # Override the GitHub.Token setting defined in the Xamarin Release group
+  value: $(github--pat--vs-mobiletools-engineering-service2)  # Use a token dedicated to critical production workflows and help avoid GitHub throttling
+- name: AzDoBuildAccess.Token
+  value: $(pat--xamarinc--build-access)
+- name: system.debug
+  value: true
+
+
+jobs:
+- job: publish_results
+  displayName: Publish Results
+  pool:
+    vmImage: ubuntu-latest
+  workspace:
+    clean: all
+
+  steps:
+  - template: templates/publish-html-result.yml 
+    parameters:
+      reason: 'ci'

--- a/tools/devops/automation/publish-pr-html-results.yml
+++ b/tools/devops/automation/publish-pr-html-results.yml
@@ -1,0 +1,50 @@
+# YAML pipeline for publishing the test results as a static gitbub page in a different 
+# repository:
+# This pipeline will trigger in a succesful build of a build with a prBuild tag.
+
+trigger: none
+pr: none
+
+resources:
+  repositories:
+  - repository: self
+    checkoutOptions:
+      submodules: false  # no need
+
+  - repository: macios.ci
+    type: github
+    name: xamarin/macios.ci
+    ref: refs/heads/main # get main and create the branch from main
+    endpoint: xamarin
+
+  pipelines:
+  - pipeline: macios
+    source: xamarin-macios
+    trigger: true # always do trigger
+    tags:
+      - prBuild # used to identify builds for PRS, this is a workaround to get it working within vsts limits
+
+variables:
+- group: xamops-azdev-secrets
+- group: Xamarin-Secrets
+- group: Xamarin Release
+- name: GitHub.Token                                          # Override the GitHub.Token setting defined in the Xamarin Release group
+  value: $(github--pat--vs-mobiletools-engineering-service2)  # Use a token dedicated to critical production workflows and help avoid GitHub throttling
+- name: AzDoBuildAccess.Token
+  value: $(pat--xamarinc--build-access)
+- name: system.debug
+  value: true
+
+
+jobs:
+- job: publish_results
+  displayName: Publish Results
+  pool:
+    vmImage: ubuntu-latest
+  workspace:
+    clean: all
+
+  steps:
+  - template: templates/publish-html-result.yml 
+    parameters:
+      reason: 'pr'

--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -103,6 +103,7 @@ steps:
 
       Write-Host "##vso[task.setvariable variable=prBuild;isOutput=true]True"
     } else {
+      $tags.Add("ciBuild")
       # set the name of the branch under build
       $tags.Add("$buildSourceBranchName")
       Write-Host "##vso[task.setvariable variable=prBuild;isOutput=true]False"

--- a/tools/devops/automation/templates/publish-html-result.yml
+++ b/tools/devops/automation/templates/publish-html-result.yml
@@ -1,0 +1,21 @@
+# generic steps to get the test results, remove any private informaiton and add them to the github page.
+parameters:
+
+- name: reason 
+  type: string 
+  default: 'pr' # default reason is a pr build 
+
+steps:
+
+- checkout: self
+  persistCredentials: true
+
+- pwsh: |
+    Write-Host "Work in progress"
+  displayName: 'Remove logs'
+  timeoutInMinutes: 1
+
+- pwsh: |
+    Write-Host "Work in progress"
+  displayName: 'Create remote branch'
+  timeoutInMinutes: 1


### PR DESCRIPTION
Create two pipelines that will be triggered when a new build is
completed and contains tests results. There are some important details:

1. pipeline triggers have to specify all branches or a subset. We use
   tags to trigger for PRs.
2. Tags are and, not or, so we need to pipelines (lame lame).

Due to 2. we add a new tag to identify ci builds.