### PR TITLE
[runtime] Complete support for exception marshalling on CoreCLR.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -177,6 +177,22 @@ xamarin_bridge_shutdown ()
 }
 
 void
+xamarin_coreclr_unhandled_exception_handler (void *context)
+{
+	// 'context' is the GCHandle returned by the managed Runtime.UnhandledExceptionPropagationHandler function.
+	GCHandle exception_gchandle = (GCHandle) context;
+
+	LOG_CORECLR (stderr, "%s (%p)\n", __func__, context);
+
+	// xamarin_process_managed_exception_gchandle will free the GCHandle
+	xamarin_process_managed_exception_gchandle (exception_gchandle);
+
+	// The call to xamarin_process_managed_exception_gchandle should either abort or throw an Objective-C exception,
+	// and in neither case should we end up here, so just assert.
+	xamarin_assertion_message ("Failed to process unhandled managed exception.");
+}
+
+void
 xamarin_enable_new_refcount ()
 {
 	// Nothing to do here.

--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -177,6 +177,28 @@ xamarin_bridge_shutdown ()
 }
 
 void
+xamarin_coreclr_reference_tracking_begin_end_callback ()
+{
+	LOG_CORECLR (stderr, "%s () reference_tracking_end: %i\n", __func__, reference_tracking_end);
+}
+
+int
+xamarin_coreclr_reference_tracking_is_referenced_callback (void* ptr)
+{
+	int rv = 0;
+
+	LOG_CORECLR (stderr, "%s (%p) => %i\n", __func__, ptr, rv);
+
+	return rv;
+}
+
+void
+xamarin_coreclr_reference_tracking_tracked_object_entered_finalization (void* ptr)
+{
+	LOG_CORECLR (stderr, "%s (%p)\n", __func__, ptr);
+}
+
+void
 xamarin_coreclr_unhandled_exception_handler (void *context)
 {
 	// 'context' is the GCHandle returned by the managed Runtime.UnhandledExceptionPropagationHandler function.

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -154,6 +154,9 @@ struct InitializationOptions {
 	void *xamarin_objc_msgsend_stret;
 	void *xamarin_objc_msgsend_super_stret;
 	void *unhandled_exception_handler;
+	void *reference_tracking_begin_end_callback;
+	void *reference_tracking_is_referenced_callback;
+	void *reference_tracking_tracked_object_entered_finalization;
 #endif
 };
 
@@ -1270,6 +1273,9 @@ xamarin_initialize ()
 	options.xamarin_objc_msgsend_super_stret = (void *) xamarin_dyn_objc_msgSendSuper_stret;
 #endif // !defined(__aarch64__)
 	options.unhandled_exception_handler = (void *) &xamarin_coreclr_unhandled_exception_handler;
+	options.reference_tracking_begin_end_callback = (void *) &xamarin_coreclr_reference_tracking_begin_end_callback;
+	options.reference_tracking_is_referenced_callback = (void *) &xamarin_coreclr_reference_tracking_is_referenced_callback;
+	options.reference_tracking_tracked_object_entered_finalization = (void *) &xamarin_coreclr_reference_tracking_tracked_object_entered_finalization;
 #endif // defined(CORECLR_RUNTIME)
 
 	xamarin_bridge_call_runtime_initialize (&options, &exception_gchandle);

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -153,6 +153,7 @@ struct InitializationOptions {
 	void *xamarin_objc_msgsend_super;
 	void *xamarin_objc_msgsend_stret;
 	void *xamarin_objc_msgsend_super_stret;
+	void *unhandled_exception_handler;
 #endif
 };
 
@@ -1268,6 +1269,7 @@ xamarin_initialize ()
 	options.xamarin_objc_msgsend_stret = (void *) xamarin_dyn_objc_msgSend_stret;
 	options.xamarin_objc_msgsend_super_stret = (void *) xamarin_dyn_objc_msgSendSuper_stret;
 #endif // !defined(__aarch64__)
+	options.unhandled_exception_handler = (void *) &xamarin_coreclr_unhandled_exception_handler;
 #endif // defined(CORECLR_RUNTIME)
 
 	xamarin_bridge_call_runtime_initialize (&options, &exception_gchandle);

--- a/runtime/xamarin/coreclr-bridge.h
+++ b/runtime/xamarin/coreclr-bridge.h
@@ -44,6 +44,15 @@ struct _MonoMethodSignature {
 };
 
 void
+xamarin_coreclr_reference_tracking_begin_end_callback ();
+
+int
+xamarin_coreclr_reference_tracking_is_referenced_callback (void* ptr);
+
+void
+xamarin_coreclr_reference_tracking_tracked_object_entered_finalization (void* ptr);
+
+void
 xamarin_coreclr_unhandled_exception_handler (void *context);
 
 #ifdef __cplusplus

--- a/runtime/xamarin/coreclr-bridge.h
+++ b/runtime/xamarin/coreclr-bridge.h
@@ -43,6 +43,9 @@ struct _MonoMethodSignature {
 	MonoObject *parameters[];
 };
 
+void
+xamarin_coreclr_unhandled_exception_handler (void *context);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -96,7 +96,10 @@ namespace ObjCRuntime {
 			if (options->xamarin_objc_msgsend_super_stret != IntPtr.Zero)
 				ObjectiveCMarshal.SetMessageSendCallback (ObjectiveCMarshal.MessageSendFunction.MsgSendSuperStret, options->xamarin_objc_msgsend_super_stret);
 
-			ObjectiveCMarshal.Initialize (null, null, null, UnhandledExceptionPropagationHandler);
+			delegate* unmanaged<void> beginEndCallback = (delegate* unmanaged<void>) options->reference_tracking_begin_end_callback;
+			delegate* unmanaged<IntPtr, int> isReferencedCallback = (delegate* unmanaged<IntPtr, int>) options->reference_tracking_is_referenced_callback;
+			delegate* unmanaged<IntPtr, void> trackedObjectEnteredFinalization = (delegate* unmanaged<IntPtr, void>) options->reference_tracking_tracked_object_entered_finalization;
+			ObjectiveCMarshal.Initialize (beginEndCallback, isReferencedCallback, trackedObjectEnteredFinalization, UnhandledExceptionPropagationHandler);
 		}
 
 		static unsafe delegate* unmanaged<IntPtr, void> UnhandledExceptionPropagationHandler (Exception exception, RuntimeMethodHandle lastMethod, out IntPtr context)

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -95,6 +95,15 @@ namespace ObjCRuntime {
 
 			if (options->xamarin_objc_msgsend_super_stret != IntPtr.Zero)
 				ObjectiveCMarshal.SetMessageSendCallback (ObjectiveCMarshal.MessageSendFunction.MsgSendSuperStret, options->xamarin_objc_msgsend_super_stret);
+
+			ObjectiveCMarshal.Initialize (null, null, null, UnhandledExceptionPropagationHandler);
+		}
+
+		static unsafe delegate* unmanaged<IntPtr, void> UnhandledExceptionPropagationHandler (Exception exception, RuntimeMethodHandle lastMethod, out IntPtr context)
+		{
+			var exceptionHandler = (delegate* unmanaged<IntPtr, void>) options->unhandled_exception_handler;
+			context = AllocGCHandle (exception);
+			return exceptionHandler;
 		}
 
 		internal static void RegisterToggleReferenceCoreCLR (NSObject obj, IntPtr handle, bool isCustomType)

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -162,6 +162,7 @@ namespace ObjCRuntime {
 			public IntPtr xamarin_objc_msgsend_super;
 			public IntPtr xamarin_objc_msgsend_stret;
 			public IntPtr xamarin_objc_msgsend_super_stret;
+			public IntPtr unhandled_exception_handler;
 #endif
 			public bool IsSimulator {
 				get {

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -163,6 +163,9 @@ namespace ObjCRuntime {
 			public IntPtr xamarin_objc_msgsend_stret;
 			public IntPtr xamarin_objc_msgsend_super_stret;
 			public IntPtr unhandled_exception_handler;
+			public IntPtr reference_tracking_begin_end_callback;
+			public IntPtr reference_tracking_is_referenced_callback;
+			public IntPtr reference_tracking_tracked_object_entered_finalization;
 #endif
 			public bool IsSimulator {
 				get {

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1174,4 +1174,15 @@ partial class TestRuntime
 #endif
 		}
 	}
+
+#if NET
+	// There's no official API yet for distinguishing between CoreCLR and MonoVM (https://github.com/dotnet/runtime/issues/49481)
+	// (checking for the Mono.Runtime type doesn't work, because the BCL is the same, so there's never a Mono.Runtime type).
+	// However, the System.__Canon type seems to be CoreCLR-only.
+	public static bool IsCoreCLR {
+		get {
+			return Type.GetType ("System.__Canon") is not null;
+		}
+	}
+#endif
 }

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -433,9 +433,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		}
 
 		[Test]
-#if NET
-		[Ignore ("Ignored on CoreCLR for now due to missing support for marshalling exceptions")]
-#endif
 		public void TestGeneric ()
 		{
 			var g1 = new GenericTestClass<string> ();
@@ -1233,6 +1230,31 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 		void ThrowsICEIfDebug (TestDelegate code, string message, bool execute_release_mode = true)
 		{
+#if NET
+			if (TestRuntime.IsCoreCLR) {
+				if (execute_release_mode) {
+					// In CoreCLR will either throw an ArgumentException:
+					//     <System.ArgumentException: Object of type 'Foundation.NSObject' cannot be converted to type 'Foundation.NSSet'.
+					// or a RuntimeException:
+					//     <ObjCRuntime.RuntimeException: Failed to marshal the value at index 0.
+					var noException = false;
+					try {
+						code ();
+						noException = true;
+					} catch (ArgumentException) {
+						// OK
+					} catch (RuntimeException) {
+						// OK
+					} catch (Exception e) {
+						Assert.Fail ($"Unexpectedly failed with exception of type {e.GetType ()} - expected either ArgumentException or RuntimeException: {message}");
+					}
+					if (noException)
+						Assert.Fail ($"Unexpectedly no exception occured: {message}");
+				}
+				return;
+			}
+#endif
+
 // The type checks have been disabled for now.
 //#if DEBUG
 //			Assert.Throws<InvalidCastException> (code, message);


### PR DESCRIPTION
* This also required an empty implementation of the toggle ref machinery,
  because the ObjectiveCMarshal.Initialize call to initialize unhandled
  exception support requires passing toggle ref callbacks as well. The
  complete implementation is more complex, and will come in an uncoming PR.

* The TestConstrainedGenericType test can now be re-enabled, after a few
  updates.