### PR TITLE
[passkit] Disable default ctor on PKPaymentAuthorizationViewController

### DIFF
--- a/src/PassKit/PKCompat.cs
+++ b/src/PassKit/PKCompat.cs
@@ -1,0 +1,16 @@
+#if !XAMCORE_4_0
+
+using System;
+
+namespace PassKit {
+
+	partial class PKPaymentAuthorizationViewController {
+
+		[Obsolete ("This constructor does not create a valid instance of the type")]
+		public PKPaymentAuthorizationViewController ()
+		{
+		}
+	}
+}
+
+#endif

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1371,6 +1371,7 @@ PASSKIT_API_SOURCES = \
 	PassKit/PKEnums.cs \
 	
 PASSKIT_SOURCES = \
+	PassKit/PKCompat.cs	\
 	PassKit/PKPaymentRequest.cs	\
 
 # PencilKit

--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -350,6 +350,7 @@ namespace PassKit {
 	[Mac (11,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (UIViewController), Delegates=new string []{"Delegate"}, Events=new Type [] {typeof(PKPaymentAuthorizationViewControllerDelegate)})]
+	[DisableDefaultCtor]
 	interface PKPaymentAuthorizationViewController {
 		[DesignatedInitializer]
 		[Export ("initWithPaymentRequest:")]


### PR DESCRIPTION
It's not valid and macOS 12 complains.

Replaced by a stub to maintain binary compatibility.