### PR TITLE
[CoreCLR] Disable debug spew by default.

### DIFF
--- a/runtime/xamarin/coreclr-bridge.h
+++ b/runtime/xamarin/coreclr-bridge.h
@@ -8,8 +8,8 @@
 
 #include <stdatomic.h>
 
-//#define LOG_CORECLR(...)
-#define LOG_CORECLR(...) fprintf (__VA_ARGS__)
+#define LOG_CORECLR(...)
+//#define LOG_CORECLR(...) fprintf (__VA_ARGS__)
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
It just ends up flooding everything now because of the progress made.