### PR TITLE
[dotnet][linker] Use substitutions to stub debug helpers in UIApplication

### DIFF
--- a/src/ILLink.Substitutions.ios.xml
+++ b/src/ILLink.Substitutions.ios.xml
@@ -3,6 +3,10 @@
     <type fullname="ObjCRuntime.Runtime">
       <method signature="System.Boolean get_IsCoreCLR()" body="stub" value="false" />
     </type>
+    <type fullname="UIKit.UIApplication">
+      <method name="EnsureEventAndDelegateAreNotMismatched" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
+      <method name="EnsureDelegateAssignIsNotOverwritingInternalDelegate" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
+    </type>
     <type fullname="UIKit.UIButton">
       <method signature="System.Void VerifyIsUIButton()" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
     </type>

--- a/src/ILLink.Substitutions.tvos.xml
+++ b/src/ILLink.Substitutions.tvos.xml
@@ -3,6 +3,10 @@
     <type fullname="ObjCRuntime.Runtime">
       <method signature="System.Boolean get_IsCoreCLR()" body="stub" value="false" />
     </type>
+    <type fullname="UIKit.UIApplication">
+      <method signature="System.Void EnsureEventAndDelegateAreNotMismatched(System.Object,System.Type)" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
+      <method signature="System.Void EnsureDelegateAssignIsNotOverwritingInternalDelegate(System.Object,System.Object,System.Type)" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
+    </type>
     <type fullname="UIKit.UIButton">
       <method signature="System.Void VerifyIsUIButton()" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
     </type>

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -1064,6 +1064,20 @@ namespace LinkSdk {
 			Assert.That (il.Length, Is.EqualTo (1), "il == 1");
 #endif
 		}
+
+		[Test]
+		public void EnsureEventAndDelegateAreNotMismatched ()
+		{
+			var m = typeof (UIApplication).GetMethod ("EnsureEventAndDelegateAreNotMismatched", BindingFlags.Static | BindingFlags.NonPublic);
+			CheckILLinkStubbedMethod (m);
+		}
+
+		[Test]
+		public void EnsureDelegateAssignIsNotOverwritingInternalDelegate ()
+		{
+			var m = typeof (UIApplication).GetMethod ("EnsureDelegateAssignIsNotOverwritingInternalDelegate", BindingFlags.Static | BindingFlags.NonPublic);
+			CheckILLinkStubbedMethod (m);
+		}
 #endif
 
 		[Test]


### PR DESCRIPTION
Both
* EnsureEventAndDelegateAreNotMismatched
* EnsureDelegateAssignIsNotOverwritingInternalDelegate

are helpers that will warn, on console, if ObjC delegates are mis-used
inside the application. Those message are not useful at runtime and we
can use ILLink's substitutions to remove the content of the checks for
release builds.