### PR TITLE
[msbuild] Fixes remote tasks execution

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.3.21</MessagingVersion>
+		<MessagingVersion>1.3.24</MessagingVersion>
 	</PropertyGroup>
 </Project>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Extensions/TaskExtensions.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Extensions/TaskExtensions.cs
@@ -1,0 +1,11 @@
+using System;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.Build.Tasks
+{
+	public static class TaskExtensions
+	{
+		public static bool ShouldExecuteRemotely (this Task task, string sessionId)
+			=> Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (sessionId);
+	}
+}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 
 using Microsoft.Build.Framework;
+using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 
 using Xamarin.Localization.MSBuild;
@@ -128,7 +129,7 @@ namespace Xamarin.MacDev.Tasks {
 			return rv;
 		}
 
-		public bool ShouldExecuteRemotely () => Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty(SessionId);
+		public bool ShouldExecuteRemotely () => this.ShouldExecuteRemotely (SessionId);
 	}
 }
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
@@ -127,6 +127,8 @@ namespace Xamarin.MacDev.Tasks {
 
 			return rv;
 		}
+
+		public bool ShouldExecuteRemotely () => Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty(SessionId);
 	}
 }
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinToolTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinToolTask.cs
@@ -1,6 +1,6 @@
 using System;
 
-using Microsoft.Build.Framework;
+using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 
 using Xamarin.Localization.MSBuild;
@@ -73,7 +73,7 @@ namespace Xamarin.MacDev.Tasks {
 			}
 		}
 
-		public bool ShouldExecuteRemotely () => Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId);
+		public bool ShouldExecuteRemotely () => this.ShouldExecuteRemotely (SessionId);
 	}
 }
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinToolTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinToolTask.cs
@@ -72,6 +72,8 @@ namespace Xamarin.MacDev.Tasks {
 				}
 			}
 		}
+
+		public bool ShouldExecuteRemotely () => Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId);
 	}
 }
 

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Copy.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Copy.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xamarin.Messaging.Build.Client;
+﻿using Xamarin.Messaging.Build.Client;
 
 namespace Microsoft.Build.Tasks
 {
@@ -7,7 +6,7 @@ namespace Microsoft.Build.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (Environment.OSVersion.Platform != PlatformID.Win32NT || string.IsNullOrEmpty (SessionId))
+			if (!this.ShouldExecuteRemotely (SessionId))
 				return base.Execute ();
 
 			var taskRunner = new TaskRunner (SessionId, BuildEngine4);

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Copy.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Copy.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Messaging.Build.Client;
+﻿using System;
+using Xamarin.Messaging.Build.Client;
 
 namespace Microsoft.Build.Tasks
 {
@@ -6,7 +7,7 @@ namespace Microsoft.Build.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (string.IsNullOrEmpty (SessionId))
+			if (Environment.OSVersion.Platform != PlatformID.Win32NT || string.IsNullOrEmpty (SessionId))
 				return base.Execute ();
 
 			var taskRunner = new TaskRunner (SessionId, BuildEngine4);

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Delete.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Delete.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Messaging.Build.Client;
+﻿using System;
+using Xamarin.Messaging.Build.Client;
 
 namespace Microsoft.Build.Tasks
 {
@@ -8,7 +9,7 @@ namespace Microsoft.Build.Tasks
 		{
 			var result = base.Execute ();
 
-			if (string.IsNullOrEmpty (SessionId)) {
+			if (Environment.OSVersion.Platform != PlatformID.Win32NT || string.IsNullOrEmpty (SessionId)) {
 				return result;
 			}
 

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Delete.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Delete.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xamarin.Messaging.Build.Client;
+﻿using Xamarin.Messaging.Build.Client;
 
 namespace Microsoft.Build.Tasks
 {
@@ -9,7 +8,7 @@ namespace Microsoft.Build.Tasks
 		{
 			var result = base.Execute ();
 
-			if (Environment.OSVersion.Platform != PlatformID.Win32NT || string.IsNullOrEmpty (SessionId)) {
+			if (!this.ShouldExecuteRemotely (SessionId)) {
 				return result;
 			}
 

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Exec.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Exec.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.Tasks
 
 		public override bool Execute ()
 		{
-			if (Environment.OSVersion.Platform != PlatformID.Win32NT || string.IsNullOrEmpty (SessionId))
+			if (!this.ShouldExecuteRemotely (SessionId))
 				return base.Execute ();
 
 			if (string.IsNullOrEmpty (ServerPassword))
@@ -60,7 +60,7 @@ namespace Microsoft.Build.Tasks
 
 		public override void Cancel ()
 		{
-			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId))
+			if (this.ShouldExecuteRemotely (SessionId))
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 
 			base.Cancel ();

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Exec.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Exec.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.Tasks
 
 		public override bool Execute ()
 		{
-			if (string.IsNullOrEmpty (SessionId))
+			if (Environment.OSVersion.Platform != PlatformID.Win32NT || string.IsNullOrEmpty (SessionId))
 				return base.Execute ();
 
 			if (string.IsNullOrEmpty (ServerPassword))
@@ -60,7 +60,7 @@ namespace Microsoft.Build.Tasks
 
 		public override void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId))
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 
 			base.Cancel ();

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/MakeDir.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/MakeDir.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
@@ -11,7 +12,7 @@ namespace Microsoft.Build.Tasks
 		{
 			var result = base.Execute ();
 
-			if (!string.IsNullOrEmpty (SessionId))
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId))
 				result = new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return result;

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/MakeDir.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/MakeDir.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
@@ -12,7 +11,7 @@ namespace Microsoft.Build.Tasks
 		{
 			var result = base.Execute ();
 
-			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId))
+			if (this.ShouldExecuteRemotely (SessionId))
 				result = new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return result;

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Move.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Move.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
@@ -10,7 +9,7 @@ namespace Microsoft.Build.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId))
+			if (this.ShouldExecuteRemotely (SessionId))
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Move.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Move.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
@@ -9,7 +10,7 @@ namespace Microsoft.Build.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId))
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/RemoveDir.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/RemoveDir.cs
@@ -1,5 +1,3 @@
-using System;
-using Xamarin.MacDev.Tasks;
 using Xamarin.Messaging.Build.Client;
 
 namespace Microsoft.Build.Tasks
@@ -12,7 +10,7 @@ namespace Microsoft.Build.Tasks
 		{
 			var result = base.Execute ();
 
-			if (Environment.OSVersion.Platform != PlatformID.Win32NT || string.IsNullOrEmpty (SessionId)) {
+			if (!this.ShouldExecuteRemotely (SessionId)) {
 				return result;
 			}
 

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/RemoveDir.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/RemoveDir.cs
@@ -1,3 +1,4 @@
+using System;
 using Xamarin.MacDev.Tasks;
 using Xamarin.Messaging.Build.Client;
 
@@ -11,7 +12,7 @@ namespace Microsoft.Build.Tasks
 		{
 			var result = base.Execute ();
 
-			if (string.IsNullOrEmpty (SessionId)) {
+			if (Environment.OSVersion.Platform != PlatformID.Win32NT || string.IsNullOrEmpty (SessionId)) {
 				return result;
 			}
 

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Touch.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Touch.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Xamarin.MacDev.Tasks;
@@ -12,7 +13,7 @@ namespace Microsoft.Build.Tasks
 		{
 			bool result;
 
-			if (!string.IsNullOrEmpty (SessionId))
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId))
 				result = new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 			else
 				result = base.Execute ();

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Touch.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Touch.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Framework;
-using Xamarin.MacDev.Tasks;
 using Xamarin.Messaging.Build.Client;
 
-namespace Microsoft.Build.Tasks
+namespace Microsoft.Build.Tasks 
 {
 	public class Touch : TouchBase, ITaskCallback
 	{
@@ -13,7 +11,7 @@ namespace Microsoft.Build.Tasks
 		{
 			bool result;
 
-			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId))
+			if (this.ShouldExecuteRemotely (SessionId))
 				result = new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 			else
 				result = base.Execute ();

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/WriteLinesToFile.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/WriteLinesToFile.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xamarin.Messaging.Build.Client;
+﻿using Xamarin.Messaging.Build.Client;
 
 namespace Microsoft.Build.Tasks
 {
@@ -7,7 +6,7 @@ namespace Microsoft.Build.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId))
+			if (this.ShouldExecuteRemotely (SessionId))
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/WriteLinesToFile.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/WriteLinesToFile.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Messaging.Build.Client;
+﻿using System;
+using Xamarin.Messaging.Build.Client;
 
 namespace Microsoft.Build.Tasks
 {
@@ -6,7 +7,7 @@ namespace Microsoft.Build.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId))
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompile.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompile.cs
@@ -10,7 +10,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -30,7 +30,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ArTool.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ArTool.cs
@@ -9,7 +9,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -23,7 +23,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public override void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 
 			base.Cancel ();

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Codesign.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Codesign.cs
@@ -9,7 +9,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -23,7 +23,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CollectBundleResources.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CollectBundleResources.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
 
@@ -9,7 +9,7 @@ namespace Xamarin.MacDev.Tasks
 		public override bool Execute ()
 		{
 			try {
-				if (!string.IsNullOrEmpty (SessionId)) {
+				if (ShouldExecuteRemotely ()) {
 					// Copy the bundle files to the build server
 					new TaskRunner (SessionId, BuildEngine4).CopyInputsAsync (this).Wait ();
 				}
@@ -25,7 +25,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CollectFrameworks.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CollectFrameworks.cs
@@ -9,7 +9,7 @@ using Xamarin.Messaging.Build.Client;
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -23,7 +23,7 @@ using Xamarin.Messaging.Build.Client;
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -10,7 +10,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (string.IsNullOrEmpty (SessionId))
+			if (!ShouldExecuteRemotely ())
 				return base.Execute ();
 
 			foreach (var info in CompileInfo)
@@ -43,7 +43,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ComputeBundleResourceOutputPaths.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ComputeBundleResourceOutputPaths.cs
@@ -9,7 +9,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (string.IsNullOrEmpty (SessionId))
+			if (!ShouldExecuteRemotely ())
 				return base.Execute ();
 
 			var result = new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
@@ -27,7 +27,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CoreMLCompiler.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CoreMLCompiler.cs
@@ -7,7 +7,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateAssetPackManifest.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateAssetPackManifest.cs
@@ -7,7 +7,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreatePkgInfo.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreatePkgInfo.cs
@@ -7,7 +7,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/DSymUtil.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/DSymUtil.cs
@@ -9,7 +9,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -19,7 +19,7 @@ namespace Xamarin.MacDev.Tasks
 		{
 			base.Cancel ();
 
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Ditto.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Ditto.cs
@@ -10,7 +10,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId)) {
+			if (ShouldExecuteRemotely ()) {
 				var taskRunner = new TaskRunner (SessionId, BuildEngine4);
 
 				taskRunner.FixReferencedItems (new ITaskItem [] { Source });
@@ -25,7 +25,7 @@ namespace Xamarin.MacDev.Tasks
 		{
 			base.Cancel ();
 
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/EmbedProvisionProfile.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/EmbedProvisionProfile.cs
@@ -6,7 +6,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMinimumOSVersion.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMinimumOSVersion.cs
@@ -1,4 +1,4 @@
-using Xamarin.Messaging.Build.Client;
+﻿using Xamarin.Messaging.Build.Client;
 
 namespace Xamarin.MacDev.Tasks
 {
@@ -6,7 +6,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetNativeExecutableName.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetNativeExecutableName.cs
@@ -7,7 +7,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCode.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCode.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
@@ -12,7 +12,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId)) {
+			if (ShouldExecuteRemotely ()) {
 				outputPath = Path.GetDirectoryName (OutputFile);
 
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/PackLibraryResources.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/PackLibraryResources.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Framework;
@@ -10,7 +10,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (string.IsNullOrEmpty (SessionId))
+			if (!ShouldExecuteRemotely ())
 				return base.Execute ();
 
 			// Fix LogicalName path for the Mac
@@ -47,7 +47,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/PrepareResourceRules.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/PrepareResourceRules.cs
@@ -1,4 +1,4 @@
-using Microsoft.Build.Framework;
+﻿using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
 
 namespace Xamarin.MacDev.Tasks
@@ -7,7 +7,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ReadItemsFromFile.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ReadItemsFromFile.cs
@@ -9,7 +9,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/SmartCopy.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/SmartCopy.cs
@@ -9,7 +9,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId)) {
+			if (ShouldExecuteRemotely ()) {
 				var taskRunner = new TaskRunner (SessionId, BuildEngine4);
 
 				taskRunner.FixReferencedItems (SourceFiles);
@@ -22,7 +22,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/SpotlightIndexer.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/SpotlightIndexer.cs
@@ -7,7 +7,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public override void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 
 			base.Execute ();

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/SymbolStrip.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/SymbolStrip.cs
@@ -7,7 +7,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public override void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 
 			base.Execute ();

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/UnpackLibraryResources.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/UnpackLibraryResources.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Collections.Generic;
 
 using Mono.Cecil;
@@ -15,7 +15,7 @@ namespace Xamarin.MacDev.Tasks
 		{
 			bool result;
 
-			if (!string.IsNullOrEmpty (SessionId)) {
+			if (ShouldExecuteRemotely ()) {
 				result = new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 				if (result && BundleResourcesWithLogicalNames != null) {
@@ -37,7 +37,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Zip.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Zip.cs
@@ -9,7 +9,7 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -17,7 +17,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public override void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 
 			base.Cancel ();

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ACTool.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ACTool.cs
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks {
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks {
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ALToolUpload.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ALToolUpload.cs
@@ -1,4 +1,4 @@
-using Microsoft.Build.Framework;
+﻿using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
 
 namespace Xamarin.iOS.Tasks
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks
 
 		public override void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 
 			base.Cancel ();

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ALToolValidate.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ALToolValidate.cs
@@ -1,4 +1,4 @@
-using Xamarin.Messaging.Build.Client;
+﻿using Xamarin.Messaging.Build.Client;
 
 namespace Xamarin.iOS.Tasks
 {
@@ -6,7 +6,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -14,7 +14,7 @@ namespace Xamarin.iOS.Tasks
 
 		public override void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 
 			base.Cancel ();

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/Archive.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/Archive.cs
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/BTouch.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/BTouch.cs
@@ -14,7 +14,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (string.IsNullOrEmpty (SessionId))
+			if (!ShouldExecuteRemotely ())
 				return base.Execute ();
 
 			try {

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CodesignVerify.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CodesignVerify.cs
@@ -6,7 +6,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -14,7 +14,7 @@ namespace Xamarin.iOS.Tasks
 
 		public override void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 
 			base.Cancel ();

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CollectAssetPacks.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CollectAssetPacks.cs
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CollectITunesArtwork.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CollectITunesArtwork.cs
@@ -9,7 +9,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -23,7 +23,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CollectITunesSourceFiles.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CollectITunesSourceFiles.cs
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CompileAppManifest.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CompileAppManifest.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
@@ -9,7 +9,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -30,7 +30,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CompileEntitlements.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CompileEntitlements.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Xamarin.MacDev.Tasks;
@@ -8,7 +8,7 @@ namespace Xamarin.iOS.Tasks {
 	public class CompileEntitlements : CompileEntitlementsTaskBase, ITaskCallback, ICancelableTask {
 		protected override string DefaultEntitlementsPath {
 			get {
-				if (!string.IsNullOrEmpty (SessionId)) {
+				if (ShouldExecuteRemotely ()) {
 					return "Entitlements.plist";
 				}
 
@@ -18,7 +18,7 @@ namespace Xamarin.iOS.Tasks {
 
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -38,7 +38,7 @@ namespace Xamarin.iOS.Tasks {
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CompileITunesMetadata.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CompileITunesMetadata.cs
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CompileSceneKitAssets.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CompileSceneKitAssets.cs
@@ -8,7 +8,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (string.IsNullOrEmpty (SessionId))
+			if (!ShouldExecuteRemotely ())
 				return base.Execute ();
 
 			var taskRunner = new TaskRunner (SessionId, BuildEngine4);
@@ -22,7 +22,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CreateAssetPack.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CreateAssetPack.cs
@@ -6,7 +6,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -14,7 +14,7 @@ namespace Xamarin.iOS.Tasks
 
 		public override void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 
 			base.Cancel ();

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CreateBindingResourcePackage.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CreateBindingResourcePackage.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 
@@ -13,7 +13,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -37,7 +37,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CreateDebugConfiguration.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CreateDebugConfiguration.cs
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CreateDebugSettings.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CreateDebugSettings.cs
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CreateEmbeddedResources.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CreateEmbeddedResources.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.MacDev.Tasks;
+﻿using System;
+using Xamarin.MacDev.Tasks;
 
 namespace Xamarin.iOS.Tasks
 {
@@ -6,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId)) {
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId)) {
 				foreach (var bundleResource in this.BundleResources) {
 					var logicalName = bundleResource.GetMetadata ("LogicalName");
 

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CreateEmbeddedResources.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CreateEmbeddedResources.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using Microsoft.Build.Tasks;
 using Xamarin.MacDev.Tasks;
 
 namespace Xamarin.iOS.Tasks
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId)) {
+			if (this.ShouldExecuteRemotely (SessionId)) {
 				foreach (var bundleResource in this.BundleResources) {
 					var logicalName = bundleResource.GetMetadata ("LogicalName");
 

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/DetectDebugNetworkConfiguration.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/DetectDebugNetworkConfiguration.cs
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/DetectSdkLocations.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/DetectSdkLocations.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
 
@@ -10,7 +10,7 @@ namespace Xamarin.iOS.Tasks
 
 		public override bool Execute ()
 		{
-			if (string.IsNullOrEmpty (SessionId))
+			if (!ShouldExecuteRemotely())
 				return base.Execute ();
 
 			// The new targets do not support the "default" value for the MtouchSdkVersion
@@ -23,7 +23,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/DetectSigningIdentity.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/DetectSigningIdentity.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Xamarin.MacDev.Tasks;
@@ -10,7 +10,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -24,7 +24,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/FindWatchOS2AppBundle.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/FindWatchOS2AppBundle.cs
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (string.IsNullOrEmpty (SessionId))
+			if (!ShouldExecuteRemotely ())
 				return base.Execute ();
 
 			var taskRunner = new TaskRunner (SessionId, BuildEngine4);
@@ -19,7 +19,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/GetDirectories.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/GetDirectories.cs
@@ -9,7 +9,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -23,7 +23,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/GetFiles.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/GetFiles.cs
@@ -9,7 +9,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -23,7 +23,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/GetFullPath.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/GetFullPath.cs
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/GetMlaunchArguments.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/GetMlaunchArguments.cs
@@ -1,4 +1,4 @@
-using Microsoft.Build.Framework;
+﻿using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
 
 namespace Xamarin.iOS.Tasks
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/GetPropertyValue.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/GetPropertyValue.cs
@@ -10,7 +10,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -49,7 +49,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/IBTool.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/IBTool.cs
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ILLink.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ILLink.cs
@@ -1,14 +1,14 @@
-﻿using System;
+﻿using ILLink.Tasks;
+using Microsoft.Build.Tasks;
 using Xamarin.Messaging.Build.Client;
-using ILLink.Tasks;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.iOS.Tasks 
 {
 	public class ILLink : ILLinkBase
 	{
 		public override bool Execute ()
 		{
-			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId))
+			if (this.ShouldExecuteRemotely (SessionId))
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -16,7 +16,7 @@ namespace Xamarin.iOS.Tasks
 
 		public override void Cancel ()
 		{
-			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId))
+			if (this.ShouldExecuteRemotely (SessionId))
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 			else
 				base.Cancel ();

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ILLink.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ILLink.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Messaging.Build.Client;
+﻿using System;
+using Xamarin.Messaging.Build.Client;
 using ILLink.Tasks;
 
 namespace Xamarin.iOS.Tasks
@@ -7,7 +8,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId))
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +16,7 @@ namespace Xamarin.iOS.Tasks
 
 		public override void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty (SessionId))
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 			else
 				base.Cancel ();

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/MTouch.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/MTouch.cs
@@ -13,7 +13,7 @@ namespace Xamarin.iOS.Tasks
 
 		public override bool Execute ()
 		{
-			if (string.IsNullOrEmpty (SessionId))
+			if (!ShouldExecuteRemotely ())
 				return base.Execute ();
 
 			var frameworkAssemblies = References.Where (x => x.IsFrameworkItem ());

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/Metal.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/Metal.cs
@@ -6,7 +6,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -14,7 +14,7 @@ namespace Xamarin.iOS.Tasks
 
 		public override void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 
 			base.Cancel ();

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/MetalLib.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/MetalLib.cs
@@ -9,7 +9,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -25,7 +25,7 @@ namespace Xamarin.iOS.Tasks
 		{
 			base.Cancel ();
 
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/OptimizeImage.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/OptimizeImage.cs
@@ -9,7 +9,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/OptimizePropertyList.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/OptimizePropertyList.cs
@@ -10,7 +10,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/PrepareNativeReferences.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/PrepareNativeReferences.cs
@@ -13,7 +13,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (string.IsNullOrEmpty (SessionId))
+			if (!ShouldExecuteRemotely ())
 				return base.Execute ();
 
 			var taskRunner = new TaskRunner (SessionId, BuildEngine4);
@@ -50,7 +50,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ResolveNativeWatchApp.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ResolveNativeWatchApp.cs
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ScnTool.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ScnTool.cs
@@ -6,7 +6,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -14,7 +14,7 @@ namespace Xamarin.iOS.Tasks
 
 		public override void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 
 			base.Execute ();

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/TextureAtlas.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/TextureAtlas.cs
@@ -8,7 +8,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -16,7 +16,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ValidateAppBundleTask.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ValidateAppBundleTask.cs
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/WriteAssetPackManifest.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/WriteAssetPackManifest.cs
@@ -7,7 +7,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
 			return base.Execute ();
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void Cancel ()
 		{
-			if (!string.IsNullOrEmpty (SessionId))
+			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 	}


### PR DESCRIPTION
When building from Windows we stopped including the `SessionId` value when executing tasks remotely, because we started using that value to decide whether we should execute a task locally or remotely. The problem is the SessionId is also used from some of the base tasks (like ACToolTaskBase) to execute different code paths depending if the build is being executed from Windows or macOS (regardless where the task is currently being executed). Most of those code paths are related to calculating relative paths, and we started getting reports of weird behaviors like missing icons when deploying apps or even Apple Store submission errors.

To fix this problem we're back propagating the SessionId value when executing tasks remotely, and to decide if a task should be executed remotely or not we also check the Environment.OSVersion.Platform value (because SessionId will have a value on macOS too when executing the task remotely), so we only try to execute tasks remotely if the task is being executed from Windows and SessionId is not empty.