### PR TITLE
[d16-10] Remove extra (managed) setters on readonly (native) properties

### DIFF
--- a/src/mlcompute.cs
+++ b/src/mlcompute.cs
@@ -567,7 +567,13 @@ namespace MLCompute {
 		MLCDevice Device { get; }
 
 		[Export ("optimizerData", ArgumentSemantic.Copy)]
-		MLCTensorData[] OptimizerData { get; set; }
+		MLCTensorData[] OptimizerData {
+			get;
+#if !XAMCORE_4_0
+			[NotImplemented]
+			set;
+#endif
+		}
 
 		[Export ("optimizerDeviceData", ArgumentSemantic.Copy)]
 		MLCTensorOptimizerDeviceData[] OptimizerDeviceData { get; }

--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -1686,7 +1686,12 @@ namespace NetworkExtension {
 		NWEndpoint LocalEndpoint { get; }
 
 		[Export ("socketFamily")]
-		int SocketFamily { get; set; }
+		int SocketFamily {
+			get;
+#if !XAMCORE_4_0
+			[NotImplemented] set;
+#endif
+		}
 
 		[Export ("socketType")]
 		int SocketType {

--- a/src/vision.cs
+++ b/src/vision.cs
@@ -1707,7 +1707,13 @@ namespace Vision {
 	interface VNImageTranslationAlignmentObservation {
 
 		[Export ("alignmentTransform", ArgumentSemantic.Assign)]
-		CGAffineTransform AlignmentTransform { get; set; }
+		CGAffineTransform AlignmentTransform {
+			get;
+#if !XAMCORE_4_0
+			[NotImplemented]
+			set;
+#endif
+		}
 	}
 
 	[TV (11,0), Mac (10,13), iOS (11,0)]
@@ -1719,8 +1725,10 @@ namespace Vision {
 		Matrix3 WarpTransform {
 			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 			get;
-			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+#if !XAMCORE_4_0
+			[NotImplemented]
 			set;
+#endif
 		}
 	}
 

--- a/tests/xtro-sharpie/common-Vision.ignore
+++ b/tests/xtro-sharpie/common-Vision.ignore
@@ -126,3 +126,7 @@
 !missing-selector! VNStatefulRequest::requestFrameAnalysisSpacing not bound
 !missing-selector! VNVideoProcessor::addRequest:withProcessingOptions:error: not bound
 !missing-selector! VNVideoProcessor::analyzeWithTimeRange:error: not bound
+
+## removed in xcode 13 and rejected by app store
+!missing-selector! VNImageHomographicAlignmentObservation::setWarpTransform: not bound
+!missing-selector! VNImageTranslationAlignmentObservation::setAlignmentTransform: not bound


### PR DESCRIPTION
When used they can cause rejection from the app store (but in most
case the managed linker will remove them from the app code)


Backport of #11907
