### PR TITLE
[Localization] Update Localization READMEs

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/README.md
+++ b/msbuild/Xamarin.Localization.MSBuild/README.md
@@ -2,34 +2,15 @@
 
 Messages for new MSBuild error codes live in `MSBStrings.resx`.
 
-If changes are made to `MBStrings.resx`, you will hit:
+* You can now make changes to `MSBStrings.resx` in the Visual Studio for Mac IDE or from any text editor.
 
-    XliffTasks.targets(91,5): error : 'xlf\MSBStrings.cs.xlf' is out-of-date with 'MSBStrings.resx'.
-    Run `msbuild /t:UpdateXlf` to update .xlf files or set UpdateXlfOnBuild=true to update them on every build,
-    but note that it is strongly discouraged to set UpdateXlfOnBuild=true in official/CI build environments
-    as they should not modify source code during the build.
+* If you make changes in the IDE, you should see changes automatically copy into MSBStrings.Designer.cs. Be sure to rebuild the project after making your changes.
 
-To regenerate the `.xlf` files run:
+* If you make changes from a text editor, be sure to run `make` inside the xamarin-macios/msbuild/Xamarin.Localization.MSBuild directory.
 
-    $ msbuild msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj -restore -t:UpdateXlf
+See [Localization Wiki][Localization-wiki] for more details on our localization process
 
-For `mtouch`, `Errors.resx` contains the localizable strings. Use
-these commands instead to update `.xlf` files:
+or the [OneLocBuild Wiki][OneLocBuild-wiki] for information on OneLocBuild.
 
-    $ nuget restore tools
-    $ msbuild tools/mtouch/mtouch.csproj -t:UpdateXlf
-
-For `generator`, `src/Resources.resx`, contains the localizable
-strings. To update the `.xlf` files:
-
-    $ nuget restore src
-    $ msbuild src/generator.csproj -t:UpdateXlf
-
-*NOTE: `nuget restore` can be used instead of the MSBuild `-restore`
-switch for projects using `packages.config`*
-
-See [dotnet/xliff-tasks][xliff-tasks] or [Xamarin.Android's
-documentation][xamarin-android] for details.
-
-[xliff-tasks]: https://github.com/dotnet/xliff-tasks
-[xamarin-android]: https://github.com/xamarin/xamarin-android/blob/master/Documentation/workflow/Localization.md
+[Localization-wiki]: https://github.com/xamarin/maccore/wiki/Localization
+[OneLocBuild-wiki]: https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task

--- a/src/README.md
+++ b/src/README.md
@@ -188,3 +188,14 @@ For example, to build an API for all of iOS but only 64-bit OS X (Xamarin.Mac):
 ...
 #endif
 ```
+
+
+## Source Localization ##
+Coming soon!
+
+See [Localization Wiki][Localization-wiki] for more details on our localization process
+
+or the [OneLocBuild Wiki][OneLocBuild-wiki] for information on OneLocBuild.
+
+[Localization-wiki]: https://github.com/xamarin/maccore/wiki/Localization
+[OneLocBuild-wiki]: https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task

--- a/tools/mtouch/README.md
+++ b/tools/mtouch/README.md
@@ -1,0 +1,16 @@
+# Mtouch Localization
+
+Messages for new mtouch error codes live in `Errors.resx`.
+
+* You can now make changes to `Errors.resx` in the Visual Studio for Mac IDE or from any text editor.
+
+* If you make changes in the IDE, you should see changes automatically copy into Errors.Designer.cs. Be sure to rebuild the project after making your changes.
+
+* If you make changes from a text editor, be sure to run `make` inside the xamarin-macios/tools/mtouch directory.
+
+See [Localization Wiki][Localization-wiki] for more details on our localization process
+
+or the [OneLocBuild Wiki][OneLocBuild-wiki] for information on OneLocBuild.
+
+[Localization-wiki]: https://github.com/xamarin/maccore/wiki/Localization
+[OneLocBuild-wiki]: https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task


### PR DESCRIPTION
The README.md file inside msbuild is now outdated since we switched Localization processes.
I also removed information about the source and mtouch localization from this README 
and added them to src and mtouch READMEs. I think this makes more sense, but I can change it back if preferred.