### PR TITLE
[CI] Use NuGet to MSI conversion v2 (#12205)

### DIFF
--- a/dotnet/Workloads/vs-workload.template.props
+++ b/dotnet/Workloads/vs-workload.template.props
@@ -8,9 +8,12 @@
     <ShortNames Include="@PACK_VERSION_LONG@">
       <Replacement>@PACK_VERSION_SHORT@</Replacement>
     </ShortNames>
-    <ComponentResources Include="ios" Category=".NET" Title=".NET SDK for iOS" Description=".NET SDK Workload for building iOS applications."/>
-    <ComponentVersions Include="ios" Version="@IOS_WORKLOAD_VERSION@" />
-    <ComponentResources Include="maccatalyst" Category=".NET" Title=".NET SDK for Mac Catalyst" Description=".NET SDK Workload for building macOS applications with Mac Catalyst."/>
-    <ComponentVersions Include="maccatalyst" Version="@MACCATALYST_WORKLOAD_VERSION@" />
+    <ShortNames Include="Microsoft.MacCatalyst.Runtime.maccatalyst">
+      <Replacement>Microsoft.MacCatalyst.Runtime</Replacement>
+    </ShortNames>
+    <ComponentResources Include="ios" Version="@IOS_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for iOS" Description=".NET SDK Workload for building iOS applications."/>
+    <ComponentResources Include="maccatalyst" Version="@MACCATALYST_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for Mac Catalyst" Description=".NET SDK Workload for building macOS applications with Mac Catalyst."/>
+    <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.iOS.Manifest*.nupkg" Version="@IOS_WORKLOAD_VERSION@" />
+    <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.MacCatalyst.Manifest*.nupkg" Version="@MACCATALYST_WORKLOAD_VERSION@" />
   </ItemGroup>
 </Project>

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -21,7 +21,7 @@ stages:
       usePipelineArtifactTasks: true
 
   # Check - "xamarin-macios (Prepare Release Convert NuGet to MSI)"
-  - template: nuget-msi-convert/job/v1.yml@templates
+  - template: nuget-msi-convert/job/v2.yml@templates
     parameters:
       yamlResourceName: templates
       dependsOn: signing


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/121

Backport of: https://github.com/xamarin/xamarin-macios/pull/12205

Uses new versions of the nuget-msi-convert templates to support creation
of .msi files for workload manifest packs via the `GenerateManifestMsi`
task available in the `Microsoft.DotNet.Build.Tasks.Workloads` arcade
sdk.  