### PR TITLE
[link sdk] Fix incorrect test logic in HttpClientHandlerTest for Mac Catalyst. Fixes #xamarin/maccore@2472.

### DIFF
--- a/tests/linker/ios/link sdk/HttpClientHandlerTest.cs
+++ b/tests/linker/ios/link sdk/HttpClientHandlerTest.cs
@@ -20,7 +20,7 @@ namespace LinkSdk.Net.Http {
 		{
 			using (var handler = new HttpClientHandler ()) {
 				Assert.True (handler.AllowAutoRedirect, "AllowAutoRedirect");
-#if NET && !__MACCATALYST__ // https://github.com/dotnet/runtime/issues/55986
+#if NET // https://github.com/dotnet/runtime/issues/55986
 				Assert.Null (handler.CookieContainer, "CookieContainer");
 #else
 				Assert.NotNull (handler.CookieContainer, "CookieContainer");


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/2472.