### PR TITLE
[release/6.0.1xx-preview7] [xharness] Bump timeout for the .NET unit tests.

### DIFF
--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -225,7 +225,7 @@ namespace Xharness.Jenkins {
 				TestProject = buildDotNetTestsProject,
 				Platform = TestPlatform.All,
 				TestName = "DotNet tests",
-				Timeout = TimeSpan.FromMinutes (30),
+				Timeout = TimeSpan.FromMinutes (60),
 				Ignored = !IncludeDotNet,
 			};
 			Tasks.Add (runDotNetTests);


### PR DESCRIPTION
Adding more and more tests make the tests take longer and longer...


Backport of #12240
