### PR TITLE
[CI] Do not run monotouch mac dotnet if it is not dotnet enabled. (#11654)

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -296,6 +296,7 @@ namespace Xharness {
 				IsDotNetProject = true,
 				TargetFrameworkFlavors = MacFlavors.DotNet,
 				Platform = "AnyCPU",
+				Ignore = !ENABLE_DOTNET,
 			});
 
 			foreach (var flavor in new MonoNativeFlavor [] { MonoNativeFlavor.Compat, MonoNativeFlavor.Unified }) {


### PR DESCRIPTION
backport of https://github.com/xamarin/xamarin-macios/pull/11654