### PR TITLE
Updated Xamarin.Messaging version

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.3.24</MessagingVersion>
+		<MessagingVersion>1.3.26</MessagingVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
We need this bump so we can fix a P1 in XamarinVS d16-11, which is referencing macios from d16-10