### PR TITLE
[xtro] Do not allow to leave empty todo files in xtro.

### DIFF
--- a/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
+++ b/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.IO;
 
@@ -169,6 +170,17 @@ namespace Extrospection {
 			}
 		}
 
+		static void NoEmptyTodo ()
+		{
+			foreach (var file in Directory.GetFiles (directory, "*.todo")) {
+				if (!IsIncluded (file))
+					continue;
+				if (!(File.ReadLines(file).Count() > 0)) {
+					Log ($"?empty-todo? File '{Path.GetFileName (file)}' is empty. Empty todo files should be removed.");
+				}
+			}
+		}
+
 		static string directory;
 		static Dictionary<string, List<string>> commons = new Dictionary<string, List<string>> ();
 		static int count;
@@ -300,6 +312,9 @@ namespace Extrospection {
 
 			// entries in .todo should be found in .raw files - else it's likely fixed (and out of date)
 			NoFixedTodo ();
+
+			// empty files should be removed
+			NoEmptyTodo ();
 
 			if (count == 0)
 				Console.WriteLine ("Sanity check passed");


### PR DESCRIPTION
To avoid things like the ones fixed in https://github.com/xamarin/xamarin-macios/pull/12088 we add a new
test to ensure that todo files do have content.

PS: PR will fail until https://github.com/xamarin/xamarin-macios/pull/12088 is merge, but that is a nice test :) 

Example output:
```
[14:56] Manuel de la Pena Saenz
rm -f *.unclassified
/Applications/Xcode_13.0.0-beta2.app/Contents/Developer/usr/bin/make -j8 classify-ios classify-tvos classify-watchos classify-macos classify-maccatalyst
mono64 --debug bin/Debug/xtro-sharpie.exe iphoneos15.0-arm64.pch ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/64bits/iOS/Xamarin.iOS.dll ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/OpenTK-1.0.dll
mono64 --debug bin/Debug/xtro-sharpie.exe appletvos15.0-arm64.pch ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/64bits/tvOS/Xamarin.TVOS.dll ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/OpenTK-1.0.dll
mono64 --debug bin/Debug/xtro-sharpie.exe watchos8.0-armv7.pch ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/32bits/watchOS/Xamarin.WatchOS.dll
mono64 --debug bin/Debug/xtro-sharpie.exe macosx12.0-x86_64.pch ../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/64bits/mobile/Xamarin.Mac.dll
mono64 --debug bin/Debug/xtro-sharpie.exe ios15.0-macabi-x86_64.pch ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/64bits/MacCatalyst/Xamarin.MacCatalyst.dll
mono64 --debug xtro-sanity/bin/Debug/xtro-sanity.exe .
?empty-todo?File 'watchOS-Accessibility.todo' is empty. Empty todo files should be removed.
?empty-todo?File 'MacCatalyst-Accessibility.todo' is empty. Empty todo files should be removed.
?empty-todo?File 'MacCatalyst-VideoSubscriberAccount.todo' is empty. Empty todo files should be removed.
?empty-todo?File 'MacCatalyst-LocalAuthenticationUIView.todo' is empty. Empty todo files should be removed.
?empty-todo?File 'MacCatalyst-MapKit.todo' is empty. Empty todo files should be removed.
?empty-todo?File 'tvOS-Accessibility.todo' is empty. Empty todo files should be removed.
?empty-todo?File 'iOS-MapKit.todo' is empty. Empty todo files should be removed.
?empty-todo?File 'macOS-LocalAuthenticationUIView.todo' is empty. Empty todo files should be removed.
?empty-todo?File 'iOS-Accounts.todo' is empty. Empty todo files should be removed.
?empty-todo?File 'tvOS-MapKit.todo' is empty. Empty todo files should be removed.
?empty-todo?File 'iOS-Accessibility.todo' is empty. Empty todo files should be removed.
?empty-todo?File 'macOS-MapKit.todo' is empty. Empty todo files should be removed.
?empty-todo?File 'macOS-Accessibility.todo' is empty. Empty todo files should be removed.
Sanity check failed (13)
make: *** [classify] Error 13


```