### PR TITLE
[dynamic registrar] Out parameters must be released.

### DIFF
--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -640,6 +640,8 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 				MonoObject *pvalue = (MonoObject *) arg_copy [i + mofs];
 				NSObject *obj = NULL;
 
+				ADD_TO_MONOOBJECT_RELEASE_LIST (value);
+
 				if (value == pvalue) {
 					// No need to copy back if the value didn't change
 					// For arrays this means that we won't copy back arrays if an element in the array changed (which can happen in managed code: the array pointer and size are immutable, but array elements can change).


### PR DESCRIPTION
Before:

    There were 258042 MonoObjects created, 235166 MonoObjects freed, so 22876 were not freed. (dynamic registrar)
    There were 205804 MonoObjects created, 204219 MonoObjects freed, so 1585 were not freed. (static registrar)

After:

    There were 258058 MonoObjects created, 235308 MonoObjects freed, so 22750 were not freed. (dynamic registrar)
    There were 205804 MonoObjects created, 204219 MonoObjects freed, so 1585 were not freed. (static registrar)