### PR TITLE
[d16-10] [apidiff] Bump definitions now that `xcode12.5` support is on stable

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -36,7 +36,7 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 
 include $(TOP)/Make.versions
 
-APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/d16-9/3836759d42ce0edd81433ac6044fcdf3f4bdb247/4459227/package/bundle.zip
+APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/xcode12.5/ab40b131d3e87a96c3414447dcded5fec45bce36/4679032/package/bundle.zip
 
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 


### PR DESCRIPTION



Backport of #11558
