### PR TITLE
[tests][intro] Fix Phase tests on macOS 12 and iOS devices

### DIFF
--- a/tests/introspection/ApiBaseTest.cs
+++ b/tests/introspection/ApiBaseTest.cs
@@ -239,6 +239,9 @@ namespace Introspection {
 				// generated code uses CoreMIDI correctly
 				libname = "CoreMIDI";
 				break;
+			case "Phase":
+				libname = "PHASE";
+				break;
 			default:
 				if (requiresFullPath && (Path.GetDirectoryName (libname).Length == 0))
 					ReportError ("[FAIL] Library '{0}' is specified without a path", libname);


### PR DESCRIPTION
It's a `Phase` vs `PHASE` lookup that make the tests checking for
fields fail.

```
FieldExists: 3 errors found in 6603 fields validated: PHASESpatialCategoryDirectPathTransmission, PHASESpatialCategoryEarlyReflections, PHASESpatialCategoryLateReverb
```