### PR TITLE
[CI] Do not run monotouch mac dotnet if it is not dotnet enabled.

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -304,6 +304,7 @@ namespace Xharness {
 				IsDotNetProject = true,
 				TargetFrameworkFlavors = MacFlavors.MacCatalyst,
 				Platform = "AnyCPU",
+				Ignore = !ENABLE_DOTNET,
 			});
 
 			foreach (var flavor in new MonoNativeFlavor [] { MonoNativeFlavor.Compat, MonoNativeFlavor.Unified }) {

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -297,6 +297,7 @@ namespace Xharness {
 				IsDotNetProject = true,
 				TargetFrameworkFlavors = MacFlavors.DotNet,
 				Platform = "AnyCPU",
+				Ignore = !ENABLE_DOTNET,
 			});
 
 			MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "monotouch-test", "dotnet", "MacCatalyst", "monotouch-test.csproj"))) {


### PR DESCRIPTION
Other tests are variations and therefore the logic of the test variation factory applies but the monotouch-tests for mac on dotnet do not fall in that area. Ignore if we do not have the build enabled.