### PR TITLE
[dotnet/msbuild] Fix publishing user frameworks and dynamic libraries from binding projects.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -416,6 +416,7 @@
 				PartialStaticRegistrarLibrary=$(_LibPartialStaticRegistrar)
 				Platform=$(_PlatformName)
 				PlatformAssembly=$(_PlatformAssemblyName).dll
+				RelativeAppBundlePath=$(_RelativeAppBundlePath)
 				Registrar=$(_BundlerRegistrar)
 				RuntimeConfigurationFile=$(_RuntimeConfigurationFile)
 				SdkDevPath=$(_SdkDevPath)
@@ -545,7 +546,7 @@
 	</Target>
 
 	<!-- Look in the NativeReference items for frameworks that need to be added to the app bundle, and add all those frameworks to ResolvedFileToPublish (as separate files) -->
-	<Target Name="_ComputeFrameworkFilesToPublish" DependsOnTargets="_ExpandNativeReferences;_ComputeVariables">
+	<Target Name="_ComputeFrameworkFilesToPublish" DependsOnTargets="_ExpandNativeReferences;_ComputeVariables;_LoadLinkerOutput">
 		<ItemGroup>
 			<!-- Expand each framework (which are directories) into all the files in the framework -->
 			<!-- Support a 'CopyToAppBundle' metadata that can be set to 'false' to avoid copying a framework to the app bundle -->
@@ -569,7 +570,7 @@
 	</Target>
 
 	<!-- Look in the NativeReference items for dylibs that need to be added to the app bundle, and add all those frameworks to ResolvedFileToPublish (as separate files) -->
-	<Target Name="_ComputeDynamicLibrariesToPublish" DependsOnTargets="_ExpandNativeReferences;_ComputeVariables">
+	<Target Name="_ComputeDynamicLibrariesToPublish" DependsOnTargets="_ExpandNativeReferences;_ComputeVariables;_LoadLinkerOutput">
 		<ItemGroup>
 			<!-- Support a 'CopyToAppBundle' metadata that can be set to 'false' to avoid copying a framework to the app bundle -->
 			<_DynamicLibraryToPublish Include="@(_FileNativeReference)" Condition="'%(_FileNativeReference.Kind)' == 'Dynamic' And '%(_FileNativeReference.CopyToAppBundle)' != 'false'">
@@ -584,7 +585,7 @@
 		</ItemGroup>
 	</Target>
 
-	<Target Name="_LoadLinkerOutput">
+	<Target Name="_LoadLinkerOutput" DependsOnTargets="ComputeFilesToPublish">
 		<!-- Load _MainFile -->
 		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_MainFile.items" Condition="Exists('$(_LinkerItemsDirectory)/_MainFile.items')">
 			<Output TaskParameter="Items" ItemName="_MainFile" />
@@ -624,6 +625,14 @@
 		<!-- Load _AssembliesToAOT -->
 		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_AssembliesToAOT.items" Condition="Exists('$(_LinkerItemsDirectory)/_AssembliesToAOT.items')">
 			<Output TaskParameter="Items" ItemName="_AssembliesToAOT" />
+		</ReadItemsFromFile>
+		<!-- Load _FrameworkFilesToPublish -->
+		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_FrameworkFilesToPublish.items" Condition="Exists('$(_LinkerItemsDirectory)/_FrameworkFilesToPublish.items')">
+			<Output TaskParameter="Items" ItemName="_FrameworkFilesToPublish" />
+		</ReadItemsFromFile>
+		<!-- Load _DynamicLibraryToPublish -->
+		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_DynamicLibraryToPublish.items" Condition="Exists('$(_LinkerItemsDirectory)/_DynamicLibraryToPublish.items')">
+			<Output TaskParameter="Items" ItemName="_DynamicLibraryToPublish" />
 		</ReadItemsFromFile>
 	</Target>
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/LinkNativeCodeTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/LinkNativeCodeTaskBase.cs
@@ -156,11 +156,6 @@ namespace Xamarin.MacDev.Tasks {
 				arguments.Add (DylibRPath ?? "@executable_path");
 			}
 
-			if (hasEmbeddedFrameworks) {
-				arguments.Add ("-rpath");
-				arguments.Add (FrameworkRPath ?? "@executable_path/Frameworks");
-			}
-
 			if (Frameworks != null) {
 				foreach (var fw in Frameworks) {
 					var is_weak = fw.GetMetadata ("IsWeak") == "true";
@@ -170,10 +165,16 @@ namespace Xamarin.MacDev.Tasks {
 						arguments.Add ("-F");
 						arguments.Add (Path.GetDirectoryName (Path.GetFullPath (framework)));
 						framework = Path.GetFileNameWithoutExtension (framework);
+						hasEmbeddedFrameworks = true;
 					}
 					arguments.Add (is_weak ? "-weak_framework" : "-framework");
 					arguments.Add (framework);
 				}
+			}
+
+			if (hasEmbeddedFrameworks) {
+				arguments.Add ("-rpath");
+				arguments.Add (FrameworkRPath ?? "@executable_path/Frameworks");
 			}
 
 			if (ObjectFiles != null)

--- a/tests/framework-test/dotnet/shared.mk
+++ b/tests/framework-test/dotnet/shared.mk
@@ -2,6 +2,8 @@ TOP=../../../..
 include $(TOP)/Make.config
 include $(TOP)/mk/colors.mk
 
+TESTNAME:=$(notdir $(shell dirname $(shell dirname $(CURDIR))))
+
 prepare:
 	$(Q) $(MAKE) -C $(TOP)/tests/dotnet copy-dotnet-config
 
@@ -25,5 +27,11 @@ build: prepare
 run: prepare
 	$(Q) $(DOTNET6) build /bl *.csproj $(MSBUILD_VERBOSITY) $(BUILD_ARGUMENTS) -t:Run
 
+run-bare:
+	$(Q) ./bin/Debug/net6.0-*/*/$(TESTNAME).app/Contents/MacOS/$(TESTNAME)
+
 diag: prepare
 	$(Q) $(DOTNET6) build /v:diag msbuild.binlog
+
+clean:
+	rm -Rf bin obj *.binlog

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -375,12 +375,14 @@ namespace Xharness {
 				TestPlatform = TestPlatform.MacCatalyst,
 			});
 
+			// framework-test
+
 			MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "framework-test", "dotnet", "macOS", "framework-test.csproj"))) {
 				Name = "framework-test",
 				IsDotNetProject = true,
 				TargetFrameworkFlavors = MacFlavors.DotNet,
 				Platform = "AnyCPU",
-				Ignore = true, // TODO: these tests fail currently !ENABLE_DOTNET,
+				Ignore = !ENABLE_DOTNET,
 				TestPlatform = TestPlatform.Mac,
 			});
 
@@ -389,7 +391,7 @@ namespace Xharness {
 				IsDotNetProject = true,
 				TargetFrameworkFlavors = MacFlavors.MacCatalyst,
 				Platform = "AnyCPU",
-				Ignore = true, // TODO: these tests fail currently !ENABLE_DOTNET,
+				Ignore = !ENABLE_DOTNET,
 				TestPlatform = TestPlatform.MacCatalyst,
 			});
 
@@ -523,8 +525,8 @@ namespace Xharness {
 			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "fsharp", "dotnet", "tvOS", "fsharp.fsproj"))) { Name = "fsharp", IsDotNetProject = true, SkipiOSVariation = true, SkiptvOSVariation = true, SkipwatchOSVariation = true, SkipTodayExtensionVariation = true, SkipDeviceVariations = false, SkipiOS32Variation = true, GenerateVariations = false, TestPlatform = TestPlatform.tvOS, });
 
 			// framework-test
-			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "framework-test", "dotnet", "iOS", "framework-test.csproj"))) { Name = "framework-test", IsDotNetProject = true, SkipiOSVariation = false, SkiptvOSVariation = true, SkipwatchOSVariation = true, SkipTodayExtensionVariation = true, SkipDeviceVariations = false, SkipiOS32Variation = true, SkipMacCatalystVariation = true, TestPlatform = TestPlatform.iOS_Unified, Ignore = true /* This test currently fails */, });
-			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "framework-test", "dotnet", "tvOS", "framework-test.csproj"))) { Name = "framework-test", IsDotNetProject = true, SkipiOSVariation = true, SkiptvOSVariation = true, SkipwatchOSVariation = true, SkipTodayExtensionVariation = true, SkipDeviceVariations = false, SkipiOS32Variation = true, GenerateVariations = false, TestPlatform = TestPlatform.tvOS, Ignore = true /* This test currently fails */, });
+			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "framework-test", "dotnet", "iOS", "framework-test.csproj"))) { Name = "framework-test", IsDotNetProject = true, SkipiOSVariation = false, SkiptvOSVariation = true, SkipwatchOSVariation = true, SkipTodayExtensionVariation = true, SkipDeviceVariations = false, SkipiOS32Variation = true, SkipMacCatalystVariation = true, TestPlatform = TestPlatform.iOS_Unified, });
+			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "framework-test", "dotnet", "tvOS", "framework-test.csproj"))) { Name = "framework-test", IsDotNetProject = true, SkipiOSVariation = true, SkiptvOSVariation = true, SkipwatchOSVariation = true, SkipTodayExtensionVariation = true, SkipDeviceVariations = false, SkipiOS32Variation = true, GenerateVariations = false, TestPlatform = TestPlatform.tvOS, });
 
 			foreach (var flavor in new MonoNativeFlavor [] { MonoNativeFlavor.Compat, MonoNativeFlavor.Unified }) {
 				var monoNativeInfo = new MonoNativeInfo (DevicePlatform.iOS, flavor, RootDirectory, Log);

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -168,14 +168,36 @@ namespace Xamarin.Bundler {
 
 		public string FrameworksDirectory {
 			get {
+				return Path.Combine (AppDirectory, RelativeFrameworksPath);
+			}
+		}
+
+		public string RelativeFrameworksPath {
+			get {
 				switch (Platform) {
 				case ApplePlatform.iOS:
 				case ApplePlatform.TVOS:
 				case ApplePlatform.WatchOS:
-					return Path.Combine (AppDirectory, "Frameworks");
+					return "Frameworks";
 				case ApplePlatform.MacOSX:
 				case ApplePlatform.MacCatalyst:
-					return Path.Combine (AppDirectory, "Contents", "Frameworks");
+					return Path.Combine ("Contents", "Frameworks");
+				default:
+					throw ErrorHelper.CreateError (71, Errors.MX0071, Platform, ProductName);
+				}
+			}
+		}
+
+		public string RelativeDylibPublishPath {
+			get {
+				switch (Platform) {
+				case ApplePlatform.iOS:
+				case ApplePlatform.TVOS:
+				case ApplePlatform.WatchOS:
+					return string.Empty;
+				case ApplePlatform.MacOSX:
+				case ApplePlatform.MacCatalyst:
+					return Path.Combine ("Contents", CustomBundleName);
 				default:
 					throw ErrorHelper.CreateError (71, Errors.MX0071, Platform, ProductName);
 				}

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -33,6 +33,7 @@ namespace Xamarin.Linker {
 		public string PartialStaticRegistrarLibrary { get; set; }
 		public ApplePlatform Platform { get; private set; }
 		public string PlatformAssembly { get; private set; }
+		public string RelativeAppBundlePath { get; private set; }
 		public Version SdkVersion { get; private set; }
 		public string SdkRootDirectory { get; private set; }
 		public int Verbosity => Driver.Verbosity;
@@ -213,6 +214,9 @@ namespace Xamarin.Linker {
 				case "PlatformAssembly":
 					PlatformAssembly = Path.GetFileNameWithoutExtension (value);
 					break;
+				case "RelativeAppBundlePath":
+					RelativeAppBundlePath = value;
+					break;
 				case "Registrar":
 					Application.ParseRegistrar (value);
 					break;
@@ -359,6 +363,7 @@ namespace Xamarin.Linker {
 				Console.WriteLine ($"    PartialStaticRegistrarLibrary: {PartialStaticRegistrarLibrary}");
 				Console.WriteLine ($"    Platform: {Platform}");
 				Console.WriteLine ($"    PlatformAssembly: {PlatformAssembly}.dll");
+				Console.WriteLine ($"    RelativeAppBundlePath: {RelativeAppBundlePath}");
 				Console.WriteLine ($"    Registrar: {Application.Registrar} (Options: {Application.RegistrarOptions})");
 				Console.WriteLine ($"    RuntimeConfigurationFile: {Application.RuntimeConfigurationFile}");
 				Console.WriteLine ($"    SdkDevPath: {Driver.SdkRoot}");


### PR DESCRIPTION
We extract frameworks from third-party libraries when running the linker, and
we need to store this information on disk and the reload it after the linker
has executed, and add it to the existing MSBuild variables that keep track of
the user frameworks and dynamic libraries that have to be copied to the app
bundle.

Fixes the framework-test tests.