### PR TITLE
[release/6.0.1xx-preview7] [dotnet] Put the 'createdump' executable in the app bundle when using CoreCLR. Fixes #11432.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -935,6 +935,21 @@
 				            '%(ResolvedFileToPublish.NuGetPackageId)' == '$(_MonoNugetPackageId)'
 				            "
 			/>
+
+			<!-- Put the 'createdump' executable in the expected location in the app bundle when using CoreCLR -->
+			<!-- Ref: https://github.com/xamarin/xamarin-macios/issues/11432 -->
+			<ResolvedFileToPublish
+				Update="@(ResolvedFileToPublish)"
+				RelativePath="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory)\$(PublishDir),$(_DylibPublishDir)))\%(Filename)%(Extension)"
+				Condition=" '$(UseMonoRuntime)' == 'false' And
+				            '%(ResolvedFileToPublish.Filename)' == 'createdump' And
+				            '%(ResolvedFileToPublish.Extension)' == '' And
+				            '%(ResolvedFileToPublish.AssetType)' == 'native' And
+				            '%(ResolvedFileToPublish.RuntimeIdentifier)' == '$(RuntimeIdentifier)' And
+				            '%(ResolvedFileToPublish.NuGetPackageId)' == '$(_MonoNugetPackageId)'
+				            "
+			/>
+
 		</ItemGroup>
 	</Target>
 


### PR DESCRIPTION
So that CoreCLR can create crash dumps.

Fixes https://github.com/xamarin/xamarin-macios/issues/11432.


Backport of #12210
