### PR TITLE
[runtime] Add support for logging exceptions that go through exception marshalling using an environment variable. Fixes #12343.

### DIFF
--- a/runtime/xamarin/main.h
+++ b/runtime/xamarin/main.h
@@ -90,6 +90,12 @@ enum XamarinNativeLinkMode : int {
 	XamarinNativeLinkModeFramework,
 };
 
+enum XamarinTriState : int {
+	XamarinTriStateNone,
+	XamarinTriStateEnabled,
+	XamarinTriStateDisabled,
+};
+
 extern bool mono_use_llvm; // this is defined inside mono
 
 #if DEBUG

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -258,6 +258,9 @@ MonoException *	xamarin_create_system_exception (const char *message);
 MonoException *	xamarin_create_system_invalid_cast_exception (const char *message);
 MonoException *	xamarin_create_system_entry_point_not_found_exception (const char *entrypoint);
 NSString *		xamarin_print_all_exceptions (GCHandle handle);
+bool			xamarin_log_marshalled_exceptions ();
+void			xamarin_log_managed_exception (GCHandle handle, MarshalManagedExceptionMode mode);
+void			xamarin_log_objectivec_exception (NSException *exception, MarshalObjectiveCExceptionMode mode);
 
 id				xamarin_invoke_objc_method_implementation (id self, SEL sel, IMP xamarin_impl);
 MonoType *		xamarin_get_nsnumber_type ();


### PR DESCRIPTION
Setting the XAMARIN_LOG_MARSHALLED_EXCEPTIONS environment variable will now
make us print all exceptions that go through exception marshalling, and how
we'll handle them.

Fixes https://github.com/xamarin/xamarin-macios/issues/12343.