### PR TITLE
[monotouch-test] Ignore a few audio-related tests when we're running on a VM.

### DIFF
--- a/tests/monotouch-test/AVFoundation/AVAudioIONode.cs
+++ b/tests/monotouch-test/AVFoundation/AVAudioIONode.cs
@@ -17,6 +17,8 @@ namespace Xamarin.Mac.Tests
 		[Test]
 		public void AVAudioIONodeTests_AudioUnitTest ()
 		{
+			TestRuntime.AssertNotVirtualMachine ();
+
 			Asserts.EnsureYosemite ();
 
 			AVAudioEngine eng = new AVAudioEngine();

--- a/tests/monotouch-test/AudioUnit/AUGraphTestMac.cs
+++ b/tests/monotouch-test/AudioUnit/AUGraphTestMac.cs
@@ -54,6 +54,8 @@ namespace Xamarin.Mac.Tests
 		[Test]
 		public void DoTest ()
 		{
+			TestRuntime.AssertNotVirtualMachine ();
+
 			SetupAUGraph ();
 
 			// One of these has to be commented out depending on old\new build

--- a/tests/monotouch-test/AudioUnit/AudioUnit.cs
+++ b/tests/monotouch-test/AudioUnit/AudioUnit.cs
@@ -31,6 +31,8 @@ namespace Xamarin.Mac.Tests
 		[Test]
 		public void GetCurrentDevice_Test ()
 		{
+			TestRuntime.AssertNotVirtualMachine ();
+
 			theUnit unit = GetAudioUnitForTest ();
 
 			uint device = unit.GetCurrentDevice (AudioUnitScopeType.Global);


### PR DESCRIPTION
Fixes these failures when on a VM:

    Xamarin.Mac.Tests.AudioUnitTests
    	[FAIL] GetCurrentDevice_Test :   Expected: True
      But was:  False

    		  at Xamarin.Mac.Tests.AudioUnitTests.GetCurrentDevice_Test () [0x00011] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/AudioUnit/AudioUnit.cs:37
    Xamarin.Mac.Tests.AudioUnitTests : 13 ms

    Xamarin.Mac.Tests.AUGraphTests
    	[FAIL] DoTest : Did not see events after 1 second
    		  at Xamarin.Mac.Tests.AUGraphTests.WaitOnGraphAndMixerCallbacks () [0x00050] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/AudioUnit/AUGraphTestMac.cs:93
    		  at Xamarin.Mac.Tests.AUGraphTests.DoTest () [0x0004c] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/AudioUnit/AUGraphTestMac.cs:66
    Xamarin.Mac.Tests.AUGraphTests : 3113 ms

    Xamarin.Mac.Tests.AVAudioIONodeTests
    	[FAIL] AVAudioIONodeTests_AudioUnitTest : Foundation.ObjCException : com.apple.coreaudio.avfaudio: error -10879
    		  at (wrapper managed-to-native) ObjCRuntime.Messaging.IntPtr_objc_msgSend(intptr,intptr)
    		  at AVFoundation.AVAudioEngine.get_OutputNode () [0x00030] in /Users/builder/azdo/_work/1/s/xamarin-macios/src/build/mac/mobile/AVFoundation/AVAudioEngine.g.cs:1099
    		  at Xamarin.Mac.Tests.AVAudioIONodeTests.AVAudioIONodeTests_AudioUnitTest () [0x0000d] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/AVFoundation/AVAudioIONode.cs:23
    		  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
    		  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs:395
    Xamarin.Mac.Tests.AVAudioIONodeTests : 7 ms