### PR TITLE
[generator] Use new `CFArray.StringArrayFromHandle` instead of the existing `NSArray` API

### DIFF
--- a/src/AssetsLibrary/ALAsset.cs
+++ b/src/AssetsLibrary/ALAsset.cs
@@ -10,6 +10,7 @@
 using ObjCRuntime;
 using Foundation;
 using CoreGraphics;
+using CoreFoundation;
 using CoreLocation;
 using UIKit;
 using MediaPlayer;
@@ -59,10 +60,10 @@ namespace AssetsLibrary {
 			}
 		}
 
-		public string [] Representations {
+		public string[] Representations {
 			get {
 				var k = ValueForProperty (_PropertyRepresentations);
-				return NSArray.StringArrayFromHandle (k.Handle);
+				return CFArray.StringArrayFromHandle (k.Handle)!;
 			}
 		}
 

--- a/src/AudioUnit/AudioComponent.cs
+++ b/src/AudioUnit/AudioComponent.cs
@@ -71,7 +71,7 @@ namespace AudioUnit
 				var array = GetNativeValue<NSArray> (userClientK);
 				if (array == null )
 					return null;
-				return NSArray.StringArrayFromHandle (array.Handle);
+				return CFArray.StringArrayFromHandle (array.Handle);
 			} 
 			set {
 				if (value == null)
@@ -86,7 +86,7 @@ namespace AudioUnit
 				var array = GetNativeValue<NSArray> (globalNameK);
 				if (array == null)
 					return null;
-				return NSArray.StringArrayFromHandle (array.Handle);
+				return CFArray.StringArrayFromHandle (array.Handle);
 			} 
 			set {
 				if (value == null)
@@ -212,7 +212,7 @@ namespace AudioUnit
 				var array = GetNativeValue<NSArray> (tagsK);
 				if (array == null)
 					return null;
-				return NSArray.StringArrayFromHandle (array.Handle);
+				return CFArray.StringArrayFromHandle (array.Handle);
 			} 
 			set {
 				if (value == null)

--- a/src/CoreFoundation/CFArray.cs
+++ b/src/CoreFoundation/CFArray.cs
@@ -128,6 +128,20 @@ namespace CoreFoundation {
 		extern static CFArrayRef CFArrayCreateCopy (CFAllocatorRef allocator, CFArrayRef theArray);
 
 		internal CFArray Clone () => new CFArray (CFArrayCreateCopy (IntPtr.Zero, GetCheckedHandle ()), true);
+
+		// identical signature to NSArray API
+		static public string?[]? StringArrayFromHandle (IntPtr handle)
+		{
+			if (handle == IntPtr.Zero)
+				return null;
+
+			var c = CFArrayGetCount (handle);
+			string?[] ret = new string [c];
+
+			for (nint i = 0; i < c; i++)
+				ret [i] = CFString.FromHandle (CFArrayGetValueAtIndex (handle, i));
+			return ret;
+		}
 	}
 }
 

--- a/src/CoreServices/LaunchServices.cs
+++ b/src/CoreServices/LaunchServices.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Runtime.InteropServices;
 
+using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
@@ -218,7 +219,7 @@ namespace CoreServices
 			if (contentType == null)
 				throw new ArgumentNullException (nameof (contentType));
 
-			return NSArray.StringArrayFromHandle (
+			return CFArray.StringArrayFromHandle (
 				LSCopyAllRoleHandlersForContentType (new NSString (contentType).Handle, roles)
 			);
 		}
@@ -266,7 +267,7 @@ namespace CoreServices
 			if (urlScheme == null)
 				throw new ArgumentNullException (nameof (urlScheme));
 
-			return NSArray.StringArrayFromHandle (
+			return CFArray.StringArrayFromHandle (
 				LSCopyAllHandlersForURLScheme (new NSString (urlScheme).Handle)
 			);
 		}

--- a/src/CoreText/Adapter.cs
+++ b/src/CoreText/Adapter.cs
@@ -95,7 +95,7 @@ namespace CoreText {
 			var value = dictionary [key];
 			if (value == null)
 				return Array.Empty<string> ();
-			return NSArray.StringArrayFromHandle (value.Handle);
+			return CFArray.StringArrayFromHandle (value.Handle);
 		}
 
 		public static string GetStringValue (IDictionary<NSObject, NSObject> dictionary, NSObject key)

--- a/src/Foundation/NSArray.cs
+++ b/src/Foundation/NSArray.cs
@@ -250,6 +250,7 @@ namespace Foundation {
 	#endif
 		}
 			
+		[Obsolete ("Use of 'CFArray.StringArrayFromHandle' offers better performance.")]
 		static public string [] StringArrayFromHandle (IntPtr handle)
 		{
 			if (handle == IntPtr.Zero)

--- a/src/Foundation/NSMetadataItem.cs
+++ b/src/Foundation/NSMetadataItem.cs
@@ -210,7 +210,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] Keywords {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.KeywordsKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.KeywordsKey));
 			}
 		}
 
@@ -224,28 +224,28 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] Authors {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.AuthorsKey)); 
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.AuthorsKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] Editors {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.EditorsKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.EditorsKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] Participants {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.ParticipantsKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.ParticipantsKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] Projects {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.ProjectsKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.ProjectsKey));
 			}
 		}
 
@@ -259,7 +259,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] WhereFroms {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.WhereFromsKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.WhereFromsKey));
 			}
 		}
 
@@ -315,7 +315,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] ContactKeywords {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.ContactKeywordsKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.ContactKeywordsKey));
 			}
 		}
 
@@ -406,7 +406,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] LayerNames {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.LayerNamesKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.LayerNamesKey));
 			}
 		}
 
@@ -637,14 +637,14 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] Codecs {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.CodecsKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.CodecsKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] MediaTypes {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.MediaTypesKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.MediaTypesKey));
 			}
 		}
 
@@ -875,13 +875,14 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] Organizations {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.OrganizationsKey));			}
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.OrganizationsKey));
+			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] Languages {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.LanguagesKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.LanguagesKey));
 			}
 		}
 
@@ -895,21 +896,21 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] Publishers {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.PublishersKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.PublishersKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] Contributors {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.ContributorsKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.ContributorsKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] Coverage {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.CoverageKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.CoverageKey));
 			}
 		}
 
@@ -944,7 +945,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] Audiences {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.AudiencesKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.AudiencesKey));
 			}
 		}
 
@@ -986,7 +987,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] EncodingApplications {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.EncodingApplicationsKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.EncodingApplicationsKey));
 			}
 		}
 
@@ -1007,21 +1008,21 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] PhoneNumbers {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.PhoneNumbersKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.PhoneNumbersKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] EmailAddresses {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.EmailAddressesKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.EmailAddressesKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] InstantMessageAddresses {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.InstantMessageAddressesKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.InstantMessageAddressesKey));
 			}
 		}
 
@@ -1035,7 +1036,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] Recipients {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.RecipientsKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.RecipientsKey));
 			}
 		}
 
@@ -1049,7 +1050,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] Fonts {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.FontsKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.FontsKey));
 			}
 		}
 
@@ -1077,7 +1078,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] AppleLoopDescriptors {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.AppleLoopDescriptorsKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.AppleLoopDescriptorsKey));
 			}
 		}
 
@@ -1133,7 +1134,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] Performers {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.PerformersKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.PerformersKey));
 			}
 		}
 
@@ -1154,28 +1155,28 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] AuthorEmailAddresses {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.AuthorEmailAddressesKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.AuthorEmailAddressesKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] RecipientEmailAddresses {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.RecipientEmailAddressesKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.RecipientEmailAddressesKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] AuthorAddresses {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.AuthorAddressesKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.AuthorAddressesKey));
 			}
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] RecipientAddresses {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.RecipientAddressesKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.RecipientAddressesKey));
 			}
 		}
 
@@ -1189,7 +1190,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] ExecutableArchitectures {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.ExecutableArchitecturesKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.ExecutableArchitecturesKey));
 			}
 		}
 
@@ -1203,7 +1204,7 @@ namespace Foundation {
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
 		public string [] ApplicationCategories {
 			get {
-				return NSArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.ApplicationCategoriesKey));
+				return CFArray.StringArrayFromHandle (GetHandle (NSMetadataQuery.ApplicationCategoriesKey));
 			}
 		}
 

--- a/src/Foundation/NSSearchPath.cs
+++ b/src/Foundation/NSSearchPath.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Runtime.InteropServices;
 
+using CoreFoundation;
 using ObjCRuntime;
 
 namespace Foundation
@@ -37,7 +38,7 @@ namespace Foundation
 	{
 		public static string[] GetDirectories (NSSearchPathDirectory directory, NSSearchPathDomain domainMask, bool expandTilde = true)
 		{
-			return NSArray.StringArrayFromHandle (NSSearchPathForDirectoriesInDomains ((nuint)(ulong)directory, (nuint)(ulong)domainMask, expandTilde));
+			return CFArray.StringArrayFromHandle (NSSearchPathForDirectoriesInDomains ((nuint)(ulong)directory, (nuint)(ulong)domainMask, expandTilde));
 		}
 
 		[DllImport (Constants.FoundationLibrary)]

--- a/src/ImageIO/CGImageDestination.cs
+++ b/src/ImageIO/CGImageDestination.cs
@@ -165,7 +165,7 @@ namespace ImageIO {
 		public static string [] TypeIdentifiers {
 			get {
 				var handle = CGImageDestinationCopyTypeIdentifiers ();
-				var array = NSArray.StringArrayFromHandle (handle);
+				var array = CFArray.StringArrayFromHandle (handle);
 				CFObject.CFRelease (handle);
 				return array;
 			}

--- a/src/ImageIO/CGImageSource.cs
+++ b/src/ImageIO/CGImageSource.cs
@@ -124,7 +124,7 @@ namespace ImageIO {
 		public static string [] TypeIdentifiers {
 			get {
 				var handle = CGImageSourceCopyTypeIdentifiers ();
-				var array = NSArray.StringArrayFromHandle (handle);
+				var array = CFArray.StringArrayFromHandle (handle);
 				CFObject.CFRelease (handle);
 				return array;
 			}

--- a/src/MediaAccessibility/MediaAccessibility.cs
+++ b/src/MediaAccessibility/MediaAccessibility.cs
@@ -282,7 +282,7 @@ namespace MediaAccessibility {
 			var handle = MAAudibleMediaCopyPreferredCharacteristics ();
 			if (handle == IntPtr.Zero)
 				return null;
-			var result = NSArray.StringArrayFromHandle (handle);
+			var result = CFArray.StringArrayFromHandle (handle);
 			CFObject.CFRelease (handle); // *Copy* API
 			return result;
 		}

--- a/src/MobileCoreServices/UTType.cs
+++ b/src/MobileCoreServices/UTType.cs
@@ -100,7 +100,7 @@ namespace MobileCoreServices {
 			var a = NSString.CreateNative (tagClass);
 			var b = NSString.CreateNative (tag);
 			var c = NSString.CreateNative (conformingToUti);
-			var ret = NSArray.StringArrayFromHandle (UTTypeCreateAllIdentifiersForTag (a, b, c));
+			var ret = CFArray.StringArrayFromHandle (UTTypeCreateAllIdentifiersForTag (a, b, c));
 			NSString.ReleaseNative (a);
 			NSString.ReleaseNative (b);
 			NSString.ReleaseNative (c);
@@ -125,7 +125,7 @@ namespace MobileCoreServices {
 
 			var a = NSString.CreateNative (uti);
 			var b = NSString.CreateNative (tagClass);
-			var ret = NSArray.StringArrayFromHandle (UTTypeCopyAllTagsWithClass (a, b));
+			var ret = CFArray.StringArrayFromHandle (UTTypeCopyAllTagsWithClass (a, b));
 			NSString.ReleaseNative (a);
 			NSString.ReleaseNative (b);
 			return ret;

--- a/src/NaturalLanguage/NLStrongDictionary.cs
+++ b/src/NaturalLanguage/NLStrongDictionary.cs
@@ -23,7 +23,7 @@ namespace NaturalLanguage {
 					throw new ArgumentNullException (nameof (key));
 
 				var value = CFDictionary.GetValue (Dictionary.Handle, key.Handle);
-				return NSArray.StringArrayFromHandle (value);
+				return CFArray.StringArrayFromHandle (value);
 			}
 			set {
 				SetArrayValue (key, value);

--- a/src/PrintCore/PrintCore.cs
+++ b/src/PrintCore/PrintCore.cs
@@ -159,7 +159,7 @@ namespace PrintCore {
 				return code;
 			}
 
-			printerList = NSArray.StringArrayFromHandle (array);
+			printerList = CFArray.StringArrayFromHandle (array);
 			CFObject.CFRelease (array);
 			if (printerHandle != IntPtr.Zero){
 				// Now get the printer, we do not own it, so retain.
@@ -617,7 +617,7 @@ namespace PrintCore {
 				mimeTypes = null;
 				return code;
 			}
-			mimeTypes = NSArray.StringArrayFromHandle (m);
+			mimeTypes = CFArray.StringArrayFromHandle (m);
 			return PMStatusCode.Ok;
 		}
 

--- a/src/SceneKit/SCNSceneSource.cs
+++ b/src/SceneKit/SCNSceneSource.cs
@@ -10,6 +10,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
@@ -26,7 +27,7 @@ namespace SceneKit
 
 		public string [] GetIdentifiersOfEntries<T> ()
 		{
-			return NSArray.StringArrayFromHandle (Messaging.IntPtr_objc_msgSend_IntPtr (this.Handle, Selector.GetHandle ("identifiersOfEntriesWithClass:"), new Class (typeof(T)).Handle));
+			return CFArray.StringArrayFromHandle (Messaging.IntPtr_objc_msgSend_IntPtr (this.Handle, Selector.GetHandle ("identifiersOfEntriesWithClass:"), new Class (typeof(T)).Handle))!;
 		}
 	}
 }

--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -324,7 +324,7 @@ namespace Security {
 			string[] results = null;
 			IntPtr emails;
 			if (SecCertificateCopyEmailAddresses (handle, out emails) == 0) {
-				results = NSArray.StringArrayFromHandle (emails);
+				results = CFArray.StringArrayFromHandle (emails);
 				if (emails != IntPtr.Zero)
 					CFObject.CFRelease (emails);
 			}

--- a/src/Security/SslContext.cs
+++ b/src/Security/SslContext.cs
@@ -679,7 +679,7 @@ namespace Security {
 			error = SSLCopyALPNProtocols (Handle, ref protocols);
 			if (protocols == IntPtr.Zero)
 				return Array.Empty<string> ();
-			var result = NSArray.StringArrayFromHandle (protocols);
+			var result = CFArray.StringArrayFromHandle (protocols);
 			CFObject.CFRelease (protocols);
 			return result;
 		}

--- a/src/SystemConfiguration/CaptiveNetwork.cs
+++ b/src/SystemConfiguration/CaptiveNetwork.cs
@@ -141,7 +141,7 @@ namespace SystemConfiguration {
 				return StatusCodeError.SCError ();
 			}
 			
-			supportedInterfaces = NSArray.StringArrayFromHandle (array);
+			supportedInterfaces = CFArray.StringArrayFromHandle (array);
 			CFObject.CFRelease (array);
 			return StatusCode.OK;
 		}

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1743,7 +1743,7 @@ public partial class Generator : IMemberGatherer {
 		
 			if (pi.ParameterType == TypeManager.System_String_Array){
 				pars.AppendFormat ("IntPtr {0}", safe_name);
-				invoke.AppendFormat ("NSArray.StringArrayFromHandle ({0})", safe_name);
+				invoke.AppendFormat ("CFArray.StringArrayFromHandle ({0})!", safe_name);
 				continue;
 			}
 			if (pi.ParameterType == TypeManager.System_String){
@@ -3087,7 +3087,7 @@ public partial class Generator : IMemberGatherer {
 					else if (propertyType == TypeManager.NSString)
 						print ("return new NSString (value);");
 					else if (propertyType == TypeManager.System_String_Array){
-						print ("return NSArray.StringArrayFromHandle (value);");
+						print ("return CFArray.StringArrayFromHandle (value)!;");
 					} else {
 						Type underlying = propertyType.IsEnum ? TypeManager.GetUnderlyingEnumType (propertyType) : propertyType;
 						string cast = propertyType.IsEnum ? "(" + propertyType.FullName + ") " : "";
@@ -3845,8 +3845,8 @@ public partial class Generator : IMemberGatherer {
 				cast_b += $"NSArray.ArrayFromHandleFunc <{FormatType (bindAsT.DeclaringType, bindAsT)}> (retvalarrtmp, {GetFromBindAsWrapper (minfo, out suffix)})" + suffix;
 				cast_b += "))";
 			} else if (etype == TypeManager.System_String) {
-				cast_a = "NSArray.StringArrayFromHandle (";
-				cast_b = ")";
+				cast_a = "CFArray.StringArrayFromHandle (";
+				cast_b = ")!";
 			} else if (minfo != null && minfo.protocolize) {
 				cast_a = "NSArray.ArrayFromHandle<global::" + etype.Namespace + ".I" + etype.Name + ">(";
 				cast_b = ")";
@@ -4320,7 +4320,7 @@ public partial class Generator : IMemberGatherer {
 					if (isArrayOfNSObject || isArrayOfINativeObjectSubclass) {
 						by_ref_processing.AppendFormat ("{0} = NSArray.ArrayFromHandle<{1}> ({0}Value);\n", pi.Name.GetSafeParamName (), RenderType (elementType.GetElementType ()));
 					} else if (isArrayOfString) {
-						by_ref_processing.AppendFormat ("{0} = NSArray.StringArrayFromHandle ({0}Value);\n", pi.Name.GetSafeParamName ());
+						by_ref_processing.AppendFormat ("{0} = CFArray.StringArrayFromHandle ({0}Value)!;\n", pi.Name.GetSafeParamName ());
 					} else {
 						throw ErrorHelper.CreateError (88, mai.Type, mi);
 					}

--- a/tests/perftest/TollFreeBridge.cs
+++ b/tests/perftest/TollFreeBridge.cs
@@ -89,5 +89,36 @@ namespace PerfTest {
 			var p = CFString.CreateNative (value);
 			CFString.ReleaseNative (p);
 		}
+
+		public IEnumerable<object []> ArraysOfStrings ()
+		{
+			yield return new object [] { "empty", new NSArray () };
+			yield return new object [] { "few", NSArray.FromStrings ("Bonjour", "Québec", "汉语 漢語", "I'm feeling 🤪 tonight.") };
+			yield return new object [] { "mutable", new NSMutableArray<NSString> (new NSString ("Québec"), new NSString ("汉语 漢語")) };
+			var large = new NSMutableArray ();
+			for (int i = 0; i < 4096; i++)
+				large.Add (new NSString (new string ('#', i) ));
+			yield return new object [] { "large_mutable", large };
+		}
+
+		/*
+		 * Measure time required to create a managed `string[]` array from a native one using `CFArray.StringArrayFromHandle`
+		 */
+		[Benchmark]
+		[ArgumentsSource (nameof (ArraysOfStrings))]
+		public void CFArray_StringArrayFromHandle (string name, NSArray value)
+		{
+			CFArray.StringArrayFromHandle (value.Handle);
+		}
+
+		/*
+		 * Measure time required to create a managed `string[]` array from a native one using `CFArray.StringArrayFromHandle`
+		 */
+		[Benchmark]
+		[ArgumentsSource (nameof (ArraysOfStrings))]
+		public void NSArray_StringArrayFromHandle (string name, NSArray value)
+		{
+			NSArray.StringArrayFromHandle (value.Handle);
+		}
     }
 }


### PR DESCRIPTION
This is another example that p/invokes are much faster than calling
selectors.

Beside the generator the manual bindings were updated to use the newer
API and the old one was decorated as `[Obsolete]`.

|                        Method |          name |                value |            Mean |           Error |        StdDev |
|------------------------------ |-------------- |--------------------- |----------------:|----------------:|--------------:|
| CFArray_StringArrayFromHandle |         empty |                   () |        123.9 ns |        68.92 ns |       3.78 ns |
| NSArray_StringArrayFromHandle |         empty |                   () |      1,422.6 ns |        25.83 ns |       1.42 ns |
| CFArray_StringArrayFromHandle |           few |    (  (...).") [108] |      1,885.2 ns |        46.37 ns |       2.54 ns |
| NSArray_StringArrayFromHandle |           few |    (  (...).") [108] |      8,530.0 ns |       594.40 ns |      32.58 ns |
| CFArray_StringArrayFromHandle | large_mutable |    ((...)) [8419330] | 15,821,101.0 ns | 4,803,631.19 ns | 263,303.23 ns |
| NSArray_StringArrayFromHandle | large_mutable |    ((...)) [8419330] | 22,823,871.9 ns | 6,589,380.43 ns | 361,186.18 ns |
| CFArray_StringArrayFromHandle |       mutable |   (   (...)9e") [54] |        867.4 ns |        59.23 ns |       3.25 ns |
| NSArray_StringArrayFromHandle |       mutable |   (   (...)9e") [54] |      4,939.6 ns |       203.28 ns |      11.14 ns |

note: `NSArray.StringArrayFromHandle` was already using (p/invoke-based)
`CFString.FromHandle` instead of (selector-based) `NSString.FromHandle`
to create the managed `string` instances inside the `string[]`.