### PR TITLE
[dotnet] Only limit the default inclusion items with a condition on 'EnableDefault<Platform>Items'. Fixes #11990.

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
+++ b/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
@@ -32,7 +32,7 @@
 	</ItemGroup>
 
 	<!-- Default Asset Catalog file inclusion -->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == '@PLATFORM@' And '$(_EnableDefaultXamarinItems)' == 'true' ">
+	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
 		<ImageAsset Include="**\*.xcassets\**\*.png;**\*.xcassets\*\*.jpg;**\*.xcassets\**\*.pdf;**\*.xcassets\**\*.json" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)">
 			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
 			<Visible>false</Visible>
@@ -57,7 +57,7 @@
 	</ItemGroup>
 
 	<!-- Default CoreMLModel inclusion -->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == '@PLATFORM@' And '$(_EnableDefaultXamarinItems)' == 'true' ">
+	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
 		<CoreMLModel Include="**\*.mlmodel" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
 			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
 			<IsDefaultItem>true</IsDefaultItem>
@@ -65,7 +65,7 @@
 	</ItemGroup>
 
 	<!-- Default Metal inclusion -->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == '@PLATFORM@' And '$(_EnableDefaultXamarinItems)' == 'true' ">
+	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
 		<Metal Include="**\*.metal" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
 			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
 			<IsDefaultItem>true</IsDefaultItem>
@@ -73,7 +73,7 @@
 	</ItemGroup>
 
 	<!-- Default SceneKit assets inclusion -->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == '@PLATFORM@' And '$(_EnableDefaultXamarinItems)' == 'true' ">
+	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
 		<SceneKitAsset Include="**\*.scnassets\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
 			<IsDefaultItem>true</IsDefaultItem>
 		</SceneKitAsset>

--- a/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
+++ b/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
@@ -18,14 +18,14 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<!-- Default plist file inclusion -->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == '@PLATFORM@' And '$(_EnableDefaultXamarinItems)' == 'true'">
+	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
 		<None Include="*.plist">
 			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
 		</None>
 	</ItemGroup>
 
 	<!-- Default SceneKit assets inclusion -->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == '@PLATFORM@' And '$(_EnableDefaultXamarinItems)' == 'true'">
+	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
 		<SceneKitAsset Include="**\*.scnassets\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
 			<IsDefaultItem>true</IsDefaultItem>
 		</SceneKitAsset>
@@ -41,7 +41,7 @@
 	</ItemGroup>
 
 	<!-- Default Storyboard file inclusion -->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == '@PLATFORM@' And '$(_EnableDefaultXamarinItems)' == 'true'">
+	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
 		<InterfaceDefinition Include="**\*.storyboard;**\*.xib" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
 			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
 			<IsDefaultItem>true</IsDefaultItem>
@@ -49,7 +49,7 @@
 	</ItemGroup>
 
 	<!-- Default Atlas Texture file inclusion -->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == '@PLATFORM@' And '$(_EnableDefaultXamarinItems)' == 'true'">
+	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
 		<AtlasTexture Include="**\*.atlas\*.png" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
 			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
 			<IsDefaultItem>true</IsDefaultItem>

--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -10,11 +10,6 @@
     <EnableDefaultwatchOSItems Condition=" '$(_PlatformName)' == 'watchOS' And '$(EnableDefaultwatchOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaultwatchOSItems>
     <EnableDefaultmacOSItems Condition=" '$(_PlatformName)' == 'macOS' And '$(EnableDefaultmacOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaultmacOSItems>
     <EnableDefaultMacCatalystItems Condition=" '$(_PlatformName)' == 'MacCatalyst' And '$(EnableDefaultMacCatalystItems)' == '' ">$(EnableDefaultItems)</EnableDefaultMacCatalystItems>
-    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'iOS' ">$(EnableDefaultiOSItems)</_EnableDefaultXamarinItems>
-    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'tvOS' ">$(EnableDefaulttvOSItems)</_EnableDefaultXamarinItems>
-    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'watchOS' ">$(EnableDefaultwatchOSItems)</_EnableDefaultXamarinItems>
-    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'macOS' ">$(EnableDefaultmacOSItems)</_EnableDefaultXamarinItems>
-    <_EnableDefaultXamarinItems Condition=" '$(_PlatformName)' == 'MacCatalyst' ">$(EnableDefaultMacCatalystItems)</_EnableDefaultXamarinItems>
 
     <!-- Don't include default Compile items for binding projects, because that would pick up ApiDefinition.cs and StructsAndEnums.cs -->
     <EnableDefaultCompileItems Condition=" '$(IsBindingProject)' == 'true' ">false</EnableDefaultCompileItems>


### PR DESCRIPTION
* This is the way Android does it:
  https://github.com/xamarin/xamarin-android/blob/15b40af7d62e0e2003d2a009576834a71967dbb2/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props#L23
* Makes it easier for the default inclusion logic to be used by
  Xamarin.Legacy.Sdk (as explained in the fixed issue).

Fixes https://github.com/xamarin/xamarin-macios/issues/11990.