### PR TITLE
[CoreFoundation] Fix CFBundle.Architecture constants.

### DIFF
--- a/src/CoreFoundation/Architecture.cs
+++ b/src/CoreFoundation/Architecture.cs
@@ -18,10 +18,10 @@ namespace CoreFoundation {
 		public enum Architecture {
 			I386     = 0x00000007,
 			X86_64   = 0x01000007,
-			ARM      = 0x00000012,
-			ARM64    = 0x01000012,
-			PPC      = 0x00000018,
-			PPC64    = 0x01000018,
+			ARM      = 0x0000000c,
+			ARM64    = 0x01000000 | ARM,
+			PPC      = 0x00000012,
+			PPC64    = 0x01000000 | PPC,
 		}
     }
 }


### PR DESCRIPTION
There was a confusion between hex and decimal values, the values are written
using decimal in the headers, but were treated as hex values in the C# source.

This is a breaking change, but the values are just plain wrong, so I don't
really see a way around this. Also there's no good way to work around it by
accepting the old values and converting in our managed wrapper method, because
the old ARM values match the new PPC values, so there's no way to know if the
input is using old values or new values.