### PR TITLE
[runtime] Implement mono_runtime_invoke for CoreCLR.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -255,4 +255,23 @@ mono_object_isinst (MonoObject * obj, MonoClass * klass)
 	return rv ? obj : NULL;
 }
 
+MonoObject *
+mono_runtime_invoke (MonoMethod * method, void * obj, void ** params, MonoObject ** exc)
+{
+	MonoObject *rv = NULL;
+	GCHandle exception_gchandle = INVALID_GCHANDLE;
+
+	LOG_CORECLR (stderr, "%s (%p, %p, %p, %p)\n", __func__, method, obj, params, exc);
+
+	rv = xamarin_bridge_runtime_invoke_method (method, (MonoObject *) obj, params, &exception_gchandle);
+
+	if (exc == NULL) {
+		xamarin_handle_bridge_exception (exception_gchandle, __func__);
+	} else {
+		*exc = xamarin_gchandle_unwrap (exception_gchandle);
+	}
+
+	return rv;
+}
+
 #endif // CORECLR_RUNTIME

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -382,6 +382,17 @@
 			OnlyDynamicUsage = false,
 			OnlyCoreCLR = true,
 		},
+
+		new XDelegate ("MonoObject *", "MonoObject *", "xamarin_bridge_runtime_invoke_method",
+			"MonoObject *", "MonoObject *", "method",
+			"MonoObject *", "MonoObject *", "instance",
+			"void**", "IntPtr", "parameters"
+		) {
+			WrappedManagedFunction = "InvokeMethod",
+			OnlyDynamicUsage = false,
+			OnlyCoreCLR = true,
+		},
+
 	};
 	delegates.CalculateLengths ();
 #><#+

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -99,7 +99,9 @@
 			"void *",        "obj",
 			"void **",       "params",
 			"MonoObject **", "exc"
-		),
+		) {
+			HasCoreCLRBridgeFunction = true,
+		},
 
 		new Export ("uint32_t", "mono_gchandle_new",
 			"MonoObject *", "obj",

--- a/runtime/monovm-bridge.m
+++ b/runtime/monovm-bridge.m
@@ -298,6 +298,24 @@ xamarin_bridge_vm_initialize (int propertyCount, const char **propertyKeys, cons
 	return rv == 0;
 }
 
+// We have a P/Invoke to xamarin_mono_object_retain in managed code, but the
+// corresponding native method only really exists when using CoreCLR. However,
+// the P/Invoke might not always be linked away (if the linker isn't enabled
+// for instance), in which case we must still have a native function. So
+// provide an empty implementation of xamarin_mono_object_retain (since it
+// doesn't have to do anything when using MonoVM). We still keep the #define
+// that does nothing, so that all the native code that calls
+// xamarin_mono_object_retain, will completely disappear when using MonoVM.
+#undef xamarin_mono_object_retain
+extern "C" {
+	void xamarin_mono_object_retain (MonoObject *mobj);
+}
+void
+xamarin_mono_object_retain (MonoObject *mobj)
+{
+	// Nothing to do here
+}
+
 #endif // DOTNET
 
 #endif // !CORECLR_RUNTIME

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -2106,4 +2106,23 @@
 		<value>Internal consistency error. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new.
 		</value>
 	</data>
+
+	<!-- 8000 -> 8036 are missing here (except 8018), so skip to 8037 -->
+	<data name="MX8037" xml:space="preserve">
+		<value>Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</value>
+		<comment>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</comment>
+	</data>
+
+	<data name="MX8038" xml:space="preserve">
+		<value>Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</value>
+		<comment>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</comment>
+	</data>
 </root>

--- a/tools/mtouch/xlf/Errors.cs.xlf
+++ b/tools/mtouch/xlf/Errors.cs.xlf
@@ -2788,6 +2788,24 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX8037">
+        <source>Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX8038">
+        <source>Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
         <source>The linker step '{0}' failed during processing: {1}</source>
         <target state="new">The linker step '{0}' failed during processing: {1}</target>

--- a/tools/mtouch/xlf/Errors.de.xlf
+++ b/tools/mtouch/xlf/Errors.de.xlf
@@ -2788,6 +2788,24 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX8037">
+        <source>Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX8038">
+        <source>Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
         <source>The linker step '{0}' failed during processing: {1}</source>
         <target state="new">The linker step '{0}' failed during processing: {1}</target>

--- a/tools/mtouch/xlf/Errors.es.xlf
+++ b/tools/mtouch/xlf/Errors.es.xlf
@@ -2788,6 +2788,24 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX8037">
+        <source>Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX8038">
+        <source>Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
         <source>The linker step '{0}' failed during processing: {1}</source>
         <target state="new">The linker step '{0}' failed during processing: {1}</target>

--- a/tools/mtouch/xlf/Errors.fr.xlf
+++ b/tools/mtouch/xlf/Errors.fr.xlf
@@ -2788,6 +2788,24 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX8037">
+        <source>Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX8038">
+        <source>Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
         <source>The linker step '{0}' failed during processing: {1}</source>
         <target state="new">The linker step '{0}' failed during processing: {1}</target>

--- a/tools/mtouch/xlf/Errors.it.xlf
+++ b/tools/mtouch/xlf/Errors.it.xlf
@@ -2788,6 +2788,24 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX8037">
+        <source>Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX8038">
+        <source>Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
         <source>The linker step '{0}' failed during processing: {1}</source>
         <target state="new">The linker step '{0}' failed during processing: {1}</target>

--- a/tools/mtouch/xlf/Errors.ja.xlf
+++ b/tools/mtouch/xlf/Errors.ja.xlf
@@ -2788,6 +2788,24 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX8037">
+        <source>Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX8038">
+        <source>Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
         <source>The linker step '{0}' failed during processing: {1}</source>
         <target state="new">The linker step '{0}' failed during processing: {1}</target>

--- a/tools/mtouch/xlf/Errors.ko.xlf
+++ b/tools/mtouch/xlf/Errors.ko.xlf
@@ -2788,6 +2788,24 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX8037">
+        <source>Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX8038">
+        <source>Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
         <source>The linker step '{0}' failed during processing: {1}</source>
         <target state="new">The linker step '{0}' failed during processing: {1}</target>

--- a/tools/mtouch/xlf/Errors.pl.xlf
+++ b/tools/mtouch/xlf/Errors.pl.xlf
@@ -2788,6 +2788,24 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX8037">
+        <source>Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX8038">
+        <source>Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
         <source>The linker step '{0}' failed during processing: {1}</source>
         <target state="new">The linker step '{0}' failed during processing: {1}</target>

--- a/tools/mtouch/xlf/Errors.pt-BR.xlf
+++ b/tools/mtouch/xlf/Errors.pt-BR.xlf
@@ -2788,6 +2788,24 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX8037">
+        <source>Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX8038">
+        <source>Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
         <source>The linker step '{0}' failed during processing: {1}</source>
         <target state="new">The linker step '{0}' failed during processing: {1}</target>

--- a/tools/mtouch/xlf/Errors.ru.xlf
+++ b/tools/mtouch/xlf/Errors.ru.xlf
@@ -2788,6 +2788,24 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX8037">
+        <source>Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX8038">
+        <source>Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
         <source>The linker step '{0}' failed during processing: {1}</source>
         <target state="new">The linker step '{0}' failed during processing: {1}</target>

--- a/tools/mtouch/xlf/Errors.tr.xlf
+++ b/tools/mtouch/xlf/Errors.tr.xlf
@@ -2788,6 +2788,24 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX8037">
+        <source>Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX8038">
+        <source>Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
         <source>The linker step '{0}' failed during processing: {1}</source>
         <target state="new">The linker step '{0}' failed during processing: {1}</target>

--- a/tools/mtouch/xlf/Errors.zh-Hans.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hans.xlf
@@ -2788,6 +2788,24 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX8037">
+        <source>Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX8038">
+        <source>Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
         <source>The linker step '{0}' failed during processing: {1}</source>
         <target state="new">The linker step '{0}' failed during processing: {1}</target>

--- a/tools/mtouch/xlf/Errors.zh-Hant.xlf
+++ b/tools/mtouch/xlf/Errors.zh-Hant.xlf
@@ -2788,6 +2788,24 @@
 		</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="MX8037">
+        <source>Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
+      <trans-unit id="MX8038">
+        <source>Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</source>
+        <target state="new">Don't know how to marshal back the parameter of type {0} for parameter {1} in call to {2}</target>
+        <note>
+{0} - The name of a type.
+{1} - The name of a parameter.
+{2} - The name of a method.
+		</note>
+      </trans-unit>
       <trans-unit id="MX_ConfigurationAwareStep">
         <source>The linker step '{0}' failed during processing: {1}</source>
         <target state="new">The linker step '{0}' failed during processing: {1}</target>


### PR DESCRIPTION
Next failure is:

> monotouchtest[57078:31039077] Xamarin.Mac: The method mono_method_signature has not been implemented for CoreCLR.

```
3   com.xamarin.monotouch-test          0x00000001002c5828 xamarin_assertion_message + 408 (runtime.m:1446)
4   com.xamarin.monotouch-test          0x0000000100294d61 mono_method_signature + 33 (mono-runtime.m:2090)
5   com.xamarin.monotouch-test          0x00000001002d2f2c xamarin_invoke_trampoline + 1132 (trampolines-invoke.m:183)
6   com.xamarin.monotouch-test          0x00000001002dc777 xamarin_arch_trampoline + 119 (trampolines-x86_64.m:491)
7   com.xamarin.monotouch-test          0x00000001002dd9de xamarin_x86_64_common_trampoline + 118 (trampolines-x86_64-asm.s:51)
8   com.xamarin.monotouch-test          0x00000001002ce421 xamarin_copyWithZone_trampoline2 + 113 (trampolines.m:617)
9   com.xamarin.monotouch-test          0x00000001002ddb59 xamarin_dyn_objc_msgSend + 217 (trampolines-x86_64-objc_msgSend.s:15)
```