### PR TITLE
[dotnet] don't import RuntimeConfigParser.Task for MacCatalyst

### DIFF
--- a/dotnet/Workloads/Microsoft.NET.Sdk.MacCatalyst/WorkloadManifest.targets
+++ b/dotnet/Workloads/Microsoft.NET.Sdk.MacCatalyst/WorkloadManifest.targets
@@ -1,8 +1,6 @@
 <Project>
 	<Import Project="Sdk.props" Sdk="Microsoft.MacCatalyst.Sdk" Condition="'$(TargetPlatformIdentifier)' == 'MacCatalyst'" />
 
-	<Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.RuntimeConfigParser.Task" Condition="'$(TargetPlatformIdentifier)' == 'MacCatalyst'" />
-
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">
 		<SdkSupportedTargetPlatformIdentifier Include="maccatalyst" DisplayName="Mac Catalyst" />
 	</ItemGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/blob/ae5ee8f02d6fc99469e1f194be45b5f649c2da1a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets#L30-L32

Building dotnet/maui, I get warnings for any MacCatalyst projects:

    WorkloadManifest.targets(22,9): warning MSB4011: "C:\src\maui\bin\dotnet\packs\Microsoft.NET.Runtime.RuntimeConfigParser.Task\6.0.0-preview.6.21352.12\Sdk\Sdk.props" cannot be imported again.
    It was already imported at "C:\src\maui\bin\dotnet\sdk-manifests\6.0.100\microsoft.net.sdk.maccatalyst\WorkloadManifest.targets (8,2)". This is most likely a build authoring error. This subsequent import will be ignored.

I believe we can remove this `<Import/>` now, as the Mono workload is
doing the importing for MacCatalyst.

It appears that this is still needed for the macOS workload, however.