### PR TITLE
[runtime] Implement computing and passing the NATIVE_DLL_SEARCH_DIRECTORIES runtime property. Fixes #10504.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -711,6 +711,7 @@
 			<_RuntimeConfigReservedProperties Include="PINVOKE_OVERRIDE" />
 			<_RuntimeConfigReservedProperties Include="ICU_DAT_FILE_PATH" />
 			<_RuntimeConfigReservedProperties Include="TRUSTED_PLATFORM_ASSEMBLIES" />
+			<_RuntimeConfigReservedProperties Include="NATIVE_DLL_SEARCH_DIRECTORIES" />
 		</ItemGroup>
 		<RuntimeConfigParserTask
 			Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'"


### PR DESCRIPTION
This adds support to compute the NATIVE_DLL_SEARCH_DIRECTORIES value and pass
it to the runtime. It's the last property listed in #10504, so this fixes that
issue.

Fixes https://github.com/xamarin/xamarin-macios/issues/10504