### PR TITLE
[tests] Build the custom-type-assembly separately for .NET

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2154,7 +2154,11 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void CustomUserTypeWithDynamicallyLoadedAssembly ()
 		{
+#if NET
+			var customTypeAssemblyPath = global::System.IO.Path.Combine (global::Xamarin.Tests.Configuration.RootPath, "tests", "test-libraries", "custom-type-assembly", ".libs", "dotnet", "macos", "custom-type-assembly.dll");
+#else
 			var customTypeAssemblyPath = global::System.IO.Path.Combine (global::Xamarin.Tests.Configuration.RootPath, "tests", "test-libraries", "custom-type-assembly", ".libs", "macos", "custom-type-assembly.dll");
+#endif
 			Assert.That (customTypeAssemblyPath, Does.Exist, "existence");
 
 			var size = 10;

--- a/tests/test-libraries/custom-type-assembly/Makefile
+++ b/tests/test-libraries/custom-type-assembly/Makefile
@@ -3,12 +3,24 @@ TOP=../../..
 include $(TOP)/Make.config
 
 .libs/macos/custom-type-assembly.dll: custom-type-assembly.cs Makefile | .libs/macos
-	$(MAC_mobile_CSC) $< -out:$@ -r:$(TOP)/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/Xamarin.Mac/Xamarin.Mac.dll -target:library
+	$(Q_CSC) $(MAC_mobile_CSC) $< -out:$@ -r:$(TOP)/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/Xamarin.Mac/Xamarin.Mac.dll -target:library
 
-.libs/macos:
+.libs/dotnet/macos/custom-type-assembly.dll: custom-type-assembly.cs Makefile | .libs/dotnet/macos
+	$(Q_CSC) $(DOTNET6_CSC) $< -out:$@ -r:$(TOP)/_build/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.dll -target:library -r:$(DOTNET6_BCL_DIR)/System.Runtime.dll /nologo
+
+.libs/macos .libs/dotnet/macos:
 	$(Q) mkdir -p $@
 
+ifdef INCLUDE_XAMARIN_LEGACY
 TARGETS += \
 	.libs/macos/custom-type-assembly.dll \
+
+endif
+
+ifdef ENABLE_DOTNET
+TARGETS += \
+	.libs/dotnet/macos/custom-type-assembly.dll \
+
+endif
 
 build-assembly: $(TARGETS)


### PR DESCRIPTION
It's a bit weird to build it twice, but it's the most straight forward way of
making the test work if either the .NET build or the legacy build is disabled.