### PR TITLE
[mmp] Set minimum Xcode to Xcode 12 to get a better error message. Fixes #11937.

### DIFF
--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -31,7 +31,13 @@ namespace Xamarin.Bundler {
 		public static bool IsUnifiedFullSystemFramework { get { return TargetFramework == TargetFramework.Xamarin_Mac_4_5_System; } }
 		public static bool IsUnifiedMobile { get { return TargetFramework == TargetFramework.Xamarin_Mac_2_0_Mobile; } }
 
+#if MMP
+		// We know that Xamarin.Mac apps won't compile unless the developer is using Xcode 12+: https://github.com/xamarin/xamarin-macios/issues/11937, so just set that as the min Xcode version.
+		static Version min_xcode_version = new Version (12, 0);
+#else
 		static Version min_xcode_version = new Version (6, 0);
+#endif
+
 #if !NET
 		public static int Main (string [] args)
 		{


### PR DESCRIPTION
Developers will now get the helpful:

> error MM0051: Xamarin.Mac 7.99.0 requires Xcode 12.0 or later. The current Xcode version (found in /Applications/Xcode_11.7.app/Contents/Developer) is 11.7.

instead of:

> error MM5309: Failed to execute the tool 'clang', it failed with an error code '1'. Please check the build log for details.

(and no clue from the build log that they need to upgrade their Xcode).

Xamarin.iOS projects still build fine with at least Xcode 11.3.1, so I've only
updated the minimum Xcode version for Xamarin.Mac.

Fixes https://github.com/xamarin/xamarin-macios/issues/11937.