### PR TITLE
[PDFKit] Updating Xcode13 Beta 1

### DIFF
--- a/src/pdfkit.cs
+++ b/src/pdfkit.cs
@@ -317,6 +317,20 @@ namespace PdfKit {
 		Push,
 	}
 
+	[Native]
+	[iOS (15,0), Mac (12,0), MacCatalyst (15,0)]
+	public enum PdfAccessPermissions : ulong
+	{
+		LowQualityPrinting = (1uL << 0),
+		HighQualityPrinting = (1uL << 1),
+		DocumentChanges = (1uL << 2),
+		DocumentAssembly = (1uL << 3),
+		ContentCopying = (1uL << 4),
+		ContentAccessibility = (1uL << 5),
+		Commenting = (1uL << 6),
+		FormFieldEntry = (1uL << 7),
+	}
+
 	[Mac (10,13)]
 	[iOS (11,0)]
 	[Static]
@@ -1157,6 +1171,18 @@ namespace PdfKit {
 		[Notification]
 		NSString DidEndPageWriteNotification { get; }
 
+		[iOS (15,0), Mac (12,0), MacCatalyst (15,0)]
+		[Field ("PDFDocumentFoundSelectionKey")]
+		NSString FoundSelectionKey { get; }
+
+		[iOS (15,0), Mac (12,0), MacCatalyst (15,0)]
+		[Field ("PDFDocumentPageIndexKey")]
+		NSString PageIndexKey { get; }
+
+		[iOS (15,0), Mac (12,0), MacCatalyst (15,0)]
+		[Field ("PDFDocumentAccessPermissionsOption")]
+		NSString AccessPermissionsOption { get; }
+
 		// - (instancetype)init NS_DESIGNATED_INITIALIZER;
 		[Export ("init")]
 		[DesignatedInitializer]
@@ -1182,6 +1208,10 @@ namespace PdfKit {
 		[Export ("documentAttributes", ArgumentSemantic.Copy)]
 		[NullAllowed]
 		NSDictionary DocumentAttributes { get; set; }
+
+		[iOS (15,0), Mac (12,0), MacCatalyst (15,0)]
+		[Export ("accessPermissions")]
+		PdfAccessPermissions AccessPermissions { get; }
 
 		[Wrap ("new PdfDocumentAttributes (DocumentAttributes)")]
 		PdfDocumentAttributes GetDocumentAttributes ();

--- a/src/pdfkit.cs
+++ b/src/pdfkit.cs
@@ -438,6 +438,8 @@ namespace PdfKit {
 
 		string OwnerPassword { get; set; }
 		string UserPassword { get; set; }
+
+		[iOS (15,0), Mac (12,0), MacCatalyst (15,0)]
 		string AccessPermissions { get; set; }
 	}
 

--- a/src/pdfkit.cs
+++ b/src/pdfkit.cs
@@ -425,6 +425,10 @@ namespace PdfKit {
 
 		[Field ("PDFDocumentUserPasswordOption", "+PDFKit")]
 		NSString UserPasswordKey { get; }
+
+		[iOS (15,0), Mac (12,0), MacCatalyst (15,0)]
+		[Field ("PDFDocumentAccessPermissionsOption", "+PDFKit")]
+		NSString AccessPermissionsKey { get; }
 	}
 
 	[Mac (10,13)]
@@ -434,6 +438,7 @@ namespace PdfKit {
 
 		string OwnerPassword { get; set; }
 		string UserPassword { get; set; }
+		string AccessPermissions { get; set; }
 	}
 
 	[Mac (10,13)]
@@ -1178,10 +1183,6 @@ namespace PdfKit {
 		[iOS (15,0), Mac (12,0), MacCatalyst (15,0)]
 		[Field ("PDFDocumentPageIndexKey")]
 		NSString PageIndexKey { get; }
-
-		[iOS (15,0), Mac (12,0), MacCatalyst (15,0)]
-		[Field ("PDFDocumentAccessPermissionsOption")]
-		NSString AccessPermissionsOption { get; }
 
 		// - (instancetype)init NS_DESIGNATED_INITIALIZER;
 		[Export ("init")]

--- a/tests/xtro-sharpie/MacCatalyst-PDFKit.todo
+++ b/tests/xtro-sharpie/MacCatalyst-PDFKit.todo
@@ -1,5 +1,0 @@
-!missing-enum! PDFAccessPermissions not bound
-!missing-field! PDFDocumentAccessPermissionsOption not bound
-!missing-field! PDFDocumentFoundSelectionKey not bound
-!missing-field! PDFDocumentPageIndexKey not bound
-!missing-selector! PDFDocument::accessPermissions not bound

--- a/tests/xtro-sharpie/iOS-PDFKit.todo
+++ b/tests/xtro-sharpie/iOS-PDFKit.todo
@@ -1,5 +1,0 @@
-!missing-enum! PDFAccessPermissions not bound
-!missing-field! PDFDocumentAccessPermissionsOption not bound
-!missing-field! PDFDocumentFoundSelectionKey not bound
-!missing-field! PDFDocumentPageIndexKey not bound
-!missing-selector! PDFDocument::accessPermissions not bound

--- a/tests/xtro-sharpie/macOS-PDFKit.todo
+++ b/tests/xtro-sharpie/macOS-PDFKit.todo
@@ -1,5 +1,0 @@
-!missing-enum! PDFAccessPermissions not bound
-!missing-field! PDFDocumentAccessPermissionsOption not bound
-!missing-field! PDFDocumentFoundSelectionKey not bound
-!missing-field! PDFDocumentPageIndexKey not bound
-!missing-selector! PDFDocument::accessPermissions not bound


### PR DESCRIPTION
Wasn't sure if the PdfAccessPermissions type should be ulong.
Sharpie gave it the ulong type and used the `(1uL << #)` but the original header used NSUInteger which according to [this](https://docs.microsoft.com/en-us/xamarin/cross-platform/macios/binding/objective-c-libraries?context=xamarin%2Fios&tabs=macos#simple-types) should be `nuint`