### PR TITLE
[AppKit/UIKit/Foundation] Use NSWritingDirection from Foundation. Partial fix for #6573.

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1225,16 +1225,21 @@ namespace AppKit {
 		Natural = 4
 	}
 
+#if !XAMCORE_4_0 && MONOMAC
+	// Not hard deprecating now but until XAMCORE_4_0 happens or we can
+	// properly fix all the API using this.
+	// see: https://github.com/xamarin/xamarin-macios/issues/6573
+	// [Obsolete ("Use NSWritingDirection in Foundation instead.")]
 	[Flags]
 	[Native]
 	public enum NSWritingDirection : long {
 		Natural = -1, LeftToRight, RightToLeft,
+		[Obsolete ("Use 'LeftToRight' instead.")]
 		Embedding = 0,
-#if !XAMCORE_4_0
 		[Obsolete ("This API is not available on this platform.")]
 		Override = 2,
-#endif
 	}
+#endif // !XAMCORE_4_0 && MONOMAC
 
 #if !XAMCORE_4_0
 	[Native]

--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -857,15 +857,14 @@ namespace Foundation  {
 	}
 #endif
 
-#if !MONOMAC || !XAMCORE_3_0
+	// There's an AppKit.NSWritingDirection, which is deprecated.
+	// There's also an UIKit.UITextWritingDirection, which is deprecated too.
+	// This is the enum we should be using.
+	// See https://github.com/xamarin/xamarin-macios/issues/6573
 	[Native]
-#if MONOMAC
-	[Obsolete ("Use NSWritingDirection in AppKit instead.")]
-#endif
 	public enum NSWritingDirection : long {
 		Natural = -1, LeftToRight = 0, RightToLeft = 1,
 	}
-#endif // !MONOMAC || !XAMCORE_3_0
 
 	[Flags]
 	[Native]

--- a/src/UIKit/UIEnums.cs
+++ b/src/UIKit/UIEnums.cs
@@ -1155,7 +1155,7 @@ namespace UIKit {
 	// Not hard deprecating now but until XAMCORE_4_0 happens or we can
 	// properly fix all the API using this.
 	// see: https://github.com/xamarin/xamarin-macios/issues/6573
-	// Use Foundation.NSWritingDirection instead.
+	// [Obsolete ("Use NSWritingDirection in Foundation instead.")]
 	[Native]
 	[NoWatch]
 	public enum UITextWritingDirection : long {

--- a/tests/xtro-sharpie/macOS-Foundation.ignore
+++ b/tests/xtro-sharpie/macOS-Foundation.ignore
@@ -10,6 +10,10 @@
 !missing-selector! NSXPCCoder::encodeXPCObject:forKey: not bound
 !missing-protocol-conformance! NSXPCConnection should conform to NSXPCProxyCreating
 
+## The AppKit version will be removed in XAMCORE_4_0.
+## See https://github.com/xamarin/xamarin-macios/issues/6573
+!duplicate-type-name! NSWritingDirection enum exists as both Foundation.NSWritingDirection and AppKit.NSWritingDirection
+
 ## unsorted
 
 !extra-designated-initializer! NSScriptCommand::initWithCoder: is incorrectly decorated with an [DesignatedInitializer] attribute


### PR DESCRIPTION
Make the NSWritingDirection enum from Foundation the main version, and
deprecate the others (AppKit.NSWritingDirection,
UIKit.UITextWritingDirection).

This makes things a bit easier with Mac Catalyst, which ships both AppKit and UIKit.

Ref: https://github.com/xamarin/xamarin-macios/issues/6573