### PR TITLE
[runtime] Skip early from xamarin_pinvoke_override to avoid a later logging statement.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2604,6 +2604,8 @@ xamarin_pinvoke_override (const char *libraryName, const char *entrypointName)
 			} else {
 				return NULL;
 			}
+		} else {
+			return NULL;
 		}
 #endif // defined (__i386__) || defined (__x86_64__) || defined (__arm64__)
 #endif // !defined (CORECLR_RUNTIME)


### PR DESCRIPTION
This avoids unnecessary and confusing logging which apparently claims that we
couldn't find a symbol, when we didn't even try (on purpose).