### PR TITLE
[MediaToolbox] Don't use Action<T> in reverse P/Invokes.

### DIFF
--- a/src/MediaToolbox/MTAudioProcessingTap.cs
+++ b/src/MediaToolbox/MTAudioProcessingTap.cs
@@ -49,6 +49,8 @@ namespace MediaToolbox
 #endif
 	{
 #if !COREBUILD
+		delegate void Action_IntPtr (IntPtr arg);
+
 		// MTAudioProcessingTapCallbacks
 		[StructLayout (LayoutKind.Sequential, Pack = 1)]
 		unsafe struct Callbacks
@@ -57,9 +59,9 @@ namespace MediaToolbox
 			/* int */ int version; // kMTAudioProcessingTapCallbacksVersion_0 == 0
 			public /* void* */ IntPtr clientInfo;
 			public /* MTAudioProcessingTapInitCallback */ MTAudioProcessingTapInitCallbackProxy init;
-			public /* MTAudioProcessingTapFinalizeCallback */ Action<IntPtr> finalize;
+			public /* MTAudioProcessingTapFinalizeCallback */ Action_IntPtr finalize;
 			public /* MTAudioProcessingTapPrepareCallback */ MTAudioProcessingTapPrepareCallbackProxy prepare;
-			public /* MTAudioProcessingTapUnprepareCallback */ Action<IntPtr> unprepare;
+			public /* MTAudioProcessingTapUnprepareCallback */ Action_IntPtr unprepare;
 			public /* MTAudioProcessingTapProcessCallback */ MTAudioProcessingTapProcessCallbackProxy process;
 #pragma warning restore 169
 		}
@@ -217,7 +219,7 @@ namespace MediaToolbox
 			numberFramesOut = (IntPtr) numberOut;
 		}
 
-		[MonoPInvokeCallback (typeof (Action<IntPtr>))]
+		[MonoPInvokeCallback (typeof (Action_IntPtr))]
 		static void FinalizeProxy (IntPtr tap)
 		{
 			MTAudioProcessingTap apt;
@@ -235,7 +237,7 @@ namespace MediaToolbox
 			apt.callbacks.Prepare (apt, (nint) maxFrames, ref processingFormat);
 		}
 
-		[MonoPInvokeCallback (typeof (Action<IntPtr>))]
+		[MonoPInvokeCallback (typeof (Action_IntPtr))]
 		static void UnprepareProxy (IntPtr tap)
 		{
 			MTAudioProcessingTap apt;


### PR DESCRIPTION
CoreCLR doesn't support it.

Ref: https://github.com/dotnet/runtime/issues/32963