### PR TITLE
[mmp] Link symbols if and only if we're packaging debug symbols. Fixes #12263.

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1096,7 +1096,7 @@ namespace Xamarin.Bundler {
 			var options = new LinkerOptions {
 				MainAssembly = BuildTarget.Resolver.GetAssembly (App.References [App.References.Count - 1]),
 				OutputDirectory = mmp_dir,
-				LinkSymbols = App.EnableDebug,
+				LinkSymbols = App.PackageManagedDebugSymbols,
 				LinkMode = App.LinkMode,
 				Resolver = resolver,
 				SkippedAssemblies = App.LinkSkipped,


### PR DESCRIPTION
This makes it possible to preserve embedded debug symbols for a release build:
by passing "--package-debug-symbols=true" to mmp. Previously we'd remove the
symbols unconditionally for release builds.

This also conserves the old behavior (strip symbols in release builds), unless
users have explicitly passed "--package-debug-symbols=true" to mmp (because
PackageManagedDebugSymbols defaults to the same value as EnableDebug).

Fixes https://github.com/xamarin/xamarin-macios/issues/12263.