### PR TITLE
[monotouch-test] Use unique file names to avoid issues when multiple proceseses of monotouch-test are running simultaneously. Fixes #xamarin/maccore@2461.

### DIFF
--- a/tests/monotouch-test/Foundation/FileManagerTest.cs
+++ b/tests/monotouch-test/Foundation/FileManagerTest.cs
@@ -8,6 +8,7 @@
 //
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using Foundation;
@@ -109,7 +110,7 @@ namespace MonoTouchFixtures.Foundation {
 			
 			Assert.False (NSFileManager.GetSkipBackupAttribute (NSBundle.MainBundle.ExecutableUrl.ToString ()), "MainBundle");
 
-			string filename = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), "DoNotBackupMe-NSFileManager");
+			string filename = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), $"DoNotBackupMe-NSFileManager-{Process.GetCurrentProcess ().Id}");
 			try {
 				File.WriteAllText (filename, "not worth a bit");
 				

--- a/tests/monotouch-test/Foundation/UrlTest.cs
+++ b/tests/monotouch-test/Foundation/UrlTest.cs
@@ -8,6 +8,7 @@
 //
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using Foundation;
 #if MONOMAC
@@ -47,7 +48,7 @@ namespace MonoTouchFixtures.Foundation {
 			Assert.That (value, Is.TypeOf (typeof (NSNumber)), "NSNumber");
 			Assert.That ((int) (value as NSNumber), Is.EqualTo (0), "0");
 			
-			string filename = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), "DoNotBackupMe-NSUrl");
+			string filename = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), $"DoNotBackupMe-NSUrl-{Process.GetCurrentProcess ().Id}");
 			try {
 				File.WriteAllText (filename, "not worth a bit");
 				using (NSUrl url = NSUrl.FromFilename (filename)) {


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/2461.