### PR TITLE
[release/6.0.xx-preview7] Fix version to be preview 7.X, not preview 7X.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -75,7 +75,7 @@ endif
 
 # For release branches, modify the following variables to hardcode a version name
 # Set the NUGET_HARDCODED_PRERELEASE_IDENTIFIER variable to the prerelease identifer you want (say "preview.5")
-NUGET_HARDCODED_PRERELEASE_IDENTIFIER=preview.7
+NUGET_HARDCODED_PRERELEASE_IDENTIFIER=preview.7.
 # Set the NUGET_HARDCODED_PRERELEASE_BRANCH variable to the exact name for the branch the above variable should apply to (so that any other branches won't pick it up by accident).
 # For the previous example, this would be "release/6.0.1xx-preview5"
 NUGET_HARDCODED_PRERELEASE_BRANCH=release/6.0.1xx-preview7


### PR DESCRIPTION
Preview 7X turns out to be something like preview 7228, which isn't quite right.