### PR TITLE
[d16-10] [CI] If api & generator fail also ignore in publish html.

### DIFF
--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -111,7 +111,11 @@ steps:
 
       $buildReason = "$(Build.Reason)"
       $buildSourceBranchName = "$(Build.SourceBranchName)"
-      $apiGeneratorComment= Join-Path -Path "$Env:STABLE_APID_GENERATOR_DIFF_PATH" -ChildPath "api-diff-comments.md"
+      if ($Env:STABLE_APID_GENERATOR_DIFF_PATH) {
+        $apiGeneratorComment= Join-Path -Path "$Env:STABLE_APID_GENERATOR_DIFF_PATH" -ChildPath "api-diff-comments.md"
+      } else {
+        $apiGeneratorComment = ""
+      }
 
       if ($buildReason -ne "PullRequest" -or $Env:BUILD_PACKAGE -eq "True") {
         Write-Host "Json path is $Env:ARTIFACTS_JSON_PATH"

--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -29,6 +29,10 @@ parameters:
   type: boolean
   default: true
 
+- name: apiGeneratorDiffBuilt
+  type: string 
+  default: true
+
 steps:
 
 - checkout: self
@@ -37,6 +41,7 @@ steps:
 - template: download-artifacts.yml 
   parameters:
     runTests: ${{ parameters.runTests }}
+    apiGeneratorDiffBuilt: ${{ contains(parameters.apiGeneratorDiffBuilt, 'True') }}
 
 - ${{ if eq(parameters.runTests, true) }}:
   - pwsh: |

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -190,4 +190,5 @@ jobs:
       statusContext: "Build"
       runTests: ${{ parameters.runTests }}
       vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
+      apiGeneratorDiffBuilt: $[ dependencies.build.outputs['apiGeneratorDiff.API_GENERATOR_BUILT'] ]
       devicePrefix: sim


### PR DESCRIPTION
Needed since it was forgotten in the original change.


Backport of #11570
