### PR TITLE
[runtime] Implement mono_reflection_type_get_type for CoreCLR.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -245,6 +245,17 @@ mono_method_get_object (MonoDomain *domain, MonoMethod *method, MonoClass *refcl
 	return rv;
 }
 
+MonoType *
+mono_reflection_type_get_type (MonoReflectionType *reftype)
+{
+	// MonoType and MonoReflectionType are identical in CoreCLR (both are actually MonoObjects).
+	// However, we're returning a retained object, so we need to retain here.
+	MonoType *rv = reftype;
+	xamarin_mono_object_retain (rv);
+	LOG_CORECLR (stderr, "%s (%p) => %p\n", __func__, reftype, rv);
+	return rv;
+}
+
 int
 mono_jit_exec (MonoDomain * domain, MonoAssembly * assembly, int argc, const char** argv)
 {

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -415,7 +415,9 @@
 
 		new Export ("MonoType *", "mono_reflection_type_get_type",
 			"MonoReflectionType *", "reftype"
-		),
+		) {
+			HasCoreCLRBridgeFunction = true,
+		},
 		#endregion
 
 		#region metadata/metadata.h

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -407,8 +407,11 @@ xamarin_is_class_nullable (MonoClass *cls, MonoClass **element_type, GCHandle *e
 
 		MonoReflectionType *nullable_type = (MonoReflectionType *) xamarin_gchandle_unwrap (nullable_type_handle);
 
-		if (element_type != NULL && nullable_type != NULL)
-			*element_type = mono_class_from_mono_type (mono_reflection_type_get_type (nullable_type));
+		if (element_type != NULL && nullable_type != NULL) {
+			MonoType *mono_type = mono_reflection_type_get_type (nullable_type);
+			*element_type = mono_class_from_mono_type (mono_type);
+			xamarin_mono_object_release (&mono_type);
+		}
 
 		bool is_nullable = nullable_type != NULL;
 		xamarin_mono_object_release (&nullable_type);

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -252,7 +252,9 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 			if (desc->bindas [i + 1].original_type_handle != INVALID_GCHANDLE) {
 				MonoReflectionType *original_type = (MonoReflectionType *) xamarin_gchandle_get_target (desc->bindas [i + 1].original_type_handle);
 				ADD_TO_MONOOBJECT_RELEASE_LIST (original_type);
-				arg_ptrs [i + mofs] = xamarin_generate_conversion_to_managed ((id) arg, mono_reflection_type_get_type (original_type), p, method, &exception_gchandle, (void *) INVALID_TOKEN_REF, (void **) &free_list);
+				MonoType *original_mono_type = mono_reflection_type_get_type (original_type);
+				ADD_TO_MONOOBJECT_RELEASE_LIST (original_mono_type);
+				arg_ptrs [i + mofs] = xamarin_generate_conversion_to_managed ((id) arg, original_mono_type, p, method, &exception_gchandle, (void *) INVALID_TOKEN_REF, (void **) &free_list);
 				if (exception_gchandle != INVALID_GCHANDLE)
 					goto exception_handling;
 				ofs++;


### PR DESCRIPTION
This also meant reviewing calling code to make sure that the return value is
released when it should be.