### PR TITLE
[dotnet][linker] Use signature (not name) for iOS substitutions (just like tvOS)

### DIFF
--- a/src/ILLink.Substitutions.ios.xml
+++ b/src/ILLink.Substitutions.ios.xml
@@ -4,8 +4,8 @@
       <method signature="System.Boolean get_IsCoreCLR()" body="stub" value="false" />
     </type>
     <type fullname="UIKit.UIApplication">
-      <method name="EnsureEventAndDelegateAreNotMismatched" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
-      <method name="EnsureDelegateAssignIsNotOverwritingInternalDelegate" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
+      <method signature="System.Void EnsureEventAndDelegateAreNotMismatched(System.Object,System.Type)" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
+      <method signature="System.Void EnsureDelegateAssignIsNotOverwritingInternalDelegate(System.Object,System.Object,System.Type)" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
     </type>
     <type fullname="UIKit.UIButton">
       <method signature="System.Void VerifyIsUIButton()" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />


### PR DESCRIPTION
ref: https://github.com/xamarin/maccore/issues/2446