### PR TITLE
[runtime] The return value from mono_class_from_mono_type must be released.

### DIFF
--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -1462,9 +1462,11 @@ xamarin_get_nsnumber_converter (MonoClass *managedType, MonoMethod *method, bool
 	} else if (!strcmp (fullname, "System.nfloat")) {
 		func = to_managed ? (void *) xamarin_nsnumber_to_nfloat : (void *) xamarin_nfloat_to_nsnumber;
 	} else if (mono_class_is_enum (managedType)) {
-		MonoClass *baseClass = mono_class_from_mono_type (mono_class_enum_basetype (managedType));
+		MonoType *baseType = mono_class_enum_basetype (managedType);
+		MonoClass *baseClass = mono_class_from_mono_type (baseType);
 		func = xamarin_get_nsnumber_converter (baseClass, method, to_managed, exception_gchandle);
 		xamarin_mono_object_release (&baseClass);
+		xamarin_mono_object_release (&baseType);
 	} else {
 		MonoType *nsnumberType = xamarin_get_nsnumber_type ();
 		*exception_gchandle = xamarin_create_bindas_exception (mtype, nsnumberType, method);


### PR DESCRIPTION
Before:

    There were 258042 MonoObjects created, 235166 MonoObjects freed, so 22876 were not freed. (dynamic registrar)
    There were 205804 MonoObjects created, 204219 MonoObjects freed, so 1585 were not freed. (static registrar)

After:

    There were 258050 MonoObjects created, 235177 MonoObjects freed, so 22873 were not freed. (dynamic registrar)
    There were 205804 MonoObjects created, 204219 MonoObjects freed, so 1585 were not freed. (static registrar)