### PR TITLE
[runtime] Fix call to xamarin_print_all_exceptions.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2305,7 +2305,10 @@ xamarin_process_managed_exception (MonoObject *exception)
 #endif
 	case MarshalManagedExceptionModeAbort:
 	default:
-		xamarin_assertion_message ("Aborting due to trying to marshal managed exception:\n%s\n", [xamarin_print_all_exceptions (exception) UTF8String]);
+		handle = xamarin_gchandle_new (exception, false);
+		const char *msg = [xamarin_print_all_exceptions (handle) UTF8String];
+		xamarin_gchandle_free (handle);
+		xamarin_assertion_message ("Aborting due to trying to marshal managed exception:\n%s\n", msg);
 		break;
 	}
 }


### PR DESCRIPTION
Passing a 'MonoObject*' to a function that expects a GCHandle doesn't quite
work, so make sure to get a GCHandle for the exception we want to print
information about.