### PR TITLE
[generator] Use `is` instead of `==` when doing null checks

### DIFF
--- a/src/NativeTypes/Drawing.tt
+++ b/src/NativeTypes/Drawing.tt
@@ -165,7 +165,7 @@ namespace CoreGraphics
 #if !COREBUILD
 		public static bool TryParse (NSDictionary dictionaryRepresentation, out <#= type.Name #> <#= type.ArgName #>)
 		{
-			if (dictionaryRepresentation == null){
+			if (dictionaryRepresentation is null) {
 			   	<#= type.ArgName #> = Empty;
 				return false;
 			}
@@ -597,7 +597,7 @@ namespace CoreGraphics
 #if !COREBUILD
 		public static bool TryParse (NSDictionary dictionaryRepresentation, out CGRect rect)
 		{
-			if (dictionaryRepresentation == null){
+			if (dictionaryRepresentation is null) {
 			   	rect = Empty;
 				return false;
 			}

--- a/src/NativeTypes/Primitives.tt
+++ b/src/NativeTypes/Primitives.tt
@@ -393,7 +393,7 @@ namespace System
 		{
 			if (source == IntPtr.Zero)
 				throw new ArgumentNullException ("source");
-			if (destination == null)
+			if (destination is null)
 				throw new ArgumentNullException ("destination");
 			if (destination.Rank != 1)
 				throw new ArgumentException ("destination", "array is multi-dimensional");
@@ -410,7 +410,7 @@ namespace System
 
 		public static void CopyArray (<#= type.NSName #> [] source, int startIndex, IntPtr destination, int length)
 		{
-			if (source == null)
+			if (source is null)
 				throw new ArgumentNullException ("source");
 			if (destination == IntPtr.Zero)
 				throw new ArgumentNullException ("destination");

--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -118,7 +118,7 @@ public partial class Generator {
 			print ("public static NSString? GetDomain (this {0} self)", type.Name);
 			print ("{");
 			indent++;
-			print ("if (_domain == null)");
+			print ("if (_domain is null)");
 			indent++;
 			print ("_domain = Dlfcn.GetStringConstant (Libraries.{0}.Handle, \"{1}\");", library_name, error.ErrorDomain);
 			indent--;
@@ -191,7 +191,7 @@ public partial class Generator {
 			print ("public static {0} GetValue (NSString{1} constant)", type.Name, nullable ? "?" : "");
 			print ("{");
 			indent++;
-			print ("if (constant == null)");
+			print ("if (constant is null)");
 			indent++;
 			// if we do not have a enum value that maps to a null field then we throw
 			if (!nullable)

--- a/src/generator-filters.cs
+++ b/src/generator-filters.cs
@@ -84,7 +84,7 @@ public partial class Generator {
 		print ("public {0} (NSCoder coder) : base (NSObjectFlag.Empty)", type_name);
 		print ("{");
 		indent++;
-		print ("if (coder == null)");
+		print ("if (coder is null)");
 		indent++;
 		print ("throw new ArgumentNullException (nameof (coder));");
 		indent--;
@@ -359,7 +359,7 @@ public partial class Generator {
 			indent--;
 			break;
 		case "CIVector[]":
-			print ("if (value == null) {");
+			print ("if (value is null) {");
 			indent++;
 			print ($"SetHandle (\"{propertyName}\", IntPtr.Zero);");
 			indent--;

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1377,10 +1377,10 @@ public partial class Generator : IMemberGatherer {
 		var isEnum = retType.IsEnum;
 		var parameterName = pi != null ? pi.Name.GetSafeParamName () : "value";
 		var denullify = isNullable ? ".Value" : string.Empty;
-		var nullCheck = isNullable ? $"{parameterName} == null ? null : " : string.Empty;
+		var nullCheck = isNullable ? $"{parameterName} is null ? null : " : string.Empty;
 
 		if (isNullable || !isValueType)
-			temp = string.Format ("{0} == null ? null : ", parameterName);
+			temp = string.Format ("{0} is null ? null : ", parameterName);
 
 		if (originalType == TypeManager.NSNumber) {
 			var enumCast = isEnum ? $"(int)" : string.Empty;
@@ -1397,7 +1397,7 @@ public partial class Generator : IMemberGatherer {
 			}
 			temp = string.Format ("{3}NSValue.From{0} ({2}{1});", typeStr, denullify, parameterName, nullCheck);
 		} else if (originalType == TypeManager.NSString && IsSmartEnum (retType)) {
-			temp = isNullable ? $"{parameterName} == null ? null : " : string.Empty;
+			temp = isNullable ? $"{parameterName} is null ? null : " : string.Empty;
 			temp += $"{FormatType (retType.DeclaringType, retType)}Extensions.GetConstant ({parameterName}{denullify});";
 		} else if (originalType.IsArray && originalType.GetArrayRank () == 1) {
 			if (!retType.IsArray) {
@@ -1726,7 +1726,7 @@ public partial class Generator : IMemberGatherer {
 					var refname = $"__xamarin_pref{pi.Position}";
 					convert.Append ($"var {refname} = Runtime.GetINativeObject<{RenderType (nt)}> ({safe_name}, false);");
 					pars.Append ($"ref IntPtr {safe_name}");
-					postConvert.Append ($"{safe_name} = {refname} == null ? IntPtr.Zero : {refname}.Handle;");
+					postConvert.Append ($"{safe_name} = {refname} is null ? IntPtr.Zero : {refname}.Handle;");
 					invoke.Append ($"ref {refname}");
 					continue;
 				}
@@ -1820,9 +1820,9 @@ public partial class Generator : IMemberGatherer {
 		}
 
 		if (HasBindAsAttribute (pi))
-			return string.Format ("nsb_{0} == null ? IntPtr.Zero : nsb_{0}.Handle", pi.Name);
+			return string.Format ("nsb_{0} is null ? IntPtr.Zero : nsb_{0}.Handle", pi.Name);
 		if (propInfo != null && HasBindAsAttribute (propInfo))
-			return string.Format ("nsb_{0} == null ? IntPtr.Zero : nsb_{0}.Handle", propInfo.Name);
+			return string.Format ("nsb_{0} is null ? IntPtr.Zero : nsb_{0}.Handle", propInfo.Name);
 
 		var safe_name = pi.Name.GetSafeParamName ();
 
@@ -1847,7 +1847,7 @@ public partial class Generator : IMemberGatherer {
 				
 				if (mai.ZeroCopyStringMarshal){
 					if (allow_null)
-						return String.Format ("{0} == null ? IntPtr.Zero : (IntPtr)(&_s{0})", pi.Name);
+						return String.Format ("{0} is null ? IntPtr.Zero : (IntPtr)(&_s{0})", pi.Name);
 					else
 						return String.Format ("(IntPtr)(&_s{0})", pi.Name);
 				} else {
@@ -1870,7 +1870,7 @@ public partial class Generator : IMemberGatherer {
 			//Type etype = pi.ParameterType.GetElementType ();
 
 			if (null_allowed_override || AttributeManager.HasAttribute<NullAllowedAttribute> (pi))
-				return String.Format ("nsa_{0} == null ? IntPtr.Zero : nsa_{0}.Handle", pi.Name);
+				return String.Format ("nsa_{0} is null ? IntPtr.Zero : nsa_{0}.Handle", pi.Name);
 			return "nsa_" + pi.Name + ".Handle";
 		}
 
@@ -1892,13 +1892,13 @@ public partial class Generator : IMemberGatherer {
 
 		if (IsDictionaryContainerType(pi.ParameterType)){
 			if (null_allowed_override || AttributeManager.HasAttribute<NullAllowedAttribute> (pi))
-				return String.Format ("{0} == null ? IntPtr.Zero : {0}.Dictionary.Handle", safe_name);
+				return String.Format ("{0} is null ? IntPtr.Zero : {0}.Dictionary.Handle", safe_name);
 			return safe_name + ".Dictionary.Handle";
 		}
 
 		if (pi.ParameterType.IsGenericParameter) {
 			if (null_allowed_override || AttributeManager.HasAttribute<NullAllowedAttribute> (pi))
-				return string.Format ("{0} == null ? IntPtr.Zero : {0}.Handle", safe_name);
+				return string.Format ("{0} is null ? IntPtr.Zero : {0}.Handle", safe_name);
 			return safe_name + ".Handle";
 		}
 
@@ -3021,7 +3021,7 @@ public partial class Generator : IMemberGatherer {
 				}
 				// [NullAllowed] on `UserInfo` requires a check for every case
 				print ("var userinfo = Notification.UserInfo;");
-				print ("if (userinfo == null)");
+				print ("if (userinfo is null)");
 				indent++;
 				if (probe_presence)
 					print ("return false;");
@@ -4063,7 +4063,7 @@ public partial class Generator : IMemberGatherer {
 			"_s{0}.ClassPtr = ObjCRuntime.NSStringStruct.ReferencePtr;\n" +
 			"_s{0}.Flags = 0x010007d1; // RefCount=1, Unicode, InlineContents = 0, DontFreeContents\n" +
 			"_s{0}.UnicodePtr = _p{0};\n" + 
-			"_s{0}.Length = " + (probe_null ? "{1} == null ? 0 : {1}.Length;" : "{1}.Length;\n");
+			"_s{0}.Length = " + (probe_null ? "{1} is null ? 0 : {1}.Length;" : "{1}.Length;\n");
 	}
 	
 	public string GenerateDisposeString (bool probe_null, bool must_copy)
@@ -4191,7 +4191,7 @@ public partial class Generator : IMemberGatherer {
 					disposes.AppendFormat ("\nnsb_{0}?.Dispose ();", propInfo.Name);
 				} else if (etype == TypeManager.System_String) {
 					if (null_allowed_override || AttributeManager.HasAttribute<NullAllowedAttribute> (pi)) {
-						convs.AppendFormat ("var nsa_{0} = {1} == null ? null : NSArray.FromStrings ({1});\n", pi.Name, pi.Name.GetSafeParamName ());
+						convs.AppendFormat ("var nsa_{0} = {1} is null ? null : NSArray.FromStrings ({1});\n", pi.Name, pi.Name.GetSafeParamName ());
 						disposes.AppendFormat ("if (nsa_{0} != null)\n\tnsa_{0}.Dispose ();\n", pi.Name);
 					} else {
 						convs.AppendFormat ("var nsa_{0} = NSArray.FromStrings ({1});\n", pi.Name, pi.Name.GetSafeParamName ());
@@ -4201,7 +4201,7 @@ public partial class Generator : IMemberGatherer {
 					exceptions.Add (ErrorHelper.CreateError (1065, mai.Type.FullName, string.IsNullOrEmpty (pi.Name) ? $"#{pi.Position}" : pi.Name, mi.DeclaringType.FullName, mi.Name));
 				} else {
 					if (null_allowed_override || AttributeManager.HasAttribute<NullAllowedAttribute> (pi)) {
-						convs.AppendFormat ("var nsa_{0} = {1} == null ? null : NSArray.FromNSObjects ({1});\n", pi.Name, pi.Name.GetSafeParamName ());
+						convs.AppendFormat ("var nsa_{0} = {1} is null ? null : NSArray.FromNSObjects ({1});\n", pi.Name, pi.Name.GetSafeParamName ());
 						disposes.AppendFormat ("if (nsa_{0} != null)\n\tnsa_{0}.Dispose ();\n", pi.Name);
 					} else {
 						convs.AppendFormat ("var nsa_{0} = NSArray.FromNSObjects ({1});\n", pi.Name, pi.Name.GetSafeParamName ());
@@ -4216,7 +4216,7 @@ public partial class Generator : IMemberGatherer {
 				convs.AppendFormat ("BlockLiteral *block_ptr_{0};\n", pi.Name);
 				convs.AppendFormat ("BlockLiteral block_{0};\n", pi.Name);
 				if (null_allowed){
-					convs.AppendFormat ("if ({0} == null){{\n", pi.Name.GetSafeParamName ());
+					convs.AppendFormat ("if ({0} is null){{\n", pi.Name.GetSafeParamName ());
 					convs.AppendFormat ("\tblock_ptr_{0} = null;\n", pi.Name);
 					convs.AppendFormat ("}} else {{\n");
 					extra = "\t";
@@ -4277,12 +4277,12 @@ public partial class Generator : IMemberGatherer {
 						by_ref_init.AppendFormat ("IntPtr {0}OriginalValue = {0}Value;\n", pi.Name.GetSafeParamName ());
 					} else if (isArrayOfNSObject || isArrayOfINativeObjectSubclass) {
 						by_ref_init.Insert (0, string.Format ("NSArray {0}ArrayValue = NSArray.FromNSObjects ({0});\n", pi.Name.GetSafeParamName ()));
-						by_ref_init.AppendFormat ("{0}ArrayValue == null ? IntPtr.Zero : {0}ArrayValue.Handle;\n", pi.Name.GetSafeParamName ());
+						by_ref_init.AppendFormat ("{0}ArrayValue is null ? IntPtr.Zero : {0}ArrayValue.Handle;\n", pi.Name.GetSafeParamName ());
 					} else if (isArrayOfString) {
-						by_ref_init.Insert (0, string.Format ("NSArray {0}ArrayValue = {0} == null ? null : NSArray.FromStrings ({0});\n", pi.Name.GetSafeParamName ()));
-						by_ref_init.AppendFormat ("{0}ArrayValue == null ? IntPtr.Zero : {0}ArrayValue.Handle;\n", pi.Name.GetSafeParamName ());
+						by_ref_init.Insert (0, string.Format ("NSArray {0}ArrayValue = {0} is null ? null : NSArray.FromStrings ({0});\n", pi.Name.GetSafeParamName ()));
+						by_ref_init.AppendFormat ("{0}ArrayValue is null ? IntPtr.Zero : {0}ArrayValue.Handle;\n", pi.Name.GetSafeParamName ());
 					} else if (isNSObject || isINativeObjectSubclass) {
-						by_ref_init.AppendFormat ("{0} == null ? IntPtr.Zero : {0}.Handle;\n", pi.Name.GetSafeParamName ());
+						by_ref_init.AppendFormat ("{0} is null ? IntPtr.Zero : {0}.Handle;\n", pi.Name.GetSafeParamName ());
 					} else {
 						throw ErrorHelper.CreateError (88, mai.Type, mi);
 					}
@@ -4294,7 +4294,7 @@ public partial class Generator : IMemberGatherer {
 					by_ref_processing.AppendFormat ("{0} = NSString.FromHandle ({0}Value);\n", pi.Name.GetSafeParamName ());
 				} else if (isArray) {
 					if (!pi.IsOut)
-						by_ref_processing.AppendFormat ("if ({0}Value != ({0}ArrayValue == null ? IntPtr.Zero : {0}ArrayValue.Handle))\n\t", pi.Name.GetSafeParamName ());
+						by_ref_processing.AppendFormat ("if ({0}Value != ({0}ArrayValue is null ? IntPtr.Zero : {0}ArrayValue.Handle))\n\t", pi.Name.GetSafeParamName ());
 
 					if (isArrayOfNSObject || isArrayOfINativeObjectSubclass) {
 						by_ref_processing.AppendFormat ("{0} = NSArray.ArrayFromHandle<{1}> ({0}Value);\n", pi.Name.GetSafeParamName (), RenderType (elementType.GetElementType ()));
@@ -4310,7 +4310,7 @@ public partial class Generator : IMemberGatherer {
 					by_ref_processing.AppendFormat ("{0} = Runtime.GetNSObject<{1}> ({0}Value);\n", pi.Name.GetSafeParamName (), RenderType (elementType));
 				} else if (isINativeObjectSubclass) {
 					if (!pi.IsOut)
-						by_ref_processing.AppendFormat ("if ({0}Value != ({0} == null ? IntPtr.Zero : {0}.Handle))\n\t", pi.Name.GetSafeParamName ());
+						by_ref_processing.AppendFormat ("if ({0}Value != ({0} is null ? IntPtr.Zero : {0}.Handle))\n\t", pi.Name.GetSafeParamName ());
 					by_ref_processing.AppendFormat ("{0} = Runtime.GetINativeObject<{1}> ({0}Value, {2}, {3});\n", pi.Name.GetSafeParamName (), RenderType (elementType), isForcedType ? "true" : "false", isForcedType ? isForcedOwns : "false");
 				} else {
 					throw ErrorHelper.CreateError (88, mai.Type, mi);
@@ -4354,7 +4354,7 @@ public partial class Generator : IMemberGatherer {
 					print ($"var {safe_name}__handle__ = {safe_name}.GetHandle ();");
 				}
 			} else if (needs_null_check) {
-				print ("if ({0} == null)", safe_name);
+				print ("if ({0} is null)", safe_name);
 				print ("\tObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof ({0}));", safe_name);
 			}
 		}
@@ -4886,7 +4886,7 @@ public partial class Generator : IMemberGatherer {
 
 				if (IsDictionaryContainerType (pi.PropertyType)) {
 					print ("var src = {0} != null ? new NSMutableDictionary ({0}) : null;", wrap);
-					print ("return src == null ? null! : new {0}(src);", FormatType (pi.DeclaringType, pi.PropertyType));
+					print ("return src is null ? null! : new {0}(src);", FormatType (pi.DeclaringType, pi.PropertyType));
 				} else {
 					if (IsArrayOfWrappedType (pi.PropertyType))
 						print ("return NSArray.FromArray<{0}>({1} as NSArray);", FormatType (pi.DeclaringType, pi.PropertyType.GetElementType ()), wrap);
@@ -4908,7 +4908,7 @@ public partial class Generator : IMemberGatherer {
 
 				if (minfo.protocolize || is_protocol_wrapper){
 					print ("var rvalue = value as NSObject;");
-					print ("if (value != null && rvalue == null)");
+					print ("if (!(value is null) && rvalue is null)");
 					print ("\tthrow new ArgumentException (\"The object passed of type \" + value.GetType () + \" does not derive from NSObject\");");
 				}
 							
@@ -6912,19 +6912,19 @@ public partial class Generator : IMemberGatherer {
 					print ("get {");
 					indent++;
 					if (field_pi.PropertyType == TypeManager.NSString){
-						print ("if (_{0} == null)", field_pi.Name);
+						print ("if (_{0} is null)", field_pi.Name);
 						indent++;
 						print ("_{0} = Dlfcn.GetStringConstant (Libraries.{2}.Handle, \"{1}\");", field_pi.Name, fieldAttr.SymbolName, library_name);
 						indent--;
 						print ("return _{0};", field_pi.Name);
 					} else if (field_pi.PropertyType.Name == "NSArray"){
-						print ("if (_{0} == null)", field_pi.Name);
+						print ("if (_{0} is null)", field_pi.Name);
 						indent++;
 						print ("_{0} = Runtime.GetNSObject<NSArray> (Dlfcn.GetIndirect (Libraries.{2}.Handle, \"{1}\"));", field_pi.Name, fieldAttr.SymbolName, library_name);
 						indent--;
 						print ("return _{0};", field_pi.Name);
 					} else if (field_pi.PropertyType.Name == "UTType") {
-						print ("if (_{0} == null)", field_pi.Name);
+						print ("if (_{0} is null)", field_pi.Name);
 						indent++;
 						print ("_{0} = Runtime.GetNSObject<UTType> (Dlfcn.GetIntPtr (Libraries.{2}.Handle, \"{1}\"));", field_pi.Name, fieldAttr.SymbolName, library_name);
 						indent--;
@@ -6964,7 +6964,7 @@ public partial class Generator : IMemberGatherer {
 					} else if (field_pi.PropertyType.IsEnum) {
 						var btype = field_pi.PropertyType.GetEnumUnderlyingType ();
 						if (smartEnumTypeName != null) {
-							print ("if (_{0} == null)", field_pi.Name);
+							print ("if (_{0} is null)", field_pi.Name);
 							indent++;
 							print ("_{0} = Dlfcn.GetStringConstant (Libraries.{2}.Handle, \"{1}\");", field_pi.Name, fieldAttr.SymbolName, library_name);
 							indent--;
@@ -7146,14 +7146,14 @@ public partial class Generator : IMemberGatherer {
 
 						print ("var del = {1} as _{0};", dtype.Name, delName);
 
-						print ("if (del == null){");
+						print ("if (del is null){");
 						indent++;
 						if (!hasKeepRefUntil)
 							print ("del = (_{0}){1} ();", dtype.Name, delegateCreationMethodName);
 						else {
 							string oref = "new object[] {\"oref\"}";
 							print ("del = (_{0}){1} ({2});", dtype.Name, delegateCreationMethodName, oref);
-							print ("if (instances == null) instances = new System.Collections.ArrayList ();");
+							print ("if (instances is null) instances = new System.Collections.ArrayList ();");
 							print ("if (!instances.Contains (this)) instances.Add (this);");
 						}
 						print ("{0} = (I{1})del;", delName, dtype.Name);
@@ -7163,10 +7163,10 @@ public partial class Generator : IMemberGatherer {
 					}
 					else {
 						print ("var del = {0};", delName);
-						print ("if (del == null || (!(del is _{0}))){{", dtype.Name);
+						print ("if (del is null || (!(del is _{0}))){{", dtype.Name);
 						print ("\tdel = new _{0} ({1});", dtype.Name, bta.KeepRefUntil == null ? "" : "oref");
 						if (hasKeepRefUntil) {
-							print ("\tif (instances == null) instances = new System.Collections.ArrayList ();");
+							print ("\tif (instances is null) instances = new System.Collections.ArrayList ();");
 							print ("\tif (!instances.Contains (this)) instances.Add (this);");
 						}
 						print ("\t{0} = del;", delName);
@@ -7333,7 +7333,7 @@ public partial class Generator : IMemberGatherer {
 						print ("public override bool RespondsToSelector (Selector? sel)");
 						print ("{");
 						++indent;
-						print ("if (sel == null)");
+						print ("if (sel is null)");
 						++indent;
 						print ("return false;");
 						--indent;

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -492,7 +492,7 @@ namespace MapKit {
 		void Register ([NullAllowed] Class viewClass, string identifier);
 
 		[TV (11,0)][iOS (11,0)][Mac (10,13)]
-		[Wrap ("Register (viewType == null ? null : new Class (viewType), identifier)")]
+		[Wrap ("Register (viewType is null ? null : new Class (viewType), identifier)")]
 		void Register ([NullAllowed] Type viewType, string identifier);
 
 		[Export ("selectAnnotation:animated:")]

--- a/src/safariservices.cs
+++ b/src/safariservices.cs
@@ -58,7 +58,7 @@ namespace SafariServices {
 
 		[Static, Export ("supportsURL:")]
 		// Apple says it's __nonnull so let's be safe and maintain compatibility with our current behaviour
-		[PreSnippet ("if (url == null) return false;")]
+		[PreSnippet ("if (url is null) return false;")]
 		bool SupportsUrl ([NullAllowed] NSUrl url);
 
 		[Export ("addReadingListItemWithURL:title:previewText:error:")]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -2435,7 +2435,7 @@ namespace UIKit {
 		void OpenUrl (NSUrl url, UIApplicationOpenUrlOptions options, [NullAllowed] Action<bool> completion);
 
 		[Export ("canOpenURL:")]
-		[PreSnippet ("if (url == null) return false;")] // null not really allowed (but it's a behaviour change with known bug reports)
+		[PreSnippet ("if (url is null) return false;")] // null not really allowed (but it's a behaviour change with known bug reports)
 		bool CanOpenUrl ([NullAllowed] NSUrl url);
 		
 		[Export ("sendEvent:")]
@@ -19954,7 +19954,7 @@ namespace UIKit {
 
 		Type SceneType {
 			[Wrap ("Class.Lookup (SceneClass)")] get;
-			[Wrap ("SceneClass = value == null ? null : new Class (value)")] set;
+			[Wrap ("SceneClass = value is null ? null : new Class (value)")] set;
 		}
 
 		[Advice ("You can use 'DelegateType' with a 'Type' instead.")]
@@ -19963,7 +19963,7 @@ namespace UIKit {
 
 		Type DelegateType {
 			[Wrap ("Class.Lookup (DelegateClass)")] get;
-			[Wrap ("DelegateClass = value == null ? null : new Class (value)")] set;
+			[Wrap ("DelegateClass = value is null ? null : new Class (value)")] set;
 		}
 
 		[NullAllowed, Export ("storyboard", ArgumentSemantic.Strong)]


### PR DESCRIPTION
In most cases this will generate the exact same IL [1].

However it will perform _better_ (like you expect) if the `==` operator
is overloaded (even more if the operator implementation is buggy).

A last, small benefit is that avoiding `==` means the linker is more
likely to be able to remove it from the final applications.

This PR only change the generated code. IOW not the generator code,
nor the manual bindings. Those should also be updated but requires
more work.

References:
[1] https://gist.github.com/spouliot/fb05e733e1f9f403de69ab3ab6bdac2b
[2] https://www.thomasclaudiushuber.com/2020/03/19/c-why-you-should-prefer-the-is-keyword-over-the-operator/