### PR TITLE
[net6] Fixes LinkNativeCode task execution from Windows

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCode.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCode.cs
@@ -13,7 +13,7 @@ namespace Xamarin.MacDev.Tasks
 		public override bool Execute ()
 		{
 			if (ShouldExecuteRemotely ()) {
-				outputPath = Path.GetDirectoryName (OutputFile);
+				outputPath = Path.GetDirectoryName (OutputFile).Replace ("\\", "/");
 
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 			}
@@ -23,7 +23,7 @@ namespace Xamarin.MacDev.Tasks
 
 		// We should avoid copying files from the output path because those already exist on the Mac
 		// and the ones on Windows are empty, so we will break the build
-		public bool ShouldCopyToBuildServer (ITaskItem item) => Path.GetDirectoryName (item.ItemSpec) != outputPath;
+		public bool ShouldCopyToBuildServer (ITaskItem item) => !item.ItemSpec.StartsWith (outputPath);
 
 		public bool ShouldCreateOutputFile (ITaskItem item) => false;
 


### PR DESCRIPTION
This is an improvement on how we detect if the file that is going to be copied to the Mac is coming from the output path or not. Copying files from the Windows output dir to the Mac will make the build fail.

There were two problems:
- The paths we were comparing could contain different path separators.
- The item we are trying to copy may be in a folder that is inside the output dir.

For example:
- OutputFile = `obj\Debug\net6.0-ios\iossimulator-x64\nativelibraries/Foo`
- Item to copy: `obj/Debug/net6.0-ios/iossimulator-x64/nativelibraries/aot-output/x86_64/System.Private.CoreLib.dll.o`