### PR TITLE
[corefoundation] Enable nullability on `CFString` and `NativeObject`

### DIFF
--- a/src/CoreFoundation/NativeObject.cs
+++ b/src/CoreFoundation/NativeObject.cs
@@ -13,6 +13,8 @@ using System.Runtime.InteropServices;
 using ObjCRuntime;
 using Foundation;
 
+#nullable enable
+
 namespace CoreFoundation {
 	//
 	// The NativeObject class is intended to be a base class for many CoreFoundation

--- a/src/CoreImage/CIFilter.cs
+++ b/src/CoreImage/CIFilter.cs
@@ -281,13 +281,13 @@ namespace CoreImage {
 #endif
 
 		// Calls the selName selector for cases where we do not have an instance created
-		static internal string GetFilterName (IntPtr filterHandle)
+		static internal string? GetFilterName (IntPtr filterHandle)
 		{
 			return CFString.FromHandle (ObjCRuntime.Messaging.IntPtr_objc_msgSend (filterHandle, Selector.GetHandle ("name")));
 		}
 
 		// TODO could be generated too
-		internal static CIFilter FromName (string filterName, IntPtr handle)
+		internal static CIFilter FromName (string? filterName, IntPtr handle)
 		{
 			switch (filterName){
 			case "CIAdditionCompositing":

--- a/src/CoreImage/CIImage.cs
+++ b/src/CoreImage/CIImage.cs
@@ -117,7 +117,7 @@ namespace CoreImage {
 			var ret = new CIFilter [count];
 			for (nuint i = 0; i < count; i++){
 				IntPtr filterHandle = filters.ValueAt (i);
-				string filterName = CIFilter.GetFilterName (filterHandle);
+				string? filterName = CIFilter.GetFilterName (filterHandle);
 									 
 				ret [i] = CIFilter.FromName (filterName, filterHandle);
 			}

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1748,7 +1748,7 @@ public partial class Generator : IMemberGatherer {
 			}
 			if (pi.ParameterType == TypeManager.System_String){
 				pars.AppendFormat ("IntPtr {0}", safe_name);
-				invoke.AppendFormat ("CFString.FromHandle ({0})", safe_name);
+				invoke.AppendFormat ("CFString.FromHandle ({0})!", safe_name);
 				continue;
 			}
 
@@ -2877,7 +2877,7 @@ public partial class Generator : IMemberGatherer {
 									enumTypeStr + ") num.Int32Value;\n\t}}\n}})";
 								setter = "SetArrayValue<" + enumTypeStr + "> ({0}, value)";
 							} else if (elementType == TypeManager.System_String){
-								getter = "GetArray<string> ({0}, (ptr) => CFString.FromHandle (ptr))";
+								getter = "GetArray<string> ({0}, (ptr) => CFString.FromHandle (ptr)!)";
 								setter = "SetArrayValue ({0}, value)";
 							} else {
 								throw new BindingException (1033, true, pi.PropertyType, dictType, pi.Name);
@@ -3079,7 +3079,7 @@ public partial class Generator : IMemberGatherer {
 					else if (fullname == "CoreGraphics.CGRect")
 						print (GenerateNSValue ("CGRectValue"));
 					else if (is_system_string)
-						print ("return CFString.FromHandle (value);");
+						print ("return CFString.FromHandle (value)!;");
 					else if (propertyType == TypeManager.NSString)
 						print ("return new NSString (value);");
 					else if (propertyType == TypeManager.System_String_Array){
@@ -3819,7 +3819,7 @@ public partial class Generator : IMemberGatherer {
 			cast_b = ", false)";
 		} else if (mai.Type == TypeManager.System_String && !mai.PlainString){
 			cast_a = "CFString.FromHandle (";
-			cast_b = ")";
+			cast_b = ")!";
 		} else if (mi.ReturnType.IsSubclassOf (TypeManager.System_Delegate)){
 			cast_a = "";
 			cast_b = "";
@@ -4291,7 +4291,7 @@ public partial class Generator : IMemberGatherer {
 				if (isString) {
 					if (!pi.IsOut)
 						by_ref_processing.AppendFormat ("if ({0}Value != {0}OriginalValue)\n\t", pi.Name.GetSafeParamName ());
-					by_ref_processing.AppendFormat ("{0} = CFString.FromHandle ({0}Value);\n", pi.Name.GetSafeParamName ());
+					by_ref_processing.AppendFormat ("{0} = CFString.FromHandle ({0}Value)!;\n", pi.Name.GetSafeParamName ());
 				} else if (isArray) {
 					if (!pi.IsOut)
 						by_ref_processing.AppendFormat ("if ({0}Value != ({0}ArrayValue is null ? IntPtr.Zero : {0}ArrayValue.Handle))\n\t", pi.Name.GetSafeParamName ());


### PR DESCRIPTION
then fix the impact this had on existing nullable-aware code,
including the generator

Also
* Hide `CFObject` empty (of public members) for future profiles
* Fix `CFString.ToString ()` to never return `null`