### PR TITLE
[builds] Use the dotnet-install.sh script to install .NET locally.

### DIFF
--- a/builds/.gitignore
+++ b/builds/.gitignore
@@ -1,3 +1,4 @@
+dotnet-install.sh
 BundledNETCorePlatformsPackageVersion.txt
 downloads
 .stamp*

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -27,7 +27,6 @@ DOWNLOADS = \
 	downloads/$(MONO_IOS_FILENAME) \
 	downloads/$(MONO_MAC_FILENAME) \
 	downloads/$(MONO_MACCATALYST_FILENAME) \
-	downloads/$(DOTNET6_TARBALL_NAME) \
 
 # This target downloads the mono archives, there's one for Xamarin.iOS and one for Xamarin.Mac.
 # If doing many clean builds, it's possible to copy the downloaded zip file to ~/Library/Caches/xamarin-macios
@@ -65,16 +64,6 @@ downloads/%: downloads/%.7z
 	$(Q) mv $@.tmp $@
 	$(Q) echo "Unzipped $*."
 
-downloads/%: downloads/%.tar.gz
-	$(Q) echo "Untarring $*..."
-	$(Q) rm -Rf $@.tmp
-	$(Q) mkdir -p $@.tmp
-	$(Q) tar xf $< -C $@.tmp
-	$(Q) xattr -s -d -r com.apple.quarantine $@.tmp
-	$(Q) find $@.tmp -exec touch {} +
-	$(Q) mv $@.tmp $@
-	$(Q) echo "Untarred $*."
-
 downloads/%: downloads/%.nupkg
 	$(Q) echo "Unzipping $*..."
 	$(Q) rm -Rf $@.tmp
@@ -82,6 +71,18 @@ downloads/%: downloads/%.nupkg
 	$(Q) find $@.tmp -exec touch {} +
 	$(Q) mv $@.tmp $@
 	$(Q) echo "Unzipped $*."
+
+downloads/$(basename $(basename $(DOTNET6_TARBALL_NAME))): dotnet-install.sh
+	$(Q) echo "Downloading and installing .NET $(DOTNET6_VERSION) into $@..."
+	$(Q) ./dotnet-install.sh --install-dir "$@.tmp" --version "$(DOTNET6_VERSION)" --architecture x64 --no-path
+	$(Q) rm -Rf "$@"
+	$(Q) mv "$@.tmp" "$@"
+	$(Q) echo "Downloaded and installed .NET $(DOTNET6_VERSION) into $@."
+
+dotnet-install.sh: Makefile
+	$(Q) curl --retry 20 --retry-delay 2 --connect-timeout 15 -S -L $(if $(V),-v,-s) https://dot.net/v1/dotnet-install.sh --output $@.tmp
+	$(Q) chmod +x $@.tmp
+	$(Q) mv $@.tmp $@
 
 # Fix the BCL assemblies we get for Mac Catalyst
 fix-maccatalyst-assembly/bin/Debug/fix-maccatalyst-assembly.exe: $(wildcard fix-maccatalyst-assembly/*.cs*) Makefile


### PR DESCRIPTION
Hopefully this will solve issues with random curl errors (56) that happens
when trying to download .NET (and which break the build randomly).