### PR TITLE
[msbuild] Fix the inclusion of the mtouch errors in the Xamarin.MacDev.Tasks.Core assembly.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -62,14 +62,72 @@
       <Link>external\FileUtils.cs</Link>
     </Compile>
   </ItemGroup>
+
   <ItemGroup>
-    <EmbeddedResource Include="..\..\tools\mtouch\errors.resx">
+    <EmbeddedResource Include="../../tools/mtouch/Errors.resx">
+      <Type>Resx</Type>
       <Generator>ResXFileCodeGenerator</Generator>
-      <XlfSourceFormat>Resx</XlfSourceFormat>
-      <XlfOutputItem>EmbeddedResource</XlfOutputItem>
-      <LastGenOutput>Errors.Designer.cs</LastGenOutput>
+      <LastGenOutput>../../tools/mtouch/Errors.Designer.cs</LastGenOutput>
       <CustomToolNamespace>Xamarin.Bundler</CustomToolNamespace>
-      <LogicalName>mtouch.Errors.resources</LogicalName>
+      <ManifestResourceName>Xamarin.Bundler.Errors</ManifestResourceName>
+      <StronglyTypedFileName>../../tools/mtouch/Errors.Designer.cs</StronglyTypedFileName>
+      <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
+      <StronglyTypedNamespace>Xamarin.Bundler</StronglyTypedNamespace>
+      <StronglyTypedClassName>Errors</StronglyTypedClassName>
+      <GenerateResource>true</GenerateResource>
+      <PublicClass>true</PublicClass>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../tools/mtouch/TranslatedAssemblies\Errors.cs.resx">
+      <Link>Errors.cs.resx</Link>
+      <ManifestResourceName>Xamarin.Bundler.Errors.cs</ManifestResourceName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../tools/mtouch/TranslatedAssemblies\Errors.de.resx">
+      <Link>Errors.de.resx</Link>
+      <ManifestResourceName>Xamarin.Bundler.Errors.de</ManifestResourceName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../tools/mtouch/TranslatedAssemblies\Errors.es.resx">
+      <Link>Errors.es.resx</Link>
+      <ManifestResourceName>Xamarin.Bundler.Errors.es</ManifestResourceName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../tools/mtouch/TranslatedAssemblies\Errors.fr.resx">
+      <Link>Errors.fr.resx</Link>
+      <ManifestResourceName>Xamarin.Bundler.Errors.fr</ManifestResourceName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../tools/mtouch/TranslatedAssemblies\Errors.it.resx">
+      <Link>Errors.it.resx</Link>
+      <ManifestResourceName>Xamarin.Bundler.Errors.it</ManifestResourceName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../tools/mtouch/TranslatedAssemblies\Errors.ja.resx">
+      <Link>Errors.ja.resx</Link>
+      <ManifestResourceName>Xamarin.Bundler.Errors.ja</ManifestResourceName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../tools/mtouch/TranslatedAssemblies\Errors.ko.resx">
+      <Link>Errors.ko.resx</Link>
+      <ManifestResourceName>Xamarin.Bundler.Errors.ko</ManifestResourceName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../tools/mtouch/TranslatedAssemblies\Errors.pl.resx">
+      <Link>Errors.pl.resx</Link>
+      <ManifestResourceName>Xamarin.Bundler.Errors.pl</ManifestResourceName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../tools/mtouch/TranslatedAssemblies\Errors.pt-BR.resx">
+      <Link>Errors.pt-BR.resx</Link>
+      <ManifestResourceName>Xamarin.Bundler.Errors.pt-BR</ManifestResourceName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../tools/mtouch/TranslatedAssemblies\Errors.ru.resx">
+      <Link>Errors.ru.resx</Link>
+      <ManifestResourceName>Xamarin.Bundler.Errors.ru</ManifestResourceName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../tools/mtouch/TranslatedAssemblies\Errors.tr.resx">
+      <Link>Errors.tr.resx</Link>
+      <ManifestResourceName>Xamarin.Bundler.Errors.tr</ManifestResourceName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../tools/mtouch/TranslatedAssemblies\Errors.zh-Hans.resx">
+      <Link>Errors.zh-Hans.resx</Link>
+      <ManifestResourceName>Xamarin.Bundler.Errors.zh-Hans</ManifestResourceName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../tools/mtouch/TranslatedAssemblies\Errors.zh-Hant.resx">
+      <Link>Errors.zh-Hant.resx</Link>
+      <ManifestResourceName>Xamarin.Bundler.Errors.zh-Hant</ManifestResourceName>
     </EmbeddedResource>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Otherwise we'll end up showing a MissingManifestResourceException whenever we
try to show any of the mtouch errors from the msbuild targets.