### PR TITLE
[ci] Sign .NET 6 VS Hot Restart content

### DIFF
--- a/dotnet/Workloads/SignList.xml
+++ b/dotnet/Workloads/SignList.xml
@@ -3,11 +3,23 @@
   <ItemGroup>
     <Skip Include="Mono.Options.dll" />
     <Skip Include="System.Reflection.MetadataLoadContext.dll" />
+    <Skip Include="Microsoft.Win32.Registry.dll" />
+    <Skip Include="System.Buffers.dll" />
+    <Skip Include="System.Memory.dll" />
+    <Skip Include="System.Numerics.Vectors.dll" />
+    <Skip Include="System.Runtime.CompilerServices.Unsafe.dll" />
+    <Skip Include="System.Security.AccessControl.dll" />
+    <Skip Include="System.Security.Cryptography.Pkcs.dll" />
+    <Skip Include="System.Security.Cryptography.ProtectedData.dll" />
+    <Skip Include="System.Security.Principal.Windows.dll" />
+    <Skip Include="ws2_32.dll" />
   </ItemGroup>
 
-  <!--ItemGroup>
-    <ThirdParty Include="" />
-  </ItemGroup-->
+  <ItemGroup>
+    <ThirdParty Include="BouncyCastle.Crypto.dll" />
+    <ThirdParty Include="imobiledevice*\*.dll" />
+    <ThirdParty Include="imobiledevice*\*.exe" />
+  </ItemGroup>
 
   <ItemGroup>
     <FirstParty Include="bgen.dll" />
@@ -21,5 +33,8 @@
     <FirstParty Include="System.dll" />
     <FirstParty Include="System.Numerics.dll" />
     <FirstParty Include="System.Xml.dll" />
+    <!-- Microsoft.iOS.Windows.Sdk content -->
+    <FirstParty Include="iSign.Core.dll" />
+    <FirstParty Include="System.Diagnostics.Tracer.dll" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5074495&view=logs&j=f8a716f9-5318-5935-19a4-149a64409b96&t=773a1aad-99f2-5f0b-eafa-0deb88171543

Commit 9dbf451d added files required to support Hot Restart in .NET 6
packages, however it did not update SignList.xml to also include these
new file additions.  This caused .nupkg signing issues:

    C:\a\_temp\artifact-signing\SignFiles.proj(66,5): error : Unknown assemblies:
    C:\a\_temp\artifact-signing\SignFiles.proj(66,5): error :     C:\a\_temp\artifact-signing\extracted\Microsoft.iOS.Windows.Sdk.15.0.100-ci.main.446\tools\msbuild\iOS\BouncyCastle.Crypto.dll;
    C:\a\_temp\artifact-signing\SignFiles.proj(66,5): error :     C:\a\_temp\artifact-signing\extracted\Microsoft.iOS.Windows.Sdk.15.0.100-ci.main.446\tools\msbuild\iOS\imobiledevice-x64\bz2.dll;
    C:\a\_temp\artifact-signing\SignFiles.proj(66,5): error :     C:\a\_temp\artifact-signing\extracted\Microsoft.iOS.Windows.Sdk.15.0.100-ci.main.446\tools\msbuild\iOS\imobiledevice-x64\getopt.dll;
    C:\a\_temp\artifact-signing\SignFiles.proj(66,5): error :     C:\a\_temp\artifact-signing\extracted\Microsoft.iOS.Windows.Sdk.15.0.100-ci.main.446\tools\msbuild\iOS\imobiledevice-x64\ideviceactivation.dll;
    ...

Fix signing by listing all new content that should be skipped or signed
with first/third party certs.