### PR TITLE
[monotouch-test] Adjust CalendarTest.DateComponentsTest to use a specific time zone.

### DIFF
--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -23,15 +23,16 @@ namespace MonoTouchFixtures.Foundation {
 		public void DateComponentsTest ()
 		{
 			var cal = new NSCalendar (NSCalendarType.Gregorian);
-			var now = DateTime.Now;
+			var now = DateTime.UtcNow;
 			NSDateComponents comps;
 
+			cal.TimeZone = NSTimeZone.FromName ("Europe/Madrid");
 			comps = cal.Components (NSCalendarUnit.Year | NSCalendarUnit.Month | NSCalendarUnit.Day, (NSDate) now);
 			Assert.AreEqual ((nint) now.Year, comps.Year, "a year");
 			Assert.AreEqual ((nint) now.Month, comps.Month, "a month");
 			Assert.AreEqual ((nint) now.Day, comps.Day, "a day");
 
-			var dayCompare = now.ToUniversalTime ();
+			var dayCompare = now;
 			comps = cal.Components (NSCalendarUnit.Hour, (NSDate) dayCompare.AddHours (-1), (NSDate) dayCompare, NSDateComponentsWrappingBehavior.None);
 			Assert.AreEqual ((nint) 1, comps.Hour, "b hour");
 		}


### PR DESCRIPTION
Hopefully avoids random test failures like https://github.com/xamarin/maccore/issues/2471#issuecomment-887517838.