### PR TITLE
[monotouch-test] Teach HealthKit tests about new HKQuantityTypeIdentifiers/HKCategoryTypeIdnetifiers.

### DIFF
--- a/tests/monotouch-test/HealthKit/CategoryTypeIdentifierTest.cs
+++ b/tests/monotouch-test/HealthKit/CategoryTypeIdentifierTest.cs
@@ -10,6 +10,7 @@
 #if HAS_HEALTHKIT
 
 using System;
+using System.Collections.Generic;
 
 using Foundation;
 using HealthKit;
@@ -26,6 +27,8 @@ namespace MonoTouchFixtures.HealthKit {
 		public void EnumValues_22351 ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
+
+			var failures = new List<string> ();
 
 			foreach (HKCategoryTypeIdentifier value in Enum.GetValues (typeof (HKCategoryTypeIdentifier))) {
 
@@ -105,6 +108,12 @@ namespace MonoTouchFixtures.HealthKit {
 					if (!TestRuntime.CheckXcodeVersion (12, 3))
 						continue;
 					break;
+				case HKCategoryTypeIdentifier.AppleWalkingSteadinessEvent:
+				case HKCategoryTypeIdentifier.PregnancyTestResult:
+				case HKCategoryTypeIdentifier.ProgesteroneTestResult:
+					if (!TestRuntime.CheckXcodeVersion (13, 0))
+						continue;
+					break;
 				default:
 					if (!TestRuntime.CheckXcodeVersion (7, 0))
 						continue;
@@ -117,9 +126,11 @@ namespace MonoTouchFixtures.HealthKit {
 					}
 				}
 				catch (Exception e) {
-					Assert.Fail ("{0} could not be created: {1}", value, e);
+					failures.Add ($"{value} could not be created: {e}");
 				}
 			}
+
+			Assert.That (failures, Is.Empty, "No failures");
 		}
 	}
 }

--- a/tests/monotouch-test/HealthKit/QuantityTypeIdentifierTest.cs
+++ b/tests/monotouch-test/HealthKit/QuantityTypeIdentifierTest.cs
@@ -10,6 +10,7 @@
 #if HAS_HEALTHKIT
 
 using System;
+using System.Collections.Generic;
 
 using Foundation;
 using HealthKit;
@@ -26,6 +27,8 @@ namespace MonoTouchFixtures.HealthKit {
 		public void EnumValues_22351 ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
+
+			var failures = new List<string> ();
 
 			foreach (HKQuantityTypeIdentifier value in Enum.GetValues (typeof (HKQuantityTypeIdentifier))) {
 
@@ -81,6 +84,11 @@ namespace MonoTouchFixtures.HealthKit {
 					if (!TestRuntime.CheckXcodeVersion (12, 5))
 						continue;
 					break;
+				case HKQuantityTypeIdentifier.AppleWalkingSteadiness:
+				case HKQuantityTypeIdentifier.NumberOfAlcoholicBeverages:
+					if (!TestRuntime.CheckXcodeVersion (13, 0))
+						continue;
+					break;
 				}
 
 				try {
@@ -89,9 +97,11 @@ namespace MonoTouchFixtures.HealthKit {
 					}
 				}
 				catch (Exception e) {
-					Assert.Fail ("{0} could not be created: {1}", value, e);
+					failures.Add ($"{value} could not be created: {e}");
 				}
 			}
+
+			Assert.That (failures, Is.Empty, "No failures");
 		}
 	}
 }


### PR DESCRIPTION
Fixes these test failures:

    MonoTouchFixtures.HealthKit.CategoryTypeIdentifier
    	[FAIL] EnumValues_22351 : AppleWalkingSteadinessEvent could not be created: System.ArgumentNullException: Value cannot be null.
    Parameter name: hkCategoryTypeIdentifier
      at ObjCRuntime.NativeObjectExtensions.GetNonNullHandle (ObjCRuntime.INativeObject self, System.String argumentName) [0x00003] in /Users/builder/azdo/_work/1/s/xamarin-macios/src/ObjCRuntime/INativeObject.cs:27
      at HealthKit.HKObjectType.GetCategoryType (Foundation.NSString hkCategoryTypeIdentifier) [0x00000] in /Users/builder/azdo/_work/1/s/xamarin-macios/src/build/ios/native/HealthKit/HKObjectType.g.cs:111
      at HealthKit.HKCategoryType.Create (HealthKit.HKCategoryTypeIdentifier kind) [0x00000] in /Users/builder/azdo/_work/1/s/xamarin-macios/src/HealthKit/HKObjectType.cs:26
      at MonoTouchFixtures.HealthKit.CategoryTypeIdentifier.EnumValues_22351 () [0x001fd] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/HealthKit/CategoryTypeIdentifierTest.cs:115
      at MonoTouchFixtures.HealthKit.CategoryTypeIdentifier.EnumValues_22351 () [0x0024f] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/HealthKit/CategoryTypeIdentifierTest.cs:120

    MonoTouchFixtures.HealthKit.QuantityTypeIdentifier
    	[FAIL] EnumValues_22351 : AppleWalkingSteadiness could not be created: System.ArgumentNullException: Value cannot be null.
    Parameter name: hkTypeIdentifier
      at ObjCRuntime.NativeObjectExtensions.GetNonNullHandle (ObjCRuntime.INativeObject self, System.String argumentName) [0x00003] in /Users/builder/azdo/_work/1/s/xamarin-macios/src/ObjCRuntime/INativeObject.cs:27
      at HealthKit.HKObjectType.GetQuantityType (Foundation.NSString hkTypeIdentifier) [0x00000] in /Users/builder/azdo/_work/1/s/xamarin-macios/src/build/ios/native/HealthKit/HKObjectType.g.cs:162
      at HealthKit.HKQuantityType.Create (HealthKit.HKQuantityTypeIdentifier kind) [0x00000] in /Users/builder/azdo/_work/1/s/xamarin-macios/src/HealthKit/HKObjectType.cs:19
      at MonoTouchFixtures.HealthKit.QuantityTypeIdentifier.EnumValues_22351 () [0x0017a] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/HealthKit/QuantityTypeIdentifierTest.cs:87
      at MonoTouchFixtures.HealthKit.QuantityTypeIdentifier.EnumValues_22351 () [0x001cc] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/HealthKit/QuantityTypeIdentifierTest.cs:92

Also make these tests show all failing enum values at once, instead of having
to run the test after adding each new case.