### PR TITLE
[runtime] Disable LOG_MONOVM logging by default.

### DIFF
--- a/runtime/xamarin/monovm-bridge.h
+++ b/runtime/xamarin/monovm-bridge.h
@@ -15,8 +15,8 @@
 
 #include "mono-runtime.h"
 
-//#define LOG_MONOVM(...)
-#define LOG_MONOVM(...) fprintf (__VA_ARGS__)
+#define LOG_MONOVM(...)
+//#define LOG_MONOVM(...) fprintf (__VA_ARGS__)
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This should have been disabled from the beginning.