### PR TITLE
[dotnet][tests] Fix monotouch-test RegistrarRemoval

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -1349,7 +1349,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			Assert.AreNotEqual (IntPtr.Zero, Runtime.GetProtocol (iProtocol), "IProtocol");
 			Assert.IsTrue (Messaging.bool_objc_msgSend_IntPtr (Class.GetHandle (typeof (MyProtocolImplementation)), Selector.GetHandle ("conformsToProtocol:"), Runtime.GetProtocol (iProtocol)), "Interface/IProtocol");
 #if !__TVOS__ && !__WATCHOS__ && !MONOMAC
+	#if !NET // https://github.com/xamarin/xamarin-macios/issues/11540
 			Assert.IsTrue (Messaging.bool_objc_msgSend_IntPtr (Class.GetHandle (typeof (Test24970)), Selector.GetHandle ("conformsToProtocol:"), Protocol.GetHandle ("UIApplicationDelegate")), "UIApplicationDelegate/17669");
+	#endif
 #endif
 			// We don't support [Adopts] (yet at least).
 //			Assert.IsTrue (Messaging.bool_objc_msgSend_IntPtr (Class.GetHandle (typeof (ConformsToProtocolTestClass)), Selector.GetHandle ("conformsToProtocol:"), Runtime.GetProtocol ("NSCoding")), "Adopts/ConformsToProtocolTestClass");

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -60,13 +60,10 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		}
 
 		[Test]
-#if NET
-		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/10512")]
-#endif
 		public void RegistrarRemoval ()
 		{
 			// define set by xharness when creating test variations.
-			// It's not safe to remove the dynamic registrar in monotouch-test (by design; some of the tested API makes it unsafe, and the linker correcty detects this),
+			// It's not safe to remove the dynamic registrar in monotouch-test (by design; some of the tested API makes it unsafe, and the linker correctly detects this),
 			// so the dynamic registrar will only be removed if manually requested.
 			// Also removal of the dynamic registrar is not supported in XM
 #if OPTIMIZEALL && !__MACOS__

--- a/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
@@ -16,6 +16,7 @@
     <DefineConstants Condition="'$(Platform)' == 'iPhoneSimulator'">$(DefineConstants);DYNAMIC_REGISTRAR</DefineConstants>
     <DefineConstants Condition="'$(Platform)' != 'iPhoneSimulator'">$(DefineConstants);DEVICE</DefineConstants>
     <RootTestsDirectory>..\..\..</RootTestsDirectory>
+    <MtouchLink>None</MtouchLink>
     <MtouchExtraArgs>-xml=${ProjectDir}/../extra-linker-defs.xml</MtouchExtraArgs>
   </PropertyGroup>
 

--- a/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
@@ -15,6 +15,7 @@
     <DefineConstants>$(DefineConstants);MONOMAC;XAMMAC_TESTS</DefineConstants>
     <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);DEBUG;DYNAMIC_REGISTRAR</DefineConstants>
     <RootTestsDirectory>..\..\..</RootTestsDirectory>
+    <LinkMode>None</LinkMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/monotouch-test/dotnet/tvOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/tvOS/monotouch-test.csproj
@@ -16,6 +16,7 @@
     <DefineConstants Condition="'$(Platform)' == 'iPhoneSimulator'">$(DefineConstants);DYNAMIC_REGISTRAR</DefineConstants>
     <DefineConstants Condition="'$(Platform)' != 'iPhoneSimulator'">$(DefineConstants);DEVICE</DefineConstants>
     <RootTestsDirectory>..\..\..</RootTestsDirectory>
+    <MtouchLink>None</MtouchLink>
     <MtouchExtraArgs>-xml=${ProjectDir}/../extra-linker-defs.xml</MtouchExtraArgs>
   </PropertyGroup>
 

--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -97,7 +97,7 @@ namespace Xharness.Jenkins {
 				switch (test.TestName) {
 				case "monotouch-test":
 					// The default is to run monotouch-test with the dynamic registrar (in the simulator), so that's already covered
-					yield return new TestData { Variation = "Debug (LinkSdk)", Debug = true, Profiling = false, LinkMode = "LinkSdk", Ignored = ignore };
+					yield return new TestData { Variation = "Debug (LinkSdk)", Debug = true, Profiling = false, LinkMode = test.TestProject.IsDotNetProject ? "SdkOnly" : "LinkSdk", Ignored = ignore };
 					yield return new TestData { Variation = "Debug (static registrar)", MTouchExtraArgs = "--registrar:static", Debug = true, Profiling = false, Undefines = "DYNAMIC_REGISTRAR", Ignored = ignore };
 					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, LinkMode = "Full", Defines = "OPTIMIZEALL", Undefines = "DYNAMIC_REGISTRAR", Ignored = ignore };
 					yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all,-remove-uithread-checks", Debug = true, Profiling = false, LinkMode = "Full", Defines = "OPTIMIZEALL", Undefines = "DYNAMIC_REGISTRAR", Ignored = ignore ?? !jenkins.IncludeAll };


### PR DESCRIPTION
The registrar removal was fixed recently but the test was still failing.
Turns out xharness modify the linker setting for this test (as the
linker is required for this optimization) but the newer dotnet csproj
did not have an entry (to modify).

Fixes https://github.com/xamarin/xamarin-macios/issues/10512