### PR TITLE
[dotnet] Make CoreCLR the only option for macOS. Fixes #12477.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -14,7 +14,8 @@
     <!-- Don't include default Compile items for binding projects, because that would pick up ApiDefinition.cs and StructsAndEnums.cs -->
     <EnableDefaultCompileItems Condition=" '$(IsBindingProject)' == 'true' ">false</EnableDefaultCompileItems>
 
-    <UseMonoRuntime Condition=" '$(UseMonoRuntime)' == ''">true</UseMonoRuntime>
+    <UseMonoRuntime Condition=" '$(UseMonoRuntime)' == '' And '$(_PlatformName)' != 'macOS'">true</UseMonoRuntime>
+    <UseMonoRuntime Condition=" '$(UseMonoRuntime)' == '' And '$(_PlatformName)' == 'macOS'">false</UseMonoRuntime>
   </PropertyGroup>
 
   <!-- Architecture -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -678,8 +678,16 @@
 		</ItemGroup>
 	</Target>
 
+	<Target Name="_VerifyValidRuntime">
+		<Error Text="Only CoreCLR is supported on macOS. Set 'UseMonoRuntime=false' to use CoreCLR." Condition="'$(_PlatformName)' == 'macOS' And '$(UseMonoRuntime)' != 'false'" />
+	</Target>
+
 	<PropertyGroup>
-		<_ComputeVariablesDependsOn>_GenerateBundleName;_ComputeFrameworkVariables</_ComputeVariablesDependsOn>
+		<_ComputeVariablesDependsOn>
+			_VerifyValidRuntime;
+			_GenerateBundleName;
+			_ComputeFrameworkVariables;
+		</_ComputeVariablesDependsOn>
 		<!--
 			Don't execute ComputeResolvedFileToPublishList if we're in the
 			outer build of a multi-rid build, because there's nothing to

--- a/tests/linker/BaseOptimizeGeneratedCodeTest.cs
+++ b/tests/linker/BaseOptimizeGeneratedCodeTest.cs
@@ -153,11 +153,13 @@ namespace Linker.Shared
 			Assert.AreEqual (19, counter, "Counter");
 		}
 
+		public delegate void Action_IntPtr (IntPtr param);
+
 		[DllImport (Constants.libcLibrary)]
 		extern static void dispatch_sync (IntPtr queue, IntPtr block);
-		static Action<IntPtr> block_callback = BlockCallback;
+		static Action_IntPtr block_callback = BlockCallback;
 
-		[MonoPInvokeCallback (typeof (Action<IntPtr>))]
+		[MonoPInvokeCallback (typeof (Action_IntPtr))]
 		unsafe static void BlockCallback (IntPtr block)
 		{
 			var descriptor = (BlockLiteral*) block;
@@ -183,7 +185,7 @@ namespace Linker.Shared
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		void SetupBlockOptimized_SpecificArgument (Action<IntPtr> block_callback, Action callback)
+		void SetupBlockOptimized_SpecificArgument (Action_IntPtr block_callback, Action callback)
 		{
 			// ldarg_0
 			BlockLiteral block = new BlockLiteral ();
@@ -193,7 +195,7 @@ namespace Linker.Shared
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		void SetupBlockOptimized_SpecificArgument (Action callback, Action<IntPtr> block_callback)
+		void SetupBlockOptimized_SpecificArgument (Action callback, Action_IntPtr block_callback)
 		{
 			// ldarg_1
 			BlockLiteral block = new BlockLiteral ();
@@ -203,7 +205,7 @@ namespace Linker.Shared
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		void SetupBlockOptimized_SpecificArgument (Action callback, int dummy1, Action<IntPtr> block_callback)
+		void SetupBlockOptimized_SpecificArgument (Action callback, int dummy1, Action_IntPtr block_callback)
 		{
 			// ldarg_2
 			BlockLiteral block = new BlockLiteral ();
@@ -213,7 +215,7 @@ namespace Linker.Shared
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		void SetupBlockOptimized_SpecificArgument (Action callback, int dummy1, int dummy2, Action<IntPtr> block_callback)
+		void SetupBlockOptimized_SpecificArgument (Action callback, int dummy1, int dummy2, Action_IntPtr block_callback)
 		{
 			// ldarg_3
 			BlockLiteral block = new BlockLiteral ();
@@ -223,7 +225,7 @@ namespace Linker.Shared
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		void SetupBlockOptimized_SpecificArgument (Action callback, int dummy1, int dummy2, int dummy3, Action<IntPtr> block_callback)
+		void SetupBlockOptimized_SpecificArgument (Action callback, int dummy1, int dummy2, int dummy3, Action_IntPtr block_callback)
 		{
 			// ldarg_S
 			BlockLiteral block = new BlockLiteral ();
@@ -233,7 +235,7 @@ namespace Linker.Shared
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		void SetupBlockOptimized_SpecificArgument (Action callback, int dummy1, int dummy2, int dummy3, int dummy4, Action<IntPtr> block_callback)
+		void SetupBlockOptimized_SpecificArgument (Action callback, int dummy1, int dummy2, int dummy3, int dummy4, Action_IntPtr block_callback)
 		{
 			// ldarg_S
 			BlockLiteral block = new BlockLiteral ();
@@ -243,7 +245,7 @@ namespace Linker.Shared
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		void SetupBlockOptimized_SpecificArgument (Action callback, int dummy1, int dummy2, int dummy3, int dummy4, int dummy5, Action<IntPtr> block_callback)
+		void SetupBlockOptimized_SpecificArgument (Action callback, int dummy1, int dummy2, int dummy3, int dummy4, int dummy5, Action_IntPtr block_callback)
 		{
 			// ldarg_S
 			BlockLiteral block = new BlockLiteral ();
@@ -288,7 +290,7 @@ namespace Linker.Shared
 			int dummy208 = 0, int dummy218 = 0, int dummy228 = 0, int dummy238 = 0, int dummy248 = 0, int dummy258 = 0, int dummy268 = 0, int dummy278 = 0, int dummy288 = 0, int dummy298 = 0,
 			int dummy209 = 0, int dummy219 = 0, int dummy229 = 0, int dummy239 = 0, int dummy249 = 0, int dummy259 = 0, int dummy269 = 0, int dummy279 = 0, int dummy289 = 0, int dummy299 = 0,
 
-			Action<IntPtr> block_callback = null
+			Action_IntPtr block_callback = null
 		)
 		{
 			// ldarg
@@ -298,7 +300,7 @@ namespace Linker.Shared
 			block.CleanupBlock ();
 		}
 
-		Action<IntPtr> block_callback_instance_field;
+		Action_IntPtr block_callback_instance_field;
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		void SetupBlockOptimized_LoadField (Action callback)
 		{
@@ -321,7 +323,7 @@ namespace Linker.Shared
 			block.CleanupBlock ();
 		}
 
-		protected virtual Action<IntPtr> GetBlockCallbackInstance ()
+		protected virtual Action_IntPtr GetBlockCallbackInstance ()
 		{
 			return block_callback;
 		}
@@ -336,7 +338,7 @@ namespace Linker.Shared
 			block.CleanupBlock ();
 		}
 
-		static Action<IntPtr> GetBlockCallbackStatic ()
+		static Action_IntPtr GetBlockCallbackStatic ()
 		{
 			return block_callback;
 		}

--- a/tests/linker/ios/link sdk/ReflectionTest.cs
+++ b/tests/linker/ios/link sdk/ReflectionTest.cs
@@ -38,8 +38,8 @@ namespace Linker.Shared.Reflection {
 				Assert.That (p [0].ToString (), Is.EqualTo ("System.String firstParameter"), "1");
 				Assert.That (p [1].ToString (), Is.EqualTo ("Int32 secondParameter"), "2");
 			} else {
-				Assert.That (p [0].ToString (), Is.EqualTo ("System.String "), "1");
-				Assert.That (p [1].ToString (), Is.EqualTo ("Int32 "), "2");
+				Assert.That (p [0].ToString (), Is.EqualTo ("System.String ").Or.EqualTo ("System.String"), "1");
+				Assert.That (p [1].ToString (), Is.EqualTo ("Int32 ").Or.EqualTo ("Int32"), "2");
 			}
 		}
 	}

--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -127,13 +127,10 @@ namespace Xharness.Jenkins {
 				switch (test.TestName) {
 				case "monotouch-test":
 					if (test.TestProject.IsDotNetProject) {
-						if (test.Platform != TestPlatform.MacCatalyst)
-							yield return new TestData { Variation = "Debug (CoreCLR)", Debug = true, UseMonoRuntime = false, Ignored = !jenkins.IncludeMac, };
 						yield return new TestData { Variation = "Debug (ARM64)", Debug = true, Profiling = false, Ignored = !jenkins.IncludeMac || !mac_supports_arm64, RuntimeIdentifier = arm64_runtime_identifier, };
 						if (test.Platform != TestPlatform.MacCatalyst) {
-							yield return new TestData { Variation = "Debug (CoreCLR, ARM64)", Debug = true, UseMonoRuntime = false, Profiling = false, Ignored = !jenkins.IncludeMac || !mac_supports_arm64, RuntimeIdentifier = arm64_runtime_identifier, };
-							yield return new TestData { Variation = "Debug (CoreCLR, static registrar)", MonoBundlingExtraArgs = "--registrar:static", Debug = true, UseMonoRuntime = false, Undefines = "DYNAMIC_REGISTRAR", Ignored = !jenkins.IncludeMac, };
-							yield return new TestData { Variation = "Debug (CoreCLR, static registrar, ARM64)", MonoBundlingExtraArgs = "--registrar:static", Debug = true, UseMonoRuntime = false, Undefines = "DYNAMIC_REGISTRAR", Profiling = false, Ignored = !jenkins.IncludeMac || !mac_supports_arm64, RuntimeIdentifier = arm64_runtime_identifier, };
+							yield return new TestData { Variation = "Debug (static registrar)", MonoBundlingExtraArgs = "--registrar:static", Debug = true, Undefines = "DYNAMIC_REGISTRAR", Ignored = !jenkins.IncludeMac, };
+							yield return new TestData { Variation = "Debug (static registrar, ARM64)", MonoBundlingExtraArgs = "--registrar:static", Debug = true, Undefines = "DYNAMIC_REGISTRAR", Profiling = false, Ignored = !jenkins.IncludeMac || !mac_supports_arm64, RuntimeIdentifier = arm64_runtime_identifier, };
 						}
 					}
 					break;


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/12477.