### PR TITLE
[generator] Adjust generated code to not assume that only device-specific code can be ARM64.

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3972,35 +3972,38 @@ public partial class Generator : IMemberGatherer {
 
 		if (need_multi_path) {
 			if (is_stret_multi) {
-				print ("if (Runtime.Arch == Arch.DEVICE) {");
-				indent++;
-				if (BindingTouch.CurrentPlatform == PlatformName.WatchOS) {
-					print ("if (global::ObjCRuntime.Runtime.IsARM64CallingConvention) {");
-				} else {
-					print ("if (IntPtr.Size == 8) {");
-
-				}
+				// First check for arm64
+				print ("if (global::ObjCRuntime.Runtime.IsARM64CallingConvention) {");
 				indent++;
 				GenerateInvoke (false, supercall, mi, minfo, selector, args [index64], assign_to_temp, category_type, false, EnumMode.Bit64);
 				indent--;
-				print ("} else {");
+				// If we're not arm64, but we're 64-bit, then we're x86_64
+				print ("} else if (IntPtr.Size == 8) {");
+				indent++;
+				GenerateInvoke (x64_stret, supercall, mi, minfo, selector, args[index64], assign_to_temp, category_type, aligned && x64_stret, EnumMode.Bit64);
+				indent--;
+				// if we're not 64-bit, but we're on device, then we're 32-bit arm
+				print ("} else if (Runtime.Arch == Arch.DEVICE) {");
 				indent++;
 				GenerateInvoke (arm_stret, supercall, mi, minfo, selector, args [0], assign_to_temp, category_type, aligned && arm_stret, EnumMode.Bit32);
 				indent--;
-				print ("}");
+				// if we're none of the above, we're x86
+				print ("} else {");
+				indent++;
+				GenerateInvoke (x86_stret, supercall, mi, minfo, selector, args[0], assign_to_temp, category_type, aligned && x86_stret, EnumMode.Bit32);
 				indent--;
-				print ("} else if (IntPtr.Size == 8) {");
+				print ("}");
 			} else {
 				print ("if (IntPtr.Size == 8) {");
+				indent++;
+				GenerateInvoke (x64_stret, supercall, mi, minfo, selector, args[index64], assign_to_temp, category_type, aligned && x64_stret, EnumMode.Bit64);
+				indent--;
+				print ("} else {");
+				indent++;
+				GenerateInvoke (x86_stret, supercall, mi, minfo, selector, args[0], assign_to_temp, category_type, aligned && x86_stret, EnumMode.Bit32);
+				indent--;
+				print ("}");
 			}
-			indent++;
-			GenerateInvoke (x64_stret, supercall, mi, minfo, selector, args[index64], assign_to_temp, category_type, aligned && x64_stret, EnumMode.Bit64);
-			indent--;
-			print ("} else {");
-			indent++;
-			GenerateInvoke (x86_stret, supercall, mi, minfo, selector, args[0], assign_to_temp, category_type, aligned && x86_stret, EnumMode.Bit32);
-			indent--;
-			print ("}");
 		} else {
 			GenerateInvoke (false, supercall, mi, minfo, selector, args[0], assign_to_temp, category_type, false);
 		}


### PR DESCRIPTION
We can have ARM64 code everywhere now, so our conditions to select the correct
objc_msgSend overload must not think that we only need the ARM64 code paths on
a mobile device.

Old style:

	if (Runtime.Arch == Arch.DEVICE) {
		if (IntPtr.Size == 8) {
			// arm64 codepath
		} else {
			// 32-bit arm codepath
		}
	} else if (IntPtr.Size == 8) {
		// x86_64 codepath
	} else {
		// x86 codepath
	}

New style:

	if (global::ObjCRuntime.Runtime.IsARM64CallingConvention) {
		// arm64 codepath
	} else if (IntPtr.Size == 8) {
		// x86_64 codepath
	} else if (Runtime.Arch == Arch.DEVICE) {
		// 32-bit arm codepath
	} else {
		// x86 codepath
	}