### PR TITLE
[runtime] Intercept the objc_msgSend family of functions using CoreCLR's supported mechanisms.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -146,6 +146,12 @@ struct InitializationOptions {
 	const char *EntryAssemblyPath;
 #endif
 	struct AssemblyLocations* AssemblyLocations;
+#if DOTNET
+	void *xamarin_objc_msgsend;
+	void *xamarin_objc_msgsend_super;
+	void *xamarin_objc_msgsend_stret;
+	void *xamarin_objc_msgsend_super_stret;
+#endif
 };
 
 static struct Trampolines trampolines = {
@@ -1252,6 +1258,15 @@ xamarin_initialize ()
 	options.LaunchMode = xamarin_launch_mode;
 	options.EntryAssemblyPath = xamarin_entry_assembly_path;
 #endif
+
+#if defined (CORECLR_RUNTIME)
+	options.xamarin_objc_msgsend = (void *) xamarin_dyn_objc_msgSend;
+	options.xamarin_objc_msgsend_super = (void *) xamarin_dyn_objc_msgSendSuper;
+#if !defined(__aarch64__)
+	options.xamarin_objc_msgsend_stret = (void *) xamarin_dyn_objc_msgSend_stret;
+	options.xamarin_objc_msgsend_super_stret = (void *) xamarin_dyn_objc_msgSendSuper_stret;
+#endif // !defined(__aarch64__)
+#endif // defined(CORECLR_RUNTIME)
 
 	xamarin_bridge_call_runtime_initialize (&options, &exception_gchandle);
 	if (exception_gchandle != INVALID_GCHANDLE) {
@@ -2368,6 +2383,7 @@ xamarin_pinvoke_override (const char *libraryName, const char *entrypointName)
 
 	if (!strcmp (libraryName, "__Internal")) {
 		symbol = dlsym (RTLD_DEFAULT, entrypointName);
+#if !defined (CORECLR_RUNTIME) // we're intercepting objc_msgSend calls using the managed System.Runtime.InteropServices.ObjectiveC.Bridge.SetMessageSendCallback instead.
 #if defined (__i386__) || defined (__x86_64__) || defined (__arm64__)
 	} else if (!strcmp (libraryName, "/usr/lib/libobjc.dylib")) {
 		if (xamarin_marshal_objectivec_exception_mode != MarshalObjectiveCExceptionModeDisable) {
@@ -2384,6 +2400,7 @@ xamarin_pinvoke_override (const char *libraryName, const char *entrypointName)
 			}
 		}
 #endif // defined (__i386__) || defined (__x86_64__) || defined (__arm64__)
+#endif // !defined (CORECLR_RUNTIME)
 	}
 
 	return symbol;

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -147,6 +147,8 @@ struct InitializationOptions {
 #endif
 	struct AssemblyLocations* AssemblyLocations;
 #if DOTNET
+	// This struct must be kept in sync with the corresponding struct in Runtime.cs, and since we use the same managed code for both MonoVM and CoreCLR,
+	// we can't restrict the following fields to CORECLR_RUNTIME only, we can only exclude it from legacy Xamarin.
 	void *xamarin_objc_msgsend;
 	void *xamarin_objc_msgsend_super;
 	void *xamarin_objc_msgsend_stret;

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -20,8 +20,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ObjectiveC;
 using System.Text;
 
 using Foundation;
@@ -79,6 +80,21 @@ namespace ObjCRuntime {
 		static void log_coreclr (string message)
 		{
 			NSLog (message);
+		}
+
+		static unsafe void InitializeCoreCLRBridge (InitializationOptions* options)
+		{
+			if (options->xamarin_objc_msgsend != IntPtr.Zero)
+				ObjectiveCMarshal.SetMessageSendCallback (ObjectiveCMarshal.MessageSendFunction.MsgSend, options->xamarin_objc_msgsend);
+
+			if (options->xamarin_objc_msgsend_super != IntPtr.Zero)
+				ObjectiveCMarshal.SetMessageSendCallback (ObjectiveCMarshal.MessageSendFunction.MsgSendSuper, options->xamarin_objc_msgsend_super);
+
+			if (options->xamarin_objc_msgsend_stret != IntPtr.Zero)
+				ObjectiveCMarshal.SetMessageSendCallback (ObjectiveCMarshal.MessageSendFunction.MsgSendStret, options->xamarin_objc_msgsend_stret);
+
+			if (options->xamarin_objc_msgsend_super_stret != IntPtr.Zero)
+				ObjectiveCMarshal.SetMessageSendCallback (ObjectiveCMarshal.MessageSendFunction.MsgSendSuperStret, options->xamarin_objc_msgsend_super_stret);
 		}
 
 		internal static void RegisterToggleReferenceCoreCLR (NSObject obj, IntPtr handle, bool isCustomType)

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -157,6 +157,12 @@ namespace ObjCRuntime {
 #endif
 			IntPtr AssemblyLocations;
 
+#if NET
+			public IntPtr xamarin_objc_msgsend;
+			public IntPtr xamarin_objc_msgsend_super;
+			public IntPtr xamarin_objc_msgsend_stret;
+			public IntPtr xamarin_objc_msgsend_super_stret;
+#endif
 			public bool IsSimulator {
 				get {
 					return (Flags & InitializationFlags.IsSimulator) == InitializationFlags.IsSimulator;
@@ -279,6 +285,11 @@ namespace ObjCRuntime {
 
 			objc_exception_mode = options->MarshalObjectiveCExceptionMode;
 			managed_exception_mode = options->MarshalManagedExceptionMode;
+
+#if NET
+			if (IsCoreCLR)
+				InitializeCoreCLRBridge (options);
+#endif
 
 			initialized = true;
 #if PROFILE

--- a/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
@@ -85,9 +85,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 		// Simulator/desktop only (except for watchOS, where it works everywhere)
 		[Test]
-#if NET
-		[Ignore ("Ignored on CoreCLR for now due to missing support for marshalling exceptions")]
-#endif
 		public void ObjCException ()
 		{
 #if !__WATCHOS__ && !__MACOS__
@@ -134,9 +131,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 		// Simulator/desktop only test (except for watchOS, where it works everywhere)
 		[Test]
-#if NET
-		[Ignore ("Ignored on CoreCLR for now due to missing support for marshalling exceptions")]
-#endif
 		public void ManagedExceptionPassthrough ()
 		{
 			Exception thrownException = null;

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -1243,9 +1243,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		}
 
 		[Test]
-#if NET
-		[Ignore ("Ignored on CoreCLR for now due to missing support for marshalling exceptions")]
-#endif
 		public void TestConstrainedGenericType ()
 		{
 			IntPtr value;

--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -616,9 +616,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 #if DYNAMIC_REGISTRAR
 		[Test]
-#if NET
-		[Ignore ("Ignored on CoreCLR for now due to missing support for marshalling exceptions")]
-#endif
 		public void MX8029_b ()
 		{
 			try {
@@ -640,9 +637,6 @@ Additional information:
 		}
 
 		[Test]
-#if NET
-		[Ignore ("Ignored on CoreCLR for now due to missing support for marshalling exceptions")]
-#endif
 		public void MX8033 ()
 		{
 			try {


### PR DESCRIPTION
This allows us to re-introduce a few tests.