### PR TITLE
[Localization] Typo in the scheduled build

### DIFF
--- a/tools/devops/automation/templates/build/configure.yml
+++ b/tools/devops/automation/templates/build/configure.yml
@@ -174,7 +174,7 @@ steps:
   inputs:
     locProj: '$(Build.SourcesDirectory)\Localize\LocProject.json'
     outDir: '$(Build.ArtifactStagingDirectory)'
-    isCreatePrSelected: eq(variables.isSchedule, 'True')
+    isCreatePrSelected: eq(variables.isScheduled, 'True')
     packageSourceAuth: patAuth
     patVariable: '$(OneLocBuild--PAT)'
     isAutoCompletePrSelected: false


### PR DESCRIPTION
I am kicking myself for this typo haha.

This is the first Sunday build since onboarding with the Loc team that we didn't have merge conflicts!
Therefore we should finally be able to get the Localization Translations in our repo!...

Inside the Job Preparation Parameters, we can see that `isScheduled` is true.
```
isScheduled:
    Parsing expression: <eq(variables['Build.Reason'], 'Schedule')>
    Evaluating: eq(variables['Build.Reason'], 'Schedule')
    Expanded: eq('Schedule', 'Schedule')
    Result: 'True'
```

However, the check to see if we want a PR containing the translated resx files is examining `isSchedule` is false
(since 'isSchedule' does not exist)
```
##[debug]INPUT_ISCREATEPRSELECTED: 'eq(variables.isSchedule, 'True')'
##[debug] Converted to bool: False
```