### PR TITLE
[editorconfig] Set the charset to utf-8.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,14 +1,17 @@
 [*.{props,targets}]
 indent_style = tab
 indent_size = 4
+charset = utf-8
 
 [*.{csproj}]
 indent_style = space
 indent_size = 2
+charset = utf-8
 
 # C# files
 [*.cs]
 max_line_length = 120
+charset = utf-8
 
 #### Core EditorConfig Options ####
 


### PR DESCRIPTION
An additional point here is that the 'utf-8' charset is specifically defined
to not include the byte-order-mark.

Ref: https://editorconfig.org