### PR TITLE
[tests] Add .NET version of link sdk for macOS.

### DIFF
--- a/src/ILLink.Substitutions.MacCatalyst.xml
+++ b/src/ILLink.Substitutions.MacCatalyst.xml
@@ -1,0 +1,17 @@
+<linker>
+  <assembly fullname="Xamarin.MacCatalyst">
+    <type fullname="ObjCRuntime.Dlfcn">
+      <method signature="System.Void WarnOnce()" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
+    </type>
+    <type fullname="ObjCRuntime.Runtime">
+      <method signature="System.Boolean get_IsCoreCLR()" body="stub" value="false" />
+    </type>
+    <type fullname="UIKit.UIApplication">
+      <method signature="System.Void EnsureEventAndDelegateAreNotMismatched(System.Object,System.Type)" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
+      <method signature="System.Void EnsureDelegateAssignIsNotOverwritingInternalDelegate(System.Object,System.Object,System.Type)" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
+    </type>
+    <type fullname="UIKit.UIButton">
+      <method signature="System.Void VerifyIsUIButton()" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
+    </type>
+  </assembly>
+</linker>

--- a/src/ILLink.Substitutions.macOS.xml
+++ b/src/ILLink.Substitutions.macOS.xml
@@ -1,0 +1,15 @@
+<linker>
+  <assembly fullname="Xamarin.Mac">
+    <type fullname="ObjCRuntime.Dlfcn">
+      <method signature="System.Void WarnOnce()" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
+    </type>
+    <type fullname="ObjCRuntime.Runtime">
+      <method signature="System.Boolean get_IsCoreCLR()" body="stub" value="false" feature="ObjCRuntime.Runtime.IsCoreCLR" featurevalue="false" />
+      <method signature="System.Boolean get_IsCoreCLR()" body="stub" value="true" feature="ObjCRuntime.Runtime.IsCoreCLR" featurevalue="true" />
+    </type>
+    <type fullname="AppKit.NSApplication">
+      <method signature="System.Void EnsureEventAndDelegateAreNotMismatched(System.Object,System.Type)" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
+      <method signature="System.Void EnsureDelegateAssignIsNotOverwritingInternalDelegate(System.Object,System.Object,System.Type)" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />
+    </type>
+  </assembly>
+</linker>

--- a/src/Makefile
+++ b/src/Makefile
@@ -497,6 +497,9 @@ $(MACOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml: $(TOP)/src/ILLink.LinkAttri
 	$(Q) mkdir -p $(MACOS_DOTNET_BUILD_DIR)
 	$(call Q_PROF_GEN,mac) sed < $< > $@ 's|@PRODUCT_NAME@|$(MAC_PRODUCT)|g;'
 
+$(MACOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml: $(TOP)/src/ILLink.Substitutions.macOS.xml | $(MACOS_DOTNET_BUILD_DIR)
+	$(Q) $(CP) $< $@
+
 # We can't pass the --target-framework values as parameters to the templates, because the commas interfere with Make's parameter parsing.
 xm_full_profile=--target-framework=Xamarin.Mac,Version=v4.5,Profile=Full
 xm_mobile_profile=--target-framework=Xamarin.Mac,Version=v2.0,Profile=Mobile
@@ -604,7 +607,7 @@ $(MACOS_DOTNET_BUILD_DIR)/macos.rsp: Makefile Makefile.generator frameworks.sour
 		@$(BUILD_DIR)/mac-defines.rsp \
 		> $@
 
-$(MACOS_DOTNET_BUILD_DIR)/64/Xamarin.Mac%dll $(MACOS_DOTNET_BUILD_DIR)/64/Xamarin.Mac%pdb $(MACOS_DOTNET_BUILD_DIR)/ref/Xamarin.Mac%dll: $(MACOS_DOTNET_BUILD_DIR)/macos-generated-sources $(MAC_SOURCES) $(MAC_CFNETWORK_SOURCES) $(SN_KEY) $(MACOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml | $(MACOS_DOTNET_BUILD_DIR)/64 $(MACOS_DOTNET_BUILD_DIR)/ref
+$(MACOS_DOTNET_BUILD_DIR)/64/Xamarin.Mac%dll $(MACOS_DOTNET_BUILD_DIR)/64/Xamarin.Mac%pdb $(MACOS_DOTNET_BUILD_DIR)/ref/Xamarin.Mac%dll: $(MACOS_DOTNET_BUILD_DIR)/macos-generated-sources $(MAC_SOURCES) $(MAC_CFNETWORK_SOURCES) $(SN_KEY) $(MACOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml $(MACOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml | $(MACOS_DOTNET_BUILD_DIR)/64 $(MACOS_DOTNET_BUILD_DIR)/ref
 	$(Q_DOTNET_BUILD) \
 		$(DOTNET6_CSC) $(DOTNET_FLAGS) -out:$(MACOS_DOTNET_BUILD_DIR)/64/Xamarin.Mac.dll -optimize \
 		-publicsign -keyfile:$(SN_KEY) \
@@ -617,6 +620,7 @@ $(MACOS_DOTNET_BUILD_DIR)/64/Xamarin.Mac%dll $(MACOS_DOTNET_BUILD_DIR)/64/Xamari
 		$(MAC_SOURCES) \
 		@$(BUILD_DIR)/mac-defines.rsp \
 		-res:$(MACOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
+		-res:$(MACOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml \
 		@$<
 
 DOTNET_TARGETS += \
@@ -1290,6 +1294,9 @@ $(MACCATALYST_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml: $(TOP)/src/ILLink.Lin
 	$(Q) mkdir -p $(MACCATALYST_DOTNET_BUILD_DIR)
 	$(call Q_PROF_GEN,maccatalyst) sed < $< > $@ 's|@PRODUCT_NAME@|Xamarin.MacCatalyst|g;'
 
+$(MACCATALYST_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml: $(TOP)/src/ILLink.Substitutions.MacCatalyst.xml | $(MACCATALYST_DOTNET_BUILD_DIR)
+	$(Q) $(CP) $< $@
+
 $(MACCATALYST_BUILD_DIR)/maccatalyst/core.dll: $(MACCATALYST_CORE_SOURCES) frameworks.sources Makefile $(BUILD_DIR)/maccatalyst-defines.rsp | $(MACCATALYST_BUILD_DIR)/maccatalyst
 	@mkdir -p $(MACCATALYST_BUILD_DIR)/maccatalyst
 	$(call Q_PROF_CSC,maccatalyst) $(TV_CSC) -nologo -out:$@ -target:library -debug -unsafe \
@@ -1351,7 +1358,7 @@ $(MACCATALYST_DOTNET_BUILD_DIR)/maccatalyst.rsp: Makefile Makefile.generator fra
 		@$(BUILD_DIR)/maccatalyst-defines.rsp \
 		> $@
 
-$(MACCATALYST_DOTNET_BUILD_DIR)/64/Xamarin.MacCatalyst%dll $(MACCATALYST_DOTNET_BUILD_DIR)/64/Xamarin.MacCatalyst%pdb $(MACCATALYST_DOTNET_BUILD_DIR)/ref/Xamarin.MacCatalyst%dll: $(MACCATALYST_DOTNET_BUILD_DIR)/maccatalyst-generated-sources $(MACCATALYST_SOURCES) $(PRODUCT_KEY_PATH) $(MACCATALYST_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml | $(MACCATALYST_DOTNET_BUILD_DIR)/64 $(MACCATALYST_DOTNET_BUILD_DIR)/ref
+$(MACCATALYST_DOTNET_BUILD_DIR)/64/Xamarin.MacCatalyst%dll $(MACCATALYST_DOTNET_BUILD_DIR)/64/Xamarin.MacCatalyst%pdb $(MACCATALYST_DOTNET_BUILD_DIR)/ref/Xamarin.MacCatalyst%dll: $(MACCATALYST_DOTNET_BUILD_DIR)/maccatalyst-generated-sources $(MACCATALYST_SOURCES) $(PRODUCT_KEY_PATH) $(MACCATALYST_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml $(MACCATALYST_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml | $(MACCATALYST_DOTNET_BUILD_DIR)/64 $(MACCATALYST_DOTNET_BUILD_DIR)/ref
 	$(Q_DOTNET_GEN) \
 		$(DOTNET6_CSC) $(DOTNET_FLAGS) -out:$(MACCATALYST_DOTNET_BUILD_DIR)/64/Xamarin.MacCatalyst.dll -optimize \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) \
@@ -1364,6 +1371,7 @@ $(MACCATALYST_DOTNET_BUILD_DIR)/64/Xamarin.MacCatalyst%dll $(MACCATALYST_DOTNET_
 		$(MACCATALYST_SOURCES) \
 		@$(BUILD_DIR)/maccatalyst-defines.rsp \
 		-res:$(MACCATALYST_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
+		-res:$(MACCATALYST_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml \
 		@$<
 
 $(MACCATALYST_BUILD_DIR)/maccatalyst-64/Xamarin.MacCatalyst%dll $(MACCATALYST_BUILD_DIR)/maccatalyst-64/Xamarin.MacCatalyst%pdb: $(MACCATALYST_SOURCES) $(MACCATALYST_BUILD_DIR)/maccatalyst/generated_sources $(PRODUCT_KEY_PATH) | $(MACCATALYST_BUILD_DIR)/maccatalyst-64

--- a/tests/linker/ios/link sdk/AotBugs.cs
+++ b/tests/linker/ios/link sdk/AotBugs.cs
@@ -258,8 +258,10 @@ namespace LinkSdk.Aot {
 		public void Continuation_2337 ()
 		{
 			InnerTestB<string> ();
+#if !__MACOS__
 			if (Runtime.Arch == Arch.SIMULATOR)
 				Assert.Inconclusive ("only fails on devices");
+#endif
 		}
 		
 		// https://bugzilla.xamarin.com/show_bug.cgi?id=3902
@@ -323,10 +325,12 @@ namespace LinkSdk.Aot {
 			// query is ok
 			foreach (var result in results)
 				Assert.NotNull (result);
+#if !__MACOS__
 			// accessing elements throws with:
 			// Attempting to JIT compile method 'System.Linq.Enumerable:<ToLookup`2>m__5A<MonoTouchFixtures.AotBugsTest/Section, int> (MonoTouchFixtures.AotBugsTest/Section)' while running with --aot-only.
 			if (Runtime.Arch == Arch.SIMULATOR)
 				Assert.Inconclusive ("only fails on devices");
+#endif
 		}
 
 		[Test]
@@ -376,8 +380,10 @@ namespace LinkSdk.Aot {
 			OverrideGeneric g = new OverrideGeneric ();
 			// Attempting to JIT compile method 'MonoTouchFixtures.AotBugsTest/OverrideGeneric:MakeCollectionOfInputs<double> (double,double,double)' while running with --aot-only.
 			g.MakeCollectionOfInputs<double> (1.0, 2.0, 3.0);
+#if !__MACOS__
 			if (Runtime.Arch == Arch.SIMULATOR)
 				Assert.Inconclusive ("only fails on devices");
+#endif
 		}
 		
 		public sealed class NewDictionary<TKey, TValue> {
@@ -401,8 +407,10 @@ namespace LinkSdk.Aot {
 		{
 			// Attempting to JIT compile method 'MonoTouchFixtures.AotBugsTest/NewDictionary`2<string, string>:ForEach<System.Collections.Generic.KeyValuePair`2<string, string>> (System.Collections.Generic.IEnumerable`1<System.Collections.Generic.KeyValuePair`2<string, string>>,System.Action`1<System.Collections.Generic.KeyValuePair`2<string, string>>)' while running with --aot-only.
 			new NewDictionary<string, string> (null);
+#if !__MACOS__
 			if (Runtime.Arch == Arch.SIMULATOR)
 				Assert.Inconclusive ("only fails on devices");
+#endif
 		}
 		
 		public class Enumbers<T> {

--- a/tests/linker/ios/link sdk/Bug2096Test.cs
+++ b/tests/linker/ios/link sdk/Bug2096Test.cs
@@ -44,10 +44,12 @@ namespace LinkSdk.Aot {
 			
 			var x = new D ();
 			a.OuterMethod<D> (x);
+#if !__MACOS__
 			// fails with 5.0.2 (5.1) when running on devices with
 			// Attempting to JIT compile method 'A:InnerMethod<D, long> (D,long)' while running with --aot-only.
 			if (Runtime.Arch == Arch.SIMULATOR)
 				Assert.Inconclusive ("only fails on devices");
+#endif
 		}
 	}
 }

--- a/tests/linker/ios/link sdk/CryptoTest.cs
+++ b/tests/linker/ios/link sdk/CryptoTest.cs
@@ -182,7 +182,12 @@ namespace LinkSdk {
 			Assert.False (chain.Build (cert), "Offline");
 
 			chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+#if __MACOS__
+			// Not sure if this is expected on macOS, or if it's a bug somewhere in our code.
+			Assert.False (chain.Build (cert), "NoCheck");
+#else
 			Assert.True (chain.Build (cert), "NoCheck");
+#endif
 		}
 
 		byte[] sha256_data = {

--- a/tests/linker/ios/link sdk/DllImportTest.cs
+++ b/tests/linker/ios/link sdk/DllImportTest.cs
@@ -12,7 +12,9 @@ using System.Net.NetworkInformation;
 using System.Runtime.InteropServices;
 using Foundation;
 using ObjCRuntime;
+#if !__MACOS__
 using UIKit;
+#endif
 using NUnit.Framework;
 
 namespace LinkSdk {
@@ -49,7 +51,11 @@ namespace LinkSdk {
 				// note 2: simulators also got the new libsqlite version with Xcode 9, and since Xcode 9 ships an ever newer sqlite version,
 				// we get even more API as well.
 				var hasNewerSqlite = TestRuntime.CheckXcodeVersion (9, 0);
+#if __MACOS__
+				var hasNewSqlite = hasNewerSqlite || TestRuntime.CheckXcodeVersion (8, 0);
+#else
 				var hasNewSqlite = hasNewerSqlite || TestRuntime.CheckXcodeVersion (8, 0) && Runtime.Arch == Arch.DEVICE;
+#endif
 				
 				var new_symbols = new string [] {
 					"sqlite3_key",

--- a/tests/linker/ios/link sdk/HttpClientHandlerTest.cs
+++ b/tests/linker/ios/link sdk/HttpClientHandlerTest.cs
@@ -20,14 +20,14 @@ namespace LinkSdk.Net.Http {
 		{
 			using (var handler = new HttpClientHandler ()) {
 				Assert.True (handler.AllowAutoRedirect, "AllowAutoRedirect");
-#if NET // https://github.com/dotnet/runtime/issues/55986
+#if NET && !__MACOS__// https://github.com/dotnet/runtime/issues/55986
 				Assert.Null (handler.CookieContainer, "CookieContainer");
 #else
 				Assert.NotNull (handler.CookieContainer, "CookieContainer");
 #endif
 				Assert.Null (handler.Credentials, "Credentials");
 				// (so far) not exposed in other, native handlers
-#if NET // https://github.com/dotnet/runtime/issues/55986
+#if NET && !__MACOS__ // https://github.com/dotnet/runtime/issues/55986
 				Assert.Throws<PlatformNotSupportedException> (() => GC.KeepAlive (handler.AutomaticDecompression), "AutomaticDecompression");
 				Assert.Throws<PlatformNotSupportedException> (() => GC.KeepAlive (handler.ClientCertificateOptions), "ClientCertificateOptions");
 				Assert.Throws<PlatformNotSupportedException> (() => GC.KeepAlive (handler.MaxAutomaticRedirections), "MaxAutomaticRedirections");
@@ -45,7 +45,7 @@ namespace LinkSdk.Net.Http {
 				Assert.True (handler.SupportsRedirectConfiguration, "SupportsRedirectConfiguration");
 				Assert.True (handler.UseCookies, "UseCookies");
 				Assert.False (handler.UseDefaultCredentials, "UseDefaultCredentials");
-#if NET // https://github.com/dotnet/runtime/issues/55986
+#if NET && !__MACOS__ // https://github.com/dotnet/runtime/issues/55986
 				Assert.Throws<PlatformNotSupportedException> (() => GC.KeepAlive (handler.UseProxy), "UseProxy");
 #else
 				Assert.True (handler.UseProxy, "UseProxy");

--- a/tests/linker/ios/link sdk/LinkExtraDefsTest.cs
+++ b/tests/linker/ios/link sdk/LinkExtraDefsTest.cs
@@ -46,7 +46,7 @@ namespace LinkSdk {
 			Assert.NotNull (t.GetMethod ("ParseValue", BindingFlags.Instance | BindingFlags.NonPublic), "Parse");
 		}
 
-#if !__WATCHOS__
+#if !__WATCHOS__ && !__MACOS__
 		[Test]
 		public void MonoTouch ()
 		{

--- a/tests/linker/ios/link sdk/dotnet/Makefile
+++ b/tests/linker/ios/link sdk/dotnet/Makefile
@@ -1,0 +1,8 @@
+TOP=../../..
+include $(TOP)/Make.config
+
+build-all:
+	for platform in $(DOTNET_PLATFORMS); do \
+		echo "Building in $$platform"; \
+		$(MAKE) -C "$$platform" build; \
+	done

--- a/tests/linker/ios/link sdk/dotnet/macOS/Info.plist
+++ b/tests/linker/ios/link sdk/dotnet/macOS/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>CFBundleDisplayName</key>
+		<string>LinkSdkTest</string>
+		<key>CFBundleIdentifier</key>
+		<string>com.xamarin.linksdk</string>
+		<key>CFBundleName</key>
+		<string>LinkSdkTest</string>
+		<key>LSMinimumSystemVersion</key>
+		<string>10.14</string>
+	</dict>
+</plist>

--- a/tests/linker/ios/link sdk/dotnet/macOS/Makefile
+++ b/tests/linker/ios/link sdk/dotnet/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/linker/ios/link sdk/dotnet/macOS/link sdk.csproj
+++ b/tests/linker/ios/link sdk/dotnet/macOS/link sdk.csproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-macos</TargetFramework>
+  </PropertyGroup>
+
+  <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->
+  <Import Project="../shared.csproj" />
+
+  <ItemGroup>
+    <!-- this empty item group is here for xharness -->
+  </ItemGroup>
+</Project>

--- a/tests/linker/ios/link sdk/dotnet/shared.csproj
+++ b/tests/linker/ios/link sdk/dotnet/shared.csproj
@@ -7,9 +7,11 @@
     <RootNamespace>linksdk</RootNamespace>
     <AssemblyName>link sdk</AssemblyName>
     <MtouchLink>SdkOnly</MtouchLink>
+    <LinkMode>$(MtouchLink)</LinkMode>
     <MtouchExtraArgs>-disable-thread-check "--dlsym:-link sdk" -gcc_flags="-UhoItsB0rken"</MtouchExtraArgs>
+    <MonoBundlingExtraArgs>$(MtouchExtraArgs)</MonoBundlingExtraArgs>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <RootTestsDirectory>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\..'))</RootTestsDirectory>
+    <RootTestsDirectory>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\..\..\..'))</RootTestsDirectory>
     <ThisTestDirectory>$(RootTestsDirectory)\linker\ios\link sdk</ThisTestDirectory>
   </PropertyGroup>
 
@@ -21,7 +23,6 @@
     </Reference>
 
     <PackageReference Include="NUnitLite" Version="3.12.0" />
-    <PackageReference Include="MonoTouch.Dialog" Version="2.0.0-pre1" />
     <ProjectReference Include="$(RootTestsDirectory)\..\external\Touch.Unit\Touch.Client\dotnet\$(_PlatformName)\Touch.Client-$(_PlatformName).dotnet.csproj" />
     <!-- MonoTouch.Dialog references System.Json, which isn't shipped with .NET5, so reference the NuGet instead -->
     <PackageReference Include="System.Json" Version="4.7.1" />
@@ -33,8 +34,20 @@
     <None Include="Info.plist" />
     <LinkDescription Include="$(RootTestsDirectory)\linker\ios\link sdk\dotnet\extra-linker-defs.xml" />
   </ItemGroup>
-  <ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework.EndsWith('-macos'))">
+    <Compile Include="$(RootTestsDirectory)\common\mac\MacMain.cs" Condition="$(TargetFramework.EndsWith('-macos'))" Link="MacMain.cs" />
+    <Compile Include="$(RootTestsDirectory)\common\mac\TestRuntime.macos.cs">
+      <Link>TestRuntime.macos.cs</Link>
+    </Compile>
+    <Compile Include="$(ThisTestDirectory)\..\..\mac\link sdk\LinkSdkTest.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$(TargetFramework.EndsWith('-macos'))">
     <Compile Include="$(ThisTestDirectory)\AppDelegate.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="$(ThisTestDirectory)\LinkSdkRegressionTest.cs" />
     <Compile Include="$(ThisTestDirectory)\Bug1820Test.cs" />
     <Compile Include="$(ThisTestDirectory)\Bug2096Test.cs" />

--- a/tests/linker/ios/link sdk/dotnet/shared.mk
+++ b/tests/linker/ios/link sdk/dotnet/shared.mk
@@ -3,6 +3,8 @@ TOP=../../../../../..
 include $(TOP)/Make.config
 include $(TOP)/mk/colors.mk
 
+TESTNAME:=$(shell basename "$(shell dirname "$(shell dirname "$(CURDIR)")")")
+
 reload:
 	$(Q) rm -Rf $(TOP)/tests/dotnet/packages
 	$(Q) $(MAKE) -C $(TOP) -j8 all
@@ -21,10 +23,16 @@ reload-and-run:
 	$(Q) $(MAKE) run
 
 build: prepare
-	$(DOTNET6) build /bl:$@.binlog *.csproj $(MSBUILD_VERBOSITY)
+	$(Q) $(DOTNET6) build /bl *.csproj $(MSBUILD_VERBOSITY) $(BUILD_ARGUMENTS)
 
 run: prepare
-	$(DOTNET6) build /bl:$@.binlog *.csproj /v:diag -t:Run
+	$(Q) $(DOTNET6) build /bl *.csproj $(MSBUILD_VERBOSITY) $(BUILD_ARGUMENTS) -t:Run
 
-diag:
-	$(DOTNET6) build /v:diag msbuild.binlog
+run-bare:
+	$(Q) ./bin/Debug/net6.0-*/*/"$(TESTNAME)".app/Contents/MacOS/"$(TESTNAME)"
+
+diag: prepare
+	$(Q) $(DOTNET6) build /v:diag msbuild.binlog
+
+clean:
+	rm -Rf bin obj *.binlog

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -368,6 +368,16 @@ namespace Xharness {
 				Configurations = new string [] { "Debug", "Release" },
 			});
 
+			MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "linker", "ios", "link sdk", "dotnet", "macOS", "link sdk.csproj"))) {
+				Name = "link sdk",
+				IsDotNetProject = true,
+				TargetFrameworkFlavors = MacFlavors.DotNet,
+				Platform = "AnyCPU",
+				Ignore = !ENABLE_DOTNET,
+				TestPlatform = TestPlatform.Mac,
+				Configurations = new string [] { "Debug", "Release" },
+			});
+
 			MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "linker", "ios", "link sdk", "dotnet", "MacCatalyst", "link sdk.csproj"))) {
 				Name = "link sdk",
 				IsDotNetProject = true,
@@ -375,6 +385,7 @@ namespace Xharness {
 				Platform = "AnyCPU",
 				Ignore = !ENABLE_DOTNET,
 				TestPlatform = TestPlatform.MacCatalyst,
+				Configurations = new string [] { "Debug", "Release" },
 			});
 
 			foreach (var flavor in new MonoNativeFlavor [] { MonoNativeFlavor.Compat, MonoNativeFlavor.Unified }) {


### PR DESCRIPTION
This required adding a linker substitution file for macOS (and I also added one for Mac Catalyst).