### PR TITLE
[Runtime/CoreCLR] Only read/write a single byte for booleans when marshalling parameters in dynamic method calls for CoreCLR.

### DIFF
--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -286,7 +286,12 @@ namespace ObjCRuntime {
 			if (obj == null)
 				return;
 
-			Marshal.StructureToPtr (obj, ptr, false);
+			if (obj is bool b) {
+				// Only write a single byte for bools
+				Marshal.WriteByte (ptr, b ? (byte) 1 : (byte) 0);
+			} else {
+				Marshal.StructureToPtr (obj, ptr, false);
+			}
 		}
 
 		static IntPtr WriteStructure (object obj)
@@ -725,6 +730,10 @@ namespace ObjCRuntime {
 		{
 			if (ptr == IntPtr.Zero)
 				return null;
+
+			// Only read a single byte for bools.
+			if (type == typeof (bool))
+				return Marshal.ReadByte (ptr) != 0;
 
 			return Marshal.PtrToStructure (ptr, type);
 		}


### PR DESCRIPTION
Fixes this unit test:

    TestINativeObject: #b1
        Expected: 0
        But was: 140187942967200