### PR TITLE
[tests] Make ImageCaptioningTest.SetCaption restore the original value at the end.

### DIFF
--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -110,6 +110,12 @@ namespace MonoTouchFixtures.MediaAccessibility {
 						Assert.Null (s, "ro / back to original");
 					}
 					Assert.Null (e, "ro / get back / no error");
+
+					// Restore original value
+					Assert.True (MAImageCaptioning.SetCaption (url, null, out e), "Set 2");
+					s = MAImageCaptioning.GetCaption (url, out e);
+					Assert.Null (s, "ro / back to null");
+					Assert.Null (e, "ro / get back null / no error");
 				}
 
 				// 2nd try with a read/write copy


### PR DESCRIPTION
This makes it so that ImageCaptioningTest.GetCaption doesn't fail because it
gets values it doesn't expect.