### PR TITLE
Bump maccore.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 49974a981858f73a3d84ee675a4dcd685988f40a
+NEEDED_MACCORE_VERSION := e14b89f9ebd4d1d0dbd2e62ea95cb6676b85da99
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
Fixes this build breakage:

    cp -R ../../xamarin-macios/msbuild/Xamarin.iOS.Tasks.Windows/bin/Release/netstandard2.0/win/ msbuild/iOS
    cp: ../../xamarin-macios/msbuild/Xamarin.iOS.Tasks.Windows/bin/Release/netstandard2.0/win/: No such file or directory
    make[3]: *** [msbuild.zip] Error 1
    make[2]: *** [release] Error 2
    make[1]: *** [package] Error 2
    make: *** [package] Error 2

New commits in xamarin/maccore:

* xamarin/maccore@e14b89f9eb Revert "Fixes for msbuild.zip creation (https://github.com/xamarin/maccore/pull/2483)" (https://github.com/xamarin/maccore/pull/2484)

Diff: https://github.com/xamarin/maccore/compare/49974a981858f73a3d84ee675a4dcd685988f40a..e14b89f9ebd4d1d0dbd2e62ea95cb6676b85da99