### PR TITLE
[CI] Run post build job after prepare release

### DIFF
--- a/tools/devops/automation/post-build-pipeline.yml
+++ b/tools/devops/automation/post-build-pipeline.yml
@@ -1,5 +1,5 @@
 # YAML pipeline for post build operations. 
-# This pipeline will trigger automatically after successful completion of the `build_packages` stage against the specified branches.
+# This pipeline will trigger automatically after successful completion of the `prepare_release` stage against the specified branches.
 
 trigger: none
 pr: none
@@ -13,7 +13,7 @@ resources:
       - main
       - release/*
       stages:
-      - build_packages
+      - prepare_release
 
 jobs:
 - job: post_build


### PR DESCRIPTION
Commit 2af23dbd introduced a new "Prepare Release" stage that will
sign .NET 6 NuGet packages, and push them to the xamarin-impl feed.
The post build pipeline that pushes build metadata to Maestro for
downstream dependency updating should run after this stage.  There is
no reason to push build information to Maestro without also pushing
packages to a feed for external consumption.