### PR TITLE
[runtime] Release the block_wrapper_queue and xamarin_wrapper_hash dictionaries upon process exit.

### DIFF
--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -495,6 +495,8 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 
 	xamarin_mono_object_release (&assembly);
 	
+	xamarin_release_static_dictionaries ();
+
 	xamarin_bridge_shutdown ();
 
 	return rv;

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2071,6 +2071,22 @@ xamarin_get_block_for_delegate (MonoMethod *method, MonoObject *delegate, const 
 }
 
 void
+xamarin_release_static_dictionaries ()
+{
+#if defined (CORECLR_RUNTIME)
+	// Release static dictionaries of cached objects. If we end up trying to
+	// add objects to these dictionaries after this point (on a background
+	// thread), the dictionaries will be re-created (and leak) - which
+	// shouldn't be a problem, because at this point the process is about to
+	// exit anyway.
+	pthread_mutex_lock (&wrapper_hash_lock);
+	xamarin_mono_object_release (&block_wrapper_queue);
+	xamarin_mono_object_release (&xamarin_wrapper_hash);
+	pthread_mutex_unlock (&wrapper_hash_lock);
+#endif
+}
+
+void
 xamarin_set_use_sgen (bool value)
 {
 }

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -230,6 +230,7 @@ bool			xamarin_set_gchandle_with_flags_safe (id self, GCHandle gchandle, enum Xa
 void			xamarin_create_gchandle (id self, void *managed_object, enum XamarinGCHandleFlags flags, bool force_weak);
 void            xamarin_release_managed_ref (id self, bool user_type);
 void			xamarin_notify_dealloc (id self, GCHandle gchandle);
+void			xamarin_release_static_dictionaries ();
 
 int				xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode);
 


### PR DESCRIPTION
While not strictly necessary to not leak (because the process is exiting
anyway), it makes it easier to read leak reports, because these dictionaries
won't show up as leaked memory anymore.

Before:

    There were 258096 MonoObjects created, 258015 MonoObjects freed, so 81 were not freed. (dynamic registrar)
    There were 205834 MonoObjects created, 205833 MonoObjects freed, so 1 were not freed. (static registrar)

After:

    There were 258104 MonoObjects created, 258025 MonoObjects freed, so 79 were not freed. (dynamic registrar)
    There were 205834 MonoObjects created, 205834 MonoObjects freed, so no leaked MonoObjects. (static registrar)