### PR TITLE
Bump maccore.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := e14b89f9ebd4d1d0dbd2e62ea95cb6676b85da99
+NEEDED_MACCORE_VERSION := 49c78df930c108297fcce4501432b451656190de
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@49c78df930 Fixes for msbuild.zip creation (#2483)
* xamarin/maccore@2fc29b2c02 [mlaunch] Create a binlog when building mlaunch. (#2485)

Diff: https://github.com/xamarin/maccore/compare/e14b89f9ebd4d1d0dbd2e62ea95cb6676b85da99..49c78df930c108297fcce4501432b451656190de