### PR TITLE
[tests] Adjust MX8029_b and MX8033 tests to cope with slightly different exception message output for CoreCLR.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1180,7 +1180,7 @@ partial class TestRuntime
 	// However, the System.__Canon type seems to be CoreCLR-only.
 	public static bool IsCoreCLR {
 		get {
-			return Type.GetType ("System.__Canon") is not null;
+			return !(Type.GetType ("System.__Canon") is null);
 		}
 	}
 }

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1175,7 +1175,6 @@ partial class TestRuntime
 		}
 	}
 
-#if NET
 	// There's no official API yet for distinguishing between CoreCLR and MonoVM (https://github.com/dotnet/runtime/issues/49481)
 	// (checking for the Mono.Runtime type doesn't work, because the BCL is the same, so there's never a Mono.Runtime type).
 	// However, the System.__Canon type seems to be CoreCLR-only.
@@ -1184,5 +1183,4 @@ partial class TestRuntime
 			return Type.GetType ("System.__Canon") is not null;
 		}
 	}
-#endif
 }

--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -625,11 +625,21 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				}
 			} catch (RuntimeException re) {
 				Assert.AreEqual (8029, re.Code, "Code");
-				Assert.AreEqual (@"Unable to marshal the array parameter #1 whose managed type is 'System.Int32[]' to managed.
+				string expectedExceptionMessage;
+				if (TestRuntime.IsCoreCLR) {
+					expectedExceptionMessage = @"Unable to marshal the array parameter #1 whose managed type is 'System.Int32[]' to managed.
+Additional information:
+	Selector: setIntArray:
+	Method: System.Void MonoTouchFixtures.ObjCRuntime.RuntimeTest+Dummy.SetIntArray (System.Int32[])
+";
+				} else {
+					expectedExceptionMessage = @"Unable to marshal the array parameter #1 whose managed type is 'System.Int32[]' to managed.
 Additional information:
 	Selector: setIntArray:
 	Method: MonoTouchFixtures.ObjCRuntime.RuntimeTest/Dummy:SetIntArray (int[])
-", re.Message, "Message");
+";
+				}
+				Assert.AreEqual (expectedExceptionMessage, re.Message, "Message");
 				var inner = (RuntimeException)re.InnerException;
 				Assert.AreEqual (8031, inner.Code, "Inner Code");
 				Assert.AreEqual ("Unable to convert from an NSArray to a managed array of System.Int32.", inner.Message, "Inner Message");
@@ -644,11 +654,21 @@ Additional information:
 				Assert.Fail ("An exception should have been thrown");
 			} catch (RuntimeException re) {
 				Assert.AreEqual (8033, re.Code, "Code");
-				Assert.AreEqual (@"Unable to marshal the return value of type 'System.Int32[]' to Objective-C.
+				string expectedExceptionMessage;
+				if (TestRuntime.IsCoreCLR) {
+					expectedExceptionMessage = @"Unable to marshal the return value of type 'System.Int32[]' to Objective-C.
+Additional information:
+	Selector: intArray
+	Method: System.Int32[] MonoTouchFixtures.ObjCRuntime.RuntimeTest+Dummy.GetIntArray ()
+";
+				} else {
+					expectedExceptionMessage = @"Unable to marshal the return value of type 'System.Int32[]' to Objective-C.
 Additional information:
 	Selector: intArray
 	Method: MonoTouchFixtures.ObjCRuntime.RuntimeTest/Dummy:GetIntArray ()
-", re.Message, "Message");
+";
+				}
+				Assert.AreEqual (expectedExceptionMessage, re.Message, "Message");
 				var inner = (RuntimeException) re.InnerException;
 				Assert.AreEqual (8032, inner.Code, "Inner Code");
 				Assert.AreEqual ("Unable to convert from a managed array of System.Int32 to an NSArray.", inner.Message, "Inner Message");


### PR DESCRIPTION
Fixes these unit tests:

    [FAIL] MX8029_b :   Message
      Expected string length 217 but was 238. Strings differ at index 149.
      Expected: "...lector: setIntArray:\n\tMethod: MonoTouchFixtures.ObjCRuntim..."
      But was:  "...lector: setIntArray:\n\tMethod: System.Void MonoTouchFixture..."
      ----------------------------------------------^
      at MonoTouchFixtures.ObjCRuntime.RuntimeTest.MX8029_b() in /Users/rolf/work/maccore/onedotnet/xamarin-macios/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs:line 625

    [FAIL] MX8033 :   Message
      Expected string length 192 but was 207. Strings differ at index 129.
      Expected: "...\n\tSelector: intArray\n\tMethod: MonoTouchFixtures.ObjCRuntim..."
      But was:  "...\n\tSelector: intArray\n\tMethod: System.Int32[] MonoTouchFixt..."
      ------------------------------------------------^
      at MonoTouchFixtures.ObjCRuntime.RuntimeTest.MX8033() in /Users/rolf/work/maccore/onedotnet/xamarin-macios/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs:line 644