### PR TITLE
[runtime] Add logging when a P/Invoke can't be resolved in xamarin_pinvoke_override.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2440,10 +2440,18 @@ xamarin_pinvoke_override (const char *libraryName, const char *entrypointName)
 			} else if (!strcmp (entrypointName, "objc_msgSendSuper_stret")) {
 				symbol = (void *) &xamarin_dyn_objc_msgSendSuper_stret;
 #endif // !defined (__arm64__)
+			} else {
+				return NULL;
 			}
 		}
 #endif // defined (__i386__) || defined (__x86_64__) || defined (__arm64__)
 #endif // !defined (CORECLR_RUNTIME)
+	} else {
+		return NULL;
+	}
+
+	if (symbol == NULL) {
+		LOG (PRODUCT ": Unable to resolve P/Invoke '%s' in the library '%s'", entrypointName, libraryName);
 	}
 
 	return symbol;


### PR DESCRIPTION
Return early when we're not going to try resolving anything, which means that
if we didn't find something by the end, we know that it's because we failed
(and not because we weren't supposed to try), and we log that.

This makes it easier to diagnose a few failure conditions.