### PR TITLE
[dotnet] Add support for implicit namespace imports. Fixes #12084.

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -18,6 +18,7 @@ $(1)_NUGET_TARGETS = \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/data/UnixFilePermissions.xml \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/Sdk/AutoImport.props \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/Sdk/Sdk.props \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.ImplicitNamespaceImports.props \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.SupportedTargetPlatforms.props \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.DefaultItems.props \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.props \

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/AppDelegate.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/AppDelegate.cs
@@ -1,5 +1,3 @@
-﻿using Foundation;
-using UIKit;
 
 namespace MacCatalystApp1 {
 	[Register ("AppDelegate")]

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/Main.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/Main.cs
@@ -1,5 +1,3 @@
-using UIKit;
-
 using MacCatalystApp1;
 
 // This is the main entry point of the application.

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/SceneDelegate.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/SceneDelegate.cs
@@ -1,5 +1,3 @@
-using Foundation;
-using UIKit;
 
 namespace MacCatalystApp1 {
 	[Register ("SceneDelegate")]

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/Controller1.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/Controller1.cs
@@ -1,5 +1,3 @@
-using Foundation;
-using UIKit;
 
 namespace iOSApp1 {
 	[Register ("Controller1")]

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/AppDelegate.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/AppDelegate.cs
@@ -1,5 +1,3 @@
-﻿using Foundation;
-using UIKit;
 
 namespace iOSApp1 {
 	[Register ("AppDelegate")]

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/Main.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/Main.cs
@@ -1,5 +1,3 @@
-using UIKit;
-
 using iOSApp1;
 
 // This is the main entry point of the application.

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/SceneDelegate.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/SceneDelegate.cs
@@ -1,5 +1,3 @@
-using Foundation;
-using UIKit;
 
 namespace iOSApp1 {
 	[Register ("SceneDelegate")]

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/AppDelegate.cs
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/AppDelegate.cs
@@ -1,5 +1,3 @@
-﻿using AppKit;
-using Foundation;
 
 namespace macOSApp1 {
 	[Register ("AppDelegate")]

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/Main.cs
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/Main.cs
@@ -1,5 +1,3 @@
-using AppKit;
-
 using macOSApp1;
 
 // This is the main entry point of the application.

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/ViewController.cs
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/ViewController.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 using AppKit;
 using Foundation;

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/ViewController.designer.cs
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/ViewController.designer.cs
@@ -4,7 +4,6 @@
 // actions made in the UI designer. If it is removed, they will be lost.
 // Manual changes to this file may not be handled correctly.
 //
-using Foundation;
 
 namespace macOSApp1 {
 	[Register ("ViewController")]

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/AppDelegate.cs
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/AppDelegate.cs
@@ -1,5 +1,3 @@
-﻿using Foundation;
-using UIKit;
 
 namespace tvOSApp1 {
 	[Register ("AppDelegate")]

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/Main.cs
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/Main.cs
@@ -1,5 +1,3 @@
-using UIKit;
-
 using tvOSApp1;
 
 // This is the main entry point of the application.

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/ViewController.cs
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/ViewController.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using UIKit;
 
 namespace tvOSApp1 {
 	public partial class ViewController : UIViewController {

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/ViewController.designer.cs
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/ViewController.designer.cs
@@ -3,7 +3,6 @@
 // actions made in the Xcode designer. If it is removed, they will be lost.
 // Manual changes to this file may not be handled correctly.
 //
-using Foundation;
 
 namespace tvOSApp1 {
 	[Register ("ViewController")]

--- a/dotnet/targets/Microsoft.MacCatalyst.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.MacCatalyst.Sdk.ImplicitNamespaceImports.props
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+	This file contains implicit namespace imports
+
+	*** WARNING ***
+
+	This file is imported by AutoImport.props, and will be imported by all
+	projects using Microsoft.NET.Sdk.  All Item includes in this file *MUST*
+	be hidden behind a TargetPlatformIdentifier based condition.
+
+	This file can also not define any properties. However, due to the
+	order MSBuild evaluates properties, it's possible to use properties
+	defined in our .targets files in conditions in ItemGroups in this
+	file.
+
+	*** WARNING ***
+
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<!-- There's a master switch, DisableImplicitNamespaceImports, which, if set, will prevent all implicit namespace imports - this is done automatically, we don't have to check DisableImplicitNamespaceImports here -->
+	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'MacCatalyst' And '$(DisableImplicitNamespaceImports_MacCatalyst)' != 'true'">
+		<Import Include="CoreGraphics" />
+		<Import Include="Foundation" />
+		<Import Include="UIKit" />
+	</ItemGroup>
+</Project>

--- a/dotnet/targets/Microsoft.iOS.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.iOS.Sdk.ImplicitNamespaceImports.props
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+	This file contains implicit namespace imports
+
+	*** WARNING ***
+
+	This file is imported by AutoImport.props, and will be imported by all
+	projects using Microsoft.NET.Sdk.  All Item includes in this file *MUST*
+	be hidden behind a TargetPlatformIdentifier based condition.
+
+	This file can also not define any properties. However, due to the
+	order MSBuild evaluates properties, it's possible to use properties
+	defined in our .targets files in conditions in ItemGroups in this
+	file.
+
+	*** WARNING ***
+
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<!-- There's a master switch, DisableImplicitNamespaceImports, which, if set, will prevent all implicit namespace imports - this is done automatically, we don't have to check DisableImplicitNamespaceImports here -->
+	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'iOS' And '$(DisableImplicitNamespaceImports_iOS)' != 'true'">
+		<Import Include="CoreGraphics" />
+		<Import Include="Foundation" />
+		<Import Include="UIKit" />
+	</ItemGroup>
+</Project>

--- a/dotnet/targets/Microsoft.macOS.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.macOS.Sdk.ImplicitNamespaceImports.props
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+	This file contains implicit namespace imports
+
+	*** WARNING ***
+
+	This file is imported by AutoImport.props, and will be imported by all
+	projects using Microsoft.NET.Sdk.  All Item includes in this file *MUST*
+	be hidden behind a TargetPlatformIdentifier based condition.
+
+	This file can also not define any properties. However, due to the
+	order MSBuild evaluates properties, it's possible to use properties
+	defined in our .targets files in conditions in ItemGroups in this
+	file.
+
+	*** WARNING ***
+
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<!-- There's a master switch, DisableImplicitNamespaceImports, which, if set, will prevent all implicit namespace imports - this is done automatically, we don't have to check DisableImplicitNamespaceImports here -->
+	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'macOS' And '$(DisableImplicitNamespaceImports_macOS)' != 'true'">
+		<Import Include="AppKit" />
+		<Import Include="CoreGraphics" />
+		<Import Include="Foundation" />
+	</ItemGroup>
+</Project>

--- a/dotnet/targets/Microsoft.tvOS.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.tvOS.Sdk.ImplicitNamespaceImports.props
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+	This file contains implicit namespace imports
+
+	*** WARNING ***
+
+	This file is imported by AutoImport.props, and will be imported by all
+	projects using Microsoft.NET.Sdk.  All Item includes in this file *MUST*
+	be hidden behind a TargetPlatformIdentifier based condition.
+
+	This file can also not define any properties. However, due to the
+	order MSBuild evaluates properties, it's possible to use properties
+	defined in our .targets files in conditions in ItemGroups in this
+	file.
+
+	*** WARNING ***
+
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<!-- There's a master switch, DisableImplicitNamespaceImports, which, if set, will prevent all implicit namespace imports - this is done automatically, we don't have to check DisableImplicitNamespaceImports here -->
+	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'tvOS' And '$(DisableImplicitNamespaceImports_tvOS)' != 'true'">
+		<Import Include="CoreGraphics" />
+		<Import Include="Foundation" />
+		<Import Include="UIKit" />
+	</ItemGroup>
+</Project>

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -6,6 +6,9 @@
 	<!-- This contains the OS versions we support for target platform -->
 	<Import Project="Microsoft.$(_PlatformName).Sdk.SupportedTargetPlatforms.props" />
 
+	<!-- This contains support for implicit namespace imports -->
+	<Import Project="Microsoft.$(_PlatformName).Sdk.ImplicitNamespaceImports.props" />
+
 	<Import Project="Xamarin.Shared.Sdk.TargetFrameworkInference.props" />
 
 	<PropertyGroup>

--- a/tests/monotouch-test/ImageIO/ImageMetadataTest.cs
+++ b/tests/monotouch-test/ImageIO/ImageMetadataTest.cs
@@ -13,6 +13,8 @@ using ImageIO;
 using ObjCRuntime;
 using NUnit.Framework;
 
+using CGImageProperties = ImageIO.CGImageProperties;
+
 namespace MonoTouchFixtures.ImageIO {
 
 	[TestFixture]

--- a/tests/monotouch-test/ImageIO/MutableImageMetadataTest.cs
+++ b/tests/monotouch-test/ImageIO/MutableImageMetadataTest.cs
@@ -13,6 +13,8 @@ using ImageIO;
 using ObjCRuntime;
 using NUnit.Framework;
 
+using CGImageProperties = ImageIO.CGImageProperties;
+
 namespace MonoTouchFixtures.ImageIO {
 
 	[TestFixture]


### PR DESCRIPTION
Also update our templates to remove any using statements for implicitly imported
namespaces.

Fixes https://github.com/xamarin/xamarin-macios/issues/12084.