### PR TITLE
[tests] Fix introspection on macOS 12

### DIFF
--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -815,6 +815,18 @@ namespace Introspection {
 					break;
 				}
 				break;
+			case "MTLCommandBufferDescriptor":
+				switch (selectorName) {
+				case "errorOptions":
+				case "setErrorOptions:":
+				case "retainedReferences":
+				case "setRetainedReferences:":
+					// iOS 15 sim (and macOS 12) fails, API added in 14.0
+					if (TestRuntime.CheckXcodeVersion (13, 0))
+						return true;
+					break;
+				}
+				break;
 			}
 
 			// old binding mistake

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -352,18 +352,6 @@ namespace Introspection {
 					break;
 				}
 				break;
-			case "MTLCommandBufferDescriptor":
-				switch (name) {
-				case "errorOptions":
-				case "setErrorOptions:":
-				case "retainedReferences":
-				case "setRetainedReferences:":
-					// iOS 15 sim fails, API added in 14.0
-					if (TestRuntime.CheckXcodeVersion (13, 0))
-						return true;
-					break;
-				}
-				break;
 #if __TVOS__ || __MACCATALYST__
 			// broken with Xcode 12 beta 1
 			case "CKDiscoveredUserInfo":


### PR DESCRIPTION
This was fixed for iOS 15 but also happens on macOS 12 so the case
was moved into the common, shared test sources.