### PR TITLE
[release/6.0.1xx-preview6] [dotnet] use copyOnly for .png files in templates

### DIFF
--- a/dotnet/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/template.json
+++ b/dotnet/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/template.json
@@ -11,6 +11,13 @@
     "type": "project"
   },
   "sourceName": "MacCatalystApp1",
+  "sources": [
+    {
+      "source": "./",
+      "target": "./",
+      "copyOnly": "**/*.png"
+    }
+  ],
   "preferNameDirectory": true,
   "primaryOutputs": [
     { "path": "MacCatalystApp1.csproj" }

--- a/dotnet/Microsoft.iOS.Templates/ios/.template.config/template.json
+++ b/dotnet/Microsoft.iOS.Templates/ios/.template.config/template.json
@@ -11,6 +11,13 @@
       "type": "project"
     },
     "sourceName": "iOSApp1",
+    "sources": [
+      {
+        "source": "./",
+        "target": "./",
+        "copyOnly": "**/*.png"
+      }
+    ],
     "preferNameDirectory": true,
     "primaryOutputs": [
       { "path": "iOSApp1.csproj" }

--- a/dotnet/Microsoft.macOS.Templates/macos/.template.config/template.json
+++ b/dotnet/Microsoft.macOS.Templates/macos/.template.config/template.json
@@ -11,6 +11,13 @@
       "type": "project"
     },
     "sourceName": "macOSApp1",
+    "sources": [
+      {
+        "source": "./",
+        "target": "./",
+        "copyOnly": "**/*.png"
+      }
+    ],
     "preferNameDirectory": true,
     "primaryOutputs": [
       { "path": "macOSApp1.csproj" }

--- a/dotnet/Microsoft.tvOS.Templates/tvos/.template.config/template.json
+++ b/dotnet/Microsoft.tvOS.Templates/tvos/.template.config/template.json
@@ -11,6 +11,13 @@
     "type": "project"
   },
   "sourceName": "tvOSApp1",
+  "sources": [
+    {
+      "source": "./",
+      "target": "./",
+      "copyOnly": "**/*.png"
+    }
+  ],
   "preferNameDirectory": true,
   "primaryOutputs": [
     { "path": "tvOSApp1.csproj" }


### PR DESCRIPTION
Context: https://github.com/dotnet/templating/issues/3325
Context: https://github.com/dotnet/templating/wiki/Reference-for-template.json#content-manipulation

In current .NET 6 Preview 6 builds, there is an issue if a template
includes a binary file larger than ~8kb, it seems to get truncated when
`dotnet new` extracts the template.

A workaround is to use the `copyOnly` feature for binary files. Really,
we should be doing this anyway, because otherwise the templating system
considers replacing *text* in these binary files. It improves
performance to do this and would hopefully prevent a future bug of
random bytes getting replaced.


Backport of #12016
