### PR TITLE
[release/6.0.1xx-preview7] [ImageIO] Add support for Xcode 13 beta 3.

### DIFF
--- a/src/imageio.cs
+++ b/src/imageio.cs
@@ -576,6 +576,9 @@ namespace ImageIO {
 		NSString PNGSoftware { get; }
 		[Field ("kCGImagePropertyPNGTitle")]
 		NSString PNGTitle { get; }
+		[Mac (12, 0), iOS (15, 0), TV (15,0), MacCatalyst (15,0), Watch (8,0)]
+		[Field ("kCGImagePropertyPNGPixelsAspectRatio")]
+		NSString PNGPixelsAspectRatio { get; }
 
 		[iOS (9,0)][Mac (10,11)]
 		[Field ("kCGImagePropertyPNGCompressionFilter")]

--- a/tests/xtro-sharpie/MacCatalyst-ImageIO.todo
+++ b/tests/xtro-sharpie/MacCatalyst-ImageIO.todo
@@ -1,1 +1,0 @@
-!missing-field! kCGImagePropertyPNGPixelsAspectRatio not bound

--- a/tests/xtro-sharpie/iOS-ImageIO.todo
+++ b/tests/xtro-sharpie/iOS-ImageIO.todo
@@ -1,1 +1,0 @@
-!missing-field! kCGImagePropertyPNGPixelsAspectRatio not bound

--- a/tests/xtro-sharpie/macOS-ImageIO.todo
+++ b/tests/xtro-sharpie/macOS-ImageIO.todo
@@ -1,1 +1,0 @@
-!missing-field! kCGImagePropertyPNGPixelsAspectRatio not bound

--- a/tests/xtro-sharpie/tvOS-ImageIO.todo
+++ b/tests/xtro-sharpie/tvOS-ImageIO.todo
@@ -1,1 +1,0 @@
-!missing-field! kCGImagePropertyPNGPixelsAspectRatio not bound

--- a/tests/xtro-sharpie/watchOS-ImageIO.todo
+++ b/tests/xtro-sharpie/watchOS-ImageIO.todo
@@ -1,1 +1,0 @@
-!missing-field! kCGImagePropertyPNGPixelsAspectRatio not bound


### PR DESCRIPTION
@spouliot the headers say iOS 19 which makes no sense (although is good to know apple is thinking that far ahead ;) So I added 15, I wonder if adding 19 and wait for the next beta is the correct way to go.


Backport of #12145
