### PR TITLE
Improve support for ARM64 on macOS.

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -25,7 +25,7 @@ SHIPPED_HEADERS +=         \
 SHARED_SOURCES += mono-runtime.m bindings.m bindings-generated.m shared.m runtime.m trampolines.m trampolines-invoke.m xamarin-support.m nsstring-localization.m trampolines-varargs.m monovm-bridge.m coreclr-bridge.m
 SHARED_I386_SOURCES += trampolines-i386.m trampolines-i386-asm.s trampolines-i386-objc_msgSend.s trampolines-i386-objc_msgSendSuper.s trampolines-i386-objc_msgSend_stret.s trampolines-i386-objc_msgSendSuper_stret.s
 SHARED_X86_64_SOURCES += trampolines-x86_64.m trampolines-x86_64-asm.s trampolines-x86_64-objc_msgSend.s trampolines-x86_64-objc_msgSendSuper.s trampolines-x86_64-objc_msgSend_stret.s trampolines-x86_64-objc_msgSendSuper_stret.s
-SHARED_ARM64_SOURCES += trampolines-arm64.m trampolines-arm64-asm.s
+SHARED_ARM64_SOURCES += trampolines-arm64.m trampolines-arm64-asm.s trampolines-arm64-objc_msgSend.s trampolines-arm64-objc_msgSendSuper.s
 SHARED_HEADERS += shared.h product.h delegates.h runtime-internal.h $(SHARED_INC) $(SHIPPED_HEADERS) trampolines-internal.h slinked-list.h
 
 SHARED_FILES = $(SHARED_SOURCES) $(SHARED_HEADERS) $(SHARED_I386_SOURCES) $(SHARED_X86_64_SOURCES) $(SHARED_ARM64_SOURCES)

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2331,7 +2331,7 @@ xamarin_create_product_exception_with_inner_exception (int code, GCHandle inner_
 void
 xamarin_insert_dllmap ()
 {
-#if defined (OBJC_ZEROCOST_EXCEPTIONS) && (defined (__i386__) || defined (__x86_64__))
+#if defined (OBJC_ZEROCOST_EXCEPTIONS) && (defined (__i386__) || defined (__x86_64__) || defined (__arm64__))
 	if (xamarin_marshal_objectivec_exception_mode == MarshalObjectiveCExceptionModeDisable)
 		return;
 #if DYLIB
@@ -2341,10 +2341,12 @@ xamarin_insert_dllmap ()
 #endif
 	mono_dllmap_insert (NULL, "/usr/lib/libobjc.dylib", "objc_msgSend",            lib, "xamarin_dyn_objc_msgSend");
 	mono_dllmap_insert (NULL, "/usr/lib/libobjc.dylib", "objc_msgSendSuper",       lib, "xamarin_dyn_objc_msgSendSuper");
+#if !defined (__arm64__)
 	mono_dllmap_insert (NULL, "/usr/lib/libobjc.dylib", "objc_msgSend_stret",      lib, "xamarin_dyn_objc_msgSend_stret");
 	mono_dllmap_insert (NULL, "/usr/lib/libobjc.dylib", "objc_msgSendSuper_stret", lib, "xamarin_dyn_objc_msgSendSuper_stret");
+#endif
 	LOG (PRODUCT ": Added dllmap for objc_msgSend");
-#endif // defined (__i386__) || defined (__x86_64__)
+#endif // defined (__i386__) || defined (__x86_64__) || defined (__arm64__)
 }
 #endif // !DOTNET
 
@@ -2381,20 +2383,22 @@ xamarin_pinvoke_override (const char *libraryName, const char *entrypointName)
 
 	if (!strcmp (libraryName, "__Internal")) {
 		symbol = dlsym (RTLD_DEFAULT, entrypointName);
-#if defined (__i386__) || defined (__x86_64__)
+#if defined (__i386__) || defined (__x86_64__) || defined (__arm64__)
 	} else if (!strcmp (libraryName, "/usr/lib/libobjc.dylib")) {
 		if (xamarin_marshal_objectivec_exception_mode != MarshalObjectiveCExceptionModeDisable) {
 			if (!strcmp (entrypointName, "objc_msgSend")) {
 				symbol = (void *) &xamarin_dyn_objc_msgSend;
 			} else if (!strcmp (entrypointName, "objc_msgSendSuper")) {
 				symbol = (void *) &xamarin_dyn_objc_msgSendSuper;
+#if !defined (__arm64__)
 			} else if (!strcmp (entrypointName, "objc_msgSend_stret")) {
 				symbol = (void *) &xamarin_dyn_objc_msgSend_stret;
 			} else if (!strcmp (entrypointName, "objc_msgSendSuper_stret")) {
 				symbol = (void *) &xamarin_dyn_objc_msgSendSuper_stret;
+#endif // !defined (__arm64__)
 			}
 		}
-#endif // defined (__i386__) || defined (__x86_64__)
+#endif // defined (__i386__) || defined (__x86_64__) || defined (__arm64__)
 	}
 
 	return symbol;

--- a/runtime/trampolines-arm64-asm.s
+++ b/runtime/trampolines-arm64-asm.s
@@ -18,50 +18,58 @@
 #if __arm64__
 
 .subsections_via_symbols
-.text
-.align 2
+.section	__TEXT,__text,regular,pure_instructions
+.globl _xamarin_arm64_common_trampoline
+.p2align 2
 _xamarin_arm64_common_trampoline:
-	mov x9, sp ;#Save sp to a temporary register
-	sub sp, sp, #256 ;# allocate 224 bytes from the stack (stack must always be 16-byte aligned) + 16 bytes for the stack frame + 8*2 bytes for _self and _sel
+	.cfi_startproc
+
+	mov x9, sp ; Save sp to a temporary register
 
 	# Create stack frame
-	stp x29, x30, [sp, #0x00]
-	mov x29, sp
+	stp	x29, x30, [sp, #-16]!           ; Push x29, x30 to the stack
+	mov	x29, sp
+	.cfi_def_cfa x29, 16
+	.cfi_offset x30, -8
+	.cfi_offset x29, -16
 
-	stp x16, x9, [sp, #0x10]
-	stp  x0, x1, [sp, #0x20]
-	stp  x2, x3, [sp, #0x30]
-	stp  x4, x5, [sp, #0x40]
-	stp  x6, x7, [sp, #0x50]
-	str  x8,     [sp, #0x60]
+	sub sp, sp, #240 ;# allocate 224 bytes from the stack (stack must always be 16-byte aligned) + 8*2 bytes for _self and _sel
 
-	stp  q0, q1, [sp, #0x70]
-	stp  q2, q3, [sp, #0x90]
-	stp  q4, q5, [sp, #0xb0]
-	stp  q6, q7, [sp, #0xd0]
+	stp x16, x9, [sp, #0x00]
+	stp  x0, x1, [sp, #0x10]
+	stp  x2, x3, [sp, #0x20]
+	stp  x4, x5, [sp, #0x30]
+	stp  x6, x7, [sp, #0x40]
+	str  x8,     [sp, #0x50]
 
-	add x0, sp, #0x10 ;# the first two pointers are the stack frame (x29, x30), the rest is a pointer to a XamarinCallState struct.
+	stp  q0, q1, [sp, #0x60]
+	stp  q2, q3, [sp, #0x80]
+	stp  q4, q5, [sp, #0xa0]
+	stp  q6, q7, [sp, #0xc0]
+
+	mov x0, sp
 	bl	_xamarin_arch_trampoline
 
 	# get return value(s)
 
-	ldp x16, x9, [sp, #0x10]
-	ldp  x0, x1, [sp, #0x20]
-	ldp  x2, x3, [sp, #0x30]
-	ldp  x4, x5, [sp, #0x40]
-	ldp  x6, x7, [sp, #0x50]
-	ldr  x8,     [sp, #0x60]
+	ldp x16, x9, [sp, #0x00]
+	ldp  x0, x1, [sp, #0x10]
+	ldp  x2, x3, [sp, #0x20]
+	ldp  x4, x5, [sp, #0x30]
+	ldp  x6, x7, [sp, #0x40]
+	ldr  x8,     [sp, #0x50]
 
-	ldp  q0, q1, [sp, #0x70]
-	ldp  q2, q3, [sp, #0x90]
-	ldp  q4, q5, [sp, #0xb0]
-	ldp  q6, q7, [sp, #0xd0]
+	ldp  q0, q1, [sp, #0x60]
+	ldp  q2, q3, [sp, #0x80]
+	ldp  q4, q5, [sp, #0xa0]
+	ldp  q6, q7, [sp, #0xc0]
 
-	ldp	x29, x30, [sp, #0x00]
-	add sp, sp, #256 ;# deallocate 224 bytes from the stack + 16 bytes for stack frame + 8*2 bytes for _self and _sel
+	add sp, sp, #240          ; deallocate 224 bytes from the stack + 8*2 bytes for _self and _sel
+
+	ldp	x29, x30, [sp], #16   ; pop x29, x30
 
 	ret
-
+.cfi_endproc
 #
 # trampolines
 #

--- a/runtime/trampolines-arm64-objc_msgSend.inc.s
+++ b/runtime/trampolines-arm64-objc_msgSend.inc.s
@@ -1,0 +1,198 @@
+; The initial code for this file was generated using clang:
+;
+;    clang -c testfile -otestfile.s -arch arm64 -S -O -fverbose-asm
+;
+; Relevant and helpful documentation:
+; * https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst
+; * https://github.com/ARM-software/abi-aa/blob/main/cppabi64/cppabi64.rst
+;
+
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	OBJCMSGFUNC       ; -- Begin function xamarin_dyn_objc_msgSend[Super]
+	.p2align	2
+OBJCMSGFUNC:              ; @xamarin_dyn_objc_msgSend[Super]
+Lfunc_begin2:
+	.cfi_startproc
+	.cfi_personality 155, ___objc_personality_v0
+	.cfi_lsda 16, Lexception0
+
+	stp	x20, x19, [sp, #-32]!           ; 16-byte Folded Spill
+	stp	x29, x30, [sp, #16]             ; 16-byte Folded Spill
+	add	x29, sp, #16
+	.cfi_def_cfa w29, 16
+	.cfi_offset w30, -8
+	.cfi_offset w29, -16
+	.cfi_offset w19, -24
+	.cfi_offset w20, -32
+Lbeforeinvoke:
+
+	; calculate the amount of stack space we need
+	sub sp, sp, #400
+
+	; we need to preserve:
+	;   x0-x8, x16, x19
+	;   q0-q7
+
+	stp  x0, x1, [sp, #0x00]
+	stp  x2, x3, [sp, #0x10]
+	stp  x4, x5, [sp, #0x20]
+	stp  x6, x7, [sp, #0x30]
+	stp  x8,x16, [sp, #0x40]
+	stp x21,x22, [sp, #0x50]
+
+	stp  q0, q1, [sp, #0x60]
+	stp  q2, q3, [sp, #0x80]
+	stp  q4, q5, [sp, #0xa0]
+	stp  q6, q7, [sp, #0xc0]
+
+	; potentially resolve objc_super* [handle, class_handle] to the actual instance
+	RESOLVESUPER
+
+	; figure out how much stack space we need
+	bl	_xamarin_get_frame_length
+
+	; x0 holds the amount of stack space we need
+	; first align stack requirement to 16 bytes
+	add x0, x0, #15
+	lsr x0, x0, #4
+	lsl x0, x0, #4
+
+	; save the current stack location
+	mov x22, sp
+
+	; save how much space we need
+	mov x21, x0
+
+	; then make space for the arguments
+	sub sp, sp, x0
+
+	; copy arguments from old location in the stack to new location in the stack
+    ; x2 will hold the amount of bytes left to copy. This will be a multiple of 8.
+    ; x1 the current src location
+    ; x0 the current dst location
+
+    mov x2, x0        ; x2 = frame_length
+    add x1, x29, #16  ; x1 = address of first argument we got
+    mov x0, sp        ; x0 = address of the bottom of the stack
+
+L_start:
+    cmp  x2, #0                ;
+    b.eq L_end                 ; while (left != 0) {
+    sub  x2, x2, #8            ;    len -= 8                 x2 -= 8
+    ldr  x3, [x1, x2]          ;    tmp = src [len]          x3 = x1 [x2]
+    str  x3, [x0, x2]          ;    dst [len] = tmp          x0 [x2] = x3
+    b    L_start               ; }
+L_end:
+
+	; restore original input registers, except x21 and x22, which we're still using
+	ldp  x0, x1, [x22, #0x00]
+	ldp  x2, x3, [x22, #0x10]
+	ldp  x4, x5, [x22, #0x20]
+	ldp  x6, x7, [x22, #0x30]
+	ldp  x8,x16, [x22, #0x40]
+
+	ldp  q0, q1, [x22, #0x60]
+	ldp  q2, q3, [x22, #0x80]
+	ldp  q4, q5, [x22, #0xa0]
+	ldp  q6, q7, [x22, #0xc0]
+
+	bl	OBJCMSGCALL
+
+Lafterinvoke:
+	; restore the stack to it's previous value
+	add sp, sp, x21
+
+	; now restore x21 and x22
+	ldp x21, x22, [sp, #0x50]
+
+	add sp, sp, #400
+
+	ldp	x29, x30, [sp, #16]             ; 16-byte Folded Reload
+	ldp	x20, x19, [sp], #32             ; 16-byte Folded Reload
+	ret
+Lcatchhandler:
+	mov	x19, x0
+	cmp	w1, #1                          ; =1
+	b.ne	Lnomatchexception
+
+	; check if xamarin_marshal_objectivec_exception_mode == disable, if so, just don't handle the exception
+Lloh0:
+	adrp	x8, _xamarin_marshal_objectivec_exception_mode@GOTPAGE
+Lloh1:
+	ldr	x8, [x8, _xamarin_marshal_objectivec_exception_mode@GOTPAGEOFF]
+Lloh2:
+	ldr	w0, [x8]
+	cmp	w0, #4
+	b.eq	Lnomatchexception
+
+	mov	x0, x19
+	bl	_objc_begin_catch
+Lcatchbegin:
+	mov	w1, #0
+	mov	x2, #0
+	bl	_xamarin_process_nsexception_using_mode
+Lcatchend:
+	bl	_objc_end_catch
+	b	Lafterinvoke
+Lcatchcatchhandler:
+	mov	x19, x0
+	bl	_objc_end_catch
+Lnomatchexception:
+	mov	x0, x19
+	bl	__Unwind_Resume
+	brk	#0x1
+Lfunc_end2:
+	.loh AdrpLdrGotLdr	Lloh0, Lloh1, Lloh2
+	.cfi_endproc
+
+
+
+	.section	__TEXT,__gcc_except_tab
+	.p2align	2
+GCC_except_table0:
+Lexception0:
+	.byte	255                             ; @LPStart Encoding = omit
+	.byte	155                             ; @TType Encoding = indirect pcrel sdata4
+	.uleb128 Lttbase0-Lttbaseref0
+Lttbaseref0:
+	.byte	1                               ; Call site Encoding = uleb128
+	.uleb128 Lcst_end0-Lcst_begin0
+Lcst_begin0:
+	.uleb128 Lbeforeinvoke-Lfunc_begin2             ; >> Call Site 1 <<
+	.uleb128 Lafterinvoke-Lbeforeinvoke                    ;   Call between Lbeforeinvoke and Lafterinvoke
+	.uleb128 Lcatchhandler-Lfunc_begin2             ;     jumps to Lcatchhandler
+	.byte	3                               ;   On action: 2
+	.uleb128 Lafterinvoke-Lfunc_begin2             ; >> Call Site 2 <<
+	.uleb128 Lcatchbegin-Lafterinvoke                    ;   Call between Lafterinvoke and Lcatchbegin
+	.byte	0                               ;     has no landing pad
+	.byte	0                               ;   On action: cleanup
+	.uleb128 Lcatchbegin-Lfunc_begin2             ; >> Call Site 3 <<
+	.uleb128 Lcatchend-Lcatchbegin                    ;   Call between Lcatchbegin and Lcatchend
+	.uleb128 Lcatchcatchhandler-Lfunc_begin2             ;     jumps to Lcatchcatchhandler
+	.byte	0                               ;   On action: cleanup
+	.uleb128 Lcatchend-Lfunc_begin2             ; >> Call Site 4 <<
+	.uleb128 Lfunc_end2-Lcatchend               ;   Call between Lcatchend and Lfunc_end2
+	.byte	0                               ;     has no landing pad
+	.byte	0                               ;   On action: cleanup
+Lcst_end0:
+	.byte	0                               ; >> Action Record 1 <<
+                                        ;   Cleanup
+	.byte	0                               ;   No further actions
+	.byte	1                               ; >> Action Record 2 <<
+                                        ;   Catch TypeInfo 1
+	.byte	125                             ;   Continue to action 1
+	.p2align	2
+                                        ; >> Catch TypeInfos <<
+Ltmp8:                                  ; TypeInfo 1
+	.long	_OBJC_EHTYPE_$_NSException@GOT-Ltmp8
+Lttbase0:
+	.p2align	2
+                                        ; -- End function
+
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+L_OBJC_IMAGE_INFO:
+	.long	0
+	.long	64
+
+.subsections_via_symbols

--- a/runtime/trampolines-arm64-objc_msgSend.s
+++ b/runtime/trampolines-arm64-objc_msgSend.s
@@ -1,0 +1,6 @@
+#if __arm64__
+#define OBJCMSGFUNC _xamarin_dyn_objc_msgSend
+#define OBJCMSGCALL _objc_msgSend
+#define RESOLVESUPER
+#include "trampolines-arm64-objc_msgSend.inc.s"
+#endif

--- a/runtime/trampolines-arm64-objc_msgSendSuper.s
+++ b/runtime/trampolines-arm64-objc_msgSendSuper.s
@@ -1,0 +1,7 @@
+#if __arm64__
+#define OBJCMSGFUNC _xamarin_dyn_objc_msgSendSuper
+#define OBJCMSGCALL _objc_msgSendSuper
+#define RESOLVESUPER ldr	x0, [x0]
+#include "trampolines-arm64-objc_msgSend.inc.s"
+#endif
+

--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -144,6 +144,12 @@ namespace Registrar {
 			}
 		}
 
+		protected override bool IsARM64 {
+			get {
+				return Runtime.IsARM64CallingConvention;
+			}
+		}
+
 		public void RegisterMethod (Type type, MethodInfo minfo, ExportAttribute ea)
 		{
 			if (!IsNSObject (type))

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -1106,6 +1106,7 @@ namespace Registrar {
 		protected abstract int GetValueTypeSize (TType type);
 		protected abstract bool IsSimulatorOrDesktop { get; }
 		protected abstract bool Is64Bits { get; }
+		protected abstract bool IsARM64 { get; } 
 		protected abstract Exception CreateExceptionImpl (int code, bool error, Exception innerException, TMethod method, string message, params object[] args);
 		protected abstract Exception CreateExceptionImpl (int code, bool error, Exception innerException, TType type, string message, params object [] args);
 		protected abstract string PlatformName { get; }
@@ -2629,7 +2630,7 @@ namespace Registrar {
 			case "System.Boolean":
 				// map managed 'bool' to ObjC BOOL = 'unsigned char' in OSX and 32bit iOS architectures and 'bool' in 64bit iOS architectures
 				#if MONOMAC
-				return "c";
+				return IsARM64 ? "B" : "c";
 				#else
 				return Is64Bits ? "B" : "c";
 				#endif

--- a/tests/bindings-test/macOS/bindings-test.csproj
+++ b/tests/bindings-test/macOS/bindings-test.csproj
@@ -11,7 +11,7 @@
     <MacResourcePrefix>Resources</MacResourcePrefix>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Debug32' Or '$(Configuration)' == 'Debug64' Or '$(Configuration)' == 'Debug64_32' Or '$(Configuration)' == 'DebugARM64' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -21,7 +21,7 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' Or '$(Configuration)' == 'Release32' Or '$(Configuration)' == 'Release64' Or '$(Configuration)' == 'Release-bitcode' Or '$(Configuration)' == 'Release64_32' Or '$(Configuration)' == 'ReleaseARM64' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>
     <DefineConstants></DefineConstants>

--- a/tests/monotouch-test/CoreFoundation/BundleTest.cs
+++ b/tests/monotouch-test/CoreFoundation/BundleTest.cs
@@ -362,6 +362,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 			var isArm64Executable = global::System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == global::System.Runtime.InteropServices.Architecture.Arm64;
 
 			bool loadable_x86_64 = CFBundle.IsArchitectureLoadable (CFBundle.Architecture.X86_64);
+			// Due to Rosetta, both x64 and arm64 executables are loadable on Apple Silicon.
 			if (isX64Executable || isArm64Executable)
 				Assert.IsTrue (loadable_x86_64, "x86_64 Expected => true");
 			else

--- a/tests/monotouch-test/CoreFoundation/BundleTest.cs
+++ b/tests/monotouch-test/CoreFoundation/BundleTest.cs
@@ -358,14 +358,17 @@ namespace MonoTouchFixtures.CoreFoundation {
 		{
 			TestRuntime.AssertXcodeVersion (12, 2);
 
+			var isX64Executable = global::System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == global::System.Runtime.InteropServices.Architecture.X64;
+			var isArm64Executable = global::System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == global::System.Runtime.InteropServices.Architecture.Arm64;
+
 			bool loadable_x86_64 = CFBundle.IsArchitectureLoadable (CFBundle.Architecture.X86_64);
-			if (global::System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == global::System.Runtime.InteropServices.Architecture.X64)
+			if (isX64Executable || isArm64Executable)
 				Assert.IsTrue (loadable_x86_64, "x86_64 Expected => true");
 			else
 				Assert.IsFalse (loadable_x86_64, "x86_64 Expected => false");
 
 			bool loadable_arm64 = CFBundle.IsArchitectureLoadable (CFBundle.Architecture.ARM64);
-			if (global::System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == global::System.Runtime.InteropServices.Architecture.Arm64)
+			if (isArm64Executable)
 				Assert.IsTrue (loadable_arm64, "arm64 Expected => true");
 			else
 				Assert.IsFalse (loadable_arm64, "arm64 Expected => false");

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -1364,7 +1364,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			var cl = new Class (typeof (TestTypeEncodingsClass));
 			var sig = Runtime.GetNSObject<NSMethodSignature> (Messaging.IntPtr_objc_msgSend_IntPtr (cl.Handle, Selector.GetHandle ("methodSignatureForSelector:"), Selector.GetHandle ("foo::::::::::::::::")));
 #if MONOMAC
-			var boolEncoding = "c";
+			var boolEncoding = TrampolineTest.IsArm64CallingConvention ? "B" : "c";
 #else
 			var boolEncoding = (IntPtr.Size == 8 || TrampolineTest.IsArmv7k || TrampolineTest.IsArm64CallingConvention) ? "B" : "c";
 

--- a/tests/monotouch-test/ObjCRuntime/TrampolineTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/TrampolineTest.cs
@@ -25,24 +25,22 @@ namespace MonoTouchFixtures.ObjCRuntime {
 	public class TrampolineTest {
 		public static readonly nfloat pi = 3.14159f;
 #if MONOMAC
-		public static bool IsSim64 { get { return IntPtr.Size == 8; } }
-		public static bool IsSim32 { get { return IntPtr.Size == 4; } }
-		public static bool IsArm64 { get { return false; } }
-		public static bool IsArm32 { get { return false; } }
+		public static bool IsX64 { get { return IntPtr.Size == 8 && !IsArm64CallingConvention; } }
+		public static bool IsX86 { get { return IntPtr.Size == 4; } }
 #else
-		public static bool IsSim64 { get { return IntPtr.Size == 8 && Runtime.Arch == Arch.SIMULATOR; } }
-		public static bool IsSim32 { get { return IntPtr.Size == 4 && Runtime.Arch == Arch.SIMULATOR; } }
-		public static bool IsArm64 { get { return IntPtr.Size == 8 && Runtime.Arch == Arch.DEVICE; } }
+		public static bool IsX64 { get { return IntPtr.Size == 8 && Runtime.Arch == Arch.SIMULATOR && !IsArm64CallingConvention; } }
+		public static bool IsX86 { get { return IntPtr.Size == 4 && Runtime.Arch == Arch.SIMULATOR; } }
+#endif
+		public static bool IsArm64 { get { return IntPtr.Size == 8 && IsArm64CallingConvention; } }
 		public static bool IsArm32 {
 			get {
-#if __WATCHOS__
+#if __WATCHOS__ || __MACOS__
 				return false;
 #else
 				return IntPtr.Size == 4 && Runtime.Arch == Arch.DEVICE;
 #endif
 			}
 		}
-#endif
 
 		public static bool IsArm64CallingConvention {
 			get {

--- a/tests/test-libraries/testgenerator.cs
+++ b/tests/test-libraries/testgenerator.cs
@@ -9,8 +9,8 @@ static class C {
 	enum Architecture
 	{
 		None = 0,
-		Sim32 = 1,
-		Sim64 = 2,
+		X86 = 1,
+		X64 = 2,
 		Arm32 = 4,
 		Armv7k = 8,
 		// Arm64 is never stret
@@ -1625,10 +1625,10 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				w.Append ("TrampolineTest.IsArm32 || ");
 			if ((stret & Architecture.Armv7k) == Architecture.Armv7k)
 				w.Append ("TrampolineTest.IsArmv7k || ");
-			if ((stret & Architecture.Sim32) == Architecture.Sim32)
-				w.Append ("TrampolineTest.IsSim32 || ");
-			if ((stret & Architecture.Sim64) == Architecture.Sim64)
-				w.Append ("TrampolineTest.IsSim64 || ");
+			if ((stret & Architecture.X86) == Architecture.X86)
+				w.Append ("TrampolineTest.IsX86 || ");
+			if ((stret & Architecture.X64) == Architecture.X64)
+				w.Append ("TrampolineTest.IsX64 || ");
 			w.Length -= 4;
 			w.AppendLine (") {");
 		}

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -38,6 +38,29 @@
     <CodeSignEntitlements>Entitlements.plist</CodeSignEntitlements>
     <CodeSignProvision>Automatic</CodeSignProvision>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugARM64|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\arm64\Debug</OutputPath>
+    <DefineConstants>DEBUG;MONOMAC;XAMMAC_TESTS;DYNAMIC_REGISTRAR</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>0</WarningLevel>
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <CreatePackage>false</CreatePackage>
+    <EnablePackageSigning>false</EnablePackageSigning>
+    <IncludeMonoRuntime>false</IncludeMonoRuntime>
+    <HttpClientHandler>HttpClientHandler</HttpClientHandler>
+    <TlsProvider>Default</TlsProvider>
+    <LinkMode>None</LinkMode>
+    <XamMacArch>ARM64</XamMacArch>
+    <CodeSigningKey>Mac Developer</CodeSigningKey>
+    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CodeSignEntitlements>Entitlements.plist</CodeSignEntitlements>
+    <CodeSignProvision>Automatic</CodeSignProvision>
+    <MmpDebug>true</MmpDebug>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\x86\Release</OutputPath>
@@ -53,6 +76,23 @@
     <TlsProvider>Default</TlsProvider>
     <LinkMode>None</LinkMode>
     <XamMacArch>x86_64</XamMacArch>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseARM64|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\arm64\Release</OutputPath>
+    <DefineConstants>MONOMAC;XAMMAC_TESTS</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>0</WarningLevel>
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <CreatePackage>false</CreatePackage>
+    <EnablePackageSigning>false</EnablePackageSigning>
+    <IncludeMonoRuntime>false</IncludeMonoRuntime>
+    <UseSGen>false</UseSGen>
+    <HttpClientHandler>HttpClientHandler</HttpClientHandler>
+    <TlsProvider>Default</TlsProvider>
+    <LinkMode>None</LinkMode>
+    <XamMacArch>ARM64</XamMacArch>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/xharness/Jenkins/TestData.cs
+++ b/tests/xharness/Jenkins/TestData.cs
@@ -21,5 +21,6 @@ namespace Xharness.Jenkins {
 		public bool? UseMonoRuntime;
 		public MonoNativeLinkMode MonoNativeLinkMode;
 		public IEnumerable<IDevice> Candidates;
+		public string XamMacArch;
 	}
 }

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -783,6 +783,12 @@ namespace Registrar {
 			}
 		}
 
+		protected override bool IsARM64 {
+			get {
+				return Application.IsArchEnabled (Target?.Abis ?? App.Abis, Xamarin.Abi.ARM64);
+			}
+		}
+
 		protected override Exception CreateExceptionImpl (int code, bool error, Exception innerException, MethodDefinition method, string message, params object[] args)
 		{
 			return ErrorHelper.Create (App, code, error, innerException, method, message, args);

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -302,13 +302,12 @@ namespace Xamarin.Bundler {
 			if (dynamic_symbols != null)
 				return;
 
-			string [] dyn_msgSend_functions = new string [] {
-				"xamarin_dyn_objc_msgSend",
-				"xamarin_dyn_objc_msgSendSuper",
-				"xamarin_dyn_objc_msgSend_stret",
-				"xamarin_dyn_objc_msgSendSuper_stret",
+			var dyn_msgSend_functions = new [] {
+				new { Name = "xamarin_dyn_objc_msgSend", ValidAbis = Abi.SimulatorArchMask | Abi.ARM64 },
+				new { Name = "xamarin_dyn_objc_msgSendSuper", ValidAbis = Abi.SimulatorArchMask | Abi.ARM64 },
+				new { Name = "xamarin_dyn_objc_msgSend_stret", ValidAbis = Abi.SimulatorArchMask },
+				new { Name = "xamarin_dyn_objc_msgSendSuper_stret", ValidAbis = Abi.SimulatorArchMask },
 			};
-			Abi dyn_msgSend_valid_abis = Abi.SimulatorArchMask;
 
 			var cache_location = Path.Combine (App.Cache.Location, "entry-points.txt");
 			if (cached_link) {
@@ -342,7 +341,7 @@ namespace Xamarin.Bundler {
 					break;
 				case ApplePlatform.MacCatalyst:
 				case ApplePlatform.MacOSX:
-					has_dyn_msgSend = App.MarshalObjectiveCExceptions != MarshalObjectiveCExceptionMode.Disable && !App.RequiresPInvokeWrappers && Application.IsArchEnabled (Abis, Abi.x86_64);
+					has_dyn_msgSend = App.MarshalObjectiveCExceptions != MarshalObjectiveCExceptionMode.Disable && !App.RequiresPInvokeWrappers;
 					break;
 				default:
 					throw ErrorHelper.CreateError (71, Errors.MX0071, App.Platform, App.ProductName);
@@ -350,7 +349,7 @@ namespace Xamarin.Bundler {
 
 				if (has_dyn_msgSend) {
 					foreach (var dyn_msgSend_function in dyn_msgSend_functions)
-						dynamic_symbols.AddFunction (dyn_msgSend_function);
+						dynamic_symbols.AddFunction (dyn_msgSend_function.Name);
 				}
 
 #if MONOTOUCH
@@ -361,10 +360,10 @@ namespace Xamarin.Bundler {
 				dynamic_symbols.Save (cache_location);
 			}
 
-			foreach (var name in dyn_msgSend_functions) {
-				var symbol = dynamic_symbols.Find (name);
+			foreach (var dynamicFunction in dyn_msgSend_functions) {
+				var symbol = dynamic_symbols.Find (dynamicFunction.Name);
 				if (symbol != null) {
-					symbol.ValidAbis = dyn_msgSend_valid_abis;
+					symbol.ValidAbis = dynamicFunction.ValidAbis;
 				}
 			}
 


### PR DESCRIPTION
* Implement our xamarin_dyn_objc_msgSend[Super] overrides for ARM64.
* Modify mmp to use those overrides.
* Fix an issue with the existing xamarin_arm64_common_trampoline that caused
  exceptions to not unwind correctly.
* Add an ARM64 variation of xammac tests in xharness.
* Various test fixes.

There are two other issues that prevents xammac tests from turning green:

* https://github.com/xamarin/xamarin-macios/pull/11499
* https://github.com/xamarin/xamarin-macios/issues/11498

Once those are fixed/merged, then xammac tests will be green on ARM64, for both Debug and Release.

This PR is probably easiest to review commit-by-commit.