### PR TITLE
[msbuild] Move app manifest loading code from ACTool/IBTool to the base XcodeCompiler tool.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
@@ -16,7 +16,6 @@ namespace Xamarin.MacDev.Tasks
 	{
 		ITaskItem partialAppManifest;
 		string outputSpecs;
-		PDictionary plist;
 
 		#region Inputs
 
@@ -70,63 +69,62 @@ namespace Xamarin.MacDev.Tasks
 
 		protected override void AppendCommandLineArguments (IDictionary<string, string> environment, CommandLineArgumentBuilder args, ITaskItem[] items)
 		{
-			if (plist != null) {
-				PString value;
+			var plist = GetAppManifest ();
+			PString value = null;
 
-				var assetDirs = new HashSet<string> (items.Select (x => BundleResource.GetVirtualProjectPath (ProjectDir, x, !string.IsNullOrEmpty (SessionId))));
+			var assetDirs = new HashSet<string> (items.Select (x => BundleResource.GetVirtualProjectPath (ProjectDir, x, !string.IsNullOrEmpty (SessionId))));
 
-				if (plist.TryGetValue (ManifestKeys.XSAppIconAssets, out value) && !string.IsNullOrEmpty (value.Value)) {
-					int index = value.Value.IndexOf (".xcassets" + Path.DirectorySeparatorChar, StringComparison.Ordinal);
-					string assetDir = null;
-					var rpath = value.Value;
+			if (plist?.TryGetValue (ManifestKeys.XSAppIconAssets, out value) == true && !string.IsNullOrEmpty (value.Value)) {
+				int index = value.Value.IndexOf (".xcassets" + Path.DirectorySeparatorChar, StringComparison.Ordinal);
+				string assetDir = null;
+				var rpath = value.Value;
 
-					if (index != -1)
-						assetDir = rpath.Substring (0, index + ".xcassets".Length);
+				if (index != -1)
+					assetDir = rpath.Substring (0, index + ".xcassets".Length);
 
-					if (assetDirs != null && assetDirs.Contains (assetDir)) {
-						var assetName = Path.GetFileNameWithoutExtension (rpath);
+				if (assetDirs != null && assetDirs.Contains (assetDir)) {
+					var assetName = Path.GetFileNameWithoutExtension (rpath);
 
-						if (PartialAppManifest == null) {
-							args.Add ("--output-partial-info-plist");
-							args.AddQuoted (partialAppManifest.GetMetadata ("FullPath"));
+					if (PartialAppManifest == null) {
+						args.Add ("--output-partial-info-plist");
+						args.AddQuoted (partialAppManifest.GetMetadata ("FullPath"));
 
-							PartialAppManifest = partialAppManifest;
-						}
-
-						args.Add ("--app-icon");
-						args.AddQuoted (assetName);
-
-						if (IsMessagesExtension (plist))
-							args.Add ("--product-type com.apple.product-type.app-extension.messages");
+						PartialAppManifest = partialAppManifest;
 					}
+
+					args.Add ("--app-icon");
+					args.AddQuoted (assetName);
+
+					if (IsMessagesExtension (plist))
+						args.Add ("--product-type com.apple.product-type.app-extension.messages");
 				}
-
-				if (plist.TryGetValue (ManifestKeys.XSLaunchImageAssets, out value) && !string.IsNullOrEmpty (value.Value)) {
-					int index = value.Value.IndexOf (".xcassets" + Path.DirectorySeparatorChar, StringComparison.Ordinal);
-					string assetDir = null;
-					var rpath = value.Value;
-
-					if (index != -1)
-						assetDir = rpath.Substring (0, index + ".xcassets".Length);
-
-					if (assetDirs != null && assetDirs.Contains (assetDir)) {
-						var assetName = Path.GetFileNameWithoutExtension (rpath);
-
-						if (PartialAppManifest == null) {
-							args.Add ("--output-partial-info-plist");
-							args.AddQuoted (partialAppManifest.GetMetadata ("FullPath"));
-
-							PartialAppManifest = partialAppManifest;
-						}
-
-						args.Add ("--launch-image");
-						args.AddQuoted (assetName);
-					}
-				}
-
-				if (plist.TryGetValue (ManifestKeys.CLKComplicationGroup, out value) && !string.IsNullOrEmpty (value.Value))
-					args.Add ("--complication", value);
 			}
+
+			if (plist?.TryGetValue (ManifestKeys.XSLaunchImageAssets, out value) == true && !string.IsNullOrEmpty (value.Value)) {
+				int index = value.Value.IndexOf (".xcassets" + Path.DirectorySeparatorChar, StringComparison.Ordinal);
+				string assetDir = null;
+				var rpath = value.Value;
+
+				if (index != -1)
+					assetDir = rpath.Substring (0, index + ".xcassets".Length);
+
+				if (assetDirs != null && assetDirs.Contains (assetDir)) {
+					var assetName = Path.GetFileNameWithoutExtension (rpath);
+
+					if (PartialAppManifest == null) {
+						args.Add ("--output-partial-info-plist");
+						args.AddQuoted (partialAppManifest.GetMetadata ("FullPath"));
+
+						PartialAppManifest = partialAppManifest;
+					}
+
+					args.Add ("--launch-image");
+					args.AddQuoted (assetName);
+				}
+			}
+
+			if (plist?.TryGetValue (ManifestKeys.CLKComplicationGroup, out value) == true && !string.IsNullOrEmpty (value.Value))
+				args.Add ("--complication", value);
 
 			if (OptimizePNGs)
 				args.Add ("--compress-pngs");
@@ -153,7 +151,7 @@ namespace Xamarin.MacDev.Tasks
 			}				
 
 			if (plist != null) {
-				foreach (var targetDevice in GetTargetDevices (plist))
+				foreach (var targetDevice in GetTargetDevices ())
 					args.Add ("--target-device", targetDevice);
 			}
 
@@ -216,15 +214,6 @@ namespace Xamarin.MacDev.Tasks
 			var clones = new HashSet<string> ();
 			var items = new List<ITaskItem> ();
 			var specs = new PArray ();
-
-			if (AppManifest != null) {
-				try {
-					plist = PDictionary.FromFile (AppManifest.ItemSpec);
-				} catch (Exception ex) {
-					Log.LogError (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, "{0}", ex.Message);
-					return false;
-				}
-			}
 
 			for (int i = 0; i < ImageAssets.Length; i++) {
 				var vpath = BundleResource.GetVirtualProjectPath (ProjectDir, ImageAssets[i], !string.IsNullOrEmpty (SessionId));

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
@@ -14,7 +14,6 @@ namespace Xamarin.MacDev.Tasks
 	public abstract class IBToolTaskBase : XcodeCompilerToolTask
 	{
 		static readonly string[] WatchAppExtensions = { "-glance.plist", "-notification.plist" };
-		PDictionary plist;
 
 		#region Inputs
 
@@ -61,7 +60,7 @@ namespace Xamarin.MacDev.Tasks
 
 			args.Add ("--minimum-deployment-target", MinimumOSVersion);
 			
-			foreach (var targetDevice in GetTargetDevices (plist))
+			foreach (var targetDevice in GetTargetDevices ())
 				args.Add ("--target-device", targetDevice);
 
 			if (AppleSdkSettings.XcodeVersion.Major >= 6 && AutoActivateCustomFonts)
@@ -184,7 +183,7 @@ namespace Xamarin.MacDev.Tasks
 		{
 			var mapping = new Dictionary<string, IDictionary> ();
 			var unique = new Dictionary<string, ITaskItem> ();
-			var targets = GetTargetDevices (plist).ToList ();
+			var targets = GetTargetDevices ().ToList ();
 
 			changed = false;
 
@@ -419,10 +418,6 @@ namespace Xamarin.MacDev.Tasks
 			bool changed;
 
 			if (InterfaceDefinitions.Length > 0) {
-				if (AppManifest != null) {
-					plist = PDictionary.FromFile (AppManifest.ItemSpec);
-				}
-
 				Directory.CreateDirectory (ibtoolManifestDir);
 				Directory.CreateDirectory (ibtoolOutputDir);
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
@@ -22,6 +22,7 @@ namespace Xamarin.MacDev.Tasks
 		protected bool Link { get; set; }
 		IList<string> prefixes;
 		string toolExe;
+		PDictionary plist;
 
 		#region Inputs
 
@@ -76,6 +77,24 @@ namespace Xamarin.MacDev.Tasks
 
 		#endregion
 
+		bool loadedAppManifest;
+		protected PDictionary GetAppManifest ()
+		{
+			if (!loadedAppManifest) {
+				if (AppManifest != null) {
+					try {
+						plist = PDictionary.FromFile (AppManifest.ItemSpec);
+					} catch (Exception ex) {
+						Log.LogError (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, "{0}", ex.Message);
+						return null;
+					}
+				}
+				loadedAppManifest = true;
+			}
+
+			return plist;
+		}
+
 		protected abstract string DefaultBinDir {
 			get;
 		}
@@ -113,7 +132,12 @@ namespace Xamarin.MacDev.Tasks
 			return id.Value == "com.apple.watchkit";
 		}
 
-		protected IEnumerable<string> GetTargetDevices (PDictionary plist)
+		protected IEnumerable<string> GetTargetDevices ()
+		{
+			return GetTargetDevices (GetAppManifest ());
+		}
+
+		IEnumerable<string> GetTargetDevices (PDictionary plist)
 		{
 			var devices = IPhoneDeviceType.NotSet;
 			bool watch = false;


### PR DESCRIPTION
This unifies some code, and prepares for not loading the app manifest at all
(in the future there might not be an app manifest in the first place).

There should be no functional difference.

Due to indentation changes this is best reviewed by ignoring whitespace: https://github.com/xamarin/xamarin-macios/pull/12441/files?diff=split&w=1