### PR TITLE
[d16-10] Bump maccore to get mlaunch fixes for Xcode 13 beta 3.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := c67d7af80d005d8a1a4321e4e5d4d148918d960b
+NEEDED_MACCORE_VERSION := 7e6ffadb1fe1a8e1444485a9915b04dcc07ab95b
 NEEDED_MACCORE_BRANCH := d16-10
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@7e6ffadb1f [Xamarin.Hosting] Only warn if we try to load a framework that doesn't exist. (#2473)
* xamarin/maccore@cc42300ec4 [Xamarin.Hosting] Xcode 13 b3 doesn't have IBFoundation anymore, but it does have AssetCatalogFoundation, which we must load. (#2474)
* xamarin/maccore@3e9801ee9a [Xamarin.Hosting] Improve error reporting when dlopen fails (#2475)

Diff: https://github.com/xamarin/maccore/compare/c67d7af80d005d8a1a4321e4e5d4d148918d960b..7e6ffadb1fe1a8e1444485a9915b04dcc07ab95b