### PR TITLE
[main] [dotnet] Fix the path to the workloads in one more location.

### DIFF
--- a/dotnet/package/microsoft.workloads.csproj
+++ b/dotnet/package/microsoft.workloads.csproj
@@ -3,7 +3,7 @@
     <!-- NOTE: $(VersionBand) is passed in via Makefile -->
     <PackageId>Microsoft.NET.Sdk.$(_PlatformName).Manifest-$(VersionBand)</PackageId>
     <Description>.NET Workload for $(_PlatformName) platforms</Description>
-    <_packagePath>$(MSBuildThisFileDirectory)..\Microsoft.NET.Sdk.$(_PlatformName)\</_packagePath>
+    <_packagePath>$(MSBuildThisFileDirectory)..\Workloads\Microsoft.NET.Sdk.$(_PlatformName)\</_packagePath>
   </PropertyGroup>
   <Import Project="common.csproj" />
   <ItemGroup>


### PR DESCRIPTION
This fixes a regression where the data/WorkloadManifest.* files were missing
from the Microsoft.NET.Sdk.<platform>.Manifest-6.0.100.<version> NuGets.

Updated contents are now:

    $ unzip -l nupkgs/Microsoft.NET.Sdk.iOS.Manifest-6.0.100.*sha*.nupkg
    Archive:  nupkgs/Microsoft.NET.Sdk.iOS.Manifest-6.0.100.14.5.100-preview.5.891+sha.130c40321.nupkg
      Length      Date    Time    Name
    ---------  ---------- -----   ----
          528  06-08-2021 20:38   _rels/.rels
          845  06-08-2021 20:38   Microsoft.NET.Sdk.iOS.Manifest-6.0.100.nuspec
         6434  09-27-2016 14:08   LICENSE
          656  06-08-2021 18:36   data/WorkloadManifest.json
          645  06-02-2021 06:24   data/WorkloadManifest.targets
          594  06-08-2021 20:38   [Content_Types].xml
          664  06-08-2021 20:38   package/services/metadata/core-properties/be25c66390ef48fa911d2e7a3f184c3c.psmdcp
    ---------                     -------
        10366                     7 files

Regressed in: e4e57c703f543965ffee17a88a2cc1417dbfd508


Backport of #11866
