### PR TITLE
Use `CFString` instead of `NSString` to get a handle from a (.net) `System.String`

### DIFF
--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -115,14 +115,14 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary, CharSet=CharSet.Unicode)]
 		extern static IntPtr CFStringGetCharacters (IntPtr handle, CFRange range, IntPtr buffer);
 
-		public static IntPtr CreateNative (string str)
+		public static IntPtr CreateNative (string value)
 		{
-			if (str == null)
+			if (value is null)
 				return IntPtr.Zero;
 			
-			return CFStringCreateWithCharacters (IntPtr.Zero, str, str.Length);
+			return CFStringCreateWithCharacters (IntPtr.Zero, value, value.Length);
 		}
-		
+
 		public static void ReleaseNative (IntPtr handle)
 		{
 			if (handle != IntPtr.Zero)

--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -115,7 +115,7 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary, CharSet=CharSet.Unicode)]
 		extern static IntPtr CFStringGetCharacters (IntPtr handle, CFRange range, IntPtr buffer);
 
-		internal static IntPtr LowLevelCreate (string str)
+		public static IntPtr CreateNative (string str)
 		{
 			if (str == null)
 				return IntPtr.Zero;
@@ -123,6 +123,12 @@ namespace CoreFoundation {
 			return CFStringCreateWithCharacters (IntPtr.Zero, str, str.Length);
 		}
 		
+		public static void ReleaseNative (IntPtr handle)
+		{
+			if (handle != IntPtr.Zero)
+				CFObject.CFRelease (handle);
+		}
+
 		public CFString (string str)
 		{
 			if (str == null)

--- a/src/Foundation/NSString.cs
+++ b/src/Foundation/NSString.cs
@@ -82,6 +82,7 @@ namespace Foundation {
 			}
 		}
 
+		[Obsolete ("Use of 'CFString.CreateNative' offers better performance.")]
 		public static IntPtr CreateNative (string str)
 		{
 			return CreateNative (str, false);

--- a/src/PrintCore/PrintCore.cs
+++ b/src/PrintCore/PrintCore.cs
@@ -664,10 +664,9 @@ namespace PrintCore {
 			if (fileUrl == null)
 				throw new ArgumentNullException (nameof (fileUrl));
 				    
-			IntPtr mime = CFString.LowLevelCreate (mimeType);
+			IntPtr mime = CFString.CreateNative (mimeType);
 			var code = PMPrinterPrintWithFile (handle, settings.handle, pageFormat == null ? IntPtr.Zero : pageFormat.handle, mime, fileUrl.Handle);
-			if (mime != IntPtr.Zero)
-				CFObject.CFRelease (mime);
+			CFString.ReleaseNative (mime);
 			return code;
 		}
 
@@ -681,10 +680,9 @@ namespace PrintCore {
 			if (provider == null)
 				throw new ArgumentNullException (nameof (provider));
 				    
-			IntPtr mime = CFString.LowLevelCreate (mimeType);
+			IntPtr mime = CFString.CreateNative (mimeType);
 			var code = PMPrinterPrintWithProvider (handle, settings.handle, pageFormat == null ? IntPtr.Zero : pageFormat.handle, mime, provider.Handle);
-			if (mime != IntPtr.Zero)
-				CFObject.CFRelease (mime);
+			CFString.ReleaseNative (mime);
 			return code;
 		}
 

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4056,7 +4056,7 @@ public partial class Generator : IMemberGatherer {
 	public string GenerateMarshalString (bool probe_null, bool must_copy)
 	{
 		if (must_copy){
-			return "var ns{0} = NSString.CreateNative ({1});\n";
+			return "var ns{0} = CFString.CreateNative ({1});\n";
 		}
 		return
 			"ObjCRuntime.NSStringStruct _s{0}; Console.WriteLine (\"" + CurrentMethod + ": Marshalling: {{1}}\", {1}); \n" +
@@ -4069,7 +4069,7 @@ public partial class Generator : IMemberGatherer {
 	public string GenerateDisposeString (bool probe_null, bool must_copy)
 	{
 		if (must_copy){
-			return "NSString.ReleaseNative (ns{0});\n";
+			return "CFString.ReleaseNative (ns{0});\n";
 		} else 
 			return "if (_s{0}.Flags != 0x010007d1) throw new Exception (\"String was retained, not copied\");";
 	}

--- a/tests/perftest/TollFreeBridge.cs
+++ b/tests/perftest/TollFreeBridge.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using CoreFoundation;
 using Foundation;
@@ -10,32 +11,25 @@ using Bindings.Test;
 
 namespace PerfTest {
 
-	[Register ("StringClass")]
-	class StringClass : NSObject {
-		public override string Description => "constant";
-	}
-
 	public class TollFreeString {
-		IntPtr StringClassClassHandle = Class.GetHandle (typeof (StringClass));
+
+		static readonly NSString empty = new NSString ("");
+		static readonly NSString short_7bits = new NSString ("description");
+		static readonly NSString short_accent = new NSString ("Sébastien");
+		static readonly NSString short_unicode = new NSString ("ЉЩщӃ");
+		static readonly NSString short_emoji = new NSString ("I'm 😃 it works!");
+		static readonly NSString long_string = new NSString (new string ('!', 4096));
 
 		string s;
 
-		StringClass sc;
-		IntPtr description;
-
-		[GlobalSetup]
-		public void ReturnString_Setup ()
+		public IEnumerable<object[]> Handles ()
 		{
-			sc = new StringClass ();
-			description = Messaging.IntPtr_objc_msgSend (sc.Handle, Selector.GetHandle ("description"));
-			Messaging.void_objc_msgSend (description, Selector.GetHandle ("retain"));
-		}
-
-		[GlobalCleanup]
-		public void ReturnString_Cleanup ()
-		{
-			Messaging.void_objc_msgSend (description, Selector.GetHandle ("release"));
-			sc.Dispose ();
+			yield return new object [] { "empty", empty.Handle };
+			yield return new object [] { "short_7bits", short_7bits.Handle };
+			yield return new object [] { "short_accent", short_accent.Handle };
+			yield return new object [] { "short_unicode", short_unicode.Handle };
+			yield return new object [] { "short_emoji", short_emoji.Handle };
+			yield return new object [] { "long_string", long_string.Handle };
 		}
 
 		/*
@@ -43,9 +37,10 @@ namespace PerfTest {
 		 */
 
 		[Benchmark]
-		public string ReturnString_NSString ()
+		[ArgumentsSource (nameof (Handles))]
+		public string NSString_FromString (string name, IntPtr value)
 		{
-			var d = NSString.FromHandle (description);
+			var d = NSString.FromHandle (value);
 			return s = d;
 		}
 
@@ -54,10 +49,45 @@ namespace PerfTest {
 		 */
 
 		[Benchmark]
-		public string ReturnString_CFString ()
+		[ArgumentsSource (nameof (Handles))]
+		public string CFString_FromString (string name, IntPtr value)
 		{
-			var d = CFString.FromHandle (description);
+			var d = CFString.FromHandle (value);
 			return s = d;
+		}
+
+		public IEnumerable<object[]> Strings ()
+		{
+			yield return new object [] { "empty", "" };
+			yield return new object [] { "short_7bits", "Bonjour" };
+			yield return new object [] { "short_accent", "Québec" };
+			yield return new object [] { "short_unicode", "汉语 漢語" };
+			yield return new object [] { "short_emoji", "I'm feeling 🤪 tonight." };
+			yield return new object [] { "long_string", new string ('?', 4096) };
+		}
+
+		/*
+		 * Measure time required to create and release a native string - using NSString (ObjC) selector-based API
+		 */
+
+		[Benchmark]
+		[ArgumentsSource (nameof (Strings))]
+		public void NSString_CreateRelease (string name, string value)
+		{
+			var p = NSString.CreateNative (value);
+			NSString.ReleaseNative (p);
+		}
+
+		/*
+		 * Measure time required to create and release a native string - using CFString (C) p/invoke-based API
+		 */
+
+		[Benchmark]
+		[ArgumentsSource (nameof (Strings))]
+		public void CFString_CreateRelease (string name, string value)
+		{
+			var p = CFString.CreateNative (value);
+			CFString.ReleaseNative (p);
 		}
     }
 }


### PR DESCRIPTION
This is possible because both types are toll-free bridged [0].

How ?

* Renamed `CFString.LowLevelCreate` to `CreateNative` so it match `NSString` API
* Make it public so it can be used for generated/3rd party bindings
* Added a _safe_ `CFString.ReleaseNative` matching `NSString` API
* Update generator to use the new API (instead of the NSString version)
* Update manual bindings (using older API) to use the new API (few in PrintCore)

Why ?

It's no secret that p/invoke (C) are faster than calling a selector
(ObjC). In most cases we do not have a choice what to call... but in a
few, but commonly used, cases we can pick the fastest call.

In this case the difference is larger than the previous case [1] since there's
two call (create and release) involved.

|                 Method |          name |                value |        Mean |       Error |    StdDev |
|----------------------- |-------------- |--------------------- |------------:|------------:|----------:|
| NSString_CreateRelease |         empty |                      |  4,936.1 ns |   349.08 ns |  19.13 ns |
| CFString_CreateRelease |         empty |                      |    243.1 ns |    10.30 ns |   0.56 ns |
| NSString_CreateRelease |   long_string | ????(...)???? [4096] |  8,270.3 ns |   837.09 ns |  45.88 ns |
| CFString_CreateRelease |   long_string | ????(...)???? [4096] |  3,212.4 ns |   213.73 ns |  11.72 ns |
| NSString_CreateRelease |   short_7bits |              Bonjour |  4,858.5 ns | 1,671.67 ns |  91.63 ns |
| CFString_CreateRelease |   short_7bits |              Bonjour |    242.5 ns |    18.36 ns |   1.01 ns |
| NSString_CreateRelease |  short_accent |               Québec |  4,990.1 ns |   343.96 ns |  18.85 ns |
| CFString_CreateRelease |  short_accent |               Québec |    377.6 ns |    15.96 ns |   0.87 ns |
| NSString_CreateRelease |   short_emoji | I'm f(...)ight. [23] |  5,080.2 ns |   794.29 ns |  43.54 ns |
| CFString_CreateRelease |   short_emoji | I'm f(...)ight. [23] |    391.2 ns |     8.60 ns |   0.47 ns |
| NSString_CreateRelease | short_unicode |                汉语 漢語 |  4,980.4 ns |   272.41 ns |  14.93 ns |
| CFString_CreateRelease | short_unicode |                汉语 漢語 |    376.4 ns |    15.98 ns |   0.88 ns |

Also simplified/updated previous tests as suggested in [1].

|                 Method |          name |                value |        Mean |       Error |    StdDev |
|----------------------- |-------------- |--------------------- |------------:|------------:|----------:|
|    NSString_FromString |         empty |      140735350713040 |  2,252.2 ns |   591.63 ns |  32.43 ns |
|    CFString_FromString |         empty |      140735350713040 |    408.4 ns |    47.56 ns |   2.61 ns |
|    NSString_FromString |   long_string |      140295885995872 | 14,887.2 ns |   183.67 ns |  10.07 ns |
|    CFString_FromString |   long_string |      140295885995872 |  7,418.7 ns | 1,844.42 ns | 101.10 ns |
|    NSString_FromString |   short_7bits |  1292713981587835779 |  2,259.8 ns |   210.17 ns |  11.52 ns |
|    CFString_FromString |   short_7bits |  1292713981587835779 |    453.0 ns |   122.77 ns |   6.73 ns |
|    NSString_FromString |  short_accent |      140295885995776 |  2,448.2 ns |    97.43 ns |   5.34 ns |
|    CFString_FromString |  short_accent |      140295885995776 |    256.8 ns |    75.81 ns |   4.16 ns |
|    NSString_FromString |   short_emoji |      140296423669120 |  2,531.6 ns |   199.02 ns |  10.91 ns |
|    CFString_FromString |   short_emoji |      140296423669120 |    259.0 ns |    21.32 ns |   1.17 ns |
|    NSString_FromString | short_unicode |      140295885992304 |  2,426.2 ns |   339.06 ns |  18.58 ns |
|    CFString_FromString | short_unicode |      140295885992304 |    260.6 ns |    97.03 ns |   5.32 ns |

[1] https://github.com/xamarin/xamarin-macios/pull/11809