### PR TITLE
[runtime] Implement mono_class_get_type for CoreCLR.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -210,6 +210,20 @@ mono_domain_get (void)
 	return NULL;
 }
 
+MonoType *
+mono_class_get_type (MonoClass *klass)
+{
+	// MonoClass and MonoType are identical in CoreCLR (both are actually MonoObjects).
+	// However, we're returning a retained object, so we need to retain here.
+	MonoType *rv = klass;
+
+	xamarin_mono_object_retain (rv);
+
+	LOG_CORECLR (stderr, "%s (%p) => %p\n", __func__, klass, rv);
+
+	return rv;
+}
+
 // returns a retained MonoReflectionAssembly *
 MonoReflectionAssembly *
 mono_assembly_get_object (MonoDomain * domain, MonoAssembly * assembly)

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -82,7 +82,9 @@
 
 		new Export ("MonoType *", "mono_class_get_type",
 			"MonoClass *", "klass"
-		),
+		) {
+			HasCoreCLRBridgeFunction = true,
+		},
 		#endregion
 
 		#region metadata/class-internals.h

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -370,6 +370,7 @@ xamarin_new_nsobject (id self, MonoClass *klass, GCHandle *exception_gchandle)
 {
 	MonoType *type = mono_class_get_type (klass);
 	MonoReflectionType *rtype = mono_type_get_object (mono_domain_get (), type);
+	xamarin_mono_object_release (&type);
 
 	GCHandle obj = xamarin_create_nsobject (rtype, self, NSObjectFlagsNativeRef, exception_gchandle);
 	xamarin_mono_object_release (&rtype);
@@ -768,7 +769,11 @@ xamarin_class_get_full_name (MonoClass *klass, GCHandle *exception_gchandle)
 	// COOP: Reads managed memory, needs to be in UNSAFE mode
 	MONO_ASSERT_GC_UNSAFE;
 	
-	return xamarin_type_get_full_name (mono_class_get_type (klass), exception_gchandle);
+	MonoType *type = mono_class_get_type (klass);
+	char * rv = xamarin_type_get_full_name (type, exception_gchandle);
+	xamarin_mono_object_release (&type);
+
+	return rv;
 }
 
 char *


### PR DESCRIPTION
This also meant reviewing calling code to make sure that the return value is
released when it should be.