### PR TITLE
[xharness] Gracefully handle any exceptions that may occur when parsing build logs.

### DIFF
--- a/tests/xharness/Jenkins/TestTasks/RunTest.cs
+++ b/tests/xharness/Jenkins/TestTasks/RunTest.cs
@@ -70,16 +70,20 @@ namespace Xharness.Jenkins.TestTasks {
 				if (BuildTask.KnownFailure.HasValue)
 					testTask.KnownFailure = BuildTask.KnownFailure;
 				if (generateXmlFailures && BuildTask.BuildLog != null && File.Exists (BuildTask.BuildLog.FullPath)) {
-					var logReader = BuildTask.BuildLog.GetReader ();
-					ResultParser.GenerateFailure (
-						logs: testTask.Logs,
-						source: "build",
-						appName: testTask.TestName,
-						variation: testTask.Variation,
-						title: $"App Build {testTask.TestName} {testTask.Variation}",
-						message: $"App could not be built {testTask.FailureMessage}.",
-						stderrReader: logReader,
-						jargon: xmlResultJargon);
+					try {
+						var logReader = BuildTask.BuildLog.GetReader ();
+						ResultParser.GenerateFailure (
+							logs: testTask.Logs,
+							source: "build",
+							appName: testTask.TestName,
+							variation: testTask.Variation,
+							title: $"App Build {testTask.TestName} {testTask.Variation}",
+							message: $"App could not be built {testTask.FailureMessage}.",
+							stderrReader: logReader,
+							jargon: xmlResultJargon);
+					} catch (Exception e) {
+						testTask.FailureMessage += $" (failed to parse the logs: {e.Message}";
+					}
 				}
 			} else {
 				testTask.ExecutionResult = TestExecutingResult.Built;

--- a/tests/xharness/Jenkins/TestTasks/RunTest.cs
+++ b/tests/xharness/Jenkins/TestTasks/RunTest.cs
@@ -82,7 +82,7 @@ namespace Xharness.Jenkins.TestTasks {
 							stderrReader: logReader,
 							jargon: xmlResultJargon);
 					} catch (Exception e) {
-						testTask.FailureMessage += $" (failed to parse the logs: {e.Message}";
+						testTask.FailureMessage += $" (failed to parse the logs: {e.Message})";
 					}
 				}
 			} else {


### PR DESCRIPTION
Fixes a harness exception:

    Harness exception for 'monotouch-test': System.ArgumentException: '', hexadecimal value 0x1D, is an invalid character.
    at System.Xml.XmlEncodedRawTextWriter.InvalidXmlChar (System.Int32 ch, System.Char* pDst, System.Boolean entitize) [0x00026] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlEncodedRawTextWriter.cs:1420
    at System.Xml.XmlEncodedRawTextWriter.WriteCDataSection (System.String text) [0x00251] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlEncodedRawTextWriter.cs:1370
    at System.Xml.XmlEncodedRawTextWriter.WriteCData (System.String text) [0x0012a] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlEncodedRawTextWriter.cs:470
    at System.Xml.XmlEncodedRawTextWriterIndent.WriteCData (System.String text) [0x00007] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlEncodedRawTextWriter.cs:1750
    at System.Xml.XmlWellFormedWriter.WriteCData (System.String text) [0x00029] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlWellFormedWriter.cs:771
    at Microsoft.DotNet.XHarness.iOS.Shared.XmlResults.TestReportGenerator.WriteFailure (System.Xml.XmlWriter writer, System.String message, System.IO.TextReader stderr) [0x00031] in /_/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/TestReportGenerator.cs:41
    at Microsoft.DotNet.XHarness.iOS.Shared.XmlResults.NUnitV3TestReportGenerator.GenerateFailure (System.Xml.XmlWriter writer, System.String title, System.String message, System.IO.TextReader stderr) [0x0030e] in /_/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/NUnitV3TestReportGenerator.cs:122
    at Microsoft.DotNet.XHarness.iOS.Shared.XmlResults.XmlResultParser.GenerateFailureXml (System.String destination, System.String title, System.String message, System.IO.TextReader stderrReader, Microsoft.DotNet.XHarness.Common.XmlResultJargon jargon) [0x00033] in /_/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/XmlResultParser.cs:226
    at Microsoft.DotNet.XHarness.iOS.Shared.XmlResults.XmlResultParser.GenerateFailure (Microsoft.DotNet.XHarness.iOS.Shared.Logging.ILogs logs, System.String source, System.String appName, System.String variation, System.String title, System.String message, System.IO.TextReader stderrReader, Microsoft.DotNet.XHarness.Common.XmlResultJargon jargon) [0x000a4] in /_/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/XmlResultParser.cs:248
    at Xharness.Jenkins.TestTasks.RunTest.BuildAsync () [0x00274] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/xharness/Jenkins/TestTasks/RunTest.cs:74
    at Xharness.Jenkins.TestTasks.RunTest.ExecuteAsync () [0x000d8] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/xharness/Jenkins/TestTasks/RunTest.cs:99
    at Xharness.Jenkins.TestTasks.TestTasks.RunInternalAsync () [0x00226] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/xharness/Jenkins/TestTasks/TestTask.cs:283