### PR TITLE
[CoreGraphics] Adjust CGPDFOperatorTable to not use a generic Action delegate.

### DIFF
--- a/tests/monotouch-test/CoreGraphics/PDFScannerTest.cs
+++ b/tests/monotouch-test/CoreGraphics/PDFScannerTest.cs
@@ -8,6 +8,8 @@
 //
 
 using System;
+using System.Runtime.InteropServices;
+
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
@@ -22,7 +24,11 @@ namespace MonoTouchFixtures.CoreGraphics {
 		int bt_count;
 		int do_checks;
 
+#if NET
+		[UnmanagedCallersOnly]
+#else
 		[MonoPInvokeCallback (typeof (Action<IntPtr,IntPtr>))]
+#endif
 		static void BT (IntPtr reserved, IntPtr info)
 		{
 			// sadly the parameters are always identical and we can't know the operator name
@@ -35,7 +41,11 @@ namespace MonoTouchFixtures.CoreGraphics {
 			(scanner.UserInfo as PDFScannerTest).bt_count++;
 		}
 
+#if NET
+		[UnmanagedCallersOnly]
+#else
 		[MonoPInvokeCallback (typeof (Action<IntPtr,IntPtr>))]
+#endif
 		static void Do (IntPtr reserved, IntPtr info)
 		{
 			// sadly the parameters are always identical and we can't know the operator name
@@ -97,6 +107,13 @@ namespace MonoTouchFixtures.CoreGraphics {
 				table.SetCallback ("Do", delegate (CGPDFScanner scanner) {
 				// ... drill down to the image
 				});
+#elif NET
+				unsafe {
+					// BT == new paragraph
+					table.SetCallback ("BT", &BT);
+					// Do == the image is inside it
+					table.SetCallback ("Do", &Do);
+				}
 #else
 				// BT == new paragraph
 				table.SetCallback ("BT", BT);


### PR DESCRIPTION
* CoreCLR doesn't support generic Action delegates in reverse (P/Invokes), so
  we need to find a different solution.
* The native CGPDFOperatorTable callback API is not very friendly to us,
  because we can't pass it callback-specific data, which means that the
  managed caller must conform to the FullAOT requirement of the managed
  callback (must be a static function; must have a MonoPInvokeCallback
  attribute).
* We can leverage the new function pointer syntax in C# 9 to make these
  requirements enforced by the C# compiler (unmanaged function pointer +
  UnmanagedCallersOnly attribute). The resulting API is still clunky to use,
  but I don't see any way around that.

Fixes this monotouch-test failure with CoreCLR:

    [FAIL] Tamarin : System.Runtime.InteropServices.MarshalDirectiveException : Cannot marshal 'parameter #3': Non-blittable generic types cannot be marshaled.
               at CoreGraphics.CGPDFOperatorTable.CGPDFOperatorTableSetCallback(IntPtr table, String name, Action`2 callback)
               at CoreGraphics.CGPDFOperatorTable.SetCallback(String name, Action`2 callback)
               at MonoTouchFixtures.CoreGraphics.PDFScannerTest.Tamarin() in xamarin-macios/tests/monotouch-test/CoreGraphics/PDFScannerTest.cs:line 102

Ref: https://github.com/dotnet/runtime/issues/32963