### PR TITLE
[dotnet] add @(SdkSupportedTargetPlatformIdentifier)

### DIFF
--- a/dotnet/Workloads/Microsoft.NET.Sdk.MacCatalyst/WorkloadManifest.targets
+++ b/dotnet/Workloads/Microsoft.NET.Sdk.MacCatalyst/WorkloadManifest.targets
@@ -1,3 +1,7 @@
 <Project>
 	<Import Project="Sdk.props" Sdk="Microsoft.MacCatalyst.Sdk" Condition="'$(TargetPlatformIdentifier)' == 'MacCatalyst'" />
+
+	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">
+		<SdkSupportedTargetPlatformIdentifier Include="maccatalyst" DisplayName="Mac Catalyst" />
+	</ItemGroup>
 </Project>

--- a/dotnet/Workloads/Microsoft.NET.Sdk.iOS/WorkloadManifest.targets
+++ b/dotnet/Workloads/Microsoft.NET.Sdk.iOS/WorkloadManifest.targets
@@ -4,4 +4,8 @@
 
 	<Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.ios-arm" Condition="'$(TargetPlatformIdentifier)' == 'iOS' And '$(RuntimeIdentifier)' == 'ios-arm'" />
 	<Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.ios-arm64" Condition="'$(TargetPlatformIdentifier)' == 'iOS' And '$(RuntimeIdentifier)' == 'ios-arm64'" />
+
+	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">
+		<SdkSupportedTargetPlatformIdentifier Include="ios" DisplayName="iOS" />
+	</ItemGroup>
 </Project>

--- a/dotnet/Workloads/Microsoft.NET.Sdk.macOS/WorkloadManifest.targets
+++ b/dotnet/Workloads/Microsoft.NET.Sdk.macOS/WorkloadManifest.targets
@@ -1,3 +1,7 @@
 <Project>
 	<Import Project="Sdk.props" Sdk="Microsoft.macOS.Sdk" Condition="'$(TargetPlatformIdentifier)' == 'macOS'" />
+
+	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">
+		<SdkSupportedTargetPlatformIdentifier Include="macos" DisplayName="macOS" />
+	</ItemGroup>
 </Project>

--- a/dotnet/Workloads/Microsoft.NET.Sdk.tvOS/WorkloadManifest.targets
+++ b/dotnet/Workloads/Microsoft.NET.Sdk.tvOS/WorkloadManifest.targets
@@ -2,4 +2,8 @@
 	<Import Project="Sdk.props" Sdk="Microsoft.tvOS.Sdk" Condition="'$(TargetPlatformIdentifier)' == 'tvOS'" />
 
 	<Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.tvos-arm64" Condition="'$(TargetPlatformIdentifier)' == 'tvOS' And '$(RuntimeIdentifier)' == 'tvos-arm64'" />
+
+	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">
+		<SdkSupportedTargetPlatformIdentifier Include="tvos" DisplayName="tvOS" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/pull/16208/files
Context: https://gist.github.com/sfoslund/12e1daff114bccc8a29ebb441bc461a5#detecting-installed-platforms
Context: https://github.com/xamarin/xamarin-android/issues/5941

The VS ProjectSystem needs a way to know during MSBuild evaluation
which platforms are supported by a workload--even if the workload is
not actually installed.

On Android, for example, we added the item group:

    <SdkSupportedTargetPlatformIdentifier Include="android" DisplayName="Android" />

This enables the IDE to know that Android is supported.

In this repo, we need to make this change for the iOS, MacCatalyst,
macOS, and tvOS workloads.

/cc @sfoslund