### PR TITLE
[dotnet] publishing settings for NuGet.org

### DIFF
--- a/dotnet/package/common.csproj
+++ b/dotnet/package/common.csproj
@@ -10,7 +10,9 @@
     <RepositoryUrl>https://github.com/xamarin/xamarin-macios</RepositoryUrl>
     <RepositoryBranch>$(CurrentBranch)</RepositoryBranch>
     <RepositoryCommit>$(CurrentHash)</RepositoryCommit>
-    <Authors>Xamarin</Authors>
+    <Authors>Microsoft</Authors>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/xamarin/xamarin-macios</PackageProjectUrl>
 
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -35,10 +37,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="$(_packagePath)**">
-      <Pack>true</Pack>
-      <PackagePath>\</PackagePath>
-    </Content>
+    <None Include="$(_RepositoryPath)/LICENSE" Pack="true" PackagePath="/" />
+    <Content Include="$(_packagePath)**" Pack="true" PackagePath="/" />
   </ItemGroup>
 
   <!-- Code to automatically create FrameworkList.xml or RuntimeList.xml -->

--- a/dotnet/package/common.csproj
+++ b/dotnet/package/common.csproj
@@ -13,6 +13,7 @@
     <Authors>Microsoft</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageProjectUrl>https://github.com/xamarin/xamarin-macios</PackageProjectUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
 
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5948

Microsoft has rules for submitting signed NuGet packages with the
namespace `Microsoft.*` under the Microsoft + Xamarin organizations.

Some of these rules include:

* Package must be signed.
* Must include a license.
* `$(Authors)` should be `Microsoft`
* `$(PackageProjectUrl)` can't be blank.
* `$(Copyright)` must *exactly* say `© Microsoft Corporation. All rights reserved.`

If any of these are wrong, you'll get errors during `nuget push` such as:

    Response status code does not indicate success:
    400 (The package is not compliant with metadata requirements for Microsoft packages on NuGet.org.
    Go to https://aka.ms/Microsoft-NuGet-Compliance for more information.
    Policy violations: The package metadata is missing required ProjectUrl.

We used a script to fix up these values and resign for .NET 6 Preview
4. This was painful but got us by for the current release.

Going forward, we should just fill out these values for .NET 6 .nupkg
files.