### PR TITLE
[dotnet] Update logic for default global namespaces and fix the templates. Fixes #12457.

### DIFF
--- a/dotnet/Microsoft.MacCatalyst.Sdk/Sdk/AutoImport.props
+++ b/dotnet/Microsoft.MacCatalyst.Sdk/Sdk/AutoImport.props
@@ -1,3 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<Import Project="..\targets\Microsoft.MacCatalyst.Sdk.DefaultItems.props" />
+	<Import Project="..\targets\Microsoft.MacCatalyst.Sdk.ImplicitNamespaceImports.props" />
 </Project>

--- a/dotnet/Microsoft.iOS.Sdk/Sdk/AutoImport.props
+++ b/dotnet/Microsoft.iOS.Sdk/Sdk/AutoImport.props
@@ -1,3 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<Import Project="..\targets\Microsoft.iOS.Sdk.DefaultItems.props" />
+	<Import Project="..\targets\Microsoft.iOS.Sdk.ImplicitNamespaceImports.props" />
 </Project>

--- a/dotnet/Microsoft.macOS.Sdk/Sdk/AutoImport.props
+++ b/dotnet/Microsoft.macOS.Sdk/Sdk/AutoImport.props
@@ -1,3 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<Import Project="..\targets\Microsoft.macOS.Sdk.DefaultItems.props" />
+	<Import Project="..\targets\Microsoft.macOS.Sdk.ImplicitNamespaceImports.props" />
 </Project>

--- a/dotnet/Microsoft.tvOS.Sdk/Sdk/AutoImport.props
+++ b/dotnet/Microsoft.tvOS.Sdk/Sdk/AutoImport.props
@@ -1,3 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<Import Project="..\targets\Microsoft.tvOS.Sdk.DefaultItems.props" />
+	<Import Project="..\targets\Microsoft.tvOS.Sdk.ImplicitNamespaceImports.props" />
 </Project>

--- a/dotnet/Microsoft.watchOS.Sdk/Sdk/AutoImport.props
+++ b/dotnet/Microsoft.watchOS.Sdk/Sdk/AutoImport.props
@@ -1,3 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<Import Project="..\targets\Microsoft.watchOS.Sdk.DefaultItems.props" />
+	<Import Project="..\targets\Microsoft.watchOS.Sdk.ImplicitNamespaceImports.props" />
 </Project>

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/MacCatalystApp1.csproj
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/MacCatalystApp1.csproj
@@ -5,5 +5,6 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">MacCatalystApp1</RootNamespace>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/iOSApp1.csproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/iOSApp1.csproj
@@ -4,5 +4,6 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">iOSApp1</RootNamespace>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/iOSLib1.csproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/iOSLib1.csproj
@@ -3,5 +3,6 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">iOSLib1</RootNamespace>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/macOSApp1.csproj
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/macOSApp1.csproj
@@ -4,5 +4,6 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">macOSApp1</RootNamespace>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/tvOSApp1.csproj
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/tvOSApp1.csproj
@@ -4,5 +4,6 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">tvOSApp1</RootNamespace>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 </Project>

--- a/dotnet/targets/Microsoft.MacCatalyst.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.MacCatalyst.Sdk.ImplicitNamespaceImports.props
@@ -18,10 +18,13 @@
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<!-- There's a master switch, DisableImplicitNamespaceImports, which, if set, will prevent all implicit namespace imports - this is done automatically, we don't have to check DisableImplicitNamespaceImports here -->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'MacCatalyst' And '$(DisableImplicitNamespaceImports_MacCatalyst)' != 'true'">
-		<Import Include="CoreGraphics" />
-		<Import Include="Foundation" />
-		<Import Include="UIKit" />
+	<!--
+		These implicit usings are C#-specific, and governed by a single global property: ImplicitUsings, which can be either 'true' or 'enable'.
+		Ref: https://github.com/dotnet/sdk/issues/19793#issuecomment-900620060
+	-->
+	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'MacCatalyst' And '$(Language)' == 'C#' And ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
+		<Using Include="CoreGraphics" />
+		<Using Include="Foundation" />
+		<Using Include="UIKit" />
 	</ItemGroup>
 </Project>

--- a/dotnet/targets/Microsoft.iOS.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.iOS.Sdk.ImplicitNamespaceImports.props
@@ -18,10 +18,13 @@
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<!-- There's a master switch, DisableImplicitNamespaceImports, which, if set, will prevent all implicit namespace imports - this is done automatically, we don't have to check DisableImplicitNamespaceImports here -->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'iOS' And '$(DisableImplicitNamespaceImports_iOS)' != 'true'">
-		<Import Include="CoreGraphics" />
-		<Import Include="Foundation" />
-		<Import Include="UIKit" />
+	<!--
+		These implicit usings are C#-specific, and governed by a single global property: ImplicitUsings, which can be either 'true' or 'enable'.
+		Ref: https://github.com/dotnet/sdk/issues/19793#issuecomment-900620060
+	-->
+	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'iOS' And '$(Language)' == 'C#' And ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
+		<Using Include="CoreGraphics" />
+		<Using Include="Foundation" />
+		<Using Include="UIKit" />
 	</ItemGroup>
 </Project>

--- a/dotnet/targets/Microsoft.macOS.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.macOS.Sdk.ImplicitNamespaceImports.props
@@ -18,10 +18,13 @@
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<!-- There's a master switch, DisableImplicitNamespaceImports, which, if set, will prevent all implicit namespace imports - this is done automatically, we don't have to check DisableImplicitNamespaceImports here -->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'macOS' And '$(DisableImplicitNamespaceImports_macOS)' != 'true'">
-		<Import Include="AppKit" />
-		<Import Include="CoreGraphics" />
-		<Import Include="Foundation" />
+	<!--
+		These implicit usings are C#-specific, and governed by a single global property: ImplicitUsings, which can be either 'true' or 'enable'.
+		Ref: https://github.com/dotnet/sdk/issues/19793#issuecomment-900620060
+	-->
+	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'macOS' And '$(Language)' == 'C#' And ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
+		<Using Include="AppKit" />
+		<Using Include="CoreGraphics" />
+		<Using Include="Foundation" />
 	</ItemGroup>
 </Project>

--- a/dotnet/targets/Microsoft.tvOS.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.tvOS.Sdk.ImplicitNamespaceImports.props
@@ -18,10 +18,13 @@
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<!-- There's a master switch, DisableImplicitNamespaceImports, which, if set, will prevent all implicit namespace imports - this is done automatically, we don't have to check DisableImplicitNamespaceImports here -->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'tvOS' And '$(DisableImplicitNamespaceImports_tvOS)' != 'true'">
-		<Import Include="CoreGraphics" />
-		<Import Include="Foundation" />
-		<Import Include="UIKit" />
+	<!--
+		These implicit usings are C#-specific, and governed by a single global property: ImplicitUsings, which can be either 'true' or 'enable'.
+		Ref: https://github.com/dotnet/sdk/issues/19793#issuecomment-900620060
+	-->
+	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'tvOS' And '$(Language)' == 'C#' And ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
+		<Using Include="CoreGraphics" />
+		<Using Include="Foundation" />
+		<Using Include="UIKit" />
 	</ItemGroup>
 </Project>

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -6,9 +6,6 @@
 	<!-- This contains the OS versions we support for target platform -->
 	<Import Project="Microsoft.$(_PlatformName).Sdk.SupportedTargetPlatforms.props" />
 
-	<!-- This contains support for implicit namespace imports -->
-	<Import Project="Microsoft.$(_PlatformName).Sdk.ImplicitNamespaceImports.props" />
-
 	<Import Project="Xamarin.Shared.Sdk.TargetFrameworkInference.props" />
 
 	<PropertyGroup>

--- a/tests/dotnet/UnitTests/TemplateTest.cs
+++ b/tests/dotnet/UnitTests/TemplateTest.cs
@@ -66,7 +66,6 @@ namespace Xamarin.Tests {
 
 		[Test]
 		[TestCaseSource (nameof (Templates))]
-		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/12457")]
 		public void CreateAndBuildTemplate (string platform, string template)
 		{
 			Configuration.IgnoreIfIgnoredPlatform (platform);


### PR DESCRIPTION
* Add 'ImplicitUsings=true' to all the templates.
* Make the implicit global namespaces C#-only.
* Add the implicit global namespaces to the 'Using' itemgroup instead of the
  'Import' itemgroup.
* Make sure the global namespaces are set from AutoImport.props, so that the
  user may remove any global namespace they don't want in their project file
  (by doing something like: `<Using Remove="Foundation" />`)

Ref: https://github.com/dotnet/sdk/issues/19521
Ref: https://github.com/dotnet/sdk/issues/19793

Fixes https://github.com/xamarin/xamarin-macios/issues/12457.