### PR TITLE
[corefoundation] Simplify `CFRange`

### DIFF
--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -62,8 +62,9 @@ namespace CoreFoundation {
 		}
 
 		public CFRange (int loc, int len)
-			: this ((long) loc, (long) len)
 		{
+			this.loc = loc;
+			this.len = len;
 		}
 
 		public CFRange (long l, long len)


### PR DESCRIPTION
* Avoid chaining constructors, so one can be eliminated (if the other is not used)
* Remove casts (`int` parameters does not need them for `nint` fields)
* Reduce metadata (when a `.ctor` can be eliminated, like MySingleView)

```diff
--- a.cs	2021-06-14 20:56:22.000000000 -0400
+++ b.cs	2021-06-14 20:56:25.000000000 -0400
@@ -5068,13 +5068,8 @@

 		public CFRange(int P_0, int P_1)
 		{
-			this = new CFRange((long)P_0, (long)P_1);
-		}
-
-		public CFRange(long P_0, long P_1)
-		{
-			loc = (nint)P_0;
-			len = (nint)P_1;
+			loc = P_0;
+			len = P_1;
 		}

 		public override string ToString()
```