### PR TITLE
[monotouch-test] Ignore HKQuantityTypeIdentifier.AppleMoveTime on iOS versions where it didn't exist.

### DIFF
--- a/tests/monotouch-test/HealthKit/QuantityTypeIdentifierTest.cs
+++ b/tests/monotouch-test/HealthKit/QuantityTypeIdentifierTest.cs
@@ -77,7 +77,10 @@ namespace MonoTouchFixtures.HealthKit {
 					if (!TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch))
 						continue;
 					break;
-
+				case HKQuantityTypeIdentifier.AppleMoveTime:
+					if (!TestRuntime.CheckXcodeVersion (12, 5))
+						continue;
+					break;
 				}
 
 				try {


### PR DESCRIPTION
It was introduced with Xcode 12.5, so ignore it on earlier OS versions.

Partial fix for #11504.