### PR TITLE
[dotnet/templates] Use file-scoped namespaces. Fixes #12085.

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/AppDelegate.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/AppDelegate.cs
@@ -1,30 +1,29 @@
+namespace MacCatalystApp1;
 
-namespace MacCatalystApp1 {
-	[Register ("AppDelegate")]
-	public class AppDelegate : UIApplicationDelegate {
-		public override UIWindow? Window {
-			get;
-			set;
-		}
+[Register ("AppDelegate")]
+public class AppDelegate : UIApplicationDelegate {
+	public override UIWindow? Window {
+		get;
+		set;
+	}
 
-		public override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
-		{
-			// create a new window instance based on the screen size
-			Window = new UIWindow (UIScreen.MainScreen.Bounds);
+	public override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
+	{
+		// create a new window instance based on the screen size
+		Window = new UIWindow (UIScreen.MainScreen.Bounds);
 
-			// create a UIViewController with a single UILabel
-			var vc = new UIViewController ();
-			vc.View!.AddSubview (new UILabel (Window!.Frame) {
-				BackgroundColor = UIColor.White,
-				TextAlignment = UITextAlignment.Center,
-				Text = "Hello, Catalyst!"
-			});
-			Window.RootViewController = vc;
+		// create a UIViewController with a single UILabel
+		var vc = new UIViewController ();
+		vc.View!.AddSubview (new UILabel (Window!.Frame) {
+			BackgroundColor = UIColor.White,
+			TextAlignment = UITextAlignment.Center,
+			Text = "Hello, Catalyst!"
+		});
+		Window.RootViewController = vc;
 
-			// make the window visible
-			Window.MakeKeyAndVisible ();
+		// make the window visible
+		Window.MakeKeyAndVisible ();
 
-			return true;
-		}
+		return true;
 	}
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/SceneDelegate.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/SceneDelegate.cs
@@ -1,55 +1,55 @@
+namespace MacCatalystApp1;
 
-namespace MacCatalystApp1 {
-	[Register ("SceneDelegate")]
-	public class SceneDelegate : UIResponder, IUIWindowSceneDelegate {
+[Register ("SceneDelegate")]
+public class SceneDelegate : UIResponder, IUIWindowSceneDelegate {
 
-		[Export ("window")]
-		public UIWindow? Window { get; set; }
+	[Export ("window")]
+	public UIWindow? Window { get; set; }
 
-		[Export ("scene:willConnectToSession:options:")]
-		public void WillConnect (UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
-		{
-			// Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-			// If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-			// This delegate does not imply the connecting scene or session are new (see UIApplicationDelegate `GetConfiguration` instead).
-		}
+	[Export ("scene:willConnectToSession:options:")]
+	public void WillConnect (UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
+	{
+		// Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+		// If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+		// This delegate does not imply the connecting scene or session are new (see UIApplicationDelegate `GetConfiguration` instead).
+	}
 
-		[Export ("sceneDidDisconnect:")]
-		public void DidDisconnect (UIScene scene)
-		{
-			// Called as the scene is being released by the system.
-			// This occurs shortly after the scene enters the background, or when its session is discarded.
-			// Release any resources associated with this scene that can be re-created the next time the scene connects.
-			// The scene may re-connect later, as its session was not neccessarily discarded (see UIApplicationDelegate `DidDiscardSceneSessions` instead).
-		}
+	[Export ("sceneDidDisconnect:")]
+	public void DidDisconnect (UIScene scene)
+	{
+		// Called as the scene is being released by the system.
+		// This occurs shortly after the scene enters the background, or when its session is discarded.
+		// Release any resources associated with this scene that can be re-created the next time the scene connects.
+		// The scene may re-connect later, as its session was not neccessarily discarded (see UIApplicationDelegate `DidDiscardSceneSessions` instead).
+	}
 
-		[Export ("sceneDidBecomeActive:")]
-		public void DidBecomeActive (UIScene scene)
-		{
-			// Called when the scene has moved from an inactive state to an active state.
-			// Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
-		}
+	[Export ("sceneDidBecomeActive:")]
+	public void DidBecomeActive (UIScene scene)
+	{
+		// Called when the scene has moved from an inactive state to an active state.
+		// Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+	}
 
-		[Export ("sceneWillResignActive:")]
-		public void WillResignActive (UIScene scene)
-		{
-			// Called when the scene will move from an active state to an inactive state.
-			// This may occur due to temporary interruptions (ex. an incoming phone call).
-		}
+	[Export ("sceneWillResignActive:")]
+	public void WillResignActive (UIScene scene)
+	{
+		// Called when the scene will move from an active state to an inactive state.
+		// This may occur due to temporary interruptions (ex. an incoming phone call).
+	}
 
-		[Export ("sceneWillEnterForeground:")]
-		public void WillEnterForeground (UIScene scene)
-		{
-			// Called as the scene transitions from the background to the foreground.
-			// Use this method to undo the changes made on entering the background.
-		}
+	[Export ("sceneWillEnterForeground:")]
+	public void WillEnterForeground (UIScene scene)
+	{
+		// Called as the scene transitions from the background to the foreground.
+		// Use this method to undo the changes made on entering the background.
+	}
 
-		[Export ("sceneDidEnterBackground:")]
-		public void DidEnterBackground (UIScene scene)
-		{
-			// Called as the scene transitions from the foreground to the background.
-			// Use this method to save data, release shared resources, and store enough scene-specific state information
-			// to restore the scene back to its current state.
-		}
+	[Export ("sceneDidEnterBackground:")]
+	public void DidEnterBackground (UIScene scene)
+	{
+		// Called as the scene transitions from the foreground to the background.
+		// Use this method to save data, release shared resources, and store enough scene-specific state information
+		// to restore the scene back to its current state.
 	}
 }
+

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/Controller1.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/Controller1.cs
@@ -1,16 +1,15 @@
+namespace iOSApp1;
 
-namespace iOSApp1 {
-	[Register ("Controller1")]
-	public class Controller1 : UIViewController {
-		public override void ViewDidLoad ()
-		{
-			View = new UIView {
-				BackgroundColor = UIColor.Red,
-			};
+[Register ("Controller1")]
+public class Controller1 : UIViewController {
+	public override void ViewDidLoad ()
+	{
+		View = new UIView {
+			BackgroundColor = UIColor.Red,
+		};
 
-			base.ViewDidLoad ();
+		base.ViewDidLoad ();
 
-			// Perform any additional setup after loading the view
-		}
+		// Perform any additional setup after loading the view
 	}
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/AppDelegate.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/AppDelegate.cs
@@ -1,30 +1,29 @@
+namespace iOSApp1;
 
-namespace iOSApp1 {
-	[Register ("AppDelegate")]
-	public class AppDelegate : UIApplicationDelegate {
-		public override UIWindow? Window {
-			get;
-			set;
-		}
+[Register ("AppDelegate")]
+public class AppDelegate : UIApplicationDelegate {
+	public override UIWindow? Window {
+		get;
+		set;
+	}
 
-		public override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
-		{
-			// create a new window instance based on the screen size
-			Window = new UIWindow (UIScreen.MainScreen.Bounds);
+	public override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
+	{
+		// create a new window instance based on the screen size
+		Window = new UIWindow (UIScreen.MainScreen.Bounds);
 
-			// create a UIViewController with a single UILabel
-			var vc = new UIViewController ();
-			vc.View!.AddSubview (new UILabel (Window!.Frame) {
-				BackgroundColor = UIColor.White,
-				TextAlignment = UITextAlignment.Center,
-				Text = "Hello, iOS!"
-			});
-			Window.RootViewController = vc;
+		// create a UIViewController with a single UILabel
+		var vc = new UIViewController ();
+		vc.View!.AddSubview (new UILabel (Window!.Frame) {
+			BackgroundColor = UIColor.White,
+			TextAlignment = UITextAlignment.Center,
+			Text = "Hello, iOS!"
+		});
+		Window.RootViewController = vc;
 
-			// make the window visible
-			Window.MakeKeyAndVisible ();
+		// make the window visible
+		Window.MakeKeyAndVisible ();
 
-			return true;
-		}
+		return true;
 	}
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/SceneDelegate.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/SceneDelegate.cs
@@ -1,55 +1,54 @@
+namespace iOSApp1;
 
-namespace iOSApp1 {
-	[Register ("SceneDelegate")]
-	public class SceneDelegate : UIResponder, IUIWindowSceneDelegate {
+[Register ("SceneDelegate")]
+public class SceneDelegate : UIResponder, IUIWindowSceneDelegate {
 
-		[Export ("window")]
-		public UIWindow? Window { get; set; }
+	[Export ("window")]
+	public UIWindow? Window { get; set; }
 
-		[Export ("scene:willConnectToSession:options:")]
-		public void WillConnect (UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
-		{
-			// Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-			// If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-			// This delegate does not imply the connecting scene or session are new (see UIApplicationDelegate `GetConfiguration` instead).
-		}
+	[Export ("scene:willConnectToSession:options:")]
+	public void WillConnect (UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
+	{
+		// Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+		// If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+		// This delegate does not imply the connecting scene or session are new (see UIApplicationDelegate `GetConfiguration` instead).
+	}
 
-		[Export ("sceneDidDisconnect:")]
-		public void DidDisconnect (UIScene scene)
-		{
-			// Called as the scene is being released by the system.
-			// This occurs shortly after the scene enters the background, or when its session is discarded.
-			// Release any resources associated with this scene that can be re-created the next time the scene connects.
-			// The scene may re-connect later, as its session was not neccessarily discarded (see UIApplicationDelegate `DidDiscardSceneSessions` instead).
-		}
+	[Export ("sceneDidDisconnect:")]
+	public void DidDisconnect (UIScene scene)
+	{
+		// Called as the scene is being released by the system.
+		// This occurs shortly after the scene enters the background, or when its session is discarded.
+		// Release any resources associated with this scene that can be re-created the next time the scene connects.
+		// The scene may re-connect later, as its session was not neccessarily discarded (see UIApplicationDelegate `DidDiscardSceneSessions` instead).
+	}
 
-		[Export ("sceneDidBecomeActive:")]
-		public void DidBecomeActive (UIScene scene)
-		{
-			// Called when the scene has moved from an inactive state to an active state.
-			// Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
-		}
+	[Export ("sceneDidBecomeActive:")]
+	public void DidBecomeActive (UIScene scene)
+	{
+		// Called when the scene has moved from an inactive state to an active state.
+		// Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+	}
 
-		[Export ("sceneWillResignActive:")]
-		public void WillResignActive (UIScene scene)
-		{
-			// Called when the scene will move from an active state to an inactive state.
-			// This may occur due to temporary interruptions (ex. an incoming phone call).
-		}
+	[Export ("sceneWillResignActive:")]
+	public void WillResignActive (UIScene scene)
+	{
+		// Called when the scene will move from an active state to an inactive state.
+		// This may occur due to temporary interruptions (ex. an incoming phone call).
+	}
 
-		[Export ("sceneWillEnterForeground:")]
-		public void WillEnterForeground (UIScene scene)
-		{
-			// Called as the scene transitions from the background to the foreground.
-			// Use this method to undo the changes made on entering the background.
-		}
+	[Export ("sceneWillEnterForeground:")]
+	public void WillEnterForeground (UIScene scene)
+	{
+		// Called as the scene transitions from the background to the foreground.
+		// Use this method to undo the changes made on entering the background.
+	}
 
-		[Export ("sceneDidEnterBackground:")]
-		public void DidEnterBackground (UIScene scene)
-		{
-			// Called as the scene transitions from the foreground to the background.
-			// Use this method to save data, release shared resources, and store enough scene-specific state information
-			// to restore the scene back to its current state.
-		}
+	[Export ("sceneDidEnterBackground:")]
+	public void DidEnterBackground (UIScene scene)
+	{
+		// Called as the scene transitions from the foreground to the background.
+		// Use this method to save data, release shared resources, and store enough scene-specific state information
+		// to restore the scene back to its current state.
 	}
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/Class1.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/Class1.cs
@@ -1,4 +1,4 @@
-namespace iOSLib1 {
-	public class Class1 {
-	}
+namespace iOSLib1;
+
+public class Class1 {
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/AppDelegate.cs
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/AppDelegate.cs
@@ -1,15 +1,14 @@
+namespace macOSApp1;
 
-namespace macOSApp1 {
-	[Register ("AppDelegate")]
-	public class AppDelegate : NSApplicationDelegate {
-		public override void DidFinishLaunching (NSNotification notification)
-		{
-			// Insert code here to initialize your application
-		}
+[Register ("AppDelegate")]
+public class AppDelegate : NSApplicationDelegate {
+	public override void DidFinishLaunching (NSNotification notification)
+	{
+		// Insert code here to initialize your application
+	}
 
-		public override void WillTerminate (NSNotification notification)
-		{
-			// Insert code here to tear down your application
-		}
+	public override void WillTerminate (NSNotification notification)
+	{
+		// Insert code here to tear down your application
 	}
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/ViewController.cs
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/ViewController.cs
@@ -1,27 +1,23 @@
+namespace macOSApp1;
 
-using AppKit;
-using Foundation;
+public partial class ViewController : NSViewController {
+	public ViewController (IntPtr handle) : base (handle)
+	{
+	}
 
-namespace macOSApp1 {
-	public partial class ViewController : NSViewController {
-		public ViewController (IntPtr handle) : base (handle)
-		{
-		}
+	public override void ViewDidLoad ()
+	{
+		base.ViewDidLoad ();
 
-		public override void ViewDidLoad ()
-		{
-			base.ViewDidLoad ();
+		// Do any additional setup after loading the view.
+	}
 
-			// Do any additional setup after loading the view.
-		}
+	public override NSObject RepresentedObject {
+		get => base.RepresentedObject;
+		set {
+			base.RepresentedObject = value;
 
-		public override NSObject RepresentedObject {
-			get => base.RepresentedObject;
-			set {
-				base.RepresentedObject = value;
-
-				// Update the view, if already loaded.
-			}
+			// Update the view, if already loaded.
 		}
 	}
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/ViewController.designer.cs
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/ViewController.designer.cs
@@ -5,11 +5,11 @@
 // Manual changes to this file may not be handled correctly.
 //
 
-namespace macOSApp1 {
-	[Register ("ViewController")]
-	partial class ViewController {
-		void ReleaseDesignerOutlets ()
-		{
-		}
+namespace macOSApp1;
+
+[Register ("ViewController")]
+partial class ViewController {
+	void ReleaseDesignerOutlets ()
+	{
 	}
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/AppDelegate.cs
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/AppDelegate.cs
@@ -1,18 +1,17 @@
+namespace tvOSApp1;
 
-namespace tvOSApp1 {
-	[Register ("AppDelegate")]
-	public class AppDelegate : UIApplicationDelegate {
-		public override UIWindow? Window {
-			get;
-			set;
-		}
+[Register ("AppDelegate")]
+public class AppDelegate : UIApplicationDelegate {
+	public override UIWindow? Window {
+		get;
+		set;
+	}
 
-		public override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
-		{
-			// Override point for customization after application launch.
-			// If not required for your application you can safely delete this method
+	public override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
+	{
+		// Override point for customization after application launch.
+		// If not required for your application you can safely delete this method
 
-			return true;
-		}
+		return true;
 	}
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/ViewController.cs
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/ViewController.cs
@@ -1,8 +1,7 @@
+namespace tvOSApp1;
 
-namespace tvOSApp1 {
-	public partial class ViewController : UIViewController {
-		public ViewController (IntPtr handle) : base (handle)
-		{
-		}
+public partial class ViewController : UIViewController {
+	public ViewController (IntPtr handle) : base (handle)
+	{
 	}
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/ViewController.designer.cs
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/ViewController.designer.cs
@@ -4,11 +4,11 @@
 // Manual changes to this file may not be handled correctly.
 //
 
-namespace tvOSApp1 {
-	[Register ("ViewController")]
-	partial class ViewController {
-		void ReleaseDesignerOutlets ()
-		{
-		}
+namespace tvOSApp1;
+
+[Register ("ViewController")]
+partial class ViewController {
+	void ReleaseDesignerOutlets ()
+	{
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/12085 (final fix).

This PR is best reviewed by ignoring whitespace.