### PR TITLE
[CoreCLR] Stub out RegisterToggleRef for CoreCLR.

### DIFF
--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -60,6 +60,12 @@ namespace ObjCRuntime {
 			NSLog (message);
 		}
 
+		internal static void RegisterToggleReferenceCoreCLR (NSObject obj, IntPtr handle, bool isCustomType)
+		{
+			// This requires https://github.com/dotnet/runtime/pull/52146 to be merged and packages available.
+			Console.WriteLine ("Not implemented: RegisterToggleReferenceCoreCLR");
+		}
+
 		// Returns a retained MonoObject. Caller must release.
 		static IntPtr FindAssembly (IntPtr assembly_name)
 		{

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -175,6 +175,13 @@ namespace ObjCRuntime {
 
 		internal static unsafe InitializationOptions* options;
 
+#if NET
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		internal unsafe static bool IsCoreCLR {
+			get { return options->IsCoreCLR; }
+		}
+#endif
+
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static bool DynamicRegistrationSupported {
 			get {


### PR DESCRIPTION
We need additional API in CoreCLR to support toggle refs properly, and this is
in progress [1]. In the meantime, stub out parts of it, so that the process
doesn't abort. This way we'll have failing tests instead (and work in other
areas can progress, since the process doesn't abort).

[1]: https://github.com/dotnet/runtime/pull/52146