### PR TITLE
[dotnet] Normalize run target assembly path on the Run target for Mac Catalyst

### DIFF
--- a/dotnet/Microsoft.MacCatalyst.Sdk/targets/Microsoft.MacCatalyst.Sdk.targets
+++ b/dotnet/Microsoft.MacCatalyst.Sdk/targets/Microsoft.MacCatalyst.Sdk.targets
@@ -4,6 +4,6 @@
 
   <PropertyGroup>
     <RunCommand>open</RunCommand>
-    <RunArguments>$([MSBuild]::NormalizePath($(OutputPath)/$(AssemblyName).app))</RunArguments>
+    <RunArguments>$(TargetDir)/$(AssemblyName).app</RunArguments>
   </PropertyGroup>
 </Project>

--- a/dotnet/Microsoft.MacCatalyst.Sdk/targets/Microsoft.MacCatalyst.Sdk.targets
+++ b/dotnet/Microsoft.MacCatalyst.Sdk/targets/Microsoft.MacCatalyst.Sdk.targets
@@ -4,6 +4,6 @@
 
   <PropertyGroup>
     <RunCommand>open</RunCommand>
-    <RunArguments>$(OutputPath)/$(AssemblyName).app</RunArguments>
+    <RunArguments>$([MSBuild]::NormalizePath($(OutputPath)/$(AssemblyName).app))</RunArguments>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fix: https://github.com/dotnet/maui/issues/1238
ref: https://github.com/xamarin/xamarin-macios/pull/10724

It appears that target file is not currently resolving OS-dependent paths, so the final path contains the backslash used by Windows.

```
02:04:30.631     0>プロセス = "/usr/local/share/dotnet/dotnet"
                   MSBuild 実行可能ファイルのパス = "/usr/local/share/dotnet/sdk/6.0.100-preview.5.21302.13/MSBuild.dll"
                   コマンド ライン引数 = "/usr/local/share/dotnet/sdk/6.0.100-preview.5.21302.13/dotnet.dll run -v diag -f net6.0-maccatalyst --project MAUICameraSetting"
                   現在のディレクトリ = "/Users/yamachu/Projects/github.com/yamachu/MAUICameraSetting"
                   MSBuild バージョン = "17.0.0-preview-21302-02+018bed83d"
                   SDK 'Microsoft.NET.Sdk.Razor' を解決しています...
                   SDK 'Microsoft.NET.Sdk' を解決しています...
                   プロパティの再代入: $(MSBuildProjectExtensionsPath)="/Users/yamachu/Projects/github.com/yamachu/MAUICameraSetting/MAUICameraSetting/obj/" (以前の値: "obj\") /usr/local/share/dotnet/sdk/6.0.100-preview.5.21302.13/Current/Microsoft.Common.props (57,5)
                   SDK 'Microsoft.NET.SDK.WorkloadAutoImportPropsLocator' を解決しています...
                   SDK 'Microsoft.NET.ILLink.Tasks' を解決しています...
                   プロパティの再代入: $(TargetsForTfmSpecificContentInPackage)=";PackTool;_PackProjectToolValidation" (以前の値: ";PackTool") /usr/local/share/dotnet/sdk/6.0.100-preview.5.21302.13/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.PackProjectTool.props (15,5)
                   プロパティの再代入: $(DefaultItemExcludes)=";**\node_modules\**;node_modules\**;**\jspm_packages\**;jspm_packages\**" (以前の値: ";**\node_modules\**;node_modules\**") /usr/local/share/dotnet/sdk/6.0.100-preview.5.21302.13/Sdks/Microsoft.NET.Sdk.Razor/Sdk/Sdk.Razor.StaticAssets.ProjectSystem.props (23,5)
                   プロパティの再代入: $(DefaultItemExcludes)=";**\node_modules\**;node_modules\**;**\jspm_packages\**;jspm_packages\**;**\bower_components\**;bower_components\**" (以前の値: ";**\node_modules\**;node_modules\**;**\jspm_packages\**;jspm_packages\**") /usr/local/share/dotnet/sdk/6.0.100-preview.5.21302.13/Sdks/Microsoft.NET.Sdk.Razor/Sdk/Sdk.Razor.StaticAssets.ProjectSystem.props (24,5)
                   プロパティの再代入: $(OutputType)="Exe" (以前の値: "Library") /Users/yamachu/Projects/github.com/yamachu/MAUICameraSetting/MAUICameraSetting/MAUICameraSetting.csproj (21,3)
                   プロパティの再代入: $(PublishProfileImported)="false" (以前の値: "true") /usr/local/share/dotnet/sdk/6.0.100-preview.5.21302.13/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.ImportPublishProfile.targets (28,5)
                   プロパティの再代入: $(TargetPlatformVersion)="" (以前の値: "0.0") /usr/local/share/dotnet/sdk/6.0.100-preview.5.21302.13/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets (65,5)
                   プロパティの再代入: $(DefaultItemExcludes)=";**\node_modules\**;node_modules\**;**\jspm_packages\**;jspm_packages\**;**\bower_components\**;bower_components\**;bin\Debug//**" (以前の値: ";**\node_modules\**;node_modules\**;**\jspm_packages\**;jspm_packages\**;**\bower_components\**;bower_components\**") /usr/local/share/dotnet/sdk/6.0.100-preview.5.21302.13/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets (222,5)
                   プロパティの再代入: $(DefaultItemExcludes)=";**\node_modules\**;node_modules\**;**\jspm_packages\**;jspm_packages\**;**\bower_components\**;bower_components\**;bin\Debug//**;obj\Debug//**" (以前の値: ";**\node_modules\**;node_modules\**;**\jspm_packages\**;jspm_packages\**;**\bower_components\**;bower_components\**;bin\Debug//**") /usr/local/share/dotnet/sdk/6.0.100-preview.5.21302.13/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets (223,5)
                   プロパティの再代入: $(IntermediateOutputPath)="obj\Debug/net6.0-maccatalyst/" (以前の値: "obj\Debug/") /usr/local/share/dotnet/sdk/6.0.100-preview.5.21302.13/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets (241,5)
                   プロパティの再代入: $(OutputPath)="bin\Debug/net6.0-maccatalyst/" (以前の値: "bin\Debug/") /usr/local/share/dotnet/sdk/6.0.100-preview.5.21302.13/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets (242,5)
                   プロパティの再代入: $(IntermediateOutputPath)="obj\Debug/net6.0-maccatalyst/maccatalyst-x64/" (以前の値: "obj\Debug/net6.0-maccatalyst/") /usr/local/share/dotnet/sdk/6.0.100-preview.5.21302.13/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets (222,5)
                   プロパティの再代入: $(OutputPath)="bin\Debug/net6.0-maccatalyst/maccatalyst-x64/" (以前の値: "bin\Debug/net6.0-maccatalyst/") /usr/local/share/dotnet/sdk/6.0.100-preview.5.21302.13/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets (223,5)
```

finally this logs shows that
```
The file /Users/yamachu/Projects/github.com/yamachu/MAUICameraSetting/bin\Debug/net6.0-maccatalyst/maccatalyst-x64/MAUICameraSetting.app does not exist.
```

It may be possible to solve this problem by redefining the delimiter used in MSBuild on top of target, as in the following link code, but I don't know the extent of the impact such as building process on Windows.
Therefore, I decided to modify the path of the Run target.

https://github.com/dotnet/sdk/blob/ca20b2485314865bdb989c3cc2d60de679d5880c/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets#L198-L203

Environment
Microsoft.MacCatalyst.Sdk 14.5.100-preview.5.894
dotnet 6.0.100-preview.5.21302.13