### PR TITLE
[Actions] Clean data after a PR is closed.

### DIFF
--- a/.github/workflows/github-page-clean-up.yml
+++ b/.github/workflows/github-page-clean-up.yml
@@ -1,0 +1,39 @@
+name: Clean PR macios.ci data
+
+on:
+  pull_request:
+    types: [closed]
+
+# lock to ensrue we do not step on eachother
+concurrency: 
+  group: 'macios.ci-cleanup'
+  cancel-in-progress: false
+
+jobs:
+  clean-up:
+    runs-on: ubuntu-latest
+    name: Clean PR data
+
+    steps:
+    - run: echo "$GITHUB_CONTEXT"
+      name: 'Debug context'
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+
+    - uses: actions/checkout@master
+      with:
+        name: xamarin/macios.ci
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        path: macios.ci
+
+    - run: |
+        cd $MACIOS_CI_PATH
+        git checkout -b "pr/clean/PR$PR_NUMBER"
+        git rm -r "pr/PR$PR_NUMBER"
+        git commit -m"[Action] Remove data of PR $PR_NUMBER" -a
+        git push origin "pr/clean/PR$PR_NUMBER" -f
+      name: 'Remove data'
+      env:
+        MACIOS_CI_PATH: ${{ github.workspace }}/macios.ci 
+        PR_NUMBER: ${{ github.number }} 
+

--- a/.github/workflows/github-page-clean-up.yml
+++ b/.github/workflows/github-page-clean-up.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [closed]
 
-# lock to ensrue we do not step on eachother
+# lock to ensure we do not step on each other
 concurrency: 
   group: 'macios.ci-cleanup'
   cancel-in-progress: false
@@ -36,4 +36,3 @@ jobs:
       env:
         MACIOS_CI_PATH: ${{ github.workspace }}/macios.ci 
         PR_NUMBER: ${{ github.number }} 
-


### PR DESCRIPTION
To keep the github  webpage small we remove the data once the PR has
been closed (that means closed or merged). The data will be kept in
vsdrops, the only links that will stop working are those from the github
static webpage.

Since we are interested in making the reviewer life better this is a
good compromise.

How to avoif merge conflicts:

We want to make sure we avoid merge conflicts, this is done using two
locks:

1. macios.ci-cleanup - Lock in the xamarin-macios action that will
   ensure that we create a new branch to cleanup the data.
2. ci-results - Lock in the macios.ci action that will merge branhces
   one by one.

This repo will create a new pr that cleans the data, the macios.ci repo
will execute an action when this new branch is created and will merge it
as soon as possible making sure that previos created branches are
merged.