### PR TITLE
[CI] Add a new stage that will run windows integration tests.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -271,6 +271,13 @@ stages:
           keyringPass: $(pass--lab--mac--builder--keychain)
           checkDemands: ${{ config['checkDemands'] }}
 
+    - template: templates/windows/stage.yml
+      parameters:
+        stageName: windows-integration
+        displayName: 'Windows Integration Tests'
+        pool: 'VSEng-Xamarin-Mac-Devices' # currently ignored until the VS team provides a real one
+        statusContext: 'Windows Integration Tests'
+
 - ${{ if eq(parameters.runSamples, true) }}:
   # TODO: Not the real step
   - stage: sample_testing

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -1,0 +1,15 @@
+parameters:
+
+- name: statusContext
+  type: string 
+  default: 'Windows Integration Tests'
+
+steps:
+
+- checkout: self
+- checkout: maccore
+  persistCredentials: true  # hugely important, else there are some scripts that check a single file from maccore that will fail
+
+- pwsh : |
+    gci env: | format-table -autosize -wrap
+  displayName: 'Dump Environment'

--- a/tools/devops/automation/templates/windows/stage.yml
+++ b/tools/devops/automation/templates/windows/stage.yml
@@ -1,0 +1,45 @@
+parameters:
+# name of the pool that contains the iOS devices
+- name: pool
+  type: string
+
+- name: stageName
+  type: string
+
+- name: displayName
+  type: string
+
+- name: statusContext
+  type: string
+  default: 'Windows Integration Tests'
+
+stages:
+- stage: ${{ parameters.stageName }}
+  displayName: ${{ parameters.displayName }}
+  dependsOn:
+  - build_packages
+  # we need to have the pkgs built and the device sets to be ran, that is decided via the labels or type of build during the build_packages stage
+  condition: and(succeeded(), eq(dependencies.build_packages.outputs['build.configuration.RunDeviceTests'], 'True'))
+
+  jobs:
+  - job: run_tests
+    displayName: 'Dotnet tests'
+    timeoutInMinutes: 1000
+    workspace:
+      clean: all
+
+
+    pool:
+      vmImage: windows-latest
+
+    # The following must be used once the VS team provides us with pool and the correct
+    # capabilities
+    #pool:
+    #  name: ${{ parameters.pool }}
+    #  demands: 
+    #  - Agent.OS -equals Windows
+
+    steps:
+    - template: build.yml
+      parameters:
+        statusContext: ${{ parameters.statusContext }}


### PR DESCRIPTION
Add a new stage for the windows integration tests. Very boring since it follows the same pattern for all other stages, custom stage.yml and custom build.yml job. 

Missing parts:

1 - Add the upload and download of the tests (will be in a diff pr).
2 - A valid pool with the mac agent present. 