### PR TITLE
[dotnet] Globalization works for Mac Catalyst now. Fixes #11392.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -128,8 +128,7 @@
 		<EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
 		<EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
 		<HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
-		<!-- native bits for ICU are not ready for Catalyst - https://github.com/xamarin/xamarin-macios/issues/11392 -->
-		<InvariantGlobalization Condition="'$(_PlatformName)' == 'MacCatalyst' And '$(InvariantGlobalization)' == ''">true</InvariantGlobalization>
+		<InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
 		<StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
 		<UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
 		<UseNativeHttpHandler Condition="'$(_PlatformName)' != 'macOS' And '$(UseNativeHttpHandler)' == ''">true</UseNativeHttpHandler>

--- a/tests/EmbeddedResources/ResourcesTest.cs
+++ b/tests/EmbeddedResources/ResourcesTest.cs
@@ -41,7 +41,6 @@ namespace EmbeddedResources {
 			var manager = new ResourceManager ("EmbeddedResources.Welcome", typeof(ResourcesTest).Assembly);
 #endif
 
-#if !(NET && __MACCATALYST__) // https://github.com/xamarin/xamarin-macios/issues/11392
 			Assert.AreEqual ("Welcome", manager.GetString ("String1", new CultureInfo ("en")), "en");
 			Assert.AreEqual ("G'day", manager.GetString ("String1", new CultureInfo ("en-AU")), "en-AU");
 			Assert.AreEqual ("Willkommen", manager.GetString ("String1", new CultureInfo ("de")), "de");
@@ -49,7 +48,6 @@ namespace EmbeddedResources {
 			Assert.AreEqual ("Bienvenido", manager.GetString ("String1", new CultureInfo ("es")), "es");
 			Assert.AreEqual ("Bienvenido", manager.GetString ("String1", new CultureInfo ("es-AR")), "es-AR");
 			Assert.AreEqual ("Bienvenido", manager.GetString ("String1", new CultureInfo ("es-ES")), "es-ES");
-#endif
 		}
 	}
 }

--- a/tests/linker/ios/link all/CalendarTest.cs
+++ b/tests/linker/ios/link all/CalendarTest.cs
@@ -10,9 +10,6 @@ namespace LinkAll.Calendars {
 	[TestFixture]
 	// we want the tests to be available because we use the linker
 	[Preserve (AllMembers = true)]
-#if NET && __MACCATALYST__
-	[Ignore ("No globalization data yet for Mac Catalyst - https://github.com/xamarin/xamarin-macios/issues/11392")]
-#endif
 	public class CalendarTest {
 
 		// application *MUST* be build with I18N.MidEast and I18N.Other (Thai)

--- a/tests/linker/ios/link sdk/CalendarTest.cs
+++ b/tests/linker/ios/link sdk/CalendarTest.cs
@@ -10,9 +10,6 @@ namespace LinkSdk.Calendars {
 	[TestFixture]
 	// we want the tests to be available because we use the linker
 	[Preserve (AllMembers = true)]
-#if NET && __MACCATALYST__
-	[Ignore ("No globalization data yet for Mac Catalyst - https://github.com/xamarin/xamarin-macios/issues/11392")]
-#endif
 	public class CalendarTest {
 
 		// application must *NOT* be build with I18N.MidEast and I18N.Other (Thai)

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -468,9 +468,6 @@ namespace LinkSdk {
 #endif // !__WATCHOS__ && !__MACCATALYST__
 		
 		[Test]
-#if NET && __MACCATALYST__
-		[Ignore ("No globalization data yet for Mac Catalyst - https://github.com/xamarin/xamarin-macios/issues/11392")]
-#endif
 		public void XElement_3137 ()
 		{
 			CultureInfo current = Thread.CurrentThread.CurrentCulture;

--- a/tests/linker/ios/link sdk/LocaleTest.cs
+++ b/tests/linker/ios/link sdk/LocaleTest.cs
@@ -14,9 +14,6 @@ namespace LinkSdk {
 
 		[Test]
 		[SetCulture ("cs-CZ")]
-#if NET && __MACCATALYST__
-		[Ignore ("No globalization data yet for Mac Catalyst - https://github.com/xamarin/xamarin-macios/issues/11392")]
-#endif
 		public void CzechDictComparer ()
 		{
 			DictComparer ();
@@ -24,9 +21,6 @@ namespace LinkSdk {
 
 		[Test]
 		[SetCulture ("en-US")]
-#if NET && __MACCATALYST__
-		[Ignore ("No globalization data yet for Mac Catalyst - https://github.com/xamarin/xamarin-macios/issues/11392")]
-#endif
 		public void EnglishDictComparer ()
 		{
 			DictComparer ();

--- a/tests/monotouch-test/Foundation/LocaleTest.cs
+++ b/tests/monotouch-test/Foundation/LocaleTest.cs
@@ -38,9 +38,6 @@ namespace MonoTouchFixtures.Foundation {
 			Assert.That (NSLocale.FromLocaleIdentifier (ident).Identifier, Is.EqualTo (ident), "FromLocaleIdentifier");
 		}
 		
-#if NET && __MACCATALYST__
-		[Ignore ("No globalization for Mac Catalyst yet - https://github.com/xamarin/xamarin-macios/issues/11392")]
-#endif
 		[Test]
 		public void InitRegionInfo ()
 		{

--- a/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
+++ b/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
@@ -168,13 +168,6 @@ namespace Xamarin.Linker.Steps
 
 				case "libSystem.Globalization.Native":
 				case "System.Globalization.Native":
-#if NET
-					// https://github.com/xamarin/xamarin-macios/issues/11392
-					if (DerivedLinkContext.App.Platform == ApplePlatform.MacCatalyst) {
-						Driver.Log (4, "Did not add native reference to {0} in {1} referenced by {2} in {3}.", pinfo.EntryPoint, pinfo.Module.Name, method.FullName, method.Module.Name);
-						break;
-					}
-#endif
 					addPInvokeSymbol = true;
 					break;
 


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/11392.