### PR TITLE
[runtime] Implement functions for getting and setting array elements for CoreCLR.

### DIFF
--- a/runtime/delegates.inc.t4
+++ b/runtime/delegates.inc.t4
@@ -33,7 +33,7 @@ struct Delegates {
 		if (d.OnlyCoreCLR)
 			Write ("#if DOTNET\n");
 #>
-	func_<#= d.EntryPoint #><#= d.AlignEntryPoint #> <#= d.EntryPoint.Substring ("xamarin_".Length) #>;
+	func_<#= d.EntryPoint #><#= d.AlignEntryPoint #> <#= d.SimpleEntryPoint #>;
 <#
 		if (d.OnlyCoreCLR)
 			Write ("#endif // DOTNET\n");

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -551,6 +551,36 @@
 			OnlyDynamicUsage = false,
 			OnlyCoreCLR = true,
 		},
+
+		new XDelegate ("void", "void", "mono_array_setref",
+			"MonoArray *", "MonoObject *", "arrayobj",
+			"uint64_t", "ulong", "index",
+			"MonoObject *", "MonoObject *", "valueobj"
+		) {
+			WrappedManagedFunction = "SetArrayObjectValue",
+			OnlyDynamicUsage = false,
+			OnlyCoreCLR = true,
+		},
+
+		new XDelegate ("void", "void", "xamarin_bridge_set_array_struct_value",
+			"MonoArray *", "MonoObject *", "arrayobj",
+			"uint64_t", "ulong", "index",
+			"MonoClass *", "MonoObject *", "typeobj",
+			"void *", "IntPtr", "valueptr"
+		) {
+			WrappedManagedFunction = "SetArrayStructValue",
+			OnlyDynamicUsage = false,
+			OnlyCoreCLR = true,
+		},
+
+		new XDelegate ("MonoObject *", "MonoObject *", "mono_array_get",
+			"MonoArray *", "MonoObject *", "arrayobj",
+			"uint64_t", "ulong", "index"
+		) {
+			WrappedManagedFunction = "GetArrayObjectValue",
+			OnlyDynamicUsage = false,
+			OnlyCoreCLR = true,
+		},
 	};
 	delegates.CalculateLengths ();
 #><#+
@@ -604,7 +634,11 @@
 
 		public string DelegateName {
 			get {
-				return EntryPoint.Substring ("xamarin_".Length);
+				if (EntryPoint.StartsWith ("xamarin_"))
+					return EntryPoint.Substring ("xamarin_".Length);
+				if (EntryPoint.StartsWith ("mono_", StringComparison.Ordinal))
+					return EntryPoint.Substring ("mono_".Length);
+				throw new NotImplementedException ($"Unknown prefix for {EntryPoint}");
 			}
 		}
 
@@ -623,8 +657,8 @@
 			if (arguments.Length % 3 != 0)
 				throw new Exception (string.Format ("Export arguments params must be a multiple of 3 to form a set of (c type, managed name, name) triples for {0}", entryPoint));
 
-			if (!entryPoint.StartsWith ("xamarin_"))
-				throw new Exception ("All entry points must start with 'xamarin_'");
+			if (!entryPoint.StartsWith ("xamarin_", StringComparison.Ordinal) && !entryPoint.StartsWith ("mono_", StringComparison.Ordinal))
+				throw new Exception ("All entry points must start with 'xamarin_' or 'mono_'");
 
 			Arguments = new List<Arg> ();
 			for (var i = 0; i < arguments.Length; i += 3)
@@ -692,7 +726,7 @@
 				}
 
 				sb.Append ("delegates.");
-				sb.Append (EntryPoint.Substring ("xamarin_".Length));
+				sb.Append (DelegateName);
 				sb.Append (" (");
 				sb.Append (invoke_args);
 
@@ -732,7 +766,11 @@
 
 		public string SimpleEntryPoint {
 			get {
-				return EntryPoint.Substring ("xamarin_".Length);
+				if (EntryPoint.StartsWith ("xamarin_"))
+					return EntryPoint.Substring ("xamarin_".Length);
+				if (EntryPoint.StartsWith ("mono_", StringComparison.Ordinal))
+					return EntryPoint.Substring ("mono_".Length);
+				throw new NotImplementedException ($"Unknown prefix for {EntryPoint}");
 			}
 		}
 

--- a/runtime/mono-runtime.h.t4
+++ b/runtime/mono-runtime.h.t4
@@ -136,14 +136,16 @@ typedef struct _MonoReferenceQueue MonoReferenceQueue;
 #endif
 typedef void (*mono_reference_queue_callback) (void *user_data);
 
+#if !defined (CORECLR_RUNTIME)
 #define mono_array_addr(array,type,index) ((type*)(void*) mono_array_addr_with_size (array, sizeof (type), index))
 #define mono_array_get(array,type,index) ( *(type*)mono_array_addr ((array), type, (index)) )
-#define mono_array_setref(array,index,value)	\
+#define mono_array_setref(array,index,value,exception_gchandle)	\
 	do {	\
 		void **__p = (void **) mono_array_addr ((array), void*, (index));	\
 		mono_gc_wbarrier_set_arrayref ((array), __p, (MonoObject*)(value));	\
 		/* *__p = (value);*/	\
 	} while (0)
+#endif // !defined (CORECLR_RUNTIME)
 
 /* metadata/assembly.h */
 

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -540,6 +540,63 @@ namespace ObjCRuntime {
 			return (ulong) array.Length;
 		}
 
+		static unsafe void SetArrayObjectValue (MonoObject *arrayobj, ulong index, MonoObject *mobj)
+		{
+			var array = (Array) GetMonoObjectTarget (arrayobj);
+			var obj = GetMonoObjectTarget (mobj);
+			array.SetValue (obj, (long) index);
+		}
+
+		static unsafe void SetArrayStructValue (MonoObject *arrayobj, ulong index, MonoObject *typeobj, IntPtr valueptr)
+		{
+			var array = (Array) GetMonoObjectTarget (arrayobj);
+			var elementType = (Type) GetMonoObjectTarget (typeobj);
+			var obj = Box (elementType, valueptr);
+			array.SetValue (obj, (long) index);
+		}
+
+		static unsafe MonoObject* GetArrayObjectValue (MonoObject* arrayobj, ulong index)
+		{
+			var array = (Array) GetMonoObjectTarget (arrayobj);
+			var obj = array.GetValue ((long) index);
+			return (MonoObject *) GetMonoObject (obj);
+		}
+
+		static unsafe MonoObject* Box (MonoObject* typeobj, IntPtr value)
+		{
+			var type = (Type) GetMonoObjectTarget (typeobj);
+			var rv = Box (type, value);
+			return (MonoObject *) GetMonoObject (rv);
+		}
+
+		static object Box (Type type, IntPtr value)
+		{
+			var structType = type;
+			Type enumType = null;
+
+			// We can have a nullable enum value
+			if (IsNullable (structType)) {
+				if (value == IntPtr.Zero)
+					return null;
+
+				structType = Nullable.GetUnderlyingType (structType);
+			}
+
+			if (structType.IsEnum) {
+				// Change to underlying enum type
+				enumType = structType;
+				structType = Enum.GetUnderlyingType (structType);
+			}
+
+			var boxed = PtrToStructure (value, structType);
+			if (enumType != null) {
+				// Convert to enum value
+				boxed = Enum.ToObject (enumType, boxed);
+			}
+
+			return boxed;
+		}
+
 		static bool IsNullable (Type type)
 		{
 			if (Nullable.GetUnderlyingType (type) != null)


### PR DESCRIPTION
This is not the fastest implementation, but it's the simplest I could come up
with, with the target of sharing as much code as possible with MonoVM. It can
be improved later if we find out it's a slow path (these functions are not in
a common code path, very few API bindings end up here).