### PR TITLE
[ObjCRuntime] Unwrap TargetInvocationExceptions we get when invoking methods using reflection.

### DIFF
--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ObjectiveC;
 using System.Text;
@@ -591,7 +592,15 @@ namespace ObjCRuntime {
 			// Call the actual method
 			log_coreclr ($"    Invoking...");
 
-			var rv = method.Invoke (instance, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance, null, parameters, null);
+			object rv = null;
+
+			try {
+				rv = method.Invoke (instance, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance, null, parameters, null);
+			} catch (TargetInvocationException tie)	{
+				var ex = tie.InnerException ?? tie;
+				// This will re-throw the original exception and preserve the stacktrace.
+				ExceptionDispatchInfo.Capture (ex).Throw ();
+			}
 
 			// Copy any byref parameters back out again
 			var byrefParameterCount = 0;


### PR DESCRIPTION
Fixes this unit test:

    [FAIL] ManagedExceptionPassthrough :   exception
     Expected: same as <System.ApplicationException: 3,14
      at MonoTouchFixtures.ObjCRuntime.ExceptionsTest.ManagedExceptionTest.ThrowManagedException() in xamarin-macios/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs:line 128>
     But was:  <System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
    ---> System.ApplicationException: 3,14
      at MonoTouchFixtures.ObjCRuntime.ExceptionsTest.ManagedExceptionTest.ThrowManagedException() in xamarin-macios/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs:line 128
      --- End of inner exception stack trace ---
      at System.RuntimeMethodHandle.InvokeMethod(Object target, Span`1& arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
      at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) in System.Private.CoreLib.dll:token 0x6004d2a+0x0
      at ObjCRuntime.Runtime.InvokeMethod(MethodBase method, Object instance, IntPtr native_parameters) in Xamarin.Mac.dll:token 0x60011d1+0x254
      at ObjCRuntime.Runtime.InvokeMethod(MonoObject* methodobj, MonoObject* instanceobj, IntPtr native_parameters) in Xamarin.Mac.dll:token 0x60011d0+0x0
      at ObjCRuntime.Runtime.bridge_runtime_invoke_method(MonoObject* method, MonoObject* instance, IntPtr parameters, IntPtr& exception_gchandle) in Xamarin.Mac.dll:token 0x6001124+0x26
      at ApiDefinition.Messaging.void_objc_msgSendSuper(IntPtr receiver, IntPtr selector)
      at Bindings.Test.ObjCExceptionTest.InvokeManagedExceptionThrower() in xamarin-macios/tests/xharness/tmp-test-dir/monotouch-test2683/obj/Debug/net6.0-macos/macOS/Bindings.Test/ObjCExceptionTest.g.cs:line 105
      at MonoTouchFixtures.ObjCRuntime.ExceptionsTest.ManagedExceptionPassthrough() in xamarin-macios/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs:line 154>
      at MonoTouchFixtures.ObjCRuntime.ExceptionsTest.ManagedExceptionPassthrough() in xamarin-macios/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs:line 159