### PR TITLE
[Xtro] If the sanitizer removed all selectors, remove the file.

### DIFF
--- a/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
+++ b/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
@@ -177,6 +177,10 @@ namespace Extrospection {
 					foreach (var failure in failures)
 						sanitized.Remove (failure);
 					File.WriteAllLines (file, sanitized);
+					// since we are in AUTO_SANITIZE, if the file is empty, remove it.
+					if (!(File.ReadLines(file).Count() > 0)) {
+						File.Delete (file);
+					}
 				}
 			}
 		}

--- a/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
+++ b/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
@@ -178,7 +178,7 @@ namespace Extrospection {
 						sanitized.Remove (failure);
 					File.WriteAllLines (file, sanitized);
 					// since we are in AUTO_SANITIZE, if the file is empty, remove it.
-					if (!(sanitized.Count () > 0)) {
+					if (sanitized.Count == 0) {
 						File.Delete (file);
 					}
 				}

--- a/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
+++ b/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
@@ -178,7 +178,7 @@ namespace Extrospection {
 						sanitized.Remove (failure);
 					File.WriteAllLines (file, sanitized);
 					// since we are in AUTO_SANITIZE, if the file is empty, remove it.
-					if (!(File.ReadLines(file).Count() > 0)) {
+					if (!(sanitized.Count () > 0)) {
 						File.Delete (file);
 					}
 				}


### PR DESCRIPTION
A new check was added to ensure that empty .todo files are not added,
yet when the sanitizer removes all lines we get an error per empty file.

Since we are auto-sanitizing, we want to remove those empty files.