### PR TITLE
[objcruntime] Enable nullable on `ErrorHelper` and `RuntimeException`

### DIFF
--- a/src/ObjCRuntime/ErrorHelper.cs
+++ b/src/ObjCRuntime/ErrorHelper.cs
@@ -11,6 +11,8 @@ using System.Collections.Generic;
 using ProductException=ObjCRuntime.RuntimeException;
 #endif
 
+#nullable enable
+
 #if BUNDLER || MSBUILD_TASKS
 namespace Xamarin.Bundler {
 #else
@@ -19,20 +21,20 @@ namespace ObjCRuntime {
 	static partial class ErrorHelper {
 		public static ProductException CreateError (int code, string message, params object [] args)
 		{
-			return new ProductException (code, true, message, args);
+			return new ProductException (code, true, null, message, args);
 		}
 
-		public static ProductException CreateError (int code, Exception innerException, string message, params object [] args)
+		public static ProductException CreateError (int code, Exception? innerException, string message, params object [] args)
 		{
 			return new ProductException (code, true, innerException, message, args);
 		}
 
 		public static ProductException CreateWarning (int code, string message, params object [] args)
 		{
-			return new ProductException (code, false, message, args);
+			return new ProductException (code, false, null, message, args);
 		}
 
-		public static ProductException CreateWarning (int code, Exception innerException, string message, params object [] args)
+		public static ProductException CreateWarning (int code, Exception? innerException, string message, params object [] args)
 		{
 			return new ProductException (code, false, innerException, message, args);
 		}
@@ -47,9 +49,9 @@ namespace ObjCRuntime {
 
 		internal static void CollectExceptions (Exception ex, List<Exception> exceptions)
 		{
-			AggregateException ae = ex as AggregateException;
+			var ae = ex as AggregateException;
 
-			if (ae != null && ae.InnerExceptions.Count > 0) {
+			if (ae is not null && ae.InnerExceptions.Count > 0) {
 				foreach (var ie in ae.InnerExceptions)
 					CollectExceptions (ie, exceptions);
 			} else {

--- a/src/ObjCRuntime/RuntimeException.cs
+++ b/src/ObjCRuntime/RuntimeException.cs
@@ -3,6 +3,8 @@
 using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace ObjCRuntime {
 	public class RuntimeException : Exception {
 		public RuntimeException (string message, params object[] args)
@@ -11,7 +13,7 @@ namespace ObjCRuntime {
 		}
 
 		public RuntimeException (int code, string message, params object[] args) : 
-			this (code, false, message, args)
+			this (code, false, null, message, args)
 		{
 		}
 		
@@ -20,7 +22,7 @@ namespace ObjCRuntime {
 		{
 		}
 		
-		public RuntimeException (int code, bool error, Exception innerException, string message, params object[] args) : 
+		public RuntimeException (int code, bool error, Exception? innerException, string message, params object[] args) :
 			base (String.Format (message, args), innerException)
 		{
 			Code = code;

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>mmp</AssemblyName>
     <RootNamespace>mmp</RootNamespace>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>


### PR DESCRIPTION
also avoid intermediate/chained calls to help the linker eliminate
some methods