### PR TITLE
[d16-10] [linker] Ignore `[AssemblyMetadata]` before net6

### DIFF
--- a/src/Foundation/LinkerSafeAttribute.cs
+++ b/src/Foundation/LinkerSafeAttribute.cs
@@ -25,8 +25,10 @@
 using System;
 
 namespace Foundation {
-	
+
+#if NET
 	[Obsolete ("Replace with '[assembly: System.Reflection.AssemblyMetadata (\"IsTrimmable\", \"True\")]'.")]
+#endif
 	[AttributeUsage (AttributeTargets.Assembly)]
 	public sealed class LinkerSafeAttribute : Attribute {
 		

--- a/tools/common/Tuning.cs
+++ b/tools/common/Tuning.cs
@@ -127,13 +127,8 @@ namespace MonoMac.Tuner {
 			case "LinkerSafeAttribute":
 				return true; // namespace is not important
 			case "AssemblyMetadataAttribute":
-				if (!attribute.HasConstructorArguments)
-					return false;
-				if (at.Namespace != "System.Reflection")
-					return false;
-				if (attribute.ConstructorArguments [0].Value as string != "IsTrimmable")
-					return false;
-				return (attribute.ConstructorArguments [1].Value.ToString ().ToLowerInvariant () == "true");
+				// this is only true for net6+ and can depends on other features not available on the legacy linker
+				return false;
 			}
 			return false;
 		}


### PR DESCRIPTION
This was allowed to ease existing (3rd party) code migration into net6.

However the reverse can also happen: trying to use net6 code with the
legacy SDK. In such case it's possible other (newer) attributes are being
used to preserve members.

ref: https://github.com/dotnet/aspnetcore/issues/33269


Backport of #11940
