### PR TITLE
[runtime] Implement xamarin_get_[nsnumber|nsvalue]_type for CoreCLR.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -108,40 +108,20 @@ xamarin_bridge_get_mono_method (MonoReflectionMethod *method)
 	return method;
 }
 
-MonoClass *
-xamarin_get_nsnumber_class ()
+MonoType *
+xamarin_get_nsnumber_type ()
 {
-	xamarin_assertion_message ("The method %s it not implemented yet for CoreCLR", __func__);
+	MonoClass *rv = xamarin_bridge_lookup_class (XamarinLookupTypes_Foundation_NSNumber);
+	LOG_CORECLR (stderr, "%s () => %p\n", __func__, rv);
+	return rv;
 }
 
-MonoClass *
-xamarin_get_nsvalue_class ()
+MonoType *
+xamarin_get_nsvalue_type ()
 {
-	xamarin_assertion_message ("The method %s it not implemented yet for CoreCLR", __func__);
-}
-
-MonoClass *
-xamarin_get_inativeobject_class ()
-{
-	xamarin_assertion_message ("The method %s it not implemented yet for CoreCLR", __func__);
-}
-
-MonoClass *
-xamarin_get_nsobject_class ()
-{
-	xamarin_assertion_message ("The method %s it not implemented yet for CoreCLR", __func__);
-}
-
-MonoClass *
-xamarin_get_nsstring_class ()
-{
-	xamarin_assertion_message ("The method %s it not implemented yet for CoreCLR", __func__);
-}
-
-MonoClass *
-xamarin_get_runtime_class ()
-{
-	xamarin_assertion_message ("The method %s it not implemented yet for CoreCLR", __func__);
+	MonoClass *rv = xamarin_bridge_lookup_class (XamarinLookupTypes_Foundation_NSValue);
+	LOG_CORECLR (stderr, "%s () => %p\n", __func__, rv);
+	return rv;
 }
 
 void
@@ -492,7 +472,7 @@ mono_class_from_mono_type (MonoType *type)
 MonoClass *
 mono_get_string_class ()
 {
-	MonoClass *rv = xamarin_bridge_get_string_class ();
+	MonoClass *rv = xamarin_bridge_lookup_class (XamarinLookupTypes_System_String);
 	LOG_CORECLR (stderr, "%s () => %p.\n", __func__, rv);
 	return rv;
 }

--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -111,6 +111,8 @@ xamarin_bridge_get_mono_method (MonoReflectionMethod *method)
 MonoType *
 xamarin_get_nsnumber_type ()
 {
+	// xamarin_bridge_lookup_class returns a MonoClass*, and this method returns a MonoType*,
+	// but they're interchangeable for CoreCLR (they're all just MonoObject*s), so this is fine.
 	MonoClass *rv = xamarin_bridge_lookup_class (XamarinLookupTypes_Foundation_NSNumber);
 	LOG_CORECLR (stderr, "%s () => %p\n", __func__, rv);
 	return rv;
@@ -119,6 +121,8 @@ xamarin_get_nsnumber_type ()
 MonoType *
 xamarin_get_nsvalue_type ()
 {
+	// xamarin_bridge_lookup_class returns a MonoClass*, and this method returns a MonoType*,
+	// but they're interchangeable for CoreCLR (they're all just MonoObject*s), so this is fine.
 	MonoClass *rv = xamarin_bridge_lookup_class (XamarinLookupTypes_Foundation_NSValue);
 	LOG_CORECLR (stderr, "%s () => %p\n", __func__, rv);
 	return rv;

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -489,8 +489,10 @@
 			OnlyCoreCLR = true,
 		},
 
-		new XDelegate ("MonoObject *", "MonoObject *", "xamarin_bridge_get_string_class") {
-			WrappedManagedFunction = "GetStringClass",
+		new XDelegate ("MonoClass *", "MonoObject *", "xamarin_bridge_lookup_class",
+			"enum XamarinLookupTypes", "Runtime.TypeLookup", "type"
+		) {
+			WrappedManagedFunction = "LookupType",
 			OnlyDynamicUsage = false,
 			OnlyCoreCLR = true,
 		},

--- a/runtime/monovm-bridge.m
+++ b/runtime/monovm-bridge.m
@@ -172,20 +172,20 @@ xamarin_get_nsobject_class ()
 	return nsobject_class;
 }
 
-MonoClass *
-xamarin_get_nsvalue_class ()
+MonoType *
+xamarin_get_nsvalue_type ()
 {
 	if (nsvalue_class == NULL)
 		xamarin_assertion_message ("Internal consistency error, please file a bug (https://github.com/xamarin/xamarin-macios/issues/new). Additional data: can't get the %s class because it's been linked away.\n", "NSValue");
-	return nsvalue_class;
+	return mono_class_get_type (nsvalue_class);
 }
 
-MonoClass *
-xamarin_get_nsnumber_class ()
+MonoType *
+xamarin_get_nsnumber_type ()
 {
 	if (nsnumber_class == NULL)
 		xamarin_assertion_message ("Internal consistency error, please file a bug (https://github.com/xamarin/xamarin-macios/issues/new). Additional data: can't get the %s class because it's been linked away.\n", "NSNumber");
-	return nsnumber_class;
+	return mono_class_get_type (nsnumber_class);
 }
 
 MonoClass *
@@ -324,7 +324,6 @@ xamarin_is_class_nsnumber (MonoClass *cls)
 	// COOP: Reading managed data, must be in UNSAFE mode
 	MONO_ASSERT_GC_UNSAFE;
 
-	MonoClass *nsnumber_class = xamarin_get_nsnumber_class ();
 	if (nsnumber_class == NULL)
 		return false;
 
@@ -337,7 +336,6 @@ xamarin_is_class_nsvalue (MonoClass *cls)
 	// COOP: Reading managed data, must be in UNSAFE mode
 	MONO_ASSERT_GC_UNSAFE;
 
-	MonoClass *nsvalue_class = xamarin_get_nsvalue_class ();
 	if (nsvalue_class == NULL)
 		return false;
 

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -1462,7 +1462,7 @@ xamarin_get_nsnumber_converter (MonoClass *managedType, MonoMethod *method, bool
 		func = xamarin_get_nsnumber_converter (baseClass, method, to_managed, exception_gchandle);
 		xamarin_mono_object_release (&baseClass);
 	} else {
-		MonoType *nsnumberType = mono_class_get_type (xamarin_get_nsnumber_class ());
+		MonoType *nsnumberType = xamarin_get_nsnumber_type ();
 		*exception_gchandle = xamarin_create_bindas_exception (mtype, nsnumberType, method);
 		xamarin_mono_object_release (&nsnumberType);
 		goto exception_handling;
@@ -1533,7 +1533,7 @@ xamarin_get_nsvalue_converter (MonoClass *managedType, MonoMethod *method, bool 
 #endif
 	} else {
 		MonoType *mType = mono_class_get_type (managedType);
-		MonoType *nsvalueType = mono_class_get_type (xamarin_get_nsvalue_class ());
+		MonoType *nsvalueType = xamarin_get_nsvalue_type ();
 		*exception_gchandle = xamarin_create_bindas_exception (mType, nsvalueType, method);
 		xamarin_mono_object_release (&mType);
 		xamarin_mono_object_release (&nsvalueType);

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -251,8 +251,8 @@ GCHandle		xamarin_create_product_exception_with_inner_exception (int code, GCHan
 NSString *		xamarin_print_all_exceptions (GCHandle handle);
 
 id				xamarin_invoke_objc_method_implementation (id self, SEL sel, IMP xamarin_impl);
-MonoClass *		xamarin_get_nsnumber_class ();
-MonoClass *		xamarin_get_nsvalue_class ();
+MonoType *		xamarin_get_nsnumber_type ();
+MonoType *		xamarin_get_nsvalue_type ();
 MonoClass *		xamarin_get_inativeobject_class ();
 MonoClass *		xamarin_get_nsobject_class ();
 MonoClass *		xamarin_get_nsstring_class ();

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -145,6 +145,29 @@ namespace ObjCRuntime {
 			return rv;
 		}
 
+		static unsafe MonoObject* LookupType (TypeLookup type)
+		{
+			Type rv = null;
+
+			switch (type) {
+			case TypeLookup.Foundation_NSNumber:
+				rv = typeof (Foundation.NSNumber);
+				break;
+			case TypeLookup.Foundation_NSValue:
+				rv = typeof (Foundation.NSValue);
+				break;
+			case TypeLookup.System_String:
+				rv = typeof (string);
+				break;
+			default:
+				throw new ArgumentOutOfRangeException (nameof (type));
+			}
+
+			log_coreclr ($"LookupType ({type}) => {rv}");
+
+			return (MonoObject*) GetMonoObject (rv);
+		}
+
 		static unsafe MonoObject* GetElementClass (MonoObject* classobj)
 		{
 			var type = (Type) GetMonoObjectTarget (classobj);
@@ -626,11 +649,6 @@ namespace ObjCRuntime {
 				return true;
 
 			return false;
-		}
-
-		static unsafe MonoObject* GetStringClass ()
-		{
-			return (MonoObject *) GetMonoObject (typeof (string));
 		}
 
 		unsafe static bool IsByRef (MonoObject *typeobj)


### PR DESCRIPTION
* Remove a few unused xamarin_get_*_class functions.
* Make the remaining two (xamarin_get_[nsnumber|nsvalue]_type) return a
  MonoType* instead of MonoClass* - that makes things slightly simpler for
  CoreCLR (the MonoClass* return values from the previous functions were
  always converted to MonoType*s anyway).
* Implement the xamarin_get_[nsnumber|nsvalue]_type functions.
* Make the existing mono_get_string_class use the new (and more generic)
  xamarin_bridge_lookup_class method instead of the specific
  xamarin_bridge_get_string_class (which can now be removed).