### PR TITLE
[CI] Fix BRANCH_NAME to be the entire branch name.

### DIFF
--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -85,7 +85,7 @@ jobs:
     # old and ugly env var use by jenkins, we do have parts of the code that use it, contains the PR number
     PR_ID: $[ dependencies.configure.outputs['labels.pr-number'] ]
     # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
-    BRANCH_NAME: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')
+    BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
     XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness-labels'] ]
   pool:
     name: $(AgentPoolComputed)

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -85,7 +85,7 @@ jobs:
     # old and ugly env var use by jenkins, we do have parts of the code that use it, contains the PR number
     PR_ID: $[ dependencies.configure.outputs['labels.pr-number'] ]
     # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
-    BRANCH_NAME: $(Build.SourceBranchName)
+    BRANCH_NAME: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')
     XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness-labels'] ]
   pool:
     name: $(AgentPoolComputed)


### PR DESCRIPTION
The Build.SourceBranchName variable is documented to be the last segment of
the git ref. If the git ref is 'refs/heads/main', then Build.SourceBranchName
is 'main' (as expected). However, if the git ref is
'refs/heads/release/6.0.1xx-preview5', then Build.SourceName is
'6.0.1xx-preview5', and that's not what we want.

Instead use the Build.SourceBranch variable, which is the entire git ref, and
then we strip out the 'refs/heads/' part from the beginning. This way we get
the correct branch name.