### PR TITLE
[release/6.0.1xx-rc.1] [test][dotnet] Manually enable LLVM for app size comparison

### DIFF
--- a/tests/dotnet/Makefile
+++ b/tests/dotnet/Makefile
@@ -50,10 +50,10 @@ build-oldnet:
 	$(SYSTEM_MSBUILD) $(XBUILD_VERBOSITY) size-comparison/MySingleView/oldnet/MySingleView.csproj $(COMMON_ARGS) /bl:$@.binlog $(MSBUILD_VERBOSITY)
 
 build-dotnet: $(TARGETS)
-	$(DOTNET6) build size-comparison/MySingleView/dotnet/MySingleView.csproj --runtime ios-arm64 $(COMMON_ARGS) /bl:$@.binlog $(MSBUILD_VERBOSITY)
+	$(DOTNET6) build size-comparison/MySingleView/dotnet/MySingleView.csproj --runtime ios-arm64 /p:MtouchUseLlvm=true $(COMMON_ARGS) /bl:$@.binlog $(MSBUILD_VERBOSITY)
 
 run-dotnet: $(TARGETS)
-	$(DOTNET6) build -t:Run size-comparison/MySingleView/dotnet/MySingleView.csproj --runtime ios-arm64 $(COMMON_ARGS)
+	$(DOTNET6) build -t:Run size-comparison/MySingleView/dotnet/MySingleView.csproj --runtime ios-arm64 /p:MtouchUseLlvm=true $(COMMON_ARGS)
 
 # this will break the signature, so app won't run anymore. Use it only to compare final size w/legacy
 # https://github.com/xamarin/xamarin-macios/issues/11445


### PR DESCRIPTION
This should become the default https://github.com/xamarin/xamarin-macios/issues/12147
so this commit is only part of `rc.1` (and not `main`)

Backport of #12271
