### PR TITLE
[dotnet][linker] Eliminate code that is only required for CoreCLR on iOS and tvOS

### DIFF
--- a/runtime/Delegates.cs.t4
+++ b/runtime/Delegates.cs.t4
@@ -98,8 +98,10 @@ namespace ObjCRuntime {
 <# foreach (var d in delegates) {
 	if (d.OnlyDynamicUsage) continue; #>
 <#
-	if (d.OnlyCoreCLR)
+	if (d.OnlyCoreCLR) {
 		Write ("#if NET\n");
+		Write ("\t\t\tif (IsCoreCLR)\n\t");
+	}
 #>
 			options->Delegates-><#= d.SimpleEntryPoint #> = GetFunctionPointer (new <#= d.SimpleEntryPoint #>_delegate (<#= d.SimpleEntryPoint #>));
 <#
@@ -118,8 +120,10 @@ namespace ObjCRuntime {
 <# foreach (var d in delegates) {
 	if (!d.OnlyDynamicUsage) continue; #>
 <#
-	if (d.OnlyCoreCLR)
+	if (d.OnlyCoreCLR) {
 		Write ("#if NET\n");
+		Write ("\t\t\tif (IsCoreCLR)\n\t");
+	}
 #>
 			options->Delegates-><#= d.SimpleEntryPoint #> = GetFunctionPointer (new <#= d.SimpleEntryPoint #>_delegate (<#= d.SimpleEntryPoint #>));
 <#

--- a/src/ILLink.Substitutions.ios.xml
+++ b/src/ILLink.Substitutions.ios.xml
@@ -1,0 +1,7 @@
+<linker>
+  <assembly fullname="Xamarin.iOS">
+    <type fullname="ObjCRuntime.Runtime">
+      <method signature="System.Boolean get_IsCoreCLR()" body="stub" value="false" />
+    </type>
+  </assembly>
+</linker>

--- a/src/ILLink.Substitutions.tvos.xml
+++ b/src/ILLink.Substitutions.tvos.xml
@@ -1,0 +1,7 @@
+<linker>
+  <assembly fullname="Xamarin.TVOS">
+    <type fullname="ObjCRuntime.Runtime">
+      <method signature="System.Boolean get_IsCoreCLR()" body="stub" value="false" />
+    </type>
+  </assembly>
+</linker>

--- a/src/Makefile
+++ b/src/Makefile
@@ -152,6 +152,9 @@ $(IOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml: $(TOP)/src/ILLink.LinkAttribu
 	$(Q) mkdir -p $(IOS_DOTNET_BUILD_DIR)
 	$(call Q_PROF_GEN,ios) sed < $< > $@ 's|@PRODUCT_NAME@|$(IOS_PRODUCT)|g;'
 
+$(IOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml: $(TOP)/src/ILLink.Substitutions.ios.xml
+	$(Q) $(CP) $< $@
+
 # core.dll
 $(IOS_BUILD_DIR)/native/core.dll: $(IOS_CORE_SOURCES) frameworks.sources $(BUILD_DIR)/ios-defines.rsp
 	$(Q) mkdir -p $(IOS_BUILD_DIR)native
@@ -223,7 +226,7 @@ $(IOS_BUILD_DIR)/native-$(1)%Xamarin.iOS.dll $(IOS_BUILD_DIR)/native-$(1)%Xamari
 		@$(BUILD_DIR)/ios-defines.rsp \
 		$$(IOS_SOURCES) @$(IOS_BUILD_DIR)/native/generated_sources
 
-$(IOS_DOTNET_BUILD_DIR)/$(1)/Xamarin.iOS%dll $(IOS_DOTNET_BUILD_DIR)/$(1)/Xamarin.iOS%pdb $(2): $$(IOS_SOURCES) $$(IOS_DOTNET_BUILD_DIR)/ios-generated-sources $$(IOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml $(PRODUCT_KEY_PATH) | $(IOS_DOTNET_BUILD_DIR)/$(1) $(IOS_DOTNET_BUILD_DIR)/ref
+$(IOS_DOTNET_BUILD_DIR)/$(1)/Xamarin.iOS%dll $(IOS_DOTNET_BUILD_DIR)/$(1)/Xamarin.iOS%pdb $(2): $$(IOS_SOURCES) $$(IOS_DOTNET_BUILD_DIR)/ios-generated-sources $$(IOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml $$(IOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml $(PRODUCT_KEY_PATH) | $(IOS_DOTNET_BUILD_DIR)/$(1) $(IOS_DOTNET_BUILD_DIR)/ref
 	$$(call Q_PROF_CSC,dotnet/$(1)-bit) $(DOTNET6_CSC) $(DOTNET_FLAGS) -out:$(IOS_DOTNET_BUILD_DIR)/$(1)/Xamarin.iOS.dll -unsafe -optimize \
 		$$(ARGS_$(1)) \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) \
@@ -233,6 +236,7 @@ $(IOS_DOTNET_BUILD_DIR)/$(1)/Xamarin.iOS%dll $(IOS_DOTNET_BUILD_DIR)/$(1)/Xamari
 		$$(IOS_CSC_FLAGS_XI) \
 		@$(BUILD_DIR)/ios-defines.rsp \
 		-res:$(IOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
+		-res:$(IOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml \
 		$$(IOS_SOURCES) @$(IOS_DOTNET_BUILD_DIR)/ios-generated-sources
 
 endef
@@ -1076,6 +1080,9 @@ $(TVOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml: $(TOP)/src/ILLink.LinkAttrib
 	$(Q) mkdir -p $(TVOS_DOTNET_BUILD_DIR)
 	$(call Q_PROF_GEN,tvos) sed < $< > $@ 's|@PRODUCT_NAME@|Xamarin.TVOS|g;'
 
+$(TVOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml: $(TOP)/src/ILLink.Substitutions.tvos.xml
+	$(Q) $(CP) $< $@
+
 $(TVOS_BUILD_DIR)/tvos/core.dll: $(TVOS_CORE_SOURCES) frameworks.sources Makefile $(BUILD_DIR)/tvos-defines.rsp | $(TVOS_BUILD_DIR)/tvos
 	@mkdir -p $(TVOS_BUILD_DIR)/tvos
 	$(call Q_PROF_CSC,tvos) $(TV_CSC) -nologo -out:$@ -target:library -debug -unsafe \
@@ -1135,7 +1142,7 @@ $(TVOS_DOTNET_BUILD_DIR)/tvos.rsp: Makefile Makefile.generator frameworks.source
 		@$(BUILD_DIR)/tvos-defines.rsp \
 		> $@
 
-$(TVOS_DOTNET_BUILD_DIR)/64/Xamarin.TVOS%dll $(TVOS_DOTNET_BUILD_DIR)/64/Xamarin.TVOS%pdb $(TVOS_DOTNET_BUILD_DIR)/ref/Xamarin.TVOS%dll: $(TVOS_DOTNET_BUILD_DIR)/tvos-generated-sources $(TVOS_SOURCES) $(PRODUCT_KEY_PATH) $(TVOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml | $(TVOS_DOTNET_BUILD_DIR)/64 $(TVOS_DOTNET_BUILD_DIR)/ref
+$(TVOS_DOTNET_BUILD_DIR)/64/Xamarin.TVOS%dll $(TVOS_DOTNET_BUILD_DIR)/64/Xamarin.TVOS%pdb $(TVOS_DOTNET_BUILD_DIR)/ref/Xamarin.TVOS%dll: $(TVOS_DOTNET_BUILD_DIR)/tvos-generated-sources $(TVOS_SOURCES) $(PRODUCT_KEY_PATH) $(TVOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml $(TVOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml | $(TVOS_DOTNET_BUILD_DIR)/64 $(TVOS_DOTNET_BUILD_DIR)/ref
 	$(Q_DOTNET_GEN) \
 		$(DOTNET6_CSC) $(DOTNET_FLAGS) -out:$(TVOS_DOTNET_BUILD_DIR)/64/Xamarin.TVOS.dll -optimize \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) \
@@ -1148,6 +1155,7 @@ $(TVOS_DOTNET_BUILD_DIR)/64/Xamarin.TVOS%dll $(TVOS_DOTNET_BUILD_DIR)/64/Xamarin
 		$(TVOS_SOURCES) \
 		@$(BUILD_DIR)/tvos-defines.rsp \
 		-res:$(TVOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
+		-res:$(TVOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml \
 		@$<
 
 $(TVOS_BUILD_DIR)/tvos-64/Xamarin.TVOS%dll $(TVOS_BUILD_DIR)/tvos-64/Xamarin.TVOS%pdb: $(TVOS_SOURCES) $(TVOS_BUILD_DIR)/tvos/generated_sources $(PRODUCT_KEY_PATH) | $(TVOS_BUILD_DIR)/tvos-64

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -171,7 +171,7 @@ namespace ObjCRuntime {
 		internal unsafe static bool IsCoreCLR {
 			get {
 				// The linker may turn calls to this property into a constant
-				return (options->Flags & InitializationFlags.IsCoreCLR) == InitializationFlags.IsCoreCLR;
+				return (options->Flags.HasFlag (InitializationFlags.IsCoreCLR));
 			}
 		}
 #endif

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -162,15 +162,6 @@ namespace ObjCRuntime {
 					return (Flags & InitializationFlags.IsSimulator) == InitializationFlags.IsSimulator;
 				}
 			}
-
-#if NET
-			// Future optimization potential: make the linker change this into a constant.
-			internal bool IsCoreCLR {
-				get {
-					return (Flags & InitializationFlags.IsCoreCLR) == InitializationFlags.IsCoreCLR;
-				}
-			}
-#endif
 		}
 
 		internal static unsafe InitializationOptions* options;
@@ -178,7 +169,10 @@ namespace ObjCRuntime {
 #if NET
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		internal unsafe static bool IsCoreCLR {
-			get { return options->IsCoreCLR; }
+			get {
+				// The linker may turn calls to this property into a constant
+				return (options->Flags & InitializationFlags.IsCoreCLR) == InitializationFlags.IsCoreCLR;
+			}
 		}
 #endif
 


### PR DESCRIPTION
CoreCLR is being added for macOS only. We can eliminate a lot of recent
code additions (about half a megabyte in the past week) by eliminate code
branches under `if (IsCoreCLR)`.

Unlike handling (non required at runtime) custom attributes the
`ILLink.Substitutions.xml` will vary quite a bit across platforms so we
use a unique file for each platform.