### PR TITLE
[msbuild] Rename the GetMinimumOSVersion task to ReadAppManifest and make it read more properties from the app manifest.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -863,7 +863,7 @@
 	</Target>
 
 	<Target Name="_CompileNativeExecutable"
-		DependsOnTargets="_DetectSdkLocations;_ComputeTargetArchitectures;_GenerateBundleName;_GetMinimumOSVersion;_ComputeNativeExecutableInputs;_AOTCompile;"
+		DependsOnTargets="_DetectSdkLocations;_ComputeTargetArchitectures;_GenerateBundleName;_ReadAppManifest;_ComputeNativeExecutableInputs;_AOTCompile;"
 		Inputs="@(_CompileNativeExecutableFile)"
 		Outputs="@(_CompileNativeExecutableFile -> '%(OutputFile)')"
 		>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ReadAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ReadAppManifestTaskBase.cs
@@ -15,6 +15,12 @@ namespace Xamarin.MacDev.Tasks {
 		public string? SdkVersion { get; set; }
 
 		[Output]
+		public string? CFBundleDisplayName { get; set; }
+
+		[Output]
+		public string? CFBundleVersion { get; set; }
+
+		[Output]
 		public string? MinimumOSVersion { get; set; }
 
 		public override bool Execute ()
@@ -46,6 +52,9 @@ namespace Xamarin.MacDev.Tasks {
 					Log.LogError (MSBStrings.E0187, MinimumOSVersion);
 				MinimumOSVersion = convertedVersion;
 			}
+
+			CFBundleDisplayName = plist?.GetCFBundleDisplayName ();
+			CFBundleVersion = plist?.GetCFBundleVersion ();
 
 			return true;
 		}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ReadAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ReadAppManifestTaskBase.cs
@@ -15,6 +15,9 @@ namespace Xamarin.MacDev.Tasks {
 		public string? SdkVersion { get; set; }
 
 		[Output]
+		public string? CLKComplicationGroup { get; set; }
+
+		[Output]
 		public string? CFBundleDisplayName { get; set; }
 
 		[Output]
@@ -22,6 +25,21 @@ namespace Xamarin.MacDev.Tasks {
 
 		[Output]
 		public string? MinimumOSVersion { get; set; }
+
+		[Output]
+		public string? NSExtensionPointIdentifier { get; set; }
+
+		[Output]
+		public string? UIDeviceFamily { get; set; }
+
+		[Output]
+		public bool WKWatchKitApp { get; set; }
+
+		[Output]
+		public string? XSAppIconAssets { get; set; }
+
+		[Output]
+		public string? XSLaunchImageAssets { get; set; }
 
 		public override bool Execute ()
 		{
@@ -55,6 +73,12 @@ namespace Xamarin.MacDev.Tasks {
 
 			CFBundleDisplayName = plist?.GetCFBundleDisplayName ();
 			CFBundleVersion = plist?.GetCFBundleVersion ();
+			CLKComplicationGroup = plist?.Get<PString> (ManifestKeys.CLKComplicationGroup)?.Value;
+			NSExtensionPointIdentifier = plist?.GetNSExtensionPointIdentifier ();
+			UIDeviceFamily = plist?.GetUIDeviceFamily ().ToString ();
+			WKWatchKitApp = plist?.GetWKWatchKitApp () == true;
+			XSAppIconAssets = plist?.Get<PString> (ManifestKeys.XSAppIconAssets)?.Value;
+			XSLaunchImageAssets = plist?.Get<PString> (ManifestKeys.XSLaunchImageAssets)?.Value;
 
 			return true;
 		}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ReadAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ReadAppManifestTaskBase.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 
 using Microsoft.Build.Framework;
@@ -6,24 +8,24 @@ using Xamarin.Localization.MSBuild;
 using Xamarin.Utils;
 
 namespace Xamarin.MacDev.Tasks {
-	public abstract class GetMinimumOSVersionTaskBase : XamarinTask {
-		public ITaskItem AppManifest { get; set; }
+	public abstract class ReadAppManifestTaskBase : XamarinTask {
+		public ITaskItem? AppManifest { get; set; }
 
 		[Required]
-		public string SdkVersion { get; set; }
+		public string? SdkVersion { get; set; }
 
 		[Output]
-		public string MinimumOSVersion { get; set; }
+		public string? MinimumOSVersion { get; set; }
 
 		public override bool Execute ()
 		{
-			PDictionary plist = null;
+			PDictionary? plist = null;
 
 			if (!string.IsNullOrEmpty (AppManifest?.ItemSpec)) {
 				try {
-					plist = PDictionary.FromFile (AppManifest.ItemSpec);
+					plist = PDictionary.FromFile (AppManifest!.ItemSpec);
 				} catch (Exception ex) {
-					Log.LogError (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, MSBStrings.E0010, AppManifest.ItemSpec, ex.Message);
+					Log.LogError (null, null, null, AppManifest!.ItemSpec, 0, 0, 0, 0, MSBStrings.E0010, AppManifest.ItemSpec, ex.Message);
 					return false;
 				}
 			}
@@ -32,7 +34,7 @@ namespace Xamarin.MacDev.Tasks {
 			if (string.IsNullOrEmpty (minimumOSVersionInManifest)) {
 				MinimumOSVersion = SdkVersion;
 			} else if (!IAppleSdkVersion_Extensions.TryParse (minimumOSVersionInManifest, out var _)) {
-				Log.LogError (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, MSBStrings.E0011, minimumOSVersionInManifest);
+				Log.LogError (null, null, null, AppManifest?.ItemSpec, 0, 0, 0, 0, MSBStrings.E0011, minimumOSVersionInManifest);
 				return false;
 			} else {
 				MinimumOSVersion = minimumOSVersionInManifest;

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ReadAppManifest.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ReadAppManifest.cs
@@ -2,7 +2,7 @@ using Xamarin.Messaging.Build.Client;
 
 namespace Xamarin.MacDev.Tasks
 {
-	public class GetMinimumOSVersion : GetMinimumOSVersionTaskBase
+	public class ReadAppManifest : ReadAppManifestTaskBase
 	{
 		public override bool Execute ()
 		{

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -336,9 +336,15 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			SdkVersion="$(_SdkVersion)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			>
+			<Output TaskParameter="CLKComplicationGroup" PropertyName="_CLKComplicationGroup" />
 			<Output TaskParameter="CFBundleDisplayName" PropertyName="_CFBundleDisplayName" />
 			<Output TaskParameter="CFBundleVersion" PropertyName="_CFBundleVersion" />
 			<Output TaskParameter="MinimumOSVersion" PropertyName="_MinimumOSVersion" />
+			<Output TaskParameter="NSExtensionPointIdentifier" PropertyName="_NSExtensionPointIdentifier" />
+			<Output TaskParameter="UIDeviceFamily" PropertyName="_UIDeviceFamily" />
+			<Output TaskParameter="WKWatchKitApp" PropertyName="_WKWatchKitApp" />
+			<Output TaskParameter="XSAppIconAssets" PropertyName="_XSAppIconAssets" />
+			<Output TaskParameter="XSLaunchImageAssets" PropertyName="_XSLaunchImageAssets" />
 		</ReadAppManifest>
 	</Target>
 
@@ -421,12 +427,13 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(IBToolExe)"
 			ToolPath="$(IBToolPath)"
-			AppManifest="$(_AppManifest)"
 			BundleIdentifier="$(_BundleIdentifier)"
+			CLKComplicationGroup="$(_CLKComplicationGroup)"
 			EnableOnDemandResources="$(EnableOnDemandResources)"
 			InterfaceDefinitions="@(InterfaceDefinition)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
 			MinimumOSVersion="$(_MinimumOSVersion)"
+			NSExtensionPointIdentifier="$(_NSExtensionPointIdentifier)"
 			IsWatchApp="$(IsWatchApp)"
 			IsWatch2App="$(IsWatch2App)"
 			ProjectDir="$(MSBuildProjectDirectory)"
@@ -438,6 +445,10 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			SdkPlatform="$(_SdkPlatform)"
 			SdkVersion="$(_SdkVersion)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+			UIDeviceFamily="$(_UIDeviceFamily)"
+			WKWatchKitApp="$(_WKWatchKitApp)"
+			XSAppIconAssets="$(_XSAppIconAssets)"
+			XSLaunchImageAssets="$(_XSLaunchImageAssets)"
 			>
 			<Output TaskParameter="BundleResources" ItemName="_BundleResourceWithLogicalName" />
 
@@ -488,13 +499,14 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			Condition="'$(IsMacEnabled)' == 'true' And '@(ImageAsset)' != ''"
 			ToolExe="$(ACToolExe)"
 			ToolPath="$(ACToolPath)"
-			AppManifest="$(_AppManifest)"
 			BundleIdentifier="$(_BundleIdentifier)"
+			CLKComplicationGroup="$(_CLKComplicationGroup)"
 			DeviceModel="$(TargetDeviceModel)"
 			DeviceOSVersion="$(TargetDeviceOSVersion)"
 			EnableOnDemandResources="$(EnableOnDemandResources)"
 			ImageAssets="@(ImageAsset)"
 			MinimumOSVersion="$(_MinimumOSVersion)"
+			NSExtensionPointIdentifier="$(_NSExtensionPointIdentifier)"
 			OptimizePNGs="$(OptimizePNGs)"
 			OutputPath="$(DeviceSpecificOutputPath)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
@@ -507,6 +519,10 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			SdkPlatform="$(_SdkPlatform)"
 			SdkVersion="$(_SdkVersion)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+			UIDeviceFamily="$(_UIDeviceFamily)"
+			WKWatchKitApp="$(_WKWatchKitApp)"
+			XSAppIconAssets="$(_XSAppIconAssets)"
+			XSLaunchImageAssets="$(_XSLaunchImageAssets)"
 			>
 			<Output TaskParameter="PartialAppManifest" ItemName="PartialAppManifest" />
 			<Output TaskParameter="BundleResources" ItemName="_BundleResourceWithLogicalName" />

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -336,6 +336,8 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			SdkVersion="$(_SdkVersion)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			>
+			<Output TaskParameter="CFBundleDisplayName" PropertyName="_CFBundleDisplayName" />
+			<Output TaskParameter="CFBundleVersion" PropertyName="_CFBundleVersion" />
 			<Output TaskParameter="MinimumOSVersion" PropertyName="_MinimumOSVersion" />
 		</ReadAppManifest>
 	</Target>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -110,7 +110,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetDirectories" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetFileSystemEntries" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetFullPath" AssemblyFile="$(_TaskAssemblyName)" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetMinimumOSVersion" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetNativeExecutableName" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetPropertyListValue" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.IBTool" AssemblyFile="$(_TaskAssemblyName)" />
@@ -118,6 +117,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.ParseBundlerArguments" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.PrepareResourceRules" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.PropertyListEditor" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.ReadAppManifest" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.ReadItemsFromFile" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.ResolveNativeReferences" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.SmartCopy" AssemblyFile="$(_TaskAssemblyName)" />
@@ -274,7 +274,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<_CompileAppManifestDependsOn>
 			$(_CompileAppManifestDependsOn);
 			_DetectSdkLocations;
-			_GetMinimumOSVersion;
+			_ReadAppManifest;
 			_GenerateBundleName;
 			_DetectSigningIdentity;
 			_ComputeTargetFrameworkMoniker;
@@ -317,6 +317,27 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(AppBundleDir).dSYM" />
 		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
+	</Target>
+
+	<PropertyGroup>
+		<_ReadAppManifestDependsOn>
+			$(_ReadAppManifestDependsOn);
+			_DetectAppManifest;
+			_DetectSdkLocations;
+			_ComputeTargetFrameworkMoniker;
+		</_ReadAppManifestDependsOn>
+	</PropertyGroup>
+
+	<Target Name="_ReadAppManifest" DependsOnTargets="$(_ReadAppManifestDependsOn)">
+		<ReadAppManifest
+			Condition="'$(IsMacEnabled)' == 'true'"
+			SessionId="$(BuildSessionId)"
+			AppManifest="$(_AppManifest)"
+			SdkVersion="$(_SdkVersion)"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+			>
+			<Output TaskParameter="MinimumOSVersion" PropertyName="_MinimumOSVersion" />
+		</ReadAppManifest>
 	</Target>
 
 	<PropertyGroup>
@@ -382,7 +403,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<PropertyGroup>
 		<_CoreCompileInterfaceDefinitionsDependsOn>
 			_BeforeCoreCompileInterfaceDefinitions;
-			_GetMinimumOSVersion;
+			_ReadAppManifest;
 			_DetectSigningIdentity;
 			_ComputeTargetFrameworkMoniker;
 		</_CoreCompileInterfaceDefinitionsDependsOn>
@@ -458,7 +479,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<Target Name="_CoreCompileImageAssets"
 		Inputs="@(ImageAsset);$(_AppManifest)"
 		Outputs="$(_ACTool_PartialAppManifestCache);$(_ACTool_BundleResourceCache)"
-		DependsOnTargets="_DetectAppManifest;_GetMinimumOSVersion;_DetectSdkLocations;_BeforeCoreCompileImageAssets;_GetMinimumOSVersion;_DetectSigningIdentity;_ComputeTargetFrameworkMoniker">
+		DependsOnTargets="_DetectAppManifest;_ReadAppManifest;_DetectSdkLocations;_BeforeCoreCompileImageAssets;_DetectSigningIdentity;_ComputeTargetFrameworkMoniker">
 
 		<ACTool
 			SessionId="$(BuildSessionId)"
@@ -751,7 +772,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</ItemGroup>
 	</Target>
 
-	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations;_ComputeTargetFrameworkMoniker;_GetMinimumOSVersion">
+	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations;_ComputeTargetFrameworkMoniker;_ReadAppManifest">
 		<Metal
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' and '%(Metal.Identity)' != ''"
@@ -913,18 +934,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<_CompileToNativeInput Include="$(TargetDir)$(TargetFileName);@(_BundlerReferencePath)" />
 			<_CompileToNativeInput Condition="'@(_ResolvedAppExtensionReferences)' != ''" Include="%(_ResolvedAppExtensionReferences.Identity)\..\bundler.stamp" />
 		</ItemGroup>
-	</Target>
-
-	<Target Name="_GetMinimumOSVersion" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_ComputeTargetFrameworkMoniker">
-		<GetMinimumOSVersion
-			Condition="'$(IsMacEnabled)' == 'true'"
-			SessionId="$(BuildSessionId)"
-			AppManifest="$(_AppManifest)"
-			SdkVersion="$(_SdkVersion)"
-			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
-			>
-			<Output TaskParameter="MinimumOSVersion" PropertyName="_MinimumOSVersion" />
-		</GetMinimumOSVersion>
 	</Target>
 
 	<Target Name="_DetectSigningIdentity" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_ComputeTargetFrameworkMoniker;_GenerateBundleName">

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileITunesMetadataTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileITunesMetadataTaskBase.cs
@@ -15,7 +15,11 @@ namespace Xamarin.iOS.Tasks
 		#region Inputs
 
 		[Required]
-		public string AppBundleDir { get; set; }
+		public string BundleIdentifier { get; set; }
+
+		public string BundleDisplayName { get; set; }
+
+		public string BundleVersion { get; set; }
 
 		public ITaskItem[] ITunesMetadata { get; set; }
 
@@ -44,31 +48,21 @@ namespace Xamarin.iOS.Tasks
 					return false;
 				}
 			} else {
-				var manifest = Path.Combine (AppBundleDir, "Info.plist");
-				PDictionary plist;
-
-				try {
-					plist = PDictionary.FromFile (manifest);
-				} catch (Exception ex) {
-					Log.LogError (null, null, null, manifest, 0, 0, 0, 0, MSBStrings.E0010, manifest, ex.Message);
-					return false;
-				}
-
-				var displayName = plist.GetCFBundleDisplayName ();
-				var bundleVersion = plist.GetCFBundleVersion ();
+				var displayName = BundleDisplayName;
+				var bundleVersion = BundleVersion;
 
 				metadata = new PDictionary ();
 
 				metadata.Add ("genre", new PString ("Application"));
-				if (bundleVersion != null)
+				if (!string.IsNullOrEmpty (bundleVersion))
 					metadata.Add ("bundleVersion", (PString) bundleVersion);
-				if (displayName != null)
+				if (!string.IsNullOrEmpty (displayName))
 					metadata.Add ("itemName", (PString) displayName);
 				metadata.Add ("kind", (PString) "software");
 				if (displayName != null)
 					metadata.Add ("playlistName", (PString) displayName);
 				metadata.Add ("softwareIconNeedsShine", (PBoolean) true);
-				metadata.Add ("softwareVersionBundleId", (PString) plist.GetCFBundleIdentifier ());
+				metadata.Add ("softwareVersionBundleId", (PString) BundleIdentifier);
 			}
 
 			Directory.CreateDirectory (Path.GetDirectoryName (OutputPath.ItemSpec));

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -224,13 +224,15 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</PropertyGroup>
 
 	<Target Name="_CompileITunesMetadata" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'"
-		DependsOnTargets="_DetectSdkLocations;_DetectAppManifest;_GenerateBundleName;_CompileAppManifest"
-		Inputs="$(_AppManifest);@(ITunesMetadata)"
+		DependsOnTargets="_DetectSdkLocations;_DetectAppManifest;_GenerateBundleName;_CompileAppManifest;_ReadAppManifest"
+		Inputs="@(ITunesMetadata)"
 		Outputs="$(DeviceSPecificOutputPath)iTunesMetadata.plist" >
 		<CompileITunesMetadata
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
-			AppBundleDir="$(AppBundleDir)"
+			CFBundleIdentifier="$(_BundleIdentifier)"
+			CFBundleVersion="$(_CFBundleVersion)"
+			CFBundleDisplayName="$(_CFBundleDisplayName)"
 			ITunesMetadata="@(ITunesMetadata)"
 			OutputPath="$(DeviceSpecificOutputPath)iTunesMetadata.plist"
 		/>

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/IBToolTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/IBToolTaskTests.cs
@@ -47,7 +47,6 @@ namespace Xamarin.iOS.Tasks
 				interfaceDefinitions.Add (new TaskItem (item));
 
 			var task = CreateTask<IBTool> ();
-			task.AppManifest = new TaskItem (Path.Combine (projectDir, "Info.plist"));
 			task.InterfaceDefinitions = interfaceDefinitions.ToArray ();
 			task.IntermediateOutputPath = intermediateOutputPath;
 			task.MinimumOSVersion = PDictionary.FromFile (Path.Combine (projectDir, "Info.plist")).GetMinimumOSVersion ();


### PR DESCRIPTION
* Read CFBundleDisplayName and CFBundleVersion and use them in the
  _CompileITunesMetadata task.

* Read numerous other app manifest values and pass them to the ACTool and
  IBTool tasks.

This makes it possible to not parse the Info.plist in these tasks, which will
become more complicated in the future, when we might either not have an
Info.plist, or have many partial ones.

Also enable nullability.