### PR TITLE
[src] Use [NoMacCatalyst] everywhere.

### DIFF
--- a/src/AudioUnit/AudioComponentDescription.cs
+++ b/src/AudioUnit/AudioComponentDescription.cs
@@ -138,7 +138,6 @@ namespace AudioUnit
 #endif
 		[Mac (10,15)]
 		[Unavailable (PlatformName.MacCatalyst)]
-		[Advice ("This API is not available when using UIKit on macOS.")]
 		Reverb2=0x72766232, // 'rvb2'
 		NBandEq=0x6e626571, // 'nbeq'
 	}

--- a/src/SceneKit/Defs.cs
+++ b/src/SceneKit/Defs.cs
@@ -363,7 +363,7 @@ namespace SceneKit {
 	{
 		Metal,
 #if !MONOMAC
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[Unavailable (PlatformName.MacCatalyst)]
 		OpenGLES2,
 #else
 		OpenGLLegacy,

--- a/src/Security/SecProtocolOptions.cs
+++ b/src/Security/SecProtocolOptions.cs
@@ -47,7 +47,7 @@ namespace Security {
 		[Deprecated (PlatformName.iOS, 13,0, message: "Use 'AddTlsCipherSuite (TlsCipherSuite)' instead.")]
 		[Deprecated (PlatformName.WatchOS, 6,0, message: "Use 'AddTlsCipherSuite (TlsCipherSuite)' instead.")]
 		[Deprecated (PlatformName.TvOS, 13,0, message: "Use 'AddTlsCipherSuite (TlsCipherSuite)' instead.")]
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[Unavailable (PlatformName.MacCatalyst)]
 		public void AddTlsCipherSuite (SslCipherSuite cipherSuite) => sec_protocol_options_add_tls_ciphersuite (GetCheckedHandle (), cipherSuite);
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
@@ -88,7 +88,7 @@ namespace Security {
 		[Deprecated (PlatformName.iOS, 13,0, message: "Use 'SetTlsMinVersion (TlsProtocolVersion)' instead.")]
 		[Deprecated (PlatformName.WatchOS, 6,0, message: "Use 'SetTlsMinVersion (TlsProtocolVersion)' instead.")]
 		[Deprecated (PlatformName.TvOS, 13,0, message: "Use 'SetTlsMinVersion (TlsProtocolVersion)' instead.")]
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[Unavailable (PlatformName.MacCatalyst)]
 		public void SetTlsMinVersion (SslProtocol protocol) => sec_protocol_options_set_tls_min_version (GetCheckedHandle (), protocol);
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
@@ -109,7 +109,7 @@ namespace Security {
 		[Deprecated (PlatformName.iOS, 13,0, message: "Use 'SetTlsMaxVersion (TlsProtocolVersion)' instead.")]
 		[Deprecated (PlatformName.WatchOS, 6,0, message: "Use 'SetTlsMaxVersion (TlsProtocolVersion)' instead.")]
 		[Deprecated (PlatformName.TvOS, 13,0, message: "Use 'SetTlsMaxVersion (TlsProtocolVersion)' instead.")]
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[Unavailable (PlatformName.MacCatalyst)]
 		public void SetTlsMaxVersion (SslProtocol protocol) => sec_protocol_options_set_tls_max_version (GetCheckedHandle (), protocol);
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]

--- a/src/StoreKit/Enums.cs
+++ b/src/StoreKit/Enums.cs
@@ -114,7 +114,8 @@ namespace StoreKit {
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (14,0)]
-	[Native, Advice ("This API is not available when using UIKit on macOS.")]
+	[MacCatalyst (14,0)]
+	[Native]
 	public enum SKOverlayPosition : long {
 		SKOverlayPositionBottom = 0,
 		Raised = 1,

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -10993,7 +10993,7 @@ namespace AVFoundation {
 		bool MultiCamSupported { [Bind ("isMultiCamSupported")] get; }
 
 		[NoWatch, NoTV, NoMac, iOS (13, 0)]
-		[Advice ("This API is not available when using UIKit on macOS.")]
+		[MacCatalyst (14,0)]
 		[Export ("globalToneMappingSupported")]
 		bool GlobalToneMappingSupported { [Bind ("isGlobalToneMappingSupported")] get; }
 
@@ -12917,9 +12917,8 @@ namespace AVFoundation {
 		[Export ("paused")]
 		bool Paused { [Bind ("isPaused")] get; }
 
-		[Unavailable (PlatformName.MacCatalyst)]
 		[Watch (6,0), TV (13,0), NoMac, iOS (13,0)]
-		[Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Export ("usesApplicationAudioSession")]
 		bool UsesApplicationAudioSession { get; set; }
 

--- a/src/callkit.cs
+++ b/src/callkit.cs
@@ -296,9 +296,8 @@ namespace CallKit {
 		[Export ("getEnabledStatusForExtensionWithIdentifier:completionHandler:")]
 		void GetEnabledStatusForExtension (string identifier, Action<CXCallDirectoryEnabledStatus, NSError> completion);
 
-		[Unavailable (PlatformName.MacCatalyst)]
+		[NoMacCatalyst]
 		[NoWatch, NoTV, NoMac, iOS (13,4)]
-		[Advice ("This API is not available when using UIKit on macOS.")]
 		[Async]
 		[Export ("openSettingsWithCompletionHandler:")]
 		void OpenSettings ([NullAllowed] Action<NSError> completion);

--- a/src/coreaudiokit.cs
+++ b/src/coreaudiokit.cs
@@ -172,7 +172,7 @@ namespace CoreAudioKit {
 
 	[iOS (8,0)]
 	[Deprecated (PlatformName.iOS, 13,0, message: "Use 'AudioUnit' instead.")]
-	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[BaseType (typeof (UIView))]
 	interface CAInterAppAudioSwitcherView {
 		[Export ("initWithFrame:")]
@@ -190,7 +190,7 @@ namespace CoreAudioKit {
 
 	[iOS (8,0)]
 	[Deprecated (PlatformName.iOS, 13,0, message: "Use 'AudioUnit' instead.")]
-	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[BaseType (typeof (UIView))]
 	interface CAInterAppAudioTransportView {
 		[Export ("initWithFrame:")]

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -331,13 +331,13 @@ namespace CoreLocation {
 
 		[NoWatch][NoTV][NoMac]
 		[Deprecated (PlatformName.iOS, 13,0, message: "Not used anymore. Call will not have any effect.")]
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Export ("allowDeferredLocationUpdatesUntilTraveled:timeout:")]
 		void AllowDeferredLocationUpdatesUntil (double distance, double timeout);
 
 		[NoWatch][NoTV][NoMac]
 		[Deprecated (PlatformName.iOS, 13,0, message: "Not used anymore. Call will not have any effect.")]
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Export ("disallowDeferredLocationUpdates")]
 		void DisallowDeferredLocationUpdates ();
 
@@ -373,7 +373,7 @@ namespace CoreLocation {
 		void RequestState (CLRegion region);
 
 		[NoWatch][NoTV][NoMac]
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Deprecated (PlatformName.iOS, 13,0, message: "Use 'StartRangingBeacons(CLBeaconIdentityConstraint)' instead.")]
 		[iOS (7,0), Export ("startRangingBeaconsInRegion:")]
 		void StartRangingBeacons (CLBeaconRegion region);
@@ -383,7 +383,7 @@ namespace CoreLocation {
 		void StartRangingBeacons (CLBeaconIdentityConstraint constraint);
 
 		[NoWatch][NoTV][NoMac]
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Deprecated (PlatformName.iOS, 13,0, message: "Use 'StopRangingBeacons(CLBeaconIdentityConstraint)' instead.")]
 		[iOS (7,0), Export ("stopRangingBeaconsInRegion:")]
 		void StopRangingBeacons (CLBeaconRegion region);

--- a/src/fileprovider.cs
+++ b/src/fileprovider.cs
@@ -326,8 +326,7 @@ namespace FileProvider {
 		[Export ("hidden")]
 		bool Hidden { [Bind ("isHidden")] get; set; }
 
-		[Advice ("This API is not available when using UIKit on macOS.")]
-		[Unavailable (PlatformName.MacCatalyst)]
+		[NoMacCatalyst]
 		[NoWatch, NoTV, NoiOS, Mac (11,3)]
 		[Export ("testingModes", ArgumentSemantic.Assign)]
 		NSFileProviderDomainTestingModes TestingModes { get; set; }
@@ -742,8 +741,7 @@ namespace FileProvider {
 
 	interface INSFileProviderPendingSetEnumerator { }
 
-	[Advice ("This API is not available when using UIKit on macOS.")]
-	[Unavailable (PlatformName.MacCatalyst)]
+	[NoMacCatalyst]
 	[NoWatch, NoTV, NoiOS, Mac (11,3)]
 	[Protocol]
 	interface NSFileProviderPendingSetEnumerator : NSFileProviderEnumerator {
@@ -878,9 +876,8 @@ namespace FileProvider {
 		[Export ("requestingExecutable", ArgumentSemantic.Copy)]
 		NSUrl RequestingExecutable { get; }
 
-		[Unavailable (PlatformName.MacCatalyst)]
 		[NoWatch, NoTV, NoiOS, Mac (11,3)]
-		[Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[NullAllowed, Export ("domainVersion")]
 		NSFileProviderDomainVersion DomainVersion { get; }
 	}
@@ -1001,8 +998,7 @@ namespace FileProvider {
 		[Export ("materializedItemsDidChangeWithCompletionHandler:")]
 		void MaterializedItemsDidChange (Action completionHandler);
 
-		[Advice ("This API is not available when using UIKit on macOS.")]
-		[Unavailable (PlatformName.MacCatalyst)]
+		[NoMacCatalyst]
 		[NoWatch, NoTV, NoiOS, Mac (11,3)]
 		[Export ("pendingItemsDidChangeWithCompletionHandler:")]
 		void PendingItemsDidChange (Action completionHandler);
@@ -1010,8 +1006,7 @@ namespace FileProvider {
 
 	interface INSFileProviderDomainState { }
 
-	[Advice ("This API is not available when using UIKit on macOS.")]
-	[Unavailable (PlatformName.MacCatalyst)]
+	[NoMacCatalyst]
 	[NoWatch, NoTV, NoiOS, Mac (11,3)]
 	[Protocol]
 	interface NSFileProviderDomainState {
@@ -1033,8 +1028,7 @@ namespace FileProvider {
 		Interactive = 1uL << 1,
 	}
 
-	[Advice ("This API is not available when using UIKit on macOS.")]
-	[Unavailable (PlatformName.MacCatalyst)]
+	[NoMacCatalyst]
 	[NoWatch, NoTV, NoiOS, Mac (11,3)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -1047,9 +1041,9 @@ namespace FileProvider {
 		NSComparisonResult Compare (NSFileProviderDomainVersion otherVersion);
 	}
 
-	[Unavailable (PlatformName.MacCatalyst)]
+	[NoMacCatalyst]
 	[NoWatch, NoTV, NoiOS, Mac (11,3)]
-	[Native, Advice ("This API is not available when using UIKit on macOS.")]
+	[Native]
 	public enum NSFileProviderTestingOperationType : long {
 		Ingestion = 0,
 		Lookup = 1,
@@ -1063,9 +1057,9 @@ namespace FileProvider {
 
 	interface INSFileProviderTestingOperation : global::ObjCRuntime.INativeObject { }
 
-	[Unavailable (PlatformName.MacCatalyst)]
+	[NoMacCatalyst]
 	[NoWatch, NoTV, NoiOS, Mac (11,3)]
-	[Protocol, Advice ("This API is not available when using UIKit on macOS.")]
+	[Protocol]
 	interface NSFileProviderTestingOperation {
 
 		[Abstract]
@@ -1113,9 +1107,9 @@ namespace FileProvider {
 		INSFileProviderTestingCollisionResolution GetAsCollisionResolution ();
 	}
 
-	[Unavailable (PlatformName.MacCatalyst)]
+	[NoMacCatalyst]
 	[NoWatch, NoTV, NoiOS, Mac (11,3)]
-	[Native, Advice ("This API is not available when using UIKit on macOS.")]
+	[Native]
 	public enum NSFileProviderTestingOperationSide : ulong {
 		Disk = 0,
 		FileProvider = 1,
@@ -1123,9 +1117,9 @@ namespace FileProvider {
 
 	interface INSFileProviderTestingIngestion { }
 
-	[Unavailable (PlatformName.MacCatalyst)]
+	[NoMacCatalyst]
 	[NoWatch, NoTV, NoiOS, Mac (11,3)]
-	[Protocol, Advice ("This API is not available when using UIKit on macOS.")]
+	[Protocol]
 	interface NSFileProviderTestingIngestion : NSFileProviderTestingOperation {
 
 		[Abstract]
@@ -1143,9 +1137,8 @@ namespace FileProvider {
 
 	interface INSFileProviderTestingLookup { }
 
-	[Unavailable (PlatformName.MacCatalyst)]
 	[NoWatch, NoTV, NoiOS, Mac (11,3)]
-	[Protocol, Advice ("This API is not available when using UIKit on macOS.")]
+	[Protocol]
 	interface NSFileProviderTestingLookup : NSFileProviderTestingOperation {
 
 		[Abstract]
@@ -1159,9 +1152,8 @@ namespace FileProvider {
 
 	interface INSFileProviderTestingCreation { }
 
-	[Unavailable (PlatformName.MacCatalyst)]
 	[NoWatch, NoTV, NoiOS, Mac (11,3)]
-	[Protocol, Advice ("This API is not available when using UIKit on macOS.")]
+	[Protocol]
 	interface NSFileProviderTestingCreation : NSFileProviderTestingOperation {
 
 		[Abstract]
@@ -1179,9 +1171,9 @@ namespace FileProvider {
 
 	interface INSFileProviderTestingModification { }
 
-	[Unavailable (PlatformName.MacCatalyst)]
+	[NoMacCatalyst]
 	[NoWatch, NoTV, NoiOS, Mac (11,3)]
-	[Protocol, Advice ("This API is not available when using UIKit on macOS.")]
+	[Protocol]
 	interface NSFileProviderTestingModification : NSFileProviderTestingOperation {
 
 		[Abstract]
@@ -1211,9 +1203,9 @@ namespace FileProvider {
 
 	interface INSFileProviderTestingDeletion { }
 
-	[Unavailable (PlatformName.MacCatalyst)]
+	[NoMacCatalyst]
 	[NoWatch, NoTV, NoiOS, Mac (11,3)]
-	[Protocol, Advice ("This API is not available when using UIKit on macOS.")]
+	[Protocol]
 	interface NSFileProviderTestingDeletion : NSFileProviderTestingOperation {
 
 		[Abstract]
@@ -1239,9 +1231,9 @@ namespace FileProvider {
 
 	interface INSFileProviderTestingContentFetch { }
 
-	[Unavailable (PlatformName.MacCatalyst)]
+	[NoMacCatalyst]
 	[NoWatch, NoTV, NoiOS, Mac (11,3)]
-	[Protocol, Advice ("This API is not available when using UIKit on macOS.")]
+	[Protocol]
 	interface NSFileProviderTestingContentFetch : NSFileProviderTestingOperation {
 
 		[Abstract]
@@ -1255,9 +1247,9 @@ namespace FileProvider {
 
 	interface INSFileProviderTestingChildrenEnumeration { }
 
-	[Unavailable (PlatformName.MacCatalyst)]
+	[NoMacCatalyst]
 	[NoWatch, NoTV, NoiOS, Mac (11,3)]
-	[Protocol, Advice ("This API is not available when using UIKit on macOS.")]
+	[Protocol]
 	interface NSFileProviderTestingChildrenEnumeration : NSFileProviderTestingOperation {
 
 		[Abstract]
@@ -1271,9 +1263,9 @@ namespace FileProvider {
 
 	interface INSFileProviderTestingCollisionResolution { }
 
-	[Unavailable (PlatformName.MacCatalyst)]
+	[NoMacCatalyst]
 	[NoWatch, NoTV, NoiOS, Mac (11,3)]
-	[Protocol, Advice ("This API is not available when using UIKit on macOS.")]
+	[Protocol]
 	interface NSFileProviderTestingCollisionResolution : NSFileProviderTestingOperation {
 
 		[Abstract]

--- a/src/intentsui.cs
+++ b/src/intentsui.cs
@@ -105,8 +105,7 @@ namespace IntentsUI {
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		NSObject WeakDelegate { get; set; }
 
-		[Unavailable (PlatformName.MacCatalyst)]
-		[Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Export ("initWithShortcut:")]
 		IntPtr Constructor (INShortcut shortcut);
 	}
@@ -139,8 +138,7 @@ namespace IntentsUI {
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		NSObject WeakDelegate { get; set; }
 
-		[Unavailable (PlatformName.MacCatalyst)]
-		[Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Export ("initWithVoiceShortcut:")]
 		IntPtr Constructor (INVoiceShortcut voiceShortcut);
 	}

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -877,18 +877,16 @@ namespace Metal {
 #if XAMCORE_4_0
 		[Abstract]
 #endif
-		[Unavailable (PlatformName.MacCatalyst)]
 		[Mac (11,0), NoTV, iOS (13,0)]
-		[Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Export ("getTextureAccessCounters:region:mipLevel:slice:resetCounters:countersBuffer:countersBufferOffset:")]
 		void GetTextureAccessCounters (IMTLTexture texture, MTLRegion region, nuint mipLevel, nuint slice, bool resetCounters, IMTLBuffer countersBuffer, nuint countersBufferOffset);
 
 #if XAMCORE_4_0
 		[Abstract]
 #endif
-		[Unavailable (PlatformName.MacCatalyst)]
 		[Mac (11,0), NoTV, iOS (13,0)]
-		[Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Export ("resetTextureAccessCounters:region:mipLevel:slice:")]
 		void ResetTextureAccessCounters (IMTLTexture texture, MTLRegion region, nuint mipLevel, nuint slice);
 
@@ -1385,7 +1383,6 @@ namespace Metal {
 #endif
 		[Introduced (PlatformName.MacCatalyst, 14, 0)]
 		[Mac (11,0), NoTV, iOS (13,0)]
-		[Advice ("This API is not available when using UIKit on macOS.")]
 		[Export ("sparseTileSizeWithTextureType:pixelFormat:sampleCount:")]
 		MTLSize GetSparseTileSize (MTLTextureType textureType, MTLPixelFormat pixelFormat, nuint sampleCount);
 
@@ -1834,27 +1831,24 @@ namespace Metal {
 #if XAMCORE_4_0
 		[Abstract]
 #endif
-		[Unavailable (PlatformName.MacCatalyst)]
+		[NoMacCatalyst]
 		[Mac (11,0), NoTV, iOS (13, 0)]
-		[Advice ("This API is not available when using UIKit on macOS.")]
 		[Export ("firstMipmapInTail")]
 		nuint FirstMipmapInTail { get; }
 
 #if XAMCORE_4_0
 		[Abstract]
 #endif
-		[Unavailable (PlatformName.MacCatalyst)]
 		[Mac (11,0), NoTV, iOS (13, 0)]
-		[Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Export ("tailSizeInBytes")]
 		nuint TailSizeInBytes { get; }
 
 #if XAMCORE_4_0
 		[Abstract]
 #endif
-		[Unavailable (PlatformName.MacCatalyst)]
 		[Mac (11,0), NoTV, iOS (13, 0)]
-		[Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Export ("isSparse")]
 		bool IsSparse { get; }
 
@@ -3454,9 +3448,8 @@ namespace Metal {
 		nuint RenderTargetHeight { get; set; }
 
 /* Selectors reported missing by instrospection: https://github.com/xamarin/maccore/issues/1978
-		[Unavailable (PlatformName.MacCatalyst)]
 		[NoMac, NoTV, iOS (13, 0)]
-		[Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Export ("maxVertexAmplificationCount")]
 		nuint MaxVertexAmplificationCount { get; set; }
 */

--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -243,14 +243,14 @@ namespace PassKit {
 		PKPaymentToken Token { get; }
 
 		[NoMac]
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[NoWatch]
 		[Export ("billingAddress", ArgumentSemantic.Assign)]
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'BillingContact' instead.")]
 		ABRecord BillingAddress { get; }
 
 		[NoMac]
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[NoWatch]
 		[Export ("shippingAddress", ArgumentSemantic.Assign)]
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'ShippingContact' instead.")]
@@ -307,7 +307,7 @@ namespace PassKit {
 		[EventArgs ("PKPaymentRequestShippingMethodUpdate")]
 		void DidSelectShippingMethod2 (PKPaymentAuthorizationViewController controller, PKShippingMethod shippingMethod, Action<PKPaymentRequestShippingMethodUpdate> completion);
 
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Deprecated (PlatformName.iOS, 9, 0)]
 		[NoMac]
 		[Export ("paymentAuthorizationViewController:didSelectShippingAddress:completion:")]
@@ -481,7 +481,7 @@ namespace PassKit {
 		PKAddressField RequiredBillingAddressFields { get; set; }
 
 		[NoMac]
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[NoWatch]
 		[NullAllowed] // by default this property is null
 		[Export ("billingAddress", ArgumentSemantic.Assign)]
@@ -495,7 +495,7 @@ namespace PassKit {
 		PKAddressField RequiredShippingAddressFields { get; set; }
 
 		[NoMac]
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[NoWatch]
 		[NullAllowed] // by default this property is null
 		[Export ("shippingAddress", ArgumentSemantic.Assign)]

--- a/src/photos.cs
+++ b/src/photos.cs
@@ -131,10 +131,9 @@ namespace Photos
 
 		[Deprecated (PlatformName.TvOS, 11,0)]
 		[Deprecated (PlatformName.iOS, 11,0)]
-		[Unavailable (PlatformName.MacCatalyst)]
 		[NoMac]
 		[Static]
-		[Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Export ("fetchAssetsWithALAssetURLs:options:")]
 		PHFetchResult FetchAssets (NSUrl[] assetUrls, [NullAllowed] PHFetchOptions options);
 
@@ -1385,8 +1384,7 @@ namespace Photos
 
 	[Mac (10,13)]
 	[NoiOS][NoTV]
-	[Unavailable (PlatformName.MacCatalyst)]
-	[Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[BaseType (typeof (PHAssetCollection))]
 	interface PHProject {
 
@@ -1401,7 +1399,7 @@ namespace Photos
 	[Mac (10,13)]
 	[Unavailable (PlatformName.MacCatalyst)]
 	[NoiOS][NoTV]
-	[Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[BaseType (typeof (PHChangeRequest))]
 	interface PHProjectChangeRequest {
 

--- a/src/photosui.cs
+++ b/src/photosui.cs
@@ -477,8 +477,7 @@ namespace PhotosUI {
 	[iOS (8,0)]
 	[NoMac][NoTV]
 	[DisableDefaultCtor]
-	[Unavailable (PlatformName.MacCatalyst)]
-	[Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[Deprecated (PlatformName.iOS, 13, 0)]
 	[BaseType (typeof (NSExtensionContext))]
 	interface PHEditingExtensionContext

--- a/src/pushkit.cs
+++ b/src/pushkit.cs
@@ -96,7 +96,7 @@ namespace PushKit
 		[NoMac]
 		[Abstract] // now optional in iOS 11
 		[Deprecated (PlatformName.iOS, 11,0, message: "Use the 'DidReceiveIncomingPushWithPayload' overload accepting an 'Action' argument instead.")]
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Export ("pushRegistry:didReceiveIncomingPushWithPayload:forType:"), EventArgs ("PKPushRegistryRecieved"), EventName ("IncomingPushReceived")]
 		void DidReceiveIncomingPush (PKPushRegistry registry, PKPushPayload payload, string type);
 

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -1210,7 +1210,7 @@ namespace SceneKit {
 #if MONOMAC
 	[iOS (8,0)]
 	[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use Metal instead of OpenGL API.")]
-	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[BaseType (typeof (CAOpenGLLayer))]
 	interface SCNLayer : SCNSceneRenderer, SCNTechniqueSupport {
 //		We already pull in the Scene property from the SCNSceneRenderer protocol, no need to redefine it here.
@@ -1680,7 +1680,7 @@ namespace SceneKit {
 
 		[Deprecated (PlatformName.iOS, 10, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 12)]
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[NoWatch, NoTV]
 		[NullAllowed, Export ("borderColor", ArgumentSemantic.Retain)]
 		NSObject BorderColor { get; set; }
@@ -2511,7 +2511,7 @@ namespace SceneKit {
 		[NoTV, NoWatch]
 	#endif
 		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use the SCNProgram's Opaque property instead.")]
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Export ("programIsOpaque:")]
 		bool IsProgramOpaque (SCNProgram program);
 #endif
@@ -2568,7 +2568,7 @@ namespace SceneKit {
 		[Export ("render")]
 		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Deprecated (PlatformName.iOS, 9, 0)]
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		void Render ();
 
 		[Mac (10,10)]
@@ -3442,7 +3442,7 @@ namespace SceneKit {
 	[Internal] // we'll make it public if there's a need for them (beside the strong dictionary we provide)
 	interface SCNRenderingOptionsKeys {
 
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Field ("SCNPreferredRenderingAPIKey")]
 		NSString RenderingApiKey { get; }
 

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -2535,7 +2535,7 @@ namespace UIKit {
 		UIApplicationShortcutIcon FromSystemImageName (string systemImageName);
 
 #if IOS // This is inside ContactsUI.framework
-		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Static, Export ("iconWithContact:")]
 		UIApplicationShortcutIcon FromContact (CNContact contact);
 #endif // IOS
@@ -15329,8 +15329,7 @@ namespace UIKit {
 		IUIViewControllerTransitionCoordinator GetTransitionCoordinator ();
 	}
 
-	[Unavailable (PlatformName.MacCatalyst)]
-	[Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[NoTV]
 	[Deprecated (PlatformName.iOS, 12, 0, message: "No longer supported; please adopt 'WKWebView'.")]
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIWebViewDelegate)})]
@@ -15434,8 +15433,7 @@ namespace UIKit {
 		bool AllowsLinkPreview { get; set; }
 	}
 
-	[Unavailable (PlatformName.MacCatalyst)]
-	[Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[NoTV]
 	[Deprecated (PlatformName.iOS, 12, 0, message: "No longer supported; please adopt 'WKWebView' APIs.")]
 	[BaseType (typeof (NSObject))]

--- a/src/videosubscriberaccount.cs
+++ b/src/videosubscriberaccount.cs
@@ -24,7 +24,7 @@ namespace VideoSubscriberAccount {
 	[TV (10, 0)]
 	[Mac (10,14)]
 	[Unavailable (PlatformName.WatchOS)]
-	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[ErrorDomain ("VSErrorDomain")]
 	public enum VSErrorCode : long {
 		AccessNotGranted = 0,
@@ -42,7 +42,7 @@ namespace VideoSubscriberAccount {
 	[TV (10, 0)]
 	[Mac (10,14)]
 	[Unavailable (PlatformName.WatchOS)]
-	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	public enum VSAccountAccessStatus : long {
 		NotDetermined = 0,
 		Restricted = 1,
@@ -54,7 +54,7 @@ namespace VideoSubscriberAccount {
 	[TV (10, 0)]
 	[Mac (10,14)]
 	[Unavailable (PlatformName.WatchOS)]
-	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[Static]
 	[Internal]
 	interface VSErrorInfoKeys {
@@ -98,7 +98,7 @@ namespace VideoSubscriberAccount {
 	[TV (10, 0)]
 	[Mac (10,14)]
 	[Unavailable (PlatformName.WatchOS)]
-	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	interface VSAccountManagerDelegate {
 
@@ -158,7 +158,7 @@ namespace VideoSubscriberAccount {
 	[Unavailable (PlatformName.WatchOS)]
 	[Static]
 	[Internal]
-	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	interface VSCheckAccessOptionKeys {
 
 		[Field ("VSCheckAccessOptionPrompt")]
@@ -181,7 +181,7 @@ namespace VideoSubscriberAccount {
 	[TV (10, 0)]
 	[Mac (10,14)]
 	[Unavailable (PlatformName.WatchOS)]
-	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface VSAccountManagerResult {
@@ -194,7 +194,7 @@ namespace VideoSubscriberAccount {
 	[TV (10, 0)]
 	[Mac (10,14)]
 	[Unavailable (PlatformName.WatchOS)]
-	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	interface VSAccountMetadata {
 
@@ -219,7 +219,7 @@ namespace VideoSubscriberAccount {
 	[Mac (10,14)]
 	[TV (10, 0)]
 	[Unavailable (PlatformName.WatchOS)]
-	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	interface VSAccountMetadataRequest {
 
@@ -271,7 +271,7 @@ namespace VideoSubscriberAccount {
 	[iOS (10,2)]
 	[TV (10,1)]
 	[Mac (10,14)]
-	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	interface VSAccountProviderResponse {
 
@@ -292,7 +292,7 @@ namespace VideoSubscriberAccount {
 	[iOS (10,2)]
 	[TV (10,1)]
 	[Mac (10,14)]
-	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	enum VSAccountProviderAuthenticationScheme {
 		[Field ("VSAccountProviderAuthenticationSchemeSAML")]
 		Saml,
@@ -335,7 +335,7 @@ namespace VideoSubscriberAccount {
 
 	[TV (11,0)][iOS (11,0)]
 	[Mac (10,14)]
-	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface VSSubscriptionRegistrationCenter {
@@ -348,7 +348,7 @@ namespace VideoSubscriberAccount {
 	}
 
 	[TV (14,2), iOS (14,2), Mac (11,0)]
-	[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
+	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface VSAccountApplicationProvider {

--- a/src/xkit.cs
+++ b/src/xkit.cs
@@ -1168,7 +1168,6 @@ namespace UIKit {
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Please use 'UsesDefaultHyphenation' or 'NSParagraphStyle.HyphenationFactor' instead.")]
 		[Deprecated (PlatformName.WatchOS, 6, 0, message: "Please use 'UsesDefaultHyphenation' or 'NSParagraphStyle.HyphenationFactor' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Please use 'UsesDefaultHyphenation' or 'NSParagraphStyle.HyphenationFactor' instead.")]
-		[Advice ("This API is not available when using UIKit on macOS.")]
 		[NoMacCatalyst]
 		[Export ("hyphenationFactor")]
 #if MONOMAC
@@ -1296,8 +1295,7 @@ namespace UIKit {
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use the overload that takes 'nint glyphCount' instead.")]
 		[Deprecated (PlatformName.WatchOS, 6, 0, message: "Use the overload that takes 'nint glyphCount' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use the overload that takes 'nint glyphCount' instead.")]
-		[Unavailable (PlatformName.MacCatalyst)]
-		[Advice ("This API is not available when using UIKit on macOS.")]
+		[NoMacCatalyst]
 		[Protected] // Can be overridden
 		[Export ("showCGGlyphs:positions:count:font:matrix:attributes:inContext:")]
 		void ShowGlyphs (IntPtr glyphs, IntPtr positions, nuint glyphCount, NSFont font, CGAffineTransform textMatrix, NSDictionary attributes, CGContext graphicsContext);


### PR DESCRIPTION
Instead of this:

    [Unavailable (PlatformName.MacCatalyst)]
    [Advice ("This API is not available when using UIKit on macOS.")]

do this:

    [NoMacCatalyst]

Except when the API is actually available (in which case add the correct availability attribute), or in manual binding code (where we still have to use `[Unavailable (...)]`, although not the `[Advice (...)]`).