### PR TITLE
[d16-10] [coremidi] Remove incorrect `.ctor` on `MIDICISession`

### DIFF
--- a/src/CoreMidi/MidiCompat.cs
+++ b/src/CoreMidi/MidiCompat.cs
@@ -13,6 +13,12 @@ namespace CoreMidi {
 	public partial class MidiCISession {
 
 		[Obsolete ("Always throws 'NotSupportedException' (not a public API).")]
+		public MidiCISession (uint entity, Action handler)
+		{
+			throw new NotSupportedException ();
+		}
+
+		[Obsolete ("Always throws 'NotSupportedException' (not a public API).")]
 		public virtual void GetProperty (NSData inquiry, byte channel, MidiCIPropertyResponseHandler handler)
 			=> throw new NotSupportedException ();
 

--- a/src/coremidi.cs
+++ b/src/coremidi.cs
@@ -287,9 +287,6 @@ namespace CoreMidi {
 	[DisableDefaultCtor]
 	interface MidiCISession
 	{
-		[Export ("initWithMIDIEntity:dataReadyHandler:")]
-		IntPtr Constructor (uint entity, Action handler);
-
 		[Export ("entity")]
 		uint Entity { get; }
 


### PR DESCRIPTION
This is likely a leftover from a beta and can now cause rejections.


Backport of #11910
