### PR TITLE
[tests][intro] Add back `[Test]` on some methods

### DIFF
--- a/tests/introspection/ApiPInvokeTest.cs
+++ b/tests/introspection/ApiPInvokeTest.cs
@@ -260,7 +260,7 @@ namespace Introspection
 
 		// Note: this looks very similar to the "SymbolExists" test above (and it is)
 		// except that we never skip based on availability attributes or __Internal...
-		// since this is a test to ensure thigns will work at native link time (e.g. 
+		// since this is a test to ensure things will work at native link time (e.g.
 		// for devices) when dlsym is disabled
 
 		[Test]
@@ -286,6 +286,7 @@ namespace Introspection
 				Check (a);
 		}
 
+		[Test]
 #if __MACCATALYST__
 		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/10883")]
 #endif
@@ -296,6 +297,7 @@ namespace Introspection
 				Check (a);
 		}
 
+		[Test]
 #if __MACCATALYST__
 		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/10883")]
 #endif


### PR DESCRIPTION
Those were likely removed when we excluded the tests from Catalyst