### PR TITLE
[dotnet][linker] Only register assemblies that we're not deleting from the bundle

### DIFF
--- a/tools/dotnet-linker/Steps/RegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/RegistrarStep.cs
@@ -4,6 +4,8 @@ using System.IO;
 using Xamarin.Bundler;
 using Xamarin.Utils;
 
+using Mono.Cecil;
+
 namespace Xamarin.Linker {
 	public class RegistrarStep : ConfigurationAwareStep {
 		protected override string Name { get; } = "Registrar";
@@ -48,7 +50,12 @@ namespace Xamarin.Linker {
 				var dir = Configuration.CacheDirectory;
 				var header = Path.Combine (dir, "registrar.h");
 				var code = Path.Combine (dir, "registrar.mm");
-				Configuration.Target.StaticRegistrar.Generate (Configuration.Assemblies, header, code);
+				var bundled_assemblies = new List<AssemblyDefinition> ();
+				foreach (var assembly in Configuration.Assemblies) {
+					if (Annotations.GetAction (assembly) != Mono.Linker.AssemblyAction.Delete)
+						bundled_assemblies.Add (assembly);
+				}
+				Configuration.Target.StaticRegistrar.Generate (bundled_assemblies, header, code);
 
 				var items = new List<MSBuildItem> ();
 				foreach (var abi in Configuration.Abis) {


### PR DESCRIPTION
So we generate this, inside `registrar.mm`, for a simple app

```objc
	static const char *__xamarin_registration_assemblies []= {
		"MySingleView",
		"System.Runtime.Serialization.Formatters",
		"System.Runtime",
		"System.Private.CoreLib",
		"Xamarin.iOS"
	};
```

instead of

```objc
	static const char *__xamarin_registration_assemblies []= {
		"MySingleView",
		"Microsoft.CSharp",
		"Microsoft.VisualBasic.Core",
		"Microsoft.VisualBasic",
		"Microsoft.Win32.Primitives",
		"Microsoft.Win32.Registry",
		"System.AppContext",
		"System.Buffers",
		"System.Collections.Concurrent",
		"System.Collections.Immutable",
		"System.Collections.NonGeneric",
		"System.Collections.Specialized",
		"System.Collections",
		"System.ComponentModel.Annotations",
		"System.ComponentModel.DataAnnotations",
		"System.ComponentModel.EventBasedAsync",
		"System.ComponentModel.Primitives",
		"System.ComponentModel.TypeConverter",
		"System.ComponentModel",
		"System.Configuration",
		"System.Console",
		"System.Core",
		"System.Data.Common",
		"System.Data.DataSetExtensions",
		"System.Data",
		"System.Diagnostics.Contracts",
		"System.Diagnostics.Debug",
		"System.Diagnostics.DiagnosticSource",
		"System.Diagnostics.FileVersionInfo",
		"System.Diagnostics.Process",
		"System.Diagnostics.StackTrace",
		"System.Diagnostics.TextWriterTraceListener",
		"System.Diagnostics.Tools",
		"System.Diagnostics.TraceSource",
		"System.Diagnostics.Tracing",
		"System.Drawing.Primitives",
		"System.Drawing",
		"System.Dynamic.Runtime",
		"System.Formats.Asn1",
		"System.Globalization.Calendars",
		"System.Globalization.Extensions",
		"System.Globalization",
		"System.IO.Compression.Brotli",
		"System.IO.Compression.FileSystem",
		"System.IO.Compression.ZipFile",
		"System.IO.Compression",
		"System.IO.FileSystem.AccessControl",
		"System.IO.FileSystem.DriveInfo",
		"System.IO.FileSystem.Primitives",
		"System.IO.FileSystem.Watcher",
		"System.IO.FileSystem",
		"System.IO.IsolatedStorage",
		"System.IO.MemoryMappedFiles",
		"System.IO.Pipes.AccessControl",
		"System.IO.Pipes",
		"System.IO.UnmanagedMemoryStream",
		"System.IO",
		"System.Linq.Expressions",
		"System.Linq.Parallel",
		"System.Linq.Queryable",
		"System.Linq",
		"System.Memory",
		"System.Net.Http.Json",
		"System.Net.Http",
		"System.Net.HttpListener",
		"System.Net.Mail",
		"System.Net.NameResolution",
		"System.Net.NetworkInformation",
		"System.Net.Ping",
		"System.Net.Primitives",
		"System.Net.Quic",
		"System.Net.Requests",
		"System.Net.Security",
		"System.Net.ServicePoint",
		"System.Net.Sockets",
		"System.Net.WebClient",
		"System.Net.WebHeaderCollection",
		"System.Net.WebProxy",
		"System.Net.WebSockets.Client",
		"System.Net.WebSockets",
		"System.Net",
		"System.Numerics.Vectors",
		"System.Numerics",
		"System.ObjectModel",
		"System.Private.DataContractSerialization",
		"System.Private.Uri",
		"System.Private.Xml.Linq",
		"System.Private.Xml",
		"System.Reflection.DispatchProxy",
		"System.Reflection.Emit.ILGeneration",
		"System.Reflection.Emit.Lightweight",
		"System.Reflection.Emit",
		"System.Reflection.Extensions",
		"System.Reflection.Metadata",
		"System.Reflection.Primitives",
		"System.Reflection.TypeExtensions",
		"System.Reflection",
		"System.Resources.Reader",
		"System.Resources.ResourceManager",
		"System.Resources.Writer",
		"System.Runtime.CompilerServices.Unsafe",
		"System.Runtime.CompilerServices.VisualC",
		"System.Runtime.Extensions",
		"System.Runtime.Handles",
		"System.Runtime.InteropServices.RuntimeInformation",
		"System.Runtime.InteropServices",
		"System.Runtime.Intrinsics",
		"System.Runtime.Loader",
		"System.Runtime.Numerics",
		"System.Runtime.Serialization.Formatters",
		"System.Runtime.Serialization.Json",
		"System.Runtime.Serialization.Primitives",
		"System.Runtime.Serialization.Xml",
		"System.Runtime.Serialization",
		"System.Runtime",
		"System.Security.AccessControl",
		"System.Security.Claims",
		"System.Security.Cryptography.Algorithms",
		"System.Security.Cryptography.Cng",
		"System.Security.Cryptography.Csp",
		"System.Security.Cryptography.Encoding",
		"System.Security.Cryptography.OpenSsl",
		"System.Security.Cryptography.Primitives",
		"System.Security.Cryptography.X509Certificates",
		"System.Security.Principal.Windows",
		"System.Security.Principal",
		"System.Security.SecureString",
		"System.Security",
		"System.ServiceModel.Web",
		"System.ServiceProcess",
		"System.Text.Encoding.CodePages",
		"System.Text.Encoding.Extensions",
		"System.Text.Encoding",
		"System.Text.Encodings.Web",
		"System.Text.Json",
		"System.Text.RegularExpressions",
		"System.Threading.Channels",
		"System.Threading.Overlapped",
		"System.Threading.Tasks.Dataflow",
		"System.Threading.Tasks.Extensions",
		"System.Threading.Tasks.Parallel",
		"System.Threading.Tasks",
		"System.Threading.Thread",
		"System.Threading.ThreadPool",
		"System.Threading.Timer",
		"System.Threading",
		"System.Transactions.Local",
		"System.Transactions",
		"System.ValueTuple",
		"System.Web.HttpUtility",
		"System.Web",
		"System.Windows",
		"System.Xml.Linq",
		"System.Xml.ReaderWriter",
		"System.Xml.Serialization",
		"System.Xml.XDocument",
		"System.Xml.XPath.XDocument",
		"System.Xml.XPath",
		"System.Xml.XmlDocument",
		"System.Xml.XmlSerializer",
		"System.Xml",
		"System",
		"WindowsBase",
		"mscorlib",
		"netstandard",
		"System.Private.CoreLib",
		"Xamarin.iOS"
	};
```

It probably has a positive impact on build time (but not measured).