### PR TITLE
[tests][dotnet] Clear packages before building test apps

### DIFF
--- a/tests/dotnet/Makefile
+++ b/tests/dotnet/Makefile
@@ -36,6 +36,7 @@ run-unit-tests:
 all-local:: $(TARGETS)
 
 compare compare-size: $(TARGETS)
+	rm -rf packages
 	cd size-comparison && git clean -xfdq
 	time $(MAKE) build-oldnet
 	time $(MAKE) build-dotnet

--- a/tests/dotnet/README.md
+++ b/tests/dotnet/README.md
@@ -20,3 +20,7 @@ Add this option inside the `Release|iPhone` configuration of `size-comparison/My
 
 If you want to compare (trimmed) size you can manually call `mono-cil-strip`
 on each assembly inside the app bundle.
+
+`make strip-dotnet` will remove the IL from the dotnet app version.
+However this is done after the code signature so it will not be possible
+to deploy and execute the app afterward. Use for binary analysis only!


### PR DESCRIPTION
to make sure the latest locally build nuget are used

Also document `make strip-dotnet` as a time-saver to analyze the binary
assemblies produced for dotnet