### PR TITLE
[CI] Do not even try to do net6 publishing on not main builds.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -243,8 +243,9 @@ stages:
         xqaCertPass: $(xqa--certificates--password)
         enableDotnet: ${{ parameters.enableDotnet }}
 
-# .NET 6 Release Prep and VS Insertion Stages
-- template: templates/release/vs-insertion-prep.yml
+# .NET 6 Release Prep and VS Insertion Stages, only execute them when the build reason is not a PR or a schedule build fro OneLoc
+- ${{ if and(ne(variables['Build.Reason'], 'Schedule'), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual'))) }}:
+  - template: templates/release/vs-insertion-prep.yml
 
 # Test stages
 - ${{ if eq(parameters.runDeviceTests, true) }}:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -243,7 +243,7 @@ stages:
         xqaCertPass: $(xqa--certificates--password)
         enableDotnet: ${{ parameters.enableDotnet }}
 
-# .NET 6 Release Prep and VS Insertion Stages, only execute them when the build reason is not a PR or a schedule build fro OneLoc
+# .NET 6 Release Prep and VS Insertion Stages, only execute them when the build reason is not a PR or a schedule build from OneLoc
 - ${{ if and(ne(variables['Build.Reason'], 'Schedule'), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual'))) }}:
   - template: templates/release/vs-insertion-prep.yml
 


### PR DESCRIPTION
Lets not create steps using templates that will not be ran anyway. This removes those 2 extra steps when we are building on a PR.

Example of a internal build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5025066&view=results
External build (this PR :) )