### PR TITLE
[src] Remove the internal NSObject.SetAsProxy, and call the NSObject.IsDirectBinding setter directly.

### DIFF
--- a/src/Foundation/NSObject.mac.cs
+++ b/src/Foundation/NSObject.mac.cs
@@ -113,10 +113,6 @@ namespace Foundation {
 		[Obsolete ("Use PlatformAssembly for easier code sharing across platforms.")]
 		public static readonly Assembly MonoMacAssembly = typeof (NSObject).Assembly;
 #endif
-
-		internal void SetAsProxy () {
-			IsDirectBinding = true;
-		}
 #endif // !COREBUILD
 	}
 }

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4662,7 +4662,7 @@ public partial class Generator : IMemberGatherer {
 			print (sw, by_ref_processing.ToString ());
 		if (use_temp_return) {
 			if (AttributeManager.HasAttribute<ProxyAttribute> (AttributeManager.GetReturnTypeCustomAttributes (mi)))
-				print ("ret.SetAsProxy ();");
+				print ("ret.IsDirectBinding = true;");
 
 			if (mi.ReturnType.IsSubclassOf (TypeManager.System_Delegate)) {
 				print ("return global::ObjCRuntime.Trampolines.{0}.Create (ret)!;", trampoline_info.NativeInvokerName);


### PR DESCRIPTION
NSObject.SetAsProxy is only available for macOS, so this makes the generated
code behave (and actually work) on all platforms.