### PR TITLE
[monotouch-test] Ignore the SslSupportedCiphers test on .NET due to #11498.

### DIFF
--- a/tests/monotouch-test/Security/SecureTransportTest.cs
+++ b/tests/monotouch-test/Security/SecureTransportTest.cs
@@ -137,6 +137,9 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
+#if NET
+		[Ignore ("Fails on ARM64 due to: https://github.com/xamarin/xamarin-macios/issues/11498)")]
+#endif
 		public void SslSupportedCiphers ()
 		{
 			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);


### PR DESCRIPTION
The underlying size of the SslCipherSuite is wrong, so the test fails.

Ref: https://github.com/xamarin/xamarin-macios/issues/11498