### PR TITLE
[d16-10] [CI] Allow to ignore tests if dotnet is enabled.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -75,11 +75,6 @@ else
 # verbose build
 XHARNESS_VERBOSITY=--verbose
 endif
-ifdef ENABLE_DOTNET
-XHARNESS_CONSTANTS="ENABLE_DOTNET"
-else
-XHARNESS_CONSTANTS=""
-endif
 
 #
 # To run all the tests, just do:
@@ -113,6 +108,7 @@ test.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk
 	@echo "WATCH_SDK_VERSION=$(WATCH_SDK_VERSION)" >> $@
 	@echo "OSX_SDK_VERSION=$(OSX_SDK_VERSION)" >> $@
 	@echo "DOTNET6_BCL_DIR=$(DOTNET6_BCL_DIR)" >> $@
+	@echo "ENABLE_DOTNET=$(ENABLE_DOTNET)" >> $@
 
 test-system.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk
 	@rm -f $@
@@ -217,7 +213,7 @@ $(TOP)/tools/common/SdkVersions.cs: $(TOP)/tools/common/SdkVersions.cs.in
 	@touch $@
 
 xharness/xharness.exe: $(xharness_dependencies) test.config test-system.config .stamp-src-project-files $(TOP)/tools/common/SdkVersions.cs
-	$(Q_GEN) $(SYSTEM_MSBUILD) /restore $(MSBUILD_VERBOSITY_QUIET) xharness/xharness.csproj /p:DefineConstants=$(XHARNESS_CONSTANTS)
+	$(Q_GEN) $(SYSTEM_MSBUILD) /restore $(MSBUILD_VERBOSITY_QUIET) xharness/xharness.csproj
 xharness/xharness.csproj.inc: export BUILD_VERBOSITY=$(XBUILD_VERBOSITY)
 xharness/xharness.csproj.inc: export ABSOLUTE_PATHS=1
 -include xharness/xharness.csproj.inc

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -75,6 +75,11 @@ else
 # verbose build
 XHARNESS_VERBOSITY=--verbose
 endif
+ifdef ENABLE_DOTNET
+XHARNESS_CONSTANTS="ENABLE_DOTNET"
+else
+XHARNESS_CONSTANTS=""
+endif
 
 #
 # To run all the tests, just do:
@@ -212,7 +217,7 @@ $(TOP)/tools/common/SdkVersions.cs: $(TOP)/tools/common/SdkVersions.cs.in
 	@touch $@
 
 xharness/xharness.exe: $(xharness_dependencies) test.config test-system.config .stamp-src-project-files $(TOP)/tools/common/SdkVersions.cs
-	$(Q_GEN) $(SYSTEM_MSBUILD) /restore $(MSBUILD_VERBOSITY_QUIET) xharness/xharness.csproj
+	$(Q_GEN) $(SYSTEM_MSBUILD) /restore $(MSBUILD_VERBOSITY_QUIET) xharness/xharness.csproj /p:DefineConstants=$(XHARNESS_CONSTANTS)
 xharness/xharness.csproj.inc: export BUILD_VERBOSITY=$(XBUILD_VERBOSITY)
 xharness/xharness.csproj.inc: export ABSOLUTE_PATHS=1
 -include xharness/xharness.csproj.inc

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -42,6 +42,7 @@ namespace Xamarin.Tests
 		public static bool include_dotnet_watchos;
 		public static bool include_maccatalyst;
 		public static bool include_device;
+		public static bool include_dotnet;
 
 		static Version xcode_version;
 		public static Version XcodeVersion {
@@ -270,6 +271,7 @@ namespace Xamarin.Tests
 			include_dotnet_watchos = !string.IsNullOrEmpty (GetVariable ("INCLUDE_DOTNET_WATCH", ""));
 			include_maccatalyst = !string.IsNullOrEmpty (GetVariable ("INCLUDE_MACCATALYST", ""));
 			include_device = !string.IsNullOrEmpty (GetVariable ("INCLUDE_DEVICE", ""));
+			include_dotnet = !string.IsNullOrEmpty (GetVariable ("ENABLE_DOTNET", ""));
 			DotNet6BclDir = GetVariable ("DOTNET6_BCL_DIR", null);
 
 			XcodeVersionString = GetXcodeVersion (xcode_root);
@@ -294,6 +296,7 @@ namespace Xamarin.Tests
 			Console.WriteLine ("  INCLUDE_TVOS={0}", include_tvos);
 			Console.WriteLine ("  INCLUDE_WATCHOS={0}", include_watchos);
 			Console.WriteLine ("  INCLUDE_MACCATALYST={0}", include_maccatalyst);
+			Console.WriteLine ("  ENABLE_DOTNET={0}", include_dotnet);
 		}
 
 		public static string RootPath {
@@ -698,6 +701,13 @@ namespace Xamarin.Tests
 			if (include_device)
 				return;
 			Assert.Ignore ("This build does not include device support.");
+		}
+
+		public static void AssertDotNetAvailable ()
+		{
+			if (include_dotnet)
+				return;
+			Assert.Ignore (".NET tests not enabled");
 		}
 
 		public static string CloneTestDirectory (string directory)

--- a/tests/msbuild/Xamarin.MacDev.Tests/DotnetTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/DotnetTest.cs
@@ -1,4 +1,3 @@
-#if ENABLE_DOTNET
 using System;
 using System.IO;
 
@@ -52,6 +51,8 @@ namespace Xamarin.iOS.Tasks {
 		[TestCase ("MyXamarinFormsApp")]
 		public void CompareBuilds (string project, int expectedErrorCount = 0)
 		{
+			Configuration.AssertDotNetAvailable ();
+
 			tfi = "Xamarin.iOS";
 			switch (project) {
 			case "MyMetalGame":
@@ -92,4 +93,3 @@ namespace Xamarin.iOS.Tasks {
 		}
 	}
 }
-#endif

--- a/tests/msbuild/Xamarin.MacDev.Tests/DotnetTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/DotnetTest.cs
@@ -1,3 +1,4 @@
+#if ENABLE_DOTNET
 using System;
 using System.IO;
 
@@ -91,3 +92,4 @@ namespace Xamarin.iOS.Tasks {
 		}
 	}
 }
+#endif

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -131,6 +131,7 @@ namespace Xharness {
 		public string MONO_IOS_SDK_DESTDIR { get; }
 		public string MONO_MAC_SDK_DESTDIR { get; }
 		public bool ENABLE_XAMARIN { get; }
+		public bool ENABLE_DOTNET { get; }
 
 		// Run
 
@@ -202,6 +203,7 @@ namespace Xharness {
 			MONO_IOS_SDK_DESTDIR = config ["MONO_IOS_SDK_DESTDIR"];
 			MONO_MAC_SDK_DESTDIR = config ["MONO_MAC_SDK_DESTDIR"];
 			ENABLE_XAMARIN = config.ContainsKey ("ENABLE_XAMARIN") && !string.IsNullOrEmpty (config ["ENABLE_XAMARIN"]);
+			ENABLE_DOTNET = config.ContainsKey ("ENABLE_DOTNET") && !string.IsNullOrEmpty (config ["ENABLE_DOTNET"]);
 
 			if (string.IsNullOrEmpty (SdkRoot))
 				SdkRoot = config ["XCODE_DEVELOPER_ROOT"] ?? configuration.SdkRoot;

--- a/tests/xharness/IHarness.cs
+++ b/tests/xharness/IHarness.cs
@@ -43,6 +43,7 @@ namespace Xharness {
 		string MONO_IOS_SDK_DESTDIR { get; }
 		string MONO_MAC_SDK_DESTDIR { get; }
 		bool ENABLE_XAMARIN { get; }
+		bool ENABLE_DOTNET { get; }
 		string XcodeRoot { get; }
 		string LogDirectory { get; } 
 		double Timeout { get; }

--- a/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
+++ b/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -50,9 +50,6 @@ namespace Xharness.Jenkins {
 				SolutionPath = Path.GetFullPath (Path.Combine (HarnessConfiguration.RootDirectory, "..", "msbuild", "Xamarin.MacDev.Tasks.sln")),
 				SupportsParallelExecution = false,
 			};
-			if (jenkins.IncludeDotNet) {
-				buildiOSMSBuildIntegration.Constants.Add ("ENABLE_DOTNET");
-			}
 			var nunitExecutioniOSMSBuildIntegration = new NUnitExecuteTask (jenkins, buildiOSMSBuildIntegration, processManager) {
 				TestLibrary = Path.Combine (HarnessConfiguration.RootDirectory, "msbuild", "Xamarin.MacDev.Tests", "bin", "Debug", "net472", "Xamarin.MacDev.Tests.dll"),
 				TestProject = msbuildIntegrationTestsProject,

--- a/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
+++ b/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
@@ -49,10 +49,10 @@ namespace Xharness.Jenkins {
 				Platform = TestPlatform.iOS,
 				SolutionPath = Path.GetFullPath (Path.Combine (HarnessConfiguration.RootDirectory, "..", "msbuild", "Xamarin.MacDev.Tasks.sln")),
 				SupportsParallelExecution = false,
-#if ENABLE_DOTNET
-				Constants = { "ENABLE_DOTNET" }
-#endif
 			};
+			if (jenkins.IncludeDotNet) {
+				buildiOSMSBuildIntegration.Constants.Add ("ENABLE_DOTNET");
+			}
 			var nunitExecutioniOSMSBuildIntegration = new NUnitExecuteTask (jenkins, buildiOSMSBuildIntegration, processManager) {
 				TestLibrary = Path.Combine (HarnessConfiguration.RootDirectory, "msbuild", "Xamarin.MacDev.Tests", "bin", "Debug", "net472", "Xamarin.MacDev.Tests.dll"),
 				TestProject = msbuildIntegrationTestsProject,

--- a/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
+++ b/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
@@ -49,6 +49,9 @@ namespace Xharness.Jenkins {
 				Platform = TestPlatform.iOS,
 				SolutionPath = Path.GetFullPath (Path.Combine (HarnessConfiguration.RootDirectory, "..", "msbuild", "Xamarin.MacDev.Tasks.sln")),
 				SupportsParallelExecution = false,
+#if ENABLE_DOTNET
+				Constants = { "ENABLE_DOTNET" }
+#endif
 			};
 			var nunitExecutioniOSMSBuildIntegration = new NUnitExecuteTask (jenkins, buildiOSMSBuildIntegration, processManager) {
 				TestLibrary = Path.Combine (HarnessConfiguration.RootDirectory, "msbuild", "Xamarin.MacDev.Tests", "bin", "Debug", "net472", "Xamarin.MacDev.Tests.dll"),

--- a/tests/xharness/Jenkins/TestSelector.cs
+++ b/tests/xharness/Jenkins/TestSelector.cs
@@ -327,6 +327,11 @@ namespace Xharness.Jenkins {
 				MainLog.WriteLine ("The macOS build is disabled, so any macOS tests will be disabled as well.");
 				jenkins.IncludeMac = false;
 			}
+
+			if (!Harness.ENABLE_DOTNET) {
+				MainLog.WriteLine ("The .NET build is disabled, so any .NET tests will be disabled as well.");
+				jenkins.IncludeDotNet = false;
+			}
 		}
 	}
 }

--- a/tests/xharness/Jenkins/TestTasks/BuildTool.cs
+++ b/tests/xharness/Jenkins/TestTasks/BuildTool.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
@@ -14,6 +15,7 @@ namespace Xharness.Jenkins.TestTasks {
 
 		public bool SpecifyPlatform { get; set; } = true;
 		public bool SpecifyConfiguration { get; set; } = true;
+		public List<string> Constants { get; } = new List<string> ();
 
 		public BuildTool (IProcessManager processManager)
 		{

--- a/tests/xharness/Jenkins/TestTasks/BuildToolTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/BuildToolTask.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
@@ -31,6 +32,10 @@ namespace Xharness.Jenkins.TestTasks {
 		public bool SpecifyConfiguration {
 			get => buildToolTask.SpecifyConfiguration;
 			set => buildToolTask.SpecifyConfiguration = value;
+		}
+
+		public List<string> Constants {
+			get => buildToolTask.Constants;
 		}
 
 		public override TestProject TestProject {

--- a/tests/xharness/Jenkins/TestTasks/MSBuild.cs
+++ b/tests/xharness/Jenkins/TestTasks/MSBuild.cs
@@ -32,6 +32,8 @@ namespace Xharness.Jenkins.TestTasks {
 			if (Platform == TestPlatform.MacCatalyst)
 				args.Add ("/r");
 			args.Add (projectFile);
+			if (Constants.Count > 0)
+				args.Add($"/p:DefineConstants=\"{string.Join(";", Constants)}\"");
 			return args;
 		}
 


### PR DESCRIPTION
Allow to uses constants to ignore dotnet tests without creating a new project. 


Backport of #11604
