### PR TITLE
[xammac tests] Add Bluetooth description in the Info.plist.

### DIFF
--- a/tests/xammac_tests/Info.plist
+++ b/tests/xammac_tests/Info.plist
@@ -23,5 +23,7 @@
 	</dict>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Testing world domination through blue teeth coloring</string>
 </dict>
 </plist>


### PR DESCRIPTION
Otherwise the test app crashes when running within lldb.