### PR TITLE
[release/6.0.1xx-preview7] [CI] Add Prepare Release and VS Insertion stages (again)

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -129,6 +129,18 @@ LOCAL_WORKLOAD_TARGETS += Workloads/Microsoft.NET.Sdk.$(1)/LICENSE
 endef
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call WorkloadTargets,$(platform),$(shell echo $(platform) | tr A-Z a-z),$($(platform)_NUGET_VERSION_NO_METADATA))))
 
+$(DOTNET_NUPKG_DIR)/vs-workload.props: Workloads/vs-workload.template.props
+	$(Q) rm -f $@.tmp
+	$(Q_GEN) sed \
+		$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),-e "s/@$(platform)_WORKLOAD_VERSION@/$($(platform)_NUGET_VERSION).$($(platform)_NUGET_COMMIT_DISTANCE)/g") \
+		-e "s/@PACK_VERSION_LONG@/$(IOS_NUGET_VERSION_NO_METADATA)/g" \
+		-e "s/@PACK_VERSION_SHORT@/$(IOS_NUGET_VERSION).$(IOS_NUGET_COMMIT_DISTANCE)/g" \
+		$< > $@.tmp
+	$(Q) mv $@.tmp $@
+
+$(DOTNET_NUPKG_DIR)/SignList.xml: Workloads/SignList.xml
+	$(Q) $(CP) $< $@
+
 TEMPLATED_FILES = \
 	$(foreach platform,$(DOTNET_PLATFORMS),Microsoft.$(platform).Sdk/targets/Microsoft.$(platform).Sdk.Versions.props) \
 	$(foreach platform,$(DOTNET_PLATFORMS),Microsoft.$(platform).Sdk/targets/Microsoft.$(platform).Sdk.SupportedTargetPlatforms.props) \
@@ -144,12 +156,10 @@ $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call NupkgDefinition,$(platform)
 
 # Create the nuget in a temporary directory (nupkgs/)
 define CreateNuGetTemplate
-nupkgs/$(1)$(4).$(2)+$(NUGET_BUILD_METADATA).nupkg: $(TEMPLATED_FILES) $(WORKLOAD_TARGETS) $(3) package/$(1)/package.csproj $(wildcard package/*.csproj) $(wildcard $(DOTNET_DESTDIR)/$(1)/* $(DOTNET_DESTDIR)/$(1)/*/* $(DOTNET_DESTDIR)/$(1)/*/*/* $(DOTNET_DESTDIR)/$(1)/*/*/*/*) global.json .stamp-workaround-for-maccore-issue-2427
+nupkgs/$(1)$(4).$(2).nupkg: $(TEMPLATED_FILES) $(WORKLOAD_TARGETS) $(3) package/$(1)/package.csproj $(wildcard package/*.csproj) $(wildcard $(DOTNET_DESTDIR)/$(1)/* $(DOTNET_DESTDIR)/$(1)/*/* $(DOTNET_DESTDIR)/$(1)/*/*/* $(DOTNET_DESTDIR)/$(1)/*/*/*/*) global.json .stamp-workaround-for-maccore-issue-2427
 	@# Delete any versions of the nuget we're building
 	$$(Q) rm -f nupkgs/$(1).*.nupkg
 	$$(Q_PACK) $(DOTNET6) pack package/$(1)/package.csproj -p:VersionBand=$(DOTNET6_VERSION_BAND) --output "$$(dir $$@)" $(DOTNET_PACK_VERBOSITY) "/bl:$$@.binlog"
-	@# Nuget pack doesn't add the metadata to the filename, but we want that, so rename nuget to contain the full name
-	$$(Q) mv "nupkgs/$(1)$(4).$(2).nupkg" "$$@"
 	@# Clean the local feed
 	$$(Q_NUGET_DEL) if test -d $(DOTNET_FEED_DIR)/$(shell echo $(1) | tr A-Z a-z)/$(2); then nuget delete $(1) $(2) -source $(abspath $(DOTNET_FEED_DIR)) -NonInteractive $(NUGET_VERBOSITY); fi
 	@# Add the nupkg to our local feed
@@ -157,12 +167,10 @@ nupkgs/$(1)$(4).$(2)+$(NUGET_BUILD_METADATA).nupkg: $(TEMPLATED_FILES) $(WORKLOA
 endef
 
 define CreateWindowsNuGetTemplate
-nupkgs/$(1).$(2)+$(NUGET_BUILD_METADATA).nupkg: $(3) $(WORKLOAD_TARGETS) package/$(1)/package.csproj $(wildcard package/*.csproj) $(wildcard $(DOTNET_DESTDIR)/$(1)/* $(DOTNET_DESTDIR)/$(1)/*/* $(DOTNET_DESTDIR)/$(1)/*/*/* $(DOTNET_DESTDIR)/$(1)/*/*/*/*) global.json .stamp-workaround-for-maccore-issue-2427
+nupkgs/$(1).$(2).nupkg: $(3) $(WORKLOAD_TARGETS) package/$(1)/package.csproj $(wildcard package/*.csproj) $(wildcard $(DOTNET_DESTDIR)/$(1)/* $(DOTNET_DESTDIR)/$(1)/*/* $(DOTNET_DESTDIR)/$(1)/*/*/* $(DOTNET_DESTDIR)/$(1)/*/*/*/*) global.json .stamp-workaround-for-maccore-issue-2427
 	@# Delete any versions of the nuget we're building
 	$$(Q) rm -f nupkgs/$(1).*.nupkg
 	$$(Q_PACK) $(DOTNET6) pack package/$(1)/package.csproj --output "$$(dir $$@)" $(DOTNET_PACK_VERBOSITY) "/bl:$$@.binlog"
-	@# Nuget pack doesn't add the metadata to the filename, but we want that, so rename nuget to contain the full name
-	$$(Q) mv "nupkgs/$(1).$(2).nupkg" "$$@"
 	@# Clean the local feed
 	$$(Q_NUGET_DEL) if test -d $(DOTNET_FEED_DIR)/$(shell echo $(1) | tr A-Z a-z)/$(2); then nuget delete $(1) $(2) -source $(abspath $(DOTNET_FEED_DIR)) -NonInteractive $(NUGET_VERBOSITY); fi
 	@# Add the nupkg to our local feed
@@ -182,28 +190,28 @@ $(DOTNET_NUPKG_DIR)/%.nupkg: nupkgs/%.nupkg | $(DOTNET_NUPKG_DIR)
 	$(Q) $(CP) $< $@
 
 ifdef INCLUDE_IOS
-SDK_PACK_IOS_WINDOWS = $(DOTNET_NUPKG_DIR)/$(IOS_WINDOWS_NUGET).Sdk.$(IOS_WINDOWS_NUGET_VERSION_FULL).nupkg
+SDK_PACK_IOS_WINDOWS = $(DOTNET_NUPKG_DIR)/$(IOS_WINDOWS_NUGET).Sdk.$(IOS_WINDOWS_NUGET_VERSION_NO_METADATA).nupkg
 SDK_PACKS += $(SDK_PACK_IOS_WINDOWS)
 endif
 
 pack-ios-windows: $(SDK_PACK_IOS_WINDOWS)
 
 define PacksDefinitions
-RUNTIME_PACKS_$(1) = $$(foreach rid,$$(DOTNET_$(1)_RUNTIME_IDENTIFIERS),$(DOTNET_NUPKG_DIR)/$($(1)_NUGET).Runtime.$$(rid).$($(1)_NUGET_VERSION_FULL).nupkg)
+RUNTIME_PACKS_$(1) = $$(foreach rid,$$(DOTNET_$(1)_RUNTIME_IDENTIFIERS),$(DOTNET_NUPKG_DIR)/$($(1)_NUGET).Runtime.$$(rid).$($(1)_NUGET_VERSION_NO_METADATA).nupkg)
 RUNTIME_PACKS += $$(RUNTIME_PACKS_$(1))
-REF_PACKS_$(1) = $(DOTNET_NUPKG_DIR)/$($(1)_NUGET).Ref.$($(1)_NUGET_VERSION_FULL).nupkg
+REF_PACKS_$(1) = $(DOTNET_NUPKG_DIR)/$($(1)_NUGET).Ref.$($(1)_NUGET_VERSION_NO_METADATA).nupkg
 REF_PACKS += $$(REF_PACKS_$(1))
-SDK_PACKS_$(1) = $(DOTNET_NUPKG_DIR)/$($(1)_NUGET).Sdk.$($(1)_NUGET_VERSION_FULL).nupkg
+SDK_PACKS_$(1) = $(DOTNET_NUPKG_DIR)/$($(1)_NUGET).Sdk.$($(1)_NUGET_VERSION_NO_METADATA).nupkg
 SDK_PACKS += $$(SDK_PACKS_$(1))
-TEMPLATE_PACKS_$(1) = $(DOTNET_NUPKG_DIR)/$($(1)_NUGET).Templates.$($(1)_NUGET_VERSION_FULL).nupkg
+TEMPLATE_PACKS_$(1) = $(DOTNET_NUPKG_DIR)/$($(1)_NUGET).Templates.$($(1)_NUGET_VERSION_NO_METADATA).nupkg
 TEMPLATE_PACKS += $$(TEMPLATE_PACKS_$(1))
-WORKLOAD_PACKS_$(1) = $(DOTNET_NUPKG_DIR)/$(subst Microsoft.,Microsoft.NET.Sdk.,$($(1)_NUGET)).Manifest-$(DOTNET6_VERSION_BAND).$($(1)_NUGET_VERSION_FULL).nupkg
+WORKLOAD_PACKS_$(1) = $(DOTNET_NUPKG_DIR)/$(subst Microsoft.,Microsoft.NET.Sdk.,$($(1)_NUGET)).Manifest-$(DOTNET6_VERSION_BAND).$($(1)_NUGET_VERSION_NO_METADATA).nupkg
 WORKLOAD_PACKS += $$(WORKLOAD_PACKS_$(1))
 pack-$(shell echo $(1) | tr A-Z a-z): $$(RUNTIME_PACKS_$(1)) $$(REF_PACKS_$(1)) $$(SDK_PACKS_$(1)) $$(TEMPLATE_PACKS_$(1)) $$(WORKLOAD_PACKS_$(1))
 endef
 $(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(eval $(call PacksDefinitions,$(platform))))
 
-TARGETS += $(RUNTIME_PACKS) $(REF_PACKS) $(SDK_PACKS) $(TEMPLATE_PACKS) $(WORKLOAD_PACKS)
+TARGETS += $(RUNTIME_PACKS) $(REF_PACKS) $(SDK_PACKS) $(TEMPLATE_PACKS) $(WORKLOAD_PACKS) $(DOTNET_NUPKG_DIR)/vs-workload.props $(DOTNET_NUPKG_DIR)/SignList.xml
 
 define InstallWorkload
 # .NET comes with a workload for us, but we don't want that, we want our own. So delete the workload that comes with .NET.

--- a/dotnet/Workloads/SignList.xml
+++ b/dotnet/Workloads/SignList.xml
@@ -1,0 +1,25 @@
+<Project>
+  <!-- Do not sign files that already have a signature -->
+  <ItemGroup>
+    <Skip Include="Mono.Options.dll" />
+    <Skip Include="System.Reflection.MetadataLoadContext.dll" />
+  </ItemGroup>
+
+  <!--ItemGroup>
+    <ThirdParty Include="" />
+  </ItemGroup-->
+
+  <ItemGroup>
+    <FirstParty Include="bgen.dll" />
+    <FirstParty Include="dotnet-linker.dll" />
+    <FirstParty Include="Xamarin.*.dll" />
+    <!-- mlaunch.app MonoBundle content-->
+    <FirstParty Include="mlaunch.exe" />
+    <FirstParty Include="Mono.Security.dll" />
+    <FirstParty Include="mscorlib.dll" />
+    <FirstParty Include="System.Core.dll" />
+    <FirstParty Include="System.dll" />
+    <FirstParty Include="System.Numerics.dll" />
+    <FirstParty Include="System.Xml.dll" />
+  </ItemGroup>
+</Project>

--- a/dotnet/Workloads/vs-workload.template.props
+++ b/dotnet/Workloads/vs-workload.template.props
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <TargetName>Microsoft.NET.Sdk.MaciOS.Workload</TargetName>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Shorten package names to avoid long path caching issues in Visual Studio -->
+    <ShortNames Include="@PACK_VERSION_LONG@">
+      <Replacement>@PACK_VERSION_SHORT@</Replacement>
+    </ShortNames>
+    <ComponentResources Include="ios" Category=".NET" Title=".NET SDK for iOS" Description=".NET SDK Workload for building iOS applications."/>
+    <ComponentVersions Include="ios" Version="@IOS_WORKLOAD_VERSION@" />
+    <ComponentResources Include="maccatalyst" Category=".NET" Title=".NET SDK for Mac Catalyst" Description=".NET SDK Workload for building macOS applications with Mac Catalyst."/>
+    <ComponentVersions Include="maccatalyst" Version="@MACCATALYST_WORKLOAD_VERSION@" />
+  </ItemGroup>
+</Project>

--- a/dotnet/targets/WorkloadManifest.MacCatalyst.template.json
+++ b/dotnet/targets/WorkloadManifest.MacCatalyst.template.json
@@ -2,7 +2,7 @@
 	"version": "@VERSION@",
 	"workloads": {
 		"@PLATFORM_LOWERCASE@": {
-			"description": "Microsoft @PLATFORM@ SDK for .NET",
+			"description": ".NET SDK Workload for building macOS applications with @PLATFORM@.",
 			"packs": [
 				"Microsoft.@PLATFORM@.Sdk",
 				"Microsoft.@PLATFORM@.Ref",

--- a/dotnet/targets/WorkloadManifest.iOS.template.json
+++ b/dotnet/targets/WorkloadManifest.iOS.template.json
@@ -2,7 +2,7 @@
 	"version": "@VERSION@",
 	"workloads": {
 		"@PLATFORM_LOWERCASE@": {
-			"description": "Microsoft @PLATFORM@ SDK for .NET",
+			"description": ".NET SDK Workload for building @PLATFORM@ applications.",
 			"packs": [
 				"Microsoft.@PLATFORM@.Sdk",
 				"Microsoft.@PLATFORM@.Windows.Sdk",

--- a/dotnet/targets/WorkloadManifest.macOS.template.json
+++ b/dotnet/targets/WorkloadManifest.macOS.template.json
@@ -2,7 +2,7 @@
 	"version": "@VERSION@",
 	"workloads": {
 		"@PLATFORM_LOWERCASE@": {
-			"description": "Microsoft @PLATFORM@ SDK for .NET",
+			"description": ".NET SDK Workload for building @PLATFORM@ applications.",
 			"packs": [
 				"Microsoft.@PLATFORM@.Sdk",
 				"Microsoft.@PLATFORM@.Ref",

--- a/dotnet/targets/WorkloadManifest.tvOS.template.json
+++ b/dotnet/targets/WorkloadManifest.tvOS.template.json
@@ -2,7 +2,7 @@
 	"version": "@VERSION@",
 	"workloads": {
 		"@PLATFORM_LOWERCASE@": {
-			"description": "Microsoft @PLATFORM@ SDK for .NET",
+			"description": ".NET SDK Workload for building @PLATFORM@ applications.",
 			"packs": [
 				"Microsoft.@PLATFORM@.Sdk",
 				"Microsoft.@PLATFORM@.Ref",

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -160,6 +160,8 @@ variables:
   value: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Trusted'
 - name: CIBuildPoolUrl
   value: 'https://devdiv.visualstudio.com/_settings/agentpools?poolId=367&view=agents'
+- name: IsPRBuild
+  value: ${{ or(eq(variables['Build.Reason'], 'PullRequest'), and(eq(variables['Build.SourceBranchName'], 'merge'), or(eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.Reason'], 'IndividualCI')))) }}
 
 trigger:
   branches:
@@ -241,6 +243,10 @@ stages:
         xqaCertPass: $(xqa--certificates--password)
         enableDotnet: ${{ parameters.enableDotnet }}
 
+# .NET 6 Release Prep and VS Insertion Stages
+- template: templates/release/vs-insertion-prep.yml
+
+# Test stages
 - ${{ if eq(parameters.runDeviceTests, true) }}:
   - ${{ if and(ne(variables['Build.Reason'], 'Schedule'), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual'))) }}:
     - ${{ each config in parameters.deviceTestsConfigurations }}:

--- a/tools/devops/automation/scripts/bash/build-nugets.sh
+++ b/tools/devops/automation/scripts/bash/build-nugets.sh
@@ -13,6 +13,8 @@ DOTNET_NUPKG_DIR=$(make -C tools/devops print-abspath-variable VARIABLE=DOTNET_N
 mkdir -p ../package/
 rm -f ../package/*.nupkg
 cp -c "$DOTNET_NUPKG_DIR"/*.nupkg ../package/
+cp -c "$DOTNET_NUPKG_DIR"/vs-workload.props ../package/
+cp -c "$DOTNET_NUPKG_DIR"/SignList.xml ../package/
 
 DOTNET_PKG_DIR=$(make -C tools/devops print-abspath-variable VARIABLE=DOTNET_PKG_DIR | grep "^DOTNET_PKG_DIR=" | sed -e 's/^DOTNET_PKG_DIR=//')
 make -C dotnet package -j

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -7,10 +7,6 @@ parameters:
   type: boolean
   default: true
 
-- name: isPR
-  type: boolean
-  default: false
-
 - name: vsdropsPrefix
   type: string
 
@@ -328,11 +324,10 @@ steps:
   - template: build-nugets.yml
 
 # only sign an notarize in no PR executions
-- ${{ if ne(parameters.isPR, 'True') }}:
-  - template: sign-and-notarized.yml
-    parameters:
-      enableDotnet: ${{ parameters.enableDotnet }}
-      keyringPass: ${{ parameters.keyringPass }}
+- template: sign-and-notarized.yml
+  parameters:
+    enableDotnet: ${{ parameters.enableDotnet }}
+    keyringPass: ${{ parameters.keyringPass }}
 
 # publish nugets (must be done after signing)
 - ${{ if eq(parameters.enableDotnet, true) }}:

--- a/tools/devops/automation/templates/build/publish-nugets.yml
+++ b/tools/devops/automation/templates/build/publish-nugets.yml
@@ -5,16 +5,6 @@ steps:
 # do not publish on pull requets
 - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
   - task: NuGetCommand@2
-    displayName: 'Publish Nugets to xamarin-impl'
-    inputs:
-      command: push
-      packagesToPush: $(Build.SourcesDirectory)/package/*.nupkg
-      nuGetFeedType: external
-      publishFeedCredentials: xamarin-impl public feed
-    condition: and(succeeded(), eq(variables['configuration.BuildNugets'], 'True'))
-    continueOnError: true # should not stop the build since is not official just yet.
-
-  - task: NuGetCommand@2
     displayName: 'Publish Nugets to dotnet-eng'
     inputs:
       command: push

--- a/tools/devops/automation/templates/build/sign-and-notarized.yml
+++ b/tools/devops/automation/templates/build/sign-and-notarized.yml
@@ -12,6 +12,9 @@ parameters:
 - name: keyringPass
   type: string
 
+- name: condition
+  default: and(succeeded(), eq(variables['IsPRBuild'], 'False'))
+
 steps:
 
 - bash: |
@@ -82,7 +85,7 @@ steps:
       echo "Microsoft.MacCatalyst package found at $MACCATALYST_DOTNET_PKG"
     fi
   displayName: 'Retrieve packages to sign'
-  condition: and(succeeded(), contains(variables['configuration.BuildPkgs'], 'True'))
+  condition: and(${{ parameters.condition }}, contains(variables['configuration.BuildPkgs'], 'True'))
   timeoutInMinutes: 180
 
 - task: MicroBuildSigningPlugin@3
@@ -93,7 +96,8 @@ steps:
     zipSources: false  # we do not use the feature and makes the installation to last 10/12 mins instead of < 1 min
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
- 
+  condition: ${{ parameters.condition }}
+
 - ${{ if eq(parameters.enableDotnet, true) }}:
   - pwsh : |
       # Get the list of files to sign
@@ -124,37 +128,7 @@ steps:
       ConvertTo-Json -InputObject $SignFileList -Depth 5 | Out-File -FilePath $(Build.ArtifactStagingDirectory)/MsiFiles2Notarize.json -Force
       dotnet $Env:MBSIGN_APPFOLDER/ddsignfiles.dll /filelist:$(Build.ArtifactStagingDirectory)/MsiFiles2Notarize.json
     displayName: 'Sign .msi'
-
-- ${{ if eq(parameters.enableDotnet, true) }}:
-  - pwsh : |
-      # Get the list of files to sign
-      $nupkgFiles = Get-ChildItem -Path $(Build.SourcesDirectory)/package/ -Filter "*.nupkg"
-
-      # Add those files to an array
-      $SignFiles = @()
-      foreach($nupkg in $nupkgFiles) {
-          Write-Host "$($nupkg.FullName)"
-          $SignFiles += @{ "SrcPath"="$($nupkg.FullName)"}
-      }
-
-      Write-Host "$nupkgFiles"
-
-      # array of dicts
-      $SignFileRecord = @(
-        @{
-          "Certs" = "401405";
-          "SignFileList" = $SignFiles;
-        }
-      )
-
-      $SignFileList = @{
-          "SignFileRecordList" = $SignFileRecord
-      }
-
-      # Write the json to a file
-      ConvertTo-Json -InputObject $SignFileList -Depth 5 | Out-File -FilePath $(Build.ArtifactStagingDirectory)/NupkgFiles2Notarize.json -Force
-      dotnet $Env:MBSIGN_APPFOLDER/ddsignfiles.dll /filelist:$(Build.ArtifactStagingDirectory)/NupkgFiles2Notarize.json
-    displayName: 'Sign .nupkg'
+    condition: ${{ parameters.condition }}
 
 - bash: |
     security unlock-keychain -p $PRODUCTSIGN_KEYCHAIN_PASSWORD builder.keychain
@@ -175,6 +149,7 @@ steps:
   name: notarize
   displayName: 'Signing Release Build'
   timeoutInMinutes: 90
+  condition: ${{ parameters.condition }}
 
 - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@3
   displayName: 'Install Notarizing Plugin'
@@ -188,6 +163,7 @@ steps:
 
 - pwsh: $(Build.SourcesDirectory)/release-scripts/notarize.ps1 -FolderForApps $(Build.SourcesDirectory)/package/notarized
   displayName: 'ESRP notarizing packages'
+  condition: ${{ parameters.condition }}
 
 - pwsh: |
     $notarizedRoot = Join-Path $(Build.SourcesDirectory) package notarized
@@ -196,3 +172,4 @@ steps:
        pkgutil --check-signature "$($_.FullName)"
     }
   displayName: 'Verify ESRP notarization'
+  condition: ${{ parameters.condition }}

--- a/tools/devops/automation/templates/build/sign-and-notarized.yml
+++ b/tools/devops/automation/templates/build/sign-and-notarized.yml
@@ -184,6 +184,7 @@ steps:
     zipSources: false  # we do not use the feature and makes the installation to last 10/12 mins instead of < 1 min
   env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+  condition: ${{ parameters.condition }}
 
 - pwsh: $(Build.SourcesDirectory)/release-scripts/notarize.ps1 -FolderForApps $(Build.SourcesDirectory)/package/notarized
   displayName: 'ESRP notarizing packages'

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -98,7 +98,6 @@ jobs:
   steps:
   - template: build.yml
     parameters:
-      isPR: ${{ or(eq(variables['Build.Reason'], 'PullRequest'), and(eq(variables['Build.SourceBranchName'], 'merge'), or(eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.Reason'], 'IndividualCI')))) }}
       runTests: ${{ parameters.runTests }}
       runDeviceTests: ${{ parameters.runDeviceTests }}
       vsdropsPrefix: ${{ parameters.vsdropsPrefix }}

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -1,0 +1,66 @@
+parameters:
+- name: enableDotnet
+  type: boolean
+  default: true
+
+- name: dependsOn
+  type: string
+  default: build_packages
+
+stages:
+- stage: prepare_release
+  displayName: Prepare Release
+  dependsOn: ${{ parameters.dependsOn }}
+  condition: and(or(eq(dependencies.${{ parameters.dependsOn }}.result, 'Succeeded'), eq(dependencies.${{ parameters.dependsOn }}.result, 'SucceededWithIssues')), eq(variables.IsPRBuild, 'False'), eq(${{ parameters.enableDotnet }}, true))
+  jobs:
+  # Check - "xamarin-macios (Prepare Release Sign NuGets)"
+  - template: sign-artifacts/jobs/v2.yml@templates
+    parameters:
+      artifactName: package
+      signType: Real
+      usePipelineArtifactTasks: true
+
+  # Check - "xamarin-macios (Prepare Release Convert NuGet to MSI)"
+  - template: nuget-msi-convert/job/v1.yml@templates
+    parameters:
+      yamlResourceName: templates
+      dependsOn: signing
+      artifactName: nuget-signed
+      artifactPatterns: |
+        Microsoft.NET.Sdk.iOS.Manifest*.nupkg
+        Microsoft.NET.Sdk.MacCatalyst.Manifest*.nupkg
+        Microsoft.iOS*.nupkg
+        Microsoft.MacCatalyst*.nupkg
+      propsArtifactName: package
+      signType: Real
+
+  # Check - "xamarin-macios (Prepare Release Push NuGets)"
+  - job: push_signed_nugets
+    displayName: Push NuGets
+    dependsOn: signing
+    variables:
+      skipNugetSecurityAnalysis: true
+    pool:
+      vmImage: macOS-10.15
+    steps:
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: nuget-signed
+        downloadPath: $(Build.SourcesDirectory)/package
+        patterns: |
+          *.nupkg
+
+    - task: NuGetCommand@2
+      displayName: Publish Nugets to xamarin-impl
+      inputs:
+        command: push
+        packagesToPush: $(Build.SourcesDirectory)/package/*.nupkg
+        nuGetFeedType: external
+        publishFeedCredentials: xamarin-impl public feed
+
+# Check - "xamarin-macios (VS Insertion Wait For Approval)"
+# Check - "xamarin-macios (VS Insertion Create VS Drop and Open PR)"
+- template: vs-insertion/stage/v1.yml@templates
+  parameters:
+    dependsOn: prepare_release
+    condition: eq(variables.IsPRBuild, 'False')


### PR DESCRIPTION
Context: xamarin/yaml-templates#117

Updates the .NET 6 NuGet packaging steps to exclude package metadata,
as the .msi conversion tooling does not process .nupkg file names with
the `+sha.commit` metadata.

Two new stages have been added to facilitate the Visual Studio setup
authoring process.

The first stage named "Prepare Release" will sign the .NET 6 NuGet
package content (inside and out), convert relevant packages to .msi
installers, generate Visual Studio manifests for the .msi installers,
and push the signed packages to the `xamarin-impl` feed.

The new `SignList.xml` file is required for our NuGet signing templates.

The new `xamarin-workload.props` file contains version information
and other metadata required to generate a Visual Studio manifest.

The second stage starts with a [manual validation task][0].  This task
will pause and wait for someone to click a "Resume" or "Reject" button
that will appear on the pipeline UI.  This task is configured to be
rejected after waiting for two days, but it can be manually re-ran at a
later date if we want to trigger VS insertion for an older build.

If the manual validation task is approved, a VS Drop will be created
containing all .NET 6 .msi files.  This Drop URL can then be used to
update our component versions in Visual Studio.  This last piece is
currently manual as we will initially be introducing new components,
however we should be able to automate VS PR creation in the future.

Commit 09f911b504ec9b803eb6d725cca14cc7d3ed986e missed adding the
PR build check condition to a step in `sign-and-notarized.yml`, causing
PR builds from forks to fail.  We can fix this by adding in the missing
condition.

[0]: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/manual-validation?view=azure-devops&tabs=yaml



Backport of #12157
