### PR TITLE
[tests][dotnet] Update oldnet sample to use LLVM and add some instructions

### DIFF
--- a/tests/dotnet/README.md
+++ b/tests/dotnet/README.md
@@ -1,0 +1,22 @@
+# .net tests
+
+## size-comparison
+
+### Easier Analysis
+
+If you want to read/compare the IL inside the assemblies you need to disable IL stripping.
+
+* Legacy (oldnet)
+
+Add this option inside the `Release|iPhone` configuration of `size-comparison/MySingleView/oldnet/MySingleView.csproj`
+
+```xml
+<MtouchExtraArgs>--nostrip</MtouchExtraArgs>
+```
+
+* net6
+
+**IL stripping is not yet available** so there's nothing to disable right now.
+
+If you want to compare (trimmed) size you can manually call `mono-cil-strip`
+on each assembly inside the app bundle.

--- a/tests/dotnet/size-comparison/MySingleView/oldnet/MySingleView.csproj
+++ b/tests/dotnet/size-comparison/MySingleView/oldnet/MySingleView.csproj
@@ -47,6 +47,7 @@
     <MtouchDebug>true</MtouchDebug>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchArch>ARM64</MtouchArch>
+    <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>full</DebugType>
@@ -56,6 +57,8 @@
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchArch>ARM64</MtouchArch>
+    <MtouchUseLlvm>true</MtouchUseLlvm>
+    <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Using the AOT LLVM-backend is recommended for release and should be used
when comparing sizes.

Also add some basic instruction to ease comparing `oldnet` and `dotnet`
app bundles since IL stripping is not yet available to dotnet builds (and
without considering this the _real_ numbers are a bit off)