### PR TITLE
[dotnet] Fix _DetectSdkLocations from Windows

### DIFF
--- a/dotnet/Microsoft.iOS.Windows.Sdk/targets/Microsoft.iOS.Windows.Sdk.props
+++ b/dotnet/Microsoft.iOS.Windows.Sdk/targets/Microsoft.iOS.Windows.Sdk.props
@@ -9,6 +9,8 @@
     <_XamarinSdkRemoteRootDirectory Condition="'$(_XamarinSdkRemoteRootDirectory)' == ''">$(_XamarinSdkRootDirectory.Replace('$(NetCoreRoot)', '$(_DotNetRootRemoteDirectory)'))</_XamarinSdkRemoteRootDirectory>
     <_MlaunchPath Condition="'$(_MlaunchPath)' == ''">$(_XamarinSdkRemoteRootDirectory)tools/bin/mlaunch</_MlaunchPath>
     <AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(MSBuildThisFileDirectory)..\targets\Microsoft.iOS.Windows.Sdk.targets</AfterMicrosoftNETSdkTargets>
+
+    <_XamarinSdkRootOnMac Condition="'$(_XamarinSdkRoot)' != ''">$(_XamarinSdkRoot.Replace('$(NetCoreRoot)', '$(_DotNetRootRemoteDirectory)'))</_XamarinSdkRootOnMac>
   </PropertyGroup>
 
 </Project>

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -20,5 +20,7 @@
 
 		<!-- _XamarinSdkRoot is used by the existing MSBuild targets files -->
 		<_XamarinSdkRoot Condition="'$(_XamarinSdkRoot)' == ''">$(_XamarinSdkRootDirectory)</_XamarinSdkRoot>
+		<!-- _XamarinSdkRootOnMac this should be passed to tasks that need to access the Xamarin Sdk dir on the Mac, this value will be overriden from Windows -->
+		<_XamarinSdkRootOnMac>$(_XamarinSdkRoot)</_XamarinSdkRootOnMac>
 	</PropertyGroup>
 </Project>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -895,7 +895,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			SdkVersion="$(_SdkVersion)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			TargetArchitectures="$(TargetArchitectures)"
-			XamarinSdkRoot="$(_XamarinSdkRoot)"
+			XamarinSdkRoot="$(_XamarinSdkRootOnMac)"
 			>
 
 			<Output TaskParameter="SdkVersion" PropertyName="_SdkVersion" />


### PR DESCRIPTION
This task ends up setting as env variable the Xamarin Sdk root directory on the Mac, but when building from Windows it was setting the Windows path, so instead we need to override it with the proper value on macOS.

This should not change the original behavior when building from macOS.