### PR TITLE
[Runtime] Make Runtime.IsUserType optimizable.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1589,6 +1589,7 @@ namespace ObjCRuntime {
 			throw new ArgumentException (string.Format ("'{0}' is an unknown protocol", type.FullName));
 		}
 
+		[BindingImpl (BindingImplOptions.Optimizable)]
 		internal static bool IsUserType (IntPtr self)
 		{
 			var cls = Class.object_getClass (self);


### PR DESCRIPTION
Fixes this mmptest:

    * Xamarin.ApiTest.ApiTest.AlwaysOptimizable(macOSMobile): All methods calling optimizable API must be optimizable
        The method System.Boolean ObjCRuntime.Runtime::IsUserType(System.IntPtr) calls System.Boolean ObjCRuntime.Runtime::get_DynamicRegistrationSupported(), but it does not have a [BindingImpl (BindingImplOptions.Optimizable)] attribute.
    * Xamarin.ApiTest.ApiTest.AlwaysOptimizable(macOSFull): All methods calling optimizable API must be optimizable
        The method System.Boolean ObjCRuntime.Runtime::IsUserType(System.IntPtr) calls System.Boolean ObjCRuntime.Runtime::get_DynamicRegistrationSupported(), but it does not have a [BindingImpl (BindingImplOptions.Optimizable)] attribute.