### PR TITLE
[runtime] Set the RUNTIME_IDENTIFER and APP_CONTEXT_BASE_DIRECTORY app context values. Fixes #12444.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -769,6 +769,8 @@
 			<_RuntimeConfigReservedProperties Include="ICU_DAT_FILE_PATH" />
 			<_RuntimeConfigReservedProperties Include="TRUSTED_PLATFORM_ASSEMBLIES" />
 			<_RuntimeConfigReservedProperties Include="NATIVE_DLL_SEARCH_DIRECTORIES" />
+			<_RuntimeConfigReservedProperties Include="RUNTIME_IDENTIFIER" />
+			<_RuntimeConfigReservedProperties Include="APP_CONTEXT_BASE_DIRECTORY" />
 		</ItemGroup>
 		<RuntimeConfigParserTask
 			Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'"

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2539,18 +2539,22 @@ xamarin_vm_initialize ()
 	// All the properties we pass here must also be listed in the _RuntimeConfigReservedProperties item group
 	// for the _CreateRuntimeConfiguration target in dotnet/targets/Xamarin.Shared.Sdk.targets.
 	const char *propertyKeys[] = {
+		"APP_CONTEXT_BASE_DIRECTORY", // path to where the managed assemblies are (usually at least - RID-specific assemblies will be in subfolders)
 		"APP_PATHS",
 		"PINVOKE_OVERRIDE",
 		"ICU_DAT_FILE_PATH",
 		"TRUSTED_PLATFORM_ASSEMBLIES",
 		"NATIVE_DLL_SEARCH_DIRECTORIES",
+		"RUNTIME_IDENTIFIER",
 	};
 	const char *propertyValues[] = {
+		xamarin_get_bundle_path (),
 		xamarin_get_bundle_path (),
 		pinvokeOverride,
 		icu_dat_file_path,
 		trusted_platform_assemblies,
 		native_dll_search_directories,
+		RUNTIMEIDENTIFIER,
 	};
 	static_assert (sizeof (propertyKeys) == sizeof (propertyValues), "The number of keys and values must be the same.");
 


### PR DESCRIPTION
Mono and CoreCLR need this.

Fixes https://github.com/xamarin/xamarin-macios/issues/12444.