### PR TITLE
[runtime] Fix declaration of xamarin_bridge_get_method_declaring_type.

### DIFF
--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -471,8 +471,8 @@
 			OnlyCoreCLR = true,
 		},
 
-		new XDelegate ("MonoObject *", "IntPtr", "xamarin_bridge_get_method_declaring_type",
-			"MonoObject *", "IntPtr", "gchandle"
+		new XDelegate ("MonoObject *", "MonoObject *", "xamarin_bridge_get_method_declaring_type",
+			"MonoObject *", "MonoObject *", "mobj"
 		) {
 			WrappedManagedFunction = "GetMethodDeclaringType",
 			OnlyDynamicUsage = false,

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -337,10 +337,10 @@ namespace ObjCRuntime {
 			return (byte) obj.FlagsInternal;
 		}
 
-		static IntPtr GetMethodDeclaringType (MonoObjectPtr mobj)
+		static unsafe MonoObject* GetMethodDeclaringType (MonoObject *mobj)
 		{
 			var method = (MethodBase) GetMonoObjectTarget (mobj);
-			return GetMonoObject (method.DeclaringType);
+			return (MonoObject *) GetMonoObject (method.DeclaringType);
 		}
 
 		static IntPtr ObjectGetType (MonoObjectPtr mobj)


### PR DESCRIPTION
The native xamarin_bridge_get_method_declaring_type method and the
corresponding managed method (GetMethodDeclaringType) takes and returns a
MonoObject*, not a GCHandle.

Due to the wonders of void pointers, this worked just fine before - there's no
actual change to the compiled code - but the code is now more consistent and
less confusing.