### PR TITLE
[registrar] Return values from mono_value_box must be released.

### DIFF
--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -1009,8 +1009,12 @@ xamarin_generate_conversion_to_managed (id value, MonoType *inputType, MonoType 
 				goto exception_handling;
 			*(SList **) free_list = s_list_prepend (*(SList **) free_list, convertedValue);
 
-			if (isManagedNullable)
+			if (isManagedNullable) {
 				convertedValue = mono_value_box (mono_domain_get (), underlyingManagedType, convertedValue);
+				SList* release_list = *(SList**) release_list_ptr;
+				if (release_list != NULL)
+					*release_list_ptr = s_list_prepend (release_list, convertedValue);
+			}
 		}
 	}
 


### PR DESCRIPTION
Before:

    There were 258046 MonoObjects created, 235142 MonoObjects freed, so 22904 were not freed. (dynamic registrar)
    There were 205804 MonoObjects created, 204193 MonoObjects freed, so 1611 were not freed. (static registrar)

After:

    There were 258054 MonoObjects created, 235172 MonoObjects freed, so 22882 were not freed. (dynamic registrar)
    There were 205804 MonoObjects created, 204193 MonoObjects freed, so 1611 were not freed. (static registrar)