### PR TITLE
[monotouch-test] Ignore tests that require exception marshalling on CoreCLR for now, they fail.

### DIFF
--- a/tests/api-shared/ObjCRuntime/RegistrarTest.cs
+++ b/tests/api-shared/ObjCRuntime/RegistrarTest.cs
@@ -26,6 +26,9 @@ namespace XamarinTests.ObjCRuntime {
 		}
 
 		[Test]
+#if NET
+		[Ignore ("Ignored on CoreCLR for now due to missing support for marshalling exceptions")]
+#endif
 		public void IntPtrCtor ()
 		{
 			IntPtr ptr = IntPtr.Zero;

--- a/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
@@ -85,6 +85,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 		// Simulator/desktop only (except for watchOS, where it works everywhere)
 		[Test]
+#if NET
+		[Ignore ("Ignored on CoreCLR for now due to missing support for marshalling exceptions")]
+#endif
 		public void ObjCException ()
 		{
 #if !__WATCHOS__ && !__MACOS__
@@ -131,6 +134,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 		// Simulator/desktop only test (except for watchOS, where it works everywhere)
 		[Test]
+#if NET
+		[Ignore ("Ignored on CoreCLR for now due to missing support for marshalling exceptions")]
+#endif
 		public void ManagedExceptionPassthrough ()
 		{
 			Exception thrownException = null;

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -433,6 +433,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		}
 
 		[Test]
+#if NET
+		[Ignore ("Ignored on CoreCLR for now due to missing support for marshalling exceptions")]
+#endif
 		public void TestGeneric ()
 		{
 			var g1 = new GenericTestClass<string> ();
@@ -1240,6 +1243,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		}
 
 		[Test]
+#if NET
+		[Ignore ("Ignored on CoreCLR for now due to missing support for marshalling exceptions")]
+#endif
 		public void TestConstrainedGenericType ()
 		{
 			IntPtr value;

--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -579,6 +579,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		}
 
 		[Test]
+#if NET
+		[Ignore ("Ignored on CoreCLR for now due to missing support for marshalling exceptions")]
+#endif
 		public void MX8029 ()
 		{
 			var handle = Messaging.IntPtr_objc_msgSend (Messaging.IntPtr_objc_msgSend (Class.GetHandle (typeof (Dummy)), Selector.GetHandle ("alloc")), Selector.GetHandle ("init"));
@@ -613,6 +616,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 #if DYNAMIC_REGISTRAR
 		[Test]
+#if NET
+		[Ignore ("Ignored on CoreCLR for now due to missing support for marshalling exceptions")]
+#endif
 		public void MX8029_b ()
 		{
 			try {
@@ -634,6 +640,9 @@ Additional information:
 		}
 
 		[Test]
+#if NET
+		[Ignore ("Ignored on CoreCLR for now due to missing support for marshalling exceptions")]
+#endif
 		public void MX8033 ()
 		{
 			try {


### PR DESCRIPTION
This makes monotouch-test green when using CoreCLR, both when using the
dynamic and the static registrar.

Ref: https://github.com/xamarin/xamarin-macios/issues/10940