### PR TITLE
[runtime] Fix Runtime.Arch to be consistent on Mac Catalyst and work properly on ARM-based simulators.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1254,7 +1254,7 @@ xamarin_initialize ()
 	}
 
 	options.size = sizeof (options);
-#if MONOTOUCH && (defined(__i386__) || defined (__x86_64__))
+#if TARGET_OS_SIMULATOR
 	options.flags = (enum InitializationFlags) (options.flags | InitializationFlagsIsSimulator);
 #endif
 

--- a/src/ObjCRuntime/Runtime.iOS.cs
+++ b/src/ObjCRuntime/Runtime.iOS.cs
@@ -42,8 +42,12 @@ namespace ObjCRuntime {
 
 		unsafe static void InitializePlatform (InitializationOptions* options)
 		{
+#if __MACCATALYST__
+			Arch = Arch.SIMULATOR;
+#else
 			if (options->IsSimulator)
 				Arch = Arch.SIMULATOR;
+#endif
 
 			UIApplication.Initialize ();
 		}


### PR DESCRIPTION
* Use the Apple-provided TARGET_OS_SIMULATOR define to determine if we're
  running in a simulator, instead of checking the current architecture. This
  way we properly detect ARM64-based simulators (and it'll work correctly in
  the future).

* Always set Runtime.Arch = SIMULATOR for Mac Catalyst. The final value for
  Runtime.Arch for Mac Catalyst is tracked in #10312, but this is a stop-gap
  measure to make sure we have the same value between X64 and ARM64 on Mac
  Catalyst, and until now we've had Runtime.Arch = SIMULATOR for X64, so just
  go with that for now.