### PR TITLE
[CI] Adding GithubActions[bot] to Bypass Label Verification

### DIFF
--- a/.github/workflows/label-checker.yml
+++ b/.github/workflows/label-checker.yml
@@ -17,7 +17,7 @@ jobs:
     - run: exit 0
       name: 'Monojenkins PR'
       # always happy if monojenkins
-      if: github.actor == 'vs-mobiletools-engineering-service2'
+      if: github.actor == 'vs-mobiletools-engineering-service2' || github.actor == 'github-actions[bot]'
 
     - run: exit 1
       name: 'User PR with no labels'


### PR DESCRIPTION
Although the github actions bot successfully automatically adds 2 labels to this PR, the PR check github action did not accept it. When I added a new label (or perhaps removed one and added it back) and then ran that check, it passed.

I think somewhere along the formation of the PR, the check is missing it. I propose adding github actions bot to the ignore labels portion