### PR TITLE
[generator] Fix `[PrologueSnippetAttribute]`

### DIFF
--- a/src/generator-attribute-manager.cs
+++ b/src/generator-attribute-manager.cs
@@ -131,6 +131,8 @@ public class AttributeManager
 			return typeof (OverrideAttribute);
 		case "PostGetAttribute":
 			return typeof (PostGetAttribute);
+		case "PrologueSnippetAttribute":
+			return typeof (PrologueSnippetAttribute);
 		case "PostSnippetAttribute":
 			return typeof (PostSnippetAttribute);
 		case "PreSnippetAttribute":


### PR DESCRIPTION
Lack of mapping results in an error if the attribute is used

```
error BI1055: bgen: Internal error: failed to convert type 'PrologueSnippetAttribute, Xamarin.iOS.BindingAttributes, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
```

Unit test will be added as part of https://github.com/xamarin/xamarin-macios/pull/12165