### PR TITLE
[Localization] Changing the merge to a Pseudo Force Push

### DIFF
--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -159,11 +159,12 @@ steps:
 - powershell: |
     git config user.email "valco@microsoft.com"
     git config user.name "vs-mobiletools-engineering-service2"
-    git checkout -b Localization origin/Localization
-    git merge origin/main
+    git branch -d Localization
+    git push origin --delete Localization
+    git checkout -b Localization
     git push origin Localization
-  displayName: "Sync Localization branch with main"
-  condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'), eq(variables.isMain, 'True'))
+  displayName: "Create a new Localization branch from main"
+  condition: and(succeeded(), in(variables['build.reason'], 'Schedule'), eq(variables.isMain, 'True'))
 
 - task: OneLocBuild@2
   condition: and(succeeded(), eq(variables.isMain, 'True'))


### PR DESCRIPTION
- Currently, our Sunday builds need work, with respect to the OneLocBuild task.
- We want to try to keep the Localization branch up to date with main so that it does not get behind and cause issues for the Loc team.
- Right now, we try to merge main into Localization branch before the task is run but this causes merge conflicts: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4817479&view=logs&j=d4d86769-bae0-5955-544a-0740a81efd3c&t=37c7a955-b2ad-5a60-c99a-544de5935e6f&l=78
- Instead of this, we will try to remove the Localization branch and replace it with main right before our Sunday build.

We will need to replace the Localization branch every time we land an lcl translation file inside main: https://github.com/xamarin/xamarin-macios/issues/11791