### PR TITLE
[registrar] Define CORECLR_RUNTIME when in the generated registrar code for CoreCLR

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -4882,6 +4882,11 @@ namespace Registrar {
 				methods.WriteLine ("#define DEBUG 1");
 			}
 
+			if (App.XamarinRuntime == XamarinRuntime.CoreCLR) {
+				header.WriteLine ("#define CORECLR_RUNTIME");
+				methods.WriteLine ("#define CORECLR_RUNTIME");
+			}
+
 			header.WriteLine ("#include <stdarg.h>");
 			if (SupportsModernObjectiveC) {
 				methods.WriteLine ("#include <xamarin/xamarin.h>");


### PR DESCRIPTION
This makes sure that we build the right thing, our shipped headers behave
differently whether CORECLR_RUNTIME is defined or not.