### PR TITLE
[catalyst][coremotion] Update xtro

### DIFF
--- a/tests/xtro-sharpie/MacCatalyst-CoreMotion.ignore
+++ b/tests/xtro-sharpie/MacCatalyst-CoreMotion.ignore
@@ -1,3 +1,4 @@
+## The following types are only available on watchOS (not iOS, so definitively not Catalyst)
 !missing-enum! CMFallDetectionEventUserResolution not bound
 !missing-protocol! CMFallDetectionDelegate not bound
 !missing-selector! +CMFallDetectionManager::isAvailable not bound


### PR DESCRIPTION
The _missing_ API are for watchOS only and not available for Catalyst.