### PR TITLE
[msbuild] Add support for smelting metal for Mac Catalyst.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
@@ -100,8 +100,12 @@ namespace Xamarin.MacDev.Tasks
 			args.Add ("-o");
 			args.AddQuoted (Path.ChangeExtension (path, ".air"));
 
-			args.Add (PlatformFrameworkHelper.GetMinimumVersionArgument (TargetFrameworkMoniker, SdkIsSimulator, MinimumOSVersion));
-
+			if (Platform == ApplePlatform.MacCatalyst) {
+				args.Add ($"-target");
+				args.Add ($"air64-apple-ios{MinimumOSVersion}-macabi");
+			} else {
+				args.Add (PlatformFrameworkHelper.GetMinimumVersionArgument (TargetFrameworkMoniker, SdkIsSimulator, MinimumOSVersion));
+			}
 			args.AddQuoted (SourceFile.ItemSpec);
 
 			return args.ToString ();


### PR DESCRIPTION
This makes monotouch-test's Metal test file compile for Mac Catalyst.