### PR TITLE
[runtime] Set DOTNET_MODIFIABLE_ASSEMBLIES=debug when running an interpreted app with debug symbols. Fixes #12378.

### DIFF
--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -821,6 +821,7 @@ namespace Xamarin.Bundler {
 				sw.WriteLine ("\txamarin_debug_mode = TRUE;");
 			if (!string.IsNullOrEmpty (app.MonoGCParams))
 				sw.WriteLine ("\tsetenv (\"MONO_GC_PARAMS\", \"{0}\", 1);", app.MonoGCParams);
+			// Do this last, so that the app developer can override any other environment variable we set.
 			foreach (var kvp in app.EnvironmentVariables)
 				sw.WriteLine ("\tsetenv (\"{0}\", \"{1}\", 1);", kvp.Key.Replace ("\"", "\\\""), kvp.Value.Replace ("\"", "\\\""));
 			sw.WriteLine ("\txamarin_supports_dynamic_registration = {0};", app.DynamicRegistrationSupported ? "TRUE" : "FALSE");

--- a/tools/dotnet-linker/Steps/GenerateMainStep.cs
+++ b/tools/dotnet-linker/Steps/GenerateMainStep.cs
@@ -39,6 +39,8 @@ namespace Xamarin {
 				} else {
 					contents.AppendLine ($"\txamarin_icu_dat_file_name = \"{Configuration.GlobalizationDataFile}\";");
 				}
+				if (Configuration.Application.PackageManagedDebugSymbols && Configuration.Application.UseInterpreter)
+					contents.AppendLine ($"\tsetenv (\"DOTNET_MODIFIABLE_ASSEMBLIES\", \"debug\", 1);");
 				contents.AppendLine ("}");
 				contents.AppendLine ();
 


### PR DESCRIPTION
This is required for Hot Reload to work.

Fixes https://github.com/xamarin/xamarin-macios/issues/12378.