### PR TITLE
[registrar] Make sure to release the return value from xamarin_get_parameter_type.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -270,8 +270,10 @@ xamarin_get_parameter_type (MonoMethod *managed_method, int index)
 	if (index == -1) {
 		p = mono_signature_get_return_type (msig);
 	} else {
-		for (int i = 0; i < index + 1; i++)
+		for (int i = 0; i < index + 1; i++) {
+			xamarin_mono_object_release (&p);
 			p = mono_signature_get_params (msig, &iter);
+		}
 	}
 	
 	xamarin_bridge_free_mono_signature (&msig);

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -1618,6 +1618,7 @@ xamarin_nsstring_to_smart_enum (id value, void *ptr, MonoClass *managedType, voi
 {
 	guint32 context_ref = GPOINTER_TO_UINT (context);
 	MonoObject *obj;
+	MonoType *parameterType = NULL;
 
 	if (context_ref == INVALID_TOKEN_REF) {
 		// This requires the dynamic registrar to invoke the correct conversion function
@@ -1639,7 +1640,9 @@ xamarin_nsstring_to_smart_enum (id value, void *ptr, MonoClass *managedType, voi
 		managed_method = xamarin_get_managed_method_for_token (context_ref /* token ref */, exception_gchandle);
 		if (*exception_gchandle != INVALID_GCHANDLE) return NULL;
 
-		arg0 = xamarin_get_nsobject_with_type_for_ptr (value, false, xamarin_get_parameter_type (managed_method, 0), exception_gchandle);
+		parameterType = xamarin_get_parameter_type (managed_method, 0);
+		arg0 = xamarin_get_nsobject_with_type_for_ptr (value, false, parameterType, exception_gchandle);
+		xamarin_mono_object_release (&parameterType);
 		if (*exception_gchandle != INVALID_GCHANDLE) {
 			xamarin_mono_object_release (&managed_method);
 			return NULL;

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3396,7 +3396,10 @@ namespace Registrar {
 				if (type != nativetype) {
 					body_setup.AppendLine ("MonoClass *paramclass{0} = NULL;", i);
 					cleanup.AppendLine ("xamarin_mono_object_release (&paramclass{0});", i);
-					setup_call_stack.AppendLine ("paramclass{0} = mono_class_from_mono_type (xamarin_get_parameter_type (managed_method, {0}));", i);
+					body_setup.AppendLine ("MonoType *paramtype{0} = NULL;", i);
+					cleanup.AppendLine ("xamarin_mono_object_release (&paramtype{0});", i);
+					setup_call_stack.AppendLine ("paramtype{0} = xamarin_get_parameter_type (managed_method, {0});", i);
+					setup_call_stack.AppendLine ("paramclass{0} = mono_class_from_mono_type (paramtype{0});", i);
 					GenerateConversionToManaged (nativetype, type, setup_call_stack, descriptiveMethodName, ref exceptions, method, $"p{i}", $"arg_ptrs [{i}]", $"paramclass{i}", i);
 					if (isRef || isOut)
 						throw ErrorHelper.CreateError (4163, Errors.MT4163_B, descriptiveMethodName);
@@ -3562,7 +3565,10 @@ namespace Registrar {
 							setup_call_stack.AppendLine ("if (exception_gchandle != INVALID_GCHANDLE) goto exception_handling;");
 							cleanup.AppendLine ("xamarin_mono_object_release (&marr{0});", i);
 						} else if (isNSObject) {
-							setup_call_stack.AppendLine ("marr{0} = xamarin_nsarray_to_managed_nsobject_array (arr{0}, xamarin_get_parameter_type (managed_method, {0}), NULL, &exception_gchandle);", i);
+							body_setup.AppendLine ("MonoType *paramtype{0} = NULL;", i);
+							cleanup.AppendLine ("xamarin_mono_object_release (&paramtype{0});", i);
+							setup_call_stack.AppendLine ("paramtype{0} = xamarin_get_parameter_type (managed_method, {0});", i);
+							setup_call_stack.AppendLine ("marr{0} = xamarin_nsarray_to_managed_nsobject_array (arr{0}, paramtype{0}, NULL, &exception_gchandle);", i);
 							setup_call_stack.AppendLine ("if (exception_gchandle != INVALID_GCHANDLE) goto exception_handling;");
 							cleanup.AppendLine ("xamarin_mono_object_release (&marr{0});", i);
 						} else if (isINativeObject) {
@@ -3581,13 +3587,16 @@ namespace Registrar {
 							if (!HasIntPtrBoolCtor (nativeObjType))
 								throw ErrorHelper.CreateError (4103, Errors.MT4103, nativeObjType.FullName, descriptiveMethodName);
 
+							body_setup.AppendLine ("MonoType *paramtype{0} = NULL;", i);
+							cleanup.AppendLine ("xamarin_mono_object_release (&paramtype{0});", i);
+							setup_call_stack.AppendLine ("paramtype{0} = xamarin_get_parameter_type (managed_method, {0});", i);
 							if (isNativeObjectInterface) {
 								var resolvedElementType = ResolveType (elementType);
 								var iface_token_ref = $"0x{CreateTokenReference (resolvedElementType, TokenType.TypeDef):X} /* {resolvedElementType} */ ";
 								var implementation_token_ref = $"0x{CreateTokenReference (nativeObjType, TokenType.TypeDef):X} /* {nativeObjType} */ ";
-								setup_call_stack.AppendLine ("marr{0} = xamarin_nsarray_to_managed_inativeobject_array_static (arr{0}, xamarin_get_parameter_type (managed_method, {0}), NULL, {1}, {2}, &exception_gchandle);", i, iface_token_ref, implementation_token_ref);
+								setup_call_stack.AppendLine ("marr{0} = xamarin_nsarray_to_managed_inativeobject_array_static (arr{0}, paramtype{0}, NULL, {1}, {2}, &exception_gchandle);", i, iface_token_ref, implementation_token_ref);
 							} else {
-								setup_call_stack.AppendLine ("marr{0} = xamarin_nsarray_to_managed_inativeobject_array (arr{0}, xamarin_get_parameter_type (managed_method, {0}), NULL, &exception_gchandle);", i);
+								setup_call_stack.AppendLine ("marr{0} = xamarin_nsarray_to_managed_inativeobject_array (arr{0}, paramtype{0}, NULL, &exception_gchandle);", i);
 							}
 							cleanup.AppendLine ("xamarin_mono_object_release (&marr{0});", i);
 							setup_call_stack.AppendLine ("if (exception_gchandle != INVALID_GCHANDLE) goto exception_handling;");
@@ -3625,6 +3634,7 @@ namespace Registrar {
 								setup_call_stack.AppendLine ("nsobj{0} = *(NSObject **) p{0};", i).Unindent ();
 								setup_call_stack.AppendLine ("if (nsobj{0}) {{", i);
 								body_setup.AppendLine ("MonoType *paramtype{0} = NULL;", i);
+								cleanup.AppendLine ("xamarin_mono_object_release (&paramtype{0});", i);
 								setup_call_stack.AppendLine ("paramtype{0} = xamarin_get_parameter_type (managed_method, {0});", i);
 								setup_call_stack.AppendLine ("mobj{0} = xamarin_get_nsobject_with_type_for_ptr (nsobj{0}, false, paramtype{0}, &exception_gchandle);", i);
 								cleanup.AppendLine ("xamarin_mono_object_release (&mobj{0});", i);
@@ -3662,6 +3672,7 @@ namespace Registrar {
 							body_setup.AppendLine ("int32_t created{0} = false;", i);
 							setup_call_stack.AppendLine ("if (nsobj{0}) {{", i);
 							body_setup.AppendLine ("MonoType *paramtype{0} = NULL;", i);
+							cleanup.AppendLine ("xamarin_mono_object_release (&paramtype{0});", i);
 							setup_call_stack.AppendLine ("paramtype{0} = xamarin_get_parameter_type (managed_method, {0});", i);
 							setup_call_stack.AppendLine ("mobj{0} = xamarin_get_nsobject_with_type_for_ptr_created (nsobj{0}, false, paramtype{0}, &created{0}, &exception_gchandle);", i);
 							cleanup.AppendLine ("xamarin_mono_object_release (&mobj{0});", i);
@@ -3703,6 +3714,7 @@ namespace Registrar {
 						if (!td.IsInterface) {
 							// find the MonoClass for this parameter
 							body_setup.AppendLine ("MonoType *type{0};", i);
+							cleanup.AppendLine ("xamarin_mono_object_release (&type{0});", i);
 							setup_call_stack.AppendLine ("type{0} = xamarin_get_parameter_type (managed_method, {0});", i);
 						}
 						body_setup.AppendLine ("MonoObject *inobj{0} = NULL;", i);
@@ -3836,7 +3848,10 @@ namespace Registrar {
 				if (returntype != method.NativeReturnType) {
 					body_setup.AppendLine ("MonoClass *retparamclass = NULL;");
 					cleanup.AppendLine ("xamarin_mono_object_release (&retparamclass);");
-					setup_call_stack.AppendLine ("retparamclass = mono_class_from_mono_type (xamarin_get_parameter_type (managed_method, -1));");
+					body_setup.AppendLine ("MonoType *retparamtype = NULL;");
+					cleanup.AppendLine ("xamarin_mono_object_release (&retparamtype);");
+					setup_call_stack.AppendLine ("retparamtype = xamarin_get_parameter_type (managed_method, -1);");
+					setup_call_stack.AppendLine ("retparamclass = mono_class_from_mono_type (retparamtype);");
 					GenerateConversionToNative (returntype, method.NativeReturnType, setup_return, descriptiveMethodName, ref exceptions, method, "retval", "res", "retparamclass");
 				} else if (returntype.IsValueType) {
 					setup_return.AppendLine ("res = *({0} *) mono_object_unbox ((MonoObject *) retval);", rettype);


### PR DESCRIPTION
Before:

    There were 258046 MonoObjects created, 235142 MonoObjects freed, so 22904 were not freed. (dynamic registrar)
    There were 205804 MonoObjects created, 204193 MonoObjects freed, so 1611 were not freed. (static registrar)

After:

    There were 258054 MonoObjects created, 235172 MonoObjects freed, so 22882 were not freed. (dynamic registrar)
    There were 205804 MonoObjects created, 205190 MonoObjects freed, so 614 were not freed. (static registrar)