### PR TITLE
[corelocation] Update annotations to to fix intro on macOS 12 beta 3

### DIFF
--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -442,11 +442,13 @@ namespace CoreLocation {
 		bool IsAuthorizedForWidgetUpdates { [Bind ("isAuthorizedForWidgetUpdates")] get; }
 
 		[Async]
-		[Watch (8,0), TV (15,0), Mac (12,0), iOS (15, 0), MacCatalyst (15,0)]
+		[NoWatch, NoTV, NoMac, NoMacCatalyst]
+		[iOS (15,0)]
 		[Export ("startMonitoringLocationPushesWithCompletion:")]
 		void StartMonitoringLocationPushes ([NullAllowed] Action<NSData, NSError> completion);
 
-		[Watch (8,0), TV (15,0), Mac (12,0), iOS (15, 0), MacCatalyst (15,0)]
+		[NoWatch, NoTV, NoMac, NoMacCatalyst]
+		[iOS (15,0)]
 		[Export ("stopMonitoringLocationPushes")]
 		void StopMonitoringLocationPushes ();
 

--- a/tests/xtro-sharpie/MacCatalyst-CoreLocation.ignore
+++ b/tests/xtro-sharpie/MacCatalyst-CoreLocation.ignore
@@ -3,3 +3,7 @@
 !missing-selector! CLLocationManager::disallowDeferredLocationUpdates not bound
 !missing-selector! CLLocationManager::startRangingBeaconsInRegion: not bound
 !missing-selector! CLLocationManager::stopRangingBeaconsInRegion: not bound
+
+## only marked with ios(15.0) but (as of xcode 13 b3) lacks annotations that it's not available on other platforms
+!missing-selector! CLLocationManager::startMonitoringLocationPushesWithCompletion: not bound
+!missing-selector! CLLocationManager::stopMonitoringLocationPushes not bound

--- a/tests/xtro-sharpie/macOS-CoreLocation.ignore
+++ b/tests/xtro-sharpie/macOS-CoreLocation.ignore
@@ -13,3 +13,7 @@
 !missing-selector! CLLocationManager::startMonitoringForRegion:desiredAccuracy: not bound
 !missing-selector! CLLocationManager::allowDeferredLocationUpdatesUntilTraveled:timeout: not bound
 !missing-selector! CLLocationManager::disallowDeferredLocationUpdates not bound
+
+## only marked with ios(15.0) but (as of xcode 13 b3) lacks annotations that it's not available on other platforms
+!missing-selector! CLLocationManager::startMonitoringLocationPushesWithCompletion: not bound
+!missing-selector! CLLocationManager::stopMonitoringLocationPushes not bound

--- a/tests/xtro-sharpie/tvOS-CoreLocation.ignore
+++ b/tests/xtro-sharpie/tvOS-CoreLocation.ignore
@@ -1,0 +1,3 @@
+## only marked with ios(15.0) but (as of xcode 13 b3) lacks annotations that it's not available on other platforms
+!missing-selector! CLLocationManager::startMonitoringLocationPushesWithCompletion: not bound
+!missing-selector! CLLocationManager::stopMonitoringLocationPushes not bound

--- a/tests/xtro-sharpie/watchOS-CoreLocation.ignore
+++ b/tests/xtro-sharpie/watchOS-CoreLocation.ignore
@@ -1,0 +1,3 @@
+## only marked with ios(15.0) but (as of xcode 13 b3) lacks annotations that it's not available on other platforms
+!missing-selector! CLLocationManager::startMonitoringLocationPushesWithCompletion: not bound
+!missing-selector! CLLocationManager::stopMonitoringLocationPushes not bound


### PR DESCRIPTION
Headers only mention iOS 15.

It does not make sense on tvOS (does not move much) and it's not on
Mac (or Catalyst) as validated with macOS 12 beta 3.