### PR TITLE
Bump ObjectiveSharpie.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -167,9 +167,9 @@ MIN_CMAKE_URL=https://cmake.org/files/v3.6/cmake-3.6.2-Darwin-x86_64.dmg
 MIN_CMAKE_VERSION=2.8.8
 
 # ObjectiveSharpie min/max versions
-MIN_SHARPIE_VERSION=3.5.45
+MIN_SHARPIE_VERSION=3.5.46
 MAX_SHARPIE_VERSION=3.5.99
-MIN_SHARPIE_URL=https://download.visualstudio.microsoft.com/download/pr/77766fbc-995f-410b-9546-4a1731051956/d3f34a07d9c3a2fcdda16bb3fe5b41e8/objectivesharpie-3.5.45.pkg
+MIN_SHARPIE_URL=https://download.visualstudio.microsoft.com/download/pr/0e9ecce4-10b6-46a4-ae06-ad031b25eafc/761cd868c5c27f5b68765e1fa53fd873/objectivesharpie-3.5.46.pkg
 
 # Minimum OSX versions for building XI/XM
 MIN_OSX_BUILD_VERSION=11.0


### PR DESCRIPTION
The new version generates better attributes for Mac Catalyst.

Ref: https://github.com/xamarin/ObjectiveSharpie/pull/150