### PR TITLE
[monotouch-test] Resolve symlinks in paths before comparing them.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -848,11 +848,14 @@ Additional information:
 		[Test]
 		public void CurrentDirectory ()
 		{
+			var expectedDirectory = (string) ((NSString) Environment.CurrentDirectory).ResolveSymlinksInPath ();
+
 #if NET || !MONOMAC
-			Assert.AreEqual (Environment.CurrentDirectory, NSBundle.MainBundle.BundlePath, "Current directory at launch");
+			var actualDirectory = (string) ((NSString) NSBundle.MainBundle.BundlePath).ResolveSymlinksInPath ();
 #else
-			Assert.AreEqual (Environment.CurrentDirectory, NSBundle.MainBundle.ResourcePath, "Current directory at launch");
+			var actualDirectory = (string) ((NSString) NSBundle.MainBundle.ResourcePath).ResolveSymlinksInPath ();
 #endif
+			Assert.AreEqual (expectedDirectory, actualDirectory, "Current directory at launch");
 		}
 	}
 }


### PR DESCRIPTION
Fixes this test failure on device:

    [FAIL] CurrentDirectory :   Current directory at launch
      Expected string length 97 but was 89. Strings differ at index 1.
      Expected: "/private/var/containers/Bundle/Application/4824129A-8668-4CD9..."
      But was:  "/var/containers/Bundle/Application/4824129A-8668-4CD9-9280-7F..."