### PR TITLE
[coreclr] Support for NSAutoreleasePools has now been implemented for background threads for both MonoVM and CoreCLR. Fixes #11256.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -244,8 +244,6 @@ xamarin_bridge_vm_initialize (int propertyCount, const char **propertyKeys, cons
 void
 xamarin_install_nsautoreleasepool_hooks ()
 {
-	// https://github.com/xamarin/xamarin-macios/issues/11256
-	fprintf (stderr, "TODO: add support for wrapping all threads with NSAutoreleasePools.\n");
 }
 
 void

--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -244,6 +244,7 @@ xamarin_bridge_vm_initialize (int propertyCount, const char **propertyKeys, cons
 void
 xamarin_install_nsautoreleasepool_hooks ()
 {
+	// No need to do anything here for CoreCLR.
 }
 
 void

--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -512,8 +512,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 			// Strangely enough there seems to be a race condition here, not all threads will necessarily
 			// have completed the autorelease by this point. Some should have though, so assert that the object
-			// was released on at least one thread.
-			Assert.That ((int) obj.RetainCount, Is.LessThan (10), "RC");
+			// was released on at least half the threads.
+			Assert.That ((int) obj.RetainCount, Is.LessThan (count / 2), "RC");
 
 			obj.Dispose ();
 		}

--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -489,6 +489,34 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			obj.Dispose ();
 		}
 
+		[Test]
+		public void NSAutoreleasePoolInThread ()
+		{
+			var count = 10;
+			var threads = new Thread [count];
+			var obj = new NSObject ();
+
+			for (int i = 0; i < count; i++) {
+				threads [i] = new Thread ((v) => {
+					obj.DangerousRetain ().DangerousAutorelease ();
+				}) {
+					Name = $"NSAutoreleasePoolInThread #{i}",
+					IsBackground = true,
+				};
+				threads [i].Start ();
+			}
+
+			for (var i = 0; i < count; i++) {
+				Assert.IsTrue (threads [i].Join (TimeSpan.FromSeconds (1)), $"Thread #{i}");
+			}
+
+			// Strangely enough there seems to be a race condition here, not all threads will necessarily
+			// have completed the autorelease by this point. Some should have though, so assert that the object
+			// was released on at least one thread.
+			Assert.That ((int) obj.RetainCount, Is.LessThan (10), "RC");
+
+			obj.Dispose ();
+		}
 
 		class ResurrectedObjectsDisposedTestClass : NSObject {
 			[Export ("invokeMe:wait:")]


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/11256.