### PR TITLE
[AppKit] Move NSAccessibility enums to be in the api definition.

### DIFF
--- a/src/AppKit/NSAccessibility.cs
+++ b/src/AppKit/NSAccessibility.cs
@@ -18,58 +18,6 @@ using ObjCRuntime;
 
 namespace AppKit
 {
-	[Mac (10,10)]
-	[Native]
-	public enum NSAccessibilityOrientation : long
-	{
-		Unknown = 0,
-		Vertical = 1,
-		Horizontal = 2
-	}
-
-	[Mac (10,10)]
-	[Native]
-	public enum NSAccessibilitySortDirection : long
-	{
-		Unknown = 0,
-		Ascending = 1,
-		Descending = 2
-	}
-
-	[Mac (10,10)]
-	[Native]
-	public enum NSAccessibilityRulerMarkerType : long
-	{
-		Unknown = 0,
-		TabStopLeft = 1,
-		TabStopRight = 2,
-		TabStopCenter = 3,
-		TabStopDecimal = 4,
-		IndentHead = 5,
-		IndentTail = 6,
-		IndentFirstLine = 7
-	}
-
-	[Mac (10,10)]
-	[Native]
-	public enum NSAccessibilityUnits : long
-	{
-		Unknown = 0,
-		Inches = 1,
-		Centimeters = 2,
-		Points = 3,
-		Picas = 4
-	}
-
-	[Mac (10,9)]
-	[Native]
-	public enum NSAccessibilityPriorityLevel : long
-	{
-		Low = 10,
-		Medium = 50,
-		High = 90
-	}
-
 	[Mac (10,10)] // protocol added in 10.10
 	public partial interface INSAccessibility {}
 

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -23000,6 +23000,63 @@ namespace AppKit {
 	interface INSAccessibility {};
 	interface INSAccessibilityElement {};
 
+	[Mac (10,10)]
+	[NoMacCatalyst]
+	[Native]
+	public enum NSAccessibilityOrientation : long
+	{
+		Unknown = 0,
+		Vertical = 1,
+		Horizontal = 2,
+	}
+
+	[Mac (10,10)]
+	[NoMacCatalyst]
+	[Native]
+	public enum NSAccessibilitySortDirection : long
+	{
+		Unknown = 0,
+		Ascending = 1,
+		Descending = 2,
+	}
+
+	[Mac (10,10)]
+	[NoMacCatalyst]
+	[Native]
+	public enum NSAccessibilityRulerMarkerType : long
+	{
+		Unknown = 0,
+		TabStopLeft = 1,
+		TabStopRight = 2,
+		TabStopCenter = 3,
+		TabStopDecimal = 4,
+		IndentHead = 5,
+		IndentTail = 6,
+		IndentFirstLine = 7,
+	}
+
+	[Mac (10,10)]
+	[NoMacCatalyst]
+	[Native]
+	public enum NSAccessibilityUnits : long
+	{
+		Unknown = 0,
+		Inches = 1,
+		Centimeters = 2,
+		Points = 3,
+		Picas = 4,
+	}
+
+	[Mac (10,9)]
+	[NoMacCatalyst]
+	[Native]
+	public enum NSAccessibilityPriorityLevel : long
+	{
+		Low = 10,
+		Medium = 50,
+		High = 90,
+	}
+
 	// 10.9 for fields/notification but 10.10 for protocol
 	// attributes added to both cases in NSAccessibility.cs
 	[Protocol]


### PR DESCRIPTION
Third group of enums (there will be more!)

There should be no breaking changes.