### PR TITLE
[coregraphics] Small refactor to ease removal of code by the linker

### DIFF
--- a/src/CoreGraphics/CGAffineTransform.cs
+++ b/src/CoreGraphics/CGAffineTransform.cs
@@ -240,10 +240,12 @@ namespace CoreGraphics {
 
 		public override bool Equals(object o)
 		{
-			if (! (o is CGAffineTransform))
+			if (o is CGAffineTransform transform) {
+				return (xx == transform.xx && xy == transform.xy &&
+					yx == transform.yx && yy == transform.yy &&
+					x0 == transform.x0 && y0 == transform.y0);
+			} else
 				return false;
-			else
-				return (this == (CGAffineTransform) o);
 		}
 
 		public override int GetHashCode()

--- a/src/NativeTypes/Drawing.tt
+++ b/src/NativeTypes/Drawing.tt
@@ -50,7 +50,8 @@ namespace CoreGraphics
 
 		public static bool operator == (<#= type.Name #> l, <#= type.Name #> r)
 		{
-			return l.<#= type.X_Width #> == r.<#= type.X_Width #> && l.<#= type.Y_Height #> == r.<#= type.Y_Height #>;
+			// the following version of Equals cannot be removed by the linker, while == can be
+			return l.Equals (r);
 		}
 
 		public static bool operator != (<#= type.Name #> l, <#= type.Name #> r)
@@ -188,22 +189,18 @@ namespace CoreGraphics
 <# } #>
 		public override bool Equals (object obj)
 		{
-			if (obj is <#= type.Name #>) {
-				return this == (<#= type.Name #>)obj;
-			}
-
-			return false;
+			return (obj is <#= type.Name #> t) && Equals (t);
 		}
 
 <# if (type.Name == "CGPoint") { #>
 		public bool Equals (CGPoint point)
 		{
-			return this == point;
+			return point.<#= type.X_Width #> == <#= type.X_Width #> && point.<#= type.Y_Height #> == <#= type.Y_Height #>;
 		}
 <# } else { #>
 		public bool Equals (CGSize size)
 		{
-			return this == size;
+			return size.<#= type.X_Width #> == <#= type.X_Width #> && size.<#= type.Y_Height #> == <#= type.Y_Height #>;
 		}
 <# } #>
 
@@ -278,11 +275,8 @@ namespace CoreGraphics
 
 		public static bool operator == (CGRect left, CGRect right)
 		{
-			return
-				left.X == right.X &&
-				left.Y == right.Y &&
-				left.Width == right.Width &&
-				left.Height == right.Height;
+			// the following version of Equals cannot be removed by the linker, while == can be
+			return left.Equals (right);
 		}
 
 		public static bool operator != (CGRect left, CGRect right)
@@ -552,16 +546,16 @@ namespace CoreGraphics
 
 		public override bool Equals (object obj)
 		{
-			if (obj is CGRect) {
-				return this == (CGRect)obj;
-			}
-
-			return false;
+			return (obj is CGRect rect) && Equals (rect);
 		}
 
 		public bool Equals (CGRect rect)
 		{
-			return this == rect;
+			return
+				x == rect.x &&
+				y == rect.y &&
+				width == rect.width &&
+				height == rect.height;
 		}
 
 		public override int GetHashCode ()


### PR DESCRIPTION
The linker cannot eliminate `Equals(Object)` [1] or `Equals(T)` [2] but it
can remove the `==` operator if unused. So avoiding `Equals` calling `==`
is beneficial.

Also avoid using properties inside `CGRect` and use the fields instead
so the getter can also be removed (if unused).

[1] it's an override on `System.Object` used in many places
[2] it's _generally_ present to satisfy `IEquatable<T>` also used in many places

```diff
--- a.cs	2021-06-01 21:20:46.000000000 -0400
+++ b.cs	2021-06-01 21:20:49.000000000 -0400
@@ -3222,22 +3222,18 @@
 			return $"xx:{xx:##0.0#} yx:{yx:##0.0#} xy:{xy:##0.0#} yy:{yy:##0.0#} x0:{x0:##0.0#} y0:{y0:##0.0#}";
 		}

-		public static bool operator ==(CGAffineTransform P_0, CGAffineTransform P_1)
-		{
-			if (P_0.xx == P_1.xx && P_0.xy == P_1.xy && P_0.yx == P_1.yx && P_0.yy == P_1.yy && P_0.x0 == P_1.x0)
-			{
-				return P_0.y0 == P_1.y0;
-			}
-			return false;
-		}
-
 		public sealed override bool Equals(object P_0)
 		{
-			if (!(P_0 is CGAffineTransform))
+			if (P_0 is CGAffineTransform)
 			{
+				CGAffineTransform cGAffineTransform = (CGAffineTransform)P_0;
+				if (xx == cGAffineTransform.xx && xy == cGAffineTransform.xy && yx == cGAffineTransform.yx && yy == cGAffineTransform.yy && x0 == cGAffineTransform.x0)
+				{
+					return y0 == cGAffineTransform.y0;
+				}
 				return false;
 			}
-			return this == (CGAffineTransform)P_0;
+			return false;
 		}

 		public sealed override int GetHashCode()
@@ -3252,27 +3248,23 @@

 		private nfloat y;

-		public static bool operator ==(CGPoint P_0, CGPoint P_1)
-		{
-			if (P_0.x == P_1.x)
-			{
-				return P_0.y == P_1.y;
-			}
-			return false;
-		}
-
 		public sealed override bool Equals(object P_0)
 		{
 			if (P_0 is CGPoint)
 			{
-				return this == (CGPoint)P_0;
+				CGPoint cGPoint = (CGPoint)P_0;
+				return Equals(cGPoint);
 			}
 			return false;
 		}

 		public bool Equals(CGPoint P_0)
 		{
-			return this == P_0;
+			if (P_0.x == x)
+			{
+				return P_0.y == y;
+			}
+			return false;
 		}

 		public sealed override int GetHashCode()
@@ -3296,35 +3288,23 @@

 		private nfloat height;

-		public nfloat X => x;
-
-		public nfloat Y => y;
-
-		public nfloat Width => width;
-
-		public nfloat Height => height;
-
-		public static bool operator ==(CGRect P_0, CGRect P_1)
-		{
-			if (P_0.X == P_1.X && P_0.Y == P_1.Y && P_0.Width == P_1.Width)
-			{
-				return P_0.Height == P_1.Height;
-			}
-			return false;
-		}
-
 		public sealed override bool Equals(object P_0)
 		{
 			if (P_0 is CGRect)
 			{
-				return this == (CGRect)P_0;
+				CGRect cGRect = (CGRect)P_0;
+				return Equals(cGRect);
 			}
 			return false;
 		}

 		public bool Equals(CGRect P_0)
 		{
-			return this == P_0;
+			if (x == P_0.x && y == P_0.y && width == P_0.width)
+			{
+				return height == P_0.height;
+			}
+			return false;
 		}

 		public sealed override int GetHashCode()
```