### PR TITLE
[tools] Link away Runtime.RegisterEntryAssembly if and only if we've optimized away the dynamic registrar. Fixes #12327.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -560,8 +560,8 @@ namespace ObjCRuntime {
 		// This method will register all assemblies referenced by the entry assembly.
 		// For XM it will also register all assemblies loaded in the current appdomain.
 		//
-		// NOTE: the (XI) linker remove this method for device builds (RemoveCode.cs) and as such cannot be renamed
-		// without updating mtouch
+		// NOTE: the linker will remove this method when the dynamic registrar has been optimized away (RemoveCode.cs)
+		// and as such cannot be renamed without updating the linker
 		internal static void RegisterEntryAssembly (Assembly entry_assembly)
 		{
 			var assemblies = new List<Assembly> ();

--- a/tools/linker/MonoTouch.Tuner/RemoveCode.cs
+++ b/tools/linker/MonoTouch.Tuner/RemoveCode.cs
@@ -50,7 +50,7 @@ namespace MonoTouch.Tuner {
 			// [MonoTouch.]ObjCRuntime.Runtime.RegisterEntryAssembly is needed only for the simulator 
 			// and does not have to be preserved on devices
 			if (product) {
-				if (Device && type.Is (Namespaces.ObjCRuntime, "Runtime")) {
+				if (LinkContext.Target.App.Optimizations.RemoveDynamicRegistrar == true && type.Is (Namespaces.ObjCRuntime, "Runtime")) {
 					foreach (var m in type.Methods) {
 						if (m.Name == "RegisterEntryAssembly") {
 							ProcessMethod (m);


### PR DESCRIPTION
Previously we'd only call Runtime.RegisterEntryAssembly in the simulator if
the dynamic registrar was available, but now we may call it on device as well
(still only if the dynamic registrar is available). So modify the linker to
keep Runtime.RegisterEntryAssembly even if we're executing on device, as long
as the dynamic registrar is around.

This ensures we get the same behavior both in the simulator and on device (and
desktop for that matter).

Fixes https://github.com/xamarin/xamarin-macios/issues/12327.