### PR TITLE
[xharness] Handle exceptions that occur while listing device candidates gracefully.

### DIFF
--- a/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
+++ b/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
@@ -405,8 +405,12 @@ namespace Xharness.Jenkins.Reports {
 									candidates = (runTest as RunSimulatorTask)?.Candidates;
 								if (candidates != null) {
 									writer.WriteLine ($"Candidate devices:<br />");
-									foreach (var candidate in candidates)
-										writer.WriteLine ($"&nbsp;&nbsp;&nbsp;&nbsp;{candidate.Name} (Version: {candidate.OSVersion})<br />");
+									try {
+										foreach (var candidate in candidates)
+											writer.WriteLine ($"&nbsp;&nbsp;&nbsp;&nbsp;{candidate.Name} (Version: {candidate.OSVersion})<br />");
+									} catch (Exception e) {
+										writer.WriteLine ($"&nbsp;&nbsp;&nbsp;&nbsp;Failed to list candidates: {e}");
+									}
 								}
 								writer.WriteLine ($"Build duration: {runTest.BuildTask.Duration} <br />");
 							}


### PR DESCRIPTION
This fixes a problem where the html report wouldn't be re-generated if there
was a problem loading a device (which for instance could happen if xharness
was unable to create a required simulator).