### PR TITLE
[Tests] Ignore tests that fail on VMs

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -148,6 +148,9 @@ partial class TestRuntime
 #endif
 	}
 
+	public static bool IsVM => 
+		!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("VM_VENDOR"));
+
 	public static void AssertNotVirtualMachine ()
 	{
 #if MONOMAC

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -97,6 +97,8 @@ namespace Introspection {
 			case "NSUnitPressure": // -init should never be called on NSUnit!
 			case "NSUnitSpeed": // -init should never be called on NSUnit!
 				return true;
+			case "NSMenuView":
+				return TestRuntime.IsVM; // skip on vms due to hadware problems
 			case "MPSCnnNeuron": // Cannot directly initialize MPSCNNNeuron. Use one of the sub-classes of MPSCNNNeuron
 			case "MPSCnnNeuronPReLU":
 			case "MPSCnnNeuronHardSigmoid":

--- a/tests/introspection/Mac/MacApiProtocolTest.cs
+++ b/tests/introspection/Mac/MacApiProtocolTest.cs
@@ -32,6 +32,10 @@ namespace Introspection {
 			case "NSRemoteOpenPanel":
 			case "NSRemoteSavePanel":
 				return true;
+			case "NSMenuView":
+			case "AVCaptureSynchronizedDataCollection":
+			case "AVCaptureSynchronizedData":
+				return TestRuntime.IsVM; // skip only on vms
 			default:
 				return base.Skip (type);
 			}

--- a/tests/introspection/Mac/MacApiSelectorTest.cs
+++ b/tests/introspection/Mac/MacApiSelectorTest.cs
@@ -381,7 +381,12 @@ namespace Introspection {
 						return true;
 					}
 					break;
-
+				case "NSMenuView":
+					switch (selectorName) {
+					case "menuBarHeight":
+						return TestRuntime.IsVM; // skip on vms due to hadware problems
+					}
+					break;
 #if !XAMCORE_3_0		// These should be not be marked [Abstract] but can't fix w/o breaking change...
 				case "NSScrollView":
 				case "NSTextView":

--- a/tests/monotouch-test/CoreAnimation/CAOpenGLLayer.cs
+++ b/tests/monotouch-test/CoreAnimation/CAOpenGLLayer.cs
@@ -20,6 +20,8 @@ namespace Xamarin.Mac.Tests
 		[Test]
 		public void SubclassedTest ()
 		{
+			TestRuntime.AssertNotVirtualMachine ();
+
 			using (var layer = new OpenGLLayer ()) {
 				Messaging.IntPtr_objc_msgSend (layer.Handle, Selector.GetHandle ("copyCGLPixelFormatForDisplayMask:"));
 			}

--- a/tests/monotouch-test/ObjCRuntime/DelegateAndDataSourceTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/DelegateAndDataSourceTest.cs
@@ -132,6 +132,9 @@ namespace Xamarin.Mac.Tests
 				if (PlatformHelper.CheckSystemVersion (11, 0))
 					return true;
 				break;
+			case "SKView":
+				// on vms results on a crash
+				return TestRuntime.IsVM;
 			}
 
 			switch (t.Namespace) {


### PR DESCRIPTION
There are a number of tests that do not work on VMs yet our older
machines are using virtualization. Ignore those tests since we cannot
assert if they work or not.

fixes https://github.com/xamarin/maccore/issues/2438