### PR TITLE
[tests][dotnet] A few helping touch to do size comparison

### DIFF
--- a/tests/dotnet/.gitignore
+++ b/tests/dotnet/.gitignore
@@ -1,3 +1,3 @@
 global.json
 NuGet.config
-
+report.md

--- a/tests/dotnet/Makefile
+++ b/tests/dotnet/Makefile
@@ -60,3 +60,8 @@ build-dotnet: $(TARGETS)
 
 run-dotnet: $(TARGETS)
 	$(DOTNET6) build -t:Run size-comparison/MySingleView/dotnet/MySingleView.csproj --runtime ios-arm64 $(COMMON_ARGS)
+
+# this will break the signature, so app won't run anymore. Use it only to compare final size w/legacy
+# https://github.com/xamarin/xamarin-macios/issues/11445
+strip-dotnet:
+	$(foreach file, $(wildcard size-comparison/MySingleView/dotnet/bin/iPhone/Release/net6.0-ios/ios-arm64/MySingleView.app/*.dll), mono-cil-strip $(file) $(file);)

--- a/tools/app-compare/AppComparer.cs
+++ b/tools/app-compare/AppComparer.cs
@@ -69,6 +69,7 @@ namespace Tools {
 
 			switch (Path.GetExtension (item.Name)) {
 			case ".aotdata":
+			case ".arm64": // actually .aotdata.arm64
 				aotdata1 += s1;
 				aotdata2 += s2;
 				break;
@@ -108,7 +109,7 @@ namespace Tools {
 			Output.WriteLine ("| | | | | |");
 			WriteStats ("Native subtotal", native1 + aotdata1, native2 + aotdata2);
 			WriteStats ("    Executable", native1, native2);
-			WriteStats ("    AOT data *.aotdata", aotdata1, aotdata2);
+			WriteStats ("    AOT data", aotdata1, aotdata2);
 			Output.WriteLine ("| | | | | |");
 			WriteStats ("Managed *.dll/exe", managed1, managed2);
 			Output.WriteLine ("| | | | | |");


### PR DESCRIPTION
- Make git ignore the generated `report.md`
- Fix `.aotdata` reported total size in reports (was always 0)
- Add option to strip the dotnet app bundle (until [1]) so it's easier to compare with _oldnet_ sizes.

[1] https://github.com/xamarin/xamarin-macios/issues/11445