### PR TITLE
[mmp] Don't define CORECLR_RUNTIME when compiling the partial static registrar code

### DIFF
--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -103,9 +103,6 @@ Xamarin.Mac.registrar.full.arm64.m:   $(TOP)/src/build/mac/full-64/Xamarin.Mac.d
 	$(GENERATE_PART_REGISTRAR) --arch=arm64 --target-framework Xamarin.Mac,Version=v4.5,Profile=Full -a:$(FULL_BCL_DIR)/mscorlib.dll
 	$(Q) touch Xamarin.Mac.registrar.full.arm64.m Xamarin.Mac.registrar.full.arm64.h
 
-%.coreclr.x86_64.a: export EXTRA_DEFINES=-DCORECLR_RUNTIME
-%.coreclr.arm64.a: export EXTRA_DEFINES=-DCORECLR_RUNTIME
-
 %.x86_64.a: %.x86_64.m
 	$(Q_CC) $(MAC_CC) -DDEBUG -g -gdwarf-2 -x objective-c++ -std=c++14 -o $@ -c -arch x86_64 $< -Wall -Wno-unguarded-availability-new -I$(TOP)/runtime -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx $(EXTRA_DEFINES)
 


### PR DESCRIPTION
We already define it in the generated code, so the native compiler shows a warning:

    Microsoft.macOS.registrar.coreclr.x86_64.m:1:9: warning: 'CORECLR_RUNTIME' macro redefined [-Wmacro-redefined]
    #define CORECLR_RUNTIME
            ^
    <command line>:2:9: note: previous definition is here
    #define CORECLR_RUNTIME 1
            ^