### PR TITLE
[runtime] Implement mono_method_signature and related signature methods for CoreCLR.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -255,6 +255,8 @@ mono_object_isinst (MonoObject * obj, MonoClass * klass)
 	return rv ? obj : NULL;
 }
 
+// Return value: NULL, or a retained MonoObject* that must be freed with xamarin_mono_object_release.
+// Returns NULL in case of exception.
 MonoObject *
 mono_runtime_invoke (MonoMethod * method, void * obj, void ** params, MonoObject ** exc)
 {
@@ -272,6 +274,61 @@ mono_runtime_invoke (MonoMethod * method, void * obj, void ** params, MonoObject
 	}
 
 	return rv;
+}
+
+MonoMethodSignature *
+mono_method_signature (MonoMethod* method)
+{
+	MonoMethodSignature *rv = xamarin_bridge_method_get_signature (method);
+
+	LOG_CORECLR (stderr, "xamarin_bridge_mono_method_signature (%p) => %p\n", method, rv);
+
+	return rv;
+}
+
+MonoType *
+mono_signature_get_params (MonoMethodSignature* sig, void ** iter)
+{
+	int* p = (int *) iter;
+	if (*p >= sig->parameter_count) {
+		LOG_CORECLR (stderr, "%s (%p, %p => %i) => DONE\n", __func__, sig, iter, *p);
+		return NULL;
+	}
+
+	MonoObject *rv = sig->parameters [*p];
+	xamarin_mono_object_retain (rv);
+
+	LOG_CORECLR (stderr, "%s (%p, %p => %i) => %p NEXT\n", __func__, sig, iter, *p, rv->gchandle);
+
+	*p = *p + 1;
+
+	return rv;
+}
+
+MonoType *
+mono_signature_get_return_type (MonoMethodSignature* sig)
+{
+	MonoType *rv = sig->return_type;
+	xamarin_mono_object_retain (rv);
+
+	LOG_CORECLR (stderr, "%s (%p) => %p\n", __func__, sig, rv);
+
+	return rv;
+}
+
+void
+xamarin_bridge_free_mono_signature (MonoMethodSignature **psig)
+{
+	MonoMethodSignature *sig = *psig;
+
+	for (int i = 0; i < sig->parameter_count; i++) {
+		xamarin_mono_object_release (&sig->parameters [i]);
+	}
+	xamarin_mono_object_release (&sig->return_type);
+
+	mono_free (sig);
+
+	*psig = NULL;
 }
 
 #endif // CORECLR_RUNTIME

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -351,6 +351,14 @@
 			OnlyCoreCLR = true,
 		},
 
+		new XDelegate ("MonoMethodSignature *", "IntPtr", "xamarin_bridge_method_get_signature",
+			"MonoObject *", "MonoObject *", "method"
+		) {
+			WrappedManagedFunction = "GetMethodSignature",
+			OnlyDynamicUsage = false,
+			OnlyCoreCLR = true,
+		},
+
 		new XDelegate ("MonoObject*", "IntPtr", "xamarin_bridge_get_monoobject",
 			"GCHandle", "IntPtr", "gchandle"
 		) {

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -315,7 +315,9 @@
 
 		new Export ("MonoMethodSignature *", "mono_method_signature",
 			"MonoMethod *", "method"
-		),
+		) {
+			HasCoreCLRBridgeFunction = true,
+		},
 
 		new Export ("MonoClass *", "mono_method_get_class",
 			"MonoMethod *", "method"
@@ -391,7 +393,9 @@
 		new Export ("MonoType *", "mono_signature_get_params",
 			"MonoMethodSignature *", "sig",
 			"void **", "iter"
-		),
+		) {
+			HasCoreCLRBridgeFunction = true,
+		},
 
 		new Export ("mono_bool", "mono_type_is_byref", 
 			"MonoType *", "type"
@@ -399,7 +403,9 @@
 
 		new Export ("MonoType *", "mono_signature_get_return_type",
 			"MonoMethodSignature *", "sig"
-		),
+		) {
+			HasCoreCLRBridgeFunction = true,
+		},
 
 		new Export ("int", "mono_type_get_type",
 			"MonoType *", "type"

--- a/runtime/mono-runtime.h.t4
+++ b/runtime/mono-runtime.h.t4
@@ -96,7 +96,12 @@ typedef struct _MonoObject MonoMethod;
 typedef struct _MonoMethod MonoMethod;
 #endif
 typedef struct _MonoMethodSignature MonoMethodSignature;
+#if defined (CORECLR_RUNTIME)
+// In Mono, MonoType is not related to MonoObject at all, but for the CoreCLR bridge we use the same struct representation for both types.
+typedef struct _MonoObject MonoType;
+#else
 typedef struct _MonoType MonoType;
+#endif
 
 /* metadata/class.h */
 typedef struct MonoVTable MonoVTable;

--- a/runtime/monovm-bridge.m
+++ b/runtime/monovm-bridge.m
@@ -284,6 +284,13 @@ xamarin_install_nsautoreleasepool_hooks ()
 	mono_profiler_install_thread (thread_start, thread_end);
 }
 
+void
+xamarin_bridge_free_mono_signature (MonoMethodSignature **psig)
+{
+	// nothing to free here
+	*psig = NULL;
+}
+
 #if DOTNET
 
 bool

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -266,6 +266,8 @@ xamarin_get_parameter_type (MonoMethod *managed_method, int index)
 			p = mono_signature_get_params (msig, &iter);
 	}
 	
+	xamarin_bridge_free_mono_signature (&msig);
+
 	return p;
 }
 

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -138,7 +138,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 	MonoObject *mthis = NULL;
 	MethodDescription *desc = NULL;
 	MonoMethod *method;
-	MonoMethodSignature *msig;
+	MonoMethodSignature *msig = NULL;
 	MonoReflectionMethod *reflection_method = NULL;
 	int semantic;
 	bool isCategoryInstance;
@@ -729,6 +729,8 @@ exception_handling:
 		free (writeback);
 		writeback = NULL;
 	}
+
+	xamarin_bridge_free_mono_signature (&msig);
 
 	MONO_THREAD_DETACH; // COOP: This will switch to GC_SAFE
 

--- a/runtime/xamarin/coreclr-bridge.h
+++ b/runtime/xamarin/coreclr-bridge.h
@@ -29,6 +29,14 @@ struct _MonoObject {
 	GCHandle gchandle;
 };
 
+// This struct must be kept in sync with the MonoMethodSignature struct in Runtime.CoreCLR.cs
+struct _MonoMethodSignature {
+	MonoObject *method;
+	int parameter_count;
+	MonoObject *return_type;
+	MonoObject *parameters[];
+};
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -209,6 +209,7 @@ void*			xamarin_pinvoke_override (const char *libraryName, const char *entrypoin
 void			xamarin_bridge_call_runtime_initialize (struct InitializationOptions* options, GCHandle* exception_gchandle);
 void			xamarin_bridge_register_product_assembly (GCHandle* exception_gchandle);
 MonoMethod *	xamarin_bridge_get_mono_method (MonoReflectionMethod *method);
+void			xamarin_bridge_free_mono_signature (MonoMethodSignature **signature);
 bool			xamarin_register_monoassembly (MonoAssembly *assembly, GCHandle *exception_gchandle);
 void			xamarin_install_nsautoreleasepool_hooks ();
 


### PR DESCRIPTION
Next failure:

> monotouchtest[10753:31976403] Xamarin.Mac: The method mono_class_from_mono_type has not been implemented for CoreCLR

```
3   com.xamarin.monotouch-test    	0x00000001053353f8 xamarin_assertion_message + 408 (runtime.m:1448)
4   com.xamarin.monotouch-test    	0x00000001053041f1 mono_class_from_mono_type + 33 (mono-runtime.m:1832)
5   com.xamarin.monotouch-test    	0x0000000105343641 xamarin_invoke_trampoline + 3809 (trampolines-invoke.m:339)
6   com.xamarin.monotouch-test    	0x000000010534c667 xamarin_arch_trampoline + 119 (trampolines-x86_64.m:491)
7   com.xamarin.monotouch-test    	0x000000010534d8ce xamarin_x86_64_common_trampoline + 118 (trampolines-x86_64-asm.s:51)
8   com.xamarin.monotouch-test    	0x000000010533e0c1 xamarin_copyWithZone_trampoline2 + 113 (trampolines.m:617)
9   com.xamarin.monotouch-test    	0x000000010534da49 xamarin_dyn_objc_msgSend + 217 (trampolines-x86_64-objc_msgSend.s:15)
```