### PR TITLE
Revert "[tests] Preserve a required method in System.Private.CoreLib to work around a bug in .NET 6. (#10426)"

### DIFF
--- a/tests/monotouch-test/dotnet/MacCatalyst/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/MacCatalyst/monotouch-test.csproj
@@ -32,8 +32,6 @@
     <None Include="..\..\Entitlements.plist" />
     <None Include="..\..\app.config" />
     <None Include="..\..\EmptyNib.xib" />
-
-    <LinkDescription Include="$(RootTestsDirectory)\monotouch-test\dotnet\extra-linker-defs.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/monotouch-test/dotnet/extra-linker-defs.xml
+++ b/tests/monotouch-test/dotnet/extra-linker-defs.xml
@@ -1,9 +1,0 @@
-<linker>
-	<assembly fullname="System.Private.CoreLib">
-		<type fullname="System.Runtime.Loader.AssemblyLoadContext">
-			<!-- https://github.com/dotnet/runtime/issues/46908 -->
-			<!-- native-library.c: netcore_resolve_with_resolving_event () -->
-			<method name="MonoResolveUnmanagedDllUsingEvent" />
-		</type>
-	</assembly>
-</linker>

--- a/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
@@ -28,16 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <LinkDescription Include="$(RootTestsDirectory)\monotouch-test\dotnet\extra-linker-defs.xml" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="Info.plist" />
     <None Include="..\..\Entitlements.plist" />
     <None Include="..\..\app.config" />
     <None Include="..\..\EmptyNib.xib" />
-
-    <LinkDescription Include="$(RootTestsDirectory)\monotouch-test\dotnet\extra-linker-defs.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
@@ -33,8 +33,6 @@
     <None Include="..\..\Entitlements.plist" />
     <None Include="..\..\app.config" />
     <None Include="..\..\EmptyNib.xib" />
-
-    <LinkDescription Include="$(RootTestsDirectory)\monotouch-test\dotnet\extra-linker-defs.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/monotouch-test/dotnet/tvOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/tvOS/monotouch-test.csproj
@@ -32,8 +32,6 @@
     <None Include="..\..\Entitlements.plist" />
     <None Include="..\..\app.config" />
     <None Include="..\..\EmptyNib.xib" />
-
-    <LinkDescription Include="$(RootTestsDirectory)\monotouch-test\dotnet\extra-linker-defs.xml" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This reverts commit 29727d6a8da87f4e9f0db5bb7f8e24929078332d.

https://github.com/dotnet/runtime/issues/46908 was fixed and the other part of the workaround was removed in PR#11958