### PR TITLE
[CI] Do not generate github static pages on CI.

### DIFF
--- a/tools/devops/automation/publish-pr-html-results.yml
+++ b/tools/devops/automation/publish-pr-html-results.yml
@@ -22,9 +22,6 @@ resources:
   pipelines:
   - pipeline: macios
     source: xamarin-macios
-    trigger:
-      stages:
-      - build_packages
 
 variables:
 - group: xamops-azdev-secrets

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -561,20 +561,16 @@ function New-GitHubSummaryComment {
     }
 
     $githubPagePrefix = "https://xamarin.github.io/macios.ci"
-    if ([string]::IsNullOrEmpty($Env:PR_ID)) {
-        $githubPagePrefix = "$githubPagePrefix/ci/$Env:BUILD_SOURCEBRANCHNAME/$Env:BUILD_REVISION"
-    } else {
-        $githubPagePrefix = "$githubPagePrefix/pr/PR$Env:PR_ID"
+    if (-not [string]::IsNullOrEmpty($Env:PR_ID)) {
+        $githubPagePrefix = "$githubPagePrefix/ci/$Env:BUILD_SOURCEBRANCHNAME/$Env:BUILD_REVISION/$Env:BUILD_BUILDID"
+        $sb.AppendLine("# GitHub pages")
+        $sb.AppendLine()
+        $sb.AppendLine("Results can be found in the following github pages (it might take some time to publish):")
+        $sb.AppendLine()
+        $sb.AppendLine("* [Test results]($githubPagePrefix/HtmlReport-sim/tests/vsdrops_index.html)")
+        $sb.AppendLine("* [API diff ]($githubPagePrefix/HtmlReport-sim/api-diff/api-diff.html)")
+        $sb.AppendLine("* [API & Generator diff]($githubPagePrefix/apicomparison/api-diff.html)")
     }
-
-    $githubPagePrefix = "$githubPagePrefix/$Env:BUILD_BUILDID"
-    $sb.AppendLine("# GitHub pages")
-    $sb.AppendLine()
-    $sb.AppendLine("Results can be found in the following github pages (it might take some time to publish):")
-    $sb.AppendLine()
-    $sb.AppendLine("* [Test results]($githubPagePrefix/HtmlReport-sim/tests/vsdrops_index.html)")
-    $sb.AppendLine("* [API diff ]($githubPagePrefix/HtmlReport-sim/api-diff/api-diff.html)")
-    $sb.AppendLine("* [API & Generator diff]($githubPagePrefix/apicomparison/api-diff.html)")
 
     $headerLinks = $sb.ToString()
     $request = $null

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -562,7 +562,7 @@ function New-GitHubSummaryComment {
 
     $githubPagePrefix = "https://xamarin.github.io/macios.ci"
     if (-not [string]::IsNullOrEmpty($Env:PR_ID)) {
-        $githubPagePrefix = "$githubPagePrefix/ci/$Env:BUILD_SOURCEBRANCHNAME/$Env:BUILD_REVISION/$Env:BUILD_BUILDID"
+        $githubPagePrefix = "$githubPagePrefix/pr/PR$Env:PR_ID"
         $sb.AppendLine("# GitHub pages")
         $sb.AppendLine()
         $sb.AppendLine("Results can be found in the following github pages (it might take some time to publish):")

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -562,7 +562,7 @@ function New-GitHubSummaryComment {
 
     $githubPagePrefix = "https://xamarin.github.io/macios.ci"
     if (-not [string]::IsNullOrEmpty($Env:PR_ID)) {
-        $githubPagePrefix = "$githubPagePrefix/pr/PR$Env:PR_ID"
+        $githubPagePrefix = "$githubPagePrefix/pr/PR$Env:PR_ID/$Env:BUILD_BUILDID"
         $sb.AppendLine("# GitHub pages")
         $sb.AppendLine()
         $sb.AppendLine("Results can be found in the following github pages (it might take some time to publish):")


### PR DESCRIPTION
We added the github pages to make the life of the reviews easier, the
issue we found is that we have a limited amount of space. Due to that we
are removing the generation from the ci.

Triggers in pipleines are disable by default, removing it will stop it
from being executed. The PR are triggered via a release pipeline we
called macios.glue