### PR TITLE
[Localization] Enabling OneLocBuild for every build

### DIFF
--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -158,11 +158,10 @@ steps:
     isCreatePrSelected: eq(variables['Build.Reason'], 'Schedule')
     packageSourceAuth: patAuth
     patVariable: '$(OneLocBuild--PAT)'
-    ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
-      isAutoCompletePrSelected: false
-      prSourceBranchPrefix: 'locfiles'
-      repoType: gitHub
-      gitHubPatVariable: '$(GitHub.Token)'
+    isAutoCompletePrSelected: false
+    prSourceBranchPrefix: 'locfiles'
+    repoType: gitHub
+    gitHubPatVariable: '$(GitHub.Token)'
 
 - task: PublishBuildArtifacts@1
   condition: and(succeeded(), eq(variables.isMain, 'True'))

--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -156,12 +156,13 @@ steps:
     locProj: '$(Build.SourcesDirectory)\Localize\LocProject.json'
     outDir: '$(Build.ArtifactStagingDirectory)'
     isCreatePrSelected: eq(variables['Build.Reason'], 'Schedule')
-    isAutoCompletePrSelected: false
-    prSourceBranchPrefix: 'locfiles'
-    repoType: gitHub
-    gitHubPatVariable: '$(GitHub.Token)'
-    packageSourceAuth: patAuth
-    patVariable: '$(OneLocBuild--PAT)'
+    ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+      isAutoCompletePrSelected: false
+      prSourceBranchPrefix: 'locfiles'
+      repoType: gitHub
+      gitHubPatVariable: '$(GitHub.Token)'
+      packageSourceAuth: patAuth
+      patVariable: '$(OneLocBuild--PAT)'
 
 - task: PublishBuildArtifacts@1
   condition: and(succeeded(), eq(variables.isTJ, 'True'))

--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -148,7 +148,7 @@ steps:
   workingDirectory: $(Build.SourcesDirectory)\tools\devops 
 
 - task: OneLocBuild@2
-  condition: and(succeeded(), eq(variables.isTJ, 'True'))
+  condition: and(succeeded(), eq(variables.isMain, 'True'))
   continueOnError: true
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -165,7 +165,7 @@ steps:
       patVariable: '$(OneLocBuild--PAT)'
 
 - task: PublishBuildArtifacts@1
-  condition: and(succeeded(), eq(variables.isTJ, 'True'))
+  condition: and(succeeded(), eq(variables.isMain, 'True'))
   continueOnError: true
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'

--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -156,13 +156,13 @@ steps:
     locProj: '$(Build.SourcesDirectory)\Localize\LocProject.json'
     outDir: '$(Build.ArtifactStagingDirectory)'
     isCreatePrSelected: eq(variables['Build.Reason'], 'Schedule')
+    packageSourceAuth: patAuth
+    patVariable: '$(OneLocBuild--PAT)'
     ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
       isAutoCompletePrSelected: false
       prSourceBranchPrefix: 'locfiles'
       repoType: gitHub
       gitHubPatVariable: '$(GitHub.Token)'
-      packageSourceAuth: patAuth
-      patVariable: '$(OneLocBuild--PAT)'
 
 - task: PublishBuildArtifacts@1
   condition: and(succeeded(), eq(variables.isMain, 'True'))

--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -147,22 +147,21 @@ steps:
   continueOnError: true
   workingDirectory: $(Build.SourcesDirectory)\tools\devops 
 
-- ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
-  - task: OneLocBuild@2
-    condition: and(succeeded(), eq(variables.isMain, 'True'))
-    continueOnError: true
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    inputs:
-      locProj: '$(Build.SourcesDirectory)\Localize\LocProject.json'
-      outDir: '$(Build.ArtifactStagingDirectory)'
-      isCreatePrSelected: true
-      isAutoCompletePrSelected: false
-      prSourceBranchPrefix: 'locfiles'
-      repoType: gitHub
-      gitHubPatVariable: '$(GitHub.Token)'
-      packageSourceAuth: patAuth
-      patVariable: '$(OneLocBuild--PAT)'
+- task: OneLocBuild@2
+  condition: and(succeeded(), eq(variables.isMain, 'True'))
+  continueOnError: true
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+  inputs:
+    locProj: '$(Build.SourcesDirectory)\Localize\LocProject.json'
+    outDir: '$(Build.ArtifactStagingDirectory)'
+    isCreatePrSelected: eq(variables['Build.Reason'], 'Schedule')
+    isAutoCompletePrSelected: false
+    prSourceBranchPrefix: 'locfiles'
+    repoType: gitHub
+    gitHubPatVariable: '$(GitHub.Token)'
+    packageSourceAuth: patAuth
+    patVariable: '$(OneLocBuild--PAT)'
 
 - task: PublishBuildArtifacts@1
   condition: and(succeeded(), eq(variables.isMain, 'True'))

--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -148,7 +148,7 @@ steps:
   workingDirectory: $(Build.SourcesDirectory)\tools\devops 
 
 - task: OneLocBuild@2
-  condition: and(succeeded(), eq(variables.isMain, 'True'))
+  condition: and(succeeded(), eq(variables.isTJ, 'True'))
   continueOnError: true
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -164,7 +164,7 @@ steps:
     patVariable: '$(OneLocBuild--PAT)'
 
 - task: PublishBuildArtifacts@1
-  condition: and(succeeded(), eq(variables.isMain, 'True'))
+  condition: and(succeeded(), eq(variables.isTJ, 'True'))
   continueOnError: true
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -33,6 +33,7 @@ jobs:
 
   variables:
     isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+    isTJ: $[eq(variables['Build.SourceBranch'], 'refs/heads/OneLocBuildArtifact')]
 
   steps:
   - template: configure.yml

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -33,7 +33,6 @@ jobs:
 
   variables:
     isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
-    isTJ: $[eq(variables['Build.SourceBranch'], 'refs/heads/OneLocBuildArtifact')]
 
   steps:
   - template: configure.yml


### PR DESCRIPTION
I found out that we need to run OneLocBuild in every build since we need to publish the loc artifact every build once we are linked up with the Loc pipeline. 

Right now, we will only run the OneLocBuild task on Sundays and that is the only time we will be publishing the artifacts. 
(It will try to publish the artifacts every build, but since there is no OneLocBuild task running, there are no artifacts to publish).

This just moves the condition of checking for the schedule build reason from running the task to setting inputs.

*with help from @mandel-macaque 