### PR TITLE
Try to prevent identical version numbers across branches by matching hardcoded prerelease identifiers with hardcoded branch name.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -73,9 +73,22 @@ else ifneq ($(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER),)
 PULL_REQUEST_ID=$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)
 endif
 
+# For release branches, modify the following variables to hardcode a version name
+# Set the NUGET_HARDCODED_PRERELEASE_IDENTIFIER variable to the prerelease identifer you want (say "preview.5")
+NUGET_HARDCODED_PRERELEASE_IDENTIFIER=
+# Set the NUGET_HARDCODED_PRERELEASE_BRANCH variable to the exact name for the branch the above variable should apply to (so that any other branches won't pick it up by accident).
+# For the previous example, this would be "release/6.0.1xx-preview5"
+NUGET_HARDCODED_PRERELEASE_BRANCH=
+
+# compute the alphanumeric version of the hardcoded prerelease branch
+NUGET_HARDCODED_PRERELEASE_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%s" "$(NUGET_HARDCODED_PRERELEASE_BRANCH)" | tr -c '[a-zA-Z0-9-]' '-')
+
 # The prerelease identifier is missing the per-product commit distance, which is added below
+# DO NOT MODIFY THE BELOW CONDITIONS TO HARDCODE A VERSION NUMBER FOR RELEASE BRANCHES.
 ifneq ($(PULL_REQUEST_ID),)
 NUGET_PRERELEASE_IDENTIFIER=ci.pr.gh$(PULL_REQUEST_ID).
+else ifeq ($(NUGET_HARDCODED_PRERELEASE_BRANCH_ALPHANUMERIC),$(CURRENT_BRANCH_ALPHANUMERIC))
+NUGET_PRERELEASE_IDENTIFIER=$(NUGET_HARDCODED_PRERELEASE_IDENTIFIER)
 else
 NUGET_PRERELEASE_IDENTIFIER=ci.$(CURRENT_BRANCH_ALPHANUMERIC).
 endif


### PR DESCRIPTION
If we hardcode a prelease identifier for a .NET release, we can easily end up
with multiple branches using the same version number, because the hardcoded
prerelease identifier ends up being the same for any other branches that are
created later from the release branch (one typical example would be backport
branches).

This is bad.

So try to prevent this, by hardcoding two values instead!

We'll hardcode the branch name where the hardcoded prerelease identifier
should be applied, and this way any other branches will not use the hardcoded
prerelease identifier.

Ref: https://github.com/xamarin/xamarin-macios/pull/11891.