### PR TITLE
[linker] Split CoreTypeMapStep into two parts

### DIFF
--- a/tools/dotnet-linker/SetupStep.cs
+++ b/tools/dotnet-linker/SetupStep.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 
 using Mono.Linker;
 using Mono.Linker.Steps;
+using MonoTouch.Tuner;
 
 using Xamarin.Bundler;
 using Xamarin.Linker;
@@ -60,6 +61,9 @@ namespace Xamarin {
 			// Load the list of assemblies loaded by the linker.
 			// This would not be needed of LinkContext.GetAssemblies () was exposed to us.
 			InsertBefore (new CollectAssembliesStep (), "MarkStep");
+
+			// the final decision to remove/keep the dynamic registrar must be done before the linking step
+			InsertBefore (new RegistrarRemovalTrackingStep (), "MarkStep");
 
 			var pre_dynamic_dependency_lookup_substeps = new DotNetSubStepDispatcher ();
 			InsertBefore (pre_dynamic_dependency_lookup_substeps, "MarkStep");

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -197,6 +197,9 @@
     <Compile Include="..\common\XamarinRuntime.cs">
       <Link>tools\common\XamarinRuntime.cs</Link>
     </Compile>
+    <Compile Include="..\linker\RegistrarRemovalTrackingStep.cs">
+      <Link>tools\linker\RegistrarRemovalTrackingStep.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\mtouch\Errors.resx">

--- a/tools/linker/CoreTypeMapStep.cs
+++ b/tools/linker/CoreTypeMapStep.cs
@@ -8,15 +8,12 @@
 //
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 using Mono.Cecil;
 using Mono.Linker.Steps;
 using Mono.Tuner;
 
-using Xamarin.Bundler;
 using Xamarin.Linker;
 using Xamarin.Tuner;
 
@@ -26,123 +23,11 @@ namespace MonoTouch.Tuner {
 	public class CoreTypeMapStep : TypeMapStep {
 		HashSet<TypeDefinition> cached_isnsobject = new HashSet<TypeDefinition> ();
 		Dictionary<TypeDefinition, bool?> isdirectbinding_value = new Dictionary<TypeDefinition, bool?> ();
-		bool dynamic_registration_support_required;
 
 		DerivedLinkContext LinkContext {
 			get {
 				return (DerivedLinkContext) base.Context;
 			}
-		}
-
-		protected override void ProcessAssembly (AssemblyDefinition assembly)
-		{
-			if (LinkContext.App.Optimizations.RemoveDynamicRegistrar != false)
-				dynamic_registration_support_required |= RequiresDynamicRegistrar (assembly, LinkContext.App.Optimizations.RemoveDynamicRegistrar == true);
-
-			base.ProcessAssembly (assembly);
-		}
-
-		// If certain conditions are met, we can optimize away the code for the dynamic registrar.
-		bool RequiresDynamicRegistrar (AssemblyDefinition assembly, bool warnIfRequired)
-		{
-			// We know that the SDK assemblies we ship don't use the methods we're looking for.
-			if (Profile.IsSdkAssembly (assembly))
-				return false;
-
-			// The product assembly itself is safe as long as it's linked
-			if (Profile.IsProductAssembly (assembly))
-				return Annotations.GetAction (assembly) != Mono.Linker.AssemblyAction.Link;
-
-			// Can't touch the forbidden fruit in the product assembly unless there's a reference to it
-			var hasProductReference = false;
-			foreach (var ar in assembly.MainModule.AssemblyReferences) {
-				if (!Profile.IsProductAssembly (ar.Name))
-					continue;
-				hasProductReference = true;
-				break;
-			}
-			if (!hasProductReference)
-				return false;
-
-			// Check if the assembly references any methods that require the dynamic registrar
-			var productAssemblyName = ((MobileProfile) Profile.Current).ProductAssembly;
-			var requires = false;
-			foreach (var mr in assembly.MainModule.GetMemberReferences ()) {
-				if (mr.DeclaringType == null || string.IsNullOrEmpty (mr.DeclaringType.Namespace))
-					continue;
-				
-				var scope = mr.DeclaringType.Scope;
-				var name = string.Empty;
-				switch (scope.MetadataScopeType) {
-				case MetadataScopeType.ModuleDefinition:
-					name = ((ModuleDefinition) scope).Assembly.Name.Name;
-					break;
-				default:
-					name = scope.Name;
-					break;
-				}
-				if (name != productAssemblyName)
-					continue;
-
-				switch (mr.DeclaringType.Namespace) {
-				case "ObjCRuntime":
-					switch (mr.DeclaringType.Name) {
-					case "Runtime":
-						switch (mr.Name) {
-						case "ConnectMethod":
-							// Req 1: Nobody must call Runtime.ConnectMethod.
-							if (warnIfRequired)
-								Show2107 (assembly, mr);
-							requires = true;
-							break;
-						case "RegisterAssembly":
-							// Req 3: Nobody must call Runtime.RegisterAssembly
-							if (warnIfRequired)
-								Show2107 (assembly, mr);
-							requires = true;
-							break;
-						}
-						break;
-					case "BlockLiteral":
-						switch (mr.Name) {
-						case "SetupBlock":
-						case "SetupBlockUnsafe":
-							// Req 2: Nobody must call BlockLiteral.SetupBlock[Unsafe].
-							//
-							// Fortunately the linker is able to rewrite calls to SetupBlock[Unsafe] to call
-							// SetupBlockImpl (which doesn't need the dynamic registrar), which means we only have
-							// to look in assemblies that aren't linked.
-							if (Annotations.GetAction (assembly) == Mono.Linker.AssemblyAction.Link && LinkContext.App.Optimizations.OptimizeBlockLiteralSetupBlock == true)
-								break;
-
-							if (warnIfRequired)
-								Show2107 (assembly, mr);
-
-							requires = true;
-							break;
-						}
-						break;
-					case "TypeConverter":
-						switch (mr.Name) {
-						case "ToManaged":
-							// Req 4: Nobody must call TypeConverter.ToManaged
-							if (warnIfRequired)
-								Show2107 (assembly, mr);
-							requires = true;
-							break;
-						}
-						break;
-					}
-					break;
-				}
-			}
-
-			return requires;
-		}
-
-		void Show2107 (AssemblyDefinition assembly, MemberReference mr)
-		{
-			ErrorHelper.Warning (2107, Errors.MM2107, assembly.Name.Name, mr.DeclaringType.FullName, mr.Name, string.Join (", ", ((MethodReference) mr).Parameters.Select ((v) => v.ParameterType.FullName)));
 		}
 
 		protected override void EndProcess ()
@@ -151,23 +36,6 @@ namespace MonoTouch.Tuner {
 
 			LinkContext.CachedIsNSObject = cached_isnsobject;
 			LinkContext.IsDirectBindingValue = isdirectbinding_value;
-
-			if (!LinkContext.App.Optimizations.RemoveDynamicRegistrar.HasValue) {
-				// If dynamic registration is not required, and removal of the dynamic registrar hasn't already
-				// been disabled, then we can remove it!
-				LinkContext.App.Optimizations.RemoveDynamicRegistrar = !dynamic_registration_support_required;
-				Driver.Log (4, "Optimization dynamic registrar removal: {0}", LinkContext.App.Optimizations.RemoveDynamicRegistrar.Value ? "enabled" : "disabled");
-#if MTOUCH
-				var app = LinkContext.App;
-				if (app.IsCodeShared) {
-					foreach (var appex in app.AppExtensions) {
-						if (!appex.IsCodeShared)
-							continue;
-						appex.Optimizations.RemoveDynamicRegistrar = app.Optimizations.RemoveDynamicRegistrar;
-					}
-				}
-#endif
-			}
 		}
 
 		protected override void MapType (TypeDefinition type)

--- a/tools/linker/RegistrarRemovalTrackingStep.cs
+++ b/tools/linker/RegistrarRemovalTrackingStep.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Linker;
+using Mono.Linker.Steps;
+
+using Xamarin.Bundler;
+using Xamarin.Linker;
+#if !NET
+using Mono.Tuner;
+using Xamarin.Tuner;
+#endif
+
+namespace MonoTouch.Tuner {
+
+#if NET
+	public class RegistrarRemovalTrackingStep : ConfigurationAwareStep {
+
+		protected override string Name { get; } = "RegistrarRemovalTracking";
+		protected override int ErrorCode { get; } = 2380;
+
+		int WarnCode => ErrorCode + 7;
+
+		Profile Profile => new Profile (Configuration);
+
+		Optimizations Optimizations => Configuration.Application.Optimizations;
+
+		string PlatformAssembly => Configuration.PlatformAssembly;
+
+		protected override void TryProcessAssembly (AssemblyDefinition assembly)
+		{
+			Process (assembly);
+		}
+#else
+	public class RegistrarRemovalTrackingStep : BaseStep {
+
+		Optimizations Optimizations => ((DerivedLinkContext) Context).App.Optimizations;
+
+		string PlatformAssembly => ((MobileProfile) Profile.Current).ProductAssembly;
+
+		int WarnCode => 2107; // for compatibility
+
+		protected override void ProcessAssembly (AssemblyDefinition assembly)
+		{
+			Process (assembly);
+			base.ProcessAssembly (assembly);
+		}
+#endif
+
+		bool dynamic_registration_support_required;
+
+		void Process (AssemblyDefinition assembly)
+		{
+			if (Optimizations.RemoveDynamicRegistrar != false)
+				dynamic_registration_support_required |= RequiresDynamicRegistrar (assembly, Optimizations.RemoveDynamicRegistrar == true);
+		}
+
+		// If certain conditions are met, we can optimize away the code for the dynamic registrar.
+		bool RequiresDynamicRegistrar (AssemblyDefinition assembly, bool warnIfRequired)
+		{
+			// We know that the SDK assemblies we ship don't use the methods we're looking for.
+			if (Profile.IsSdkAssembly (assembly))
+				return false;
+
+			// The product assembly itself is safe as long as it's linked
+			if (Profile.IsProductAssembly (assembly))
+				return Annotations.GetAction (assembly) != AssemblyAction.Link;
+
+			// Can't touch the forbidden fruit in the product assembly unless there's a reference to it
+			var hasProductReference = false;
+			foreach (var ar in assembly.MainModule.AssemblyReferences) {
+				if (!Profile.IsProductAssembly (ar.Name))
+					continue;
+				hasProductReference = true;
+				break;
+			}
+			if (!hasProductReference)
+				return false;
+
+			// Check if the assembly references any methods that require the dynamic registrar
+			var productAssemblyName = PlatformAssembly;
+			var requires = false;
+			foreach (var mr in assembly.MainModule.GetMemberReferences ()) {
+				if (mr.DeclaringType == null || string.IsNullOrEmpty (mr.DeclaringType.Namespace))
+					continue;
+
+				var scope = mr.DeclaringType.Scope;
+				var name = string.Empty;
+				switch (scope.MetadataScopeType) {
+				case MetadataScopeType.ModuleDefinition:
+					name = ((ModuleDefinition) scope).Assembly.Name.Name;
+					break;
+				default:
+					name = scope.Name;
+					break;
+				}
+				if (name != productAssemblyName)
+					continue;
+
+				switch (mr.DeclaringType.Namespace) {
+				case "ObjCRuntime":
+					switch (mr.DeclaringType.Name) {
+					case "Runtime":
+						switch (mr.Name) {
+						case "ConnectMethod":
+							// Req 1: Nobody must call Runtime.ConnectMethod.
+							if (warnIfRequired)
+								Warn (assembly, mr);
+							requires = true;
+							break;
+						case "RegisterAssembly":
+							// Req 3: Nobody must call Runtime.RegisterAssembly
+							if (warnIfRequired)
+								Warn (assembly, mr);
+							requires = true;
+							break;
+						}
+						break;
+					case "BlockLiteral":
+						switch (mr.Name) {
+						case "SetupBlock":
+						case "SetupBlockUnsafe":
+							// Req 2: Nobody must call BlockLiteral.SetupBlock[Unsafe].
+							//
+							// Fortunately the linker is able to rewrite calls to SetupBlock[Unsafe] to call
+							// SetupBlockImpl (which doesn't need the dynamic registrar), which means we only have
+							// to look in assemblies that aren't linked.
+							if (Annotations.GetAction (assembly) == AssemblyAction.Link && Optimizations.OptimizeBlockLiteralSetupBlock == true)
+								break;
+
+							if (warnIfRequired)
+								Warn (assembly, mr);
+
+							requires = true;
+							break;
+						}
+						break;
+					case "TypeConverter":
+						switch (mr.Name) {
+						case "ToManaged":
+							// Req 4: Nobody must call TypeConverter.ToManaged
+							if (warnIfRequired)
+								Warn (assembly, mr);
+							requires = true;
+							break;
+						}
+						break;
+					}
+					break;
+				}
+			}
+
+			return requires;
+		}
+
+		void Warn (AssemblyDefinition assembly, MemberReference mr)
+		{
+			ErrorHelper.Warning (WarnCode, Errors.MM2107, assembly.Name.Name, mr.DeclaringType.FullName, mr.Name, string.Join (", ", ((MethodReference) mr).Parameters.Select ((v) => v.ParameterType.FullName)));
+		}
+
+#if NET
+		protected override void TryEndProcess ()
+		{
+#else
+		protected override void EndProcess ()
+		{
+			base.EndProcess ();
+#endif
+			if (!Optimizations.RemoveDynamicRegistrar.HasValue) {
+				// If dynamic registration is not required, and removal of the dynamic registrar hasn't already
+				// been disabled, then we can remove it!
+				Optimizations.RemoveDynamicRegistrar = !dynamic_registration_support_required;
+				Driver.Log (4, "Optimization dynamic registrar removal: {0}", Optimizations.RemoveDynamicRegistrar.Value ? "enabled" : "disabled");
+#if MTOUCH
+				var app = (Context as DerivedLinkContext).App;
+				if (app.IsCodeShared) {
+					foreach (var appex in app.AppExtensions) {
+						if (!appex.IsCodeShared)
+							continue;
+						appex.Optimizations.RemoveDynamicRegistrar = app.Optimizations.RemoveDynamicRegistrar;
+					}
+				}
+#endif
+			}
+		}
+	}
+}

--- a/tools/mtouch/Tuning.mtouch.cs
+++ b/tools/mtouch/Tuning.mtouch.cs
@@ -143,6 +143,7 @@ namespace MonoTouch.Tuner {
 
 			if (options.LinkMode != LinkMode.None) {
 				pipeline.Append (new CoreTypeMapStep ());
+				pipeline.Append (new RegistrarRemovalTrackingStep ());
 
 				pipeline.Append (GetSubSteps ());
 

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -484,6 +484,9 @@
     <Compile Include="..\common\XamarinRuntime.cs">
       <Link>tools\common\XamarinRuntime.cs</Link>
     </Compile>
+    <Compile Include="..\linker\RegistrarRemovalTrackingStep.cs">
+      <Link>tools\linker\RegistrarRemovalTrackingStep.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Core" />


### PR DESCRIPTION
The newly extracted `RegistrarRemovalTrackingStep` can be used inside
`dotnet-linker` to remove the dynamic registrar (if not required by some
other code).

|    Size    | MySingleView.app |
| ----------:|------------------|
|  4,579,969 | legacy           |
| 11,182,125 | dotnet [before](https://gist.github.com/spouliot/746cd36877becd5de2ca9e255a402b87) |
| 10,760,493 | dotnet [after](https://gist.github.com/spouliot/9232bd1888c93a4664dca451d3d8481f) |
