### PR TITLE
[dotnet][linker] Use substitution files to remove UIButton debug code

### DIFF
--- a/src/ILLink.Substitutions.ios.xml
+++ b/src/ILLink.Substitutions.ios.xml
@@ -3,5 +3,8 @@
     <type fullname="ObjCRuntime.Runtime">
       <method signature="System.Boolean get_IsCoreCLR()" body="stub" value="false" />
     </type>
+    <type fullname="UIKit.UIButton">
+      <method signature="System.Void VerifyIsUIButton()" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
+    </type>
   </assembly>
 </linker>

--- a/src/ILLink.Substitutions.tvos.xml
+++ b/src/ILLink.Substitutions.tvos.xml
@@ -3,5 +3,8 @@
     <type fullname="ObjCRuntime.Runtime">
       <method signature="System.Boolean get_IsCoreCLR()" body="stub" value="false" />
     </type>
+    <type fullname="UIKit.UIButton">
+      <method signature="System.Void VerifyIsUIButton()" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
+    </type>
   </assembly>
 </linker>


### PR DESCRIPTION
The debug code is removed only on release builds.

Unlike the _legacy_ linker the method itself is still present (not
removed) from the assembly - but it will be empty (no code).

Unit test was adapted to work under all conditions.

Fixes https://github.com/xamarin/xamarin-macios/issues/9613