### PR TITLE
Bump maccore to get mlaunch fix for Xcode 13 b3.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := c7809739bd04c9c878ed5cfdd5208ad7135e13d4
+NEEDED_MACCORE_VERSION := 99ad0341f436c31dcd85abcb7375c3f71072eda3
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@99ad0341f4 [Xamarin.Hosting] Improve error reporting when dlopen fails (#2466)
* xamarin/maccore@8dd9c68035 [Xamarin.Hosting] Xcode 13 b3 doesn't have IBFoundation anymore, but it does have AssetCatalogFoundation, which we must load. (#2467)
* xamarin/maccore@da6da4af29 [Xamarin.Hosting] Only warn if we try to load a framework that doesn't exist. (#2465)
* xamarin/maccore@5cec54f305 [Xamarin.Hosting] Add some helpful lldb commands when trying to figure out what Xcode does. (#2456)

Diff: https://github.com/xamarin/maccore/compare/c7809739bd04c9c878ed5cfdd5208ad7135e13d4..99ad0341f436c31dcd85abcb7375c3f71072eda3