### PR TITLE
[runtime] Don't forget to free the method field in MonoMethodSignatures.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -667,6 +667,7 @@ xamarin_bridge_free_mono_signature (MonoMethodSignature **psig)
 	if (sig == NULL)
 		return;
 
+	xamarin_mono_object_release (&sig->method);
 	for (int i = 0; i < sig->parameter_count; i++) {
 		xamarin_mono_object_release (&sig->parameters [i]);
 	}


### PR DESCRIPTION
Before:

    There were 258096 MonoObjects created, 246948 MonoObjects freed, so 11148 were not freed. (dynamic registrar)
    There were 205834 MonoObjects created, 205214 MonoObjects freed, so 620 were not freed. (static registrar)

After:

    There were 205834 MonoObjects created, 205222 MonoObjects freed, so 612 were not freed. (dynamic registrar)
    There were 258100 MonoObjects created, 258019 MonoObjects freed, so 81 were not freed. (static registrar)