### PR TITLE
[dotnet] Implement a workaround for .NET's lack of extensibility for 'dotnet run'.

### DIFF
--- a/dotnet/Microsoft.iOS.Sdk/targets/Microsoft.iOS.Sdk.targets
+++ b/dotnet/Microsoft.iOS.Sdk/targets/Microsoft.iOS.Sdk.targets
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="Xamarin.Shared.Sdk.targets" />
+
+  <!--
+       There's no way to execute a task (for instance to calculate the arguments to mlaunch) in "dotnet run",
+       so we rely on the 'Run' target instead. Quite ugly, but it seems to work, even though it won't support
+       "dotnet run" flags such as /no-build. OTOH we try to support /configuration and /runtime.
+       Ref: https://github.com/dotnet/sdk/issues/18436
+  -->
+  <PropertyGroup>
+    <RunCommand>$(NetCoreRoot)/dotnet</RunCommand>
+    <RunArguments>build "$(MSBuildProjectFullPath)" /t:Run /p:RuntimeIdentifier=$(RuntimeIdentifier) /p:Configuration=$(Configuration)</RunArguments>
+  </PropertyGroup>
 </Project>

--- a/dotnet/Microsoft.tvOS.Sdk/targets/Microsoft.tvOS.Sdk.targets
+++ b/dotnet/Microsoft.tvOS.Sdk/targets/Microsoft.tvOS.Sdk.targets
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="Xamarin.Shared.Sdk.targets" />
+
+  <!--
+       There's no way to execute a task (for instance to calculate the arguments to mlaunch) in "dotnet run",
+       so we rely on the 'Run' target instead. Quite ugly, but it seems to work, even though it won't support
+       "dotnet run" flags such as /no-build. OTOH we try to support /configuration and /runtime.
+       Ref: https://github.com/dotnet/sdk/issues/18436
+  -->
+  <PropertyGroup>
+    <RunCommand>$(NetCoreRoot)/dotnet</RunCommand>
+    <RunArguments>build "$(MSBuildProjectFullPath)" /t:Run /p:RuntimeIdentifier=$(RuntimeIdentifier) /p:Configuration=$(Configuration)</RunArguments>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
.NET doesn't support executing other targets/tasks when doing "dotnet run".
However, we need to (like we do for our current "Run" target), so implement a
rather simplistic/hacky workaround by making "dotnet run" just do "dotnet
build /t:Run".

It doesn't support everything that "dotnet run" does (for instance it doesn't
support the /no-build flag), but it should work for most use cases.

Ref: https://github.com/dotnet/sdk/issues/18436
Ref: https://github.com/xamarin/xamarin-macios/issues/12459