### PR TITLE
[src] Specialize the tvOS version of ILLink.LinkAttributes.xml.

### DIFF
--- a/src/ILLink.LinkAttributes.tvos.xml
+++ b/src/ILLink.LinkAttributes.tvos.xml
@@ -1,0 +1,74 @@
+<linker>
+  <assembly fullname="Xamarin.TVOS">
+    <!-- Foundation -->
+    <type fullname="Foundation.AdviceAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="Foundation.FieldAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="Foundation.NotImplementedAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+
+    <!-- double-check when applied -->
+    <type fullname="Foundation.PreserveAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="Foundation.FieldAttribute">
+      <attribute internal="LinkerSafeAttribute" />
+    </type>
+
+    <!-- ObjCRuntime -->
+    <type fullname="ObjCRuntime.BindingImplAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="ObjCRuntime.DesignatedInitializerAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="ObjCRuntime.RequiresSuperAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="ObjCRuntime.ThreadSafeAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+
+    <type fullname="ObjCRuntime.AvailabilityBaseAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="ObjCRuntime.DeprecatedAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="ObjCRuntime.IntroducedAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="ObjCRuntime.ObsoletedAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="ObjCRuntime.UnavailableAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="ObjCRuntime.NoiOSAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="ObjCRuntime.NoMacAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="ObjCRuntime.NoMacCatalystAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="ObjCRuntime.NoTVAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="ObjCRuntime.NoWatchAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <!-- special case (no namespace) -->
+    <type fullname="iOSAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="MacAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+  </assembly>
+</linker>

--- a/src/Makefile
+++ b/src/Makefile
@@ -1076,9 +1076,9 @@ $(TVOS_BUILD_DIR)/AssemblyInfo.cs: $(TOP)/src/AssemblyInfo.cs.in $(TOP)/Make.con
 	$(Q) rm -f $@.tmp
 	$(Q) touch $@
 
-$(TVOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml: $(TOP)/src/ILLink.LinkAttributes.xml.in
+$(TVOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml: ILLink.LinkAttributes.tvos.xml
 	$(Q) mkdir -p $(TVOS_DOTNET_BUILD_DIR)
-	$(call Q_PROF_GEN,tvos) sed < $< > $@ 's|@PRODUCT_NAME@|Xamarin.TVOS|g;'
+	$(Q) $(CP) $< $@
 
 $(TVOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml: $(TOP)/src/ILLink.Substitutions.tvos.xml
 	$(Q) $(CP) $< $@


### PR DESCRIPTION
Specialize the tvOS version of ILLink.LinkAttributes.xml, where we don't
include the "ObjCRuntime.AvailabilityAttribute" type (because it doesn't exist
in tvOS).

Fixes this linker warning:

    resource ILLink.LinkAttributes.xml in Xamarin.TVOS, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065(37,6): warning IL2008: Could not resolve type 'ObjCRuntime.AvailabilityAttribute'