### PR TITLE
Bump maccore to get mlaunch fix.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 9acbbed1f60788349c60437dba11531a866777a8
+NEEDED_MACCORE_VERSION := c7809739bd04c9c878ed5cfdd5208ad7135e13d4
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@c7809739bd [Xamarin.Hosting] Add each platform as an exposed capability to the plugin manager. Fixes #xamarin/xamarin-macios@11901. (#2455)

Diff: https://github.com/xamarin/maccore/compare/9acbbed1f60788349c60437dba11531a866777a8..c7809739bd04c9c878ed5cfdd5208ad7135e13d4