### PR TITLE
[runtime] Refactor the toggle ref code to separate MonoVM-specific code and generic logic.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -29,6 +29,12 @@ xamarin_bridge_initialize ()
 {
 }
 
+void
+xamarin_enable_new_refcount ()
+{
+	// Nothing to do here.
+}
+
 bool
 xamarin_bridge_vm_initialize (int propertyCount, const char **propertyKeys, const char **propertyValues)
 {

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -240,7 +240,9 @@
 		new Export ("void", "mono_profiler_install_gc",
 			"MonoProfileGCFunc", "callback",
 			"MonoProfileGCResizeFunc", "heap_resize_callback"
-		),
+		) {
+			XamarinRuntime = RuntimeMode.MonoVM,
+		},
 
 		new Export ("void", "mono_profiler_load",
 			"const char *", "desc"
@@ -563,7 +565,9 @@
 		new Export ("void", "mono_gc_toggleref_add",
 			"MonoObject *", "object",
 			"mono_bool", "strong_ref"
-		),
+		) {
+			XamarinRuntime = RuntimeMode.MonoVM,
+		},
 
 		new Export ("void", "mono_gc_toggleref_register_callback",
 			"MonoToggleRefCallback", "process_toggleref"

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -214,6 +214,7 @@ MonoMethod *	xamarin_bridge_get_mono_method (MonoReflectionMethod *method);
 void			xamarin_bridge_free_mono_signature (MonoMethodSignature **signature);
 bool			xamarin_register_monoassembly (MonoAssembly *assembly, GCHandle *exception_gchandle);
 void			xamarin_install_nsautoreleasepool_hooks ();
+void			xamarin_enable_new_refcount ();
 
 MonoObject *	xamarin_new_nsobject (id self, MonoClass *klass, GCHandle *exception_gchandle);
 bool			xamarin_has_managed_ref (id self);
@@ -285,6 +286,10 @@ GCHandle		xamarin_gchandle_new_weakref (MonoObject *obj, bool track_resurrection
 MonoObject *	xamarin_gchandle_get_target (GCHandle handle);
 void			xamarin_gchandle_free (GCHandle handle);
 MonoObject *	xamarin_gchandle_unwrap (GCHandle handle); // Will get the target and free the GCHandle
+
+typedef id (*xamarin_get_handle_func) (MonoObject *info);
+MonoToggleRefStatus	xamarin_gc_toggleref_callback (uint8_t flags, id handle, xamarin_get_handle_func get_handle, MonoObject *info);
+void				xamarin_gc_event (MonoGCEvent event);
 
 /*
  * In MonoVM MonoObjects are tracked in memory/the stack directly by the GC, but that doesn't


### PR DESCRIPTION
This makes it simpler to implement the toggle ref logic for CoreCLR once we can
do that.