### PR TITLE
[msbuild] Fix error message MSBStrings.W0073 -> W0074

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
@@ -113,7 +113,7 @@ namespace Xamarin.iOS.Tasks
 				Log.LogError (7069, info, MSBStrings.E7069 /* Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+. */);
 				break;
 			default:
-				Log.LogWarning (MSBStrings.W0073, name, extensionPointIdentifier);
+				Log.LogWarning (MSBStrings.W0074, name, extensionPointIdentifier);
 				break;
 			}
 		}


### PR DESCRIPTION
Due to incorrect update while adapting code for translations.

```
    <data name="W0073" xml:space="preserve">
        <value>The App Extension '{0}' has a CFBundleVersion ({1}) that does not match the main app bundle's CFBundleVersion ({2})
        </value>
    </data>

    <data name="W0074" xml:space="preserve">
        <value>The App Extension '{0}' has an unrecognized NSExtensionPointIdentifier value ('{1}').
        </value>
    </data>
```

Fixes https://github.com/xamarin/xamarin-macios/issues/11581