### PR TITLE
[tests][monotouch-test] Re-enable registrar test for conformsToProtocol for dotnet

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -1374,9 +1374,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			Assert.AreNotEqual (IntPtr.Zero, Runtime.GetProtocol (iProtocol), "IProtocol");
 			Assert.IsTrue (Messaging.bool_objc_msgSend_IntPtr (Class.GetHandle (typeof (MyProtocolImplementation)), Selector.GetHandle ("conformsToProtocol:"), Runtime.GetProtocol (iProtocol)), "Interface/IProtocol");
 #if !__TVOS__ && !__WATCHOS__ && !MONOMAC
-	#if !NET // https://github.com/xamarin/xamarin-macios/issues/11540
 			Assert.IsTrue (Messaging.bool_objc_msgSend_IntPtr (Class.GetHandle (typeof (Test24970)), Selector.GetHandle ("conformsToProtocol:"), Protocol.GetHandle ("UIApplicationDelegate")), "UIApplicationDelegate/17669");
-	#endif
 #endif
 			// We don't support [Adopts] (yet at least).
 //			Assert.IsTrue (Messaging.bool_objc_msgSend_IntPtr (Class.GetHandle (typeof (ConformsToProtocolTestClass)), Selector.GetHandle ("conformsToProtocol:"), Runtime.GetProtocol ("NSCoding")), "Adopts/ConformsToProtocolTestClass");


### PR DESCRIPTION
This works fine now. I'm fairly sure this was fixed when the the last
custom steps of the linker were ported for dotnet illink

Fix https://github.com/xamarin/xamarin-macios/issues/11540