### PR TITLE
[dotnet] Add support for 'dotnet publish'. Fixes #11807.

### DIFF
--- a/dotnet/HIERARCHY.md
+++ b/dotnet/HIERARCHY.md
@@ -52,6 +52,8 @@ Files are imported in the following order:
     * targets/Microsoft._platform_.Sdk.targets: contains logic specific to _platform_.
     * targets/Xamarin.Shared.Sdk.DefaultItems.targets: contains logic to enable the
       default behavior we want.
+    * targets/Xamarin.Shared.Sdk.DefaultItems.targets: contains logic to publish the
+      app bundle.
     * targets/Xamarin.Shared.Sdk.targets: all of the build logic shared between all
       platforms.
 

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -25,6 +25,7 @@ $(1)_NUGET_TARGETS = \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.Versions.props \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.targets \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Xamarin.Shared.Sdk.DefaultItems.targets \
+	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Xamarin.Shared.Sdk.Publish.targets \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Xamarin.Shared.Sdk.TargetFrameworkInference.props \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Xamarin.Shared.Sdk.props \
 	$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/targets/Xamarin.Shared.Sdk.targets \

--- a/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Target Name="_PrePublish">
+		<PropertyGroup>
+			<BuildIpa Condition="'$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS'">true</BuildIpa>
+			<CreatePackage Condition="'$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst'">true</CreatePackage>
+		</PropertyGroup>
+	</Target>
+	<Target Name="Publish" DependsOnTargets="_PrePublish;Build">
+		<Message Importance="high" Text="Created the package: $(IpaPackagePath)" Condition="'$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS'" />
+		<Message Importance="high" Text="Created the package: $(PkgPackagePath)" Condition="'$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst'" />
+	</Target>
+</Project>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -149,6 +149,9 @@
 	<!-- Default item includes (globs and implicit references) -->
 	<Import Project="Xamarin.Shared.Sdk.DefaultItems.targets" />
 
+	<!-- dotnet publish -->
+	<Import Project="Xamarin.Shared.Sdk.Publish.targets" />
+
 	<!-- This is a hack until we get the TFM values for real from the .NET build logic -->
 	<PropertyGroup>
 		<_TargetFrameworkPlatform Condition="'$(_PlatformName)' == 'iOS'">ios</_TargetFrameworkPlatform>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateInstallerPackageTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateInstallerPackageTaskBase.cs
@@ -44,6 +44,9 @@ namespace Xamarin.MacDev.Tasks
 
 		public string PackagingExtraArgs { get ; set; }
 
+		// both input and output
+		[Output]
+		public string PkgPackagePath { get; set; }
 		#endregion
 
 		string GetProjectVersion ()
@@ -109,9 +112,13 @@ namespace Xamarin.MacDev.Tasks
 				}
 			}
 
-			string projectVersion = GetProjectVersion ();
-			string target = string.Format ("{0}{1}.pkg", Name, String.IsNullOrEmpty (projectVersion) ? "" : "-" + projectVersion);
-			args.AddQuoted (Path.Combine (OutputDirectory, target));
+			if (string.IsNullOrEmpty (PkgPackagePath)) {
+				string projectVersion = GetProjectVersion ();
+				string target = string.Format ("{0}{1}.pkg", Name, String.IsNullOrEmpty (projectVersion) ? "" : "-" + projectVersion);
+				PkgPackagePath = Path.Combine (OutputDirectory, target);
+			}
+			args.AddQuoted (PkgPackagePath);
+
 			return args.ToString ();
 		}
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1647,9 +1647,11 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			OutputDirectory="$(TargetDir)"
 			PackageSigningKey="$(PackageSigningKey)"
 			PackagingExtraArgs="$(PackagingExtraArgs)"
+			PkgPackagePath="$(PkgPackagePath)"
 			ProductDefinition="$(_CompiledProductDefinition)"
 			ProjectPath="$(MSBuildProjectFullPath)"
 		>
+			<Output TaskParameter="PkgPackagePath" PropertyName="PkgPackagePath" />
 		</CreateInstallerPackage>
 	</Target>
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -883,8 +883,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<PropertyGroup>
 			<!-- Calculate IpaPackageDir and IpaPackageName based on IpaPackagePath, if defined. -->
-			<IpaPackageDir Condition="'$(IpaPackagePath)' != ''">$([System.Path]::GetDirectoryName('$(IpaPackagePath)'))</IpaPackageDir>
-			<IpaPackageName Condition="'$(IpaPackagePath)' != ''">$([System.Path]::GetFileName('$(IpaPackagePath)'))</IpaPackageName>
+			<IpaPackageDir Condition="'$(IpaPackagePath)' != ''">$([System.IO.Path]::GetDirectoryName('$(IpaPackagePath)'))</IpaPackageDir>
+			<IpaPackageName Condition="'$(IpaPackagePath)' != ''">$([System.IO.Path]::GetFileName('$(IpaPackagePath)'))</IpaPackageName>
 
 			<!-- Calculate an IPA package directory path if not already defined by the developer. -->
 			<!--<IpaPackageDir Condition="'$(IpaPackageDir)' == ''">$([System.Environment]::GetEnvironmentVariable('IPA_PACKAGE_DIR'))</IpaPackageDir>-->

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -24,6 +24,11 @@ namespace Xamarin.Tests {
 			}
 		}
 
+		public static ExecutionResult AssertPublish (string project, Dictionary<string, string> properties = null)
+		{
+			return Execute ("publish", project, properties, true);
+		}
+
 		public static ExecutionResult AssertBuild (string project, Dictionary<string, string> properties = null)
 		{
 			return Execute ("build", project, properties, true);
@@ -70,6 +75,7 @@ namespace Xamarin.Tests {
 			switch (verb) {
 			case "clean":
 			case "build":
+			case "publish":
 				var args = new List<string> ();
 				args.Add (verb);
 				args.Add (project);

--- a/tests/dotnet/UnitTests/TestBaseClass.cs
+++ b/tests/dotnet/UnitTests/TestBaseClass.cs
@@ -11,7 +11,6 @@ using NUnit.Framework;
 using Xamarin.Utils;
 using Xamarin.Tests;
 using Xamarin.MacDev;
-using Xamarin.Utils;
 
 namespace Xamarin.Tests {
 	[TestFixture]
@@ -20,6 +19,14 @@ namespace Xamarin.Tests {
 			{ "MtouchExtraArgs", "-v" },
 			{ "MonoBundlingExtraArgs", "-v" },
 		};
+
+		protected Dictionary<string, string> GetDefaultProperties (string? runtimeIdentifiers)
+		{
+			var rv = new Dictionary<string, string> (verbosity);
+			if (!string.IsNullOrEmpty (runtimeIdentifiers))
+				SetRuntimeIdentifiers (rv, runtimeIdentifiers);
+			return rv;
+		}
 
 		protected void SetRuntimeIdentifiers (Dictionary<string, string> properties, string runtimeIdentifiers)
 		{


### PR DESCRIPTION
* Add support for 'dotnet publish'.
* Add support for a 'PkgPackagePath' for macOS and Mac Catalyst, an MSBuild
  property to specify the resulting .pkg path, to reflect the existing
  'IpaPackagePath' (for iOS and tvOS).
* Fix MSBuild logic that uses 'IpaPackagePath'. Looks like nobody has ever
  used this...
* Add tests.

Fixes https://github.com/xamarin/xamarin-macios/issues/11807.