### PR TITLE
[tests] Fix the build for link sdk tests on .NET/macOS.

### DIFF
--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -42,7 +42,9 @@ using ObjCRuntime;
 #if !__TVOS__
 using MapKit;
 #endif
-#if !__MACOS__
+#if __MACOS__
+using AppKit;
+#else
 using UIKit;
 #endif
 #if !__WATCHOS__ && !__MACCATALYST__ && !__MACOS__


### PR DESCRIPTION
Fixes these errors:

    xamarin-macios/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs(1140,41): error CS0246: The type or namespace name 'NSApplication' could not be found (are you missing a using directive or an assembly reference?)
    xamarin-macios/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs(1156,4): error CS0103: The name 'NSApplication' does not exist in the current context
    xamarin-macios/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs(1157,4): error CS0103: The name 'NSApplication' does not exist in the current context