### PR TITLE
[msbuild] Set `UseSecureTimestamp` inside `_CodesignFrameworks` too

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1169,6 +1169,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			Resources="@(_Frameworks)"
 			SigningKey="$(_FrameworkCodeSigningKey)"
 			ExtraArgs="$(CodesignExtraArgs)"
+			UseSecureTimestamp="$(UseHardenedRuntime)"
 			>
 		</Codesign>
 


### PR DESCRIPTION
That's needed for Xamarin.Mac and was _lost_ when the task was merged
between XI and XM.

Fixes https://github.com/xamarin/xamarin-macios/issues/11784