### PR TITLE
[static registrar] Release the return value from xamarin_get_reflection_method_method in generated code.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -9,9 +9,11 @@
 #if defined (CORECLR_RUNTIME)
 
 #include <inttypes.h>
+#include <pthread.h>
 
 #include "product.h"
 #include "runtime-internal.h"
+#include "slinked-list.h"
 #include "xamarin/xamarin.h"
 #include "xamarin/coreclr-bridge.h"
 
@@ -19,6 +21,8 @@
 
 unsigned int coreclr_domainId = 0;
 void *coreclr_handle = NULL;
+pthread_mutex_t monoobject_lock = PTHREAD_MUTEX_INITIALIZER;
+SList *release_at_exit = NULL; // A list of MonoObject*s to be released at process exit
 
 #if defined (TRACK_MONOOBJECTS)
 
@@ -30,12 +34,10 @@ void *coreclr_handle = NULL;
 // MONOOBJECT_TRACKING_WITH_STACKTRACES environment variable.
 
 #include <execinfo.h>
-#include <pthread.h>
 
 static int _Atomic monoobject_created = 0;
 static int _Atomic monoobject_destroyed = 0;
 static CFMutableDictionaryRef monoobject_dict = NULL;
-static pthread_mutex_t monoobject_lock = PTHREAD_MUTEX_INITIALIZER;
 
 struct monoobject_tracked_entry {
 	char *managed;
@@ -171,6 +173,22 @@ xamarin_bridge_initialize ()
 void
 xamarin_bridge_shutdown ()
 {
+	SList *list;
+
+	// Free our list of MonoObject*s to free at process exist.
+	// No need to keep the lock locked while we traverse the list, the only thing we need to protect
+	// are reads and writes to the 'release_at_exit' variable, so let's do just that.
+	pthread_mutex_lock (&monoobject_lock);
+	list = release_at_exit;
+	release_at_exit = NULL;
+	pthread_mutex_unlock (&monoobject_lock);
+
+	while (list) {
+		xamarin_mono_object_release ((MonoObject **) &list->data);
+		list = list->next;
+	}
+	s_list_free (list);
+
 #if defined (TRACK_MONOOBJECTS)
 	xamarin_bridge_dump_monoobjects ();
 #endif
@@ -355,6 +373,14 @@ xamarin_mono_object_release (MonoObject **mobj_ref)
 	}
 
 	*mobj_ref = NULL;
+}
+
+void
+xamarin_mono_object_release_at_process_exit (MonoObject *mobj)
+{
+	pthread_mutex_lock (&monoobject_lock);
+	release_at_exit = s_list_prepend (release_at_exit, mobj);
+	pthread_mutex_unlock (&monoobject_lock);
 }
 
 /* Implementation of the Mono Embedding API */

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -306,10 +306,12 @@ void			xamarin_mono_object_retain (MonoObject *mobj);
 // Use C++ linking to be able to use method overloading, so that callers don't have to cast their variables to 'MonoObject**' (which improves type safety a lot).
 extern "C++" void	xamarin_mono_object_release (MonoObject **mobj);
 extern "C++" void	xamarin_mono_object_release (MonoString **mobj);
+void			xamarin_mono_object_release_at_process_exit (MonoObject *mobj);
 #else
 // Nothing to do here.
 #define			xamarin_mono_object_retain(x)
 #define			xamarin_mono_object_release(x) do { *x = NULL; } while (0);
+#define			xamarin_mono_object_release_at_process_exit(x)
 #endif
 
 

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -4002,6 +4002,13 @@ namespace Registrar {
 			body.WriteLine ("managed_method = xamarin_get_reflection_method_method (reflection_method);");
 			if (merge_bodies)
 				body.WriteLine ("*managed_method_ptr = managed_method;");
+
+			// If the managed_method instance is stored in a static variable, we can't release it until process exit.
+			if (merge_bodies || !isGeneric) {
+				body.WriteLine ("xamarin_mono_object_release_at_process_exit (managed_method);");
+			} else {
+				cleanup.AppendLine ("xamarin_mono_object_release (&managed_method);");
+			}
 			
 			body.WriteLine ("}");
 


### PR DESCRIPTION
* If the return value from xamarin_get_reflection_method_method is cached in a
  static variable, we can only release at process exist.
* Otherwise just release at the end of the current method.

Before:

    There were 258096 MonoObjects created, 246948 MonoObjects freed, so 11148 were not freed. (dynamic registrar)
    There were 205834 MonoObjects created, 205214 MonoObjects freed, so 620 were not freed. (static registrar)

After:

    There were 258092 MonoObjects created, 246945 MonoObjects freed, so 11147 were not freed. (dynamic registrar)
    There were 205834 MonoObjects created, 205600 MonoObjects freed, so 234 were not freed. (static registrar)