### PR TITLE
[Foundation] Add EnumDesktop.cs to the API sources to handle it with the generator.

### DIFF
--- a/src/Foundation/EnumDesktop.cs
+++ b/src/Foundation/EnumDesktop.cs
@@ -25,11 +25,11 @@
 // FIXME: EnumDesktop.cs should be merged into Enums.cs
 using System;
 
-#if MONOMAC
-
 using ObjCRuntime;
 
 namespace Foundation {
+	[NoiOS, NoTV, NoWatch, NoMacCatalyst]
+	[Internal]
 	internal enum NSAttributedStringDataType {
 		RTF,
 		RTFD,
@@ -37,29 +37,17 @@ namespace Foundation {
 		DocFormat
 	}
 
-	// Utility enum, ObjC uses NSString.  Not passed to the API, so doesn't need nint.
-	public enum NSDocumentType {
-		Unknown = -1,
-		PlainText,
-		RTF,
-		RTFD,
-		HTML,
-		MacSimpleText,
-		DocFormat,
-		WordML,
-		OfficeOpenXml,
-		WebArchive,
-		OpenDocument
-	}
-
 	// NSTask.h:typedef NS_ENUM(NSInteger, NSTaskTerminationReason)
 	[Native]
+	[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 	public enum NSTaskTerminationReason : long {
 		Exit = 1,
 		UncaughtSignal = 2
 	}
 
 	// The following constants where taken from MonoDevelop Carbon.cs MacInterop file
+	[NoiOS, NoTV, NoWatch]
+	[MacCatalyst (13, 0)]
 	public enum AEEventID : uint {
 		OpenApplication = 1868656752, // 'oapp'
 		ReopenApplication = 1918988400, //'rapp'
@@ -72,6 +60,8 @@ namespace Foundation {
 		GetUrl = 1196773964, // 'GURL'
 	}
 
+	[NoiOS, NoTV, NoWatch]
+	[MacCatalyst (13, 0)]
 	public enum AEEventClass : uint {
 		Mouse = 1836021107, // 'mous'
 		Keyboard = 1801812322, // 'keyb'
@@ -95,6 +85,7 @@ namespace Foundation {
 	}
 
 	// Added from NSUserNotification.h
+	[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 	[Native]
 	[Advice ("'NSUserNotification' usages should be replaced with 'UserNotifications' framework.")]
 	public enum NSUserNotificationActivationType : long {
@@ -106,6 +97,7 @@ namespace Foundation {
 	}
 
 	[Mac (10,11)]
+	[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 	[Native][Flags]
 	public enum NSAppleEventSendOptions : ulong
 	{
@@ -122,5 +114,3 @@ namespace Foundation {
 		DefaultOptions = WaitForReply | CanInteract
 	}
 }
-
-#endif // MONOMAC

--- a/src/Foundation/Enums.cs
+++ b/src/Foundation/Enums.cs
@@ -3,14 +3,25 @@ using ObjCRuntime;
 namespace Foundation {
 
 	// Utility enum, ObjC uses NSString
-	[NoMac]
 	[iOS (7,0)]
 	public enum NSDocumentType {
 		Unknown = -1,
 		PlainText,
 		RTF,
 		RTFD,
-		HTML
+		HTML,
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
+		MacSimpleText,
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
+		DocFormat,
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
+		WordML,
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
+		OfficeOpenXml,
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
+		WebArchive,
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
+		OpenDocument,
 	}
 
 	// Utility enum, ObjC uses NSString

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -729,6 +729,7 @@ FINDERSYNC_CORE_SOURCES = \
 FOUNDATION_API_SOURCES = \
 	Foundation/Enum.cs \
 	Foundation/Enums.cs \
+	Foundation/EnumDesktop.cs \
 
 FOUNDATION_CORE_SOURCES = \
 	Foundation/AdviceAttribute.cs \
@@ -759,7 +760,6 @@ FOUNDATION_CORE_SOURCES = \
 	Foundation/RegisterAttribute.cs \
 	Foundation/NSObject.iOS.cs \
 	Foundation/NSAttributedString.iOS.cs \
-	Foundation/EnumDesktop.cs \
 	Foundation/NSObject.mac.cs \
 	Foundation/NSDateComponents.cs \
 	Foundation/XpcInterfaceAttribute.cs \


### PR DESCRIPTION
This also meant merging the definitions for NSDocumentType.