### PR TITLE
Use `CFString` instead of `NSString` to get a (.net) `System.String` from an handle

### DIFF
--- a/src/AppKit/NSAccessibility.cs
+++ b/src/AppKit/NSAccessibility.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
+using CoreFoundation;
 using CoreGraphics;
 using Foundation;
 using ObjCRuntime;
@@ -143,7 +144,7 @@ namespace AppKit
 				subroleHandle = subrole.Handle;
 
 			IntPtr handle = NSAccessibilityRoleDescription (role.Handle, subroleHandle);
-			return NSString.FromHandle (handle);
+			return CFString.FromHandle (handle);
 		}
 
 		[DllImport (Constants.AppKitLibrary)]
@@ -155,7 +156,7 @@ namespace AppKit
 				throw new ArgumentNullException ("element");
 
 			IntPtr handle = NSAccessibilityRoleDescriptionForUIElement (element.Handle);
-			return NSString.FromHandle (handle);
+			return CFString.FromHandle (handle);
 		}
 
 		[DllImport (Constants.AppKitLibrary)]
@@ -167,7 +168,7 @@ namespace AppKit
 				throw new ArgumentNullException ("action");
 
 			IntPtr handle = NSAccessibilityActionDescription (action.Handle);
-			return NSString.FromHandle (handle);
+			return CFString.FromHandle (handle);
 		}
 
 		[DllImport (Constants.AppKitLibrary)]

--- a/src/AudioToolbox/AudioFile.cs
+++ b/src/AudioToolbox/AudioFile.cs
@@ -209,7 +209,7 @@ namespace AudioToolbox {
 
 		public string Name {
 			get {
-				return CFString.FetchString (Name_cfstringref);
+				return CFString.FromHandle (Name_cfstringref);
 			}
 		}
 	}
@@ -382,7 +382,7 @@ namespace AudioToolbox {
 
 		public string Name {
 			get {
-				return CFString.FetchString (NameWeak);
+				return CFString.FromHandle (NameWeak);
 			}
 		}
 

--- a/src/AudioToolbox/AudioFileGlobalInfo.cs
+++ b/src/AudioToolbox/AudioFileGlobalInfo.cs
@@ -80,7 +80,7 @@ namespace AudioToolbox {
 			if (AudioFileGetGlobalInfo (AudioFileGlobalProperty.FileTypeName, sizeof (AudioFileType), ref fileType, ref size, out ptr) != 0)
 				return null;
 
-			return CFString.FetchString (ptr);
+			return CFString.FromHandle (ptr);
 		}
 
 		public static AudioFormatType[] GetAvailableFormats (AudioFileType fileType)
@@ -126,7 +126,7 @@ namespace AudioToolbox {
 				if (AudioFileGetGlobalInfo (AudioFileGlobalProperty.AllExtensions, 0, IntPtr.Zero, ref size, out ptr) != 0)
 					return null;
 				
-				return NSArray.ArrayFromHandleFunc (ptr, l => CFString.FetchString (l));
+				return NSArray.ArrayFromHandleFunc (ptr, l => CFString.FromHandle (l));
 			}
 		}
 
@@ -137,7 +137,7 @@ namespace AudioToolbox {
 				if (AudioFileGetGlobalInfo (AudioFileGlobalProperty.AllUTIs, 0, IntPtr.Zero, ref size, out ptr) != 0)
 					return null;
 				
-				return NSArray.ArrayFromHandleFunc (ptr, l => CFString.FetchString (l));
+				return NSArray.ArrayFromHandleFunc (ptr, l => CFString.FromHandle (l));
 			}
 		}
 
@@ -148,7 +148,7 @@ namespace AudioToolbox {
 				if (AudioFileGetGlobalInfo (AudioFileGlobalProperty.AllMIMETypes, 0, IntPtr.Zero, ref size, out ptr) != 0)
 					return null;
 				
-				return NSArray.ArrayFromHandleFunc (ptr, l => CFString.FetchString (l));
+				return NSArray.ArrayFromHandleFunc (ptr, l => CFString.FromHandle (l));
 			}
 		}
 
@@ -179,7 +179,7 @@ namespace AudioToolbox {
 			if (AudioFileGetGlobalInfo (AudioFileGlobalProperty.ExtensionsForType, sizeof (AudioFileType), ref fileType, ref size, out ptr) != 0)
 				return null;
 				
-			return NSArray.ArrayFromHandleFunc (ptr, l => CFString.FetchString (l));
+			return NSArray.ArrayFromHandleFunc (ptr, l => CFString.FromHandle (l));
 		}
 
 		public static string[] GetUTIs (AudioFileType fileType)
@@ -189,7 +189,7 @@ namespace AudioToolbox {
 			if (AudioFileGetGlobalInfo (AudioFileGlobalProperty.UTIsForType, sizeof (AudioFileType), ref fileType, ref size, out ptr) != 0)
 				return null;
 				
-			return NSArray.ArrayFromHandleFunc (ptr, l => CFString.FetchString (l));
+			return NSArray.ArrayFromHandleFunc (ptr, l => CFString.FromHandle (l));
 		}
 
 		public static string[] GetMIMETypes (AudioFileType fileType)
@@ -199,7 +199,7 @@ namespace AudioToolbox {
 			if (AudioFileGetGlobalInfo (AudioFileGlobalProperty.MIMETypesForType, sizeof (AudioFileType), ref fileType, ref size, out ptr) != 0)
 				return null;
 				
-			return NSArray.ArrayFromHandleFunc (ptr, l => CFString.FetchString (l));
+			return NSArray.ArrayFromHandleFunc (ptr, l => CFString.FromHandle (l));
 		}
 
 /*

--- a/src/AudioToolbox/AudioQueue.cs
+++ b/src/AudioToolbox/AudioQueue.cs
@@ -951,7 +951,7 @@ namespace AudioToolbox {
 
 		public string CurrentDevice {
 			get {
-				return CFString.FetchString ((IntPtr) GetInt (AudioQueueProperty.CurrentDevice));
+				return CFString.FromHandle ((IntPtr) GetInt (AudioQueueProperty.CurrentDevice));
 			}
 
 			set {

--- a/src/AudioToolbox/AudioSession.cs
+++ b/src/AudioToolbox/AudioSession.cs
@@ -436,7 +436,7 @@ namespace AudioToolbox {
 		[Deprecated (PlatformName.iOS, 5, 0, message : "Use 'InputRoute' or 'OutputRoute' instead.")]
 		static public string AudioRoute {
 			get {
-				return CFString.FetchString (GetIntPtr (AudioSessionProperty.AudioRoute));
+				return CFString.FromHandle (GetIntPtr (AudioSessionProperty.AudioRoute));
 			}
 		}
 
@@ -461,7 +461,7 @@ namespace AudioToolbox {
 				for (int i = 0; i < res.Length; ++i) {
 					var dict = array.GetValue (i);
 					var n = new NSNumber (CFDictionary.GetValue (dict, id.Handle));
-					var desc = CFString.FetchString (CFDictionary.GetValue (dict, description.Handle));
+					var desc = CFString.FromHandle (CFDictionary.GetValue (dict, description.Handle));
 
 					res [i] = new AccessoryInfo ((int) n, desc);
 					id.Dispose ();

--- a/src/AudioUnit/AudioComponent.cs
+++ b/src/AudioUnit/AudioComponent.cs
@@ -307,7 +307,7 @@ namespace AudioUnit
 			get {
 				IntPtr r;
 				if (AudioComponentCopyName (handle, out r) == 0)
-					return CFString.FetchString (r);
+					return CFString.FromHandle (r);
 				return null;
 			}
 		}

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -235,14 +235,14 @@ namespace AudioUnit
 			info.Type = type;
 
 			if ((native.Flags & AudioUnitParameterFlag.HasCFNameString) != 0) {
-				info.Name = CFString.FetchString (native.NameString);
+				info.Name = CFString.FromHandle (native.NameString);
 
 				if ((native.Flags & AudioUnitParameterFlag.CFNameRelease) != 0)
 					CFObject.CFRelease (native.NameString);
 			}
 
 			if (native.Unit == AudioUnitParameterUnit.CustomUnit) {
-				info.UnitName = CFString.FetchString (native.UnitName);
+				info.UnitName = CFString.FromHandle (native.UnitName);
 			}
 
 			return info;

--- a/src/CoreAnimation/CATextLayer.cs
+++ b/src/CoreAnimation/CATextLayer.cs
@@ -94,7 +94,7 @@ namespace CoreAnimation {
 				else if (type == CGFont.GetTypeID ())
 					return new CGFont (handle, false);
 				else if (type == CFString.GetTypeID ())
-					return CFString.FetchString (handle);
+					return CFString.FromHandle (handle);
 #if MONOMAC
 				else return (NSFont) Runtime.GetNSObject (handle);
 #else

--- a/src/CoreFoundation/CFBundle.cs
+++ b/src/CoreFoundation/CFBundle.cs
@@ -432,7 +432,7 @@ namespace CoreFoundation {
 			using (CFString cfKey = new CFString (key),
 					cfValue = new CFString (defaultValue),
 					cfTable = new CFString (tableName)) {
-				return CFString.FetchString (CFBundleCopyLocalizedString (handle, cfKey.Handle, cfValue.Handle, cfTable.Handle), releaseHandle: true);
+				return CFString.FromHandle (CFBundleCopyLocalizedString (handle, cfKey.Handle, cfValue.Handle, cfTable.Handle), releaseHandle: true);
 			}
 		}
 
@@ -461,7 +461,7 @@ namespace CoreFoundation {
 			using (var cfArray = new CFArray (CFBundleCopyLocalizationsForPreferences (cfLocalArray.Handle, cfPrefArray.Handle), true)) {
 				var cultureInfo = new string [cfArray.Count];
 				for (int index = 0; index < cfArray.Count; index ++) {
-					cultureInfo [index] = CFString.FetchString (cfArray.GetValue (index));
+					cultureInfo [index] = CFString.FromHandle (cfArray.GetValue (index));
 				}
 				return cultureInfo;
 			}
@@ -477,7 +477,7 @@ namespace CoreFoundation {
 			using (var cfArray = new CFArray (CFBundleCopyLocalizationsForURL (bundle.Handle), true)) {
 				var cultureInfo = new string [cfArray.Count];
 				for (int index = 0; index < cfArray.Count; index++) {
-					cultureInfo [index] = CFString.FetchString (cfArray.GetValue (index));
+					cultureInfo [index] = CFString.FromHandle (cfArray.GetValue (index));
 				}
 				return cultureInfo;
 			}
@@ -499,7 +499,7 @@ namespace CoreFoundation {
 			using (var cfArray = new CFArray (CFBundleCopyPreferredLocalizationsFromArray (cfLocArray.Handle), true)) {
 				var cultureInfo = new string [cfArray.Count];
 				for (int index = 0; index < cfArray.Count; index++) {
-					cultureInfo [index] = CFString.FetchString (cfArray.GetValue (index));
+					cultureInfo [index] = CFString.FromHandle (cfArray.GetValue (index));
 				}
 				return cultureInfo;
 			}
@@ -518,14 +518,14 @@ namespace CoreFoundation {
 		extern static /* CFString */ IntPtr CFBundleGetDevelopmentRegion (IntPtr bundle );
 		
 		public string DevelopmentRegion {
-			get { return CFString.FetchString (CFBundleGetDevelopmentRegion (handle)); }
+			get { return CFString.FromHandle (CFBundleGetDevelopmentRegion (handle)); }
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFString */ IntPtr CFBundleGetIdentifier (IntPtr bundle);
 		
 		public string Identifier {
-			get { return CFString.FetchString (CFBundleGetIdentifier (handle)); }
+			get { return CFString.FromHandle (CFBundleGetIdentifier (handle)); }
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]

--- a/src/CoreFoundation/CFDictionary.cs
+++ b/src/CoreFoundation/CFDictionary.cs
@@ -147,7 +147,7 @@ namespace CoreFoundation {
 		public string GetStringValue (string key)
 		{
 			using (var str = new CFString (key)) {
-				return CFString.FetchString (CFDictionaryGetValue (Handle, str.Handle));
+				return CFString.FromHandle (CFDictionaryGetValue (Handle, str.Handle));
 			}
 		}
 

--- a/src/CoreFoundation/CFException.cs
+++ b/src/CoreFoundation/CFException.cs
@@ -91,11 +91,11 @@ namespace CoreFoundation {
 				throw new ArgumentNullException (nameof (cfErrorHandle));
 
 			var e = new CFException (
-					CFString.FetchString (CFErrorCopyDescription (cfErrorHandle), releaseHandle: true),
+					CFString.FromHandle (CFErrorCopyDescription (cfErrorHandle), releaseHandle: true),
 					(NSString) Runtime.GetNSObject (CFErrorGetDomain (cfErrorHandle)),
 					CFErrorGetCode (cfErrorHandle),
-					CFString.FetchString (CFErrorCopyFailureReason (cfErrorHandle), releaseHandle: true),
-					CFString.FetchString (CFErrorCopyRecoverySuggestion (cfErrorHandle), releaseHandle: true));
+					CFString.FromHandle (CFErrorCopyFailureReason (cfErrorHandle), releaseHandle: true),
+					CFString.FromHandle (CFErrorCopyRecoverySuggestion (cfErrorHandle), releaseHandle: true));
 
 			var cfUserInfo = CFErrorCopyUserInfo (cfErrorHandle);
 			if (cfUserInfo != IntPtr.Zero) {

--- a/src/CoreFoundation/CFMessagePort.cs
+++ b/src/CoreFoundation/CFMessagePort.cs
@@ -85,7 +85,7 @@ namespace CoreFoundation {
 		public string Name {
 			get {
 				Check ();
-				return NSString.FromHandle (CFMessagePortGetName (handle));
+				return CFString.FromHandle (CFMessagePortGetName (handle));
 			}
 			set {
 				Check ();

--- a/src/CoreFoundation/CFNotificationCenter.cs
+++ b/src/CoreFoundation/CFNotificationCenter.cs
@@ -206,7 +206,7 @@ namespace CoreFoundation {
 			else
 				return;
 
-			center.notification (NSString.FromHandle (name), userInfo == IntPtr.Zero ? null : Runtime.GetNSObject<NSDictionary> (userInfo));
+			center.notification (CFString.FromHandle (name), userInfo == IntPtr.Zero ? null : Runtime.GetNSObject<NSDictionary> (userInfo));
 		}
 
 		public void PostNotification(string notification, INativeObject objectToObserve, NSDictionary userInfo = null, bool deliverImmediately = false, bool postOnAllSessions = false) 

--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -146,7 +146,7 @@ namespace CoreFoundation {
 		}
 
 		// to be used when an API like CF*Get* returns a CFString
-		internal static string FetchString (IntPtr handle)
+		public static string FromHandle (IntPtr handle)
 		{
 			if (handle == IntPtr.Zero)
 				return null;
@@ -173,9 +173,9 @@ namespace CoreFoundation {
 		}
 
 		// to be used when an API like CF*Copy* returns a CFString
-		internal static string FetchString (IntPtr handle, bool releaseHandle)
+		internal static string FromHandle (IntPtr handle, bool releaseHandle)
 		{
-			var s = FetchString (handle);
+			var s = FromHandle (handle);
 			if (releaseHandle && (handle != IntPtr.Zero))
 				CFObject.CFRelease (handle);
 			return s;
@@ -184,7 +184,7 @@ namespace CoreFoundation {
 		public static implicit operator string (CFString x)
 		{
 			if (x.str == null)
-				x.str = FetchString (x.Handle);
+				x.str = FromHandle (x.Handle);
 			
 			return x.str;
 		}
@@ -219,7 +219,7 @@ namespace CoreFoundation {
 		{
 			if (str != null)
 				return str;
-			return FetchString (Handle);
+			return FromHandle (Handle);
 		}
 #endif // !COREBUILD
 	}

--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -173,7 +173,7 @@ namespace CoreFoundation {
 		}
 
 		// to be used when an API like CF*Copy* returns a CFString
-		internal static string FromHandle (IntPtr handle, bool releaseHandle)
+		public static string FromHandle (IntPtr handle, bool releaseHandle)
 		{
 			var s = FromHandle (handle);
 			if (releaseHandle && (handle != IntPtr.Zero))

--- a/src/CoreGraphics/CGColor.cs
+++ b/src/CoreGraphics/CGColor.cs
@@ -336,7 +336,7 @@ namespace CoreGraphics {
 
 		[iOS (14,0)][TV (14,0)][Watch (7,0)][Mac (11,0)]
 		[MacCatalyst (14,0)]
-		public string AXName => NSString.FromHandle (AXNameFromColor (handle));
+		public string AXName => CFString.FromHandle (AXNameFromColor (handle));
 
 
 #endif // !COREBUILD

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -516,7 +516,7 @@ namespace CoreGraphics {
 #endif
 		public string Name {
 			get {
-				return CFString.FetchString (CGColorSpaceCopyName (handle), true);
+				return CFString.FromHandle (CGColorSpaceCopyName (handle), true);
 			}
 		}
 

--- a/src/CoreGraphics/CGFont.cs
+++ b/src/CoreGraphics/CGFont.cs
@@ -142,7 +142,7 @@ namespace CoreGraphics {
 
 		public string PostScriptName {
 			get {
-				return CFString.FetchString (CGFontCopyPostScriptName (handle), releaseHandle: true);
+				return CFString.FromHandle (CGFontCopyPostScriptName (handle), releaseHandle: true);
 			}
 		}
 		
@@ -151,7 +151,7 @@ namespace CoreGraphics {
 
 		public string FullName {
 			get {
-				return CFString.FetchString (CGFontCopyFullName (handle), releaseHandle: true);
+				return CFString.FromHandle (CGFontCopyFullName (handle), releaseHandle: true);
 			}
 		}
 		
@@ -256,7 +256,7 @@ namespace CoreGraphics {
 
 		public string GlyphNameForGlyph (ushort glyph)
 		{
-			return CFString.FetchString (CGFontCopyGlyphNameForGlyph (handle, glyph), releaseHandle: true);
+			return CFString.FromHandle (CGFontCopyGlyphNameForGlyph (handle, glyph), releaseHandle: true);
 		}
 		
 		//[DllImport (Constants.CoreGraphicsLibrary)]

--- a/src/CoreImage/CIFilter.cs
+++ b/src/CoreImage/CIFilter.cs
@@ -108,6 +108,7 @@
 //
 using System;
 using System.Diagnostics;
+using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 using CoreGraphics;
@@ -282,7 +283,7 @@ namespace CoreImage {
 		// Calls the selName selector for cases where we do not have an instance created
 		static internal string GetFilterName (IntPtr filterHandle)
 		{
-			return NSString.FromHandle (ObjCRuntime.Messaging.IntPtr_objc_msgSend (filterHandle, Selector.GetHandle ("name")));
+			return CFString.FromHandle (ObjCRuntime.Messaging.IntPtr_objc_msgSend (filterHandle, Selector.GetHandle ("name")));
 		}
 
 		// TODO could be generated too

--- a/src/CoreMedia/CMTime.cs
+++ b/src/CoreMedia/CMTime.cs
@@ -8,6 +8,7 @@
 //
 using System;
 using System.Runtime.InteropServices;
+using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
@@ -332,7 +333,7 @@ namespace CoreMedia {
 
 		public string Description {
 			get {
-				return NSString.FromHandle (CMTimeCopyDescription (IntPtr.Zero, this));
+				return CFString.FromHandle (CMTimeCopyDescription (IntPtr.Zero, this));
 			}
 		}
 		

--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -367,7 +367,7 @@ namespace CoreMidi {
 			
 			code = MIDIObjectGetStringProperty (handle, property, out val);
 			if (code == 0){
-				var ret = NSString.FromHandle (val);
+				var ret = CFString.FromHandle (val);
 				if (val != IntPtr.Zero)
 					CFObject.CFRelease (val);
 				return ret;
@@ -643,7 +643,7 @@ namespace CoreMidi {
 				if (epc != null){
 					var data = (MidiObjectPropertyChangeNotification) Marshal.PtrToStructure (message, typeof (MidiObjectPropertyChangeNotification));
 					epc (client, new ObjectPropertyChangedEventArgs (
-						     MidiObjectFromType (data.ObjectType, data.ObjectHandle), NSString.FromHandle (data.PropertyName)));
+						     MidiObjectFromType (data.ObjectType, data.ObjectHandle), CFString.FromHandle (data.PropertyName)));
 				}
 				break;
 			case MidiNotificationMessageId.ThruConnectionsChanged:

--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -1763,7 +1763,7 @@ namespace CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCopyPostScriptName (IntPtr font);
 		public string PostScriptName {
-			get { return CFString.FetchString (CTFontCopyPostScriptName (handle), releaseHandle: true); }
+			get { return CFString.FromHandle (CTFontCopyPostScriptName (handle), releaseHandle: true); }
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -1771,7 +1771,7 @@ namespace CoreText {
 			/* CTFontRef __nonnull */ IntPtr font);
 		
 		public string FamilyName {
-			get { return CFString.FetchString (CTFontCopyFamilyName (handle), releaseHandle: true); }
+			get { return CFString.FromHandle (CTFontCopyFamilyName (handle), releaseHandle: true); }
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -1779,7 +1779,7 @@ namespace CoreText {
 			/* CTFontRef __nonnull */ IntPtr font);
 		
 		public string FullName {
-			get { return CFString.FetchString (CTFontCopyFullName (handle), releaseHandle: true); }
+			get { return CFString.FromHandle (CTFontCopyFullName (handle), releaseHandle: true); }
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -1787,14 +1787,14 @@ namespace CoreText {
 			/* CTFontRef __nonnull */ IntPtr font);
 		
 		public string DisplayName {
-			get { return CFString.FetchString (CTFontCopyDisplayName (handle), releaseHandle: true); }
+			get { return CFString.FromHandle (CTFontCopyDisplayName (handle), releaseHandle: true); }
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCopyName (IntPtr font, IntPtr nameKey);
 		public string GetName (CTFontNameKey nameKey)
 		{
-			return CFString.FetchString (CTFontCopyName (handle, CTFontNameKeyId.ToId (nameKey).Handle), releaseHandle: true);
+			return CFString.FromHandle (CTFontCopyName (handle, CTFontNameKeyId.ToId (nameKey).Handle), releaseHandle: true);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -1809,8 +1809,8 @@ namespace CoreText {
 		public string GetLocalizedName (CTFontNameKey nameKey, out string actualLanguage)
 		{
 			IntPtr actual;
-			var ret = CFString.FetchString (CTFontCopyLocalizedName (handle, CTFontNameKeyId.ToId (nameKey).Handle, out actual), releaseHandle: true);
-			actualLanguage = CFString.FetchString (actual, releaseHandle: true);
+			var ret = CFString.FromHandle (CTFontCopyLocalizedName (handle, CTFontNameKeyId.ToId (nameKey).Handle, out actual), releaseHandle: true);
+			actualLanguage = CFString.FromHandle (actual, releaseHandle: true);
 			return ret;
 		}
 #endregion
@@ -1841,7 +1841,7 @@ namespace CoreText {
 			var cfArrayRef = CTFontCopySupportedLanguages (handle);
 			if (cfArrayRef == IntPtr.Zero)
 				return Array.Empty<string> ();
-			var languages = NSArray.ArrayFromHandle<string> (cfArrayRef, CFString.FetchString);
+			var languages = NSArray.ArrayFromHandle<string> (cfArrayRef, CFString.FromHandle);
 			CFObject.CFRelease (cfArrayRef);
 			return languages;
 		}
@@ -1871,7 +1871,7 @@ namespace CoreText {
 		[Watch (7,0), TV (14,0), Mac (11,0), iOS (14,0)]
 		public string GetGlyphName (CGGlyph glyph)
 		{
-			return CFString.FetchString (CTFontCopyNameForGlyph (handle, glyph), releaseHandle: true);
+			return CFString.FromHandle (CTFontCopyNameForGlyph (handle, glyph), releaseHandle: true);
 		}
 
 		static void AssertCount (nint count)

--- a/src/CoreText/CTGlyphInfo.cs
+++ b/src/CoreText/CTGlyphInfo.cs
@@ -141,7 +141,7 @@ namespace CoreText {
 		public string GlyphName {
 			get {
 				var cfStringRef = CTGlyphInfoGetGlyphName (handle);
-				return CFString.FetchString (cfStringRef);
+				return CFString.FromHandle (cfStringRef);
 			}
 		}
 

--- a/src/Foundation/DictionaryContainer.cs
+++ b/src/Foundation/DictionaryContainer.cs
@@ -252,7 +252,7 @@ namespace Foundation {
 			if (!Dictionary.TryGetValue (key, out value))
 				return null;
 			
-			return CFString.FetchString (value.Handle);
+			return CFString.FromHandle (value.Handle);
 		}
 
 		protected string? GetStringValue (string key)
@@ -261,7 +261,7 @@ namespace Foundation {
 				throw new ArgumentNullException ("key");
 
 			using (var str = new CFString (key)) {
-				return CFString.FetchString (CFDictionary.GetValue (Dictionary.Handle, str.Handle));
+				return CFString.FromHandle (CFDictionary.GetValue (Dictionary.Handle, str.Handle));
 			}
 		}
 

--- a/src/Foundation/NSArray.cs
+++ b/src/Foundation/NSArray.cs
@@ -27,6 +27,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
+using CoreFoundation;
 using ObjCRuntime;
 
 namespace Foundation {
@@ -258,7 +259,7 @@ namespace Foundation {
 			string [] ret = new string [c];
 
 			for (nuint i = 0; i < c; i++)
-				ret [i] = NSString.FromHandle (GetAtIndex (handle, i));
+				ret [i] = CFString.FromHandle (GetAtIndex (handle, i));
 			return ret;
 		}
 

--- a/src/Foundation/NSAttributedString.cs
+++ b/src/Foundation/NSAttributedString.cs
@@ -26,6 +26,7 @@
 //
 
 using System;
+using CoreFoundation;
 using CoreText;
 using ObjCRuntime;
 #if !MONOMAC
@@ -37,7 +38,7 @@ namespace Foundation {
 
 		public string Value {
 			get {
-				return NSString.FromHandle (LowLevelValue);
+				return CFString.FromHandle (LowLevelValue);
 			}
 		}
 

--- a/src/Foundation/NSKeyedArchiver.cs
+++ b/src/Foundation/NSKeyedArchiver.cs
@@ -46,7 +46,7 @@ namespace Foundation {
 		{
 			if (kls == null)
 				throw new ArgumentNullException ("kls");
-			return NSString.FromHandle (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (class_ptr, Selector.GetHandle ("classNameForClass:"), kls.Handle));
+			return CFString.FromHandle (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (class_ptr, Selector.GetHandle ("classNameForClass:"), kls.Handle));
 		}
 
 		public bool RequiresSecureCoding {

--- a/src/Foundation/NSMetadataItem.cs
+++ b/src/Foundation/NSMetadataItem.cs
@@ -7,6 +7,7 @@
 //   Miguel de Icaza
 //
 using System;
+using CoreFoundation;
 using ObjCRuntime;
 
 namespace Foundation {
@@ -216,7 +217,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Title {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.TitleKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.TitleKey));
 			}
 		}
 
@@ -265,14 +266,14 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Comment {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.CommentKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.CommentKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Copyright {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.CopyrightKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.CopyrightKey));
 			}
 		}
 
@@ -321,7 +322,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Version {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.VersionKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.VersionKey));
 			}
 		}
 
@@ -349,7 +350,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string ColorSpace {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.ColorSpaceKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.ColorSpaceKey));
 			}
 		}
 
@@ -377,14 +378,14 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string AcquisitionMake {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.AcquisitionMakeKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.AcquisitionMakeKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string AcquisitionModel {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.AcquisitionModelKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.AcquisitionModelKey));
 			}
 		}
 
@@ -426,7 +427,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string ProfileName {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.ProfileNameKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.ProfileNameKey));
 			}
 		}
 
@@ -461,14 +462,14 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string ExifVersion {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.ExifVersionKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.ExifVersionKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string CameraOwner {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.CameraOwnerKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.CameraOwnerKey));
 			}
 		}
 
@@ -482,14 +483,14 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string LensModel {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.LensModelKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.LensModelKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string ExifGpsVersion {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.ExifGpsVersionKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.ExifGpsVersionKey));
 			}
 		}
 
@@ -545,21 +546,21 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string NamedLocation {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.NamedLocationKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.NamedLocationKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string GpsStatus {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.GpsStatusKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.GpsStatusKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string GpsMeasureMode {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.GpsMeasureModeKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.GpsMeasureModeKey));
 			}
 		}
 
@@ -573,7 +574,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string GpsMapDatum {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.GpsMapDatumKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.GpsMapDatumKey));
 			}
 		}
 
@@ -608,14 +609,14 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string GpsProcessingMethod {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.GpsProcessingMethodKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.GpsProcessingMethodKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string GpsAreaInformation {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.GpsAreaInformationKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.GpsAreaInformationKey));
 			}
 		}
 
@@ -678,14 +679,14 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string DeliveryType {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.DeliveryTypeKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.DeliveryTypeKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Album {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.AlbumKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.AlbumKey));
 			}
 		}
 
@@ -706,7 +707,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string MeteringMode {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.MeteringModeKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.MeteringModeKey));
 			}
 		}
 
@@ -727,56 +728,56 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string ExposureProgram {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.ExposureProgramKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.ExposureProgramKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string ExposureTimeString {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.ExposureTimeStringKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.ExposureTimeStringKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Headline {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.HeadlineKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.HeadlineKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Instructions {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.InstructionsKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.InstructionsKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string City {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.CityKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.CityKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string StateOrProvince {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.StateOrProvinceKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.StateOrProvinceKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Country {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.CountryKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.CountryKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string TextContent {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.TextContentKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.TextContentKey));
 			}
 		}
 
@@ -804,35 +805,35 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string KeySignature {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.KeySignatureKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.KeySignatureKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string TimeSignature {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.TimeSignatureKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.TimeSignatureKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string AudioEncodingApplication {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.AudioEncodingApplicationKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.AudioEncodingApplicationKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Composer {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.ComposerKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.ComposerKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Lyricist {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.LyricistKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.LyricistKey));
 			}
 		}
 
@@ -853,7 +854,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string MusicalGenre {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.MusicalGenreKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.MusicalGenreKey));
 			}
 		}
 
@@ -887,7 +888,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Rights {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.RightsKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.RightsKey));
 			}
 		}
 
@@ -929,14 +930,14 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Description {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.DescriptionKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.DescriptionKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Identifier {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.IdentifierKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.IdentifierKey));
 			}
 		}
 
@@ -971,14 +972,14 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string SecurityMethod {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.SecurityMethodKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.SecurityMethodKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Creator {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.CreatorKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.CreatorKey));
 			}
 		}
 
@@ -1027,7 +1028,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Kind {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.KindKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.KindKey));
 			}
 		}
 
@@ -1041,7 +1042,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string FinderComment {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.FinderCommentKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.FinderCommentKey));
 			}
 		}
 
@@ -1055,21 +1056,21 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string AppleLoopsRoot {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.AppleLoopsRootKeyKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.AppleLoopsRootKeyKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string AppleLoopsKeyFilterType {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.AppleLoopsKeyFilterTypeKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.AppleLoopsKeyFilterTypeKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string AppleLoopsLoopMode {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.AppleLoopsLoopModeKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.AppleLoopsLoopModeKey));
 			}
 		}
 
@@ -1083,49 +1084,49 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string MusicalInstrumentCategory {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.MusicalInstrumentCategoryKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.MusicalInstrumentCategoryKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string MusicalInstrumentName {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.MusicalInstrumentNameKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.MusicalInstrumentNameKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string CFBundleIdentifier {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.CFBundleIdentifierKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.CFBundleIdentifierKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Information {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.InformationKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.InformationKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Director {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.DirectorKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.DirectorKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Producer {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.ProducerKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.ProducerKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string Genre {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.GenreKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.GenreKey));
 			}
 		}
 
@@ -1139,14 +1140,14 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string OriginalFormat {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.OriginalFormatKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.OriginalFormatKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string OriginalSource {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.OriginalSourceKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.OriginalSourceKey));
 			}
 		}
 
@@ -1195,7 +1196,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string ExecutablePlatform {
 			get {
-				return NSString.FromHandle (GetHandle (NSMetadataQuery.ExecutablePlatformKey));
+				return CFString.FromHandle (GetHandle (NSMetadataQuery.ExecutablePlatformKey));
 			}
 		}
 

--- a/src/Foundation/NSString.cs
+++ b/src/Foundation/NSString.cs
@@ -164,11 +164,13 @@ namespace Foundation {
 			return new NSString (str);
 		}
 
+		[Obsolete ("Use of 'CFString.FromHandle' offers better performance.")]
 		public static string FromHandle (IntPtr usrhandle)
 		{
 			return FromHandle (usrhandle, false);
 		}
 
+		[Obsolete ("Use of 'CFString.FromHandle' offers better performance.")]
 		public static string FromHandle (IntPtr handle, bool owns)
 		{
 			if (handle == IntPtr.Zero)

--- a/src/ImageIO/CGImageSource.cs
+++ b/src/ImageIO/CGImageSource.cs
@@ -236,7 +236,7 @@ namespace ImageIO {
 		
 		public string TypeIdentifier {
 			get {
-				return NSString.FromHandle (CGImageSourceGetType (handle));
+				return CFString.FromHandle (CGImageSourceGetType (handle));
 			}
 		}
 

--- a/src/MLCompute/MLHelpers.cs
+++ b/src/MLCompute/MLHelpers.cs
@@ -23,7 +23,7 @@ namespace MLCompute {
 
 		public static string GetDebugDescription (this MLCActivationType self)
 		{
-			return CFString.FetchString (MLCActivationTypeDebugDescription (self));
+			return CFString.FromHandle (MLCActivationTypeDebugDescription (self));
 		}
 	}
 
@@ -42,7 +42,7 @@ namespace MLCompute {
 
 		public static string GetDebugDescription (this MLCArithmeticOperation self)
 		{
-			return CFString.FetchString (MLCArithmeticOperationDebugDescription (self));
+			return CFString.FromHandle (MLCArithmeticOperationDebugDescription (self));
 		}
 	}
 
@@ -61,7 +61,7 @@ namespace MLCompute {
 
 		public static string GetDebugDescription (this MLCPaddingPolicy self)
 		{
-			return CFString.FetchString (MLCPaddingPolicyDebugDescription (self));
+			return CFString.FromHandle (MLCPaddingPolicyDebugDescription (self));
 		}
 	}
 
@@ -80,7 +80,7 @@ namespace MLCompute {
 
 		public static string GetDebugDescription (this MLCLossType self)
 		{
-			return CFString.FetchString (MLCLossTypeDebugDescription (self));
+			return CFString.FromHandle (MLCLossTypeDebugDescription (self));
 		}
 	}
 
@@ -99,7 +99,7 @@ namespace MLCompute {
 
 		public static string GetDebugDescription (this MLCReductionType self)
 		{
-			return CFString.FetchString (MLCReductionTypeDebugDescription (self));
+			return CFString.FromHandle (MLCReductionTypeDebugDescription (self));
 		}
 	}
 
@@ -118,7 +118,7 @@ namespace MLCompute {
 
 		public static string GetDebugDescription (this MLCPaddingType self)
 		{
-			return CFString.FetchString (MLCPaddingTypeDebugDescription (self));
+			return CFString.FromHandle (MLCPaddingTypeDebugDescription (self));
 		}
 	}
 
@@ -137,7 +137,7 @@ namespace MLCompute {
 
 		public static string GetDebugDescription (this MLCConvolutionType self)
 		{
-			return CFString.FetchString (MLCConvolutionTypeDebugDescription (self));
+			return CFString.FromHandle (MLCConvolutionTypeDebugDescription (self));
 		}
 	}
 
@@ -156,7 +156,7 @@ namespace MLCompute {
 
 		public static string GetDebugDescription (this MLCPoolingType self)
 		{
-			return CFString.FetchString (MLCPoolingTypeDebugDescription (self));
+			return CFString.FromHandle (MLCPoolingTypeDebugDescription (self));
 		}
 	}
 
@@ -175,7 +175,7 @@ namespace MLCompute {
 
 		public static string GetDebugDescription (this MLCSoftmaxOperation self)
 		{
-			return CFString.FetchString (MLCSoftmaxOperationDebugDescription (self));
+			return CFString.FromHandle (MLCSoftmaxOperationDebugDescription (self));
 		}
 	}
 
@@ -194,7 +194,7 @@ namespace MLCompute {
 
 		public static string GetDebugDescription (this MLCSampleMode self)
 		{
-			return CFString.FetchString (MLCSampleModeDebugDescription (self));
+			return CFString.FromHandle (MLCSampleModeDebugDescription (self));
 		}
 	}
 
@@ -213,7 +213,7 @@ namespace MLCompute {
 
 		public static string GetDebugDescription (this MLCLstmResultMode self)
 		{
-			return CFString.FetchString (MLCLSTMResultModeDebugDescription (self));
+			return CFString.FromHandle (MLCLSTMResultModeDebugDescription (self));
 		}
 	}
 
@@ -232,7 +232,7 @@ namespace MLCompute {
 
 		public static string GetDebugDescription (this MLCComparisonOperation self)
 		{
-			return CFString.FetchString (MLCComparisonOperationDebugDescription (self));
+			return CFString.FromHandle (MLCComparisonOperationDebugDescription (self));
 		}
 	}
 }

--- a/src/MediaAccessibility/MAImageCaptioning.cs
+++ b/src/MediaAccessibility/MAImageCaptioning.cs
@@ -30,7 +30,7 @@ namespace MediaAccessibility {
 
 			var result = MAImageCaptioningCopyCaption (url.Handle, out var e);
 			error = e == IntPtr.Zero ? null : new NSError (e);
-			return CFString.FetchString (result, releaseHandle: true);
+			return CFString.FromHandle (result, releaseHandle: true);
 		}
 
 		[DllImport (Constants.MediaAccessibilityLibrary)]
@@ -58,7 +58,7 @@ namespace MediaAccessibility {
 
 		static public string GetMetadataTagPath ()
 		{
-			return CFString.FetchString (MAImageCaptioningCopyMetadataTagPath (), releaseHandle: true);
+			return CFString.FromHandle (MAImageCaptioningCopyMetadataTagPath (), releaseHandle: true);
 		}
 	}
 }

--- a/src/MediaAccessibility/MediaAccessibility.cs
+++ b/src/MediaAccessibility/MediaAccessibility.cs
@@ -66,7 +66,7 @@ namespace MediaAccessibility {
 			using (var langs = new CFArray (MACaptionAppearanceCopySelectedLanguages ((int) domain), owns: true)) {
 				var languages = new string [langs.Count];
 				for (int i = 0; i < langs.Count; i++) {
-					languages[i] = CFString.FetchString (langs.GetValue (i));
+					languages[i] = CFString.FromHandle (langs.GetValue (i));
 				}
 				return languages;
 			}

--- a/src/MediaToolbox/MTFormatNames.cs
+++ b/src/MediaToolbox/MTFormatNames.cs
@@ -23,7 +23,7 @@ namespace MediaToolbox {
 #endif
 		static public string GetLocalizedName (this CMMediaType mediaType)
 		{
-			return CFString.FetchString (MTCopyLocalizedNameForMediaType (mediaType), releaseHandle: true);
+			return CFString.FromHandle (MTCopyLocalizedNameForMediaType (mediaType), releaseHandle: true);
 		}
 
 #if !NET
@@ -38,7 +38,7 @@ namespace MediaToolbox {
 #endif
 		static public string GetLocalizedName (this CMMediaType mediaType, uint mediaSubType)
 		{
-			return CFString.FetchString (MTCopyLocalizedNameForMediaSubType (mediaType, mediaSubType), releaseHandle: true);
+			return CFString.FromHandle (MTCopyLocalizedNameForMediaSubType (mediaType, mediaSubType), releaseHandle: true);
 		}
 	}
 }

--- a/src/MobileCoreServices/UTType.cs
+++ b/src/MobileCoreServices/UTType.cs
@@ -80,7 +80,7 @@ namespace MobileCoreServices {
 			var a = NSString.CreateNative (tagClass);
 			var b = NSString.CreateNative (tag);
 			var c = NSString.CreateNative (conformingToUti);
-			var ret = NSString.FromHandle (UTTypeCreatePreferredIdentifierForTag (a, b, c));
+			var ret = CFString.FromHandle (UTTypeCreatePreferredIdentifierForTag (a, b, c));
 			NSString.ReleaseNative (a);
 			NSString.ReleaseNative (b);
 			NSString.ReleaseNative (c);
@@ -158,7 +158,7 @@ namespace MobileCoreServices {
 				throw new ArgumentNullException ("uti");
 
 			var a = NSString.CreateNative (uti);
-			var ret = NSString.FromHandle (UTTypeCopyDescription (a));
+			var ret = CFString.FromHandle (UTTypeCopyDescription (a));
 			NSString.ReleaseNative (a);
 			return ret;
 		}
@@ -175,7 +175,7 @@ namespace MobileCoreServices {
 
 			var a = NSString.CreateNative (uti);
 			var b = NSString.CreateNative (tagClass);
-			var ret = NSString.FromHandle (UTTypeCopyPreferredTagWithClass (a, b));
+			var ret = CFString.FromHandle (UTTypeCopyPreferredTagWithClass (a, b));
 			NSString.ReleaseNative (a);
 			NSString.ReleaseNative (b);
 			return ret;

--- a/src/PrintCore/PrintCore.cs
+++ b/src/PrintCore/PrintCore.cs
@@ -143,7 +143,7 @@ namespace PrintCore {
 			int c = (int) arr.Count;
 			ret = new string [c];
 			for (int i = 0; i < c; i++)
-				ret [i] = CFString.FetchString (arr.GetValue (i));
+				ret [i] = CFString.FromHandle (arr.GetValue (i));
 			arr.Dispose ();
 
 			return ret;
@@ -446,7 +446,7 @@ namespace PrintCore {
 				var code = PMPaperGetID (handle, out s);
 				if (code != PMStatusCode.Ok)
 					return null;
-				return CFString.FetchString (s);
+				return CFString.FromHandle (s);
 			}
 		}
 
@@ -488,7 +488,7 @@ namespace PrintCore {
 			var code = PMPaperCreateLocalizedName (handle, printer.handle, out name);
 			if (code != PMStatusCode.Ok)
 				return null;
-			var str = CFString.FetchString (name);
+			var str = CFString.FromHandle (name);
 			CFObject.CFRelease (name);
 			return str;
 		}
@@ -548,7 +548,7 @@ namespace PrintCore {
 
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static IntPtr PMPrinterGetName (IntPtr handle);
-		public string Name => CFString.FetchString (PMPrinterGetName (handle));
+		public string Name => CFString.FromHandle (PMPrinterGetName (handle));
 
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMPrinterCopyDeviceURI (IntPtr handle, out IntPtr url);
@@ -585,7 +585,7 @@ namespace PrintCore {
 			get {
 				IntPtr v;
 				if (PMPrinterGetMakeAndModelName (handle, out v) == PMStatusCode.Ok){
-					return CFString.FetchString (v);
+					return CFString.FromHandle (v);
 				}
 				return null;
 			}
@@ -758,7 +758,7 @@ namespace PrintCore {
 
 		public string Id {
 			get {
-				return CFString.FetchString (PMPrinterGetID (handle));
+				return CFString.FromHandle (PMPrinterGetID (handle));
 			}
 		}
 
@@ -770,7 +770,7 @@ namespace PrintCore {
 				PMStatusCode code = PMPrinterCopyHostName (handle, out IntPtr hostName);
 				if (code != PMStatusCode.Ok)
 					return null;
-				return CFString.FetchString (hostName, true);
+				return CFString.FromHandle (hostName, true);
 			}
 		}
 	}

--- a/src/SearchKit/SearchKit.cs
+++ b/src/SearchKit/SearchKit.cs
@@ -202,7 +202,7 @@ namespace SearchKit
 				var n = SKDocumentGetName (handle);
 				if (n == IntPtr.Zero)
 					return null;
-				return NSString.FromHandle (n);
+				return CFString.FromHandle (n);
 			}
 		}
 
@@ -226,7 +226,7 @@ namespace SearchKit
 				var s = SKDocumentGetSchemeName (handle);
 				if (s == IntPtr.Zero)
 					return null;
-				return NSString.FromHandle (s);
+				return CFString.FromHandle (s);
 			}
 		}
 	}
@@ -687,22 +687,22 @@ namespace SearchKit
 
 		public string GetSentence (nint idx)
 		{
-			return CFString.FetchString (SKSummaryCopySentenceAtIndex (handle, idx), releaseHandle: true);
+			return CFString.FromHandle (SKSummaryCopySentenceAtIndex (handle, idx), releaseHandle: true);
 		}
 
 		public string GetParagraph (nint idx)
 		{
-			return CFString.FetchString (SKSummaryCopyParagraphAtIndex (handle, idx), releaseHandle: true);
+			return CFString.FromHandle (SKSummaryCopyParagraphAtIndex (handle, idx), releaseHandle: true);
 		}
 
 		public string GetSentenceSummary (nint maxSentences)
 		{
-			return CFString.FetchString (SKSummaryCopySentenceSummaryString (handle, maxSentences), releaseHandle: true);
+			return CFString.FromHandle (SKSummaryCopySentenceSummaryString (handle, maxSentences), releaseHandle: true);
 		}
 
 		public string GetParagraphSummary (nint maxParagraphs)
 		{
-			return CFString.FetchString (SKSummaryCopyParagraphSummaryString (handle, maxParagraphs), releaseHandle: true);
+			return CFString.FromHandle (SKSummaryCopyParagraphSummaryString (handle, maxParagraphs), releaseHandle: true);
 		}
 		
 	}

--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -151,7 +151,7 @@ namespace Security {
 				if (handle == IntPtr.Zero)
 					throw new ObjectDisposedException ("SecCertificate");
 				
-				return CFString.FetchString (SecCertificateCopySubjectSummary (handle), releaseHandle: true);
+				return CFString.FromHandle (SecCertificateCopySubjectSummary (handle), releaseHandle: true);
 			}
 		}
 
@@ -306,7 +306,7 @@ namespace Security {
 		{
 			IntPtr cn;
 			if (SecCertificateCopyCommonName (handle, out cn) == 0)
-				return CFString.FetchString (cn, releaseHandle: true);
+				return CFString.FromHandle (cn, releaseHandle: true);
 			return null;
 		}
 

--- a/src/Security/SecSharedCredential.cs
+++ b/src/Security/SecSharedCredential.cs
@@ -141,7 +141,7 @@ namespace Security {
 		public static string CreateSharedWebCredentialPassword ()
 		{
 			var handle = SecCreateSharedWebCredentialPassword ();
-			var str = NSString.FromHandle (handle);
+			var str = CFString.FromHandle (handle);
 			NSObject.DangerousRelease (handle);
 			return str;
 		}

--- a/src/VideoToolbox/VTVideoEncoder.cs
+++ b/src/VideoToolbox/VTVideoEncoder.cs
@@ -205,7 +205,7 @@ namespace VideoToolbox {
 
 			// The caller must CFRelease the returned supported properties and encoder ID.
 			var ret = new VTSupportedEncoderProperties {
-				EncoderId = CFString.FetchString (encoderIdPtr, releaseHandle:true),
+				EncoderId = CFString.FromHandle (encoderIdPtr, releaseHandle:true),
 				SupportedProperties = Runtime.GetNSObject<NSDictionary> (supportedPropertiesPtr, owns: true)
 			};
 			return ret;

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1748,7 +1748,7 @@ public partial class Generator : IMemberGatherer {
 			}
 			if (pi.ParameterType == TypeManager.System_String){
 				pars.AppendFormat ("IntPtr {0}", safe_name);
-				invoke.AppendFormat ("NSString.FromHandle ({0})", safe_name);
+				invoke.AppendFormat ("CFString.FromHandle ({0})", safe_name);
 				continue;
 			}
 
@@ -2877,7 +2877,7 @@ public partial class Generator : IMemberGatherer {
 									enumTypeStr + ") num.Int32Value;\n\t}}\n}})";
 								setter = "SetArrayValue<" + enumTypeStr + "> ({0}, value)";
 							} else if (elementType == TypeManager.System_String){
-								getter = "GetArray<string> ({0}, (ptr)=>NSString.FromHandle (ptr))";
+								getter = "GetArray<string> ({0}, (ptr) => CFString.FromHandle (ptr))";
 								setter = "SetArrayValue ({0}, value)";
 							} else {
 								throw new BindingException (1033, true, pi.PropertyType, dictType, pi.Name);
@@ -3079,7 +3079,7 @@ public partial class Generator : IMemberGatherer {
 					else if (fullname == "CoreGraphics.CGRect")
 						print (GenerateNSValue ("CGRectValue"));
 					else if (is_system_string)
-						print ("return NSString.FromHandle (value);");
+						print ("return CFString.FromHandle (value);");
 					else if (propertyType == TypeManager.NSString)
 						print ("return new NSString (value);");
 					else if (propertyType == TypeManager.System_String_Array){
@@ -3818,7 +3818,7 @@ public partial class Generator : IMemberGatherer {
 			cast_a = " Runtime.GetINativeObject<" + mi.ReturnType.Name + "> (";
 			cast_b = ", false)";
 		} else if (mai.Type == TypeManager.System_String && !mai.PlainString){
-			cast_a = "NSString.FromHandle (";
+			cast_a = "CFString.FromHandle (";
 			cast_b = ")";
 		} else if (mi.ReturnType.IsSubclassOf (TypeManager.System_Delegate)){
 			cast_a = "";
@@ -4291,7 +4291,7 @@ public partial class Generator : IMemberGatherer {
 				if (isString) {
 					if (!pi.IsOut)
 						by_ref_processing.AppendFormat ("if ({0}Value != {0}OriginalValue)\n\t", pi.Name.GetSafeParamName ());
-					by_ref_processing.AppendFormat ("{0} = NSString.FromHandle ({0}Value);\n", pi.Name.GetSafeParamName ());
+					by_ref_processing.AppendFormat ("{0} = CFString.FromHandle ({0}Value);\n", pi.Name.GetSafeParamName ());
 				} else if (isArray) {
 					if (!pi.IsOut)
 						by_ref_processing.AppendFormat ("if ({0}Value != ({0}ArrayValue is null ? IntPtr.Zero : {0}ArrayValue.Handle))\n\t", pi.Name.GetSafeParamName ());

--- a/tests/perftest/TollFreeBridge.cs
+++ b/tests/perftest/TollFreeBridge.cs
@@ -1,0 +1,63 @@
+using System;
+
+using CoreFoundation;
+using Foundation;
+using ObjCRuntime;
+
+using BenchmarkDotNet.Attributes;
+
+using Bindings.Test;
+
+namespace PerfTest {
+
+	[Register ("StringClass")]
+	class StringClass : NSObject {
+			public override string Description => "constant";
+	}
+
+	public class TollFreeString {
+		IntPtr StringClassClassHandle = Class.GetHandle (typeof (StringClass));
+
+		string s;
+
+		StringClass sc;
+		IntPtr description;
+
+		[GlobalSetup]
+		public void ReturnString_Setup ()
+		{
+			sc = new StringClass ();
+			description = Messaging.IntPtr_objc_msgSend (sc.Handle, Selector.GetHandle ("description"));
+			Messaging.void_objc_msgSend (description, Selector.GetHandle ("retain"));
+		}
+
+		[GlobalCleanup]
+		public void ReturnString_Cleanup ()
+		{
+			Messaging.void_objc_msgSend (description, Selector.GetHandle ("release"));
+			sc.Dispose ();
+		}
+
+		/*
+		 * Measure time required to get a string - using NSString (ObjC) selector-based API
+		 */
+
+		[Benchmark]
+		public string ReturnString_NSString ()
+		{
+			var d = NSString.FromHandle (description);
+			return s = d;
+		}
+
+		/*
+		 * Measure time required to get a string - using CFString (C) p/invoke-based API
+		 */
+
+		[Benchmark]
+		public string ReturnString_CFString ()
+		{
+			var d = CFString.FromHandle (description);
+			return s = d;
+		}
+    }
+}

--- a/tests/perftest/TollFreeBridge.cs
+++ b/tests/perftest/TollFreeBridge.cs
@@ -12,7 +12,7 @@ namespace PerfTest {
 
 	[Register ("StringClass")]
 	class StringClass : NSObject {
-			public override string Description => "constant";
+		public override string Description => "constant";
 	}
 
 	public class TollFreeString {


### PR DESCRIPTION
This is possible because both types are toll-free bridged [0].

How ?

* Renamed `CFString.FetchString` to `FromHandle` so it match `NSString` API
* Make it `public` so it can be used for generated/3rd party bindings
* Update generator to use the new API (instead of the `NSString` version)
* Update manual bindings to use the new API

Why ?

It's no secret that p/invoke (C) are faster than calling a selector
(ObjC). In most cases we do not have a choice what to call... but in a
few, but commonly used, cases we can pick the fastest call.

```
// * Summary *

BenchmarkDotNet=v0.12.1.1528-nightly, OS=macOS Big Sur 11.3.1 (20E241) [Darwin 20.4.0]
Intel Core i7-4790K CPU 4.00GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
  [Host] : Mono 6.12.0 (2020-02/c633fe92383), X64

Job=InProcess  Toolchain=InProcessEmitToolchain  InvocationCount=1
IterationCount=3  LaunchCount=1  WarmupCount=3

|                Type |                              Method | UnrollFactor | ArraySize |            Mean |            Error |          StdDev |          Median |
|-------------------- |------------------------------------ |------------- |---------- |----------------:|-----------------:|----------------:|----------------:|
|      TollFreeString |               ReturnString_NSString |           16 |         ? |      2,522.0 ns |        878.81 ns |        48.17 ns |      2,541.7 ns |
|      TollFreeString |               ReturnString_CFString |           16 |         ? |        808.1 ns |          7.48 ns |         0.41 ns |        808.2 ns |
```

Next ?

The next step is to reduce other `NSString` selectors usage,
then `NSArray`...

[0] https://developer.apple.com/library/archive/documentation/General/Conceptual/CocoaEncyclopedia/Toll-FreeBridgin/Toll-FreeBridgin.html