### PR TITLE
[CI] Remove apitest from the tests executed in older macs.

### DIFF
--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -147,7 +147,7 @@ steps:
 
     [System.Collections.Generic.List[string]]$failures = @()
 
-    $macTest = @("dontlink", "apitest", "introspection", "linksdk", "linkall", "xammac_tests")
+    $macTest = @("dontlink", "introspection", "linksdk", "linkall", "xammac_tests")
     foreach ($t in $macTest) {
       $testName = "exec-mac-$t"
       Write-Host "Execution test $testName"


### PR DESCRIPTION
The test was merge with the xammac_tests in commit
https://github.com/xamarin/xamarin-macios/commit/93bbfe7a86abaaef369d884ad397f590ecd409af
but we did not have the tests running to know.

This should fix some of the failures we have in older macs.