### PR TITLE
[CI] Detect if we are running a vm and set the vendor.

### DIFF
--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -41,6 +41,19 @@ steps:
     ioreg -l | grep -e Manufacturer -e 'Vendor Name'
   displayName: 'Dump Hardware'
 
+- bash: |
+    vmware=$(ioreg -l | grep -e Manufacturer -e 'Vendor Name' | grep -e 'VMWare' | wc -l)
+    if [[ $vmare -gt 0 ]]; then
+      echo "##vso[task.setvariable variable=VM_VENDOR]VMWare"
+    fi
+
+    virtualbox=$(ioreg -l | grep -e Manufacturer -e 'Vendor Name' | grep -e 'VirtualBox' | wc -l)
+    if [[ $virtualbox -gt 0 ]]; then
+      echo "##vso[task.setvariable variable=VM_VENDOR]VirtualBox"
+    fi
+
+  displayName: 'Set VM Vendor'
+
 - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/clean-bot.sh
   displayName: 'Clean bot'
   env:


### PR DESCRIPTION
We are using vms for older machines, this results in certain tests that required hardware to fail, how can we skip those? If we find that there is a manufacturer that matches a known VM vendor, we set it in an env var.

Once this is landed, we can change tests to be skipped in vms. I just have 2 vendors I have tested this with, if anyone has another, we can add it.