### PR TITLE
[runtime] Skip custom command line argument parsing for macOS and Mac Catalyst.

### DIFF
--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -249,7 +249,7 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 	// are other arguments besides --app-arg), but it's a guaranteed and bound
 	// upper limit.
 	const char *managed_argv [argc + 2];
-	int managed_argc = 1;
+	int managed_argc = 0;
 
 #if defined(__x86_64__) && !DOTNET
 	patch_sigaction ();
@@ -258,7 +258,10 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 	xamarin_launch_mode = launch_mode;
 
 	memset (managed_argv, 0, sizeof (char*) * (unsigned long) (argc + 2));
-	managed_argv [0] = "monotouch";
+
+#if !(TARGET_OS_OSX || TARGET_OS_MACCATALYST)
+	managed_argv [managed_argc++] = "monotouch";
+#endif
 
 	DEBUG_LAUNCH_TIME_PRINT ("Main entered");
 
@@ -285,7 +288,7 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 
 	{
 		/*
-		 * Command line arguments:
+		 * Command line arguments for mobile targets (iOS / tvOS / watchOS):
 		 * -debugtrack: [Simulator only]
 		 *         If we should track zombie NSObjects and aggressively poke the GC to collect
 		 *         every second.
@@ -311,9 +314,16 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 		 *         specified multiple times.
 		 * -setenv=<key>=<value>
 		 *         Set the environment variable <key> to the value <value>
+		 *
+		 * For desktop targets (macOS / Mac Catalyst) we pass all the command
+		 * line arguments directly to the managed Main method.
+		 *
 		 */
 		int i = 0;
 		for (i = 0; i < argc; i++) {
+#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+			managed_argv [managed_argc++] = argv [i];
+#else
 			char *arg = argv [i];
 			char *name;
 			char *value;
@@ -395,6 +405,7 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 			}
 			
 			free (name);
+#endif // TARGET_OS_OSX || TARGET_OS_MACCATALYST
 		}
 	}
 


### PR DESCRIPTION
Due to the following reasons:

* Desktop apps like macOS and Mac catalyst can be launched directly from the
  command line by users.
* It's trivial to set environment variables for desktop apps before launching
  them.
* All the different command line arguments we support for mobile targets can
  also be set using environment variables.

We don't need additional command line argument parsing for desktop platforms,
so just remove it.

The end result is that instead of doing this to run a specific unit test:

     path/to/macOS/app/MacOS/Contents/theapp --app-arg --test --app-arg MyTestFixture

This will now work:

     path/to/macOS/app/MacOS/Contents/theapp --test MyTestFixture

Which is how apps on desktop platforms should work anyway.