### PR TITLE
[introspection] Handle a few Metal classes differently for 'encodeWithCoder:'. Fixes #11885.

### DIFF
--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -764,7 +764,7 @@ namespace Introspection {
 			case "MLSequence":
 				switch (selectorName) {
 				case "encodeWithCoder:":
-					if (!TestRuntime.CheckXcodeVersion (12, 0))
+					if (!TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch))
 						return true;
 					break;
 				}

--- a/tests/introspection/Mac/MacApiSelectorTest.cs
+++ b/tests/introspection/Mac/MacApiSelectorTest.cs
@@ -138,16 +138,6 @@ namespace Introspection {
 					if (!Mac.CheckSystemVersion (10, 12)) // NSCoding was added in 10.12
 						return true;
 					break;
-				case "MLDictionaryFeatureProvider":
-				case "MLMultiArray":
-				case "MLFeatureValue":
-				case "MLSequence":
-					// Fail on Catalina, pass in older OS
-					if (Mac.CheckSystemVersion (10, 14))
-						break;
-					if (Mac.CheckSystemVersion (10, 15))
-						return true;
-					break;
 				}
 				break;
 			case "accessibilityNotifiesWhenDestroyed":


### PR DESCRIPTION
The base ApiSelectorTest class already handles these selectors, and does it
almost right, so just remove this special case and fix the base class logic.

Fixes these failures on macOS 10.15:

    Introspection.MacApiSelectorTest
    	[FAIL] InstanceMethods :   4 errors found in 27001 instance selector validated:
    Selector not found for CoreML.MLDictionaryFeatureProvider : encodeWithCoder: in Void EncodeTo(Foundation.NSCoder) on CoreML.MLDictionaryFeatureProvider
    Selector not found for CoreML.MLMultiArray : encodeWithCoder: in Void EncodeTo(Foundation.NSCoder) on CoreML.MLMultiArray
    Selector not found for CoreML.MLFeatureValue : encodeWithCoder: in Void EncodeTo(Foundation.NSCoder) on CoreML.MLFeatureValue
    Selector not found for CoreML.MLSequence : encodeWithCoder: in Void EncodeTo(Foundation.NSCoder) on CoreML.MLSequence

Fixes https://github.com/xamarin/xamarin-macios/issues/11885.