### PR TITLE
[d16-10] [msbuild] Fixes build errors from Windows

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -25,7 +25,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 
 	<Target Name="EnsureMacConnection" 
 		DependsOnTargets="_SayHello" 
-		BeforeTargets="_CleanDebugSymbols;_CleanAppBundle;_DetectAppManifest;_DetectSdkLocations;_GenerateAppBundleName;_GenerateAppExBundleName" />
+		BeforeTargets="_CleanDebugSymbols;_CleanAppBundle;_DetectAppManifest;_DetectSdkLocations;_GenerateBundleName" />
 	
 	<PropertyGroup>
 		<CreateAppBundleDependsOn>

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/PrepareNativeReferences.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/PrepareNativeReferences.cs
@@ -14,7 +14,7 @@ namespace Xamarin.iOS.Tasks
 		public override bool Execute ()
 		{
 			if (string.IsNullOrEmpty (SessionId))
-				base.Execute ();
+				return base.Execute ();
 
 			var taskRunner = new TaskRunner (SessionId, BuildEngine4);
 


### PR DESCRIPTION
Fixes problems when building watchOS apps and binding libraries from Windows.


Backport of #11619
