### PR TITLE
[CI] If the api & generator is not built do not fail the build.

### DIFF
--- a/tools/devops/automation/scripts/bash/vsts-compare.sh
+++ b/tools/devops/automation/scripts/bash/vsts-compare.sh
@@ -10,4 +10,7 @@ if [[ $PR_ID ]]; then
 fi
 
 
-./tools/devops/automation/scripts/bash/compare.sh
+if ! ./tools/devops/automation/scripts/bash/compare.sh; then
+  echo "##vso[task.setvariable variable=API_GENERATOR_BUILT;isOutput=true]False"
+	exit 1
+fi

--- a/tools/devops/automation/scripts/bash/vsts-compare.sh
+++ b/tools/devops/automation/scripts/bash/vsts-compare.sh
@@ -11,6 +11,6 @@ fi
 
 
 if ! ./tools/devops/automation/scripts/bash/compare.sh; then
-  echo "##vso[task.setvariable variable=API_GENERATOR_BUILT;isOutput=true]False"
-	exit 1
+    echo "##vso[task.setvariable variable=API_GENERATOR_BUILT;isOutput=true]False"
+    exit 1
 fi

--- a/tools/devops/automation/templates/build/api-diff.yml
+++ b/tools/devops/automation/templates/build/api-diff.yml
@@ -10,7 +10,7 @@ steps:
 - bash:  $(Build.SourcesDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/vsts-compare.sh
   displayName: 'API & Generator comparison'
   condition: and(succeeded(), contains(variables['configuration.SkipPublicJenkins'], 'False'))
-  name: compare
+  name: apiGeneratorDiff
   env:
     BUILD_REVISION: 'jenkins'
     PR_ID:  ${{ parameters.prID }} # reusing jenkins vars, to be fixed

--- a/tools/devops/automation/templates/build/download-artifacts.yml
+++ b/tools/devops/automation/templates/build/download-artifacts.yml
@@ -48,8 +48,9 @@ steps:
 
 - powershell: |
     Write-Host "##vso[task.setvariable variable=STABLE_APIDDIFF_PATH]$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\apidiff-stable"
-    if ($Env:apiGeneratorDiffBuilt -eq "True")
+    if ($Env:apiGeneratorDiffBuilt -eq "True") {
       Write-Host "##vso[task.setvariable variable=STABLE_APID_GENERATOR_DIFF_PATH]$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\apicomparison"
+    }
   displayName: Publish apidiff paths
   name: apidiff # not to be confused with the displayName, this is used to later use the name of the step to access the output variables from an other job
   env:

--- a/tools/devops/automation/templates/build/download-artifacts.yml
+++ b/tools/devops/automation/templates/build/download-artifacts.yml
@@ -3,6 +3,10 @@ parameters:
   type: boolean
   default: true
 
+- name: apiGeneratorDiffBuilt
+  type: boolean
+  default: true
+
 steps:
 
 - checkout: self
@@ -28,24 +32,31 @@ steps:
     archiveFilePatterns: '$(System.DefaultWorkingDirectory)/Reports/apidiff-stable/apidiff-stable.zip'
     destinationFolder: '$(System.DefaultWorkingDirectory)/apidiff-stable'
 
-- task: DownloadPipelineArtifact@2
-  displayName: 'Download API & Generator comparison'
-  inputs:
-    patterns: 'apicomparison/apicomparison.zip'
-    allowFailedBuilds: true
-    path: $(System.DefaultWorkingDirectory)/Reports
+- ${{ if eq(parameters.apiGeneratorDiffBuilt, true) }}:
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Download API & Generator comparison'
+    inputs:
+      patterns: 'apicomparison/apicomparison.zip'
+      allowFailedBuilds: true
+      path: $(System.DefaultWorkingDirectory)/Reports
 
-- task: ExtractFiles@1
-  displayName: 'Extract API & Generator comparison'
-  inputs:
-    archiveFilePatterns: '$(System.DefaultWorkingDirectory)/Reports/apicomparison/apicomparison.zip'
-    destinationFolder: '$(System.DefaultWorkingDirectory)/apicomparison'
+  - task: ExtractFiles@1
+    displayName: 'Extract API & Generator comparison'
+    inputs:
+      archiveFilePatterns: '$(System.DefaultWorkingDirectory)/Reports/apicomparison/apicomparison.zip'
+      destinationFolder: '$(System.DefaultWorkingDirectory)/apicomparison'
 
 - powershell: |
     Write-Host "##vso[task.setvariable variable=STABLE_APIDDIFF_PATH]$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\apidiff-stable"
-    Write-Host "##vso[task.setvariable variable=STABLE_APID_GENERATOR_DIFF_PATH]$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\apicomparison"
+    if ($Env:apiGeneratorDiffBuilt -eq "True")
+      Write-Host "##vso[task.setvariable variable=STABLE_APID_GENERATOR_DIFF_PATH]$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\apicomparison"
   displayName: Publish apidiff paths
   name: apidiff # not to be confused with the displayName, this is used to later use the name of the step to access the output variables from an other job
+  env:
+    ${{ if eq(parameters.apiGeneratorDiffBuilt, true) }}:
+      apiGeneratorDiffBuilt: 'True'
+    ${{ if ne(parameters.apiGeneratorDiffBuilt, true) }}:
+      apiGeneratorDiffBuilt: 'False'
 
 # download the artifacts.json, which will use to find the URI of the built pkg to later be given to the user
 - task: DownloadPipelineArtifact@2

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -143,12 +143,13 @@ jobs:
     parameters:
       devicePrefix: sim
       runTests: ${{ parameters.runTests }}
+      apiGeneratorDiffBuilt: $[ dependencies.build.outputs['apiGeneratorDiff.API_GENERATOR_BUILT'] ]
 
 - job: upload_vsts_tests
   displayName: 'Upload xml to vsts'
   timeoutInMinutes: 1000
   dependsOn:  build # can start as soon as the tests are done
-  condition: and(succeededOrFailed() , contains (dependencies.build.outputs['runTests.TESTS_RAN'], 'True')) # only run when we did run the tests
+  condition: and(succeededOrFailed(), contains(dependencies.build.outputs['runTests.TESTS_RAN'], 'True')) # only run when we did run the tests
 
   pool:
     vmImage: 'windows-latest'

--- a/tools/devops/automation/templates/build/upload-vsdrops.yml
+++ b/tools/devops/automation/templates/build/upload-vsdrops.yml
@@ -10,6 +10,10 @@ parameters:
   type: boolean
   default: true
 
+- name: apiGeneratorDiffBuilt
+  type: string 
+  default: true
+
 steps:
 
 - checkout: self
@@ -18,6 +22,7 @@ steps:
 - template: download-artifacts.yml 
   parameters:
     runTests: ${{ parameters.runTests }}
+    apiGeneratorDiffBuilt: ${{ contains(parameters.apiGeneratorDiffBuilt, 'True') }}
 
 # Upload full report to vsdrops using the the build numer and id as uuids.
 - ${{ if eq(parameters.runTests, true) }}:
@@ -42,12 +47,13 @@ steps:
     detailedLog: true
     usePat: true
 
-- task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
-  displayName: 'Publish API & Generator comparisonn to Artifact Services Drop'
-  inputs:
-    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
-    dropMetadataContainerName: 'DropMetadata-APIGeneratorDiff'
-    buildNumber: 'xamarin-macios/device-tests/$(Build.BuildNumber)/$(Build.BuildId)/APIGeneratorDiff'
-    sourcePath: $(STABLE_APID_GENERATOR_DIFF_PATH)
-    detailedLog: true
-    usePat: true
+- ${{ if contains(parameters.apiGeneratorDiffBuilt, 'True') }}:
+  - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
+    displayName: 'Publish API & Generator comparisonn to Artifact Services Drop'
+    inputs:
+      dropServiceURI: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
+      dropMetadataContainerName: 'DropMetadata-APIGeneratorDiff'
+      buildNumber: 'xamarin-macios/device-tests/$(Build.BuildNumber)/$(Build.BuildId)/APIGeneratorDiff'
+      sourcePath: $(STABLE_APID_GENERATOR_DIFF_PATH)
+      detailedLog: true
+      usePat: true


### PR DESCRIPTION
If can happen that when we bump xcode we do not get an api & generator
diff. This results in a set of cascading events that make the build
fail.

We know track when the result is not 0, store it in a var and pass that
variable to all the tempaltes that need it. The pwsh script already has
an if to check if the file if present and if not, it shows a warning.