### PR TITLE
[runtime] Return values from mono_array_get must be released.

### DIFF
--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -1709,7 +1709,7 @@ xamarin_convert_managed_to_nsarray_with_func (MonoArray *array, xamarin_managed_
 #endif
 
 	for (unsigned long i = 0; i < length; i++) {
-		MonoObject *value;
+		MonoObject *value = NULL;
 #if defined (CORECLR_RUNTIME)
 		value = mono_array_get (array, i, exception_gchandle);
 #else
@@ -1725,6 +1725,8 @@ xamarin_convert_managed_to_nsarray_with_func (MonoArray *array, xamarin_managed_
 		}
 
 		buf [i] = convert (value, context, exception_gchandle);
+		xamarin_mono_object_release (&value);
+
 		if (*exception_gchandle != INVALID_GCHANDLE) {
 			*exception_gchandle = xamarin_get_exception_for_element_conversion_failure (*exception_gchandle, i);
 			goto exception_handling;


### PR DESCRIPTION
Before:

    There were 257927 MonoObjects created, 144942 MonoObjects freed, so 112985 were not freed. (dynamic registrar)
    There were 205700 MonoObjects created, 113865 MonoObjects freed, so 91835 were not freed. (static registrar)

After:

    There were 257931 MonoObjects created, 235062 MonoObjects freed, so 22869 were not freed. (dynamic registrar)
    There were 205700 MonoObjects created, 203983 MonoObjects freed, so 1717 were not freed. (static registrar)