### PR TITLE
[tests] Re-enable tests ignored due to dotnet/runtime #36897

### DIFF
--- a/tests/introspection/ApiCMAttachmentTest.cs
+++ b/tests/introspection/ApiCMAttachmentTest.cs
@@ -230,12 +230,6 @@ namespace Introspection {
 			case "SecIdentity": // hangs with xcode12.5 beta 2 while loading p12 file
 			case "SecIdentity2": // same (dupe logic)
 				return true;
-#if NET
-			case "SecTrust": // System.EntryPointNotFoundException : AppleCryptoNative_X509ImportCertificate
-			case "SecTrust2": // System.EntryPointNotFoundException : AppleCryptoNative_X509ImportCertificate
-				// Filed here: https://github.com/dotnet/runtime/issues/36897
-				return true;
-#endif
 			default:
  				return false;
 			}

--- a/tests/linker/ios/link sdk/AsyncTest.cs
+++ b/tests/linker/ios/link sdk/AsyncTest.cs
@@ -16,9 +16,6 @@ namespace LinkSdk {
 			return Task.Run (async () => await (new HttpClient ()).GetStringAsync (NetworkResources.MicrosoftUrl));
 		}
 
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		[Test]
 		public void Bug12221 ()
 		{

--- a/tests/linker/ios/link sdk/CryptoTest.cs
+++ b/tests/linker/ios/link sdk/CryptoTest.cs
@@ -23,9 +23,6 @@ namespace LinkSdk {
 	[Preserve (AllMembers = true)]
 	public class CryptoTest {
 		
-#if NET
-		[Ignore ("https://github.com/dotnet/runtime/issues/36897")]
-#endif
 		[Test]
 		public void AesCreate ()
 		{
@@ -33,14 +30,16 @@ namespace LinkSdk {
 			// located inside System.Core.dll - IOW the linker needs to be aware of this
 			Aes aes = Aes.Create ();
 			Assert.NotNull (aes, "Aes");
-			Assert.True (aes.GetType ().Assembly.FullName.StartsWith ("System.Core, ", StringComparison.Ordinal), "System.Core");
+#if NET
+			const string prefix = "System.Security.Cryptography.Algorithms, ";
+#else
+			const string prefix = "System.Core, ";
+#endif
+			Assert.True (aes.GetType ().Assembly.FullName.StartsWith (prefix, StringComparison.Ordinal), prefix);
 		}
 
 		static int trust_validation_callback;
 
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		[Test]
 		public void TrustUsingNewCallback ()
 		{
@@ -70,9 +69,6 @@ namespace LinkSdk {
 			}
 		}
 
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		[Test]
 		public void SSL_IP_5706 ()
 		{
@@ -97,9 +93,6 @@ namespace LinkSdk {
 
 		static int sne_validation_callback;
 
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		[Test]
 		public void TLS1_ServerNameExtension ()
 		{
@@ -145,14 +138,21 @@ namespace LinkSdk {
 			}
 		}
 
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainCreate")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		[Test]
 		public void Chain ()
 		{
 			X509Store store = new X509Store ("Trust");
-			store.Open (OpenFlags.ReadWrite);
+			try {
+				store.Open (OpenFlags.ReadWrite);
+			}
+			catch (CryptographicException) {
+#if NET
+				// System.PlatformNotSupportedException from Internal.Cryptography.Pal.StorePal.FromSystemStore
+				Assert.Ignore ("Not support by PAL");
+#else
+				Assert.Fail ("X509Store.Add");
+#endif
+			}
 			
 			string certString = "MIIDGjCCAgKgAwIBAgICApowDQYJKoZIhvcNAQEFBQAwLjELMAkGA1UEBhMCQ1oxDjAMBgNVBAoTBVJlYmV4MQ8wDQYDVQQDEwZUZXN0Q0EwHhcNMDAwMTAxMDAwMDAwWhcNNDkxMjMxMDAwMDAwWjAuMQswCQYDVQQGEwJDWjEOMAwGA1UEChMFUmViZXgxDzANBgNVBAMTBlRlc3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMgeRAcaNLTFaaBhFx8RDJ8b9K655dNUXmO11mbImDbPq4qVeZXDgAjnzPov8iBscwfqBvBpF38LsxBIPA2i1d0RMsQruOhJHttA9I0enElUXXj63sOEVNMSQeg1IMyvNeEotag+Gcx6SF+HYnariublETaZGzwAOD2SM49mfqUyfkgeTjdO6qp8xnoEr7dS5pEBHDg70byj/JEeZd3gFea9TiOXhbCrI89dKeWYBeoHFYhhkaSB7q9EOaUEzKo/BQ6PBHFu6odfGkOjXuwfPkY/wUy9U4uj75LmdhzvJf6ifsJS9BQZF4//JcUYSxiyzpxDYqSbTF3g9w5Ds2LOAscCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgB/MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFD1v20tPgvHTEK/0eLO09j0rL2qXMA0GCSqGSIb3DQEBBQUAA4IBAQAZIjcdR3EZiFJ67gfCnPBrxVgFNvaRAMCYEYYIGDCAUeB4bLTu9dvun9KFhgVNqjgx+xTTpx9d/5mAZx5W3YAG6faQPCaHccLefB1M1hVPmo8md2uw1a44RHU9LlM0V5Lw8xTKRkQiZz3Ysu0sY27RvLrTptbbfkE4Rp9qAMguZT9cFrgPAzh+0zuo8NNj9Jz7/SSa83yIFmflCsHYSuNyKIy2iaX9TCVbTrwJmRIB65gqtTb6AKtFGIPzsb6nayHvgGHFchrFovcNrvRpE71F38oVG+eCjT23JfiIZim+yJLppSf56167u8etDcQ39j2b9kzWlHIVkVM0REpsKF7S";
 			X509Certificate2 rootCert = new X509Certificate2 (Convert.FromBase64String (certString));
@@ -229,9 +229,6 @@ namespace LinkSdk {
 			0x43, 0x45, 0x52, 0x54, 0x49, 0x46, 0x49, 0x43, 0x41, 0x54, 0x45, 0x2D, 0x2D, 0x2D, 0x2D, 0x2D, 0x0D, 0x0A, };
 
 
-#if NET
-		[Ignore ("System.EntryPointNotFoundException : AppleCryptoNative_SecCopyErrorMessageString")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		[Test]
 		public void Sha256 ()
 		{

--- a/tests/linker/ios/link sdk/CryptoTest.cs
+++ b/tests/linker/ios/link sdk/CryptoTest.cs
@@ -53,8 +53,12 @@ namespace LinkSdk {
 				ServicePointManager.ServerCertificateValidationCallback = delegate (object sender, X509Certificate cert, X509Chain chain, SslPolicyErrors errors) {
 					Assert.That (errors, Is.EqualTo (SslPolicyErrors.None), "certificateProblem");
 					X509Certificate2 c2 = new X509Certificate2 (cert.GetRawCertData ());
+#if NET
+					Assert.True (chain.Build (c2), "Build");
+#else
 					Assert.False (chain.Build (c2), "Build");
 					Assert.AreSame (c2, chain.ChainElements [0].Certificate, "ChainElements");
+#endif
 					trust_validation_callback++;
 					return true;
 				};
@@ -113,8 +117,12 @@ namespace LinkSdk {
 				ServicePointManager.ServerCertificateValidationCallback = delegate (object sender, X509Certificate cert, X509Chain chain, SslPolicyErrors errors) {
 					Assert.That (errors, Is.EqualTo (SslPolicyErrors.None), "certificateProblem");
 					X509Certificate2 c2 = new X509Certificate2 (cert.GetRawCertData ());
+#if NET
+					Assert.True (chain.Build (c2), "Build");
+#else
 					Assert.False (chain.Build (c2), "Build");
 					Assert.AreSame (c2, chain.ChainElements [0].Certificate, "ChainElements");
+#endif
 					sne_validation_callback++;
 					return true;
 				};

--- a/tests/linker/ios/link sdk/CryptoTest.cs
+++ b/tests/linker/ios/link sdk/CryptoTest.cs
@@ -70,6 +70,9 @@ namespace LinkSdk {
 		}
 
 		[Test]
+#if NET
+		[Ignore ("Crash https://github.com/dotnet/runtime/issues/54239")]
+#endif
 		public void SSL_IP_5706 ()
 		{
 #if __WATCHOS__

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -658,9 +658,6 @@ namespace LinkSdk {
 			Assert.NotNull (NetworkInterface.GetAllNetworkInterfaces ());
 		}
 		
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		[Test]
 		public void WebClient_SSL_Leak ()
 		{

--- a/tests/monotouch-test/Foundation/UrlCredentialTest.cs
+++ b/tests/monotouch-test/Foundation/UrlCredentialTest.cs
@@ -35,9 +35,6 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_X509ImportCertificate")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		public void Ctor_Trust ()
 		{
 			using (var trust = GetTrust ())
@@ -57,9 +54,6 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_X509ImportCertificate")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		public void FromTrust ()
 		{
 			using (var trust = GetTrust ())

--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -552,11 +552,13 @@ namespace MonoTouchFixtures.Security {
 				Assert.That (cert.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
 				Assert.That (CFGetRetainCount (cert.Handle), Is.EqualTo ((nint) 1), "RetainCount");
 				using (var sc = new SecCertificate (cert)) {
-#if !NET
+#if NET
 					// dotnet PAL layer does not return the same instance
+					CheckMailGoogleCom (sc, 1); // so the new one is RC == 1
+#else
 					Assert.That (sc.Handle, Is.EqualTo (cert.Handle), "Same Handle");
+					CheckMailGoogleCom (sc, 2); // same handle means another reference was added
 #endif
-					CheckMailGoogleCom (sc, 2);
 					Assert.That (cert.ToString (true), Is.EqualTo (sc.ToX509Certificate ().ToString (true)), "X509Certificate");
 				}
 			}

--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -542,9 +542,6 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_X509ImportCertificate")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		public void MailX1 ()
 		{
 			using (var cert = new X509Certificate (mail_google_com)) {

--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -552,7 +552,10 @@ namespace MonoTouchFixtures.Security {
 				Assert.That (cert.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
 				Assert.That (CFGetRetainCount (cert.Handle), Is.EqualTo ((nint) 1), "RetainCount");
 				using (var sc = new SecCertificate (cert)) {
+#if !NET
+					// dotnet PAL layer does not return the same instance
 					Assert.That (sc.Handle, Is.EqualTo (cert.Handle), "Same Handle");
+#endif
 					CheckMailGoogleCom (sc, 2);
 					Assert.That (cert.ToString (true), Is.EqualTo (sc.ToX509Certificate ().ToString (true)), "X509Certificate");
 				}

--- a/tests/monotouch-test/Security/KeyTest.cs
+++ b/tests/monotouch-test/Security/KeyTest.cs
@@ -61,9 +61,6 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainCreate")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		public void Encrypt_Old ()
 		{
 			// the old API was not working but the crash was fixed, still you need to provide an adequatly sized buffer
@@ -80,9 +77,6 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainCreate")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		public void Encrypt_Empty ()
 		{
 			using (SecPolicy p = SecPolicy.CreateBasicX509Policy ())
@@ -99,9 +93,6 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainCreate")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		public void Encrypt_New ()
 		{
 			using (SecPolicy p = SecPolicy.CreateBasicX509Policy ())

--- a/tests/monotouch-test/Security/RecordTest.cs
+++ b/tests/monotouch-test/Security/RecordTest.cs
@@ -349,7 +349,10 @@ namespace MonoTouchFixtures.Security {
 
 				var ret = rec.GetCertificate ();
 				Assert.That (ret.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
+#if !NET
+				// dotnet PAL layer does not return the same instance
 				Assert.That (ret.Handle, Is.EqualTo (cert.Handle), "Same Handle");
+#endif
 				Assert.That (cert.ToString (true), Is.EqualTo (ret.ToX509Certificate ().ToString (true)), "X509Certificate");
 
 				Assert.Throws<InvalidOperationException> (() => rec.GetKey (), "GetKey should throw");

--- a/tests/monotouch-test/Security/RecordTest.cs
+++ b/tests/monotouch-test/Security/RecordTest.cs
@@ -340,9 +340,6 @@ namespace MonoTouchFixtures.Security {
 
 #if !MONOMAC // Works different on Mac
 		[Test]
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_X509ImportCertificate")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		public void SecRecordRecordTest ()
 		{
 			using (var cert = new X509Certificate (CertificateTest.mail_google_com))
@@ -361,9 +358,6 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainCreate")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		public void KeyRecordTest ()
 		{
 			using (var cert = new X509Certificate2 (ImportExportTest.farscape_pfx, "farscape"))

--- a/tests/monotouch-test/Security/TrustTest.cs
+++ b/tests/monotouch-test/Security/TrustTest.cs
@@ -32,9 +32,6 @@ namespace MonoTouchFixtures.Security {
 	[TestFixture]
 	// we want the test to be availble if we use the linker
 	[Preserve (AllMembers = true)]
-#if NET
-	[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_X509ImportCertificate")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 	public class TrustTest {
 
 		[DllImport (Constants.CoreFoundationLibrary)]

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -88,9 +88,6 @@ namespace MonoTests.System.Net.Http
 #if !__WATCHOS__
 		// ensure that we do get the same cookies as the managed handler
 		[Test]
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		public void TestNSUrlSessionHandlerCookies ()
 		{
 			var managedCookieResult = false;
@@ -136,9 +133,6 @@ namespace MonoTests.System.Net.Http
 
 		// ensure that we can use a cookie container to set the cookies for a url
 		[Test]
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		public void TestNSUrlSessionHandlerCookieContainer ()
 		{
 			var url = NetworkResources.Httpbin.CookiesUrl;
@@ -317,9 +311,6 @@ namespace MonoTests.System.Net.Http
 
 #endif
 
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 		// ensure that if we have a redirect, we do not have the auth headers in the following requests
 #if !__WATCHOS__
 		[TestCase (typeof (HttpClientHandler))]
@@ -367,9 +358,6 @@ namespace MonoTests.System.Net.Http
 			}
 		}
 
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 #if !__WATCHOS__
 		[TestCase (typeof (HttpClientHandler))]
 #endif
@@ -445,9 +433,6 @@ namespace MonoTests.System.Net.Http
 			}
 		}
 
-#if NET
-		[Ignore ("System.EntryPointNotFoundException: AppleCryptoNative_SecKeychainItemCopyKeychain")] // https://github.com/dotnet/runtime/issues/36897
-#endif
 #if !__WATCHOS__
 		[TestCase (typeof (HttpClientHandler))]
 #endif


### PR DESCRIPTION
They should now work (even if some tests required more changes) and
will be able to validate other changes.

ref: https://github.com/dotnet/runtime/issues/36897