### PR TITLE
[tests] Only run the RegistrarTest.CustomUserTypeWithDynamicallyLoadedAssembly test from a source checkout.

### DIFF
--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -313,6 +313,17 @@ namespace Xamarin.Tests
 				return path;
 			}
 		}
+
+		public static bool TryGetRootPath (out string rootPath)
+		{
+			try {
+				rootPath = RootPath;
+				return true;
+			} catch (Exception e) {
+				rootPath = null;
+				return false;
+			}
+		}
 			
 		static string TestAssemblyDirectory {
 			get {

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2173,10 +2173,13 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void CustomUserTypeWithDynamicallyLoadedAssembly ()
 		{
+			if (!global::Xamarin.Tests.Configuration.TryGetRootPath (out var rootPath))
+				Assert.Ignore ("This test must be executed a source checkout.");
+
 #if NET
-			var customTypeAssemblyPath = global::System.IO.Path.Combine (global::Xamarin.Tests.Configuration.RootPath, "tests", "test-libraries", "custom-type-assembly", ".libs", "dotnet", "macos", "custom-type-assembly.dll");
+			var customTypeAssemblyPath = global::System.IO.Path.Combine (rootPath, "tests", "test-libraries", "custom-type-assembly", ".libs", "dotnet", "macos", "custom-type-assembly.dll");
 #else
-			var customTypeAssemblyPath = global::System.IO.Path.Combine (global::Xamarin.Tests.Configuration.RootPath, "tests", "test-libraries", "custom-type-assembly", ".libs", "macos", "custom-type-assembly.dll");
+			var customTypeAssemblyPath = global::System.IO.Path.Combine (rootPath, "tests", "test-libraries", "custom-type-assembly", ".libs", "macos", "custom-type-assembly.dll");
 #endif
 			Assert.That (customTypeAssemblyPath, Does.Exist, "existence");
 


### PR DESCRIPTION
It needs another assembly built from the source tree, so it won't work unless
executed from a source checkout. This way we don't try to run it on older
macOS versions, where the required assembly won't exist.