### PR TITLE
[runtime] Implement mono_class_get_element_class for CoreCLR.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -463,6 +463,14 @@ mono_class_is_valuetype (MonoClass * klass)
 	return rv;
 }
 
+MonoClass *
+mono_class_get_element_class (MonoClass *klass)
+{
+	MonoClass *rv = xamarin_bridge_get_element_class (klass);
+	LOG_CORECLR (stderr, "%s (%p) => %p\n", __func__, klass, rv);
+	return rv;
+}
+
 bool
 xamarin_is_class_nsobject (MonoClass *cls)
 {

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -459,6 +459,14 @@
 			OnlyCoreCLR = true,
 		},
 
+		new XDelegate ("MonoObject *", "MonoObject *", "xamarin_bridge_get_element_class",
+			"MonoObject *", "MonoObject *", "classobj"
+		) {
+			WrappedManagedFunction = "GetElementClass",
+			OnlyDynamicUsage = false,
+			OnlyCoreCLR = true,
+		},
+
 		new XDelegate ("bool", "bool", "xamarin_bridge_is_delegate",
 			"MonoObject *", "MonoObject *", "typeobj"
 		) {

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -39,7 +39,9 @@
 
 		new Export ("MonoClass *", "mono_class_get_element_class",
 			"MonoClass *", "klass"
-		),
+		) {
+			HasCoreCLRBridgeFunction = true,
+		},
 
 		new Export ("const char *", "mono_class_get_namespace",
 			"MonoClass *", "klass"

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -870,6 +870,8 @@ xamarin_generate_conversion_to_native (MonoObject *value, MonoType *inputType, M
 
 	MonoClass *underlyingManagedType = managedType;
 	MonoClass *underlyingNativeType = nativeType;
+	MonoClass *nativeElementType = NULL;
+	MonoClass *managedElementType = NULL;
 
 	bool isManagedArray = xamarin_is_class_array (managedType);
 	bool isNativeArray = xamarin_is_class_array (nativeType);
@@ -889,8 +891,10 @@ xamarin_generate_conversion_to_native (MonoObject *value, MonoType *inputType, M
 			*exception_gchandle = xamarin_create_bindas_exception (inputType, outputType, method);
 			goto exception_handling;
 		}
-		underlyingNativeType = mono_class_get_element_class (nativeType);
-		underlyingManagedType = mono_class_get_element_class (managedType);
+		nativeElementType = mono_class_get_element_class (nativeType);
+		managedElementType = mono_class_get_element_class (managedType);
+		underlyingNativeType = nativeElementType;
+		underlyingManagedType = managedElementType;
 	} else if (isManagedNullable) {
 		underlyingManagedType = nullableManagedType;
 	}
@@ -925,6 +929,8 @@ exception_handling:
 
 	xamarin_mono_object_release (&managedType);
 	xamarin_mono_object_release (&nativeType);
+	xamarin_mono_object_release (&nativeElementType);
+	xamarin_mono_object_release (&managedElementType);
 
 	return convertedValue;
 }
@@ -945,6 +951,8 @@ xamarin_generate_conversion_to_managed (id value, MonoType *inputType, MonoType 
 
 	MonoClass *underlyingManagedType = managedType;
 	MonoClass *underlyingNativeType = nativeType;
+	MonoClass *nativeElementType = NULL;
+	MonoClass *managedElementType = NULL;
 
 	bool isManagedArray = xamarin_is_class_array (managedType);
 	bool isNativeArray = xamarin_is_class_array (nativeType);
@@ -964,8 +972,10 @@ xamarin_generate_conversion_to_managed (id value, MonoType *inputType, MonoType 
 			*exception_gchandle = xamarin_create_bindas_exception (inputType, outputType, method);
 			goto exception_handling;
 		}
-		underlyingNativeType = mono_class_get_element_class (nativeType);
-		underlyingManagedType = mono_class_get_element_class (managedType);
+		nativeElementType = mono_class_get_element_class (nativeType);
+		managedElementType = mono_class_get_element_class (managedType);
+		underlyingNativeType = nativeElementType;
+		underlyingManagedType = managedElementType;
 	} else if (isManagedNullable) {
 		underlyingManagedType = nullableManagedType;
 	}
@@ -1004,6 +1014,8 @@ exception_handling:
 
 	xamarin_mono_object_release (&managedType);
 	xamarin_mono_object_release (&nativeType);
+	xamarin_mono_object_release (&nativeElementType);
+	xamarin_mono_object_release (&managedElementType);
 
 	return convertedValue;
 }
@@ -1234,6 +1246,8 @@ xamarin_managed_inativeobject_array_to_nsarray (MonoArray *array, GCHandle *exce
 NSArray *
 xamarin_managed_array_to_nsarray (MonoArray *array, MonoType *managed_type, MonoClass *managed_class, GCHandle *exception_gchandle)
 {
+	NSArray *rv = NULL;
+
 	if (array == NULL)
 		return NULL;
 
@@ -1248,24 +1262,27 @@ xamarin_managed_array_to_nsarray (MonoArray *array, MonoType *managed_type, Mono
 	xamarin_mono_object_release (&mclass);
 
 	if (xamarin_is_class_string (e_klass)) {
-		return xamarin_managed_string_array_to_nsarray (array, exception_gchandle);
+		rv = xamarin_managed_string_array_to_nsarray (array, exception_gchandle);
 	} else if (xamarin_is_class_nsobject (e_klass)) {
-		return xamarin_managed_nsobject_array_to_nsarray (array, exception_gchandle);
+		rv = xamarin_managed_nsobject_array_to_nsarray (array, exception_gchandle);
 	} else if (xamarin_is_class_inativeobject (e_klass)) {
-		return xamarin_managed_inativeobject_array_to_nsarray (array, exception_gchandle);
+		rv = xamarin_managed_inativeobject_array_to_nsarray (array, exception_gchandle);
+	} else {
+		// Don't know how to convert: show an exception.
+		MonoType *e_type = mono_class_get_type (e_klass);
+		char *element_name = xamarin_type_get_full_name (e_type, exception_gchandle);
+		xamarin_mono_object_release (&e_type);
+		if (*exception_gchandle == INVALID_GCHANDLE) {
+			char *msg = xamarin_strdup_printf ("Unable to convert from a managed array of %s to an NSArray.", element_name);
+			*exception_gchandle = xamarin_create_product_exception_with_inner_exception (8032, *exception_gchandle, msg);
+			xamarin_free (msg);
+			xamarin_free (element_name);
+		}
 	}
 
-	// Don't know how to convert: show an exception.
-	MonoType *e_type = mono_class_get_type (e_klass);
-	char *element_name = xamarin_type_get_full_name (e_type, exception_gchandle);
-	xamarin_mono_object_release (&e_type);
-	if (*exception_gchandle != INVALID_GCHANDLE)
-		return NULL;
-	char *msg = xamarin_strdup_printf ("Unable to convert from a managed array of %s to an NSArray.", element_name);
-	*exception_gchandle = xamarin_create_product_exception_with_inner_exception (8032, *exception_gchandle, msg);
-	xamarin_free (msg);
-	xamarin_free (element_name);
-	return NULL;
+	xamarin_mono_object_release (&e_klass);
+
+	return rv;
 }
 
 MonoArray *
@@ -1277,10 +1294,13 @@ xamarin_nsarray_to_managed_string_array (NSArray *array, GCHandle *exception_gch
 MonoArray *
 xamarin_nsarray_to_managed_nsobject_array (NSArray *array, MonoType *array_type, MonoClass *element_class, GCHandle *exception_gchandle)
 {
+	MonoClass *e_class = NULL;
 	if (element_class == NULL) {
 		MonoClass *mclass = mono_class_from_mono_type (array_type);
-		element_class = mono_class_get_element_class (mclass);
+		e_class = mono_class_get_element_class (mclass);
 		xamarin_mono_object_release (&mclass);
+
+		element_class = e_class;
 	}
 
 	struct conversion_data data = { 0 };
@@ -1292,6 +1312,7 @@ xamarin_nsarray_to_managed_nsobject_array (NSArray *array, MonoType *array_type,
 
 	xamarin_mono_object_release (&data.element_type);
 	xamarin_mono_object_release (&data.element_reflection_type);
+	xamarin_mono_object_release (&e_class);
 
 	return rv;
 }
@@ -1299,10 +1320,13 @@ xamarin_nsarray_to_managed_nsobject_array (NSArray *array, MonoType *array_type,
 MonoArray *
 xamarin_nsarray_to_managed_inativeobject_array (NSArray *array, MonoType *array_type, MonoClass *element_class, GCHandle *exception_gchandle)
 {
+	MonoClass *e_class = NULL;
 	if (element_class == NULL) {
 		MonoClass *mclass = mono_class_from_mono_type (array_type);
-		element_class = mono_class_get_element_class (mclass);
+		e_class = mono_class_get_element_class (mclass);
 		xamarin_mono_object_release (&mclass);
+
+		element_class = e_class;
 	}
 
 	struct conversion_data data = { 0 };
@@ -1314,6 +1338,7 @@ xamarin_nsarray_to_managed_inativeobject_array (NSArray *array, MonoType *array_
 
 	xamarin_mono_object_release (&data.element_type);
 	xamarin_mono_object_release (&data.element_reflection_type);
+	xamarin_mono_object_release (&e_class);
 
 	return rv;
 }
@@ -1321,10 +1346,13 @@ xamarin_nsarray_to_managed_inativeobject_array (NSArray *array, MonoType *array_
 MonoArray *
 xamarin_nsarray_to_managed_inativeobject_array_static (NSArray *array, MonoType *array_type, MonoClass *element_class, uint32_t iface_token_ref, uint32_t implementation_token_ref, GCHandle *exception_gchandle)
 {
+	MonoClass *e_class = NULL;
 	if (element_class == NULL) {
 		MonoClass *mclass = mono_class_from_mono_type (array_type);
-		element_class = mono_class_get_element_class (mclass);
+		e_class = mono_class_get_element_class (mclass);
 		xamarin_mono_object_release (&mclass);
+
+		element_class = e_class;
 	}
 
 	struct conversion_data data = { 0 };
@@ -1336,6 +1364,7 @@ xamarin_nsarray_to_managed_inativeobject_array_static (NSArray *array, MonoType 
 	MonoArray *rv = xamarin_convert_nsarray_to_managed_with_func (array, data.element_class, xamarin_nsobject_to_inativeobject_static, &data, exception_gchandle);
 
 	xamarin_mono_object_release (&data.element_type);
+	xamarin_mono_object_release (&e_class);
 
 	return rv;
 }
@@ -1343,6 +1372,8 @@ xamarin_nsarray_to_managed_inativeobject_array_static (NSArray *array, MonoType 
 MonoArray *
 xamarin_nsarray_to_managed_array (NSArray *array, MonoType *managed_type, MonoClass *managed_class, GCHandle *exception_gchandle)
 {
+	MonoArray *rv = NULL;
+
 	if (array == NULL)
 		return NULL;
 
@@ -1356,24 +1387,27 @@ xamarin_nsarray_to_managed_array (NSArray *array, MonoType *managed_type, MonoCl
 
 	MonoClass *e_klass = mono_class_get_element_class (managed_class);
 	if (xamarin_is_class_string (e_klass)) {
-		return xamarin_nsarray_to_managed_string_array (array, exception_gchandle);
+		rv = xamarin_nsarray_to_managed_string_array (array, exception_gchandle);
 	} else if (xamarin_is_class_nsobject (e_klass)) {
-		return xamarin_nsarray_to_managed_nsobject_array (array, managed_type, e_klass, exception_gchandle);
+		rv = xamarin_nsarray_to_managed_nsobject_array (array, managed_type, e_klass, exception_gchandle);
 	} else if (xamarin_is_class_inativeobject (e_klass)) {
-		return xamarin_nsarray_to_managed_inativeobject_array (array, managed_type, e_klass, exception_gchandle);
+		rv = xamarin_nsarray_to_managed_inativeobject_array (array, managed_type, e_klass, exception_gchandle);
+	} else {
+		// Don't know how to convert: show an exception.
+		MonoType *e_type = mono_class_get_type (e_klass);
+		char *element_name = xamarin_type_get_full_name (e_type, exception_gchandle);
+		xamarin_mono_object_release (&e_type);
+		if (*exception_gchandle == INVALID_GCHANDLE) {
+			char *msg = xamarin_strdup_printf ("Unable to convert from an NSArray to a managed array of %s.", element_name);
+			*exception_gchandle = xamarin_create_product_exception_with_inner_exception (8031, *exception_gchandle, msg);
+			xamarin_free (msg);
+			xamarin_free (element_name);
+		}
 	}
 
-	// Don't know how to convert: show an exception.
-	MonoType *e_type = mono_class_get_type (e_klass);
-	char *element_name = xamarin_type_get_full_name (e_type, exception_gchandle);
-	xamarin_mono_object_release (&e_type);
-	if (*exception_gchandle != INVALID_GCHANDLE)
-		return NULL;
-	char *msg = xamarin_strdup_printf ("Unable to convert from an NSArray to a managed array of %s.", element_name);
-	*exception_gchandle = xamarin_create_product_exception_with_inner_exception (8031, *exception_gchandle, msg);
-	xamarin_free (msg);
-	xamarin_free (element_name);
-	return NULL;
+	xamarin_mono_object_release (&e_klass);
+
+	return rv;
 }
 
 static void *
@@ -1693,6 +1727,7 @@ xamarin_convert_managed_to_nsarray_with_func (MonoArray *array, xamarin_managed_
 
 exception_handling:
 	free (buf);
+	xamarin_mono_object_release (&element_class);
 
 	return rv;
 }

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -131,6 +131,12 @@ namespace ObjCRuntime {
 			return rv;
 		}
 
+		static unsafe MonoObject* GetElementClass (MonoObject* classobj)
+		{
+			var type = (Type) GetMonoObjectTarget (classobj);
+			return (MonoObject*) GetMonoObject (type.GetElementType ());
+		}
+
 		static IntPtr CreateGCHandle (IntPtr gchandle, GCHandleType type)
 		{
 			// It's valid to create a GCHandle to a null value.

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -4463,6 +4463,7 @@ namespace Registrar {
 				underlyingNativeType = GetElementType (nativeType);
 				underlyingManagedType = GetElementType (managedType);
 				sb.AppendLine ($"{classVariableName} = mono_class_get_element_class ({managedClassExpression});");
+				cleanup.AppendLine ($"xamarin_mono_object_release (&{classVariableName});");
 			} else if (isManagedNullable) {
 				underlyingManagedType = GetNullableType (managedType);
 				sb.AppendLine ($"{classVariableName} = xamarin_get_nullable_type ({managedClassExpression}, &exception_gchandle);");
@@ -4550,6 +4551,7 @@ namespace Registrar {
 				underlyingNativeType = GetElementType (nativeType);
 				underlyingManagedType = GetElementType (managedType);
 				sb.AppendLine ($"{classVariableName} = mono_class_get_element_class ({managedClassExpression});");
+				cleanup.AppendLine ($"xamarin_mono_object_release (&{classVariableName});");
 			} else if (isManagedNullable) {
 				underlyingManagedType = GetNullableType (managedType);
 				sb.AppendLine ($"{classVariableName} = xamarin_get_nullable_type ({managedClassExpression}, &exception_gchandle);");


### PR DESCRIPTION
This also meant reviewing calling code to make sure that the return value is
released when it should be.