### PR TITLE
[msbuild/dotnet] Don't overwrite the 'CreateAppBundleDependsOn' property, only add to it. Fixes #12325.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -203,6 +203,7 @@
 		<!-- ComputeFilesToPublish will run ILLink -->
 		<!-- single-rid build (either plain single, or inner build for multi-rid build) -->
 		<CreateAppBundleDependsOn Condition="'$(RuntimeIdentifiers)' == ''">
+			$(CreateAppBundleDependsOn);
 			_DetectAppManifest;
 			_CopyResourcesToBundle;
 			_CompileCoreMLModels;
@@ -235,6 +236,7 @@
 
 		<!-- outer build for multi-rid build -->
 		<CreateAppBundleDependsOn Condition="'$(RuntimeIdentifiers)' != ''">
+			$(CreateAppBundleDependsOn);
 			_CompileEntitlements;
 			_CreateMergedAppBundle;
 		</CreateAppBundleDependsOn>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -47,6 +47,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<PropertyGroup>
 		<CreateAppBundleDependsOn Condition="'$(UsingAppleNETSdk)' != 'true'">
+			$(CreateAppBundleDependsOn);
 			_DetectSigningIdentity;
 			_CopyResourcesToBundle;
 			_SmeltMetal;

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -107,6 +107,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<PropertyGroup Condition="'$(UsingAppleNETSdk)' != 'true'">
 		<CreateAppBundleDependsOn>
+			$(CreateAppBundleDependsOn);
 			_DetectAppManifest;
 			_DetectSigningIdentity;
 			_CopyResourcesToBundle;

--- a/tests/common/BinLog.cs
+++ b/tests/common/BinLog.cs
@@ -102,6 +102,11 @@ namespace Xamarin.Tests
 			return GetBuildMessages (path).Where (v => v.Type == BuildLogEventType.Warning);
 		}
 
+		public static IEnumerable<BuildLogEvent> GetBuildLogErrors (string path)
+		{
+			return GetBuildMessages (path).Where (v => v.Type == BuildLogEventType.Error);
+		}
+
 		public static IEnumerable<BuildLogEvent> GetBuildMessages (string path)
 		{
 			var reader = new BinLogReader ();

--- a/tests/dotnet/UnitTests/TemplateProjectTest.cs
+++ b/tests/dotnet/UnitTests/TemplateProjectTest.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+
+using NUnit.Framework;
+
+using Xamarin.Utils;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Logging.StructuredLogger;
+
+namespace Xamarin.Tests {
+	public class TemplateProjectTest : TestBaseClass {
+		const string EmptyAppManifest =
+@"<?xml version=""1.0"" encoding=""UTF-8""?>
+<!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
+<plist version=""1.0"">
+<dict>
+<key>CFBundleIdentifier</key>
+<string>ID</string>
+</dict>
+</plist>";
+
+		const string EmptyMainFile =
+@"using System;
+using Foundation;
+
+class MainClass {
+	static void Main ()
+	{
+		Console.WriteLine (typeof (NSObject));
+	}
+}
+";
+
+		[TestCase (ApplePlatform.MacOSX)]
+		public void CreateAppBundleDependsOnTest (ApplePlatform platform)
+		{
+			var magic = Guid.NewGuid ().ToString ();
+			var csproj = $@"<Project Sdk=""Microsoft.NET.Sdk"">
+<PropertyGroup>
+	<TargetFramework>{platform.ToFramework ()}</TargetFramework>
+	<OutputType>Exe</OutputType>
+	<CreateAppBundleDependsOn>FailTheBuild;$(CreateAppBundleDependsOn)</CreateAppBundleDependsOn>
+	</PropertyGroup>
+	<Target Name=""FailTheBuild"">
+		<Error Text=""{magic}"" />
+	</Target>
+</Project>";
+
+			var tmpdir = Cache.CreateTemporaryDirectory ();
+			Configuration.CopyDotNetSupportingFiles (tmpdir);
+			var project_path = Path.Combine (tmpdir, "TestProject.csproj");
+			File.WriteAllText (project_path, csproj);
+			File.WriteAllText (Path.Combine (tmpdir, "Info.plist"), EmptyAppManifest);
+			File.WriteAllText (Path.Combine (tmpdir, "Main.cs"), EmptyMainFile);
+
+			var properties = new Dictionary<string, string> (verbosity);
+			var result = DotNet.AssertBuildFailure (project_path, properties);
+			var errors = BinLog.GetBuildLogErrors (result.BinLogPath);
+			Assert.That (errors, Has.Some.Matches<BuildLogEvent> (v => v.Message.Contains (magic)), "Expected error");
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/12325.