### PR TITLE
[msbuild] Share several cleaning targets between Xamarin.iOS and Xamarin.Mac.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -84,27 +84,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		</_CodesignAppBundleDependsOn>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(UsingAppleNETSdk)' != 'true'">
-		<CleanDependsOn>
-			$(CleanDependsOn);
-			_CleanAppBundle;
-			_CleanIntermediateToolOutput;
-		</CleanDependsOn>
-	</PropertyGroup>
-
-	<Target Name="_CleanAppBundle" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_GenerateBundleName">
-		<RemoveDir Directories="$(_AppBundlePath)" />
-	</Target>
-
-	<Target Name="_CleanIntermediateToolOutput">
-		<RemoveDir Directories="$(IntermediateOutputPath)actool" />
-		<RemoveDir Directories="$(IntermediateOutputPath)ibtool" />
-		<RemoveDir Directories="$(IntermediateOutputPath)metal" />
-		<RemoveDir Directories="$(IntermediateOutputPath)scntool" />
-		<RemoveDir Directories="$(IntermediateOutputPath)TextureAtlas" />
-		<RemoveDir Directories="$(IntermediateOutputPath)" />
-	</Target>
-
 	<Target Name="_CodesignAppBundle" Condition="'$(_RequireCodeSigning)'" DependsOnTargets="$(_CodesignAppBundleDependsOn)">
 		<Codesign
 			Condition="'$(IsMacEnabled)' == 'true'"

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/GetDirectoriesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/GetDirectoriesTaskBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Collections.Generic;
 
@@ -8,7 +8,7 @@ using Microsoft.Build.Utilities;
 using Xamarin.MacDev.Tasks;
 using Xamarin.Localization.MSBuild;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	public abstract class GetDirectoriesTaskBase : XamarinTask
 	{
@@ -70,3 +70,4 @@ namespace Xamarin.iOS.Tasks
 		}
 	}
 }
+

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetDirectories.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetDirectories.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	public class GetDirectories : GetDirectoriesTaskBase, ITaskCallback, ICancelableTask
 	{
@@ -28,3 +28,4 @@ namespace Xamarin.iOS.Tasks
 		}
 	}
 }
+

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -56,7 +56,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.DetectSdkLocations" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.DetectSigningIdentity" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.FindWatchOS2AppBundle" AssemblyFile="$(_TaskAssemblyName)" />
-	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.GetDirectories" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.GetFiles" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.GetMlaunchArguments" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.IBTool" AssemblyFile="$(_TaskAssemblyName)" />
@@ -112,6 +111,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.EmbedProvisionProfile" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.FindItemWithLogicalName" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GenerateBundleName" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetDirectories" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetFullPath" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetMinimumOSVersion" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetNativeExecutableName" AssemblyFile="$(_TaskAssemblyName)" />
@@ -177,13 +177,68 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<PropertyGroup>
 		<CleanDependsOn>
 			$(CleanDependsOn);
-			_CleanBindingResourcePackage
+			_CleanAppBundle;
+			_CleanBindingResourcePackage;
+			_CleanDebugSymbols;
+			_CleanDeviceSpecificOutput;
+			_CleanIntermediateToolOutput;
+			_CleanITunesArtwork;
 		</CleanDependsOn>
 	</PropertyGroup>
+
+	<Target Name="_CleanAppBundle" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_GenerateBundleName">
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_AppBundlePath)" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)bundler.stamp" />
+	</Target>
+
 	<Target Name="_CleanBindingResourcePackage">
 		<RemoveDir Directories="$(BindingResourcePath);" />  
 	</Target>
-	
+
+	<Target Name="_CleanDebugSymbols" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_GenerateBundleName">
+		<GetDirectories SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Path="$(DeviceSpecificOutputPath)" Pattern="*.dSYM">
+			<Output TaskParameter="Directories" ItemName="_DebugSymbolDir" />
+		</GetDirectories>
+
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(AppBundleDir).mSYM;@(_DebugSymbolDir)" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '$(IsAppExtension)' == 'false'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '$(IsAppExtension)' == 'true' Or '$(_PlatformName)' == 'macOS'" Files="$(DeviceSpecificOutputPath)dsym.items" />
+	</Target>
+
+	<Target Name="_CleanITunesArtwork" Condition="'$(_CanArchive)' == 'true'" DependsOnTargets="_ComputeTargetArchitectures">
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)iTunesMetadata.plist;$(DeviceSpecificOutputPath)iTunesArtwork@2x;$(DeviceSpecificOutputPath)iTunesArtwork" />
+	</Target>
+
+	<Target Name="_CleanDeviceSpecificOutput" Condition="'$(_CanOutputAppBundle)' == 'true'">
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(IntermediateOutputPath)device-builds;$(OutputPath)device-builds" />
+	</Target>
+
+	<Target Name="_CleanIntermediateToolOutput" DependsOnTargets="_ComputeTargetArchitectures">
+		<RemoveDir SessionId="$(BuildSessionId)" 
+			Condition="'$(IsMacEnabled)' == 'true'" 
+			Directories="$(DeviceSpecificIntermediateOutputPath)actool;
+					$(DeviceSpecificIntermediateOutputPath)assetpacks;
+					$(DeviceSpecificIntermediateOutputPath)codesign;
+					$(DeviceSpecificIntermediateOutputPath)coremlc;
+					$(DeviceSpecificIntermediateOutputPath)ibtool;
+					$(DeviceSpecificIntermediateOutputPath)ibtool-link;
+					$(DeviceSpecificIntermediateOutputPath)ibtool-manifests;
+					$(DeviceSpecificIntermediateOutputPath)ipa;
+					$(DeviceSpecificIntermediateOutputPath)metal;
+					$(DeviceSpecificIntermediateOutputPath)optimized;
+					$(DeviceSpecificIntermediateOutputPath)scntool;
+					$(DeviceSpecificIntermediateOutputPath)TextureAtlas;
+					$(DeviceSpecificIntermediateOutputPath)mtouch-cache;
+					$(DeviceSpecificIntermediateOutputPath)" />
+
+		<ItemGroup>
+			<_IpaPackageFile Include="$(DeviceSpecificOutputPath)*.ipa" />
+		</ItemGroup>
+
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '$(IsAppExtension)' == 'true'" Files="$(DeviceSpecificOutputPath)codesign.items" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="@(_IpaPackageFile)" />
+	</Target>
+
 	<Target Name="_AddExtraReferences" BeforeTargets="ResolveAssemblyReferences" Condition="'$(DisableExtraReferences)' != 'true' And '$(UsingAppleNETSdk)' != 'true'">
 		<ItemGroup>
 			<!-- https://github.com/mono/mono/issues/13483 -->

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -81,11 +81,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			$(CleanDependsOn);
 			_ComputeTargetArchitectures;
 			_CleanUploaded;
-			_CleanAppBundle;
-			_CleanDebugSymbols;
-			_CleanITunesArtwork;
-			_CleanDeviceSpecificOutput;
-			_CleanIntermediateToolOutput;
 		</CleanDependsOn>
 	</PropertyGroup>
 
@@ -224,57 +219,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	
 	<Target Name="CreateIpa" Condition="'$(_CanArchive)' == 'true'" DependsOnTargets="$(CreateIpaDependsOn)" />
 
-	<Target Name="_CleanAppBundle" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_GenerateBundleName">
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_AppBundlePath)" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)bundler.stamp" />
-	</Target>
-
 	<Target Name="_CleanUploaded" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_ComputeTargetArchitectures">
 		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath).uploaded" />
-	</Target>
-
-	<Target Name="_CleanDebugSymbols" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_GenerateBundleName">
-		<GetDirectories SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Path="$(DeviceSpecificOutputPath)" Pattern="*.dSYM">
-			<Output TaskParameter="Directories" ItemName="_DebugSymbolDir" />
-		</GetDirectories>
-
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(AppBundleDir).mSYM;@(_DebugSymbolDir)" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '$(IsAppExtension)' == 'false'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '$(IsAppExtension)' == 'true'" Files="$(DeviceSpecificOutputPath)dsym.items" />
-	</Target>
-
-	<Target Name="_CleanITunesArtwork" Condition="'$(_CanArchive)' == 'true'" DependsOnTargets="_ComputeTargetArchitectures">
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)iTunesMetadata.plist;$(DeviceSpecificOutputPath)iTunesArtwork@2x;$(DeviceSpecificOutputPath)iTunesArtwork" />
-	</Target>
-
-	<Target Name="_CleanDeviceSpecificOutput" Condition="'$(_CanOutputAppBundle)' == 'true'">
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(IntermediateOutputPath)device-builds;$(OutputPath)device-builds" />
-	</Target>
-
-	<Target Name="_CleanIntermediateToolOutput" DependsOnTargets="_ComputeTargetArchitectures">
-		<RemoveDir SessionId="$(BuildSessionId)" 
-			Condition="'$(IsMacEnabled)' == 'true'" 
-			Directories="$(DeviceSpecificIntermediateOutputPath)actool;
-					$(DeviceSpecificIntermediateOutputPath)assetpacks;
-					$(DeviceSpecificIntermediateOutputPath)codesign;
-					$(DeviceSpecificIntermediateOutputPath)coremlc;
-					$(DeviceSpecificIntermediateOutputPath)ibtool;
-					$(DeviceSpecificIntermediateOutputPath)ibtool-link;
-					$(DeviceSpecificIntermediateOutputPath)ibtool-manifests;
-					$(DeviceSpecificIntermediateOutputPath)ipa;
-					$(DeviceSpecificIntermediateOutputPath)metal;
-					$(DeviceSpecificIntermediateOutputPath)optimized;
-					$(DeviceSpecificIntermediateOutputPath)scntool;
-					$(DeviceSpecificIntermediateOutputPath)TextureAtlas;
-					$(DeviceSpecificIntermediateOutputPath)mtouch-cache;
-					$(DeviceSpecificIntermediateOutputPath)" />
-
-		<ItemGroup>
-			<_IpaPackageFile Include="$(DeviceSpecificOutputPath)*.ipa" />
-		</ItemGroup>
-
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '$(IsAppExtension)' == 'true'" Files="$(DeviceSpecificOutputPath)codesign.items" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="@(_IpaPackageFile)" />
 	</Target>
 
 	<Target Name="_CreateAssetPackManifest" DependsOnTargets="_CopyResourcesToBundle">


### PR DESCRIPTION
The iOS version of the cleaning tasks were much more comprehensive, so those
won out when there were any differences.

This also required moving the GetDirectoriesTask to shared code.