### PR TITLE
[Localization] Sync Localization branch with Main

### DIFF
--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -147,6 +147,16 @@ steps:
   continueOnError: true
   workingDirectory: $(Build.SourcesDirectory)\tools\devops 
 
+- powershell: |
+    git config user.email "valco@microsoft.com"
+    git config user.name "vs-mobiletools-engineering-service2"
+    git config --global user.password "$(githubToken)"
+    git checkout -b Localization origin/Localization
+    git merge origin/main
+    git push origin Localization
+  displayName: "Sync Localization branch with main"
+  condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'))
+
 - task: OneLocBuild@2
   condition: and(succeeded(), eq(variables.isMain, 'True'))
   continueOnError: true

--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -151,7 +151,6 @@ steps:
 - powershell: |
     git config user.email "valco@microsoft.com"
     git config user.name "vs-mobiletools-engineering-service2"
-    git config --global user.password "$(githubToken)"
     git checkout -b Localization origin/Localization
     git merge origin/main
     git push origin Localization

--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -11,6 +11,7 @@ steps:
 - checkout: self          # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
   clean: true             # Executes: git clean -ffdx && git reset --hard HEAD
   submodules: false
+  persistCredentials: true
 
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/tools/devops/automation/scripts/GitHub.psm1

--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -155,7 +155,7 @@ steps:
     git merge origin/main
     git push origin Localization
   displayName: "Sync Localization branch with main"
-  condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'), eq(variables.isMain, 'True'))
 
 - task: OneLocBuild@2
   condition: and(succeeded(), eq(variables.isMain, 'True'))

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -34,7 +34,6 @@ jobs:
   variables:
     isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
     isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
-    gitHubToken: ${{ parameters.gitHubToken }}
 
   steps:
   - template: configure.yml

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -34,6 +34,7 @@ jobs:
   variables:
     isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
     isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
+    gitHubToken: ${{ parameters.gitHubToken }}
 
   steps:
   - template: configure.yml


### PR DESCRIPTION
This PR syncs the Localization branch with main on every scheduled or manual build in main.
We need this to so that the Localization branch does not get out of sync with main when the Loc team auto-merges in the Localization branch on our Sunday builds. This would create merge conflicts and cause issues on their end as well!

Example of the step in ADO working as expected found [here](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4773438&view=logs&j=d4d86769-bae0-5955-544a-0740a81efd3c&t=37c7a955-b2ad-5a60-c99a-544de5935e6f&l=70). 

Help from @cadsit and inspired from our folks on the Akvelon INC team! 