### PR TITLE
[d16-10] [src] Fix some breaking changes detected when bumping APIDIFF

### DIFF
--- a/src/AudioUnit/AUEnums.cs
+++ b/src/AudioUnit/AUEnums.cs
@@ -268,6 +268,8 @@ namespace AudioUnit
 		ParametersForOverview = 57,
 		[iOS (10,0), Mac (10,12)]
 		SupportsMpe = 58,
+		[iOS (14,5), TV (14,5), Mac (11,3)]
+		LoadedOutOfProcess = 62,
 
 #if MONOMAC
 		FastDispatch = 5,

--- a/src/UIKit/UIEnums.cs
+++ b/src/UIKit/UIEnums.cs
@@ -2468,11 +2468,11 @@ namespace UIKit {
 		[Field ("UIWindowSceneSessionRoleExternalDisplay")]
 		ExternalDisplay,
 
-#if HAS_CARPLAY
 		[NoTV][NoWatch]
+#if HAS_CARPLAY
 		[Field ("CPTemplateApplicationSceneSessionRoleApplication", "CarPlay")]
-		CarTemplateApplication,
 #endif
+		CarTemplateApplication,
 	}
 
 	[iOS (13,0), TV (13,0), NoWatch]

--- a/src/authenticationservices.cs
+++ b/src/authenticationservices.cs
@@ -51,7 +51,13 @@ namespace AuthenticationServices {
 	[Partial]
 	interface ASExtensionErrorCodeExtensions {
 
+#if TVOS || WATCH
+		// Type `ASExtensionErrorCode` is already decorated, so it becomes a duplicate (after code gen)
+		// on those platforms and intro tests complains (on other platforms, e.g. iOS, Catalyst)
+		// OTOH if we don't add them here then we'll get the extra, not really usable, extension type
+		// on tvOS and watchOS (which is incorrect)
 		[NoTV][NoWatch]
+#endif
 		[NoMac, iOS (14,0)]
 		[Field ("ASExtensionLocalizedFailureReasonErrorKey")]
 		NSString LocalizedFailureReasonErrorKey { get; }

--- a/src/authenticationservices.cs
+++ b/src/authenticationservices.cs
@@ -49,14 +49,9 @@ namespace AuthenticationServices {
 	}
 
 	[Partial]
-#if TVOS || WATCH
-	// The associated enum is not generated (which is normal)
-	// without this define the attributes would be duplicated
-	// on other platforms (where the enum exists)
-	[NoTV][NoWatch]
-#endif
 	interface ASExtensionErrorCodeExtensions {
 
+		[NoTV][NoWatch]
 		[NoMac, iOS (14,0)]
 		[Field ("ASExtensionLocalizedFailureReasonErrorKey")]
 		NSString LocalizedFailureReasonErrorKey { get; }


### PR DESCRIPTION
They were not visible (or handled differently in `main`) but
become _small_ breaking changes once we released xcode12.5 support.


Backport of #11567
