### PR TITLE
[runtime] Throw a runtime exception instead of execution engine exception.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -521,10 +521,6 @@
 
 		#region metadata/exception.h
 
-		new Export ("MonoException *", "mono_get_exception_execution_engine",
-			"const char *", "msg"
-		),
-
 		new Export ("MonoException *", "mono_exception_from_name_msg",
 			"MonoImage *", "image",
 			"const char *", "name_space",

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -619,9 +619,10 @@ xamarin_get_handle (MonoObject *obj, GCHandle *exception_gchandle)
 		char *msg = xamarin_strdup_printf ("Unable to marshal from %s.%s to an Objective-C object. "
 									"The managed class must either inherit from NSObject or implement INativeObject.",
 									mono_class_get_namespace (klass), mono_class_get_name (klass));
-		MonoException *exc = mono_get_exception_execution_engine (msg);
+		GCHandle ex_handle = xamarin_create_runtime_exception (8039, msg, exception_gchandle);
 		xamarin_free (msg);
-		*exception_gchandle = xamarin_gchandle_new ((MonoObject *) exc, FALSE);
+		if (*exception_gchandle == INVALID_GCHANDLE)
+			*exception_gchandle = ex_handle;
 	}
 
 	xamarin_mono_object_release (&klass);

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -267,7 +267,9 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 							MonoClass *p_klass = mono_class_from_mono_type (p);
 							ADD_TO_MONOOBJECT_RELEASE_LIST (p_klass);
 							if (!mono_type_is_byref (p)) {
-								exception = (MonoObject *) mono_get_exception_execution_engine ("Invalid type encoding for parameter");
+								GCHandle ex_handle = xamarin_create_runtime_exception (8040, "Invalid type encoding for parameter", &exception_gchandle);
+								if (exception_gchandle == INVALID_GCHANDLE)
+									exception_gchandle = ex_handle;
 								goto exception_handling;
 							}
 							MonoReflectionMethod *rmethod = mono_method_get_object (domain, method, NULL);

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -2129,4 +2129,16 @@
 {2} - The name of a method.
 		</comment>
 	</data>
+
+	<data name="MX8039" xml:space="preserve">
+		<value>Unable to marshal from {0} to an Objective-C object. The managed class must either inherit from NSObject or implement INativeObject.</value>
+		<comment>
+{0} - The name of a type.
+		</comment>
+	</data>
+
+	<data name="MX8040" xml:space="preserve">
+		<value>Invalid type encoding for parameter.</value>
+	</data>
+
 </root>


### PR DESCRIPTION
* One less Mono Embedding method used: good for CoreCLR.
* More consistent with the rest of our code / behavior.