### PR TITLE
[d16-10][msbuild] Backport part of b88c3bb031e4164ba2c35466d0d3b2856dfe8e61

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -17,15 +17,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.Common.props" />
 
-	<PropertyGroup>
-		<!-- Naming convention that relies on the fact that there will be a Microsoft.Windows.iOS.Sdk pack with the same version that the core SDK, on Windows installations only -->
-		<WindowsiOSSdkDirectory>$(MSBuildThisFileDirectory.Replace('Microsoft.iOS.Sdk', 'Microsoft.iOS.Windows.Sdk'))</WindowsiOSSdkDirectory>
-	</PropertyGroup>
-
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets" 
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
-	<Import Project="$(WindowsiOSSdkDirectory)$(MSBuildThisFileName).Before.targets" 
-			Condition="Exists('$(WindowsiOSSdkDirectory)$(MSBuildThisFileName).Before.targets')"/>
 
 	<!-- *** Code Analysis Setup *** -->
 	<!-- Library projects aren't supported, if we enable Xamarin.Analysis on them, we'll need to revisit the rules and deactivate some (e.g XIA0002). -->
@@ -1165,7 +1158,5 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
-	<Import Project="$(WindowsiOSSdkDirectory)$(MSBuildThisFileName).After.targets"
-		Condition="Exists('$(WindowsiOSSdkDirectory)$(MSBuildThisFileName).After.targets')"/>
 		
 </Project>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Windows.props
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Windows.props
@@ -13,9 +13,8 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<CoreiOSSdkDirectory>$(MSBuildThisFileDirectory)</CoreiOSSdkDirectory>
-		<!-- Naming convention that relies on the fact that the Microsoft.iOS.Sdk pack exists with the same version that the Windows SDK (.net6 only) -->
-		<CoreiOSSdkDirectory Condition="$(MSBuildThisFileDirectory.Contains('Microsoft.iOS.Windows.Sdk'))">$(MSBuildThisFileDirectory.Replace('Microsoft.iOS.Windows.Sdk', 'Microsoft.iOS.Sdk'))</CoreiOSSdkDirectory>
+		<!-- $(CoreiOSSdkDirectory) is defined in Microsoft.iOS.Sdk.targets, from Microsoft.iOS.Sdk package -->
+		<CoreiOSSdkDirectory Condition=" '$(CoreiOSSdkDirectory)' == '' and '$(UsingAppleNETSdk)' != 'true' ">$(MSBuildThisFileDirectory)</CoreiOSSdkDirectory>
 		<!-- Property originally defined in Xamarin.Messaging.Build.targets, from Xamarin.Messaging.Build.Client package -->
 		<MessagingBuildClientAssemblyFile>$(CoreiOSSdkDirectory)Xamarin.iOS.Tasks.dll</MessagingBuildClientAssemblyFile>
 		<MessagingAgentsDirectory>$(MSBuildThisFileDirectory)</MessagingAgentsDirectory>


### PR DESCRIPTION
Those are the non-net6 changes that also fixed a warning about
target files being imported twice.

Fixes https://github.com/xamarin/xamarin-macios/issues/11686