### PR TITLE
[dotnet] Use TargetDir instead of OutputPath for resolving assembly output directory.

### DIFF
--- a/dotnet/Microsoft.macOS.Sdk/targets/Microsoft.macOS.Sdk.targets
+++ b/dotnet/Microsoft.macOS.Sdk/targets/Microsoft.macOS.Sdk.targets
@@ -4,6 +4,6 @@
 
   <PropertyGroup>
     <RunCommand>open</RunCommand>
-    <RunArguments>$(OutputPath)/$(AssemblyName).app --args</RunArguments>
+    <RunArguments>$(TargetDir)/$(AssemblyName).app --args</RunArguments>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
OutputPath is relative to the project directory, so it doesn't work when the
current directory isn't the same as the project directory.

TargetDir is an absolute directory.

Ref: #11994 / 096c75f425e54bd20b82fc601f3bce52c9b3f8bc (same for Mac Catalyst).