### PR TITLE
[tests] Re-enable Mac Catalyst tests related to the GC not working.

### DIFF
--- a/tests/monotouch-test/CoreAnimation/LayerTest.cs
+++ b/tests/monotouch-test/CoreAnimation/LayerTest.cs
@@ -107,9 +107,6 @@ namespace MonoTouchFixtures.CoreAnimation {
 		static int TextLayersDisposed;
 		static int Generation;
 		[Test]
-#if __MACCATALYST__
-		[Ignore ("https://github.com/dotnet/runtime/issues/47407")] // The GC doesn't collect objects with finalizers
-#endif
 		public void TestBug26532()
 		{
 			TextLayersDisposed = 0;

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2033,9 +2033,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 		}
 
-#if __MACCATALYST__
-		[Ignore ("https://github.com/dotnet/runtime/issues/47407")] // The GC doesn't collect objects with finalizers
-#endif
 		[Test]
 		public void BlockCollection ()
 		{

--- a/tests/monotouch-test/mono/WeakReferenceTest.cs
+++ b/tests/monotouch-test/mono/WeakReferenceTest.cs
@@ -37,9 +37,6 @@ namespace MonoTouchFixtures {
 			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
 		}
 
-#if __MACCATALYST__
-		[Ignore ("https://github.com/dotnet/runtime/issues/47407")] // The GC doesn't collect objects with finalizers
-#endif
 		[Test]
 		public void NoRetainCyclesExpectedTest ()
 		{


### PR DESCRIPTION
This seems to be working again now.