### PR TITLE
[d16-10] [Runtime] Don't skip dynamic user type checking as long as dynamic registration is supported.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1557,8 +1557,8 @@ namespace ObjCRuntime {
 					if (idx >= 0)
 						return (map [idx].flags & MTTypeFlags.UserType) == MTTypeFlags.UserType;
 					// If using the partial static registrar, we need to continue
-					// If full static registrar, we can return false
-					if ((options->Flags & InitializationFlags.IsPartialStaticRegistrar) != InitializationFlags.IsPartialStaticRegistrar)
+					// If full static registrar, we can return false, as long as the dynamic registrar is not supported
+					if (!DynamicRegistrationSupported && (options->Flags & InitializationFlags.IsPartialStaticRegistrar) != InitializationFlags.IsPartialStaticRegistrar)
 						return false;
 				}
 			}

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1546,6 +1546,7 @@ namespace ObjCRuntime {
 			throw new ArgumentException (string.Format ("'{0}' is an unknown protocol", type.FullName));
 		}
 
+		[BindingImpl (BindingImplOptions.Optimizable)]
 		internal static bool IsUserType (IntPtr self)
 		{
 			var cls = Class.object_getClass (self);

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2145,6 +2145,55 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 		}
 
+#if __MACOS__
+		[Test]
+		public void CustomUserTypeWithDynamicallyLoadedAssembly ()
+		{
+			var customTypeAssemblyPath = global::System.IO.Path.Combine (global::Xamarin.Tests.Configuration.RootPath, "tests", "test-libraries", "custom-type-assembly", ".libs", "macos", "custom-type-assembly.dll");
+			Assert.That (customTypeAssemblyPath, Does.Exist, "existence");
+
+			var size = 10;
+			var handles = new GCHandle [size];
+			var array = new NSMutableArray ();
+
+			// Create a bunch instances of a custom object the static registrar didn't know about at build time.
+			// We do this on a different thread to prevent the GC from finding these instances on the main thread's stack.
+			var thread = new Thread (() => {
+				var customTypeAssembly = global::System.Reflection.Assembly.LoadFrom (customTypeAssemblyPath);
+				var customType = customTypeAssembly.GetType ("MyCustomType");
+				for (var i = 0; i < size; i++) {
+					var obj = (NSObject) global::System.Activator.CreateInstance (customType);
+					array.Add (obj);
+					handles [i] = GCHandle.Alloc (obj, GCHandleType.Weak);
+				}
+				// Run the GC a couple of times.
+				GC.Collect ();
+				GC.WaitForPendingFinalizers ();
+				GC.Collect ();
+				GC.WaitForPendingFinalizers ();
+			}) {
+				IsBackground = true,
+				Name = "CustomUserTypeWithDynamicallyLoadedAssembly",
+			};
+			thread.Start ();
+			Assert.IsTrue (thread.Join (TimeSpan.FromSeconds (30)), "Background thread done");
+
+			// Run the main loop for a little while.
+			var counter = size;
+			TestRuntime.RunAsync (TimeSpan.FromSeconds (10), () => { }, () => counter-- <= 0 );
+
+			// Verify that none of the managed instances have been collected by the GC:
+			for (var i = 0; i < size; i++) {
+				Assert.IsNotNull (handles [i].Target, $"Target #{i}");
+				((NSObject) handles [i].Target).Dispose ();
+			}
+
+			// Make sure the GC doesn't collect our array of custom objects.
+			array.Dispose ();
+			GC.KeepAlive (array);
+		}
+#endif
+
 #if !__WATCHOS__ && !MONOMAC
 		class Bug28757A : NSObject, IUITableViewDataSource
 		{

--- a/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
@@ -48,6 +48,9 @@
     <Compile Include="..\..\..\api-shared\CoreFoundation\CFNotificationCenterTest.cs">
       <Link>CoreFoundation\CFNotificationCenterTest.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\common\Configuration.cs">
+      <Link>Configuration.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\common\TestRuntime.cs">
       <Link>TestRuntime.cs</Link>
     </Compile>
@@ -57,14 +60,35 @@
     <Compile Include="..\..\..\common\ConditionalCompilation.cs">
       <Link>ConditionalCompilation.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\common\ExecutionHelper.cs">
+      <Link>ExecutionHelper.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\common\Extensions.cs">
       <Link>Extensions.cs</Link>
     </Compile>
     <Compile Include="..\..\..\common\PlatformInfo.cs">
       <Link>PlatformInfo.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\common\Profile.cs">
+      <Link>Extensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\mtouch\Cache.cs">
+      <Link>Cache.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\common\mac\MacMain.cs">
       <Link>MacMain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\tools\common\ApplePlatform.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\tools\common\Execution.cs">
+      <Link>Execution.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\tools\common\TargetFramework.cs">
+      <Link>TargetFramework.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\tools\common\StringUtils.cs">
+      <Link>StringUtils.cs</Link>
     </Compile>
   </ItemGroup>
 
@@ -206,6 +230,7 @@
 
   <Target Name="BuildTestLibraries" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)" BeforeTargets="BeforeBuild" >
     <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />
+    <Exec Command="make -j8 -C $(TestLibrariesDirectory)/custom-type-assembly build-assembly" />
   </Target>
   <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
 </Project>

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -1,6 +1,8 @@
 TOP=../..
 include $(TOP)/Make.config
 
+SUBDIRS += custom-type-assembly
+
 # without this many compiler warnings about unused functions and variables
 # in system headers show up.
 export CCACHE_CPP2=1

--- a/tests/test-libraries/custom-type-assembly/Makefile
+++ b/tests/test-libraries/custom-type-assembly/Makefile
@@ -1,0 +1,14 @@
+TOP=../../..
+
+include $(TOP)/Make.config
+
+.libs/macos/custom-type-assembly.dll: custom-type-assembly.cs Makefile | .libs/macos
+	$(MAC_mobile_CSC) $< -out:$@ -r:$(TOP)/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/Xamarin.Mac/Xamarin.Mac.dll -target:library
+
+.libs/macos:
+	$(Q) mkdir -p $@
+
+TARGETS += \
+	.libs/macos/custom-type-assembly.dll \
+
+build-assembly: $(TARGETS)

--- a/tests/test-libraries/custom-type-assembly/custom-type-assembly.cs
+++ b/tests/test-libraries/custom-type-assembly/custom-type-assembly.cs
@@ -1,0 +1,6 @@
+using System;
+
+using Foundation;
+
+public class MyCustomType : NSObject {
+}

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -256,9 +256,11 @@
     <GeneratedTestInput Include="..\..\tests\test-libraries\*.m" />
     <GeneratedTestInput Include="..\..\tests\test-libraries\*.h" />
     <GeneratedTestInput Include="..\..\tests\test-libraries\*.cs" />
+    <GeneratedTestInput Include="..\..\tests\test-libraries\custom-type-assembly\*.cs" />
     <GeneratedTestInput Include="..\..\tests\test-libraries\Makefile" />
     <GeneratedTestOutput Include="..\..\tests\test-libraries\TrampolineTest.generated.cs" />
     <GeneratedTestOutput Include="..\..\tests\test-libraries\RegistrarTest.generated.cs" />
+    <GeneratedTestOutput Include="..\..\tests\test-libraries\custom-type-assembly\.libs\macos\custom-type-assembly.dll" />
     <CustomMetalSmeltingInput Include="..\monotouch-test\Resources\fragmentShader.metal" />
   </ItemGroup>
   <Target Name="CustomMetalSmelting" Inputs="@(CustomMetalSmeltingInput)" Outputs="$(_AppBundlePath)\Contents\Resources\fragmentShader.metallib" DependsOnTargets="_GenerateBundleName;_DetectSdkLocations">
@@ -268,5 +270,6 @@
   </Target>
   <Target Name="BeforeBuild" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)" DependsOnTargets="CustomMetalSmelting">
     <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />
+    <Exec Command="make -j8 -C $(TestLibrariesDirectory)/custom-type-assembly build-assembly" />
   </Target>
 </Project>


### PR DESCRIPTION
When checking whether a type is a user type or not, we might have to do a
dynamic check if the dynamic registrar is available. Otherwise we may run into
a situation where the static registrar ran during the app build, but then the
app loaded additional assemblies at runtime, and those assemblies contained
user types that were registered using the dynamic registrar, so the static
registrar doesn't know about those custom types (in other words: we need to
check at runtime).

Backport of #11588.