### PR TITLE
[dotnet][generator] Do not implement `Dispose` if only needed for backing fields

### DIFF
--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -829,12 +829,18 @@ namespace Foundation {
 			}
 		}
 
-		unsafe void FreeData ()
+		void FreeData ()
 		{
 			if (super != IntPtr.Zero) {
 				Marshal.FreeHGlobal (super);
 				super = IntPtr.Zero;
 			}
+#if NET
+			foreach (var field in GetType ().GetFields (BindingFlags.Instance | BindingFlags.NonPublic)) {
+				if (field.Name.StartsWith ("__mt_", StringComparison.Ordinal))
+					field.SetValue (this, null);
+			}
+#endif
 		}
 
 		[Register ("__NSObject_Disposer")]

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -7415,7 +7415,12 @@ public partial class Generator : IMemberGatherer {
 			//
 			if (!is_static_class){
 				var disposeAttr = AttributeManager.GetCustomAttributes<DisposeAttribute> (type);
-				if (disposeAttr.Length > 0 || instance_fields_to_clear_on_dispose.Count > 0){
+#if NET
+				bool dispose_backing_fields = false; // using reflection inside NSObject
+#else
+				bool dispose_backing_fields = (instance_fields_to_clear_on_dispose.Count > 0);
+#endif
+				if (disposeAttr.Length > 0 || dispose_backing_fields){
 					print_generated_code ();
 					print ("protected override void Dispose (bool disposing)");
 					print ("{");
@@ -7427,7 +7432,7 @@ public partial class Generator : IMemberGatherer {
 					
 					print ("base.Dispose (disposing);");
 					
-					if (instance_fields_to_clear_on_dispose.Count > 0) {
+					if (dispose_backing_fields) {
 						print ("if (Handle == IntPtr.Zero) {");
 						indent++;
 						foreach (var field in instance_fields_to_clear_on_dispose.OrderBy (f => f, StringComparer.Ordinal))


### PR DESCRIPTION
instead rely on `NSObject.Dispose` and reflection to set them to `null`.

This
* allows the linker to remove backing fields (when not used)
* does not require any additional code in the linker
* does a better job (more removals) then the legacy linker `Dispose` optimizer can do

But
* there will be a performance hit (to be measured)
* requires an (optional and not yet done) "release" optimization to cancel the performance hit

Most comment should be made on proposals https://github.com/xamarin/xamarin-macios/issues/11590 and not on this draft PR.

For a small app there's no size difference. We save a bit in `Xamarin.iOS.dll` but we need a bit more for reflection in `System.Private.CoreLib.dll`. However larger apps will have more types, so more backing fields and `Dispose` method removed. The impact should be larger as app grows (their usage of bindings).

Beside app size (which was **not** the original reason for the optimization in legacy) the removal of backing field saves memory (RAM) at runtime as each instance of the types needs a pointer-sized (8 bytes) for each backing field. Huge UI with lots of `UIView[Controller]` can eat up a lot of never used memory.

| Directories / Files |  main  | PR | diff |  %  |
| ------------------- | --: | --: | ---: | --: |
| .//_CodeSignature | | | | ||     CodeResources | 5,233 | 5,233 | 0 | 0.0% |
| .// | | | | ||     archived-expanded-entitlements.xcent | 392 | 392 | 0 | 0.0% |
|     embedded.mobileprovision | 12,391 | 12,391 | 0 | 0.0% |
|     icudt.dat | 1,713,152 | 1,713,152 | 0 | 0.0% |
|     Info.plist | 1,054 | 1,054 | 0 | 0.0% |
|     MySingleView | 7,396,096 | 7,396,096 | 0 | 0.0% |
|     MySingleView.aotdata.arm64 | 792 | 792 | 0 | 0.0% |
|     MySingleView.dll | 4,608 | 4,608 | 0 | 0.0% |
|     PkgInfo | 8 | 8 | 0 | 0.0% |
|     System.Private.CoreLib.aotdata.arm64 | 664,424 | 664,536 | 112 | 0.0% |
|     System.Private.CoreLib.dll | 773,632 | 774,144 | 512 | 0.1% |
|     System.Runtime.aotdata.arm64 | 504 | 504 | 0 | 0.0% |
|     System.Runtime.dll | 5,120 | 5,120 | 0 | 0.0% |
|     Xamarin.iOS.aotdata.arm64 | 44,784 | 44,688 | -96 | -0.2% |
|     Xamarin.iOS.dll | 78,336 | 77,824 | -512 | -0.7% |
| | | | | |
| **Statistics** | | | | |
| | | | | |
| Native subtotal | 8,106,600 | 8,106,616 | 16 | 0.0% |
|     Executable | 7,396,096 | 7,396,096 | 0 | 0.0% |
|     AOT data | 710,504 | 710,520 | 16 | 0.0% |
| | | | | |
| Managed *.dll/exe | 861,696 | 861,696 | 0 | 0.0% |
| | | | | |
| **TOTAL** | 10,700,526 | 10,700,542 | 16 | 0.0% |

Source Diff

```diff
--- a.cs	2021-05-19 21:30:02.000000000 -0400
+++ b.cs	2021-05-19 21:30:05.000000000 -0400
@@ -3086,8 +3086,6 @@

 		private static readonly IntPtr class_ptr = Class.GetHandle("UIApplication");

-		private object __mt_WeakDelegate_var;
-
 		public override IntPtr ClassHandle => class_ptr;

 		[DllImport("__Internal")]
@@ -3132,15 +3130,6 @@
 			: base(handle)
 		{
 		}
-
-		protected override void Dispose(bool disposing)
-		{
-			base.Dispose(disposing);
-			if (base.Handle == IntPtr.Zero)
-			{
-				__mt_WeakDelegate_var = null;
-			}
-		}
 	}
 	[Register("UIButton", true)]
 	public class UIButton : UIControl, INativeObject, IDisposable
@@ -3231,10 +3220,6 @@
 	{
 		private static readonly IntPtr class_ptr = Class.GetHandle("UIScreen");

-		private object __mt_FocusedItem_var;
-
-		private object __mt_FocusedView_var;
-
 		public override IntPtr ClassHandle => class_ptr;

 		public virtual CGRect Bounds
@@ -3266,26 +3251,12 @@
 			: base(handle)
 		{
 		}
-
-		protected override void Dispose(bool disposing)
-		{
-			base.Dispose(disposing);
-			if (base.Handle == IntPtr.Zero)
-			{
-				__mt_FocusedItem_var = null;
-				__mt_FocusedView_var = null;
-			}
-		}
 	}
 	[Register("UIView", true)]
 	public class UIView : UIResponder, INativeObject, IDisposable
 	{
 		private static readonly IntPtr class_ptr = Class.GetHandle("UIView");

-		private object __mt_ParentFocusEnvironment_var;
-
-		private object __mt_PreferredFocusedView_var;
-
 		public override IntPtr ClassHandle => class_ptr;

 		public virtual CGRect Bounds
@@ -3327,28 +3298,12 @@
 				Messaging.void_objc_msgSendSuper_IntPtr(base.SuperHandle, Selector.GetHandle("addSubview:"), nonNullHandle);
 			}
 		}
-
-		protected override void Dispose(bool disposing)
-		{
-			base.Dispose(disposing);
-			if (base.Handle == IntPtr.Zero)
-			{
-				__mt_ParentFocusEnvironment_var = null;
-				__mt_PreferredFocusedView_var = null;
-			}
-		}
 	}
 	[Register("UIViewController", true)]
 	public class UIViewController : UIResponder, INativeObject, IDisposable
 	{
 		private static readonly IntPtr class_ptr = Class.GetHandle("UIViewController");

-		private object __mt_ParentFocusEnvironment_var;
-
-		private object __mt_PreferredFocusedView_var;
-
-		private object __mt_WeakTransitioningDelegate_var;
-
 		public override IntPtr ClassHandle => class_ptr;

 		public virtual UIView View
@@ -3387,25 +3342,12 @@
 			: base(handle)
 		{
 		}
-
-		protected override void Dispose(bool disposing)
-		{
-			base.Dispose(disposing);
-			if (base.Handle == IntPtr.Zero)
-			{
-				__mt_ParentFocusEnvironment_var = null;
-				__mt_PreferredFocusedView_var = null;
-				__mt_WeakTransitioningDelegate_var = null;
-			}
-		}
 	}
 	[Register("UIWindow", true)]
 	public class UIWindow : UIView
 	{
 		private static readonly IntPtr class_ptr = Class.GetHandle("UIWindow");

-		private object __mt_WindowScene_var;
-
 		public override IntPtr ClassHandle => class_ptr;

 		public virtual UIViewController RootViewController
@@ -3456,15 +3398,6 @@
 				Messaging.void_objc_msgSendSuper(base.SuperHandle, Selector.GetHandle("makeKeyAndVisible"));
 			}
 		}
-
-		protected override void Dispose(bool disposing)
-		{
-			base.Dispose(disposing);
-			if (base.Handle == IntPtr.Zero)
-			{
-				__mt_WindowScene_var = null;
-			}
-		}
 	}
 	[Register("UIApplicationDelegate", false)]
 	[Model]
@@ -4560,6 +4493,14 @@
 				Marshal.FreeHGlobal(super);
 				super = IntPtr.Zero;
 			}
+			FieldInfo[] fields = GetType().GetFields(BindingFlags.Instance | BindingFlags.NonPublic);
+			foreach (FieldInfo fieldInfo in fields)
+			{
+				if (fieldInfo.Name.StartsWith("__mt_", StringComparison.Ordinal))
+				{
+					fieldInfo.SetValue(this, null);
+				}
+			}
 		}

 		[Export("hash")]
```