### PR TITLE
[Translations] Fix error message format with an extra brace.

### DIFF
--- a/tools/mtouch/TranslatedAssemblies/Errors.cs.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.cs.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.de.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.de.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.es.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.es.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.fr.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.fr.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.hu.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.hu.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.it.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.it.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.ja.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.ja.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.ko.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.ko.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.nl.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.nl.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.pl.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.pl.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.pt-BR.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.pt-BR.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.pt-PT.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.pt-PT.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.ru.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.ru.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.sv.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.sv.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.tr.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.tr.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.zh-Hans.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.zh-Hans.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.zh-Hant.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.zh-Hant.resx
@@ -730,7 +730,7 @@
         </value>
     </data>
   <data name="MX0179" xml:space="preserve">
-		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior} (to try to avoid the new APIs).</value>
+		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>
 	</data>
   <data name="MX0180" xml:space="preserve">
 		<value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options &gt; Linker Behavior (to try to avoid the new APIs).</value>


### PR DESCRIPTION
Updated via:
```bash
git grep -rl "Behavior}" ./ | xargs sed -i '.back' 's/Behavior}/Behavior/g'
```