### PR TITLE
[monotouch-test] Ignore ReadingListTest.DefaultReadingList.

### DIFF
--- a/tests/monotouch-test/SafariServices/ReadingListTest.cs
+++ b/tests/monotouch-test/SafariServices/ReadingListTest.cs
@@ -26,6 +26,7 @@ namespace MonoTouchFixtures.SafariServices {
 		string local_file = Path.Combine (NSBundle.MainBundle.ResourcePath, "Hand.wav");
 
 		[Test]
+		[Ignore ("This test adds two entries every time it's executed to the global reading list in Safari. For people who use their reading lists this becomes slightly annoying.")]
 		public void DefaultReadingList ()
 		{
 			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);


### PR DESCRIPTION
This test adds entries to the global reading list in Safari, and there's no
API for the test to clean up after itself, so the reading list becomes an
endless list of entries after a whlie.

Beside the fact that this is somewhat annoying for people who actually use
their reading lists, it can also can end up consuming a significant amount of
space on the hard drive, because Safari will download each site to be
available offline.