### PR TITLE
[IOSurface] Updates for Xcode13 Beta 1

### DIFF
--- a/src/iosurface.cs
+++ b/src/iosurface.cs
@@ -228,5 +228,13 @@ namespace IOSurface {
 		[iOS (11,0)][Mac (10,13)]
 		[Internal, Export ("setPurgeable:oldState:")]
 		int _SetPurgeable (IOSurfacePurgeabilityState newState, IntPtr oldStatePtr);
+
+		[Watch (4,0), TV (11,0), Mac (10,6), iOS (11,0), MacCatalyst (13,0)]
+		[Field ("kIOSurfaceColorSpace")]
+		NSString kIOSurfaceColorSpace { get; }
+
+		[Watch (4,0), TV (11,0), Mac (10,6), iOS (11,0), MacCatalyst (13,0)]
+		[Field ("kIOSurfaceICCProfile")]
+		NSString kIOSurfaceICCProfile { get; }
 	}
 }

--- a/src/iosurface.cs
+++ b/src/iosurface.cs
@@ -228,13 +228,5 @@ namespace IOSurface {
 		[iOS (11,0)][Mac (10,13)]
 		[Internal, Export ("setPurgeable:oldState:")]
 		int _SetPurgeable (IOSurfacePurgeabilityState newState, IntPtr oldStatePtr);
-
-		[Watch (4,0), TV (11,0), Mac (10,6), iOS (11,0), MacCatalyst (13,0)]
-		[Field ("kIOSurfaceColorSpace")]
-		NSString kIOSurfaceColorSpace { get; }
-
-		[Watch (4,0), TV (11,0), Mac (10,6), iOS (11,0), MacCatalyst (13,0)]
-		[Field ("kIOSurfaceICCProfile")]
-		NSString kIOSurfaceICCProfile { get; }
 	}
 }

--- a/tests/xtro-sharpie/MacCatalyst-IOSurface.ignore
+++ b/tests/xtro-sharpie/MacCatalyst-IOSurface.ignore
@@ -1,0 +1,2 @@
+!missing-pinvoke! IOSurfaceCreateXPCObject is not bound
+!missing-pinvoke! IOSurfaceLookupFromXPCObject is not bound

--- a/tests/xtro-sharpie/MacCatalyst-IOSurface.todo
+++ b/tests/xtro-sharpie/MacCatalyst-IOSurface.todo
@@ -1,5 +1,0 @@
-!missing-pinvoke! IOSurfaceCreateXPCObject is not bound
-!missing-pinvoke! IOSurfaceLookupFromXPCObject is not bound
-## appended from unclassified file
-!missing-field! kIOSurfaceColorSpace not bound
-!missing-field! kIOSurfaceICCProfile not bound

--- a/tests/xtro-sharpie/common-IOSurface.ignore
+++ b/tests/xtro-sharpie/common-IOSurface.ignore
@@ -31,6 +31,8 @@
 !missing-field! kIOSurfacePlaneWidth not bound
 !missing-field! kIOSurfaceSubsampling not bound
 !missing-field! kIOSurfaceWidth not bound
+!missing-field! kIOSurfaceColorSpace not bound
+!missing-field! kIOSurfaceICCProfile not bound
 !missing-pinvoke! IOSurfaceAlignProperty is not bound
 !missing-pinvoke! IOSurfaceAllowsPixelSizeCasting is not bound
 !missing-pinvoke! IOSurfaceCopyAllValues is not bound

--- a/tests/xtro-sharpie/iOS-IOSurface.todo
+++ b/tests/xtro-sharpie/iOS-IOSurface.todo
@@ -1,2 +1,0 @@
-!missing-field! kIOSurfaceColorSpace not bound
-!missing-field! kIOSurfaceICCProfile not bound

--- a/tests/xtro-sharpie/macOS-IOSurface.todo
+++ b/tests/xtro-sharpie/macOS-IOSurface.todo
@@ -1,2 +1,0 @@
-!missing-field! kIOSurfaceColorSpace not bound
-!missing-field! kIOSurfaceICCProfile not bound

--- a/tests/xtro-sharpie/tvOS-IOSurface.todo
+++ b/tests/xtro-sharpie/tvOS-IOSurface.todo
@@ -1,2 +1,0 @@
-!missing-field! kIOSurfaceColorSpace not bound
-!missing-field! kIOSurfaceICCProfile not bound


### PR DESCRIPTION
I don't feel too confident with this one.
I added the missing p-invokes to the ignore since they are ignored in other platforms.

I added the two fields. They say they are supported in older versions and the iOS 11.4 intro test did not complain about them, but a good amount of other IOSurface* fields are in the common ignore and I am not sure why.