### PR TITLE
[dotnet][linker] Fix the elimitation of calls for `UIApplication::EnsureUIThread`

### DIFF
--- a/tools/linker/CoreOptimizeGeneratedCode.cs
+++ b/tools/linker/CoreOptimizeGeneratedCode.cs
@@ -811,10 +811,10 @@ namespace Xamarin.Linker {
 
 		void ProcessEnsureUIThread (MethodDefinition caller, Instruction ins)
 		{
-#if MONOTOUCH
-			const string operation = "remove calls to UIApplication::EnsureUIThread";
-#else
+#if MONOMAC
 			const string operation = "remove calls to NSApplication::EnsureUIThread";
+#else
+			const string operation = "remove calls to UIApplication::EnsureUIThread";
 #endif
 
 			if (Optimizations.RemoveUIThreadChecks != true)
@@ -822,11 +822,11 @@ namespace Xamarin.Linker {
 
 			// Verify we're checking the right get_EnsureUIThread call
 			var mr = ins.Operand as MethodReference;
-#if MONOTOUCH
-			if (!mr.DeclaringType.Is (Namespaces.UIKit, "UIApplication"))
+#if MONOMAC
+			if (!mr.DeclaringType.Is (Namespaces.AppKit, "NSApplication"))
 				return;
 #else
-			if (!mr.DeclaringType.Is (Namespaces.AppKit, "NSApplication"))
+			if (!mr.DeclaringType.Is (Namespaces.UIKit, "UIApplication"))
 				return;
 #endif
 


### PR DESCRIPTION
Lack of `MONOTOUCH` define in the dotnet csproj [1] made this look for
the AppKit (XM) version.

[1] defining `MONOTOUCH` would have required several more changes.
Simplicity won!

|    Size    | MySingleView.app |
| ----------:|------------------|
|  4,579,985 | legacy           |
| 10,787,541 | dotnet [before](https://gist.github.com/02e072567595088522f376e522e22899) |
| 10,786,829 | dotnet [after](https://gist.github.com/afa5b7d4f9bb281646f050257034be11) |

There are other ways to achieve this with ILLink [2] but again:
Simplicity (by re-using) won!

[2] https://github.com/xamarin/xamarin-macios/issues/11477

```diff
--- a.cs	2021-05-12 14:17:13.000000000 -0400
+++ b.cs	2021-05-12 14:17:17.000000000 -0400
@@ -3764,13 +3764,6 @@
 }
 namespace UIKit
 {
-	public class UIKitThreadAccessException : Exception
-	{
-		public UIKitThreadAccessException()
-			: base("UIKit Consistency error: you are calling a UIKit method that can only be invoked from the UI thread.")
-		{
-		}
-	}
 	[Register("UIApplication", true)]
 	public class UIApplication : UIResponder
 	{
@@ -3824,14 +3817,6 @@
 			UIApplicationMain(args.Length, args, principal, @delegate);
 		}

-		public static void EnsureUIThread()
-		{
-			if (CheckForIllegalCrossThreadCalls && mainThread != null && mainThread != Thread.CurrentThread)
-			{
-				throw new UIKitThreadAccessException();
-			}
-		}
-
 		protected internal UIApplication(IntPtr handle)
 			: base(handle)
 		{
@@ -3862,7 +3847,6 @@
 		public UIButton(CGRect frame)
 			: base(NSObjectFlag.Empty)
 		{
-			UIApplication.EnsureUIThread();
 			if (base.IsDirectBinding)
 			{
 				InitializeHandle(Messaging.IntPtr_objc_msgSend_CGRect(base.Handle, Selector.GetHandle("initWithFrame:"), frame), "initWithFrame:");
@@ -3876,7 +3860,6 @@
 		[Export("setTitle:forState:")]
 		public virtual void SetTitle(string title, UIControlState forState)
 		{
-			UIApplication.EnsureUIThread();
 			IntPtr arg = NSString.CreateNative(title);
 			if (base.IsDirectBinding)
 			{
@@ -3948,8 +3931,7 @@
 			[Export("bounds")]
 			get
 			{
-				//Discarded unreachable code: IL_002f
-				UIApplication.EnsureUIThread();
+				//Discarded unreachable code: IL_002b
 				if (base.IsDirectBinding)
 				{
 					_ = 8;
@@ -3965,7 +3947,6 @@
 			[Export("mainScreen")]
 			get
 			{
-				UIApplication.EnsureUIThread();
 				return Runtime.GetNSObject<UIScreen>(Messaging.IntPtr_objc_msgSend(class_ptr, Selector.GetHandle("mainScreen")));
 			}
 		}
@@ -4025,7 +4006,6 @@
 		[Export("addSubview:")]
 		public virtual void AddSubview(UIView view)
 		{
-			UIApplication.EnsureUIThread();
 			IntPtr nonNullHandle = NativeObjectExtensions.GetNonNullHandle(view, "view");
 			if (base.IsDirectBinding)
 			{
@@ -4065,7 +4045,6 @@
 			[Export("view", ArgumentSemantic.Retain)]
 			get
 			{
-				UIApplication.EnsureUIThread();
 				if (base.IsDirectBinding)
 				{
 					return Runtime.GetNSObject<UIView>(Messaging.IntPtr_objc_msgSend(base.Handle, Selector.GetHandle("view")));
@@ -4083,7 +4062,6 @@
 		public UIViewController()
 			: base(NSObjectFlag.Empty)
 		{
-			UIApplication.EnsureUIThread();
 			if (base.IsDirectBinding)
 			{
 				InitializeHandle(Messaging.IntPtr_objc_msgSend(base.Handle, Selector.GetHandle("init")), "init");
@@ -4124,7 +4102,6 @@
 			[Export("setRootViewController:", ArgumentSemantic.Retain)]
 			set
 			{
-				UIApplication.EnsureUIThread();
 				IntPtr arg = NativeObjectExtensions.GetHandle(value);
 				if (base.IsDirectBinding)
 				{
@@ -4146,7 +4123,6 @@
 		public UIWindow(CGRect frame)
 			: base(NSObjectFlag.Empty)
 		{
-			UIApplication.EnsureUIThread();
 			if (base.IsDirectBinding)
 			{
 				InitializeHandle(Messaging.IntPtr_objc_msgSend_CGRect(base.Handle, Selector.GetHandle("initWithFrame:"), frame), "initWithFrame:");
@@ -4160,7 +4136,6 @@
 		[Export("makeKeyAndVisible")]
 		public virtual void MakeKeyAndVisible()
 		{
-			UIApplication.EnsureUIThread();
 			if (base.IsDirectBinding)
 			{
 				Messaging.void_objc_msgSend(base.Handle, Selector.GetHandle("makeKeyAndVisible"));
@@ -4188,7 +4163,6 @@
 		public UIApplicationDelegate()
 			: base(NSObjectFlag.Empty)
 		{
-			UIApplication.EnsureUIThread();
 			base.IsDirectBinding = false;
 			InitializeHandle(Messaging.IntPtr_objc_msgSendSuper(base.SuperHandle, Selector.GetHandle("init")), "init");
 		}
```