### PR TITLE
[gamekit] Remove `isPresentingFriendRequestViewController` from Catalyst

### DIFF
--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -854,7 +854,8 @@ namespace GameKit {
 		Action<NSViewController, NSError> AuthenticateHandler { get; set; }
 #endif
 
-		[NoWatch, NoTV, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
+		[NoWatch, NoTV, Mac (12,0), iOS (15,0)]
+		[NoMacCatalyst]
 		[Export ("isPresentingFriendRequestViewController")]
 		bool IsPresentingFriendRequestViewController { get; }
 

--- a/tests/xtro-sharpie/MacCatalyst-GameKit.ignore
+++ b/tests/xtro-sharpie/MacCatalyst-GameKit.ignore
@@ -33,3 +33,6 @@
 # Are only available for TvOS
 !missing-selector! GKAccessPoint::isFocused not bound
 !missing-selector! GKAccessPoint::setFocused: not bound
+
+## not annotated by itself but it maps to presentFriendRequestCreatorFromViewController which is not available on Catalyst
+!missing-selector! GKLocalPlayer::isPresentingFriendRequestViewController not bound

--- a/tests/xtro-sharpie/MacCatalyst-GameKit.todo
+++ b/tests/xtro-sharpie/MacCatalyst-GameKit.todo
@@ -1,0 +1,2 @@
+## not annotated by itself but it maps to presentFriendRequestCreatorFromViewController which is not available on Catalyst
+!missing-selector! GKLocalPlayer::isPresentingFriendRequestViewController not bound

--- a/tests/xtro-sharpie/MacCatalyst-GameKit.todo
+++ b/tests/xtro-sharpie/MacCatalyst-GameKit.todo
@@ -1,2 +1,0 @@
-## not annotated by itself but it maps to presentFriendRequestCreatorFromViewController which is not available on Catalyst
-!missing-selector! GKLocalPlayer::isPresentingFriendRequestViewController not bound


### PR DESCRIPTION
The selector is not annotated by itself (wrt Catalyst) but it maps to
`presentFriendRequestCreatorFromViewController` which is not available
on Catalyst. That part is clear in the headers

```diff
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+/**
+ *  presentFriendRequestCreatorFromViewController:
...
+#elif TARGET_OS_OSX
+/**
+ *  presentFriendRequestCreatorFromWindow:
```