### PR TITLE
[release/6.0.1xx-preview6] [dotnet] add missing workload dependencies

### DIFF
--- a/dotnet/targets/WorkloadManifest.MacCatalyst.template.json
+++ b/dotnet/targets/WorkloadManifest.MacCatalyst.template.json
@@ -7,6 +7,9 @@
 				"Microsoft.@PLATFORM@.Sdk",
 				"Microsoft.@PLATFORM@.Ref",
 				"Microsoft.@PLATFORM@.Templates"
+			],
+			"extends": [ 
+				"microsoft-net-runtime-maccatalyst"
 			]
 		}
 	},

--- a/dotnet/targets/WorkloadManifest.macOS.template.json
+++ b/dotnet/targets/WorkloadManifest.macOS.template.json
@@ -7,6 +7,9 @@
 				"Microsoft.@PLATFORM@.Sdk",
 				"Microsoft.@PLATFORM@.Ref",
 				"Microsoft.@PLATFORM@.Templates"
+			],
+			"extends": [ 
+				"microsoft-net-runtime-mono-tooling"
 			]
 		}
 	},


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/blob/36e0432547d7d734ef23fce40e8c278ef80c34c8/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in

When using the MacCatalyst workload, you hit the build error:

    error NETSDK1147: To build this project, the following workloads must be installed: microsoft-net-runtime-maccatalyst

I found an `extends` was missing in `WorkloadManifest.json`.

I also found the macOS workload needs to extend
`microsoft-net-runtime-mono-tooling`, because of its usage of
`<RuntimeConfigParserTask/>`


Backport of #12045
