### PR TITLE
Changing OneLocBuild to Manual instead of Scheduled

### DIFF
--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -128,7 +128,7 @@ steps:
   continueOnError: true
   workingDirectory: $(Build.SourcesDirectory)\tools\devops 
 
-- ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+- ${{ if eq(variables['Build.Reason'], 'Manual') }}:
   - task: OneLocBuild@2
     condition: and(succeeded(), eq(variables.isMain, 'True'))
     continueOnError: true


### PR DESCRIPTION
I am changing this so I can manually push the button to get OneLocBuild set up sooner. 
Later we can revert this change!