### PR TITLE
[CoreCLR] Stub out mono_runtime_set_pending_exception for CoreCLR.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -58,6 +58,13 @@ xamarin_install_nsautoreleasepool_hooks ()
 }
 
 void
+mono_runtime_set_pending_exception (MonoException *exc, mono_bool overwrite)
+{
+	LOG_CORECLR (stderr, "%s (%p, %i)\n", __func__, exc, overwrite);
+	xamarin_bridge_set_pending_exception (exc);
+}
+
+void
 xamarin_handle_bridge_exception (GCHandle gchandle, const char *method)
 {
 	if (gchandle == INVALID_GCHANDLE)

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -329,6 +329,14 @@
 			OnlyCoreCLR = true,
 		},
 
+		new XDelegate ("void", "void", "xamarin_bridge_set_pending_exception",
+			"MonoObject *", "MonoObject *", "exception_obj"
+		) {
+			WrappedManagedFunction = "SetPendingException",
+			OnlyDynamicUsage = false,
+			OnlyCoreCLR = true,
+		},
+
 		new XDelegate ("char *", "IntPtr", "xamarin_bridge_class_get_namespace",
 			"MonoObject *", "MonoObject *", "typeobj"
 		) {

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -264,6 +264,7 @@
 		)
 		{
 			AlternativeExpression = "return mono_raise_exception (exc);",
+			HasCoreCLRBridgeFunction = true,
 		},
 
 		#endregion

--- a/runtime/mono-runtime.h.t4
+++ b/runtime/mono-runtime.h.t4
@@ -116,14 +116,15 @@ typedef struct _MonoObject MonoArray;
 typedef struct _MonoObject MonoReflectionAssembly;
 typedef struct _MonoObject MonoReflectionMethod;
 typedef struct _MonoObject MonoReflectionType;
+typedef struct _MonoObject MonoException;
 #else
 typedef struct _MonoString MonoString;
 typedef struct _MonoArray MonoArray;
 typedef struct _MonoReflectionAssembly MonoReflectionAssembly;
 typedef struct _MonoReflectionMethod MonoReflectionMethod;
 typedef struct _MonoReflectionType MonoReflectionType;
-#endif
 typedef struct _MonoException MonoException;
+#endif
 typedef struct _MonoThread MonoThread;
 typedef struct _MonoThreadsSync MonoThreadsSync;
 typedef struct _MonoObject MonoObject;

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -89,6 +89,13 @@ namespace ObjCRuntime {
 			throw new InvalidOperationException ($"Could not find any assemblies named {name}");
 		}
 
+		static unsafe void SetPendingException (MonoObject* exception_obj)
+		{
+			var exc = (Exception) GetMonoObjectTarget (exception_obj);
+			// This requires https://github.com/dotnet/runtime/pull/52146 to be merged and packages available.
+			Console.WriteLine ("Not implemented: SetPendingException ({0})", exc);;
+		}
+
 		unsafe static bool IsClassOfType (MonoObject *typeobj, TypeLookup match)
 		{
 			return IsClassOfType ((Type) GetMonoObjectTarget (typeobj), match);


### PR DESCRIPTION
We need additional API in CoreCLR to support pending exception properly, and
this is in progress [1]. In the meantime, stub out parts of it, so that the
process doesn't abort. This way we'll have failing tests instead (and work in
other areas can progress, since the process doesn't abort).

[1]: https://github.com/dotnet/runtime/pull/52146