### PR TITLE
[dotnet] Tell .NET to not generate files we don't need. Fixes #9687.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -23,9 +23,6 @@
 		<!-- _XamarinSdkRootOnMac this should be passed to tasks that need to access the Xamarin Sdk dir on the Mac, this value will be overriden from Windows -->
 		<_XamarinSdkRootOnMac>$(_XamarinSdkRoot)</_XamarinSdkRootOnMac>
 
-		<!-- We don't need any runtime configuration files -->
-		<GenerateRuntimeConfigurationFiles Condition="'$(GenerateRuntimeConfigurationFiles)' ==''">false</GenerateRuntimeConfigurationFiles>
-
 		<!-- We don't need any dependency files -->
 		<GenerateDependencyFile Condition="'$(GenerateDependencyFile)' == ''">false</GenerateDependencyFile>
 	</PropertyGroup>

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -22,5 +22,11 @@
 		<_XamarinSdkRoot Condition="'$(_XamarinSdkRoot)' == ''">$(_XamarinSdkRootDirectory)</_XamarinSdkRoot>
 		<!-- _XamarinSdkRootOnMac this should be passed to tasks that need to access the Xamarin Sdk dir on the Mac, this value will be overriden from Windows -->
 		<_XamarinSdkRootOnMac>$(_XamarinSdkRoot)</_XamarinSdkRootOnMac>
+
+		<!-- We don't need any runtime configuration files -->
+		<GenerateRuntimeConfigurationFiles Condition="'$(GenerateRuntimeConfigurationFiles)' ==''">false</GenerateRuntimeConfigurationFiles>
+
+		<!-- We don't need any dependency files -->
+		<GenerateDependencyFile Condition="'$(GenerateDependencyFile)' == ''">false</GenerateDependencyFile>
 	</PropertyGroup>
 </Project>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -132,6 +132,9 @@
 		<StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
 		<UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
 		<UseNativeHttpHandler Condition="'$(_PlatformName)' != 'macOS' And '$(UseNativeHttpHandler)' == ''">true</UseNativeHttpHandler>
+
+		<!-- We don't need to generate reference assemblies for apps or app extensions -->
+		<ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == '' And ('$(OutputType)' == 'Exe' Or '$(IsAppExtension)' == 'true')">false</ProduceReferenceAssembly>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
Tell .NET to not generate files we don't need:

* Runtime configuration file (*.runtimeconfig.json).
* Dependency file (*.deps.json).
* Reference assemblies for executable projects.

Fixes https://github.com/xamarin/xamarin-macios/issues/9687.