### PR TITLE
[CI] Fix API diff uploads since they broke when we wanted to continue on failure.

### DIFF
--- a/tools/devops/automation/templates/build/download-artifacts.yml
+++ b/tools/devops/automation/templates/build/download-artifacts.yml
@@ -3,10 +3,6 @@ parameters:
   type: boolean
   default: true
 
-- name: apiGeneratorDiffBuilt
-  type: boolean
-  default: true
-
 steps:
 
 - checkout: self
@@ -32,32 +28,28 @@ steps:
     archiveFilePatterns: '$(System.DefaultWorkingDirectory)/Reports/apidiff-stable/apidiff-stable.zip'
     destinationFolder: '$(System.DefaultWorkingDirectory)/apidiff-stable'
 
-- ${{ if eq(parameters.apiGeneratorDiffBuilt, true) }}:
-  - task: DownloadPipelineArtifact@2
-    displayName: 'Download API & Generator comparison'
-    inputs:
-      patterns: 'apicomparison/apicomparison.zip'
-      allowFailedBuilds: true
-      path: $(System.DefaultWorkingDirectory)/Reports
+- task: DownloadPipelineArtifact@2
+  displayName: 'Download API & Generator comparison'
+  condition: and(succeeded(), contains(variables.API_GENERATOR_DIFF_BUILT, 'True'))
+  inputs:
+    patterns: 'apicomparison/apicomparison.zip'
+    allowFailedBuilds: true
+    path: $(System.DefaultWorkingDirectory)/Reports
 
-  - task: ExtractFiles@1
-    displayName: 'Extract API & Generator comparison'
-    inputs:
-      archiveFilePatterns: '$(System.DefaultWorkingDirectory)/Reports/apicomparison/apicomparison.zip'
-      destinationFolder: '$(System.DefaultWorkingDirectory)/apicomparison'
+- task: ExtractFiles@1
+  displayName: 'Extract API & Generator comparison'
+  condition: and(succeeded(), contains(variables.API_GENERATOR_DIFF_BUILT, 'True'))
+  inputs:
+    archiveFilePatterns: '$(System.DefaultWorkingDirectory)/Reports/apicomparison/apicomparison.zip'
+    destinationFolder: '$(System.DefaultWorkingDirectory)/apicomparison'
 
 - powershell: |
     Write-Host "##vso[task.setvariable variable=STABLE_APIDDIFF_PATH]$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\apidiff-stable"
-    if ($Env:apiGeneratorDiffBuilt -eq "True") {
+    if ($Env:API_GENERATOR_DIFF_BUILT -eq "True") {
       Write-Host "##vso[task.setvariable variable=STABLE_APID_GENERATOR_DIFF_PATH]$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\apicomparison"
     }
   displayName: Publish apidiff paths
   name: apidiff # not to be confused with the displayName, this is used to later use the name of the step to access the output variables from an other job
-  env:
-    ${{ if eq(parameters.apiGeneratorDiffBuilt, true) }}:
-      apiGeneratorDiffBuilt: 'True'
-    ${{ if ne(parameters.apiGeneratorDiffBuilt, true) }}:
-      apiGeneratorDiffBuilt: 'False'
 
 # download the artifacts.json, which will use to find the URI of the built pkg to later be given to the user
 - task: DownloadPipelineArtifact@2

--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -29,10 +29,6 @@ parameters:
   type: boolean
   default: true
 
-- name: apiGeneratorDiffBuilt
-  type: string 
-  default: true
-
 steps:
 
 - checkout: self
@@ -41,7 +37,6 @@ steps:
 - template: download-artifacts.yml 
   parameters:
     runTests: ${{ parameters.runTests }}
-    apiGeneratorDiffBuilt: ${{ contains(parameters.apiGeneratorDiffBuilt, 'True') }}
 
 - ${{ if eq(parameters.runTests, true) }}:
   - pwsh: |

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -135,6 +135,9 @@ jobs:
   dependsOn: build # can start as soon as the tests are done
   condition: and(succeededOrFailed() , contains (dependencies.build.outputs['runTests.TESTS_RAN'], 'True')) # only run when we did run the tests
 
+  variables:
+    API_GENERATOR_BUILT: $[ dependencies.build.outputs['apiGeneratorDiff.API_GENERATOR_BUILT'] ]
+
   pool:
     vmImage: 'windows-latest'
     workspace:

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -136,7 +136,7 @@ jobs:
   condition: and(succeededOrFailed() , contains (dependencies.build.outputs['runTests.TESTS_RAN'], 'True')) # only run when we did run the tests
 
   variables:
-    API_GENERATOR_BUILT: $[ dependencies.build.outputs['apiGeneratorDiff.API_GENERATOR_BUILT'] ]
+    API_GENERATOR_DIFF_BUILT: $[ dependencies.build.outputs['apiGeneratorDiff.API_GENERATOR_BUILT'] ]
 
   pool:
     vmImage: 'windows-latest'
@@ -147,7 +147,6 @@ jobs:
     parameters:
       devicePrefix: sim
       runTests: ${{ parameters.runTests }}
-      apiGeneratorDiffBuilt: $[ dependencies.build.outputs['apiGeneratorDiff.API_GENERATOR_BUILT'] ]
 
 - job: upload_vsts_tests
   displayName: 'Upload xml to vsts'
@@ -182,6 +181,7 @@ jobs:
     TESTS_JOBSTATUS: $[ dependencies.build.outputs['runTests.TESTS_JOBSTATUS'] ]
     APIDIFF_MESSAGE: $[ dependencies.build.outputs['apidiff.APIDIFF_MESSAGE'] ]
     APIDIFF_BUILT: $[ dependencies.build.outputs['apidiff.APIDIFF_BUILT'] ]
+    API_GENERATOR_DIFF_BUILT: $[ dependencies.build.outputs['apiGeneratorDiff.API_GENERATOR_BUILT'] ]
     PR_ID: $[ dependencies.configure.outputs['labels.pr-number'] ]
   pool:
     vmImage: 'windows-latest'
@@ -193,5 +193,4 @@ jobs:
       statusContext: "Build"
       runTests: ${{ parameters.runTests }}
       vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
-      apiGeneratorDiffBuilt: $[ dependencies.build.outputs['apiGeneratorDiff.API_GENERATOR_BUILT'] ]
       devicePrefix: sim

--- a/tools/devops/automation/templates/build/upload-vsdrops.yml
+++ b/tools/devops/automation/templates/build/upload-vsdrops.yml
@@ -10,10 +10,6 @@ parameters:
   type: boolean
   default: true
 
-- name: apiGeneratorDiffBuilt
-  type: string 
-  default: true
-
 steps:
 
 - checkout: self
@@ -22,7 +18,6 @@ steps:
 - template: download-artifacts.yml 
   parameters:
     runTests: ${{ parameters.runTests }}
-    apiGeneratorDiffBuilt: ${{ contains(parameters.apiGeneratorDiffBuilt, 'True') }}
 
 # Upload full report to vsdrops using the the build numer and id as uuids.
 - ${{ if eq(parameters.runTests, true) }}:
@@ -47,13 +42,13 @@ steps:
     detailedLog: true
     usePat: true
 
-- ${{ if contains(parameters.apiGeneratorDiffBuilt, 'True') }}:
-  - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
-    displayName: 'Publish API & Generator comparisonn to Artifact Services Drop'
-    inputs:
-      dropServiceURI: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
-      dropMetadataContainerName: 'DropMetadata-APIGeneratorDiff'
-      buildNumber: 'xamarin-macios/device-tests/$(Build.BuildNumber)/$(Build.BuildId)/APIGeneratorDiff'
-      sourcePath: $(STABLE_APID_GENERATOR_DIFF_PATH)
-      detailedLog: true
-      usePat: true
+- task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
+  displayName: 'Publish API & Generator comparisonn to Artifact Services Drop'
+  condition: and(succeeded(), contains(variables.API_GENERATOR_DIFF_BUILT, 'True'))
+  inputs:
+    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
+    dropMetadataContainerName: 'DropMetadata-APIGeneratorDiff'
+    buildNumber: 'xamarin-macios/device-tests/$(Build.BuildNumber)/$(Build.BuildId)/APIGeneratorDiff'
+    sourcePath: $(STABLE_APID_GENERATOR_DIFF_PATH)
+    detailedLog: true
+    usePat: true


### PR DESCRIPTION
AZP yaml variables vs parameter is hard. The template ignores the settings of the run time variables resulting in skipping the upload and we later have urls that point nowhere. Latests comment in the commit shows we fixed this.