### PR TITLE
[runtime] Remove the declarations for mono_jit_parse_options and mono_gc_max_generation.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -486,12 +486,6 @@
 
 		#endregion
 
-		#region metadata/mono-gc.h
-
-		new Export ("int", "mono_gc_max_generation"),
-
-		#endregion
-
 		#region metadata/mono-hash.h
 
 		new Export ("MonoGHashTable *", "mono_g_hash_table_new_type",
@@ -602,11 +596,6 @@
 		) {
 			HasCoreCLRBridgeFunction = true,
 		},
-
-		new Export ("void", "mono_jit_parse_options",
-			"int", "argc",
-			"char**", "argv"
-		),
 
 		new Export ("void", "mono_jit_set_aot_mode",
 			"MonoAotMode", "mode"


### PR DESCRIPTION
We don't used these mono functions anymore.