### PR TITLE
[dotnet] Don't use an Output property to retrieve the list of native object files to link.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -545,8 +545,11 @@
 			SdkRoot="$(_SdkRoot)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 		>
-			<Output TaskParameter="ObjectFiles" ItemName="_NativeExecutableObjectFiles" />
 		</CompileNativeCode>
+
+		<ItemGroup>
+			<_NativeExecutableObjectFiles Include="@(_CompileNativeExecutableFile -> '%(OutputFile)')" />
+		</ItemGroup>
 	</Target>
 
 	<PropertyGroup>


### PR DESCRIPTION
If the task that creates the native object files doesn't execute (because the
native object files already exists and are up-to-date), the resulting list of
native object files to link will be empty.

This typically happens for a rebuild: if a native linker error occurs when
linking the main executable, building again will result in a successful build,
because we wouldn't try to link the main executable again.