### PR TITLE
[release/6.0.1xx-preview7] [dotnet] Add support for the interpreter + AOT when needed. Fixes #11421 and #11724.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -560,9 +560,9 @@
 		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_BindingLibraryLinkWith.items" Condition="Exists('$(_LinkerItemsDirectory)/_BindingLibraryLinkWith.items')">
 			<Output TaskParameter="Items" ItemName="_BindingLibraryLinkWith" />
 		</ReadItemsFromFile>
-		<!-- Load _BindingLibraryLinkerFlags -->
-		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_BindingLibraryLinkerFlags.items" Condition="Exists('$(_LinkerItemsDirectory)/_BindingLibraryLinkerFlags.items')">
-			<Output TaskParameter="Items" ItemName="_BindingLibraryLinkerFlags" />
+		<!-- Load _AssemblyLinkerFlags -->
+		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_AssemblyLinkerFlags.items" Condition="Exists('$(_LinkerItemsDirectory)/_AssemblyLinkerFlags.items')">
+			<Output TaskParameter="Items" ItemName="_AssemblyLinkerFlags" />
 		</ReadItemsFromFile>
 		<!-- Load _BindingLibraryFrameworks -->
 		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_BindingLibraryFrameworks.items" Condition="Exists('$(_LinkerItemsDirectory)/_BindingLibraryFrameworks.items')">
@@ -852,7 +852,7 @@
 			EntitlementsInExecutable="$(_CompiledEntitlements)"
 			FrameworkRPath="$(_EmbeddedFrameworksRPath)"
 			Frameworks="@(_NativeExecutableFrameworks);@(_BindingLibraryFrameworks)"
-			LinkerFlags="@(_BindingLibraryLinkerFlags);@(_ReferencesLinkerFlags);@(_MainLinkerFlags)"
+			LinkerFlags="@(_AssemblyLinkerFlags);@(_ReferencesLinkerFlags);@(_MainLinkerFlags)"
 			LinkWithLibraries="@(_XamarinMainLibraries);@(_BindingLibraryLinkWith);@(_MainLinkWith)"
 			MinimumOSVersion="$(_MinimumOSVersion)"
 			NativeReferences="@(_FileNativeReference);@(_FrameworkNativeReference)"

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -360,6 +360,7 @@
 				AOTCompiler=$(_AOTCompiler)
 				AOTOutputDirectory=$(_AOTOutputDirectory)
 				CacheDirectory=$(_LinkerCacheDirectory)
+				@(_BundlerDlsym -> 'Dlsym=%(Identity)')
 				Debug=$(_BundlerDebug)
 				DeploymentTarget=$(_MinimumOSVersion)
 				@(_BundlerEnvironmentVariables -> 'EnvironmentVariable=%(Identity)=%(Value)')

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -370,6 +370,8 @@
 				InvariantGlobalization=$(InvariantGlobalization)
 				ItemsDirectory=$(_LinkerItemsDirectory)
 				IsSimulatorBuild=$(_SdkIsSimulator)
+				LibMonoLinkMode=$(_LibMonoLinkMode)
+				LibXamarinLinkMode=$(_LibXamarinLinkMode)
 				LinkMode=$(_LinkMode)
 				MarshalManagedExceptionMode=$(_MarshalManagedExceptionMode)
 				MarshalObjectiveCExceptionMode=$(_MarshalObjectiveCExceptionMode)

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -630,6 +630,17 @@
 	</PropertyGroup>
 
 	<Target Name="_ComputeVariables" DependsOnTargets="$(_ComputeVariablesDependsOn)">
+		<PropertyGroup Condition="'$(_RunAotCompiler)' == ''">
+			<!-- Don't run the AOT compiler by default -->
+			<_RunAotCompiler>false</_RunAotCompiler>
+			<!-- We need it for device builds for mobile platforms -->
+			<_RunAotCompiler Condition="'$(_SdkIsSimulator)' != 'true' And '$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst'">true</_RunAotCompiler>
+			<!-- We need it if the interpreter is enabled, no matter where -->
+			<_RunAotCompiler Condition="'$(MtouchInterpreter)' != ''">true</_RunAotCompiler>
+			<!-- We need it for Mac Catalyst on arm64 -->
+			<_RunAotCompiler Condition="'$(RuntimeIdentifier)' == 'maccatalyst-arm64'">true</_RunAotCompiler>
+		</PropertyGroup>
+
 		<PropertyGroup>
 			<_IntermediateNativeLibraryDir>$(IntermediateOutputPath)nativelibraries/</_IntermediateNativeLibraryDir>
 			<_NativeExecutableName>$(_AppBundleName)</_NativeExecutableName>
@@ -642,11 +653,13 @@
 			<_AOTInputDirectory>$(_IntermediateNativeLibraryDir)aot-input/</_AOTInputDirectory>
 			<_AOTOutputDirectory>$(_IntermediateNativeLibraryDir)aot-output/</_AOTOutputDirectory>
 
+			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == '' And '$(_RunAotCompiler)' == 'true'">static</_LibMonoLinkMode> <!-- https://github.com/dotnet/runtime/issues/55000 -->
 			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == '' And ('$(ComputedPlatform)' != 'iPhone' Or '$(_PlatformName)' == 'macOS')">dylib</_LibMonoLinkMode>
 			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == ''">static</_LibMonoLinkMode>
 			<_LibMonoExtension Condition="'$(_LibMonoLinkMode)' == 'dylib'">dylib</_LibMonoExtension>
 			<_LibMonoExtension Condition="'$(_LibMonoLinkMode)' == 'static'">a</_LibMonoExtension>
 
+			<_LibXamarinLinkMode Condition="'$(_LibXamarinLinkMode)' == '' And '$(_RunAotCompiler)' == 'true'">static</_LibXamarinLinkMode> <!-- https://github.com/dotnet/runtime/issues/55000 -->
 			<_LibXamarinLinkMode Condition="'$(_LibXamarinLinkMode)' == '' And '$(ComputedPlatform)' != 'iPhone' And '$(_PlatformName)' != 'macOS'">dylib</_LibXamarinLinkMode>
 			<_LibXamarinLinkMode Condition="'$(_LibXamarinLinkMode)' == ''">static</_LibXamarinLinkMode>
 			<_LibXamarinExtension Condition="'$(_LibXamarinLinkMode)' == 'dylib'">dylib</_LibXamarinExtension>
@@ -702,7 +715,7 @@
 	</Target>
 
 	<Target Name="_AOTCompile"
-			Condition="'$(_SdkIsSimulator)' != 'true' And '$(_PlatformName)' != 'macOS'"
+			Condition="'$(_RunAotCompiler)' == 'true'"
 			DependsOnTargets="_ComputeVariables"
 			Inputs="@(_AssembliesToAOT)"
 			Outputs="@(_AssembliesToAOT -> '%(ObjectFile)');@(_AssembliesToAOT -> '%(LLVMFile)');">

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ParseBundlerArgumentsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ParseBundlerArgumentsTaskBase.cs
@@ -8,6 +8,9 @@ namespace Xamarin.MacDev.Tasks {
 		public string ExtraArgs { get; set; }
 
 		[Output]
+		public ITaskItem [] DlSym { get; set; }
+
+		[Output]
 		public ITaskItem[] EnvironmentVariables { get; set; }
 
 		[Output]
@@ -49,6 +52,7 @@ namespace Xamarin.MacDev.Tasks {
 				var args = CommandLineArgumentBuilder.Parse (ExtraArgs);
 				List<string> xml = null;
 				var envVariables = new List<ITaskItem> ();
+				var dlsyms = new List<ITaskItem> ();
 
 				for (int i = 0; i < args.Length; i++) {
 					var arg = args [i];
@@ -83,6 +87,9 @@ namespace Xamarin.MacDev.Tasks {
 						// in that case we do want to run the SymbolStrip target, so we
 						// do not set the MtouchNoSymbolStrip property to 'true' in that case.
 						NoSymbolStrip = string.IsNullOrEmpty (value) ? "true" : "false";
+						break;
+					case "dlsym":
+						dlsyms.Add (new TaskItem (string.IsNullOrEmpty (value) ? "true" : value));
 						break;
 					case "dsym":
 						NoDSymUtil = ParseBool (value) ? "false" : "true";
@@ -143,6 +150,11 @@ namespace Xamarin.MacDev.Tasks {
 					EnvironmentVariables = envVariables.ToArray ();
 				}
 
+				if (dlsyms.Count > 0) {
+					if (DlSym != null)
+						dlsyms.AddRange (DlSym);
+					DlSym = dlsyms.ToArray ();
+				}
 			}
 
 			return !Log.HasLoggedErrors;

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1016,6 +1016,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			NoDSymUtil="$(_NoDSymUtil)"
 			>
 			<Output TaskParameter="CustomBundleName" PropertyName="_CustomBundleName" />
+			<Output TaskParameter="DlSym" ItemName="_BundlerDlsym" />
 			<Output TaskParameter="EnvironmentVariables" ItemName="_BundlerEnvironmentVariables" />
 			<Output TaskParameter="MarshalManagedExceptionMode" PropertyName="_MarshalManagedExceptionMode" />
 			<Output TaskParameter="MarshalObjectiveCExceptionMode" PropertyName="_MarshalObjectiveCExceptionMode" />

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -426,12 +426,9 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 	xamarin_initialize ();
 	DEBUG_LAUNCH_TIME_PRINT ("\tmonotouch init time");
 
-#if defined (__arm__) || defined(__aarch64__)
-	xamarin_register_assemblies ();
-	assembly = xamarin_open_and_register (xamarin_executable_name, &exception_gchandle);
-	if (exception_gchandle != NULL)
-		xamarin_process_managed_exception_gchandle (exception_gchandle);
-#else
+	if (xamarin_register_assemblies != NULL)
+		xamarin_register_assemblies ();
+
 	if (xamarin_executable_name) {
 		assembly = xamarin_open_and_register (xamarin_executable_name, &exception_gchandle);
 		if (exception_gchandle != NULL)
@@ -455,7 +452,6 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 		if (exception_gchandle != NULL)
 			xamarin_process_managed_exception_gchandle (exception_gchandle);
 	}
-#endif
 
 	DEBUG_LAUNCH_TIME_PRINT ("\tAssembly register time");
 

--- a/runtime/monovm-bridge.m
+++ b/runtime/monovm-bridge.m
@@ -57,9 +57,8 @@ xamarin_bridge_setup ()
 void
 xamarin_bridge_initialize ()
 {
-#if defined (__arm__) || defined(__aarch64__)
-	xamarin_register_modules ();
-#endif
+	if (xamarin_register_modules != NULL)
+		xamarin_register_modules ();
 	DEBUG_LAUNCH_TIME_PRINT ("\tAOT register time");
 
 #ifdef DEBUG

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -83,6 +83,7 @@ enum MarshalManagedExceptionMode xamarin_marshal_managed_exception_mode = Marsha
 enum XamarinLaunchMode xamarin_launch_mode = XamarinLaunchModeApp;
 bool xamarin_supports_dynamic_registration = true;
 const char *xamarin_runtime_configuration_name = NULL;
+const char *xamarin_mono_native_lib_name = "__Internal";
 
 /* Callbacks */
 
@@ -2441,8 +2442,25 @@ xamarin_pinvoke_override (const char *libraryName, const char *entrypointName)
 
 	void* symbol = NULL;
 
+#if TARGET_OS_MACCATALYST
+	static void *monoNativeLibrary = NULL;
+#endif
+
 	if (!strcmp (libraryName, "__Internal")) {
 		symbol = dlsym (RTLD_DEFAULT, entrypointName);
+#if TARGET_OS_MACCATALYST
+	} else if (!strcmp (libraryName, "libSystem.Native") ||
+	           !strcmp (libraryName, "libSystem.Security.Cryptography.Native.Apple") ||
+	           !strcmp (libraryName, "libSystem.Net.Security.Native")) {
+		if (monoNativeLibrary == NULL) {
+			if (xamarin_mono_native_lib_name == NULL || !strcmp (xamarin_mono_native_lib_name, "__Internal")) {
+				monoNativeLibrary = RTLD_DEFAULT;
+			} else {
+				monoNativeLibrary = dlopen (xamarin_mono_native_lib_name, RTLD_LAZY);
+			}
+		}
+		symbol = dlsym (monoNativeLibrary, entrypointName);
+#endif // TARGET_OS_MACCATALYST
 #if !defined (CORECLR_RUNTIME) // we're intercepting objc_msgSend calls using the managed System.Runtime.InteropServices.ObjectiveC.Bridge.SetMessageSendCallback instead.
 #if defined (__i386__) || defined (__x86_64__) || defined (__arm64__)
 	} else if (!strcmp (libraryName, "/usr/lib/libobjc.dylib")) {

--- a/runtime/xamarin/main.h
+++ b/runtime/xamarin/main.h
@@ -109,6 +109,7 @@ extern enum MarshalManagedExceptionMode xamarin_marshal_managed_exception_mode;
 extern enum XamarinLaunchMode xamarin_launch_mode;
 extern bool xamarin_supports_dynamic_registration;
 extern const char *xamarin_runtime_configuration_name;
+extern const char *xamarin_mono_native_lib_name;
 
 typedef void (*xamarin_setup_callback) ();
 typedef int (*xamarin_extension_main_callback) (int argc, char** argv);

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -328,9 +328,7 @@ void			xamarin_mono_object_release_at_process_exit (MonoObject *mobj);
  */
 MonoAssembly * xamarin_open_assembly (const char *name);
 
-#if defined(__arm__) || defined(__aarch64__)
 void mono_aot_register_module (void *aot_info);
-#endif
 
 typedef void (*xamarin_register_module_callback) ();
 typedef void (*xamarin_register_assemblies_callback) ();

--- a/tests/dotnet/MyInterpretedApp/AppDelegate.cs
+++ b/tests/dotnet/MyInterpretedApp/AppDelegate.cs
@@ -3,7 +3,7 @@ using System;
 using Foundation;
 using UIKit;
 
-namespace MySingleView
+namespace MyInterpretedApp
 {
 	public partial class AppDelegate : UIApplicationDelegate
 	{
@@ -15,7 +15,7 @@ namespace MySingleView
 
 			var dvc = new UIViewController ();
 			var button = new UIButton (window.Bounds);
-			button.SetTitle ("net6!", UIControlState.Normal);
+			button.SetTitle ($"Execution mode: {Application.GetExecutionMode ()}", UIControlState.Normal);
 			dvc.Add (button);
 
 			window.RootViewController = dvc;

--- a/tests/dotnet/MyInterpretedApp/Entitlements.plist
+++ b/tests/dotnet/MyInterpretedApp/Entitlements.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/MyInterpretedApp/Info.plist
+++ b/tests/dotnet/MyInterpretedApp/Info.plist
@@ -2,25 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIDeviceFamily</key>
-	<array>
-		<integer>1</integer>
-	</array>
-	<key>UISupportedInterfaceOrientations</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
-	<key>CFBundleDisplayName</key>
-	<string>ApplicationName</string>
-	<key>CFBundleIdentifier</key>
-	<string>com.xamarin.mysingleview</string>
-	<key>XSAppIconAssets</key>
-	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
-	<key>XSLaunchImageAssets</key>
-	<string>Resources/Images.xcassets/LaunchImage.launchimage</string>
 </dict>
 </plist>

--- a/tests/dotnet/MyInterpretedApp/MacCatalyst/Makefile
+++ b/tests/dotnet/MyInterpretedApp/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/MyInterpretedApp/MacCatalyst/MyInterpretedApp.csproj
+++ b/tests/dotnet/MyInterpretedApp/MacCatalyst/MyInterpretedApp.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <RuntimeIdentifier>maccatalyst-arm64</RuntimeIdentifier>
+  </PropertyGroup>
+  <Import Project="../shared.csproj" />
+</Project>

--- a/tests/dotnet/MyInterpretedApp/Main.cs
+++ b/tests/dotnet/MyInterpretedApp/Main.cs
@@ -1,15 +1,26 @@
 using System;
+using System.Runtime.CompilerServices;
 
 using Foundation;
 using UIKit;
 
-namespace MySingleView
+namespace MyInterpretedApp
 {
 	public class Application
 	{
 		static void Main (string[] args)
 		{
+			Console.WriteLine ($"Execution mode: {GetExecutionMode ()}");
 			UIApplication.Main (args, null, typeof (AppDelegate));
+		}
+
+		public static string GetExecutionMode()
+		{
+			if (!RuntimeFeature.IsDynamicCodeSupported)
+				return "AOT";
+			if (RuntimeFeature.IsDynamicCodeCompiled)
+				return "JIT";
+			return "Interpreter";
 		}
 	}
 }

--- a/tests/dotnet/MyInterpretedApp/Makefile
+++ b/tests/dotnet/MyInterpretedApp/Makefile
@@ -2,8 +2,12 @@ TOP=../../..
 
 include $(TOP)/Make.config
 
-build:
-	$(DOTNET6) build /bl *.csproj $(MSBUILD_VERBOSITY)
+%-ios:
+	$(MAKE) -C iOS $@
 
-run:
-	$(DOTNET6) build /bl *.csproj $(MSBUILD_VERBOSITY) -t:Run
+%-tvos:
+	$(MAKE) -C tvOS $@
+
+%-maccatalyst %-maccat:
+	$(MAKE) -C MacCatalyst $@
+

--- a/tests/dotnet/MyInterpretedApp/iOS/Makefile
+++ b/tests/dotnet/MyInterpretedApp/iOS/Makefile
@@ -1,0 +1,4 @@
+include ../shared.mk
+
+dev:
+	$(DOTNET6) build /bl *.csproj $(MSBUILD_VERBOSITY) /p:RuntimeIdentifier=ios-arm64

--- a/tests/dotnet/MyInterpretedApp/iOS/MyInterpretedApp.csproj
+++ b/tests/dotnet/MyInterpretedApp/iOS/MyInterpretedApp.csproj
@@ -2,8 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0-ios</TargetFramework>
-    <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
-    <OutputType>Exe</OutputType>
-    <MtouchInterpreter>all</MtouchInterpreter>
   </PropertyGroup>
+  <Import Project="../shared.csproj" />
 </Project>

--- a/tests/dotnet/MyInterpretedApp/shared.csproj
+++ b/tests/dotnet/MyInterpretedApp/shared.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <UseInterpreter>true</UseInterpreter>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+
+    <ApplicationTitle>MyInterpretedApp</ApplicationTitle>
+    <ApplicationId>com.xamarin.myinterpretedapp</ApplicationId>
+    <ApplicationVersion>1.0</ApplicationVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../*.cs" />
+    <None Include="../Info.plist">
+      <Link>Info.plist</Link>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/dotnet/MyInterpretedApp/shared.mk
+++ b/tests/dotnet/MyInterpretedApp/shared.mk
@@ -1,0 +1,23 @@
+TOP=../../../..
+include $(TOP)/Make.config
+
+reload:
+	rm -Rf $(TOP)/tests/dotnet/packages
+	$(MAKE) -C $(TOP) -j8 all
+	$(MAKE) -C $(TOP) -j8 install
+	git clean -xfdq
+
+reload-and-build: reload
+	$(MAKE) build
+
+reload-and-run: reload
+	$(MAKE) run
+
+build:
+	$(DOTNET6) build /bl *.csproj $(MSBUILD_VERBOSITY)
+
+run:
+	$(DOTNET6) build /bl *.csproj $(MSBUILD_VERBOSITY) -t:Run
+
+diag:
+	$(DOTNET6) build /v:diag msbuild.binlog

--- a/tests/dotnet/MyInterpretedApp/tvOS/Makefile
+++ b/tests/dotnet/MyInterpretedApp/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/MyInterpretedApp/tvOS/MyInterpretedApp.csproj
+++ b/tests/dotnet/MyInterpretedApp/tvOS/MyInterpretedApp.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-tvos</TargetFramework>
+  </PropertyGroup>
+  <Import Project="../shared.csproj" />
+</Project>

--- a/tests/monotouch-test/Metal/MTLDeviceTests.cs
+++ b/tests/monotouch-test/Metal/MTLDeviceTests.cs
@@ -97,7 +97,7 @@ namespace MonoTouchFixtures.Metal {
 			string metallib_path = Path.Combine (NSBundle.MainBundle.ResourcePath, "default.metallib");
 			string fragmentshader_path = Path.Combine (NSBundle.MainBundle.ResourcePath, "fragmentShader.metallib");
 
-#if !__MACOS__
+#if !__MACOS__ && !__MACCATALYST__
 			if (Runtime.Arch == Arch.SIMULATOR)
 				Assert.Ignore ("Metal isn't available in the simulator");
 #endif
@@ -339,14 +339,16 @@ namespace MonoTouchFixtures.Metal {
 				}
 			}
 
-			using (var library = device.CreateLibrary (fragmentshader_path, out var error))
-			using (var func = library.CreateFunction ("fragmentShader2")) {
-				using (var enc = func.CreateArgumentEncoder (0)) {
-					Assert.IsNotNull (enc, "MTLFunction.CreateArgumentEncoder (nuint): NonNull");
-				}
-				using (var enc = func.CreateArgumentEncoder (0, out var reflection)) {
-					Assert.IsNotNull (enc, "MTLFunction.CreateArgumentEncoder (nuint, MTLArgument): NonNull");
-					Assert.IsNotNull (reflection, "MTLFunction.CreateArgumentEncoder (nuint, MTLArgument): NonNull reflection");
+			using (var library = device.CreateLibrary (fragmentshader_path, out var error)) {
+				Assert.IsNull (error, "MTLFunction.CreateArgumentEncoder: library creation failure");
+				using (var func = library.CreateFunction ("fragmentShader2")) {
+					using (var enc = func.CreateArgumentEncoder (0)) {
+						Assert.IsNotNull (enc, "MTLFunction.CreateArgumentEncoder (nuint): NonNull");
+					}
+					using (var enc = func.CreateArgumentEncoder (0, out var reflection)) {
+						Assert.IsNotNull (enc, "MTLFunction.CreateArgumentEncoder (nuint, MTLArgument): NonNull");
+						Assert.IsNotNull (reflection, "MTLFunction.CreateArgumentEncoder (nuint, MTLArgument): NonNull reflection");
+					}
 				}
 			}
 
@@ -378,7 +380,7 @@ namespace MonoTouchFixtures.Metal {
 
 			using (var hd = new MTLHeapDescriptor ()) {
 				hd.CpuCacheMode = MTLCpuCacheMode.DefaultCache;
-#if __MACOS__
+#if __MACOS__ || __MACCATALYST__
 				hd.StorageMode = MTLStorageMode.Private;
 #else
 				hd.StorageMode = MTLStorageMode.Shared;
@@ -388,7 +390,7 @@ namespace MonoTouchFixtures.Metal {
 					hd.Size = sa.Size;
 
 					using (var heap = device.CreateHeap (hd)) {
-#if __MACOS__
+#if __MACOS__ || __MACCATALYST__
 						txt.StorageMode = MTLStorageMode.Private;
 #endif
 						using (var texture = heap.CreateTexture (txt)) {

--- a/tests/monotouch-test/Metal/MTLDeviceTests.cs
+++ b/tests/monotouch-test/Metal/MTLDeviceTests.cs
@@ -63,6 +63,9 @@ namespace MonoTouchFixtures.Metal {
 		}
 
 		[Test]
+#if __MACCATALYST__
+		[Ignore ("This test requires a few test fixes that hasn't been backported to the release/6.0.1xx-preview7 branch - and won't be, since they're not necessary.")]
+#endif
 		public void ReturnReleaseTest ()
 		{
 			// This test tries to exercise all the Metal API that has a

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -426,13 +426,13 @@ namespace MonoTests.System.Net.Http
 				Assert.Inconclusive ("Request timedout.");
 			} else {
 				// the ServicePointManager.ServerCertificateValidationCallback will never be executed.
-				Assert.False(invalidServicePointManagerCbWasExcuted);
-				Assert.True(validationCbWasExecuted);
+				Assert.False (invalidServicePointManagerCbWasExcuted, "Invalid SPM executed");
+				Assert.True (validationCbWasExecuted, "Validation Callback called");
 				// assert the exception type
 				Assert.IsNotNull (ex, (result == null)? "Expected exception is missing and got no result" : $"Expected exception but got {result.Content.ReadAsStringAsync ().Result}");
-				Assert.IsInstanceOf (typeof (HttpRequestException), ex);
-				Assert.IsNotNull (ex.InnerException);
-				Assert.IsInstanceOf (expectedExceptionType, ex.InnerException);
+				Assert.IsInstanceOf (typeof (HttpRequestException), ex, "Exception type");
+				Assert.IsNotNull (ex.InnerException, "InnerException");
+				Assert.IsInstanceOf (expectedExceptionType, ex.InnerException, "InnerException type");
 			}
 		}
 

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -1620,8 +1620,10 @@ namespace Xamarin.Bundler {
 				return !Profile.IsSdkAssembly (Path.GetFileNameWithoutExtension (assembly));
 			case ApplePlatform.TVOS:
 			case ApplePlatform.WatchOS:
-			case ApplePlatform.MacCatalyst:
 				return false;
+			case ApplePlatform.MacCatalyst:
+				// We can't emit a direct call to the P/Invoke with the AOT compiler: https://github.com/dotnet/runtime/issues/55733
+				return IsAOTCompiled (assembly);
 			default:
 				throw ErrorHelper.CreateError (71, Errors.MX0071, Platform, ProductName);
 			}

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -182,8 +182,12 @@ namespace Xamarin.Bundler {
 		}
 
 		// How Mono should be embedded into the app.
+		AssemblyBuildTarget? libmono_link_mode;
 		public AssemblyBuildTarget LibMonoLinkMode {
 			get {
+				if (libmono_link_mode.HasValue)
+					return libmono_link_mode.Value;
+
 				if (Platform == ApplePlatform.MacOSX) {
 					// This property was implemented for iOS, but might be re-used for macOS if desired after testing to verify it works as expected.
 					throw ErrorHelper.CreateError (99, Errors.MX0099, "LibMonoLinkMode isn't a valid operation for macOS apps.");
@@ -199,11 +203,18 @@ namespace Xamarin.Bundler {
 					return AssemblyBuildTarget.StaticObject;
 				}
 			}
+			set {
+				libmono_link_mode = value;
+			}
 		}
 
 		// How libxamarin should be embedded into the app.
+		AssemblyBuildTarget? libxamarin_link_mode;
 		public AssemblyBuildTarget LibXamarinLinkMode {
 			get {
+				if (libxamarin_link_mode.HasValue)
+					return libxamarin_link_mode.Value;
+
 				if (Platform == ApplePlatform.MacOSX) {
 					// This property was implemented for iOS, but might be re-used for macOS if desired after testing to verify it works as expected.
 					throw ErrorHelper.CreateError (99, Errors.MX0099, "LibXamarinLinkMode isn't a valid operation for macOS apps.");
@@ -219,14 +230,25 @@ namespace Xamarin.Bundler {
 					return AssemblyBuildTarget.StaticObject;
 				}
 			}
+			set {
+				libxamarin_link_mode = value;
+			}
 		}
 
 		// How the generated libpinvoke library should be linked into the app.
 		public AssemblyBuildTarget LibPInvokesLinkMode => LibXamarinLinkMode;
 		// How the profiler library should be linked into the app.
 		public AssemblyBuildTarget LibProfilerLinkMode => OnlyStaticLibraries ? AssemblyBuildTarget.StaticObject : AssemblyBuildTarget.DynamicLibrary;
+
 		// How the libmononative library should be linked into the app.
-		public AssemblyBuildTarget LibMonoNativeLinkMode => HasDynamicLibraries ? AssemblyBuildTarget.DynamicLibrary : AssemblyBuildTarget.StaticObject;
+		public AssemblyBuildTarget LibMonoNativeLinkMode {
+			get {
+				// if there's a specific way libmono is being linked, use the same way.
+				if (libmono_link_mode.HasValue)
+					return libmono_link_mode.Value;
+				return HasDynamicLibraries ? AssemblyBuildTarget.DynamicLibrary: AssemblyBuildTarget.StaticObject;
+			}
+		}
 
 		// If all assemblies are compiled into static libraries.
 		public bool OnlyStaticLibraries {

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -1372,8 +1372,10 @@ namespace Xamarin.Bundler {
 			if (Platform == ApplePlatform.MacOSX)
 				throw ErrorHelper.CreateError (99, Errors.MX0099, "IsInterpreted isn't a valid operation for macOS apps.");
 
+#if !NET
 			if (IsSimulatorBuild)
 				return false;
+#endif
 
 			// IsAOTCompiled and IsInterpreted are not opposites: mscorlib.dll can be both.
 			if (!UseInterpreter)
@@ -1403,15 +1405,18 @@ namespace Xamarin.Bundler {
 		public bool IsAOTCompiled (string assembly)
 		{
 #if NET
-			if (Platform == ApplePlatform.MacOSX || Platform == ApplePlatform.MacCatalyst)
+			if (Platform == ApplePlatform.MacOSX)
 				return false; // AOT on .NET for macOS hasn't been implemented yet.
 #else	
 			if (Platform == ApplePlatform.MacOSX)
 				throw ErrorHelper.CreateError (99, Errors.MX0099, "IsAOTCompiled isn't a valid operation for macOS apps.");
 #endif
+			if (!UseInterpreter) {
+				if (Platform == ApplePlatform.MacCatalyst)
+					return IsArchEnabled (Abi.ARM64);
 
-			if (!UseInterpreter)
-				return true;
+				return IsDeviceBuild;
+			}
 
 			// IsAOTCompiled and IsInterpreted are not opposites: mscorlib.dll can be both:
 			// - mscorlib will always be processed by the AOT compiler to generate required wrapper functions for the interpreter to work

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -781,7 +781,7 @@ namespace Xamarin.Bundler {
 				var addDllMap = true;
 #endif
 				string mono_native_lib;
-				if (app.LibMonoNativeLinkMode == AssemblyBuildTarget.StaticObject)
+				if (app.LibMonoNativeLinkMode == AssemblyBuildTarget.StaticObject || Driver.IsDotNet)
 					mono_native_lib = "__Internal";
 				else
 					mono_native_lib = app.GetLibNativeName () + ".dylib";

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -668,12 +668,12 @@ namespace Xamarin.Bundler {
 			foreach (var s in assemblies) {
 				if (!s.IsAOTCompiled)
 					continue;
-				if ((abi & Abi.SimulatorArchMask) == 0) {
-					var info = s.AssemblyDefinition.Name.Name;
-					info = EncodeAotSymbol (info);
-					assembly_externs.Append ("extern void *mono_aot_module_").Append (info).AppendLine ("_info;");
-					assembly_aot_modules.Append ("\tmono_aot_register_module (mono_aot_module_").Append (info).AppendLine ("_info);");
-				}
+
+				var info = s.AssemblyDefinition.Name.Name;
+				info = EncodeAotSymbol (info);
+				assembly_externs.Append ("extern void *mono_aot_module_").Append (info).AppendLine ("_info;");
+				assembly_aot_modules.Append ("\tmono_aot_register_module (mono_aot_module_").Append (info).AppendLine ("_info);");
+
 				string sname = s.FileName;
 				if (assembly_name != sname && IsBoundAssembly (s)) {
 					register_assemblies.Append ("\txamarin_open_and_register (\"").Append (sname).Append ("\", &exception_gchandle);").AppendLine ();
@@ -681,22 +681,20 @@ namespace Xamarin.Bundler {
 				}
 			}
 
-			if ((abi & Abi.SimulatorArchMask) == 0 || app.Embeddinator) {
-				var frameworks = assemblies.Where ((a) => a.BuildTarget == AssemblyBuildTarget.Framework)
-										   .OrderBy ((a) => a.Identity, StringComparer.Ordinal);
-				foreach (var asm_fw in frameworks) {
-					var asm_name = asm_fw.Identity;
-					if (asm_fw.BuildTargetName == asm_name)
-						continue; // this is deduceable
-					var prefix = string.Empty;
-					if (!app.HasFrameworksDirectory && asm_fw.IsCodeShared)
-						prefix = "../../";
-					var suffix = string.Empty;
-					if (app.IsSimulatorBuild)
-						suffix = "/simulator";
-					assembly_location.AppendFormat ("\t{{ \"{0}\", \"{2}Frameworks/{1}.framework/MonoBundle{3}\" }},\n", asm_name, asm_fw.BuildTargetName, prefix, suffix);
-					assembly_location_count++;
-				}
+			var frameworks = assemblies.Where ((a) => a.BuildTarget == AssemblyBuildTarget.Framework)
+										.OrderBy ((a) => a.Identity, StringComparer.Ordinal);
+			foreach (var asm_fw in frameworks) {
+				var asm_name = asm_fw.Identity;
+				if (asm_fw.BuildTargetName == asm_name)
+					continue; // this is deduceable
+				var prefix = string.Empty;
+				if (!app.HasFrameworksDirectory && asm_fw.IsCodeShared)
+					prefix = "../../";
+				var suffix = string.Empty;
+				if (app.IsSimulatorBuild)
+					suffix = "/simulator";
+				assembly_location.AppendFormat ("\t{{ \"{0}\", \"{2}Frameworks/{1}.framework/MonoBundle{3}\" }},\n", asm_name, asm_fw.BuildTargetName, prefix, suffix);
+				assembly_location_count++;
 			}
 
 			sw.WriteLine ("#include \"xamarin/xamarin.h\"");
@@ -762,8 +760,11 @@ namespace Xamarin.Bundler {
 				sw.WriteLine ("\tmono_ee_interp_init (NULL);");
 #endif
 				sw.WriteLine ("\tmono_jit_set_aot_mode (MONO_AOT_MODE_INTERP);");
-			} else if (app.IsDeviceBuild)
+			} else if (app.IsDeviceBuild) {
 				sw.WriteLine ("\tmono_jit_set_aot_mode (MONO_AOT_MODE_FULL);");
+			} else if (app.Platform == ApplePlatform.MacCatalyst && ((abi & Abi.ARM64) == Abi.ARM64)) {
+				sw.WriteLine ("\tmono_jit_set_aot_mode (MONO_AOT_MODE_FULL);");
+			}
 
 			if (assembly_location.Length > 0)
 				sw.WriteLine ("\txamarin_set_assembly_directories (&assembly_locations);");

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -779,12 +779,12 @@ namespace Xamarin.Bundler {
 #else
 				var addDllMap = true;
 #endif
+				string mono_native_lib;
+				if (app.LibMonoNativeLinkMode == AssemblyBuildTarget.StaticObject)
+					mono_native_lib = "__Internal";
+				else
+					mono_native_lib = app.GetLibNativeName () + ".dylib";
 				if (addDllMap) {
-					string mono_native_lib;
-					if (app.LibMonoNativeLinkMode == AssemblyBuildTarget.StaticObject)
-						mono_native_lib = "__Internal";
-					else
-						mono_native_lib = app.GetLibNativeName () + ".dylib";
 					sw.WriteLine ();
 #if NET
 					sw.WriteLine ($"\tmono_dllmap_insert (NULL, \"libSystem.Native\", NULL, \"{mono_native_lib}\", NULL);");
@@ -796,6 +796,8 @@ namespace Xamarin.Bundler {
 					sw.WriteLine ($"\tmono_dllmap_insert (NULL, \"System.Net.Security.Native\", NULL, \"{mono_native_lib}\", NULL);");
 #endif
 					sw.WriteLine ();
+				} else {
+					sw.WriteLine ($"\txamarin_mono_native_lib_name = \"{mono_native_lib}\";");
 				}
 			}
 

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -126,6 +126,9 @@ namespace Xamarin.Linker {
 						throw new InvalidOperationException ($"Unable to parse the {key} value: {value} in {linker_file}");
 					DeploymentTarget = deployment_target;
 					break;
+				case "Dlsym":
+					Application.ParseDlsymOptions (value);
+					break;
 				case "EnvironmentVariable":
 					var separators = new char [] { ':', '=' };
 					var equals = value.IndexOfAny (separators);
@@ -328,6 +331,7 @@ namespace Xamarin.Linker {
 				Console.WriteLine ($"    AssemblyName: {Application.AssemblyName}");
 				Console.WriteLine ($"    CacheDirectory: {CacheDirectory}");
 				Console.WriteLine ($"    Debug: {Application.EnableDebug}");
+				Console.WriteLine ($"    Dlsym: {Application.DlsymOptions} {(Application.DlsymAssemblies != null ? string.Join (" ", Application.DlsymAssemblies.Select (v => (v.Item2 ? "+" : "-") + v.Item1)) : string.Empty)}");
 				Console.WriteLine ($"    DeploymentTarget: {DeploymentTarget}");
 				Console.WriteLine ($"    IntermediateLinkDir: {IntermediateLinkDir}");
 				Console.WriteLine ($"    InterpretedAssemblies: {string.Join (", ", Application.InterpretedAssemblies)}");

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -16,6 +16,8 @@ using ObjCRuntime;
 
 namespace Xamarin.Linker {
 	public class LinkerConfiguration {
+		string LinkerFile;
+
 		public List<Abi> Abis;
 		public string AOTCompiler;
 		public string AOTOutputDirectory;
@@ -73,6 +75,8 @@ namespace Xamarin.Linker {
 		{
 			if (!File.Exists (linker_file))
 				throw new FileNotFoundException ($"The custom linker file {linker_file} does not exist.");
+
+			LinkerFile = linker_file;
 
 			Profile = new BaseProfile (this);
 			DerivedLinkContext = new DerivedLinkContext { LinkerConfiguration = this, };
@@ -144,6 +148,12 @@ namespace Xamarin.Linker {
 					break;
 				case "IsSimulatorBuild":
 					IsSimulatorBuild = string.Equals ("true", value, StringComparison.OrdinalIgnoreCase);
+					break;
+				case "LibMonoLinkMode":
+					Application.LibMonoLinkMode = ParseLinkMode (value, key);
+					break;
+				case "LibXamarinLinkMode":
+					Application.LibXamarinLinkMode = ParseLinkMode (value, key);
 					break;
 				case "LinkMode":
 					if (!Enum.TryParse<LinkMode> (value, true, out var lm))
@@ -296,6 +306,17 @@ namespace Xamarin.Linker {
 
 			Application.InitializeCommon ();
 			Application.Initialize ();
+		}
+
+		AssemblyBuildTarget ParseLinkMode (string value, string variableName)
+		{
+			if (string.Equals (value, "dylib", StringComparison.OrdinalIgnoreCase)) {
+				return AssemblyBuildTarget.DynamicLibrary;
+			} else if (string.Equals (value, "static", StringComparison.OrdinalIgnoreCase)) {
+				return AssemblyBuildTarget.StaticObject;
+			}
+
+			throw new InvalidOperationException ($"Invalid {variableName} '{value}' in {LinkerFile}");
 		}
 
 		public void Write ()

--- a/tools/dotnet-linker/Steps/ComputeNativeBuildFlagsStep.cs
+++ b/tools/dotnet-linker/Steps/ComputeNativeBuildFlagsStep.cs
@@ -27,6 +27,23 @@ namespace Xamarin.Linker {
 			}
 
 			Configuration.WriteOutputForMSBuild ("_LinkerFrameworks", linkerFrameworks);
+
+			// Tell MSBuild about any additional linker flags we found
+			var linkerFlags = new List<MSBuildItem> ();
+			foreach (var asm in Configuration.Target.Assemblies) {
+				if (asm.LinkerFlags == null)
+					continue;
+				foreach (var arg in asm.LinkerFlags) {
+					var item = new MSBuildItem {
+						Include = arg,
+						Metadata = new Dictionary<string, string> {
+							{ "Assembly", asm.Identity },
+						},
+					};
+					linkerFlags.Add (item);
+				}
+			}
+			Configuration.WriteOutputForMSBuild ("_AssemblyLinkerFlags", linkerFlags);
 		}
 	}
 }

--- a/tools/dotnet-linker/Steps/ExtractBindingLibrariesStep.cs
+++ b/tools/dotnet-linker/Steps/ExtractBindingLibrariesStep.cs
@@ -55,23 +55,6 @@ namespace Xamarin.Linker {
 				}
 			}
 			Configuration.WriteOutputForMSBuild ("_BindingLibraryFrameworks", frameworks);
-
-			// Tell MSBuild about any additional linker flags we found
-			var linkerFlags = new List<MSBuildItem> ();
-			foreach (var asm in Configuration.Target.Assemblies) {
-				if (asm.LinkerFlags == null)
-					continue;
-				foreach (var arg in asm.LinkerFlags) {
-					var item = new MSBuildItem {
-						Include = arg,
-						Metadata = new Dictionary<string, string> {
-							{ "Assembly", asm.Identity },
-						},
-					};
-					linkerFlags.Add (item);
-				}
-			}
-			Configuration.WriteOutputForMSBuild ("_BindingLibraryLinkerFlags", linkerFlags);
 		}
 	}
 }

--- a/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
+++ b/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
@@ -146,7 +146,7 @@ namespace Xamarin.Linker.Steps
 				case "System.Security.Cryptography.Native.Apple":
 #if NET
 					// https://github.com/dotnet/runtime/issues/47533
-					if (DerivedLinkContext.App.Platform != ApplePlatform.MacOSX) {
+					if (DerivedLinkContext.App.Platform != ApplePlatform.MacOSX && DerivedLinkContext.App.Platform != ApplePlatform.MacCatalyst) {
 						Driver.Log (4, "Did not add native reference to {0} in {1} referenced by {2} in {3}.", pinfo.EntryPoint, pinfo.Module.Name, method.FullName, method.Module.Name);
 						break;
 					}


### PR DESCRIPTION
* Add support for the interpreter everywhere.
* Add support for the AOT compiler everywhere we didn't support it before,
  because the interpreter needs it (at least System.Private.CoreLib.dll must
  be AOT-compiled when using the interpreter).
* Do FullAOT compilation on Mac Catalyst/ARM64 if we're not using the
  interpreter, since we can't use the JIT.
* Fix monotouch-test to be green on Mac Catalyst/ARM64.

Fixes https://github.com/xamarin/xamarin-macios/issues/11724.
Fixes https://github.com/xamarin/xamarin-macios/issues/11421.


Backport of #12211
