### PR TITLE
[dotnet][linker] Do not remove `[LinkWith]` using xml

### DIFF
--- a/src/ILLink.LinkAttributes.xml.in
+++ b/src/ILLink.LinkAttributes.xml.in
@@ -23,9 +23,6 @@
     <type fullname="ObjCRuntime.DesignatedInitializerAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
-    <type fullname="ObjCRuntime.LinkWithAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
     <type fullname="ObjCRuntime.NotImplementedAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>


### PR DESCRIPTION
This is removed _too soon_ and we end up not linking with the native
library, which makes the build fail.

Fixes https://github.com/xamarin/xamarin-macios/issues/11456