### PR TITLE
[monotouch-test] Exclude any *.cs file in any obj subdirectory, not only the immediate subdirectory.

### DIFF
--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -182,7 +182,7 @@
     <None Include="EmptyNib.xib" Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs" Exclude="obj\**">
+    <Compile Include="**\*.cs" Exclude="**\obj\**\*.cs">
       <Link>%(RecursiveDir)%(Filename).cs</Link>
     </Compile>
     <Compile Include="..\..\tests\test-libraries\TrampolineTest.generated.cs" />


### PR DESCRIPTION
This means that we won't pick up generated *.cs files from the
monotouch-test/dotnet/macOS/monotouch-test.csproj project when building the
monotouch-test/monotouch-test.csproj project, which results in the C# compiler
complaining about duplicate types, or unknown types (because the generated
code is for .NET 6, while we might be compiling for legacy Xamarin).