### PR TITLE
[dotnet] Fix exclusion of mono components.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -349,10 +349,10 @@
 		<!-- We only include any mono components when linking with mono statically. The components are already included in the dynamic versions of Mono (both the dylib and the framework) -->
 		<ItemGroup Condition="'$(_LibMonoLinkMode)' == 'static'">
 			<!-- Remove files mono told us not to link with -->
-			<_MonoLibrary Remove="@(_MonoRuntimeComponentDontLink -> '$(_MonoRuntimePackPath)/native/%(Identity)')" />
+			<_MonoLibrary Remove="@(_MonoRuntimeComponentDontLink -> '$(_MonoRuntimePackPath)native/%(Identity)')" />
 
 			<!-- Add files mono told us to link with -->
-			<_MonoLibrary Include="@(_MonoRuntimeComponentLink -> '$(_MonoRuntimePackPath)/native/%(Identity)')" />
+			<_MonoLibrary Include="@(_MonoRuntimeComponentLink -> '$(_MonoRuntimePackPath)native/%(Identity)')" />
 		</ItemGroup>
 	</Target>
 


### PR DESCRIPTION
'_MonoRuntimePackPath' already contains a trailing slash, so adding another
one made two, and that was too much for MSBuild to realize that it was really
the same file as the one with only one slash in the path, and those files
weren't removed from the build correctly.

This saves ~300kb from the app size comparison:

Before: https://gist.github.com/rolfbjarne/812f3ded1cf1a8bea45c7ca9b42bf95b
After: https://gist.github.com/rolfbjarne/22b23db0a162e9b9e366392b67063907