### PR TITLE
[runtime] Add support for toggle refs to CoreCLR.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -148,6 +148,66 @@ monoobject_dict_free_value (CFAllocatorRef allocator, const void *value)
 
 #endif // defined (TRACK_MONOOBJECTS)
 
+/*
+ * Toggle-ref support for CoreCLR is a bit different than for MonoVM. It goes like this:
+ *
+ * 1) We have to opt-in for the required GC support by calling
+ *    ObjectiveCMarshal.Initialize (in managed code) at startup. This happens
+ *    in Runtime.InitializeCoreCLRBridge (in Runtime.CoreCLR.cs).
+ *
+ * 2) Types that can be toggled, must have the [ObjectiveCTrackedType]
+ *    attribute (on any subclass). We put this attribute on NSObject.
+ *
+ * 3) We have to call ObjectiveCMarshal.CreateReferenceTrackingHandle when an
+ *    object is toggled. This callback returns a GCHandle for the managed
+ *    object, and a pointer to native memory (size: 2 pointers) where we can
+ *    store whatever we want. We store the native Handle, and the Flags
+ *    property. Unfortunately this means duplicating information, and we have
+ *    to make sure they're in sync. It didn't see a sane way around this
+ *    though, because we need the Handle and the Flags somewhere accessible
+ *    from native code during the GC (so we can't store them in managed
+ *    memory), while at the same time we don't want to create an additional
+ *    native block of memory for every NSObject, nor use some complex logic to
+ *    support either a managed or a native storage. With the current solution
+ *    we're only using additional native memory for toggled objects.
+ *    Additionally, updates have to flow:
+ *
+ *    a) From managed to native for Handle and Flags, so we update the native
+ *       memory (if it's there) when the Handle or Flags properties are set.
+ *    b) From native to managed for a single flag value
+ *       (NSObjectFlagsInFinalizerQueue), which we fetch in managed code in
+ *       the Flags getter.
+ *
+ * 4) The CoreCLR GC will invoke a callback we installed when calling
+ *    ObjectiveCMarshal.Initialize to check if that toggled managed object can
+ *    be collected or not. This callback is executed during the GC, which
+ *    means it's very limited what we can do safely: but we can read and write
+ *    to the memory given to us when the managed object was toggled, which is
+ *    why we store the Handle and the Flags property - that's what we need to
+ *    know to determine whether the managed object can be collected or not.
+ *
+ * 5) When the managed object is finalized, the GC will invoke another
+ *    callback (xamarin_coreclr_reference_tracking_tracked_object_entered_finalization)
+ *    to let us know, and we'll set the corresponding flag in the flags
+ *
+ * 6) Finally, the GCHandle we got in step 3) is freed when the managed peer
+ *    is freed.
+ *
+ * Caveat: we don't support the server GC (because it uses multiple threads,
+ * and thus may call xamarin_coreclr_reference_tracking_begin_end_callback
+ * from multiple threads for the same garbage collection, which we don't
+ * support right now - but it may be possible to implement by using a
+ * different lock in xamarin_gc_event).
+ *
+ * Ref: https://github.com/dotnet/runtime/issues/44659
+ * Ref: https://github.com/dotnet/designs/blob/1bb5844c165195e2f633cb1dbe042c4b92aefc4d/accepted/2021/objectivec-interop.md
+ */
+
+struct TrackedObjectInfo {
+	id handle;
+	enum NSObjectFlags flags;
+};
+
 void
 xamarin_bridge_setup ()
 {
@@ -194,26 +254,77 @@ xamarin_bridge_shutdown ()
 #endif
 }
 
+static bool reference_tracking_end = false;
+
+// This callback will be called once before the GC starts calling xamarin_coreclr_reference_tracking_is_referenced_callback,
+// and once the GC is done. We keep track of which case we're in in the 'reference_tracking_end' variable, and raise the
+// corresponding GC event. It will only be called once for each GC, both the begin and the end on the same thread.
 void
 xamarin_coreclr_reference_tracking_begin_end_callback ()
 {
 	LOG_CORECLR (stderr, "%s () reference_tracking_end: %i\n", __func__, reference_tracking_end);
+	if (reference_tracking_end) {
+		xamarin_gc_event (MONO_GC_EVENT_POST_START_WORLD);
+	} else {
+		xamarin_gc_event (MONO_GC_EVENT_PRE_STOP_WORLD);
+	}
+	reference_tracking_end = !reference_tracking_end;
 }
 
+// This callback is called by the GC to check whether a given managed object
+// can be collected or not. The single 'ptr' argument is the native memory
+// returned by the managed call to
+// ObjectiveCMarshal.CreateReferenceTrackingHandle, and this memory can be
+// accessed while the GC is running. In here we store the native Handle for
+// the managed object, and any flags, both of which we need to know in this
+// method to determine whether the corresponding managed object can be
+// collected or not.
 int
 xamarin_coreclr_reference_tracking_is_referenced_callback (void* ptr)
 {
+	// This is a callback called by the GC, so there's not much we can do here safely.
+	// Most importantly we can't call managed code, nor access managed memory.
+	// But we can access the native memory given to us when the object was toggled
+	// (and which is passed as the 'ptr' argument), so let's get the data we need from there.
 	int rv = 0;
+	struct TrackedObjectInfo *info = (struct TrackedObjectInfo *) ptr;
+	enum NSObjectFlags flags = info->flags;
+	id handle = info->handle;
+	MonoToggleRefStatus res;
 
-	LOG_CORECLR (stderr, "%s (%p) => %i\n", __func__, ptr, rv);
+	res = xamarin_gc_toggleref_callback (flags, handle, NULL, NULL);
+
+	switch (res) {
+	case MONO_TOGGLE_REF_DROP:
+		// There's no equivalent to DROP in CoreCLR, so just treat it as weak.
+	case MONO_TOGGLE_REF_WEAK:
+		rv = 0;
+		break;
+	case MONO_TOGGLE_REF_STRONG:
+		rv = 1;
+		break;
+	default:
+		LOG_CORECLR (stderr, "%s (%p -> handle: %p flags: %i): INVALID toggle ref value: %i\n", __func__, ptr, handle, flags, res);
+		break;
+	}
+
+	LOG_CORECLR (stderr, "%s (%p -> handle: %p flags: %i) => %i (res: %i)\n", __func__, ptr, handle, flags, rv, res);
 
 	return rv;
 }
 
+// This callback is called when an object is queued for finalization. The
+// single 'ptr' argument is the native memory returned by the managed call to
+// ObjectiveCMarshal.CreateReferenceTrackingHandle, and this memory can be
+// accessed while the GC is running (which it is when this method is called).
+// In here we set the NSObjectFlagsInFinalizerQueue flag, which managed code
+// (the NSObject.flags property) will fetch.
 void
 xamarin_coreclr_reference_tracking_tracked_object_entered_finalization (void* ptr)
 {
-	LOG_CORECLR (stderr, "%s (%p)\n", __func__, ptr);
+	struct TrackedObjectInfo *info = (struct TrackedObjectInfo *) ptr;
+	info->flags = (enum NSObjectFlags) (info->flags | NSObjectFlagsInFinalizerQueue);
+	LOG_CORECLR (stderr, "%s (%p) flags: %i\n", __func__, ptr, (int) info->flags);
 }
 
 void

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1154,6 +1154,16 @@ partial class TestRuntime
 #endif
 	}
 	
+	public static byte GetFlags (NSObject obj)
+	{
+#if NET
+		const string fieldName = "actual_flags";
+#else
+		const string fieldName = "flags";
+#endif
+		return (byte) typeof (NSObject).GetField (fieldName, BindingFlags.Instance | BindingFlags.GetField | BindingFlags.NonPublic).GetValue (obj);
+	}
+
 	// Determine if linkall was enabled by checking if an unused class in this assembly is still here.
 	static bool? link_all;
 	public static bool IsLinkAll {

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -167,7 +167,7 @@ namespace Introspection {
 		
 		bool GetIsDirectBinding (NSObject obj)
 		{
-			int flags = (byte) typeof (NSObject).GetField ("flags", BindingFlags.Instance | BindingFlags.GetField | BindingFlags.NonPublic).GetValue (obj);
+			int flags = TestRuntime.GetFlags (obj);
 			return (flags & 4) == 4;
 		}
 

--- a/tests/monotouch-test/Foundation/ObjectTest.cs
+++ b/tests/monotouch-test/Foundation/ObjectTest.cs
@@ -38,7 +38,7 @@ namespace MonoTouchFixtures.Foundation {
 		
 		bool GetIsDirectBinding (NSObject obj)
 		{
-			int flags = (byte) typeof (NSObject).GetField ("flags", BindingFlags.Instance | BindingFlags.GetField | BindingFlags.NonPublic).GetValue (obj);
+			var flags = TestRuntime.GetFlags (obj);
 			return (flags & 4) == 4;
 		}
 		

--- a/tests/monotouch-test/UIKit/ControlTest.cs
+++ b/tests/monotouch-test/UIKit/ControlTest.cs
@@ -67,16 +67,9 @@ namespace MonoTouchFixtures.UIKit {
 		{
 			using (var ctrl = new UIControl ()) {
 				ctrl.AddTarget ((a, b) => { }, UIControlEvent.EditingDidBegin);
-				Assert.IsTrue ((GetFlags (ctrl) & 0x8) /* RegisteredToggleRef */ == 0x8, "RegisteredToggleRef");
+				Assert.IsTrue ((TestRuntime.GetFlags (ctrl) & 0x8) /* RegisteredToggleRef */ == 0x8, "RegisteredToggleRef");
 			}
 		}
-
-
-		byte GetFlags (NSObject obj)
-		{
-			return (byte) typeof (NSObject).GetField ("flags", BindingFlags.Instance | BindingFlags.GetField | BindingFlags.NonPublic).GetValue (obj);
-		}
-
 	}
 }
 


### PR DESCRIPTION
The code contains comments explaining the new behavior.

Some tests that poked into the private 'flags' field on NSObject had to be
updated, because the field is now named differently in .NET.

I also added two more tests for toggle ref scenarios.