### PR TITLE
[dotnet] Add a data/UnixFilePermissions.xml file to the sdk packs. Fixes #11860.

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -15,6 +15,7 @@ $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_NUGET_VERSION_NO_METAD
 
 define DefineTargets
 $(1)_NUGET_TARGETS = \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/data/UnixFilePermissions.xml \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/Sdk/AutoImport.props \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/Sdk/Sdk.props \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.SupportedTargetPlatforms.props \
@@ -43,6 +44,7 @@ DIRECTORIES += \
 	$(DOTNET_NUPKG_DIR) \
 	$(DOTNET_PKG_DIR) \
 	$(DOTNET_FEED_DIR) \
+	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/data) \
 	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/Sdk) \
 	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets) \
 	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Templates) \
@@ -62,7 +64,7 @@ $(DIRECTORIES):
 
 CURRENT_HASH_LONG:=$(shell git log -1 --pretty=%H)
 
-$(DOTNET_DESTDIR)/Microsoft.%: Microsoft.% | $(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/Sdk $(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets $(DOTNET_DESTDIR)/Microsoft.$(platform).Templates) \
+$(DOTNET_DESTDIR)/Microsoft.%: Microsoft.% | $(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/data $(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/Sdk $(DOTNET_DESTDIR)/Microsoft.$(platform).Sdk/targets $(DOTNET_DESTDIR)/Microsoft.$(platform).Templates) \
 		$(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Windows.Sdk/Sdk $(DOTNET_DESTDIR)/Microsoft.$(platform).Windows.Sdk/targets)
 	$(Q) $(CP) $< $@
 

--- a/dotnet/Microsoft.MacCatalyst.Sdk/data/UnixFilePermissions.xml
+++ b/dotnet/Microsoft.MacCatalyst.Sdk/data/UnixFilePermissions.xml
@@ -1,0 +1,5 @@
+<FileList>
+	<!-- bgen -->
+	<File Path="tools/bin/bgen" Permission="755" />
+	<File Path="tools/lib/bgen/bgen" Permission="755" />
+ </FileList>

--- a/dotnet/Microsoft.iOS.Sdk/data/UnixFilePermissions.xml
+++ b/dotnet/Microsoft.iOS.Sdk/data/UnixFilePermissions.xml
@@ -1,0 +1,8 @@
+<FileList>
+	<!-- bgen -->
+	<File Path="tools/bin/bgen" Permission="755" />
+	<File Path="tools/lib/bgen/bgen" Permission="755" />
+	<!-- mlaunch -->
+	<File Path="tools/bin/mlaunch" Permission="755" />
+	<File Path="tools/lib/mlaunch/mlaunch.app/Contents/MacOS/mlaunch" Permission="755" />
+ </FileList>

--- a/dotnet/Microsoft.macOS.Sdk/data/UnixFilePermissions.xml
+++ b/dotnet/Microsoft.macOS.Sdk/data/UnixFilePermissions.xml
@@ -1,0 +1,5 @@
+<FileList>
+	<!-- bgen -->
+	<File Path="tools/bin/bgen" Permission="755" />
+	<File Path="tools/lib/bgen/bgen" Permission="755" />
+ </FileList>

--- a/dotnet/Microsoft.tvOS.Sdk/data/UnixFilePermissions.xml
+++ b/dotnet/Microsoft.tvOS.Sdk/data/UnixFilePermissions.xml
@@ -1,0 +1,8 @@
+<FileList>
+	<!-- bgen -->
+	<File Path="tools/bin/bgen" Permission="755" />
+	<File Path="tools/lib/bgen/bgen" Permission="755" />
+	<!-- mlaunch -->
+	<File Path="tools/bin/mlaunch" Permission="755" />
+	<File Path="tools/lib/mlaunch/mlaunch.app/Contents/MacOS/mlaunch" Permission="755" />
+ </FileList>


### PR DESCRIPTION
NuGet doesn't support preserving the executable bit for files in *.nupkgs
(which are just zip files), so .NET implemented a [temporary
workaround](https://github.com/dotnet/sdk/pull/17299) for workload installs,
where they hardcoded files that should be executable.

This isn't really sustainable, and they'll remove their workaround, so we need
to use their supported method of specifying the file permissions: a
data/UnixFilePermissions.xml file.

Fixes https://github.com/xamarin/xamarin-macios/issues/11860.