### PR TITLE
[tools] Fix quoting quotes in StringUtils.QuoteForProcess.

### DIFF
--- a/tests/mtouch/StringUtilsTest.cs
+++ b/tests/mtouch/StringUtilsTest.cs
@@ -26,5 +26,17 @@ namespace Xamarin.Tests.Utils {
 			v = StringUtils.ParseVersion ("10.13.2");
 			Assert.That (v.ToString (), Is.EqualTo ("10.13.2"), "10.13.2");
 		}
+
+		[Test]
+		public void QuoteForProcess ()
+		{
+			Assert.That (StringUtils.QuoteForProcess ("a"), Is.EqualTo ("a"), "normal");
+			Assert.That (StringUtils.QuoteForProcess ("😁"), Is.EqualTo ("😁"), "😁");
+			Assert.That (StringUtils.QuoteForProcess ("b b"), Is.EqualTo ("\"b b\""), "space");
+			Assert.That (StringUtils.QuoteForProcess ("'"), Is.EqualTo ("\"'\""), "single quote");
+			Assert.That (StringUtils.QuoteForProcess ("\\"), Is.EqualTo ("\"\\\\\""), "backslash");
+			Assert.That (StringUtils.QuoteForProcess ("\""), Is.EqualTo ("\"\\\"\""), "double quote");
+			Assert.That (StringUtils.QuoteForProcess (@"C:\double "" quote\single ' quote\space here\"), Is.EqualTo (@"""C:\\double \"" quote\\single ' quote\\space here\\"""), "windows path");
+		}
 	}
 }

--- a/tools/common/StringUtils.cs
+++ b/tools/common/StringUtils.cs
@@ -84,7 +84,6 @@ namespace Xamarin.Utils {
 			foreach (var c in f) {
 				if (c == '"') {
 					s.Append ('\\');
-					s.Append (c).Append (c);
 				} else if (c == '\\') {
 					s.Append (c);
 				}


### PR DESCRIPTION
Previously quoting a string with a quote:

    a"b

would result in:

    "a\"""b"

There are way too many quotes there.

We'll now get:

    "a\"b"

which is correct.