### PR TITLE
[runtime] Implement a managed implementation of a mono_reference_queue for CoreCLR.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -351,6 +351,26 @@ xamarin_bridge_free_mono_signature (MonoMethodSignature **psig)
 	*psig = NULL;
 }
 
+MonoReferenceQueue *
+mono_gc_reference_queue_new (mono_reference_queue_callback callback)
+{
+	MonoReferenceQueue *rv = xamarin_bridge_gc_reference_queue_new (callback);
+
+	LOG_CORECLR (stderr, "%s (%p) => %p\n", __func__, callback, rv);
+
+	return rv;
+}
+
+gboolean
+mono_gc_reference_queue_add (MonoReferenceQueue *queue, MonoObject *obj, void *user_data)
+{
+	LOG_CORECLR (stderr, "%s (%p, %p, %p)\n", __func__, queue, obj, user_data);
+
+	xamarin_bridge_gc_reference_queue_add (queue, obj, user_data);
+
+	return true;
+}
+
 void
 mono_free (void *ptr)
 {

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -375,6 +375,24 @@
 			OnlyCoreCLR = true,
 		},
 
+		new XDelegate ("MonoReferenceQueue *", "MonoObject *", "xamarin_bridge_gc_reference_queue_new",
+			"mono_reference_queue_callback", "IntPtr", "callback"
+		) {
+			WrappedManagedFunction = "CreateGCReferenceQueue",
+			OnlyDynamicUsage = false,
+			OnlyCoreCLR = true,
+		},
+
+		new XDelegate ("void", "void", "xamarin_bridge_gc_reference_queue_add",
+			"MonoReferenceQueue *", "MonoObject *", "queue_handle",
+			"MonoObject *", "MonoObject *", "obj",
+			"void *", "IntPtr", "user_data"
+		) {
+			WrappedManagedFunction = "GCReferenceQueueAdd",
+			OnlyDynamicUsage = false,
+			OnlyCoreCLR = true,
+		},
+
 		new XDelegate ("MonoObject*", "IntPtr", "xamarin_bridge_get_monoobject",
 			"GCHandle", "IntPtr", "gchandle"
 		) {

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -495,17 +495,17 @@
 
 		new Export ("MonoReferenceQueue *", "mono_gc_reference_queue_new",
 			"mono_reference_queue_callback", "callback"
-		),
-
-		new Export ("void", "mono_gc_reference_queue_free",
-			"MonoReferenceQueue *", "queue"
-		),
+		) {
+			HasCoreCLRBridgeFunction = true,
+		},
 
 		new Export ("gboolean", "mono_gc_reference_queue_add",
 			"MonoReferenceQueue *", "queue",
 			"MonoObject *", "obj",
 			"void *", "user_data"
-		),
+		) {
+			HasCoreCLRBridgeFunction = true,
+		},
 
 		new Export ("void", "mono_gc_register_finalizer_callbacks",
 			"MonoGCFinalizerCallbacks *", "callbacks"

--- a/runtime/mono-runtime.h.t4
+++ b/runtime/mono-runtime.h.t4
@@ -126,7 +126,12 @@ typedef struct _MonoThread MonoThread;
 typedef struct _MonoThreadsSync MonoThreadsSync;
 typedef struct _MonoObject MonoObject;
 
+#if defined (CORECLR_RUNTIME)
+// In Mono, MonoReferenceQueue is not related to MonoObject at all, but for the CoreCLR bridge we use the same struct representation for both types.
+typedef struct _MonoObject MonoReferenceQueue;
+#else
 typedef struct _MonoReferenceQueue MonoReferenceQueue;
+#endif
 typedef void (*mono_reference_queue_callback) (void *user_data);
 
 #define mono_array_addr(array,type,index) ((type*)(void*) mono_array_addr_with_size (array, sizeof (type), index))

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -12,6 +12,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 
 using Foundation;
 
@@ -448,6 +449,49 @@ namespace ObjCRuntime {
 				return null;
 
 			return Marshal.PtrToStructure (ptr, type);
+		}
+
+		/* Managed version of a mono_reference_queue */
+		/* The semantics are:
+		 * - Adding an object to the queue will not prevent the GC from collecting it (it's a weak reference)
+		 * - A native callback will be called when the object is collected.
+		 * This can be accomplished with a ConditionalWeakTable: the object in question is the key, and then
+		 * we add a wrapper object as the value, and we call the native callback when the wrapper object is
+		 * collected.
+		 */
+		delegate void mono_reference_queue_callback (IntPtr user_data);
+
+		class ReferenceQueue {
+			public mono_reference_queue_callback Callback;
+			public ConditionalWeakTable<object, object> Table = new ConditionalWeakTable<object, object> ();
+		}
+
+		class ReferenceQueueEntry {
+			public ReferenceQueue Queue;
+			public IntPtr UserData;
+
+			~ReferenceQueueEntry ()
+			{
+				Queue.Callback (UserData);
+			}
+		}
+
+		unsafe static MonoObject* CreateGCReferenceQueue (IntPtr callback)
+		{
+			var queue = new ReferenceQueue ();
+			queue.Callback = Marshal.GetDelegateForFunctionPointer<mono_reference_queue_callback> (callback);
+			return (MonoObject *) GetMonoObject (queue);
+		}
+
+		unsafe static void GCReferenceQueueAdd (MonoObject* mqueue, MonoObject* mobj, IntPtr user_data)
+		{
+			var queue = (ReferenceQueue) GetMonoObjectTarget (mqueue);
+			var obj = GetMonoObjectTarget (mobj);
+			var entry = new ReferenceQueueEntry () {
+				Queue = queue,
+				UserData = user_data,
+			};
+			queue.Table.Add (obj, entry);
 		}
 
 		[DllImport ("__Internal")]


### PR DESCRIPTION
Also remove the declaration of mono_gc_reference_queue_free, it's never called.