### PR TITLE
[Localization] Adding localize-update workflow

### DIFF
--- a/.github/workflows/localization-update.yml
+++ b/.github/workflows/localization-update.yml
@@ -1,0 +1,24 @@
+name: Get Localization Translations
+on:
+  push:
+    branches:
+    - "lego/*"
+
+jobs:
+  pull-request:
+    name: [Open PR to main]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      name: checkout
+
+    - uses: repo-sync/pull-request@v2
+      name: pull-request
+      with:
+        destination_branch: "main"
+        pr_title: "[Localization] Pulling New Localization Translations"
+        pr_body: "Automated PR. Bring new translated changes in the lcl files for OneLocBuild to create translated resx files."
+        pr_label: "not-notes-worthy"
+        pr_milestone: "Future"
+        pr_allow_empty: false
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/localization-update.yml
+++ b/.github/workflows/localization-update.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   pull-request:
-    name: [Open PR to main]
+    name: [Localization PR to main]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR should allow us to receive PRs in main whenever the Loc team adds new translation to our lcl files in the 'Localization' branch.

Reasoning: The Loc team needs to be able to auto-merge these lcl file changes so they will do so in the 'Localization' branch.
We will create the PRs to main from the branch they are using to push into 'Localization' which has the prefix 'lego'. 
Therefore, we will look for 'lego/*'.