### PR TITLE
[dotnet] Add runtime packs to workload manifests

### DIFF
--- a/dotnet/targets/WorkloadManifest.MacCatalyst.template.json
+++ b/dotnet/targets/WorkloadManifest.MacCatalyst.template.json
@@ -6,6 +6,8 @@
 			"packs": [
 				"Microsoft.@PLATFORM@.Sdk",
 				"Microsoft.@PLATFORM@.Ref",
+				"Microsoft.@PLATFORM@.Runtime.maccatalyst-arm64",
+				"Microsoft.@PLATFORM@.Runtime.maccatalyst-x64",
 				"Microsoft.@PLATFORM@.Templates"
 			],
 			"extends": [ 
@@ -19,6 +21,14 @@
 			"version": "@VERSION@"
 		},
 		"Microsoft.@PLATFORM@.Ref": {
+			"kind": "framework",
+			"version": "@VERSION@"
+		},
+		"Microsoft.@PLATFORM@.Runtime.maccatalyst-arm64": {
+			"kind": "framework",
+			"version": "@VERSION@"
+		},
+		"Microsoft.@PLATFORM@.Runtime.maccatalyst-x64": {
 			"kind": "framework",
 			"version": "@VERSION@"
 		},

--- a/dotnet/targets/WorkloadManifest.iOS.template.json
+++ b/dotnet/targets/WorkloadManifest.iOS.template.json
@@ -7,6 +7,10 @@
 				"Microsoft.@PLATFORM@.Sdk",
 				"Microsoft.@PLATFORM@.Windows.Sdk",
 				"Microsoft.@PLATFORM@.Ref",
+				"Microsoft.@PLATFORM@.Runtime.ios-arm",
+				"Microsoft.@PLATFORM@.Runtime.ios-arm64",
+				"Microsoft.@PLATFORM@.Runtime.iossimulator-x86",
+				"Microsoft.@PLATFORM@.Runtime.iossimulator-x64",
 				"Microsoft.@PLATFORM@.Templates"
 			],
 			"extends": [
@@ -24,6 +28,22 @@
 			"version": "@VERSION@"
 		},
 		"Microsoft.@PLATFORM@.Ref": {
+			"kind": "framework",
+			"version": "@VERSION@"
+		},
+		"Microsoft.@PLATFORM@.Runtime.ios-arm": {
+			"kind": "framework",
+			"version": "@VERSION@"
+		},
+		"Microsoft.@PLATFORM@.Runtime.ios-arm64": {
+			"kind": "framework",
+			"version": "@VERSION@"
+		},
+		"Microsoft.@PLATFORM@.Runtime.iossimulator-x86": {
+			"kind": "framework",
+			"version": "@VERSION@"
+		},
+		"Microsoft.@PLATFORM@.Runtime.iossimulator-x64": {
 			"kind": "framework",
 			"version": "@VERSION@"
 		},

--- a/dotnet/targets/WorkloadManifest.macOS.template.json
+++ b/dotnet/targets/WorkloadManifest.macOS.template.json
@@ -6,6 +6,8 @@
 			"packs": [
 				"Microsoft.@PLATFORM@.Sdk",
 				"Microsoft.@PLATFORM@.Ref",
+				"Microsoft.@PLATFORM@.Runtime.osx-arm64",
+				"Microsoft.@PLATFORM@.Runtime.osx-x64",
 				"Microsoft.@PLATFORM@.Templates"
 			],
 			"extends": [ 
@@ -19,6 +21,14 @@
 			"version": "@VERSION@"
 		},
 		"Microsoft.@PLATFORM@.Ref": {
+			"kind": "framework",
+			"version": "@VERSION@"
+		},
+		"Microsoft.@PLATFORM@.Runtime.osx-arm64": {
+			"kind": "framework",
+			"version": "@VERSION@"
+		},
+		"Microsoft.@PLATFORM@.Runtime.osx-x64": {
 			"kind": "framework",
 			"version": "@VERSION@"
 		},

--- a/dotnet/targets/WorkloadManifest.tvOS.template.json
+++ b/dotnet/targets/WorkloadManifest.tvOS.template.json
@@ -6,6 +6,8 @@
 			"packs": [
 				"Microsoft.@PLATFORM@.Sdk",
 				"Microsoft.@PLATFORM@.Ref",
+				"Microsoft.@PLATFORM@.Runtime.tvos-arm64",
+				"Microsoft.@PLATFORM@.Runtime.tvossimulator-x64",
 				"Microsoft.@PLATFORM@.Templates"
 			],
 			"extends": [
@@ -19,6 +21,14 @@
 			"version": "@VERSION@"
 		},
 		"Microsoft.@PLATFORM@.Ref": {
+			"kind": "framework",
+			"version": "@VERSION@"
+		},
+		"Microsoft.@PLATFORM@.Runtime.tvos-arm64": {
+			"kind": "framework",
+			"version": "@VERSION@"
+		},
+		"Microsoft.@PLATFORM@.Runtime.tvossimulator-x64": {
 			"kind": "framework",
 			"version": "@VERSION@"
 		},


### PR DESCRIPTION
Runtime pack entries should be included in all workload manifest files,
even though they will not yet be resolved from the packs folder due to
https://github.com/dotnet/sdk/issues/14044.  These changes will also
allow us to start producing .msi files for the runtime packs for an
eventual inclusion in the Visual Studio installer.