### PR TITLE
[monotouch-test] Use the same timezone for the calendar as we do for the time (UTC) in CalendarTest.DateComponentsTest. Fixes #xamarin/maccore@2481.

### DIFF
--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -26,7 +26,7 @@ namespace MonoTouchFixtures.Foundation {
 			var now = DateTime.UtcNow;
 			NSDateComponents comps;
 
-			cal.TimeZone = NSTimeZone.FromName ("Europe/Madrid");
+			cal.TimeZone = NSTimeZone.FromName ("UTC");
 			comps = cal.Components (NSCalendarUnit.Year | NSCalendarUnit.Month | NSCalendarUnit.Day, (NSDate) now);
 			Assert.AreEqual ((nint) now.Year, comps.Year, "a year");
 			Assert.AreEqual ((nint) now.Month, comps.Month, "a month");


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/2481.