### PR TITLE
[dotnet] Fix launching macOS and Mac Catalyst apps with arguments.

### DIFF
--- a/dotnet/Microsoft.MacCatalyst.Sdk/targets/Microsoft.MacCatalyst.Sdk.targets
+++ b/dotnet/Microsoft.MacCatalyst.Sdk/targets/Microsoft.MacCatalyst.Sdk.targets
@@ -4,6 +4,6 @@
 
   <PropertyGroup>
     <RunCommand>open</RunCommand>
-    <RunArguments>$(TargetDir)/$(AssemblyName).app</RunArguments>
+    <RunArguments>$(TargetDir)/$(AssemblyName).app --args</RunArguments>
   </PropertyGroup>
 </Project>

--- a/dotnet/Microsoft.macOS.Sdk/targets/Microsoft.macOS.Sdk.targets
+++ b/dotnet/Microsoft.macOS.Sdk/targets/Microsoft.macOS.Sdk.targets
@@ -4,6 +4,6 @@
 
   <PropertyGroup>
     <RunCommand>open</RunCommand>
-    <RunArguments>$(OutputPath)/$(AssemblyName).app</RunArguments>
+    <RunArguments>$(OutputPath)/$(AssemblyName).app --args</RunArguments>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
When we're using 'open' to launch apps, we need to use '--args ...' to pass any additional argument to the app, because otherwise 'open' will try to open those arguments as if they were files:

```
$ open "/Applications/Sublime Text.app" helloworld
The file /Users/rolf/test/helloworld does not exist.
```

(and doesn't launch Sublime Text).

while this works:

```
$ open "/Applications/Sublime Text.app" --args helloworld
```

in that it opens Sublime Text.

It's also possible to not append any other arguments, so this:

```
$ open "/Applications/Sublime Text.app" --args
```

while it looks weird, it works just fine.

Ref: https://github.com/dotnet/sdk/issues/18437