### PR TITLE
[msbuild/dotnet] Add support for NativeReference items. Fixes #11061.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -685,7 +685,7 @@
 			LinkerFlags="@(_BindingLibraryLinkerFlags);@(_ReferencesLinkerFlags);@(_MainLinkerFlags)"
 			LinkWithLibraries="@(_XamarinMainLibraries);@(_BindingLibraryLinkWith);@(_MainLinkWith)"
 			MinimumOSVersion="$(_MinimumOSVersion)"
-			NativeReferences="@(NativeReference)"
+			NativeReferences="@(_FileNativeReference);@(_FrameworkNativeReference)"
 			ObjectFiles="@(_NativeExecutableObjectFiles)"
 			OutputFile="$(_IntermediateNativeLibraryDir)$(_NativeExecutableName)"
 			SdkDevPath="$(_SdkDevPath)"

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -179,6 +179,8 @@
 			_ResolveAppExtensionReferences;
 			_ExtendAppExtensionReferences;
 			_ComputeLinkerArguments;
+			_ComputeFrameworkFilesToPublish;
+			_ComputeDynamicLibrariesToPublish;
 			ComputeFilesToPublish;
 			_LoadLinkerOutput;
 			_CompileNativeExecutable;
@@ -328,6 +330,43 @@
 		<WriteLinesToFile SessionId="$(BuildSessionId)" File="$(_CustomLinkerOptionsFile)" Lines="$(_CustomLinkerOptions)" Overwrite="true" />
 	</Target>
 
+	<!-- Look in the NativeReference items for frameworks that need to be added to the app bundle, and add all those frameworks to ResolvedFileToPublish (as separate files) -->
+	<Target Name="_ComputeFrameworkFilesToPublish" DependsOnTargets="_ExpandNativeReferences;_ComputeVariables">
+		<ItemGroup>
+			<!-- Expand each framework (which are directories) into all the files in the framework -->
+			<!-- Support a 'CopyToAppBundle' metadata that can be set to 'false' to avoid copying a framework to the app bundle -->
+			<_FrameworkFilesToPublish Include="%(_FrameworkNativeReference.RootDir)%(_FrameworkNativeReference.Directory)/**/*" Condition="'%(_FrameworkNativeReference.Kind)' == 'Framework' And '%(_FrameworkNativeReference.CopyToAppBundle)' != 'false'">
+				<_FrameworkIdentity>%(RootDir)%(Directory)</_FrameworkIdentity>
+				<_FrameworkPath>$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_AppBundleFrameworksDir)))\%(Filename).framework</_FrameworkPath>
+				<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+			</_FrameworkFilesToPublish>
+
+			<!-- Compute the relative path of each file in the framework relative to the framework directory -->
+			<_FrameworkFilesToPublish Update="@(_FrameworkFilesToPublish)">
+				<_FrameworkRelativePath>$([System.String]::Copy('%(Identity)').Substring($([System.String]::Copy('%(_FrameworkIdentity)').Length)))</_FrameworkRelativePath>
+			</_FrameworkFilesToPublish>
+
+			<!-- Add all the framework files to ResolvedFileToPublish -->
+			<ResolvedFileToPublish Include="@(_FrameworkFilesToPublish)">
+				<RelativePath>%(_FrameworkFilesToPublish._FrameworkPath)\%(_FrameworkFilesToPublish._FrameworkRelativePath)</RelativePath>
+			</ResolvedFileToPublish>
+		</ItemGroup>
+	</Target>
+
+	<!-- Look in the NativeReference items for dylibs that need to be added to the app bundle, and add all those frameworks to ResolvedFileToPublish (as separate files) -->
+	<Target Name="_ComputeDynamicLibrariesToPublish" DependsOnTargets="_ExpandNativeReferences;_ComputeVariables">
+		<ItemGroup>
+			<!-- Support a 'CopyToAppBundle' metadata that can be set to 'false' to avoid copying a framework to the app bundle -->
+			<_DynamicLibraryToPublish Include="@(_FileNativeReference)" Condition="'%(_FileNativeReference.Kind)' == 'Dynamic' And '%(_FileNativeReference.CopyToAppBundle)' != 'false'">
+				<RelativePath>$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)$(PublishDir),$(_AppBundleFrameworksDir)))\$(_DylibRelativePath)%(Filename)%(Extension)</RelativePath>
+				<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+			</_DynamicLibraryToPublish>
+
+			<!-- Add all the dynamic libraries to ResolvedFileToPublish -->
+			<ResolvedFileToPublish Include="@(_DynamicLibraryToPublish)" />
+		</ItemGroup>
+	</Target>
+
 	<Target Name="_LoadLinkerOutput">
 		<!-- Load _MainFile -->
 		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_MainFile.items" Condition="Exists('$(_LinkerItemsDirectory)/_MainFile.items')">
@@ -412,6 +451,8 @@
 			<_NativeExecutableName>$(_AppBundleName)</_NativeExecutableName>
 			<_NativeExecutablePublishDir Condition="'$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS'">$(MSBuildProjectDirectory)$(_AppBundlePath)\</_NativeExecutablePublishDir>
 			<_NativeExecutablePublishDir Condition="'$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst'">$(MSBuildProjectDirectory)$(_AppBundlePath)\Contents\MacOS\</_NativeExecutablePublishDir>
+			<_AppBundleFrameworksDir Condition="'$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS'">$(MSBuildProjectDirectory)$(_AppBundlePath)\Frameworks\</_AppBundleFrameworksDir>
+			<_AppBundleFrameworksDir Condition="'$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst'">$(MSBuildProjectDirectory)$(_AppBundlePath)\Contents\Frameworks\</_AppBundleFrameworksDir>
 
 			<_AOTCompiler>$(_MonoRuntimePackPath)native/cross/$(RuntimeIdentifier)/mono-aot-cross</_AOTCompiler>
 			<_AOTInputDirectory>$(_IntermediateNativeLibraryDir)aot-input/</_AOTInputDirectory>
@@ -430,6 +471,15 @@
 			<_LibXamarinDebug Condition="'$(_BundlerDebug)' == 'true'">-debug</_LibXamarinDebug>
 			<_LibXamarinName Condition="'$(_LibXamarinName)' == ''">libxamarin-dotnet$(_LibXamarinRuntime)$(_LibXamarinDebug).$(_LibXamarinExtension)</_LibXamarinName>
 
+			<!-- the path relative to the root of the app bundle where dynamic libraries should be placed -->
+			<_DylibRelativePath Condition="'$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS'">/</_DylibRelativePath>
+			<_DylibRelativePath Condition="'$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst'">Contents/$(_CustomBundleName)/</_DylibRelativePath>
+
+			<_DylibRPath Condition="'$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS'">@executable_path</_DylibRPath>
+			<_DylibRPath Condition="'$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst'">@executable_path/../$(_CustomBundleName)/</_DylibRPath>
+
+			<_EmbeddedFrameworksRPath Condition="'$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS'">@executable_path/Frameworks</_EmbeddedFrameworksRPath>
+			<_EmbeddedFrameworksRPath Condition="'$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst'">@executable_path/../Frameworks/</_EmbeddedFrameworksRPath>
 		</PropertyGroup>
 
 		<ItemGroup>
@@ -606,18 +656,15 @@
 			Inputs="@(_NativeExecutableObjectFiles)"
 			Outputs="$(_IntermediateNativeLibraryDir)$(_NativeExecutableName)"
 		>
-
-		<PropertyGroup>
-			<_DylibRPath Condition="'$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS'">@executable_path</_DylibRPath>
-			<_DylibRPath Condition="'$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst'">@executable_path/../$(_CustomBundleName)/</_DylibRPath>
-		</PropertyGroup>
-
 		<ItemGroup>
 			<_XamarinMainLibraries Include="$(_XamarinNativeLibraryDirectory)/$(_LibXamarinName)" />
 			<!-- Link with the libraries shipped with the mono runtime pack -->
 			<_XamarinMainLibraries Include="@(_MonoLibrary)" Condition="'$(_PlatformName)' != 'macOS'" />
 			<!-- But don't link with any dylibs on macOS, because they might have library initializers which may fail - instead delay any failures until whatever feature they provide is needed -->
 			<_XamarinMainLibraries Include="@(_MonoLibrary)" Condition="'$(_PlatformName)' == 'macOS' And ('%(_MonoLibrary.Extension)' == '.a' Or '%(_MonoLibrary.Filename)' == 'libcoreclr')" />
+			<!-- Link with static libraries from NativeReference items ((xc)frameworks are handled in the _ComputeFrameworkFilesToPublish target, and dynamic libraries are handled in the _ComputeDynamicLibrariesToPublish target) -->
+			<_XamarinMainLibraries Include="@(_FileNativeReference)" />
+
 			<!-- The frameworks we need to link with (both weakly and normally) -->
 			<_NativeExecutableFrameworks Include="@(_LinkerFrameworks)" />
 
@@ -633,10 +680,12 @@
 			SessionId="$(BuildSessionId)"
 			DylibRPath="$(_DylibRPath)"
 			EntitlementsInExecutable="$(_CompiledEntitlements)"
+			FrameworkRPath="$(_EmbeddedFrameworksRPath)"
 			Frameworks="@(_NativeExecutableFrameworks);@(_BindingLibraryFrameworks)"
 			LinkerFlags="@(_BindingLibraryLinkerFlags);@(_ReferencesLinkerFlags);@(_MainLinkerFlags)"
 			LinkWithLibraries="@(_XamarinMainLibraries);@(_BindingLibraryLinkWith);@(_MainLinkWith)"
 			MinimumOSVersion="$(_MinimumOSVersion)"
+			NativeReferences="@(NativeReference)"
 			ObjectFiles="@(_NativeExecutableObjectFiles)"
 			OutputFile="$(_IntermediateNativeLibraryDir)$(_NativeExecutableName)"
 			SdkDevPath="$(_SdkDevPath)"

--- a/msbuild/Xamarin.MacDev.Tasks.Core/LinkerOptions.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/LinkerOptions.cs
@@ -37,25 +37,13 @@ namespace Xamarin.MacDev.Tasks {
 				}
 
 				if (kind == NativeReferenceKind.Static) {
-					var libName = Path.GetFileName (item.ItemSpec);
-
-					if (libName.EndsWith (".a", StringComparison.Ordinal))
-						libName = libName.Substring (0, libName.Length - 2);
-
-					if (libName.StartsWith ("lib", StringComparison.Ordinal))
-						libName = libName.Substring (3);
-
-					if (!string.IsNullOrEmpty (Path.GetDirectoryName (item.ItemSpec)))
-						Arguments.AddQuoted ("-L" + Path.GetDirectoryName (item.ItemSpec));
-
-					Arguments.AddQuoted ("-l" + libName);
-
 					value = item.GetMetadata ("ForceLoad");
 
 					if (!string.IsNullOrEmpty (value) && bool.TryParse (value, out boolean) && boolean) {
 						Arguments.Add ("-force_load");
-						Arguments.AddQuoted (item.ItemSpec);
 					}
+
+					Arguments.AddQuoted (item.ItemSpec);
 
 					value = item.GetMetadata ("IsCxx");
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/LinkerOptions.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/LinkerOptions.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Localization.MSBuild;
+
+namespace Xamarin.MacDev.Tasks {
+	public class LinkerOptions {
+		public CommandLineArgumentBuilder Arguments { get; private set; }
+		public HashSet<string> WeakFrameworks { get; private set; }
+		public HashSet<string> Frameworks { get; private set; }
+		public bool Cxx { get; set; }
+
+		public LinkerOptions ()
+		{
+			Arguments = new CommandLineArgumentBuilder ();
+			WeakFrameworks = new HashSet<string> ();
+			Frameworks = new HashSet<string> ();
+		}
+
+		public void BuildNativeReferenceFlags (TaskLoggingHelper Log, ITaskItem[] NativeReferences)
+		{
+			if (NativeReferences == null)
+				return;
+
+			foreach (var item in NativeReferences) {
+				var value = item.GetMetadata ("Kind");
+				NativeReferenceKind kind;
+				bool boolean;
+
+				if (string.IsNullOrEmpty (value) || !Enum.TryParse (value, out kind)) {
+					Log.LogWarning (MSBStrings.W0051, item.ItemSpec);
+					continue;
+				}
+
+				if (kind == NativeReferenceKind.Static) {
+					var libName = Path.GetFileName (item.ItemSpec);
+
+					if (libName.EndsWith (".a", StringComparison.Ordinal))
+						libName = libName.Substring (0, libName.Length - 2);
+
+					if (libName.StartsWith ("lib", StringComparison.Ordinal))
+						libName = libName.Substring (3);
+
+					if (!string.IsNullOrEmpty (Path.GetDirectoryName (item.ItemSpec)))
+						Arguments.AddQuoted ("-L" + Path.GetDirectoryName (item.ItemSpec));
+
+					Arguments.AddQuoted ("-l" + libName);
+
+					value = item.GetMetadata ("ForceLoad");
+
+					if (!string.IsNullOrEmpty (value) && bool.TryParse (value, out boolean) && boolean) {
+						Arguments.Add ("-force_load");
+						Arguments.AddQuoted (item.ItemSpec);
+					}
+
+					value = item.GetMetadata ("IsCxx");
+
+					if (!string.IsNullOrEmpty (value) && bool.TryParse (value, out boolean) && boolean)
+						Cxx = true;
+				} else if (kind == NativeReferenceKind.Framework) {
+					var path = item.ItemSpec;
+					// in case the full path to the library is given (msbuild)
+					if (Path.GetExtension (path) != ".framework")
+						path = Path.GetDirectoryName (path);
+					Frameworks.Add (path);
+				} else {
+					Log.LogWarning (MSBStrings.W0052, item.ItemSpec);
+					continue;
+				}
+
+				value = item.GetMetadata ("NeedsGccExceptionHandling");
+				if (!string.IsNullOrEmpty (value) && bool.TryParse (value, out boolean) && boolean) {
+					if (!Arguments.Contains ("-lgcc_eh"))
+						Arguments.Add ("-lgcc_eh");
+				}
+
+				value = item.GetMetadata ("WeakFrameworks");
+				if (!string.IsNullOrEmpty (value)) {
+					foreach (var framework in value.Split (' ', '\t'))
+						WeakFrameworks.Add (framework);
+				}
+
+				value = item.GetMetadata ("Frameworks");
+				if (!string.IsNullOrEmpty (value)) {
+					foreach (var framework in value.Split (' ', '\t'))
+						Frameworks.Add (framework);
+				}
+
+				// Note: these get merged into gccArgs by our caller
+				value = item.GetMetadata ("LinkerFlags");
+				if (!string.IsNullOrEmpty (value)) {
+					var linkerFlags = CommandLineArgumentBuilder.Parse (value);
+
+					foreach (var flag in linkerFlags)
+						Arguments.AddQuoted (flag);
+				}
+			}
+		}
+	}
+}
+

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ResolveFrameworksBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ResolveFrameworksBase.cs
@@ -57,6 +57,12 @@ namespace Xamarin.MacDev.Tasks {
 							var t = new TaskItem (resolved);
 							t.SetMetadata ("Kind", "Framework");
 							t.SetMetadata ("Name", resolved);
+
+							// add some metadata from the original item
+							var addToAppBundle = nr.GetMetadata ("AddToAppBundle");
+							if (!string.IsNullOrEmpty (addToAppBundle))
+								t.SetMetadata ("AddToAppBundle", addToAppBundle);
+
 							native_frameworks.Add (t);
 						}
 						break;

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/AppDelegate.cs
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/AppDelegate.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+namespace NativeDynamicLibraryReferencesApp
+{
+	public class Program
+	{
+		[DllImport ("libtest.dylib")]
+		static extern int theUltimateAnswer ();
+
+		static int Main (string[] args)
+		{
+			Console.WriteLine ($"Dynamic library: {theUltimateAnswer ()}");
+
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+
+			return 0;
+		}
+	}
+}

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/Info.plist
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>MinimumOSVersion</key>
+	<string>10.0</string>
+	<key>XSAppIconAssets</key>
+	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
+	<key>XSLaunchImageAssets</key>
+	<string>Resources/Images.xcassets/LaunchImage.launchimage</string>
+</dict>
+</plist>

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/Makefile
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/Makefile
@@ -17,14 +17,7 @@ all-mac: prepare
 	$(DOTNET6) build macOS/*.csproj /bl
 
 run-mac:
-	./macOS/bin/Debug/net6.0-macos/osx-x64/NativeReferences.app/Contents/MacOS/NativeReferences
-
-build:
-	cd $(TOP) && rm -Rf _build
-	cd $(TOP)/dotnet && git clean -xfd
-	cd $(TOP)/tests && git clean -xfd
-	cd $(TOP)/msbuild && git clean -xfd
-	unset MSBuildEnableWorkloadResolver && $(MAKE) -C $(TOP) all -j9 && $(MAKE) -C $(TOP) install -j9
+	./macOS/bin/Debug/net6.0-macos/osx-x64/$(notdir $(CURDIR)).app/Contents/MacOS/$(notdir $(CURDIR))
 
 diag:
 	cd .. && $(MAKE) global.json NuGet.config

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/Makefile
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/Makefile
@@ -1,0 +1,31 @@
+TOP=../../..
+
+include $(TOP)/Make.config
+
+# This is a temporary variable to enable the .NET workload resolver, because it's opt-in for now.
+# Ref: https://github.com/dotnet/sdk/issues/13849
+export MSBuildEnableWorkloadResolver=true
+
+prepare:
+	cd .. && $(MAKE) global.json NuGet.config
+	rm -Rf */bin */obj
+
+all-ios: prepare
+	$(DOTNET6) build iOS/*.csproj /bl
+
+all-mac: prepare
+	$(DOTNET6) build macOS/*.csproj /bl
+
+run-mac:
+	./macOS/bin/Debug/net6.0-macos/osx-x64/NativeReferences.app/Contents/MacOS/NativeReferences
+
+build:
+	cd $(TOP) && rm -Rf _build
+	cd $(TOP)/dotnet && git clean -xfd
+	cd $(TOP)/tests && git clean -xfd
+	cd $(TOP)/msbuild && git clean -xfd
+	unset MSBuildEnableWorkloadResolver && $(MAKE) -C $(TOP) all -j9 && $(MAKE) -C $(TOP) install -j9
+
+diag:
+	cd .. && $(MAKE) global.json NuGet.config
+	$(DOTNET6) build /v:diag *binlog

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/iOS/NativeDynamicLibraryReferencesApp.csproj
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/iOS/NativeDynamicLibraryReferencesApp.csproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-ios</TargetFramework>
+		<RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
+		<FatName>ios-fat</FatName>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>
+

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/macOS/NativeDynamicLibraryReferencesApp.csproj
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/macOS/NativeDynamicLibraryReferencesApp.csproj
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-macos</TargetFramework>
+		<RuntimeIdentifier>osx-x64</RuntimeIdentifier>
+		<FatName>macos-fat</FatName>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/shared.csproj
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/shared.csproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+
+		<ApplicationTitle>NativeDynamicLibraryReferences</ApplicationTitle>
+		<ApplicationId>com.xamarin.nativedynamiclibraryreferences</ApplicationId>
+		<ApplicationVersion>1.0</ApplicationVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<NativeReference Include="..\..\..\test-libraries\.libs\$(FatName)\libtest.dylib" Kind="Dynamic" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+		<None Include="../Info.plist">
+			<Link>Info.plist</Link>
+		</None>
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/NativeFileReferencesApp/AppDelegate.cs
+++ b/tests/dotnet/NativeFileReferencesApp/AppDelegate.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+namespace NativeFileReferencesApp
+{
+	public class Program
+	{
+		// This comes from libtest.a
+		[DllImport ("__Internal")]
+		static extern int theUltimateAnswer ();
+
+		// This comes from libtest2.a
+		[DllImport ("__Internal")]
+		static extern int getIntOfChocolate ();
+
+		static int Main (string[] args)
+		{
+			Console.WriteLine ($"libtest.a: {theUltimateAnswer ()}");
+			Console.WriteLine ($"libtest2.a: {getIntOfChocolate ()}");
+
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+
+			return 0;
+		}
+	}
+}

--- a/tests/dotnet/NativeFileReferencesApp/Info.plist
+++ b/tests/dotnet/NativeFileReferencesApp/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>MinimumOSVersion</key>
+	<string>10.0</string>
+	<key>XSAppIconAssets</key>
+	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
+	<key>XSLaunchImageAssets</key>
+	<string>Resources/Images.xcassets/LaunchImage.launchimage</string>
+</dict>
+</plist>

--- a/tests/dotnet/NativeFileReferencesApp/Makefile
+++ b/tests/dotnet/NativeFileReferencesApp/Makefile
@@ -1,0 +1,31 @@
+TOP=../../..
+
+include $(TOP)/Make.config
+
+# This is a temporary variable to enable the .NET workload resolver, because it's opt-in for now.
+# Ref: https://github.com/dotnet/sdk/issues/13849
+export MSBuildEnableWorkloadResolver=true
+
+prepare:
+	cd .. && $(MAKE) global.json NuGet.config
+	rm -Rf */bin */obj
+
+all-ios: prepare
+	$(DOTNET6) build iOS/*.csproj /bl
+
+all-mac: prepare
+	$(DOTNET6) build macOS/*.csproj /bl
+
+run-mac:
+	/Users/rolf/work/maccore/whatever/xamarin-macios/tests/dotnet/NativeReferencesApp/macOS/bin/Debug/net6.0-macos/osx-x64/NativeReferences.app/Contents/MacOS/NativeReferences
+
+build:
+	cd $(TOP) && rm -Rf _build
+	cd $(TOP)/dotnet && git clean -xfd
+	cd $(TOP)/tests && git clean -xfd
+	cd $(TOP)/msbuild && git clean -xfd
+	unset MSBuildEnableWorkloadResolver && $(MAKE) -C $(TOP) all -j9 && $(MAKE) -C $(TOP) install -j9
+
+diag:
+	cd .. && $(MAKE) global.json NuGet.config
+	$(DOTNET6) build /v:diag *binlog

--- a/tests/dotnet/NativeFileReferencesApp/Makefile
+++ b/tests/dotnet/NativeFileReferencesApp/Makefile
@@ -17,14 +17,7 @@ all-mac: prepare
 	$(DOTNET6) build macOS/*.csproj /bl
 
 run-mac:
-	/Users/rolf/work/maccore/whatever/xamarin-macios/tests/dotnet/NativeReferencesApp/macOS/bin/Debug/net6.0-macos/osx-x64/NativeReferences.app/Contents/MacOS/NativeReferences
-
-build:
-	cd $(TOP) && rm -Rf _build
-	cd $(TOP)/dotnet && git clean -xfd
-	cd $(TOP)/tests && git clean -xfd
-	cd $(TOP)/msbuild && git clean -xfd
-	unset MSBuildEnableWorkloadResolver && $(MAKE) -C $(TOP) all -j9 && $(MAKE) -C $(TOP) install -j9
+	./macOS/bin/Debug/net6.0-macos/osx-x64/$(notdir $(CURDIR)).app/Contents/MacOS/$(notdir $(CURDIR))
 
 diag:
 	cd .. && $(MAKE) global.json NuGet.config

--- a/tests/dotnet/NativeFileReferencesApp/iOS/NativeFileReferencesApp.csproj
+++ b/tests/dotnet/NativeFileReferencesApp/iOS/NativeFileReferencesApp.csproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-ios</TargetFramework>
+		<RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
+		<FatName>ios-fat</FatName>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>
+

--- a/tests/dotnet/NativeFileReferencesApp/macOS/NativeFileReferencesApp.csproj
+++ b/tests/dotnet/NativeFileReferencesApp/macOS/NativeFileReferencesApp.csproj
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-macos</TargetFramework>
+		<RuntimeIdentifier>osx-x64</RuntimeIdentifier>
+		<FatName>macos-fat</FatName>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/NativeFileReferencesApp/shared.csproj
+++ b/tests/dotnet/NativeFileReferencesApp/shared.csproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+
+		<ApplicationTitle>NativeFileReferences</ApplicationTitle>
+		<ApplicationId>com.xamarin.nativefilereferences</ApplicationId>
+		<ApplicationVersion>1.0</ApplicationVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<NativeReference Include="..\..\..\test-libraries\.libs\$(FatName)\libtest.a" Kind="Static" />
+		<NativeReference Include="..\..\..\test-libraries\.libs\$(FatName)\libtest2.a" Kind="Static" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+		<None Include="../Info.plist">
+			<Link>Info.plist</Link>
+		</None>
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/NativeFrameworkReferencesApp/AppDelegate.cs
+++ b/tests/dotnet/NativeFrameworkReferencesApp/AppDelegate.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+namespace NativeFrameworkReferencesApp
+{
+	public class Program
+	{
+		[DllImport ("XTest.framework/XTest")]
+		static extern int theUltimateAnswer ();
+
+		// This comes from XStaticArTest.framework
+		[DllImport ("__Internal")]
+		static extern int ar_theUltimateAnswer ();
+
+		// This comes from XStaticObjectTest.framework
+		[DllImport ("__Internal", EntryPoint = "theUltimateAnswer")]
+		static extern int object_theUltimateAnswer ();
+
+		static int Main (string[] args)
+		{
+			Console.WriteLine ($"Framework: {theUltimateAnswer ()}");
+			Console.WriteLine ($"Framework with ar files: {ar_theUltimateAnswer ()}");
+			Console.WriteLine ($"Framework with object files: {object_theUltimateAnswer ()}");
+
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+
+			return 0;
+		}
+	}
+}

--- a/tests/dotnet/NativeFrameworkReferencesApp/Info.plist
+++ b/tests/dotnet/NativeFrameworkReferencesApp/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>MinimumOSVersion</key>
+	<string>10.0</string>
+	<key>XSAppIconAssets</key>
+	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
+	<key>XSLaunchImageAssets</key>
+	<string>Resources/Images.xcassets/LaunchImage.launchimage</string>
+</dict>
+</plist>

--- a/tests/dotnet/NativeFrameworkReferencesApp/Makefile
+++ b/tests/dotnet/NativeFrameworkReferencesApp/Makefile
@@ -1,0 +1,31 @@
+TOP=../../..
+
+include $(TOP)/Make.config
+
+# This is a temporary variable to enable the .NET workload resolver, because it's opt-in for now.
+# Ref: https://github.com/dotnet/sdk/issues/13849
+export MSBuildEnableWorkloadResolver=true
+
+prepare:
+	cd .. && $(MAKE) global.json NuGet.config
+	rm -Rf */bin */obj
+
+all-ios: prepare
+	$(DOTNET6) build iOS/*.csproj /bl
+
+all-mac: prepare
+	$(DOTNET6) build macOS/*.csproj /bl
+
+run-mac:
+	/Users/rolf/work/maccore/whatever/xamarin-macios/tests/dotnet/NativeReferencesApp/macOS/bin/Debug/net6.0-macos/osx-x64/NativeReferences.app/Contents/MacOS/NativeReferences
+
+build:
+	cd $(TOP) && rm -Rf _build
+	cd $(TOP)/dotnet && git clean -xfd
+	cd $(TOP)/tests && git clean -xfd
+	cd $(TOP)/msbuild && git clean -xfd
+	unset MSBuildEnableWorkloadResolver && $(MAKE) -C $(TOP) all -j9 && $(MAKE) -C $(TOP) install -j9
+
+diag:
+	cd .. && $(MAKE) global.json NuGet.config
+	$(DOTNET6) build /v:diag *binlog

--- a/tests/dotnet/NativeFrameworkReferencesApp/Makefile
+++ b/tests/dotnet/NativeFrameworkReferencesApp/Makefile
@@ -17,14 +17,7 @@ all-mac: prepare
 	$(DOTNET6) build macOS/*.csproj /bl
 
 run-mac:
-	/Users/rolf/work/maccore/whatever/xamarin-macios/tests/dotnet/NativeReferencesApp/macOS/bin/Debug/net6.0-macos/osx-x64/NativeReferences.app/Contents/MacOS/NativeReferences
-
-build:
-	cd $(TOP) && rm -Rf _build
-	cd $(TOP)/dotnet && git clean -xfd
-	cd $(TOP)/tests && git clean -xfd
-	cd $(TOP)/msbuild && git clean -xfd
-	unset MSBuildEnableWorkloadResolver && $(MAKE) -C $(TOP) all -j9 && $(MAKE) -C $(TOP) install -j9
+	./macOS/bin/Debug/net6.0-macos/osx-x64/$(notdir $(CURDIR)).app/Contents/MacOS/$(notdir $(CURDIR))
 
 diag:
 	cd .. && $(MAKE) global.json NuGet.config

--- a/tests/dotnet/NativeFrameworkReferencesApp/iOS/NativeFrameworkReferencesApp.csproj
+++ b/tests/dotnet/NativeFrameworkReferencesApp/iOS/NativeFrameworkReferencesApp.csproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-ios</TargetFramework>
+		<RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
+		<FatName>ios-fat</FatName>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>
+

--- a/tests/dotnet/NativeFrameworkReferencesApp/macOS/NativeFrameworkReferencesApp.csproj
+++ b/tests/dotnet/NativeFrameworkReferencesApp/macOS/NativeFrameworkReferencesApp.csproj
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-macos</TargetFramework>
+		<RuntimeIdentifier>osx-x64</RuntimeIdentifier>
+		<FatName>macos-fat</FatName>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/NativeFrameworkReferencesApp/shared.csproj
+++ b/tests/dotnet/NativeFrameworkReferencesApp/shared.csproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+
+		<ApplicationTitle>NativeFrameworkReferences</ApplicationTitle>
+		<ApplicationId>com.xamarin.nativeframeworkreferences</ApplicationId>
+		<ApplicationVersion>1.0</ApplicationVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<NativeReference Include="..\..\..\test-libraries\.libs\$(FatName)\XTest.framework" Kind="Framework" />
+		<NativeReference Include="..\..\..\test-libraries\.libs\$(FatName)\XStaticArTest.framework" Kind="Framework" CopyToAppBundle="false" />
+		<NativeReference Include="..\..\..\test-libraries\.libs\$(FatName)\XStaticObjectTest.framework" Kind="Framework" CopyToAppBundle="false" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+		<None Include="../Info.plist">
+			<Link>Info.plist</Link>
+		</None>
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/AppDelegate.cs
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/AppDelegate.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+namespace NativeFrameworkReferencesApp
+{
+	public class Program
+	{
+		[DllImport ("XTest.framework/XTest")]
+		static extern int theUltimateAnswer ();
+
+		static int Main (string[] args)
+		{
+			Console.WriteLine ($"XCFramework: {theUltimateAnswer ()}");
+
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+
+			return 0;
+		}
+	}
+}

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/Info.plist
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>MinimumOSVersion</key>
+	<string>10.0</string>
+	<key>XSAppIconAssets</key>
+	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
+	<key>XSLaunchImageAssets</key>
+	<string>Resources/Images.xcassets/LaunchImage.launchimage</string>
+</dict>
+</plist>

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/Makefile
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/Makefile
@@ -1,0 +1,31 @@
+TOP=../../..
+
+include $(TOP)/Make.config
+
+# This is a temporary variable to enable the .NET workload resolver, because it's opt-in for now.
+# Ref: https://github.com/dotnet/sdk/issues/13849
+export MSBuildEnableWorkloadResolver=true
+
+prepare:
+	cd .. && $(MAKE) global.json NuGet.config
+	rm -Rf */bin */obj
+
+all-ios: prepare
+	$(DOTNET6) build iOS/*.csproj /bl
+
+all-mac: prepare
+	$(DOTNET6) build macOS/*.csproj /bl
+
+run-mac:
+	/Users/rolf/work/maccore/whatever/xamarin-macios/tests/dotnet/NativeReferencesApp/macOS/bin/Debug/net6.0-macos/osx-x64/NativeReferences.app/Contents/MacOS/NativeReferences
+
+build:
+	cd $(TOP) && rm -Rf _build
+	cd $(TOP)/dotnet && git clean -xfd
+	cd $(TOP)/tests && git clean -xfd
+	cd $(TOP)/msbuild && git clean -xfd
+	unset MSBuildEnableWorkloadResolver && $(MAKE) -C $(TOP) all -j9 && $(MAKE) -C $(TOP) install -j9
+
+diag:
+	cd .. && $(MAKE) global.json NuGet.config
+	$(DOTNET6) build /v:diag *binlog

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/Makefile
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/Makefile
@@ -17,14 +17,7 @@ all-mac: prepare
 	$(DOTNET6) build macOS/*.csproj /bl
 
 run-mac:
-	/Users/rolf/work/maccore/whatever/xamarin-macios/tests/dotnet/NativeReferencesApp/macOS/bin/Debug/net6.0-macos/osx-x64/NativeReferences.app/Contents/MacOS/NativeReferences
-
-build:
-	cd $(TOP) && rm -Rf _build
-	cd $(TOP)/dotnet && git clean -xfd
-	cd $(TOP)/tests && git clean -xfd
-	cd $(TOP)/msbuild && git clean -xfd
-	unset MSBuildEnableWorkloadResolver && $(MAKE) -C $(TOP) all -j9 && $(MAKE) -C $(TOP) install -j9
+	./macOS/bin/Debug/net6.0-macos/osx-x64/$(notdir $(CURDIR)).app/Contents/MacOS/$(notdir $(CURDIR))
 
 diag:
 	cd .. && $(MAKE) global.json NuGet.config

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/iOS/NativeXCFrameworkReferencesApp.csproj
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/iOS/NativeXCFrameworkReferencesApp.csproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-ios</TargetFramework>
+		<RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
+		<FatName>ios-fat</FatName>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>
+

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/macOS/NativeXCFrameworkReferencesApp.csproj
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/macOS/NativeXCFrameworkReferencesApp.csproj
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-macos</TargetFramework>
+		<RuntimeIdentifier>osx-x64</RuntimeIdentifier>
+		<FatName>macos-fat</FatName>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/shared.csproj
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/shared.csproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+
+		<ApplicationTitle>NativeFrameworkReferences</ApplicationTitle>
+		<ApplicationId>com.xamarin.nativeframeworkreferences</ApplicationId>
+		<ApplicationVersion>1.0</ApplicationVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<NativeReference Include="..\..\..\test-libraries\.libs\XTest.xcframework" Kind="Framework" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+		<None Include="../Info.plist">
+			<Link>Info.plist</Link>
+		</None>
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -394,6 +394,8 @@ namespace Xamarin.Tests {
 		[TestCase ("NativeFileReferencesApp", ApplePlatform.MacOSX, "osx-x64")]
 		[TestCase ("NativeFrameworkReferencesApp", ApplePlatform.iOS, "iossimulator-x64")]
 		[TestCase ("NativeFrameworkReferencesApp", ApplePlatform.MacOSX, "osx-x64")]
+		[TestCase ("NativeXCFrameworkReferencesApp", ApplePlatform.iOS, "iossimulator-x64")]
+		[TestCase ("NativeXCFrameworkReferencesApp", ApplePlatform.MacOSX, "osx-x64")]
 		public void BuildAndExecuteNativeReferencesTestApp (string project, ApplePlatform platform, string runtimeIdentifier)
 		{
 			Configuration.IgnoreIfIgnoredPlatform (platform);

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -84,14 +84,14 @@ COMMON_DYLIB_ARGS=-g -dynamiclib -gdwarf-2 -fms-extensions libframework.m -o $$@
 .libs/$(1)/libtest.x86.dylib: ARCH=i386
 .libs/$(1)/libtest.%.dylib: libframework.m | .libs/$(1)
 	$$(call Q_2,CC,    [$(1)]) $$(XCODE_CC) $$(COMMON_DYLIB_ARGS) -arch $$(if $$(ARCH),$$(ARCH),$$*) $(5) $$($(2)_$$(shell echo $$* | tr a-z A-Z)_OBJC_CFLAGS)
-	$$(Q) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool -id @rpath/XTest.framework/XTest $$@
+	$$(Q) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool -id @rpath/libtest.dylib $$@
 
 ## The following arm64_32 rule is required for this to work with newer make versions, otherwise a rule in mk/rules.mk is chosen instead.
 ## The problem is that 'arm64_32' is longer than 'libtest', the former is a stem in the rule just above, while the latter is a rule in mk/rules.mk,
 ## and in newer make versions make will choose the rule that matches the shorter stem.
 .libs/$(1)/libtest.arm64_32.dylib: libframework.m | .libs/$(1)
 	$$(call Q_2,CC,    [$(1)]) $$(XCODE_CC) $$(COMMON_DYLIB_ARGS) -arch arm64_32 $(5) $$($(2)_$$(shell echo $$* | tr a-z A-Z)_OBJC_CFLAGS)
-	$$(Q) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool -id @rpath/XTest.framework/XTest $$@
+	$$(Q) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool -id @rpath/libtest.dylib $$@
 
 .libs/$(1)/libtest.dylib: $$(foreach arch,$(3),.libs/$(1)/libtest.$$(arch).dylib)
 	$$(call Q_2,LIPO   [$(1)]) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo $$^ -create -output $$@
@@ -99,6 +99,7 @@ COMMON_DYLIB_ARGS=-g -dynamiclib -gdwarf-2 -fms-extensions libframework.m -o $$@
 # XTest is a framework where the binary code is a (fat) dynamic library
 .libs/$(1)/XTest.framework/XTest: .libs/$(1)/libtest.dylib | .libs/$(1)/XTest.framework
 	$$(Q) $(CP) $$^ $$@
+	$$(Q) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool -id @rpath/XTest.framework/XTest $$@
 
 .libs/$(1)/XTest.framework/Info.plist: XTest-Info.plist | .libs/$(1)/XTest.framework
 	$$(Q) $(CP) $$^ $$@
@@ -201,10 +202,14 @@ endif
 .libs/$(1)/libtest2.a: .libs/$(2)/libtest2.a .libs/$(3)/libtest2.a | .libs/$(1)
 	$(Q) lipo -create -output $$@ $$^
 
+.libs/$(1)/libtest.dylib: .libs/$(2)/libtest.dylib .libs/$(3)/libtest.dylib | .libs/$(1)
+	$(Q) lipo -create -output $$@ $$^
+
 $(3)_TARGETS += \
 	.libs/$(1)/XTest.framework/XTest .libs/$(1)/XTest.framework/Info.plist \
 	.libs/$(1)/XStaticObjectTest.framework/XStaticObjectTest \
 	.libs/$(1)/XStaticArTest.framework/XStaticArTest \
+	.libs/$(1)/libtest.dylib \
 	.libs/$(1)/libtest.a \
 	.libs/$(1)/libtest2.a \
 

--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -225,7 +225,7 @@ namespace Xharness.Jenkins {
 				TestProject = buildDotNetTestsProject,
 				Platform = TestPlatform.All,
 				TestName = "DotNet tests",
-				Timeout = TimeSpan.FromMinutes (15),
+				Timeout = TimeSpan.FromMinutes (30),
 				Ignored = !IncludeDotNet,
 			};
 			Tasks.Add (runDotNetTests);

--- a/tools/common/ApplePlatform.cs
+++ b/tools/common/ApplePlatform.cs
@@ -34,5 +34,24 @@ namespace Xamarin.Utils
 				return "Unknown";
 			}
 		}
+
+		public static string ToFramework (this ApplePlatform @this)
+		{
+			var netVersion = "net6.0";
+			switch (@this) {
+			case ApplePlatform.iOS:
+				return netVersion + "-ios";
+			case ApplePlatform.MacOSX:
+				return netVersion + "-macos";
+			case ApplePlatform.WatchOS:
+				return netVersion + "-watchos";
+			case ApplePlatform.TVOS:
+				return netVersion + "-tvos";
+			case ApplePlatform.MacCatalyst:
+				return netVersion + "-maccatalyst";
+			default:
+				return "Unknown";
+			}
+		}
 	}
 }


### PR DESCRIPTION
* Pass any native references to the LinkNativeCode task so that they're linked
  with the main executable.
* Copy frameworks and dynamic libraries to the app bundle (also add support
  for MSBuild metadata - the CopyToAppBundle property - to avoid copying a
  framework / dynamic library to the app bundle).
* Refactor MTouchTaskBase a bit to make parts of it reusable from the
  LinkNativeCode task.
* Add tests.

Fixes https://github.com/xamarin/xamarin-macios/issues/11061.