### PR TITLE
[monotouch-tests] Use a LinkDescription item to specify extra linker description files

### DIFF
--- a/tests/monotouch-test/dotnet/MacCatalyst/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/MacCatalyst/monotouch-test.csproj
@@ -17,7 +17,6 @@
     <DefineConstants Condition="'$(Platform)' != 'iPhoneSimulator'">$(DefineConstants);DEVICE</DefineConstants>
     <RootTestsDirectory>..\..\..</RootTestsDirectory>
     <MtouchLink>None</MtouchLink>
-    <MtouchExtraArgs>-xml=${ProjectDir}/../extra-linker-defs.xml</MtouchExtraArgs>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +32,8 @@
     <None Include="..\..\Entitlements.plist" />
     <None Include="..\..\app.config" />
     <None Include="..\..\EmptyNib.xib" />
+
+    <LinkDescription Include="$(RootTestsDirectory)\monotouch-test\dotnet\extra-linker-defs.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
@@ -17,7 +17,6 @@
     <DefineConstants Condition="'$(Platform)' != 'iPhoneSimulator'">$(DefineConstants);DEVICE</DefineConstants>
     <RootTestsDirectory>..\..\..</RootTestsDirectory>
     <MtouchLink>None</MtouchLink>
-    <MtouchExtraArgs>-xml=${ProjectDir}/../extra-linker-defs.xml</MtouchExtraArgs>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,10 +28,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <LinkDescription Include="$(RootTestsDirectory)\monotouch-test\dotnet\extra-linker-defs.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="Info.plist" />
     <None Include="..\..\Entitlements.plist" />
     <None Include="..\..\app.config" />
     <None Include="..\..\EmptyNib.xib" />
+
+    <LinkDescription Include="$(RootTestsDirectory)\monotouch-test\dotnet\extra-linker-defs.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/monotouch-test/dotnet/tvOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/tvOS/monotouch-test.csproj
@@ -17,7 +17,6 @@
     <DefineConstants Condition="'$(Platform)' != 'iPhoneSimulator'">$(DefineConstants);DEVICE</DefineConstants>
     <RootTestsDirectory>..\..\..</RootTestsDirectory>
     <MtouchLink>None</MtouchLink>
-    <MtouchExtraArgs>-xml=${ProjectDir}/../extra-linker-defs.xml</MtouchExtraArgs>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +32,8 @@
     <None Include="..\..\Entitlements.plist" />
     <None Include="..\..\app.config" />
     <None Include="..\..\EmptyNib.xib" />
+
+    <LinkDescription Include="$(RootTestsDirectory)\monotouch-test\dotnet\extra-linker-defs.xml" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* It's easier to fix up the path to the linker description in xharness when
  cloning project files. This way maybe we'll be able to remove the [hardcoded
  logic in xharness][1] to handle ${ProjectDir}.
* .NET doesn't understand the ${ProjectDir} syntax, so this makes it possible
  to build these projects from the command line.

[1]: https://github.com/dotnet/xharness/blob/b2297d610df1ae15fc7ba8bd8c9bc0a7192aaefa/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs#L1268