### PR TITLE
[HomeKit] Updates for Xcode13 Beta 5

### DIFF
--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -85,6 +85,7 @@ namespace HomeKit {
 
 		[iOS (13,0), NoWatch, NoTV, NoMac]
 		[NoMacCatalyst]
+		[Deprecated (PlatformName.iOS, 15, 0, message: "This method is no longer supported.")]
 		[Export("homeManager:didReceiveAddAccessoryRequest:"), EventArgs ("HMHomeManagerAddAccessoryRequest")]
 		void DidReceiveAddAccessoryRequest (HMHomeManager manager, HMAddAccessoryRequest request);
 		
@@ -1738,6 +1739,7 @@ namespace HomeKit {
 
 	[iOS (13,0), NoWatch, NoMac, NoTV]
 	[NoMacCatalyst]
+	[Deprecated (PlatformName.iOS, 15, 0, message: "This class is no longer supported.")]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
 	interface HMAddAccessoryRequest {


### PR DESCRIPTION
Not 100% sure if this is correct. 
The headers showed that they are now deprecated, but Sharpie and the web docs do not reflect this. 
I will test in Xcode to be sure!