### PR TITLE
[corefoundation] Fix minimum version on MacCatalyst

### DIFF
--- a/src/CoreFoundation/OSLog.cs
+++ b/src/CoreFoundation/OSLog.cs
@@ -29,7 +29,6 @@ namespace CoreFoundation {
 
 #if !NET
 	[Mac (10,12), iOS (10,0), Watch (3,0), TV (10,0)]
-	[Introduced (PlatformName.MacCatalyst, 13, 0)]
 #endif
 	public sealed class OSLog : NativeObject {
 

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -167,7 +167,7 @@ namespace Introspection {
 		}
 
 		[Test]
-#if NET || __MACCATALYST__
+#if NET
 		[Ignore ("Requires attributes update - see status in https://github.com/xamarin/xamarin-macios/issues/10834")]
 #endif
 		public void Introduced ()


### PR DESCRIPTION
There's no need in having availability attributes for versions earlier
than the current minimum.

Re-enable the `Introduced` test for _legacy_ Catalyst as it's fine since
it use the older attributes. It's still not possible to enable it for
`NET` until all manual bindings are updated.