### PR TITLE
[AppKit] Make the files containing enums API source files instead of Core source files.

### DIFF
--- a/src/AppKit/Compat.cs
+++ b/src/AppKit/Compat.cs
@@ -40,4 +40,13 @@ namespace AppKit {
 		}
 #endif
 	}
+
+#if !XAMCORE_4_0
+	public static class NSFileTypeForHFSTypeCode
+	{
+		public static readonly string ComputerIcon = "root";
+		public static readonly string DesktopIcon = "desk";
+		public static readonly string FinderIcon = "FNDR";
+	}
+#endif
 }

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2096,15 +2096,6 @@ namespace AppKit {
 		Bottom
 	}
 
-#if !XAMCORE_4_0
-	public static class NSFileTypeForHFSTypeCode
-	{
-		public static readonly string ComputerIcon = "root";
-		public static readonly string DesktopIcon = "desk";
-		public static readonly string FinderIcon = "FNDR";
-	}
-#endif
-
 	// FileType 4cc values to use with NSFileTypeForHFSTypeCode.
 	public enum HfsTypeCode : uint
 	{

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -76,10 +76,12 @@ ADSUPPORT_SOURCES = \
 
 # AppKit
 
-APPKIT_CORE_SOURCES = \
-	AppKit/Defs.cs \
+APPKIT_API_SOURCES = \
 	AppKit/Enums.cs \
 	AppKit/XEnums.cs \
+
+APPKIT_CORE_SOURCES = \
+	AppKit/Defs.cs \
 	AppKit/NSAccessibility.cs \
 	XKit/Types.cs \
 	XKit/XKitCompat.cs \


### PR DESCRIPTION
This makes it easier to include/exclude certain enums in Mac Catalyst (since
we can use [NoMacCatalyst] instead of littering the files with "#if
MACCATALYST").

It required moving a little bit of unrelated code out of the enums source
files, but this is a much smaller change than moving all of the enums out of
these files (see #12185 for how that ends up).