### PR TITLE
[dotnet][linker] Fix incorrect namespace for `[NotImplementedAttribute]`

### DIFF
--- a/src/ILLink.LinkAttributes.xml.in
+++ b/src/ILLink.LinkAttributes.xml.in
@@ -7,6 +7,9 @@
     <type fullname="Foundation.FieldAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
+    <type fullname="Foundation.NotImplementedAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
 
     <!-- double-check when applied -->
     <type fullname="Foundation.PreserveAttribute">
@@ -21,9 +24,6 @@
       <attribute internal="RemoveAttributeInstances" />
     </type>
     <type fullname="ObjCRuntime.DesignatedInitializerAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
-    <type fullname="ObjCRuntime.NotImplementedAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
     <type fullname="ObjCRuntime.RequiresSuperAttribute">


### PR DESCRIPTION
Fix warning

> resource ILLink.LinkAttributes.xml in Xamarin.iOS, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065(26,6): warning IL2008: Could not resolve type 'ObjCRuntime.NotImplementedAttribute' [/Users/poupou/git/xamarin/xamarin-macios/tests/dotnet/size-comparison/MySingleView/dotnet/MySingleView.csproj]