### PR TITLE
[generator] Use new CFArray.ArrayFromHandle instead of the existing NSArray API

### DIFF
--- a/src/CoreFoundation/CFArray.cs
+++ b/src/CoreFoundation/CFArray.cs
@@ -142,5 +142,31 @@ namespace CoreFoundation {
 				ret [i] = CFString.FromHandle (CFArrayGetValueAtIndex (handle, i));
 			return ret;
 		}
+
+		static T? UnsafeGetItem<T> (IntPtr handle, nint index) where T : class, INativeObject
+		{
+			var val = CFArrayGetValueAtIndex (handle, index);
+			// Native code could return a CFArray with kCFNull inside its elements
+			// and they should be valid for things like T : NSDate so we handle
+			// them as just null values inside the array
+			if (val == CFNullHandle)
+				return null;
+
+			return Runtime.GetINativeObject<T> (val, false);
+		}
+
+		// identical signature to NSArray API
+		static public T?[]? ArrayFromHandle<T> (IntPtr handle) where T : class, INativeObject
+		{
+			if (handle == IntPtr.Zero)
+				return null;
+
+			var c = CFArrayGetCount (handle);
+			T?[] ret = new T [c];
+
+			for (nint i = 0; i < c; i++)
+				ret [i] = UnsafeGetItem<T> (handle, i);
+			return ret;
+		}
 	}
 }

--- a/src/corefoundation.cs
+++ b/src/corefoundation.cs
@@ -30,6 +30,13 @@ namespace CoreFoundation {
 	}
 
 	[Partial]
+	interface CFArray {
+
+		[Internal][Field ("kCFNull")]
+		IntPtr /* CFNullRef */ CFNullHandle { get; }
+	}
+
+	[Partial]
 	[Internal]
 	interface CFBoolean {
 		[Internal]

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1760,7 +1760,7 @@ public partial class Generator : IMemberGatherer {
 				Type et = pi.ParameterType.GetElementType ();
 				if (IsWrappedType (et)){
 					pars.AppendFormat ("IntPtr {0}", safe_name);
-					invoke.AppendFormat ("NSArray.ArrayFromHandle<{0}> ({1})", FormatType (null, et), safe_name);
+					invoke.AppendFormat ("CFArray.ArrayFromHandle<{0}> ({1})!", FormatType (null, et), safe_name);
 					continue;
 				}
 			}
@@ -2708,7 +2708,7 @@ public partial class Generator : IMemberGatherer {
 			if (by_ref_processing.Length > 0)
 				print (sw, by_ref_processing.ToString ());
 			if (use_temp_return)
-				print ("return ret;");
+				print ("return ret!;");
 			indent--; print ("}");
 			indent--;
 			print ("}} /* class {0} */", ti.NativeInvokerName);
@@ -3067,7 +3067,7 @@ public partial class Generator : IMemberGatherer {
 					var fullname = propertyType.FullName;
 
 					if (is_property_array_wrapped_type) {
-						print ("return NSArray.ArrayFromHandle<{0}> (value);", RenderType (et));
+						print ("return CFArray.ArrayFromHandle<{0}> (value)!;", RenderType (et));
 					} else if (is_property_wrapped_type) {
 						print ("return Runtime.GetNSObject<{0}> (value);", RenderType (propertyType));
 					} else if (propertyType == TypeManager.System_Double)
@@ -3852,16 +3852,16 @@ public partial class Generator : IMemberGatherer {
 				cast_a = "CFArray.StringArrayFromHandle (";
 				cast_b = ")!";
 			} else if (minfo != null && minfo.protocolize) {
-				cast_a = "NSArray.ArrayFromHandle<global::" + etype.Namespace + ".I" + etype.Name + ">(";
-				cast_b = ")";
+				cast_a = "CFArray.ArrayFromHandle<global::" + etype.Namespace + ".I" + etype.Name + ">(";
+				cast_b = ")!";
 			} else if (etype == TypeManager.Selector) {
 				exceptions.Add (ErrorHelper.CreateError (1066, mai.Type.FullName, mi.DeclaringType.FullName, mi.Name));
 			} else {
 				if (NamespaceManager.NamespacesThatConflictWithTypes.Contains (etype.Namespace))
-					cast_a = "NSArray.ArrayFromHandle<global::" + etype + ">(";
+					cast_a = "CFArray.ArrayFromHandle<global::" + etype + ">(";
 				else
-					cast_a = "NSArray.ArrayFromHandle<" + FormatType (mi.DeclaringType, etype) + ">(";
-				cast_b = ")";
+					cast_a = "CFArray.ArrayFromHandle<" + FormatType (mi.DeclaringType, etype) + ">(";
+				cast_b = ")!";
 			}
 		}
 	}
@@ -4322,7 +4322,7 @@ public partial class Generator : IMemberGatherer {
 						by_ref_processing.AppendFormat ("if ({0}Value != ({0}ArrayValue is null ? IntPtr.Zero : {0}ArrayValue.Handle))\n\t", pi.Name.GetSafeParamName ());
 
 					if (isArrayOfNSObject || isArrayOfINativeObjectSubclass) {
-						by_ref_processing.AppendFormat ("{0} = NSArray.ArrayFromHandle<{1}> ({0}Value);\n", pi.Name.GetSafeParamName (), RenderType (elementType.GetElementType ()));
+						by_ref_processing.AppendFormat ("{0} = CFArray.ArrayFromHandle<{1}> ({0}Value)!;\n", pi.Name.GetSafeParamName (), RenderType (elementType.GetElementType ()));
 					} else if (isArrayOfString) {
 						by_ref_processing.AppendFormat ("{0} = CFArray.StringArrayFromHandle ({0}Value)!;\n", pi.Name.GetSafeParamName ());
 					} else {

--- a/tests/perftest/TollFreeBridge.cs
+++ b/tests/perftest/TollFreeBridge.cs
@@ -120,5 +120,25 @@ namespace PerfTest {
 		{
 			NSArray.StringArrayFromHandle (value.Handle);
 		}
-    }
+
+		/*
+		 * Measure time required to create a managed `NSObject[]` array from a native one using `CFArray.ArrayFromHandle`
+		 */
+		[Benchmark]
+		[ArgumentsSource (nameof (ArraysOfStrings))]
+		public void CFArray_ArrayFromHandle (string name, NSArray value)
+		{
+			CFArray.ArrayFromHandle<NSString> (value.Handle);
+		}
+
+		/*
+		 * Measure time required to create a managed `NSObject[]` array from a native one using `CFArray.ArrayFromHandle`
+		 */
+		[Benchmark]
+		[ArgumentsSource (nameof (ArraysOfStrings))]
+		public void NSArray_ArrayFromHandle (string name, NSArray value)
+		{
+			NSArray.ArrayFromHandle<NSString> (value.Handle);
+		}
+	}
 }

--- a/tests/xtro-sharpie/common-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/common-CoreFoundation.ignore
@@ -127,7 +127,6 @@
 !missing-field! kCFLocaleScriptCode not bound
 !missing-field! kCFLocaleUsesMetricSystem not bound
 !missing-field! kCFLocaleVariantCode not bound
-!missing-field! kCFNull not bound
 !missing-field! kCFNumberFormatterAlwaysShowDecimalSeparator not bound
 !missing-field! kCFNumberFormatterCurrencyCode not bound
 !missing-field! kCFNumberFormatterCurrencyDecimalSeparator not bound


### PR DESCRIPTION
Similar to https://github.com/xamarin/xamarin-macios/pull/12368

p/invoke are faster than selectors, so we use them inside generated
bindings and suggest (thru `[Obsolete]`) the use of `CFArray` in manual
bindings and 3rd-party code.

|                        Method |          name |               value |            Mean |            Error |          StdDev |
|------------------------------ |-------------- |-------------------- |----------------:|-----------------:|----------------:|
|       CFArray_ArrayFromHandle |         empty |                  () |        120.1 ns |         31.37 ns |         1.72 ns |
|       NSArray_ArrayFromHandle |         empty |                  () |      1,433.4 ns |        168.78 ns |         9.25 ns |
|       CFArray_ArrayFromHandle |           few |   (  (...).") [108] |      4,113.2 ns |        290.55 ns |        15.93 ns |
|       NSArray_ArrayFromHandle |           few |   (  (...).") [108] |      8,617.3 ns |      1,958.88 ns |       107.37 ns |
|       CFArray_ArrayFromHandle | large_mutable |   ((...)) [8419330] |  4,045,002.6 ns |    438,639.47 ns |    24,043.31 ns |
|       NSArray_ArrayFromHandle | large_mutable |   ((...)) [8419330] |  7,138,524.0 ns |  1,147,635.42 ns |    62,905.77 ns |
|       CFArray_ArrayFromHandle |       mutable |  (   (...)9e") [54] |      1,974.9 ns |        576.90 ns |        31.62 ns |
|       NSArray_ArrayFromHandle |       mutable |  (   (...)9e") [54] |      4,882.9 ns |        269.60 ns |        14.78 ns |

Note: the use of `CFArrayGetValues` as suggested before (see https://github.com/xamarin/xamarin-macios/issues/12375)
would also apply here - but that needs a bit more fine-tuning (to offset
the extra allocation) so it will be handled by a future PR.

# Side Effect Trivia

Along with previous work this means that a _minimal_ app can now trim both `NSArray` and `NSNull` (managed code) and their need to be registered at startup.

```diff
--- a.cs	2021-08-12 08:18:15.000000000 -0400
+++ b.cs	2021-08-12 08:19:35.000000000 -0400
@@ -2111,6 +2111,11 @@
 		{
 			public static readonly IntPtr Handle = Dlfcn._dlopen("/usr/lib/libSystem.dylib", 0);
 		}
+
+		public static class CoreFoundation
+		{
+			public static readonly IntPtr Handle = Dlfcn._dlopen("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation", 0);
+		}
 	}
 	public static class Dlfcn
 	{
@@ -2119,6 +2124,16 @@
 
 		[DllImport("/usr/lib/libSystem.dylib")]
 		public static extern IntPtr dlsym(IntPtr P_0, string P_1);
+
+		public static IntPtr GetIntPtr(IntPtr P_0, string P_1)
+		{
+			IntPtr intPtr = dlsym(P_0, P_1);
+			if (intPtr == IntPtr.Zero)
+			{
+				return IntPtr.Zero;
+			}
+			return Marshal.ReadIntPtr(intPtr);
+		}
 	}
 	internal static class ErrorHelper
 	{
@@ -3114,9 +3129,6 @@
 		public static extern void void_objc_msgSend(IntPtr P_0, IntPtr P_1);
 
 		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
-		public static extern IntPtr IntPtr_objc_msgSend_nuint(IntPtr P_0, IntPtr P_1, nuint P_2);
-
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
 		public static extern CGRect CGRect_objc_msgSend(IntPtr P_0, IntPtr P_1);
 
 		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
@@ -3590,54 +3602,6 @@
 			return stringBuilder.ToString();
 		}
 	}
-	[Register("NSArray", true)]
-	public sealed class NSArray : NSObject, INativeObject, IDisposable
-	{
-		private static readonly IntPtr class_ptr = Class.GetHandle("NSArray");
-
-		public sealed override IntPtr ClassHandle => class_ptr;
-
-		internal static nuint GetCount(IntPtr P_0)
-		{
-			return Messaging.nuint_objc_msgSend(P_0, Selector.GetHandle("count"));
-		}
-
-		internal static IntPtr GetAtIndex(IntPtr P_0, nuint P_1)
-		{
-			return Messaging.IntPtr_objc_msgSend_nuint(P_0, Selector.GetHandle("objectAtIndex:"), P_1);
-		}
-
-		public static T[] ArrayFromHandle<T>(IntPtr P_0) where T : class, INativeObject
-		{
-			if (P_0 == IntPtr.Zero)
-			{
-				return null;
-			}
-			nuint count = GetCount(P_0);
-			T[] array = new T[(ulong)count];
-			for (uint num = 0u; num < count; num++)
-			{
-				array[num] = UnsafeGetItem<T>(P_0, num);
-			}
-			return array;
-		}
-
-		private static T UnsafeGetItem<T>(IntPtr P_0, nuint P_1) where T : class, INativeObject
-		{
-			IntPtr atIndex = GetAtIndex(P_0, P_1);
-			if (atIndex == NSNull.Null.Handle)
-			{
-				return null;
-			}
-			return Runtime.GetINativeObject<T>(atIndex, false);
-		}
-
-		[EditorBrowsable(EditorBrowsableState.Advanced)]
-		protected internal NSArray(IntPtr P_0)
-			: base(P_0)
-		{
-		}
-	}
 	[DefaultMember("Item")]
 	[Register("NSDictionary", true)]
 	public sealed class NSDictionary : NSObject, IDictionary, ICollection<KeyValuePair<NSObject, NSObject>>, IEnumerable<KeyValuePair<NSObject, NSObject>>, INativeObject, IDisposable
@@ -3665,7 +3629,7 @@
 			{
 				using (new NSAutoreleasePool())
 				{
-					return NSArray.ArrayFromHandle<NSObject>(Messaging.IntPtr_objc_msgSend(base.Handle, Selector.GetHandle("allKeys")));
+					return CFArray.ArrayFromHandle<NSObject>(Messaging.IntPtr_objc_msgSend(base.Handle, Selector.GetHandle("allKeys")));
 				}
 			}
 		}
@@ -3717,43 +3681,6 @@
 			return Runtime.GetNSObject(Messaging.IntPtr_objc_msgSend_IntPtr(base.Handle, Selector.GetHandle("objectForKey:"), nonNullHandle));
 		}
 	}
-	[Register("NSNull", true)]
-	public sealed class NSNull : NSObject, INativeObject, IDisposable
-	{
-		private static NSNull _null;
-
-		private static readonly IntPtr class_ptr = Class.GetHandle("NSNull");
-
-		public static NSNull Null
-		{
-			get
-			{
-				if (_null == null)
-				{
-					_null = _Null;
-				}
-				return _null;
-			}
-		}
-
-		public sealed override IntPtr ClassHandle => class_ptr;
-
-		internal static NSNull _Null
-		{
-			[System.Runtime.CompilerServices.NullableContext(1)]
-			[Export("null")]
-			get
-			{
-				return Runtime.GetNSObject<NSNull>(Messaging.IntPtr_objc_msgSend(class_ptr, Selector.GetHandle("null")));
-			}
-		}
-
-		[EditorBrowsable(EditorBrowsableState.Advanced)]
-		protected internal NSNull(IntPtr P_0)
-			: base(P_0)
-		{
-		}
-	}
 	[Register("NSRunLoop", true)]
 	public sealed class NSRunLoop : NSObject
 	{
@@ -4702,26 +4629,11 @@
 			return (int)P_0.v;
 		}
 
-		public static implicit operator nuint(uint P_0)
-		{
-			return new nuint(P_0);
-		}
-
 		public static explicit operator nuint(ulong P_0)
 		{
 			return new nuint(P_0);
 		}
 
-		public static implicit operator ulong(nuint P_0)
-		{
-			return P_0.v;
-		}
-
-		public static bool operator <(nuint P_0, nuint P_1)
-		{
-			return P_0.v < P_1.v;
-		}
-
 		public int CompareTo(nuint P_0)
 		{
 			return v.CompareTo(P_0.v);
@@ -4867,6 +4779,8 @@
 {
 	public sealed class CFArray : NativeObject
 	{
+		internal static IntPtr CFNullHandle => Dlfcn.GetIntPtr(Libraries.CoreFoundation.Handle, "kCFNull");
+
 		internal CFArray(IntPtr P_0)
 			: base(P_0, false)
 		{
@@ -4897,6 +4811,31 @@
 			}
 			return array;
 		}
+
+		private static T? UnsafeGetItem<T>(IntPtr P_0, nint P_1) where T : class, INativeObject
+		{
+			IntPtr intPtr = CFArrayGetValueAtIndex(P_0, P_1);
+			if (intPtr == CFNullHandle)
+			{
+				return null;
+			}
+			return Runtime.GetINativeObject<T>(intPtr, false);
+		}
+
+		public static T?[]? ArrayFromHandle<T>(IntPtr P_0) where T : class, INativeObject
+		{
+			if (P_0 == IntPtr.Zero)
+			{
+				return null;
+			}
+			nint nint = CFArrayGetCount(P_0);
+			T[] array = new T[(long)nint];
+			for (nint nint2 = 0; nint2 < nint; ++nint2)
+			{
+				array[(long)nint2] = UnsafeGetItem<T>(P_0, nint2);
+			}
+			return array;
+		}
 	}
 	public struct CFRange
 	{
```
