### PR TITLE
[xtro] Ignore Obsoleted enums in EnumCheck.

### DIFF
--- a/tests/xtro-sharpie/AttributeHelpers.cs
+++ b/tests/xtro-sharpie/AttributeHelpers.cs
@@ -104,6 +104,19 @@ namespace Extrospection
 			return false;
 		}
 
+		public static bool HasAnyObsoleted (ICustomAttributeProvider item)
+		{
+			if (Skip (item))
+				return false;
+
+			foreach (var attribute in item.CustomAttributes) {
+				if (AttributeHelpers.HasObsoleted (attribute, Helpers.Platform))
+					return true;
+			}
+
+			return false;
+		}
+
 		static Platforms[] GetRelatedPlatforms ()
 		{
 			// TV and Watch also implictly accept iOS

--- a/tests/xtro-sharpie/EnumCheck.cs
+++ b/tests/xtro-sharpie/EnumCheck.cs
@@ -25,6 +25,9 @@ namespace Extrospection {
 			if (type.IsObsolete ())
 				return;
 
+			if (AttributeHelpers.HasAnyObsoleted (type))
+				return;
+
 			var name = type.Name;
 			// e.g. WatchKit.WKErrorCode and WebKit.WKErrorCode :-(
 			if (!enums.TryGetValue (name, out var td))

--- a/tests/xtro-sharpie/EnumCheck.cs
+++ b/tests/xtro-sharpie/EnumCheck.cs
@@ -10,6 +10,7 @@ namespace Extrospection {
 	class EnumCheck : BaseVisitor {
 
 		Dictionary<string,TypeDefinition> enums = new Dictionary<string, TypeDefinition> (StringComparer.InvariantCultureIgnoreCase);
+		Dictionary<string,TypeDefinition> obsoleted_enums = new Dictionary<string,TypeDefinition> ();
 		Dictionary<long, FieldDefinition> managed_signed_values = new Dictionary<long, FieldDefinition> ();
 		Dictionary<ulong, FieldDefinition> managed_unsigned_values = new Dictionary<ulong, FieldDefinition> ();
 		Dictionary<long, string> native_signed_values = new Dictionary<long, string> ();
@@ -21,14 +22,19 @@ namespace Extrospection {
 			if (!type.IsEnum || type.IsNested)
 				return;
 			
-			// exclude obsolete enums, presumably we already know there's something wrong with them if they've been obsoleted.
-			if (type.IsObsolete ())
-				return;
-
-			if (AttributeHelpers.HasAnyObsoleted (type))
-				return;
-
 			var name = type.Name;
+
+			// exclude obsolete enums, presumably we already know there's something wrong with them if they've been obsoleted.
+			if (type.IsObsolete ()) {
+				obsoleted_enums [name] = type;
+				return;
+			}
+
+			if (AttributeHelpers.HasAnyObsoleted (type)) {
+				obsoleted_enums [name] = type;
+				return;
+			}
+
 			// e.g. WatchKit.WKErrorCode and WebKit.WKErrorCode :-(
 			if (!enums.TryGetValue (name, out var td))
 				enums.Add (name, type);
@@ -65,6 +71,11 @@ namespace Extrospection {
 				return;
 			
 			var mname = Helpers.GetManagedName (name);
+
+			// If our enum is obsoleted, then don't process it.
+			if (obsoleted_enums.ContainsKey (mname))
+				return;
+
 			if (!enums.TryGetValue (mname, out var type)) {
 				Log.On (framework).Add ($"!missing-enum! {name} not bound");
 				return;
@@ -299,6 +310,8 @@ namespace Extrospection {
 			// e.g. a typo in the name
 			foreach (var extra in enums) {
 				var t = extra.Value;
+				if (obsoleted_enums.ContainsKey (t.Name))
+					continue;
 				if (!IsNative (t))
 					continue;
 				var framework = Helpers.GetFramework (t);

--- a/tests/xtro-sharpie/iOS-CoreTelephony.ignore
+++ b/tests/xtro-sharpie/iOS-CoreTelephony.ignore
@@ -13,8 +13,6 @@
 !unknown-field! CTRadioAccessTechnologyNR bound
 !unknown-field! CTRadioAccessTechnologyNRNSA bound
 !unknown-field! CTServiceRadioAccessTechnologyDidChangeNotification bound
-!unknown-native-enum! CTCellularDataRestrictedState bound
-!unknown-native-enum! CTCellularPlanProvisioningAddPlanResult bound
 !unknown-protocol! CTSubscriberDelegate bound
 !unknown-protocol! CTTelephonyNetworkInfoDelegate bound
 !unknown-type! CTCall bound

--- a/tests/xtro-sharpie/iOS-iAd.ignore
+++ b/tests/xtro-sharpie/iOS-iAd.ignore
@@ -1,5 +1,0 @@
-## removed in Xcode 13 beta 1
-## enums kept for binary compatibility
-!unknown-native-enum! ADAdType bound
-!unknown-native-enum! ADError bound
-!unknown-native-enum! ADInterstitialPresentationPolicy bound

--- a/tests/xtro-sharpie/macOS-Intents.todo
+++ b/tests/xtro-sharpie/macOS-Intents.todo
@@ -1,13 +1,7 @@
 ## appended from unclassified file
 !missing-enum! INCallAudioRoute not bound
-!missing-enum! INCallCapability not bound
-!missing-enum! INCallCapabilityOptions not bound
-!missing-enum! INCallDestinationType not bound
-!missing-enum! INCallRecordTypeOptions not bound
 !missing-enum! INFocusStatusAuthorizationStatus not bound
 !missing-enum! INOutgoingMessageType not bound
-!missing-enum! INSendMessageIntentResponseCode not bound
-!missing-enum! INSendMessageRecipientUnsupportedReason not bound
 !missing-enum! INShareFocusStatusIntentResponseCode not bound
 !missing-enum! INStartCallCallRecordToCallBackUnsupportedReason not bound
 !missing-protocol! INShareFocusStatusIntentHandling not bound

--- a/tests/xtro-sharpie/macOS-QTKit.ignore
+++ b/tests/xtro-sharpie/macOS-QTKit.ignore
@@ -1,6 +1,0 @@
-## QTKit headers were removed - but our API still exists for binary compatibility (and the linker can remove them)
-
-!unknown-native-enum! QTCaptureDestination bound
-!unknown-native-enum! QTCaptureDeviceControlsSpeed bound
-!unknown-native-enum! QTCaptureDevicePlaybackMode bound
-!unknown-native-enum! QTError bound

--- a/tests/xtro-sharpie/macOS-SafariServices.ignore
+++ b/tests/xtro-sharpie/macOS-SafariServices.ignore
@@ -4,6 +4,3 @@
 !missing-selector! SFSafariExtensionState::isEnabled not bound
 !missing-type! SFSafariExtensionManager not bound
 !missing-type! SFSafariExtensionState not bound
-
-## it's present but it's unused and the [Obsolete] attribute skips it (so it's reported)
-!missing-enum! SFSafariServicesVersion not bound


### PR DESCRIPTION
Treat [Obsoleted] enums as [Obsolete] enums: ignore them. This makes it
possible to remove a few ignored entries.