### PR TITLE
[runtime] Don't include a workaround for a ancient bug anymore in .NET.

### DIFF
--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -27,7 +27,7 @@
 #include "runtime-internal.h"
 #include "delegates.h"
 
-#if defined(__x86_64__)
+#if defined(__x86_64__) && !DOTNET
 #include "../tools/mtouch/monotouch-fixes.c"
 #endif
 
@@ -251,7 +251,7 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 	const char *managed_argv [argc + 2];
 	int managed_argc = 1;
 
-#if defined(__x86_64__)
+#if defined(__x86_64__) && !DOTNET
 	patch_sigaction ();
 #endif
 


### PR DESCRIPTION
The workaround doesn't work anymore anyway, this is printed on every launch:

> MonoTouch: Could not install sigaction override, unexpected sigaction implementation.

Ref: https://github.com/xamarin/maccore/commit/054bbdce96eccb353e19c0718f3187eee43b513f