### PR TITLE
[CI] Changing Cron Job's Occurrence

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -207,7 +207,7 @@ schedules:
 
 # the translations team wants a green build, we can do that on sundays even if 
 # the code did not change and without the device tests.
-- cron: "0 12 * * 0"
+- cron: "0 18 * * 1-5,0"
   displayName: Weekly Translations build (Sunday @ noon)
   branches:
     include:


### PR DESCRIPTION
This change will trigger the scheduled build at 1800 UTC (8:00 pm in Spain, 2 pm EST) on every day-of-week from Monday through Friday and also on Sunday. This will give me more chances to debug what is going on with the OneLocBuild inputs!