### PR TITLE
[xharness] Add ARM64 variations for macOS/.NET using both MonoVM and CoreCLR.

### DIFF
--- a/tests/xharness/Jenkins/TestData.cs
+++ b/tests/xharness/Jenkins/TestData.cs
@@ -22,5 +22,6 @@ namespace Xharness.Jenkins {
 		public MonoNativeLinkMode MonoNativeLinkMode;
 		public IEnumerable<IDevice> Candidates;
 		public string XamMacArch;
+		public string RuntimeIdentifier;
 	}
 }


### PR DESCRIPTION
The CoreCLR version gets to the exact same place for ARM64 as the x86_64 version (good!).

The MonoVM version crashes at launch with:

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_platform.dylib      	0x0000000190fbf6c8 _platform_memset_pattern16 + 296
1   libcoreclr.dylib              	0x00000001035a49a0 mono_arch_create_sdb_trampoline + 76
2   libcoreclr.dylib              	0x000000010356b6ac mini_get_breakpoint_trampoline + 80
3   libcoreclr.dylib              	0x0000000103595908 mono_arch_init + 48
4   libcoreclr.dylib              	0x00000001034db268 mini_init + 580
5   libcoreclr.dylib              	0x000000010352eae8 mono_jit_init_version + 20
6   com.xamarin.monotouch-test    	0x0000000102ca0498 xamarin_bridge_initialize + 192 (monovm-bridge.m:84)
7   com.xamarin.monotouch-test    	0x0000000102ca5de8 xamarin_main + 1332 (monotouch-main.m:408)
```

~This needs further investigation (the curious part is that this doesn't happen with the legacy Xamarin.Mac version).~

This is due to: https://github.com/dotnet/runtime/issues/52635