### PR TITLE
[CI] Adding changes to make sure tests are not run in scheduled builds

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -224,8 +224,8 @@ stages:
     - template: templates/build/stage.yml
       parameters:
         vsdropsPrefix: ${{ variables.vsdropsPrefix }}
-        runTests: ${{ parameters.runTests }}
-        runDeviceTests: ${{ parameters.runDeviceTests }}
+        runTests: ${{ and(parameters.runTests, ne(variables['Build.Reason'], 'Schedule'))}}
+        runDeviceTests: ${{ and(parameters.runDeviceTests, ne(variables['Build.Reason'], 'Schedule')) }}
         keyringPass: $(xma-password)
         gitHubToken: ${{ variables['GitHub.Token'] }}
         xqaCertPass: $(xqa--certificates--password)

--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -155,7 +155,7 @@ steps:
   inputs:
     locProj: '$(Build.SourcesDirectory)\Localize\LocProject.json'
     outDir: '$(Build.ArtifactStagingDirectory)'
-    isCreatePrSelected: eq(variables['Build.Reason'], 'Schedule')
+    isCreatePrSelected: eq(variables.isSchedule, 'True')
     packageSourceAuth: patAuth
     patVariable: '$(OneLocBuild--PAT)'
     isAutoCompletePrSelected: false

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -33,6 +33,7 @@ jobs:
 
   variables:
     isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+    isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
 
   steps:
   - template: configure.yml


### PR DESCRIPTION
This PR makes sure that when we are doing a scheduled build, we are not trying to upload test results.
This was occurring and causing issues for the localization drops/ localization team.

I ran the scheduled build in a different branch last night and the results were as expected!
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4750211&view=results