### PR TITLE
[CI] Use LFS for the static page checkout.

### DIFF
--- a/tools/devops/automation/templates/publish-html-result.yml
+++ b/tools/devops/automation/templates/publish-html-result.yml
@@ -16,6 +16,7 @@ steps:
 
 - checkout: macios.ci 
   clean: true
+  lfs: true
 
 # downlod ALL artifacts
 - download: macios 


### PR DESCRIPTION
PR https://github.com/xamarin/xamarin-macios/pull/11754 created a 50+MB
for the generator diff that resulted in a 250 mb index file. This is too
large and github rejects the push. USing LFS fixes the issue.

fixes: https://github.com/xamarin/maccore/issues/2449