### PR TITLE
[release/6.0.1xx-preview7] [net6] Stops replacing custom linker steps on Windows

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -321,16 +321,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 			<!-- Include Debug symbols as input so those are copied to the server -->
 			<_ILLinkDebugSymbols Include="@(_DebugSymbolsIntermediatePath)" Condition="'$(_DebugSymbolsProduced)'=='true'" />
 		</ItemGroup>
-
-		<ItemGroup>
-			<!-- Replace the custom steps using the remote file paths for those -->
-			<_TrimmerCustomSteps Remove="$(_AdditionalTaskAssembly)" />
-			<_TrimmerCustomSteps Include="$([System.String]::Copy('$(_AdditionalTaskAssembly)').Replace('$(NetCoreRoot)', '$(_DotNetRootRemoteDirectory)'))">
-				<BeforeStep>MarkStep</BeforeStep>
-				<Type>Xamarin.SetupStep</Type>
-			</_TrimmerCustomSteps>
-		</ItemGroup>
-
+		
 		<Delete SessionId="$(BuildSessionId)" Files="@(_LinkedResolvedFileToPublishCandidate)" />
 		<Xamarin.iOS.Tasks.ILLink 
 				SessionId="$(BuildSessionId)"


### PR DESCRIPTION
The `_AdditionalTaskAssembly` prop was already fixed by https://github.com/xamarin/xamarin-macios/commit/7c66aa3829c31ca9a80542230a190c0af9004105, so we don't need to do this anymore. This breaks building from Windows because we're missing custom steps.

I missed adding this file to that commit.


Backport of #12362
