### PR TITLE
[dotnet-tools] Fix Profile.Is[Product|Sdk]Assembly. Fixes #12276.

### DIFF
--- a/tools/dotnet-linker/Compat.cs
+++ b/tools/dotnet-linker/Compat.cs
@@ -160,9 +160,9 @@ namespace Xamarin.Linker {
 			get { return Configuration.PlatformAssembly; }
 		}
 
-		public bool IsProductAssembly (string filename)
+		public bool IsProductAssembly (string assemblyName)
 		{
-			return Assembly.GetIdentity (filename) == Configuration.PlatformAssembly;
+			return assemblyName == Configuration.PlatformAssembly;
 		}
 
 		public bool IsProductAssembly (AssemblyDefinition assembly)
@@ -175,9 +175,9 @@ namespace Xamarin.Linker {
 			return Configuration.FrameworkAssemblies.Contains (Assembly.GetIdentity (assembly));
 		}
 
-		public bool IsSdkAssembly (string filename)
+		public bool IsSdkAssembly (string assemblyName)
 		{
-			return Configuration.FrameworkAssemblies.Contains (Assembly.GetIdentity (filename));
+			return Configuration.FrameworkAssemblies.Contains (assemblyName);
 		}
 	}
 }


### PR DESCRIPTION
In mtouch and mmp's implementation of these functions, they take the assembly
name, not the assembly path.

So for .NET, we'd previouslyget input such as "Xamarin.iOS", think it was a
filename, strip the extension, and compare "Xamarin" to the platform assembly
name, which didn't work.

Fixes https://github.com/xamarin/xamarin-macios/issues/12276.