### PR TITLE
[msbuild] Add a property that specifies the final path to the Info.plist in the app bundle

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1061,7 +1061,7 @@
 		<GetMlaunchArguments
 			SessionId="$(BuildSessionId)"
 			AppBundlePath="$(_AppBundlePath)"
-			AppManifestPath="$(_AppBundlePath)$(_AppBundleManifestRelativePath)Info.plist"
+			AppManifestPath="$(_AppBundleManifest)"
 			DeviceName="$(_DeviceName)"
 			InstallApp="$(_AppBundlePath)"
 			MlaunchPath="$(_MlaunchPath)"
@@ -1088,7 +1088,7 @@
 		<GetMlaunchArguments
 			SessionId="$(BuildSessionId)"
 			AppBundlePath="$(_AppBundlePath)"
-			AppManifestPath="$(_AppBundlePath)$(_AppBundleManifestRelativePath)Info.plist"
+			AppManifestPath="$(_AppBundleManifest)"
 			CaptureOutput="$(_MlaunchCaptureOutput)"
 			DeviceName="$(_DeviceName)"
 			LaunchApp="$(_AppBundlePath)"

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -35,6 +35,7 @@ namespace Xamarin.MacDev.Tasks
 		public string BundleIdentifier { get; set; }
 
 		[Required]
+		[Output] // This is required to create an empty file on Windows for the Input/Outputs check.
 		public string CompiledAppManifest { get; set; }
 
 		[Required]

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -29,13 +29,13 @@ namespace Xamarin.MacDev.Tasks
 		public string AppManifest { get; set; }
 
 		[Required]
-		public string AppManifestBundleDirectory { get; set; }
-
-		[Required]
 		public string AssemblyName { get; set; }
 
 		[Required]
 		public string BundleIdentifier { get; set; }
+
+		[Required]
+		public string CompiledAppManifest { get; set; }
 
 		[Required]
 		public bool Debug { get; set; }
@@ -71,13 +71,6 @@ namespace Xamarin.MacDev.Tasks
 		public bool SdkIsSimulator { get; set; }
 
 		public string TargetArchitectures { get; set; }
-		#endregion
-
-		#region Outputs
-
-		[Output]
-		public ITaskItem CompiledAppManifest { get; set; }
-
 		#endregion
 
 		protected TargetArchitecture architectures;
@@ -132,8 +125,7 @@ namespace Xamarin.MacDev.Tasks
 			// Merge with any partial plists...
 			MergePartialPlistTemplates (plist);
 
-			CompiledAppManifest = new TaskItem (Path.Combine (AppManifestBundleDirectory, "Info.plist"));
-			plist.Save (CompiledAppManifest.ItemSpec, true, true);
+			plist.Save (CompiledAppManifest, true, true);
 
 			return !Log.HasLoggedErrors;
 		}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -36,7 +36,7 @@ namespace Xamarin.MacDev.Tasks
 
 		[Required]
 		[Output] // This is required to create an empty file on Windows for the Input/Outputs check.
-		public string CompiledAppManifest { get; set; }
+		public ITaskItem CompiledAppManifest { get; set; }
 
 		[Required]
 		public bool Debug { get; set; }
@@ -126,7 +126,7 @@ namespace Xamarin.MacDev.Tasks
 			// Merge with any partial plists...
 			MergePartialPlistTemplates (plist);
 
-			plist.Save (CompiledAppManifest, true, true);
+			plist.Save (CompiledAppManifest.ItemSpec, true, true);
 
 			return !Log.HasLoggedErrors;
 		}

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -287,7 +287,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<Target Name="_CompileAppManifest"
 		DependsOnTargets="$(_CompileAppManifestDependsOn)"
 		Inputs="$(_AppManifest);@(PartialAppManifest)"
-		Outputs="$(_AppBundlePath)$(_AppBundleManifestRelativePath)Info.plist" >
+		Outputs="$(_AppBundleManifest)" >
 		<CompileAppManifest
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
@@ -296,9 +296,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			ApplicationVersion="$(ApplicationVersion)"
 			AppBundleName="$(_AppBundleName)"
 			AppManifest="$(_AppManifest)"
-			AppManifestBundleDirectory="$(_AppBundlePath)$(_AppBundleManifestRelativePath)"
 			AssemblyName="$(AssemblyName)"
 			BundleIdentifier="$(_BundleIdentifier)"
+			CompiledAppManifest="$(_AppBundleManifest)"
 			Debug="$(_BundlerDebug)"
 			DefaultSdkVersion="$(_SdkVersion)"
 			GenerateApplicationManifest="$(GenerateApplicationManifest)"
@@ -787,7 +787,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</MetalLib>
 	</Target>
 
-	<Target Name="_DetectAppManifest">
+	<Target Name="_DetectAppManifest" DependsOnTargets="_GenerateBundleName">
 		<!--
 			This targets runs for Library projects as well, so that Library
 			projects can specify an Info.plist with MinimumOSVersion to pass
@@ -821,7 +821,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</FindItemWithLogicalName>
 		<Error Condition="'$(_AppManifest)' == '' And '$(_CanOutputAppBundle)' == 'true'" Text="Info.plist not found."/>
 		<PropertyGroup>
-			<_AppBundleManifestPath>$(_AppBundlePath)$(_AppBundleManifestRelativePath)$(_AppManifest)</_AppBundleManifestPath>
+			<_AppBundleManifest>$(_AppBundlePath)$(_AppBundleManifestRelativePath)Info.plist</_AppBundleManifest>
 		</PropertyGroup>
 	</Target>
 
@@ -1358,7 +1358,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<GetNativeExecutableName
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
-			AppManifest="$(_AppBundlePath)$(_AppBundleManifestRelativePath)Info.plist"
+			AppManifest="$(_AppBundleManifest)"
 			>
 			<Output TaskParameter="ExecutableName" PropertyName="_ExecutableName" />
 		</GetNativeExecutableName>

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
@@ -33,7 +33,7 @@ namespace Xamarin.iOS.Tasks
 			Task = CreateTask<CompileAppManifest> ();
 
 			Task.AppBundleName = appBundleName;
-			Task.AppManifestBundleDirectory = Path.Combine (Cache.CreateTemporaryDirectory (), "AppBundlePath");
+			Task.CompiledAppManifest = Path.Combine (Cache.CreateTemporaryDirectory (), "AppBundlePath", "Info.plist");
 			Task.AssemblyName = assemblyName;
 			Task.AppManifest = CreateTempFile ("foo.plist");
 			Task.BundleIdentifier = bundleIdentifier;
@@ -53,7 +53,7 @@ namespace Xamarin.iOS.Tasks
 			ConfigureTask ();
 
 			Task.Execute ();
-			CompiledPlist = PDictionary.FromFile (Task.CompiledAppManifest.ItemSpec);
+			CompiledPlist = PDictionary.FromFile (Task.CompiledAppManifest);
 		}
 
 		#region General tests
@@ -69,7 +69,7 @@ namespace Xamarin.iOS.Tasks
 		{
 			Assert.IsTrue (Task.Execute (), "#1");
 			Assert.IsNotNull (Task.CompiledAppManifest, "#2");
-			Assert.IsTrue (File.Exists (Task.CompiledAppManifest.ItemSpec), "#3");
+			Assert.IsTrue (File.Exists (Task.CompiledAppManifest), "#3");
 		}
 
 		[Test]

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
@@ -2,6 +2,8 @@ using System.IO;
 
 using NUnit.Framework;
 
+using Microsoft.Build.Utilities;
+
 using Xamarin.MacDev;
 using System.Linq;
 
@@ -33,7 +35,7 @@ namespace Xamarin.iOS.Tasks
 			Task = CreateTask<CompileAppManifest> ();
 
 			Task.AppBundleName = appBundleName;
-			Task.CompiledAppManifest = Path.Combine (Cache.CreateTemporaryDirectory (), "AppBundlePath", "Info.plist");
+			Task.CompiledAppManifest = new TaskItem (Path.Combine (Cache.CreateTemporaryDirectory (), "AppBundlePath", "Info.plist"));
 			Task.AssemblyName = assemblyName;
 			Task.AppManifest = CreateTempFile ("foo.plist");
 			Task.BundleIdentifier = bundleIdentifier;
@@ -53,7 +55,7 @@ namespace Xamarin.iOS.Tasks
 			ConfigureTask ();
 
 			Task.Execute ();
-			CompiledPlist = PDictionary.FromFile (Task.CompiledAppManifest);
+			CompiledPlist = PDictionary.FromFile (Task.CompiledAppManifest.ItemSpec);
 		}
 
 		#region General tests
@@ -68,8 +70,8 @@ namespace Xamarin.iOS.Tasks
 		public void NormalPlist ()
 		{
 			Assert.IsTrue (Task.Execute (), "#1");
-			Assert.IsNotNull (Task.CompiledAppManifest, "#2");
-			Assert.IsTrue (File.Exists (Task.CompiledAppManifest), "#3");
+			Assert.IsNotNull (Task.CompiledAppManifest?.ItemSpec, "#2");
+			Assert.IsTrue (File.Exists (Task.CompiledAppManifest.ItemSpec), "#3");
 		}
 
 		[Test]


### PR DESCRIPTION
* Add an '_AppBundleManifest' property that specifies the final path to the
  Info.plist in the app bundle.
* Remove the '_AppBundleManifestPath' property, it's not used anywhere.
* Adjust the CompileAppManifest task to take the final path to the Info.plist,
  instead of computing it and returning it. This way the CompileAppManifest
  task does not output anything back into MSBuild (which is important, because
  the CompileAppManifest task won't execute if the output file is up-to-date,
  and if it's not executed, any output properties won't be set either).