### PR TITLE
[CI] Sign *.nupkg too. Fixes #11952.

### DIFF
--- a/tools/devops/automation/templates/build/build-nugets.yml
+++ b/tools/devops/automation/templates/build/build-nugets.yml
@@ -1,4 +1,4 @@
-# all steps that are required to build the nugets and publish them
+# all steps that are required to build the nugets
 
 steps:
 
@@ -27,32 +27,3 @@ steps:
     targetPath: $(Build.ArtifactStagingDirectory)/build-binlogs
     artifactName: build-binlogs
   condition: and(succeededOrFailed(), contains(variables['configuration.BuildNugets'], 'True'))
-
-# do not publish on pull requets
-- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-  - task: NuGetCommand@2
-    displayName: 'Publish Nugets to xamarin-impl'
-    inputs:
-      command: push
-      packagesToPush: $(Build.SourcesDirectory)/package/*.nupkg
-      nuGetFeedType: external
-      publishFeedCredentials: xamarin-impl public feed
-    condition: and(succeeded(), eq(variables['configuration.BuildNugets'], 'True'))
-    continueOnError: true # should not stop the build since is not official just yet.
-
-  - task: NuGetCommand@2
-    displayName: 'Publish Nugets to dotnet-eng'
-    inputs:
-      command: push
-      packagesToPush: $(Build.SourcesDirectory)/mlaunch/*.nupkg
-      nuGetFeedType: external
-      publishFeedCredentials: dotnet-eng
-    condition: and(succeeded(), eq(variables['configuration.BuildNugets'], 'True'))
-    continueOnError: true # should not stop the build since is not official just yet.
-
-# Only executed when the publshing of the nugets failed.
-- bash: |
-    echo "##vso[task.setvariable variable=NUGETS_PUBLISHED;isOutput=true]Failed"
-  name: nugetPublishing
-  displayName: 'Failed publishing nugets'
-  condition: failed()

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -334,6 +334,10 @@ steps:
       enableDotnet: ${{ parameters.enableDotnet }}
       keyringPass: ${{ parameters.keyringPass }}
 
+# publish nugets (must be done after signing)
+- ${{ if eq(parameters.enableDotnet, true) }}:
+  - template: publish-nugets.yml
+
 - template: generate-workspace-info.yml@templates
   parameters:
     GitHubToken: $(GitHub.Token)

--- a/tools/devops/automation/templates/build/publish-nugets.yml
+++ b/tools/devops/automation/templates/build/publish-nugets.yml
@@ -1,0 +1,32 @@
+# all steps that are required to publish the nugets
+
+steps:
+
+# do not publish on pull requets
+- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - task: NuGetCommand@2
+    displayName: 'Publish Nugets to xamarin-impl'
+    inputs:
+      command: push
+      packagesToPush: $(Build.SourcesDirectory)/package/*.nupkg
+      nuGetFeedType: external
+      publishFeedCredentials: xamarin-impl public feed
+    condition: and(succeeded(), eq(variables['configuration.BuildNugets'], 'True'))
+    continueOnError: true # should not stop the build since is not official just yet.
+
+  - task: NuGetCommand@2
+    displayName: 'Publish Nugets to dotnet-eng'
+    inputs:
+      command: push
+      packagesToPush: $(Build.SourcesDirectory)/mlaunch/*.nupkg
+      nuGetFeedType: external
+      publishFeedCredentials: dotnet-eng
+    condition: and(succeeded(), eq(variables['configuration.BuildNugets'], 'True'))
+    continueOnError: true # should not stop the build since is not official just yet.
+
+# Only executed when the publishing of the nugets failed.
+- bash: |
+    echo "##vso[task.setvariable variable=NUGETS_PUBLISHED;isOutput=true]Failed"
+  name: nugetPublishing
+  displayName: 'Failed publishing nugets'
+  condition: failed()

--- a/tools/devops/automation/templates/build/sign-and-notarized.yml
+++ b/tools/devops/automation/templates/build/sign-and-notarized.yml
@@ -98,6 +98,7 @@ steps:
   - pwsh : |
       # Get the list of files to sign
       $msiFiles = Get-ChildItem -Path $(Build.SourcesDirectory)/package/ -Filter "*.msi"
+      $nupgkFiles = Get-ChildItem -Path $(Build.SourcesDirectory)/package/ -Filter "*.nupkg"
 
       # Add those files to an array
       $SignFiles = @()
@@ -105,8 +106,13 @@ steps:
           Write-Host "$($msi.FullName)"
           $SignFiles += @{ "SrcPath"="$($msi.FullName)"}
       }
+      foreach($nupkg in $nupkgFiles) {
+          Write-Host "$($nupkg.FullName)"
+          $SignFiles += @{ "SrcPath"="$($nupkg.FullName)"}
+      }
 
       Write-Host "$msiFiles"
+      Write-Host "$nupkgFiles"
 
       # array of dicts
       $SignFileRecord = @(
@@ -123,7 +129,7 @@ steps:
       # Write the json to a file
       ConvertTo-Json -InputObject $SignFileList -Depth 5 | Out-File -FilePath $(Build.ArtifactStagingDirectory)/MsiFiles2Notarize.json -Force
       dotnet $Env:MBSIGN_APPFOLDER/ddsignfiles.dll /filelist:$(Build.ArtifactStagingDirectory)/MsiFiles2Notarize.json
-    displayName: 'Sign .msi'
+    displayName: 'Sign .msi and .nupkg'
 
 - bash: |
     security unlock-keychain -p $PRODUCTSIGN_KEYCHAIN_PASSWORD builder.keychain

--- a/tools/devops/automation/templates/build/sign-and-notarized.yml
+++ b/tools/devops/automation/templates/build/sign-and-notarized.yml
@@ -98,7 +98,7 @@ steps:
   - pwsh : |
       # Get the list of files to sign
       $msiFiles = Get-ChildItem -Path $(Build.SourcesDirectory)/package/ -Filter "*.msi"
-      $nupgkFiles = Get-ChildItem -Path $(Build.SourcesDirectory)/package/ -Filter "*.nupkg"
+      $nupkgFiles = Get-ChildItem -Path $(Build.SourcesDirectory)/package/ -Filter "*.nupkg"
 
       # Add those files to an array
       $SignFiles = @()

--- a/tools/devops/automation/templates/build/sign-and-notarized.yml
+++ b/tools/devops/automation/templates/build/sign-and-notarized.yml
@@ -98,7 +98,6 @@ steps:
   - pwsh : |
       # Get the list of files to sign
       $msiFiles = Get-ChildItem -Path $(Build.SourcesDirectory)/package/ -Filter "*.msi"
-      $nupkgFiles = Get-ChildItem -Path $(Build.SourcesDirectory)/package/ -Filter "*.nupkg"
 
       # Add those files to an array
       $SignFiles = @()
@@ -106,13 +105,8 @@ steps:
           Write-Host "$($msi.FullName)"
           $SignFiles += @{ "SrcPath"="$($msi.FullName)"}
       }
-      foreach($nupkg in $nupkgFiles) {
-          Write-Host "$($nupkg.FullName)"
-          $SignFiles += @{ "SrcPath"="$($nupkg.FullName)"}
-      }
 
       Write-Host "$msiFiles"
-      Write-Host "$nupkgFiles"
 
       # array of dicts
       $SignFileRecord = @(
@@ -129,7 +123,38 @@ steps:
       # Write the json to a file
       ConvertTo-Json -InputObject $SignFileList -Depth 5 | Out-File -FilePath $(Build.ArtifactStagingDirectory)/MsiFiles2Notarize.json -Force
       dotnet $Env:MBSIGN_APPFOLDER/ddsignfiles.dll /filelist:$(Build.ArtifactStagingDirectory)/MsiFiles2Notarize.json
-    displayName: 'Sign .msi and .nupkg'
+    displayName: 'Sign .msi'
+
+- ${{ if eq(parameters.enableDotnet, true) }}:
+  - pwsh : |
+      # Get the list of files to sign
+      $nupkgFiles = Get-ChildItem -Path $(Build.SourcesDirectory)/package/ -Filter "*.nupkg"
+
+      # Add those files to an array
+      $SignFiles = @()
+      foreach($nupkg in $nupkgFiles) {
+          Write-Host "$($nupkg.FullName)"
+          $SignFiles += @{ "SrcPath"="$($nupkg.FullName)"}
+      }
+
+      Write-Host "$nupkgFiles"
+
+      # array of dicts
+      $SignFileRecord = @(
+        @{
+          "Certs" = "401405";
+          "SignFileList" = $SignFiles;
+        }
+      )
+
+      $SignFileList = @{
+          "SignFileRecordList" = $SignFileRecord
+      }
+
+      # Write the json to a file
+      ConvertTo-Json -InputObject $SignFileList -Depth 5 | Out-File -FilePath $(Build.ArtifactStagingDirectory)/NupkgFiles2Notarize.json -Force
+      dotnet $Env:MBSIGN_APPFOLDER/ddsignfiles.dll /filelist:$(Build.ArtifactStagingDirectory)/NupkgFiles2Notarize.json
+    displayName: 'Sign .nupkg'
 
 - bash: |
     security unlock-keychain -p $PRODUCTSIGN_KEYCHAIN_PASSWORD builder.keychain


### PR DESCRIPTION
This required reordering operations a bit, so that we can sign before publishing.

Fixes https://github.com/xamarin/xamarin-macios/issues/11952.