### PR TITLE
[runtime] Implement mono_class_is_delegate for CoreCLR.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -339,4 +339,12 @@ mono_class_from_mono_type (MonoType *type)
 	return rv;
 }
 
+mono_bool
+mono_class_is_delegate (MonoClass *klass)
+{
+	bool rv = xamarin_bridge_is_delegate (klass);
+	LOG_CORECLR (stderr, "%s (%p) => %i\n", __func__, klass, rv);
+	return rv;
+}
+
 #endif // CORECLR_RUNTIME

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -408,6 +408,14 @@
 			OnlyDynamicUsage = false,
 			OnlyCoreCLR = true,
 		},
+
+		new XDelegate ("bool", "bool", "xamarin_bridge_is_delegate",
+			"MonoObject *", "MonoObject *", "typeobj"
+		) {
+			WrappedManagedFunction = "IsDelegate",
+			OnlyDynamicUsage = false,
+			OnlyCoreCLR = true,
+		},
 	};
 	delegates.CalculateLengths ();
 #><#+

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -33,7 +33,9 @@
 
 		new Export ("mono_bool", "mono_class_is_delegate",
 			"MonoClass *", "klass"
-		),
+		) {
+			HasCoreCLRBridgeFunction = true,
+		},
 
 		new Export ("MonoClass *", "mono_class_get_element_class",
 			"MonoClass *", "klass"

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -185,6 +185,14 @@ namespace ObjCRuntime {
 			return GetMonoObject (obj.GetType ());
 		}
 
+		unsafe static bool IsDelegate (MonoObject* typeobj)
+		{
+			var type = (Type) GetMonoObjectTarget (typeobj);
+			var rv = typeof (MulticastDelegate).IsAssignableFrom (type);
+			log_coreclr ($"IsDelegate ({type.FullName}) => {rv}");
+			return rv;
+		}
+
 		static bool IsInstance (MonoObjectPtr mobj, MonoObjectPtr mtype)
 		{
 			var obj = GetMonoObjectTarget (mobj);


### PR DESCRIPTION
Next failure is:

> monotouchtest[99604:32343536] Xamarin.Mac: The method xamarin_get_inativeobject_class it not implemented yet for CoreCLR

```
3   com.xamarin.monotouch-test          0x000000010379ae98 xamarin_assertion_message + 408 (runtime.m:1452)
4   com.xamarin.monotouch-test          0x00000001037abb29 xamarin_get_inativeobject_class + 25 (coreclr-bridge.m:117)
5   com.xamarin.monotouch-test          0x000000010379e229 xamarin_is_class_inativeobject + 25 (runtime.m:390)
6   com.xamarin.monotouch-test          0x00000001037a947e xamarin_invoke_trampoline + 4030 (trampolines-invoke.m:350)
7   com.xamarin.monotouch-test          0x00000001037b2507 xamarin_arch_trampoline + 119 (trampolines-x86_64.m:491)
8   com.xamarin.monotouch-test          0x00000001037b376e xamarin_x86_64_common_trampoline + 118 (trampolines-x86_64-asm.s:51)
9   com.xamarin.monotouch-test          0x00000001037a3d41 xamarin_copyWithZone_trampoline2 + 113 (trampolines.m:619)
10  com.xamarin.monotouch-test          0x00000001037b38e9 xamarin_dyn_objc_msgSend + 217 (trampolines-x86_64-objc_msgSend.s:15)
```