### PR TITLE
[CI] Ignore readme files and github actions.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -171,14 +171,17 @@ trigger:
     - refs/heads/locfiles/*
   paths:
     exclude:
+    - .github
     - docs
     - CODEOWNERS
     - ISSUE_TEMPLATE.md
     - LICENSE
     - NOTICE.txt
-    - README.md
     - SECURITY.MD
+    - README.md
     - src/README.md
+    - tools/mtouch/README.md
+    - msbuild/Xamarin.Localization.MSBuild/README.md
 
 pr:
   autoCancel: true
@@ -190,14 +193,17 @@ pr:
     - release/*
   paths:
     exclude:
+    - .github
     - docs
     - CODEOWNERS
     - ISSUE_TEMPLATE.md
     - LICENSE
     - NOTICE.txt
-    - README.md
     - SECURITY.MD
+    - README.md
     - src/README.md
+    - tools/mtouch/README.md
+    - msbuild/Xamarin.Localization.MSBuild/README.md
 
 schedules:
 


### PR DESCRIPTION
We have to list each readme as per vsts docs:

```
Tips:
* Wild cards are not supported with path filters.
* Paths are always specified relative to the root of the repository.
* If you don't set path filters, then the root folder of the repo is implicitly included by default.
* If you exclude a path, you cannot also include it unless you qualify it to a deeper folder. For example if you exclude /tools then you could include /tools/trigger-runs-on-these
* The order of path filters doesn't matter.
* Paths in Git are case-sensitive. Be sure to use the same case as the real folders.
* You cannot use variables in paths, as variables are evaluated at runtime (after the trigger has fired).
```

src:  https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#ci-triggers