### PR TITLE
[catalyst][adsupport] Update xtro - framework is not available

### DIFF
--- a/src/AdSupport/ASCompat.cs
+++ b/src/AdSupport/ASCompat.cs
@@ -1,0 +1,22 @@
+#if !XAMCORE_4_0
+
+using System;
+using System.Runtime.Versioning;
+
+namespace AdSupport {
+
+	public  partial class ASIdentifierManager {
+
+#if MONOMAC
+#if NET
+		[UnsupportedOSPlatform ("macos")]
+#endif
+		[Obsolete ("Empty stub. This member was retroactively marked as unavailable for macOS.")]
+		public virtual void ClearAdvertisingIdentifier ()
+		{
+		}
+#endif
+	}
+}
+
+#endif

--- a/src/adsupport.cs
+++ b/src/adsupport.cs
@@ -32,6 +32,7 @@ namespace AdSupport {
 		NSUuid AdvertisingIdentifier { get; }
 
 		[NoTV][NoiOS]
+		[NoMac] // unclear when that was changed (xcode 12 GM allowed it)
 		[Export ("clearAdvertisingIdentifier")]
 		void ClearAdvertisingIdentifier ();
 	}

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -64,6 +64,11 @@ ADDRESSBOOKUI_SOURCES = \
 	AddressBookUI/ABUnknownPersonViewController.cs \
 	AddressBookUI/DisplayedPropertiesCollection.cs \
 
+# AdSupport
+
+ADSUPPORT_SOURCES = \
+	AdSupport/ASCompat.cs \
+
 # AppKit
 
 APPKIT_CORE_SOURCES = \

--- a/tests/xtro-sharpie/MacCatalyst-AdSupport.ignore
+++ b/tests/xtro-sharpie/MacCatalyst-AdSupport.ignore
@@ -1,0 +1,3 @@
+## weird case, it was available on macOS (xcode12 GM) but later removed so it's not in iOS, tvOS or macOS
+## there's no annotation specific for Catalyst but it does not make sense to have it
+!missing-selector! ASIdentifierManager::clearAdvertisingIdentifier not bound

--- a/tests/xtro-sharpie/MacCatalyst-AdSupport.todo
+++ b/tests/xtro-sharpie/MacCatalyst-AdSupport.todo
@@ -1,1 +1,0 @@
-!missing-selector! ASIdentifierManager::clearAdvertisingIdentifier not bound


### PR DESCRIPTION
also found out an API was removed by Apple... turned it into
a stub for compatibility.