### PR TITLE
[corefoundation] Fix `CFString.ToString` to cache the result

### DIFF
--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -217,9 +217,9 @@ namespace CoreFoundation {
 		
 		public override string ToString ()
 		{
-			if (str != null)
-				return str;
-			return FromHandle (Handle);
+			if (str is null)
+				str = FromHandle (Handle);
+			return str;
 		}
 #endif // !COREBUILD
 	}


### PR DESCRIPTION
`CFString` cache the native immutable string into it's `str` field and
use it to avoid p/invokes when possible.

`ToString` retrieved the string without setting `str` (if `null`) so it
missed opportunities to avoid the native calls.