### PR TITLE
[release/6.0.1xx-preview7] [monotouch-test] Fix CalendarTest.TestOrdinality to use UTC instead of local datetimes. Fixes #xamarin/maccore@2471.

### DIFF
--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -423,6 +423,10 @@ namespace MonoTouchFixtures.Foundation {
 			var date = new DateTime (year, month, day, 0, 0, 0, DateTimeKind.Utc);
 			var dt = (NSDate) date;
 			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {cal.Ordinality (smaller, larger, dt)} Calendar: {cal} TimeZone: {cal.TimeZone} Locale: {cal.Locale}={cal.Locale?.LocaleIdentifier}={cal.Locale?.Identifier}={cal.Locale?.CountryCode}");
+			cal.TimeZone = NSTimeZone.FromName ("Europe/Madrid");
+			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {cal.Ordinality (smaller, larger, dt)} Calendar: {cal} TimeZone: {cal.TimeZone} Locale: {cal.Locale}={cal.Locale?.LocaleIdentifier}={cal.Locale?.Identifier}={cal.Locale?.CountryCode}");
+			cal.TimeZone = NSTimeZone.FromName ("America/New_York");
+			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {cal.Ordinality (smaller, larger, dt)} Calendar: {cal} TimeZone: {cal.TimeZone} Locale: {cal.Locale}={cal.Locale?.LocaleIdentifier}={cal.Locale?.Identifier}={cal.Locale?.CountryCode}");
 			cal.TimeZone = NSTimeZone.FromName ("America/Los_Angeles");
 			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {cal.Ordinality (smaller, larger, dt)} Calendar: {cal} TimeZone: {cal.TimeZone} Locale: {cal.Locale}={cal.Locale?.LocaleIdentifier}={cal.Locale?.Identifier}={cal.Locale?.CountryCode}");
 			Assert.AreEqual ((nuint) expected, cal.Ordinality (smaller, larger, dt), $"Ticks: {date.Ticks} Kind: {date.Kind} NSDate: {dt}");

--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -421,8 +421,10 @@ namespace MonoTouchFixtures.Foundation {
 		{
 			var cal = new NSCalendar (NSCalendarType.Gregorian);
 			var date = new DateTime (year, month, day, 0, 0, 0, DateTimeKind.Utc);
-			var ordinality = cal.Ordinality (smaller, larger, (NSDate) date);
-			Assert.AreEqual (ordinality, (nuint) expected);
+			var dt = (NSDate) date;
+			var ordinality = cal.Ordinality (smaller, larger, dt);
+			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {ordinality}");
+			Assert.AreEqual ((nuint) expected, ordinality, $"Ticks: {date.Ticks} Kind: {date.Kind} NSDate: {dt}");
 		}
 
 		[TestCase (2010, 1, 11, NSCalendarUnit.Day, 86400.0)]

--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -423,7 +423,9 @@ namespace MonoTouchFixtures.Foundation {
 			var date = new DateTime (year, month, day, 0, 0, 0, DateTimeKind.Utc);
 			var dt = (NSDate) date;
 			var ordinality = cal.Ordinality (smaller, larger, dt);
-			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {ordinality}");
+			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {ordinality} Calendar: {cal} TimeZone: {cal.TimeZone} Locale: {cal.Locale}={cal.Locale?.LocaleIdentifier}={cal.Locale?.Identifier}={cal.Locale?.CountryCode}");
+			cal.TimeZone = NSTimeZone.FromName ("America/Los_Angeles");
+			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {ordinality} Calendar: {cal} TimeZone: {cal.TimeZone} Locale: {cal.Locale}={cal.Locale?.LocaleIdentifier}={cal.Locale?.Identifier}={cal.Locale?.CountryCode}");
 			Assert.AreEqual ((nuint) expected, ordinality, $"Ticks: {date.Ticks} Kind: {date.Kind} NSDate: {dt}");
 		}
 

--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -422,11 +422,10 @@ namespace MonoTouchFixtures.Foundation {
 			var cal = new NSCalendar (NSCalendarType.Gregorian);
 			var date = new DateTime (year, month, day, 0, 0, 0, DateTimeKind.Utc);
 			var dt = (NSDate) date;
-			var ordinality = cal.Ordinality (smaller, larger, dt);
-			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {ordinality} Calendar: {cal} TimeZone: {cal.TimeZone} Locale: {cal.Locale}={cal.Locale?.LocaleIdentifier}={cal.Locale?.Identifier}={cal.Locale?.CountryCode}");
+			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {cal.Ordinality (smaller, larger, dt)} Calendar: {cal} TimeZone: {cal.TimeZone} Locale: {cal.Locale}={cal.Locale?.LocaleIdentifier}={cal.Locale?.Identifier}={cal.Locale?.CountryCode}");
 			cal.TimeZone = NSTimeZone.FromName ("America/Los_Angeles");
-			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {ordinality} Calendar: {cal} TimeZone: {cal.TimeZone} Locale: {cal.Locale}={cal.Locale?.LocaleIdentifier}={cal.Locale?.Identifier}={cal.Locale?.CountryCode}");
-			Assert.AreEqual ((nuint) expected, ordinality, $"Ticks: {date.Ticks} Kind: {date.Kind} NSDate: {dt}");
+			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {cal.Ordinality (smaller, larger, dt)} Calendar: {cal} TimeZone: {cal.TimeZone} Locale: {cal.Locale}={cal.Locale?.LocaleIdentifier}={cal.Locale?.Identifier}={cal.Locale?.CountryCode}");
+			Assert.AreEqual ((nuint) expected, cal.Ordinality (smaller, larger, dt), $"Ticks: {date.Ticks} Kind: {date.Kind} NSDate: {dt}");
 		}
 
 		[TestCase (2010, 1, 11, NSCalendarUnit.Day, 86400.0)]

--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -420,7 +420,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void TestOrdinality (int year, int month, int day, NSCalendarUnit smaller, NSCalendarUnit larger, int expected)
 		{
 			var cal = new NSCalendar (NSCalendarType.Gregorian);
-			var date = new DateTime (year, month, day, 0, 0, 0, DateTimeKind.Local);
+			var date = new DateTime (year, month, day, 0, 0, 0, DateTimeKind.Utc);
 			var ordinality = cal.Ordinality (smaller, larger, (NSDate) date);
 			Assert.AreEqual (ordinality, (nuint) expected);
 		}

--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -422,14 +422,8 @@ namespace MonoTouchFixtures.Foundation {
 			var cal = new NSCalendar (NSCalendarType.Gregorian);
 			var date = new DateTime (year, month, day, 0, 0, 0, DateTimeKind.Utc);
 			var dt = (NSDate) date;
-			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {cal.Ordinality (smaller, larger, dt)} Calendar: {cal} TimeZone: {cal.TimeZone} Locale: {cal.Locale}={cal.Locale?.LocaleIdentifier}={cal.Locale?.Identifier}={cal.Locale?.CountryCode}");
 			cal.TimeZone = NSTimeZone.FromName ("Europe/Madrid");
-			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {cal.Ordinality (smaller, larger, dt)} Calendar: {cal} TimeZone: {cal.TimeZone} Locale: {cal.Locale}={cal.Locale?.LocaleIdentifier}={cal.Locale?.Identifier}={cal.Locale?.CountryCode}");
-			cal.TimeZone = NSTimeZone.FromName ("America/New_York");
-			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {cal.Ordinality (smaller, larger, dt)} Calendar: {cal} TimeZone: {cal.TimeZone} Locale: {cal.Locale}={cal.Locale?.LocaleIdentifier}={cal.Locale?.Identifier}={cal.Locale?.CountryCode}");
-			cal.TimeZone = NSTimeZone.FromName ("America/Los_Angeles");
-			Console.WriteLine ($"TestOrdinality ({year}, {month}, {day}, {smaller}, {larger}, {expected}) Ticks: {date.Ticks} NSDate: {dt} Ordinality: {cal.Ordinality (smaller, larger, dt)} Calendar: {cal} TimeZone: {cal.TimeZone} Locale: {cal.Locale}={cal.Locale?.LocaleIdentifier}={cal.Locale?.Identifier}={cal.Locale?.CountryCode}");
-			Assert.AreEqual ((nuint) expected, cal.Ordinality (smaller, larger, dt), $"Ticks: {date.Ticks} Kind: {date.Kind} NSDate: {dt}");
+			Assert.AreEqual ((nuint) expected, cal.Ordinality (smaller, larger, dt), $"Ordinality");
 		}
 
 		[TestCase (2010, 1, 11, NSCalendarUnit.Day, 86400.0)]


### PR DESCRIPTION
This is a bit of a shot in the dark, because I can't reproduce the issue, however:

* The test only fails on Mac Catalyst / .NET.
* The only place we're missing globalization data (such as time zone info) is on Mac Catalyst / .NET.
* The test needs time zone info, because it's converting a date from the local time zone to UTC.
* The test sometimes succeeds, sometimes fails (on the bots).
* I'm not in the same time zone as the bots.

My guess is that the lack of time zone info means that at certain times of the
day the test will fail, and exactly which times depend on the current time
zone where the test is executed.

Modifying the test to use UTC datetimes instead of local datetimes should make
the problem independent of the local time zone, and always have the same
behavior. And the test still passes for me, so I'm hoping it'll fix the test
on the bots too.

Fixes https://github.com/xamarin/maccore/issues/2471.


Backport of #12192
