### PR TITLE
[dynamic registrar] Free the return value from mono_signature_get_params and mono_signature_get_return_type.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -270,8 +270,10 @@ xamarin_get_parameter_type (MonoMethod *managed_method, int index)
 	if (index == -1) {
 		p = mono_signature_get_return_type (msig);
 	} else {
-		for (int i = 0; i < index + 1; i++)
+		for (int i = 0; i < index + 1; i++) {
+			xamarin_mono_object_release (&p);
 			p = mono_signature_get_params (msig, &iter);
+		}
 	}
 	
 	xamarin_bridge_free_mono_signature (&msig);


### PR DESCRIPTION
Before:

    There were 258042 MonoObjects created, 235166 MonoObjects freed, so 22876 were not freed. (dynamic registrar)
    There were 205804 MonoObjects created, 204219 MonoObjects freed, so 1585 were not freed. (static registrar)

After:

    There were 258066 MonoObjects created, 246781 MonoObjects freed, so 11285 were not freed. (dynamic registrar)
    There were 205804 MonoObjects created, 204491 MonoObjects freed, so 1313 were not freed. (static registrar)