### PR TITLE
[Localization] Test to make sure the new resx files are compiled to Resources

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
+++ b/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
@@ -7,19 +7,17 @@
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Update="MSBStrings.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>MSBStrings.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
     <Compile Update="MSBStrings.Designer.cs">
       <DependentUpon>MSBStrings.resx</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MSBStrings.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>MSBStrings.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="TranslatedAssemblies/MSBStrings.cs.resx">
       <Link>MSBStrings.cs.resx</Link>
     </EmbeddedResource>

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/LocalizationStringTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/LocalizationStringTest.cs
@@ -10,6 +10,7 @@ using Xamarin.Localization.MSBuild;
 using System.ComponentModel;
 using System.Linq;
 using System.Text;
+using System.Xml.Linq;
 
 namespace Xamarin.iOS.Tasks {
 	[TestFixture]
@@ -159,6 +160,28 @@ namespace Xamarin.iOS.Tasks {
 			if (!File.Exists (path))
 				return Array.Empty<string> ();
 			return File.ReadAllLines (path).Where (line => !line.StartsWith ("#", StringComparison.Ordinal) && line != string.Empty).ToList ();
+		}
+
+		readonly string [] ignoreList = {
+			"ResourceManager",
+			"Culture",
+		};
+
+		[Test]
+		public void UpdatedResources ()
+		{
+			var resxPath = Path.Combine (Directory.GetCurrentDirectory (), "../../../../msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx");
+			var xml = XDocument.Load (resxPath);
+			var resxNames = xml.Root.Descendants ().Where (n => n.Name == "data").Select (n => n.Attribute ("name").Value);
+			var resxHashSet = new HashSet<string> (resxNames);
+			var resourceNames = typeof (MSBStrings).GetProperties ().Select (s => s.Name);
+			var resourceHashSet = new HashSet<string> (resourceNames);
+
+			var errorsNotInResources = string.Join (" ", resxHashSet.Where (n => !resourceHashSet.Contains (n) && !ignoreList.Contains (n)));
+			var errorsNotInResx = string.Join (" ", resourceHashSet.Where (n => !resxHashSet.Contains (n) && !ignoreList.Contains (n)));
+
+			Assert.IsEmpty (errorsNotInResources, $"The following error(s) were found in MSBStrings.resx but not through the MSBStrings resource. Try to recompile the msbuild project and then the test project\n{errorsNotInResources}");
+			Assert.IsEmpty (errorsNotInResx, $"The following error(s) were found in the MSBStrings resource but not in MSBStrings.resx. Try to recompile the msbuild project and then the test project\n{errorsNotInResx}");
 		}
 	}
 }

--- a/tests/mtouch/LocalizationTests.cs
+++ b/tests/mtouch/LocalizationTests.cs
@@ -6,6 +6,9 @@ using System.Reflection;
 using System.Resources;
 using System.Text;
 using System.Collections.Generic;
+using System.IO;
+using System.Xml.Linq;
+using System.Linq;
 
 namespace Xamarin.Tests
 {
@@ -105,6 +108,32 @@ namespace Xamarin.Tests
 				}
 			}
 			Assert.IsEmpty (errorList.ToString (), $"The following errors were not translated:");
+		}
+
+		readonly string [] ignoreList = {
+			"ResourceManager",
+			"Culture",
+			"_default",
+			"default",
+		};
+
+		[Test]
+		public void UpdatedResources ()
+		{
+			var resxPath = Path.Combine (Directory.GetCurrentDirectory (), "../../tools/mtouch/Errors.resx");
+			var xml = XDocument.Load (resxPath);
+			var resxNames = xml.Root.Descendants ().Where (n => n.Name == "data").Select (n => n.Attribute ("name").Value);
+			var resxHashSet = new HashSet<string> (resxNames);
+
+			var errorsAssembly = typeof (MachO).Assembly.GetType ("Xamarin.Bundler.Errors");
+			var resourceNames = errorsAssembly.GetProperties (BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Static).Select (s => s.Name);
+			var resourceHashSet = new HashSet<string> (resourceNames);
+
+			var errorsNotInResources = string.Join (" ", resxHashSet.Where (n => !resourceHashSet.Contains (n) && !ignoreList.Contains (n)));
+			var errorsNotInResx = string.Join (" ", resourceHashSet.Where (n => !resxHashSet.Contains (n) && !ignoreList.Contains (n)));
+
+			Assert.IsEmpty (errorsNotInResources, $"The following error(s) were found in Errors.resx but not through the mtouch resources. Try to recompile the mtouch project and then the test project\n{errorsNotInResources}");
+			Assert.IsEmpty (errorsNotInResx, $"The following error(s) were found in the mtouch resources but not in Errors.resx. Try to recompile the mtouch project and then the test project\n{errorsNotInResx}");
 		}
 	}
 }

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -11,17 +11,17 @@
 namespace Xamarin.Bundler {
     using System;
     using System.Reflection;
-
-
-    [System.CodeDom.Compiler.GeneratedCodeAttribute ("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
-    [System.Diagnostics.DebuggerNonUserCodeAttribute ()]
-    [System.Runtime.CompilerServices.CompilerGeneratedAttribute ()]
+    
+    
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Errors {
-
+        
         private static System.Resources.ResourceManager resourceMan;
-
+        
         private static System.Globalization.CultureInfo resourceCulture;
-
+        
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Errors() {
         }
@@ -30,7 +30,7 @@ namespace Xamarin.Bundler {
         internal static System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.Equals(null, resourceMan)) {
-                    System.Resources.ResourceManager temp = new System.Resources.ResourceManager("Errors.mtouch", typeof(Errors).Assembly);
+                    System.Resources.ResourceManager temp = new System.Resources.ResourceManager("mtouch.Errors", typeof(Errors).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -2432,6 +2432,30 @@ namespace Xamarin.Bundler {
         internal static string MT8018 {
             get {
                 return ResourceManager.GetString("MT8018", resourceCulture);
+            }
+        }
+        
+        internal static string MX8037 {
+            get {
+                return ResourceManager.GetString("MX8037", resourceCulture);
+            }
+        }
+        
+        internal static string MX8038 {
+            get {
+                return ResourceManager.GetString("MX8038", resourceCulture);
+            }
+        }
+        
+        internal static string MX8039 {
+            get {
+                return ResourceManager.GetString("MX8039", resourceCulture);
+            }
+        }
+        
+        internal static string MX8040 {
+            get {
+                return ResourceManager.GetString("MX8040", resourceCulture);
             }
         }
     }


### PR DESCRIPTION
I randomly reflected today on [this comment](https://github.com/xamarin/xamarin-macios/pull/11599/files#r634590317) left by @spouliot last week on Rolf's PR. I looked at my reply and think it was a half truth (or half lie) by accident of course. 

As new strings are added to the english resx files (either mtouch/Errors.resx or MSBStrings.resx), I believe the corresponding translated resx files should not be updated to contain english versions of these errors. When we call these new errors, the resource manager should see that they are not available in the other languages and just return us the english string. 

However, looking back at it, I thought it was suspicious that nothing was added to the MSBStrings.designer.cs file. I **do not** think it is true that if something is added inside the designer file, that it will be included in the resources, but I **do** think that if a string is not in the designer then it is probably not included in the resources.

I created a test to make sure that all the strings in the resx files are showing up in the resources and every string in the resources are showing up in the resx files. I ran the test on a branch straight from main and it in fact turns out that these strings (and a few others) weren't in the resources as shown in the picture below.

![image](https://user-images.githubusercontent.com/50846373/119588791-209fff80-bd97-11eb-94c0-1ab332600b9a.png)

I made sure to recompile both the mtouch project and the test project and the strings were added to both the designer and resources although the designer was a little finicky/inconsistent.

This does not make a huge difference right now as the mtouch strings are not yet translated, but perhaps this can help us in the future as calling these error strings would have produced an error (I believe).