### PR TITLE
[chip] Remove API to fix intro on macOS 12 beta 3

### DIFF
--- a/src/chip.cs
+++ b/src/chip.cs
@@ -1765,9 +1765,6 @@ namespace Chip {
 		[Export ("commissioningFlow", ArgumentSemantic.Assign)]
 		ChipCommissioningFlow CommissioningFlow { get; set; }
 
-		[Export ("requiresCustomFlow")]
-		bool RequiresCustomFlow { get; set; }
-
 		[Export ("rendezvousInformation", ArgumentSemantic.Assign)]
 		ChipRendezvousInformationFlags RendezvousInformation { get; set; }
 


### PR DESCRIPTION
That API was removed in beta 3.
https://github.com/xamarin/xamarin-macios/wiki/CHIP-iOS-xcode13.0-beta3

but this was missed by https://github.com/xamarin/xamarin-macios/pull/12143