### PR TITLE
[monotouch-test] Don't run SystemSound tests in the simulator.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -148,6 +148,14 @@ partial class TestRuntime
 #endif
 	}
 
+	public static void AssertNotSimulator ()
+	{
+#if !__MACOS__
+		if (ObjCRuntime.Runtime.Arch == Arch.SIMULATOR)
+			NUnit.Framework.Assert.Ignore ("This test does not work in the simulator.");
+#endif
+	}
+
 	public static bool IsVM => 
 		!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("VM_VENDOR"));
 

--- a/tests/monotouch-test/AudioToolbox/SystemSoundTest.cs
+++ b/tests/monotouch-test/AudioToolbox/SystemSoundTest.cs
@@ -28,11 +28,9 @@ namespace MonoTouchFixtures.AudioToolbox {
 		[Test]
 		public void FromFile ()
 		{
+			TestRuntime.AssertNotSimulator ();
+
 			var path = NSBundle.MainBundle.PathForResource ("1", "caf", "AudioToolbox");
-#if !MONOMAC
-			if (Runtime.Arch == Arch.SIMULATOR)
-				Assert.Ignore ("PlaySystemSound doesn't work in the simulator");
-#endif
 
 			using (var ss = SystemSound.FromFile (NSUrl.FromFilename (path))) {
 				var completed = false;
@@ -63,6 +61,7 @@ namespace MonoTouchFixtures.AudioToolbox {
 		[Test]
 		public void TestCallbackPlaySystem ()
 		{
+			TestRuntime.AssertNotSimulator ();
 			TestRuntime.AssertSystemVersion (PlatformName.iOS, 9, 0, throwIfOtherPlatform: false);
 
 			string path = Path.Combine (NSBundle.MainBundle.ResourcePath, "drum01.mp3");
@@ -82,6 +81,7 @@ namespace MonoTouchFixtures.AudioToolbox {
 		[Test]
 		public void TestCallbackPlayAlert ()
 		{
+			TestRuntime.AssertNotSimulator ();
 			TestRuntime.AssertSystemVersion (PlatformName.iOS, 9, 0, throwIfOtherPlatform: false);
 
 			string path = Path.Combine (NSBundle.MainBundle.ResourcePath, "drum01.mp3");


### PR DESCRIPTION
Sometimes they work, sometimes they don't.

Just ignore them to avoid unreliable test results.

Partial fix for #11504.