### PR TITLE
[introspection] Make green on .NET/Mac Catalyst. Fixes #10215.

### DIFF
--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -393,7 +393,7 @@ namespace Introspection {
 		}
 
 		[Test]
-#if IOS || TVOS
+#if IOS || TVOS || __MACCATALYST__
 		[Ignore ("work in progress")]
 #endif
 		public void LegacyAttributes ()

--- a/tests/introspection/ApiPInvokeTest.cs
+++ b/tests/introspection/ApiPInvokeTest.cs
@@ -271,7 +271,7 @@ namespace Introspection
 		// it's not complete (there's many more SDK assemblies) but we cannot add all of them into a single project anyway
 
 		[Test]
-#if __MACCATALYST__
+#if __MACCATALYST__ && !NET
 		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/10883")]
 #endif
 		public void Corlib ()
@@ -282,7 +282,7 @@ namespace Introspection
 		}
 
 		[Test]
-#if __MACCATALYST__
+#if __MACCATALYST__ && !NET
 		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/10883")]
 #endif
 		public void System ()
@@ -293,7 +293,7 @@ namespace Introspection
 		}
 
 		[Test]
-#if __MACCATALYST__
+#if __MACCATALYST__ && !NET
 		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/10883")]
 #endif
 		public void SystemCore ()

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -297,7 +297,7 @@ namespace Xharness {
 				IsDotNetProject = true,
 				TargetFrameworkFlavors = MacFlavors.MacCatalyst,
 				Platform = "AnyCPU",
-				Ignore = true /* always ignored for now, it has known failures */,
+				Ignore = !ENABLE_DOTNET,
 			});
 
 			MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "monotouch-test", "dotnet", "macOS", "monotouch-test.csproj"))) {


### PR DESCRIPTION
* #10883 only applies to Mac Catalyst for legacy Xamarin.
* Ignore the ApiAvailabilityTest.LegacyAttribute test on Mac Catalyst as well.
* introspection is now green on .NET/Mac Catalyst, so enable it in xharness.

Fixes https://github.com/xamarin/xamarin-macios/issues/10215.