### PR TITLE
[objcruntime] Enable nullable on `Selector` class

### DIFF
--- a/src/ObjCRuntime/Selector.cs
+++ b/src/ObjCRuntime/Selector.cs
@@ -26,6 +26,8 @@ using System;
 using System.Runtime.InteropServices;
 using Foundation;
 
+#nullable enable
+
 namespace ObjCRuntime {
 	public partial class Selector : IEquatable<Selector>, INativeObject {
 		internal const string Alloc = "alloc";
@@ -89,12 +91,14 @@ namespace ObjCRuntime {
 			return left.handle == right.handle;
 		}
 
-		public override bool Equals (object right) {
+		public override bool Equals (object? right)
+		{
 			return Equals (right as Selector);
 		}
 
-		public bool Equals (Selector right) {
-			if (right == null)
+		public bool Equals (Selector? right)
+		{
+			if (right is null)
 				return false;
 
 			return handle == right.handle;
@@ -107,12 +111,12 @@ namespace ObjCRuntime {
 
 		internal static string GetName (IntPtr handle)
 		{
-			return Marshal.PtrToStringAuto (sel_getName (handle));
+			return Marshal.PtrToStringAuto (sel_getName (handle))!;
 		}
 
 		// return null, instead of throwing, if an invalid pointer is used (e.g. IntPtr.Zero)
 		// so this looks better in the debugger watch when no selector is assigned (ref: #10876)
-		public static Selector FromHandle (IntPtr sel)
+		public static Selector? FromHandle (IntPtr sel)
 		{
 			if (!sel_isMapped (sel))
 				return null;

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -1845,6 +1845,7 @@ namespace AppKit {
 		void EditItemAtIndexPath (NSIndexPath indexPath, NSEvent theEvent, bool select);
 
 		//Detected properties
+		[NullAllowed]
 		[Export ("doubleAction")]
 		Selector DoubleAction { get; set; }
 
@@ -5186,9 +5187,11 @@ namespace AppKit {
 		[Export ("initWithDrawSelector:delegate:")]
 		IntPtr Constructor (Selector drawSelectorMethod, NSObject delegateObject);
 
+		[NullAllowed]
 		[Export ("drawSelector")]
 		Selector DrawSelector { get; }
 		
+		[NullAllowed]
 		[Export ("delegate", ArgumentSemantic.Assign)]  
 		NSObject Delegate { get; }  
 	}	
@@ -7901,6 +7904,7 @@ namespace AppKit {
 		[Export ("target", ArgumentSemantic.Weak), NullAllowed]
 		NSObject Target { get; set; }
 
+		[NullAllowed]
 		[Export ("action")]
 		Selector Action { get; set; }
 
@@ -10541,6 +10545,7 @@ namespace AppKit {
 		[Export ("drawsBackground")]
 		bool DrawsBackground { get; set; }
 
+		[NullAllowed]
 		[Export ("doubleAction")]
 		Selector DoubleAction { get; set; }
 
@@ -11291,6 +11296,7 @@ namespace AppKit {
 		[Export ("mouseExited:withFrame:inView:")]
 		void MouseExited (NSEvent evt, CGRect frame, NSView view);
 
+		[NullAllowed]
 		[Export ("doubleAction")]
 		Selector DoubleAction { get; set; }
 
@@ -11348,6 +11354,7 @@ namespace AppKit {
 		[Export ("setDraggingSourceOperationMask:forLocal:")]
 		void SetDraggingSource (NSDragOperation operationMask, bool isLocal);
 
+		[NullAllowed]
 		[Export ("doubleAction")]
 		Selector DoubleAction { get; set; }
 
@@ -14793,6 +14800,7 @@ namespace AppKit {
 
 		//Detected properties
 		[Availability (Deprecated = Platform.Mac_10_10, Message = "Soft-deprecation, forwards message to button, but will be gone in the future.")]
+		[NullAllowed]
 		[Export ("doubleAction")]
 		Selector DoubleAction { get; set; }
 
@@ -16949,6 +16957,7 @@ namespace AppKit {
 		[Export ("rowHeight")]
 		nfloat RowHeight { get; set; }
 	
+		[NullAllowed]
 		[Export ("doubleAction")]
 		Selector DoubleAction { get; set; }
 	

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -1386,6 +1386,7 @@ namespace Foundation
 		[Export ("rightExpression")]
 		NSExpression RightExpression { get; }
 
+		[NullAllowed]
 		[Export ("customSelector")]
 		Selector CustomSelector { get; }
 
@@ -5036,6 +5037,7 @@ namespace Foundation
 		[Export ("ascending")]
 		bool Ascending { get; }
 
+		[NullAllowed]
 		[Export ("selector")]
 		Selector Selector { get; }
 

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -2224,7 +2224,7 @@ public partial class Generator : IMemberGatherer {
 		GeneratedTypes = new GeneratedTypes (this);
 
 		marshal_types.Add (new MarshalType (TypeManager.NSObject, create: "Runtime.GetNSObject ("));
-		marshal_types.Add (new MarshalType (TypeManager.Selector, create: "Selector.FromHandle ("));
+		marshal_types.Add (new MarshalType (TypeManager.Selector, create: "Selector.FromHandle (", closingCreate: ")!"));
 		marshal_types.Add (new MarshalType (TypeManager.BlockLiteral, "BlockLiteral", "{0}", "THIS_IS_BROKEN"));
 		if (TypeManager.MusicSequence != null)
 			marshal_types.Add (new MarshalType (TypeManager.MusicSequence, create: "global::AudioToolbox.MusicSequence.Lookup ("));

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -15973,6 +15973,7 @@ namespace UIKit {
 		[Export ("unwindAction")]
 		Selector UnwindAction { get; }
 
+		[NullAllowed]
 		[Export ("sender")]
 		NSObject Sender { get; }
 	}

--- a/tests/xtro-sharpie/MacCatalyst-UIKit.todo
+++ b/tests/xtro-sharpie/MacCatalyst-UIKit.todo
@@ -158,7 +158,6 @@
 !missing-null-allowed! 'Foundation.NSObject UIKit.UIManagedDocument::AdditionalContent(Foundation.NSUrl,Foundation.NSError&)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject UIKit.UIPasteboard::GetValue(System.String)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject UIKit.UIResponder::GetTargetForAction(ObjCRuntime.Selector,Foundation.NSObject)' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'Foundation.NSObject UIKit.UIStoryboardUnwindSegueSource::get_Sender()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject[] UIKit.UICollisionBehavior::get_BoundaryIdentifiers()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSProgress UIKit.UIDocument::get_Progress()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSSet UIKit.UIEvent::TouchesForGestureRecognizer(UIKit.UIGestureRecognizer)' is missing an [NullAllowed] on return type

--- a/tests/xtro-sharpie/common-Foundation.ignore
+++ b/tests/xtro-sharpie/common-Foundation.ignore
@@ -1216,8 +1216,6 @@
 !missing-null-allowed! 'ObjCRuntime.Class Foundation.NSBundle::ClassNamed(System.String)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'ObjCRuntime.Class Foundation.NSBundle::get_PrincipalClass()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'ObjCRuntime.Class Foundation.NSKeyedUnarchiverDelegate::CannotDecodeClass(Foundation.NSKeyedUnarchiver,System.String,System.String[])' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'ObjCRuntime.Selector Foundation.NSComparisonPredicate::get_CustomSelector()' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'ObjCRuntime.Selector Foundation.NSSortDescriptor::get_Selector()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'System.Boolean Foundation.NSFileManager::CreateFile(System.String,Foundation.NSData,Foundation.NSDictionary)' is missing an [NullAllowed] on parameter #1
 !missing-null-allowed! 'System.Boolean Foundation.NSPredicate::EvaluateWithObject(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Boolean Foundation.NSPredicate::EvaluateWithObject(Foundation.NSObject,Foundation.NSDictionary)' is missing an [NullAllowed] on parameter #0

--- a/tests/xtro-sharpie/iOS-UIKit.ignore
+++ b/tests/xtro-sharpie/iOS-UIKit.ignore
@@ -172,7 +172,6 @@
 !missing-null-allowed! 'Foundation.NSObject UIKit.UIManagedDocument::AdditionalContent(Foundation.NSUrl,Foundation.NSError&)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject UIKit.UIPasteboard::GetValue(System.String)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject UIKit.UIResponder::GetTargetForAction(ObjCRuntime.Selector,Foundation.NSObject)' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'Foundation.NSObject UIKit.UIStoryboardUnwindSegueSource::get_Sender()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject[] UIKit.UICollisionBehavior::get_BoundaryIdentifiers()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSProgress UIKit.UIDocument::get_Progress()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSSet UIKit.UIEvent::get_AllTouches()' is missing an [NullAllowed] on return type

--- a/tests/xtro-sharpie/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/macOS-AppKit.ignore
@@ -711,7 +711,6 @@
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSComboBox::get_SelectedValue()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSComboBoxCell::get_SelectedValue()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSComboBoxDataSource::ObjectValueForItem(AppKit.NSComboBox,System.nint)' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'Foundation.NSObject AppKit.NSCustomImageRep::get_Delegate()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSDockTile::get_Owner()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSDocumentController::MakeDocument(Foundation.NSUrl,Foundation.NSUrl,System.String,Foundation.NSError&)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSDocumentController::MakeDocument(Foundation.NSUrl,System.String,Foundation.NSError&)' is missing an [NullAllowed] on return type
@@ -791,7 +790,6 @@
 !missing-null-allowed! 'ObjCRuntime.Class AppKit.NSImageRep::ImageRepClassForPasteboardType(System.String)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'ObjCRuntime.Class AppKit.NSImageRep::ImageRepClassForType(System.String)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'ObjCRuntime.Class Foundation.NSObject::BindingValueClass(System.String)' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'ObjCRuntime.Selector AppKit.NSCustomImageRep::get_DrawSelector()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'OpenGL.CGLContext AppKit.NSOpenGLContext::get_CGLContext()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'OpenGL.CGLPixelFormat AppKit.NSOpenGLPixelFormat::get_CGLPixelFormat()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'System.Boolean AppKit.NSBrowser::IsLeafItem(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
@@ -956,7 +954,6 @@
 !missing-null-allowed! 'System.Void AppKit.NSBrowser::EditItemAtIndexPath(Foundation.NSIndexPath,AppKit.NSEvent,System.Boolean)' is missing an [NullAllowed] on parameter #1
 !missing-null-allowed! 'System.Void AppKit.NSBrowser::SelectAll(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSBrowser::set_CellPrototype(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void AppKit.NSBrowser::set_DoubleAction(ObjCRuntime.Selector)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSBrowserCell::set_AlternateImage(AppKit.NSImage)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSBrowserCell::set_Image(AppKit.NSImage)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSBrowserDelegate::SetObjectValue(AppKit.NSBrowser,Foundation.NSObject,Foundation.NSObject)' is missing an [NullAllowed] on parameter #1
@@ -1060,7 +1057,6 @@
 !missing-null-allowed! 'System.Void AppKit.NSFormCell::.ctor(System.String)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSFormCell::set_PlaceholderAttributedString(Foundation.NSAttributedString)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSFormCell::set_PlaceholderString(System.String)' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void AppKit.NSGestureRecognizer::set_Action(ObjCRuntime.Selector)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSHelpManager::FindString(System.String,System.String)' is missing an [NullAllowed] on parameter #1
 !missing-null-allowed! 'System.Void AppKit.NSHelpManager::OpenHelpAnchor(System.String,System.String)' is missing an [NullAllowed] on parameter #1
 !missing-null-allowed! 'System.Void AppKit.NSLayoutManagerDelegate::LayoutCompleted(AppKit.NSLayoutManager,AppKit.NSTextContainer,System.Boolean)' is missing an [NullAllowed] on parameter #1
@@ -1070,7 +1066,6 @@
 !missing-null-allowed! 'System.Void AppKit.NSMatrix::SelectAll(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSMatrix::SelectText(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSMatrix::set_CellBackgroundColor(AppKit.NSColor)' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void AppKit.NSMatrix::set_DoubleAction(ObjCRuntime.Selector)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSMatrix::set_KeyCell(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSMatrix::set_Prototype(AppKit.NSCell)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSMenu::set_Font(AppKit.NSFont)' is missing an [NullAllowed] on parameter #0
@@ -1105,7 +1100,6 @@
 !missing-null-allowed! 'System.Void AppKit.NSPasteboardItemDataProvider::ProvideDataForType(AppKit.NSPasteboard,AppKit.NSPasteboardItem,System.String)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSPathCell::set_AllowedTypes(System.String[])' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSPathCell::set_BackgroundColor(AppKit.NSColor)' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void AppKit.NSPathCell::set_DoubleAction(ObjCRuntime.Selector)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSPathCell::set_PlaceholderAttributedString(Foundation.NSAttributedString)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSPathCell::set_PlaceholderString(System.String)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSPathCell::set_Url(Foundation.NSUrl)' is missing an [NullAllowed] on parameter #0
@@ -1113,7 +1107,6 @@
 !missing-null-allowed! 'System.Void AppKit.NSPathComponentCell::set_Image(AppKit.NSImage)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSPathComponentCell::set_Url(Foundation.NSUrl)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSPathControl::set_AllowedTypes(Foundation.NSString[])' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void AppKit.NSPathControl::set_DoubleAction(ObjCRuntime.Selector)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSPathControl::set_PlaceholderAttributedString(Foundation.NSAttributedString)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSPathControl::set_PlaceholderString(System.String)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSPathControl::set_Url(Foundation.NSUrl)' is missing an [NullAllowed] on parameter #0
@@ -1184,7 +1177,6 @@
 !missing-null-allowed! 'System.Void AppKit.NSStatusItem::set_AlternateImage(AppKit.NSImage)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSStatusItem::set_AttributedTitle(Foundation.NSAttributedString)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSStatusItem::set_AutosaveName(System.String)' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void AppKit.NSStatusItem::set_DoubleAction(ObjCRuntime.Selector)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSStatusItem::set_Image(AppKit.NSImage)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSStatusItem::set_Title(System.String)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSTableCellView::set_ImageView(AppKit.NSImageView)' is missing an [NullAllowed] on parameter #0
@@ -1193,7 +1185,6 @@
 !missing-null-allowed! 'System.Void AppKit.NSTableHeaderView::set_TableView(AppKit.NSTableView)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSTableView::set_AutosaveName(System.String)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSTableView::set_CornerView(AppKit.NSView)' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void AppKit.NSTableView::set_DoubleAction(ObjCRuntime.Selector)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSTableView::set_HighlightedTableColumn(AppKit.NSTableColumn)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSTableViewDataSource::SetObjectValue(AppKit.NSTableView,Foundation.NSObject,AppKit.NSTableColumn,System.nint)' is missing an [NullAllowed] on parameter #1
 !missing-null-allowed! 'System.Void AppKit.NSTableViewDataSource::SetObjectValue(AppKit.NSTableView,Foundation.NSObject,AppKit.NSTableColumn,System.nint)' is missing an [NullAllowed] on parameter #2

--- a/tests/xtro-sharpie/tvOS-UIKit.ignore
+++ b/tests/xtro-sharpie/tvOS-UIKit.ignore
@@ -170,7 +170,6 @@
 !missing-null-allowed! 'Foundation.NSIndexPath[] UIKit.UITableView::get_IndexPathsForSelectedRows()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject UIKit.UIFontDescriptor::GetObject(Foundation.NSString)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject UIKit.UIResponder::GetTargetForAction(ObjCRuntime.Selector,Foundation.NSObject)' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'Foundation.NSObject UIKit.UIStoryboardUnwindSegueSource::get_Sender()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject[] UIKit.UICollisionBehavior::get_BoundaryIdentifiers()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSSet UIKit.UIEvent::get_AllTouches()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSSet UIKit.UIEvent::TouchesForGestureRecognizer(UIKit.UIGestureRecognizer)' is missing an [NullAllowed] on return type


### PR DESCRIPTION
This requires a small change to the generator since `Selector.FromHandle`
can return `null` but it does not means the invoked API can (and we are
interested in the later).

Fixed up existing API returning potentially `null` `Selector`, IOW adding
the missing `[NullAllowed]` on them and updating xtro.