### PR TITLE
[release/6.0.1xx-preview5] [dotnet] Remove the .NET workload resolver workaround, it's not needed anymore.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -49,10 +49,6 @@ export MSBuildExtensionsPathFallbackPathsOverride=$(IOS_DESTDIR)/Library/Framewo
 export XAMMAC_FRAMEWORK_PATH=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 export XamarinMacFrameworkRoot=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 
-# This is a temporary variable to enable the .NET workload resolver, because it's opt-in for now.
-# Ref: https://github.com/dotnet/sdk/issues/13849
-export MSBuildEnableWorkloadResolver=true
-
 ifneq ($(RELEASE),)
 ifneq ($(BITCODE),)
 CONFIG=Release-bitcode

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -57,9 +57,6 @@ namespace Xamarin.Tests {
 				var env = new Dictionary<string, string> ();
 				env ["MSBuildSDKsPath"] = null;
 				env ["MSBUILD_EXE_PATH"] = null;
-				// This is a temporary variable to enable the .NET workload resolver, because it's opt-in for now.
-				// Ref: https://github.com/dotnet/sdk/issues/13849
-				env ["MSBuildEnableWorkloadResolver"] = "true";
 				var output = new StringBuilder ();
 				var rv = Execution.RunWithStringBuildersAsync (Executable, args, env, output, output, Console.Out, workingDirectory: Path.GetDirectoryName (project), timeout: TimeSpan.FromMinutes (10)).Result;
 				if (assert_success && rv.ExitCode != 0) {

--- a/tests/dotnet/Makefile
+++ b/tests/dotnet/Makefile
@@ -2,10 +2,6 @@ TOP=../..
 
 include $(TOP)/Make.config
 
-# This is a temporary variable to enable the .NET workload resolver, because it's opt-in for now.
-# Ref: https://github.com/dotnet/sdk/issues/13849
-export MSBuildEnableWorkloadResolver=true
-
 # This tells NuGet to use the nupkgs we're building locally,
 # and to put any extracted packages in the 'packages' directory (to not clutter up ~/.nuget/packages)
 NuGet.config: $(TOP)/NuGet.config Makefile
@@ -41,8 +37,6 @@ run-unit-tests:
 	cd UnitTests && $(DOTNET) test DotNetUnitTests.csproj $(TEST_FILTER)
 
 all-local:: $(TARGETS)
-
-export MSBuildEnableWorkloadResolver=true
 
 compare compare-size: $(TARGETS)
 	cd size-comparison && git clean -xfdq

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/Makefile
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/Makefile
@@ -2,10 +2,6 @@ TOP=../../..
 
 include $(TOP)/Make.config
 
-# This is a temporary variable to enable the .NET workload resolver, because it's opt-in for now.
-# Ref: https://github.com/dotnet/sdk/issues/13849
-export MSBuildEnableWorkloadResolver=true
-
 prepare:
 	cd .. && $(MAKE) global.json NuGet.config
 	rm -Rf */bin */obj

--- a/tests/dotnet/NativeFileReferencesApp/Makefile
+++ b/tests/dotnet/NativeFileReferencesApp/Makefile
@@ -2,10 +2,6 @@ TOP=../../..
 
 include $(TOP)/Make.config
 
-# This is a temporary variable to enable the .NET workload resolver, because it's opt-in for now.
-# Ref: https://github.com/dotnet/sdk/issues/13849
-export MSBuildEnableWorkloadResolver=true
-
 prepare:
 	cd .. && $(MAKE) global.json NuGet.config
 	rm -Rf */bin */obj

--- a/tests/dotnet/NativeFrameworkReferencesApp/Makefile
+++ b/tests/dotnet/NativeFrameworkReferencesApp/Makefile
@@ -2,10 +2,6 @@ TOP=../../..
 
 include $(TOP)/Make.config
 
-# This is a temporary variable to enable the .NET workload resolver, because it's opt-in for now.
-# Ref: https://github.com/dotnet/sdk/issues/13849
-export MSBuildEnableWorkloadResolver=true
-
 prepare:
 	cd .. && $(MAKE) global.json NuGet.config
 	rm -Rf */bin */obj

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/Makefile
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/Makefile
@@ -2,10 +2,6 @@ TOP=../../..
 
 include $(TOP)/Make.config
 
-# This is a temporary variable to enable the .NET workload resolver, because it's opt-in for now.
-# Ref: https://github.com/dotnet/sdk/issues/13849
-export MSBuildEnableWorkloadResolver=true
-
 prepare:
 	cd .. && $(MAKE) global.json NuGet.config
 	rm -Rf */bin */obj

--- a/tests/monotouch-test/dotnet/macOS/Makefile
+++ b/tests/monotouch-test/dotnet/macOS/Makefile
@@ -3,10 +3,6 @@ TOP=../../../..
 include $(TOP)/Make.config
 include $(TOP)/mk/colors.mk
 
-# This is a temporary variable to enable the .NET workload resolver, because it's opt-in for now.
-# Ref: https://github.com/dotnet/sdk/issues/13849
-export MSBuildEnableWorkloadResolver=true
-
 # To run monotouch-test with MonoVM:
 #    make run-monovm
 # To run monotouch-test with CoreCLR:

--- a/tests/perftest/Makefile
+++ b/tests/perftest/Makefile
@@ -2,10 +2,6 @@ TOP=../..
 
 include $(TOP)/Make.config
 
-# This is a temporary variable to enable the .NET workload resolver, because it's opt-in for now.
-# Ref: https://github.com/dotnet/sdk/issues/13849
-export MSBuildEnableWorkloadResolver=true
-
 dotnet/global.json: $(TOP)/NuGet.config Makefile
 	$(Q) $(MAKE) -C ../dotnet $(notdir $@)
 	$(Q) $(CP) ../dotnet/$(notdir $@) $@

--- a/tests/xharness/Jenkins/TestTasks/MSBuildTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/MSBuildTask.cs
@@ -99,11 +99,6 @@ namespace Xharness.Jenkins.TestTasks {
 			environment ["MSBuildSDKsPath"] = null;
 			environment ["TargetFrameworkFallbackSearchPaths"] = null;
 			environment ["MSBuildExtensionsPathFallbackPathsOverride"] = null;
-
-			// This is a temporary variable to enable the .NET workload resolver, because it's opt-in for now.
-			// Ref: https://github.com/dotnet/sdk/issues/13849
-			environment ["MSBuildEnableWorkloadResolver"] = "true";
-			System.Environment.SetEnvironmentVariable ("MSBuildEnableWorkloadResolver", "true");
 		}
 	}
 }


### PR DESCRIPTION



Backport of #11695
