### PR TITLE
[Foundation] Add reminder about NSAutoreleasePool.

### DIFF
--- a/src/Foundation/NSAutoreleasePool.cs
+++ b/src/Foundation/NSAutoreleasePool.cs
@@ -28,6 +28,10 @@ using System.Runtime.InteropServices;
 
 using ObjCRuntime;
 
+#if XAMCORE_4_0
+#error Turn this entire file into generated code.
+#endif
+
 namespace Foundation {
 	[Register ("NSAutoreleasePool", true)]
 	public class NSAutoreleasePool : NSObject


### PR DESCRIPTION
It's not trivial to do now, because the existing constructors are public,
which the generator isn't able to re-create without modifications (to the
generator).

So just add a reminder instead.