### PR TITLE
[runtime] Print more information about the exception for unhandled managed exceptions.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -64,8 +64,8 @@ xamarin_handle_bridge_exception (GCHandle gchandle, const char *method)
 	if (method == NULL)
 		method = "<unknown method";
 
-	fprintf (stderr, "%s threw an exception: %p\n", method, gchandle);
-	xamarin_assertion_message ("%s threw an exception: %p", method, gchandle);
+	fprintf (stderr, "%s threw an exception: %p => %s\n", method, gchandle, [xamarin_print_all_exceptions (gchandle) UTF8String]);
+	xamarin_assertion_message ("%s threw an exception: %p = %s", method, gchandle, [xamarin_print_all_exceptions (gchandle) UTF8String]);
 }
 
 typedef void (*xamarin_runtime_initialize_decl)(struct InitializationOptions* options);


### PR DESCRIPTION
This eases debugging when trying to figure out what went wrong.