### PR TITLE
[release/6.0.1xx-preview5] [dotnet] Don't allow any other branches to pretend to be release branches.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -76,8 +76,10 @@ endif
 # The prerelease identifier is missing the per-product commit distance, which is added below
 ifneq ($(PULL_REQUEST_ID),)
 NUGET_PRERELEASE_IDENTIFIER=ci.pr.gh$(PULL_REQUEST_ID).
-else
+else ifeq ($(CURRENT_BRANCH_ALPHANUMERIC),release-6-0-1xx-preview5)
 NUGET_PRERELEASE_IDENTIFIER=preview.5.
+else
+NUGET_PRERELEASE_IDENTIFIER=ci.$(CURRENT_BRANCH_ALPHANUMERIC).
 endif
 NUGET_BUILD_METADATA=sha.$(CURRENT_HASH)
 


### PR DESCRIPTION
This prevents a problem where:

a) A branch is created in origin based on this release branch.
b) The new branch is automatically built in CI, and produces packages which
   are uploaded to NuGet.
c) Some other PR is merged into the same release branch.
d) The merged commit ends up with the same version number as the branch from
   b), because we hardcoded branch name in the version number.
e) The CI for the merged commit tries to upload packages to NuGet, which
   fails, because there already are packages on NuGet.
e) Hair pulling ensues.