### PR TITLE
[release/6.0.1xx-rc.1] [msbuild] Add a task to compute the path to the AOT compiler.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -784,10 +784,10 @@
 		<Warning Condition="'$(GenerateRuntimeConfigurationFiles)' != 'true'" Text="Some features may not work correctly, because the generation of the runtime configure file (*.runtimeconfig.json) has been disabled." />
 	</Target>
 
-	<Target Name="_FindAotCompiler">
+	<Target Name="_FindAotCompiler" DependsOnTargets="_ComputeVariables">
 		<FindAotCompiler
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true'"
+			Condition="'$(IsMacEnabled)' == 'true' And '$(_RunAotCompiler)' == 'true'"
 			MonoAotCrossCompiler="@(MonoAotCrossCompiler)"
 			RuntimeIdentifier="$(RuntimeIdentifier)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -7,6 +7,7 @@
 	</PropertyGroup>
 
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.CompileNativeCode" AssemblyFile="$(_XamarinTaskAssembly)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.FindAotCompiler" AssemblyFile="$(_XamarinTaskAssembly)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.LinkNativeCode" AssemblyFile="$(_XamarinTaskAssembly)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.SymbolStrip" AssemblyFile="$(_XamarinTaskAssembly)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.MergeAppBundles" AssemblyFile="$(_XamarinTaskAssembly)" />
@@ -367,6 +368,7 @@
 			_ComputeVariables;
 			_CreateRuntimeConfiguration;
 			_ComputeMonoLibraries;
+			_FindAotCompiler;
 		</_ComputeLinkerArgumentsDependsOn>
 	</PropertyGroup>
 
@@ -716,7 +718,6 @@
 			<_AppBundleFrameworksDir Condition="'$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS'">$(_RelativeAppBundlePath)\Frameworks\</_AppBundleFrameworksDir>
 			<_AppBundleFrameworksDir Condition="'$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst'">$(_RelativeAppBundlePath)\Contents\Frameworks\</_AppBundleFrameworksDir>
 
-			<_AOTCompiler>@(MonoAotCrossCompiler->WithMetadataValue("RuntimeIdentifier", "$(RuntimeIdentifier)"))</_AOTCompiler>
 			<_AOTInputDirectory>$(_IntermediateNativeLibraryDir)aot-input/</_AOTInputDirectory>
 			<_AOTOutputDirectory>$(_IntermediateNativeLibraryDir)aot-output/</_AOTOutputDirectory>
 
@@ -783,13 +784,25 @@
 		<Warning Condition="'$(GenerateRuntimeConfigurationFiles)' != 'true'" Text="Some features may not work correctly, because the generation of the runtime configure file (*.runtimeconfig.json) has been disabled." />
 	</Target>
 
-	<Target Name="_AOTCompile"
-			Condition="'$(_RunAotCompiler)' == 'true'"
-			DependsOnTargets="_ComputeVariables"
-			Inputs="@(_AssembliesToAOT)"
-			Outputs="@(_AssembliesToAOT -> '%(ObjectFile)');@(_AssembliesToAOT -> '%(LLVMFile)');">
+	<Target Name="_FindAotCompiler">
+		<FindAotCompiler
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			MonoAotCrossCompiler="@(MonoAotCrossCompiler)"
+			RuntimeIdentifier="$(RuntimeIdentifier)"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+		>
+			<Output TaskParameter="AotCompiler" PropertyName="_AOTCompiler" />
+		</FindAotCompiler>
 
 		<Error Text="The AOT compiler '$(_AOTCompiler)' does not exist." Condition="!Exists ($(_AOTCompiler))" />
+	</Target>
+
+	<Target Name="_AOTCompile"
+			Condition="'$(_RunAotCompiler)' == 'true'"
+			DependsOnTargets="_ComputeVariables;_FindAotCompiler"
+			Inputs="@(_AssembliesToAOT)"
+			Outputs="@(_AssembliesToAOT -> '%(ObjectFile)');@(_AssembliesToAOT -> '%(LLVMFile)');">
 
 		<AOTCompile
 			SessionId="$(BuildSessionId)"

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -794,8 +794,6 @@
 		>
 			<Output TaskParameter="AotCompiler" PropertyName="_AOTCompiler" />
 		</FindAotCompiler>
-
-		<Error Text="The AOT compiler '$(_AOTCompiler)' does not exist." Condition="!Exists ($(_AOTCompiler))" />
 	</Target>
 
 	<Target Name="_AOTCompile"

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -1886,6 +1886,15 @@ namespace Xamarin.Localization.MSBuild {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The AOT compiler &apos;{0}&apos; does not exist..
+        /// </summary>
+        public static string E7081 {
+            get {
+                return ResourceManager.GetString("E7081", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid framework: {0}.
         /// </summary>
         public static string InvalidFramework {

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1296,4 +1296,12 @@
             {1}: the full path to the file in question
         </comment>
     </data>
+
+    <data name="E7081" xml:space="preserve">
+        <value>The AOT compiler '{0}' does not exist.</value>
+        <comment>
+            AOT: Ahead-Of-Time
+            {0}: the path to the compiler
+        </comment>
+    </data>
 </root>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindAotCompilerTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindAotCompilerTaskBase.cs
@@ -7,12 +7,12 @@ using Microsoft.Build.Framework;
 
 namespace Xamarin.MacDev.Tasks {
 	public abstract class FindAotCompilerTaskBase : XamarinTask {
-		[Required]		
+		[Required]
 		public ITaskItem[] MonoAotCrossCompiler { get; set; }
-		
+
 		[Required]
 		public string RuntimeIdentifier { get; set; }
-		
+
 		[Output]
 		public string AotCompiler { get; set; }
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindAotCompilerTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindAotCompilerTaskBase.cs
@@ -33,7 +33,7 @@ namespace Xamarin.MacDev.Tasks {
 				AotCompiler = ComputeAotCompilerPath ();
 			}
 
-			if (File.Exists (AotCompiler))
+			if (!File.Exists (AotCompiler))
 				Log.LogError (MSBStrings.E7081 /*"The AOT compiler '{0}' does not exist." */, AotCompiler);
 
 			return !Log.HasLoggedErrors;

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindAotCompilerTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindAotCompilerTaskBase.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Microsoft.Build.Framework;
+
+namespace Xamarin.MacDev.Tasks {
+	public abstract class FindAotCompilerTaskBase : XamarinTask {
+		[Required]		
+		public ITaskItem[] MonoAotCrossCompiler { get; set; }
+		
+		[Required]
+		public string RuntimeIdentifier { get; set; }
+		
+		[Output]
+		public string AotCompiler { get; set; }
+
+		public override bool Execute ()
+		{
+			if (MonoAotCrossCompiler?.Length > 0) {
+				var aotCompilerItem = MonoAotCrossCompiler.SingleOrDefault (v => v.GetMetadata ("RuntimeIdentifier") == RuntimeIdentifier);
+
+				if (aotCompilerItem == null) {
+					Log.LogWarning ("Unable to find the AOT compiler for the RuntimeIdentifier '{0}'", RuntimeIdentifier);
+					AotCompiler = ComputeAotCompilerPath ();
+				} else {
+					AotCompiler = aotCompilerItem.ItemSpec;
+				}
+			} else {
+				AotCompiler = ComputeAotCompilerPath ();
+			}
+
+			Log.LogMessage (MessageImportance.Low, "Computed AOT compiler path: {0}", AotCompiler);
+
+			return !Log.HasLoggedErrors;
+		}
+
+		// If we can't find the AOT compiler path in MonoAotCrossCompiler, evaluate a project file that does know how to find it.
+		// This happens when executing remotely from Windows, because the MonoAotCrossCompiler item group will be empty in that case.
+		string ComputeAotCompilerPath ()
+		{
+			var projectPath = Path.GetTempFileName ();
+			var outputFile = Path.GetTempFileName ();
+
+			File.Delete (projectPath);
+			projectPath += ".csproj";
+			var csproj = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+	<PropertyGroup>
+		<TargetFramework>net6.0-{PlatformName}</TargetFramework>
+	</PropertyGroup>
+	<Target Name=""ComputeAotCompilerPath"">
+		<PropertyGroup>
+			<_AOTCompiler>@(MonoAotCrossCompiler->WithMetadataValue(""RuntimeIdentifier"", ""$(RuntimeIdentifier)""))</_AOTCompiler>
+		</PropertyGroup>
+		<WriteLinesToFile File=""$(OutputFilePath)"" Lines=""$(_AOTCompiler)"" />
+	</Target>
+</Project>
+";
+			File.WriteAllText (projectPath, csproj);
+
+			var executable = Environment.GetEnvironmentVariable ("DOTNET_HOST_PATH");
+			if (string.IsNullOrEmpty (executable))
+				executable = "dotnet";
+
+			var arguments = new List<string> ();
+			arguments.Add ("build");
+			arguments.Add ("/p:OutputFilePath=" + outputFile);
+			arguments.Add ("/p:RuntimeIdentifier=" + RuntimeIdentifier);
+			arguments.Add ("/t:ComputeAotCompilerPath");
+			arguments.Add (projectPath);
+
+			try {
+				ExecuteAsync (executable, arguments).Wait ();
+				return File.ReadAllText (outputFile).Trim ();
+			} finally {
+				File.Delete (projectPath);
+				File.Delete (outputFile);
+			}
+		}
+	}
+}
+

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindAotCompilerTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindAotCompilerTaskBase.cs
@@ -5,6 +5,8 @@ using System.Linq;
 
 using Microsoft.Build.Framework;
 
+using Xamarin.Localization.MSBuild;
+
 namespace Xamarin.MacDev.Tasks {
 	public abstract class FindAotCompilerTaskBase : XamarinTask {
 		[Required]
@@ -31,7 +33,8 @@ namespace Xamarin.MacDev.Tasks {
 				AotCompiler = ComputeAotCompilerPath ();
 			}
 
-			Log.LogMessage (MessageImportance.Low, "Computed AOT compiler path: {0}", AotCompiler);
+			if (File.Exists (AotCompiler))
+				Log.LogError (MSBStrings.E7081 /*"The AOT compiler '{0}' does not exist." */, AotCompiler);
 
 			return !Log.HasLoggedErrors;
 		}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindAotCompilerTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindAotCompilerTaskBase.cs
@@ -24,7 +24,7 @@ namespace Xamarin.MacDev.Tasks {
 				var aotCompilerItem = MonoAotCrossCompiler.SingleOrDefault (v => v.GetMetadata ("RuntimeIdentifier") == RuntimeIdentifier);
 
 				if (aotCompilerItem == null) {
-					Log.LogWarning ("Unable to find the AOT compiler for the RuntimeIdentifier '{0}'", RuntimeIdentifier);
+					Log.LogMessage (MessageImportance.Low, "Unable to find the AOT compiler for the RuntimeIdentifier '{0}' in the MonoAotCrossCompiler item group", RuntimeIdentifier);
 					AotCompiler = ComputeAotCompilerPath ();
 				} else {
 					AotCompiler = aotCompilerItem.ItemSpec;

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
@@ -98,7 +98,7 @@ namespace Xamarin.MacDev.Tasks {
 			}
 		}
 
-		protected async System.Threading.Tasks.Task<Execution> ExecuteAsync (string fileName, IList<string> arguments, string sdkDevPath, Dictionary<string, string> environment = null, bool mergeOutput = true, bool showErrorIfFailure = true)
+		protected async System.Threading.Tasks.Task<Execution> ExecuteAsync (string fileName, IList<string> arguments, string sdkDevPath = null, Dictionary<string, string> environment = null, bool mergeOutput = true, bool showErrorIfFailure = true)
 		{
 			// Create a new dictionary if we're given one, to make sure we don't change the caller's dictionary.
 			var launchEnvironment = environment == null ? new Dictionary<string, string> () : new Dictionary<string, string> (environment);

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FindAotCompiler.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FindAotCompiler.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+using System.Collections.Generic;
+
+using Xamarin.Messaging.Build.Client;
+using Microsoft.Build.Framework;
+
+namespace Xamarin.MacDev.Tasks
+{
+	public class FindAotCompiler : FindAotCompilerTaskBase, ITaskCallback, ICancelableTask {
+		public override bool Execute ()
+		{
+			bool result;
+
+			if (ShouldExecuteRemotely ()) {
+				result = new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
+			} else {
+				result = base.Execute ();
+			}
+
+			return result;
+		}
+
+		public void Cancel ()
+		{
+			if (ShouldExecuteRemotely ())
+				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+		}
+
+		public bool ShouldCopyToBuildServer (ITaskItem item)
+		{
+			return false;
+		}
+
+		public bool ShouldCreateOutputFile (ITaskItem item) => false;
+
+		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied () => Enumerable.Empty<ITaskItem> ();
+	}
+}
+


### PR DESCRIPTION
The MonoAotCrossCompiler item group is empty when executing remotely from
Windows, so in that case we evaluate a csproj on the Mac side to compute the
AOT compiler path instead of relying in the task input from Windows.

Ref: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1362367


Backport of #12474
