### PR TITLE
[tests] Add dummy variable to put System.Runtime.CompilerServices.Unsafe.dll next to the test assembly.

### DIFF
--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -16,6 +16,9 @@ namespace GeneratorTests
 	[Parallelizable (ParallelScope.All)]
 	public class BGenTests
 	{
+		// Removing the following variable might make running the unit tests in VSMac fail.
+		static Type variable_to_keep_reference_to_system_runtime_compilerservices_unsafe_assembly = typeof (System.Runtime.CompilerServices.Unsafe);
+
 		[Test]
 #if !NET
 		[TestCase (Profile.macOSFull)]


### PR DESCRIPTION
Otherwise this happens when running tests from within the IDE:

```
error BI0000: Unexpected error - Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
System.IO.FileNotFoundException: Could not load file or assembly 'System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies.
File name: 'System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
  at System.ReadOnlySpan`1[T].op_Implicit (T[] array) [0x00000] in <16786cfd571c4686983021cfcee42fb4>:0
  at System.Reflection.TypeLoading.CoreTypes..ctor (System.Reflection.MetadataLoadContext loader, System.String coreAssemblyName) [0x0003d] in <49552709e6e14610b2a2f34b9d5f4c52>:0
  at System.Reflection.MetadataLoadContext..ctor (System.Reflection.MetadataAssemblyResolver resolver, System.String coreAssemblyName) [0x00046] in <49552709e6e14610b2a2f34b9d5f4c52>:0
  at BindingTouch.Main3 (System.String[] args) [0x00e91] in /Users/rolf/work/maccore/msbuild/xamarin-macios/src/btouch.cs:454
  at BindingTouch.Main2 (System.String[] args) [0x00007] in /Users/rolf/work/maccore/msbuild/xamarin-macios/src/btouch.cs:199
  at BindingTouch.Main (System.String[] args) [0x00002] in /Users/rolf/work/maccore/msbuild/xamarin-macios/src/btouch.cs:91
  at System.Environment.get_StackTrace () [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/corlib/System/Environment.cs:316
  at ErrorHelper.ShowInternal (System.Exception e) [0x0010f] in /Users/rolf/work/maccore/msbuild/xamarin-macios/src/error.cs:175
  at ErrorHelper.Show (System.Exception e, System.Boolean rethrow_errors) [0x00089] in /Users/rolf/work/maccore/msbuild/xamarin-macios/src/error.cs:125
  at BindingTouch.Main (System.String[] args) [0x0000d] in /Users/rolf/work/maccore/msbuild/xamarin-macios/src/btouch.cs:93
  at Xamarin.Tests.BGenTool.Execute () [0x000a1] in /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/generator/BGenTool.cs:228
  at Xamarin.Tests.BGenTool.AssertExecute (System.String message) [0x00001] in /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/generator/BGenTool.cs:207
  at GeneratorTests.BGenTests.BuildFile (Xamarin.Tests.Profile profile, System.Boolean nowarnings, System.Boolean processEnums, System.Collections.Generic.IEnumerable`1[T] references, System.String[] filenames) [0x000ab] in /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/generator/BGenTests.cs:764
  at GeneratorTests.BGenTests.BuildFile (Xamarin.Tests.Profile profile, System.Boolean nowarnings, System.Boolean processEnums, System.String[] filenames) [0x00001] in /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/generator/BGenTests.cs:750
  at GeneratorTests.BGenTests.BuildFile (Xamarin.Tests.Profile profile, System.String[] filenames) [0x00001] in /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/generator/BGenTests.cs:740
  at GeneratorTests.BGenTests.IgnoreUnavailableProtocol () [0x00001] in /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/generator/BGenTests.cs:636
  at System.Reflection.RuntimeMethodInfo.InternalInvoke (System.Reflection.RuntimeMethodInfo , System.Object , System.Object[] , System.Exception& ) [0x00000] in <08f46039e5064c628bf7795f9b970b7b>:0
  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs:395
  at System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/external/corefx/src/Common/src/CoreLib/System/Reflection/MethodBase.cs:53
  at NUnit.Framework.Internal.Reflect.InvokeMethod (System.Reflection.MethodInfo method, System.Object fixture, System.Object[] args) [0x00000] in <be0e2b70ca254bb684417cccea7d5290>:0
  at NUnit.Framework.Internal.MethodWrapper.Invoke (System.Object fixture, System.Object[] args) [0x00000] in <be0e2b70ca254bb684417cccea7d5290>:0
  at NUnit.Framework.Internal.Commands.TestMethodCommand.InvokeTestMethod (NUnit.Framework.Internal.TestExecutionContext context) [0x00000] in <be0e2b70ca254bb684417cccea7d5290>:0
  at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod (NUnit.Framework.Internal.TestExecutionContext context) [0x00000] in <be0e2b70ca254bb684417cccea7d5290>:0
  at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute (NUnit.Framework.Internal.TestExecutionContext context) [0x00000] in <be0e2b70ca254bb684417cccea7d5290>:0
  at NUnit.Framework.Internal.Execution.SimpleWorkItem.PerformWork () [0x00000] in <be0e2b70ca254bb684417cccea7d5290>:0
  at NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread () [0x00000] in <be0e2b70ca254bb684417cccea7d5290>:0
  at NUnit.Framework.Internal.Execution.WorkItem.Execute () [0x00000] in <be0e2b70ca254bb684417cccea7d5290>:0
  at NUnit.Framework.Internal.Execution.TestWorker.TestWorkerThreadProc () [0x00000] in <be0e2b70ca254bb684417cccea7d5290>:0
  at System.Threading.ThreadHelper.ThreadStart_Context (System.Object state) [0x00014] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/thread.cs:74
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00071] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:968
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:910
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state) [0x0002b] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:899
  at System.Threading.ThreadHelper.ThreadStart () [0x00008] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/thread.cs:111
```