### PR TITLE
.NET: make main the 'rc.1' release.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -74,11 +74,12 @@ PULL_REQUEST_ID=$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)
 endif
 
 # For release branches, modify the following variables to hardcode a version name
-# Set the NUGET_HARDCODED_PRERELEASE_IDENTIFIER variable to the prerelease identifer you want (say "preview.5")
-NUGET_HARDCODED_PRERELEASE_IDENTIFIER=
+# Set the NUGET_HARDCODED_PRERELEASE_IDENTIFIER variable to the prerelease identifer you want (say "preview.5." (the trailing dot is important)
+NUGET_HARDCODED_PRERELEASE_IDENTIFIER=rc.1.
 # Set the NUGET_HARDCODED_PRERELEASE_BRANCH variable to the exact name for the branch the above variable should apply to (so that any other branches won't pick it up by accident).
 # For the previous example, this would be "release/6.0.1xx-preview5"
-NUGET_HARDCODED_PRERELEASE_BRANCH=
+# When creating a release branch from main, this must be changed from "main" to the new release branch.
+NUGET_HARDCODED_PRERELEASE_BRANCH=main
 
 # compute the alphanumeric version of the hardcoded prerelease branch
 NUGET_HARDCODED_PRERELEASE_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%s" "$(NUGET_HARDCODED_PRERELEASE_BRANCH)" | tr -c '[a-zA-Z0-9-]' '-')


### PR DESCRIPTION
This way we follow what the rest of .NET and Android do.

When we branch for RC 1, we'll make main RC 2 (and so on).

Ref: https://github.com/xamarin/xamarin-android/pull/6187