### PR TITLE
[src] Augment the Native attribute to support custom conversion functions. Fixes #12111.

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -405,7 +405,7 @@ namespace AppKit {
 
 	[NoMacCatalyst]
 	[Mac (10,10)]
-	[Native]
+	[Native (ConvertToNative = "NSImageResizingModeExtensions.ToNative", ConvertToManaged = "NSImageResizingModeExtensions.ToManaged")]
 	public enum NSImageResizingMode : long {
 		Stretch,
 		Tile
@@ -1304,7 +1304,7 @@ namespace AppKit {
 	}
 
 	[NoMacCatalyst]
-	[Native]
+	[Native (ConvertToNative = "NSTextAlignmentExtensions.ToNative", ConvertToManaged = "NSTextAlignmentExtensions.ToManaged")]
 	public enum NSTextAlignment : ulong {
 		Left = 0,
 		Right = 1, 

--- a/src/AppKit/NSEnumsExtensions.cs
+++ b/src/AppKit/NSEnumsExtensions.cs
@@ -1,0 +1,87 @@
+//
+// NSEnumsExtensions.cs:
+//
+// Copyright 2021, Microsoft Corp
+//
+
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace AppKit {
+
+#if !__MACCATALYST__
+	public static class NSImageResizingModeExtensions {
+		public static nint ToNative (NSImageResizingMode value)
+		{
+			// For backwards compat reasons, the values we have in managed code corresponds with the X64 values.
+			if (Runtime.IsARM64CallingConvention) {
+				// Stretch and Tile are switched on arm64 on macOS
+				switch (value) {
+				case (NSImageResizingMode) 0:
+					value = (NSImageResizingMode) 1;
+					break;
+				case (NSImageResizingMode) 1:
+					value = (NSImageResizingMode) 0;
+					break;
+				}
+			}
+			return (nint) (long) value;
+		}
+
+		public static NSImageResizingMode ToManaged (nint value)
+		{
+			// For backwards compat reasons, the values we have in managed code corresponds with the X64 values.
+			if (Runtime.IsARM64CallingConvention) {
+				// Stretch and Tile are switched on arm64 on macOS
+				switch (value) {
+				case 0:
+					value = (nint) 1;
+					break;
+				case 1:
+					value = (nint) 0;
+					break;
+				}
+			}
+			return (NSImageResizingMode) (long) value;
+		}
+	}
+
+	public static class NSTextAlignmentExtensions {
+		public static nuint ToNative (NSTextAlignment value)
+		{
+			// For backwards compat reasons, the values we have in managed code corresponds with the X64 values.
+			if (Runtime.IsARM64CallingConvention) {
+				// Center and Right are switched on arm64 on macOS
+				switch (value) {
+				case (NSTextAlignment) 2:
+					value = (NSTextAlignment) 1;
+					break;
+				case (NSTextAlignment) 1:
+					value = (NSTextAlignment) 2;
+					break;
+				}
+			}
+			return (nuint) (ulong) value;
+		}
+
+		public static NSTextAlignment ToManaged (nuint value)
+		{
+			// For backwards compat reasons, the values we have in managed code corresponds with the X64 values.
+			if (Runtime.IsARM64CallingConvention) {
+				// Center and Right are switched on arm64 on macOS
+				switch (value) {
+				case 1:
+					value = (nuint) 2;
+					break;
+				case 2:
+					value = (nuint) 1;
+					break;
+				}
+			}
+			return (NSTextAlignment) (ulong) value;
+		}
+	}
+#endif // !__MACCATALYST__
+}
+

--- a/src/ObjCRuntime/NativeAttribute.cs
+++ b/src/ObjCRuntime/NativeAttribute.cs
@@ -28,5 +28,15 @@ namespace ObjCRuntime
 		}
 
 		public string NativeName { get; set; }
+
+		// methods to use to convert a managed enum value to native (and vice versa)
+		// The methods should have the following signatures:
+		//     public static NativeType ConvertToNative (MyEnum value) { }
+		//     public static MyEnum ConvertToManaged (NativeType value) { }
+		// Where <integral type> is any of [S]Byte, [U]Int16, [U]Int32, [U]Int64, n[u]int (our own versions).
+		// <integral type> must be the same for both methods.
+		// If one of these methods is specified, the other one must be as well.
+		public string ConvertToNative { get; set; }
+		public string ConvertToManaged { get; set; }
 	}
 }

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1942,6 +1942,40 @@ namespace ObjCRuntime {
 
 			throw exc;
 		}
+
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
+		public static ulong ConvertNativeEnumValueToManaged (nuint value, bool targetTypeHasMaxValue)
+		{
+#if ARCH_32
+			// Check if we got UInt32.MaxValue, which should probably be UInt64.MaxValue
+			if (targetTypeHasMaxValue && value == nuint.MaxValue)
+				return ulong.MaxValue;
+#endif
+			return (ulong) value;
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
+		public static long ConvertNativeEnumValueToManaged (nint value, bool targetTypeHasMaxValue)
+		{
+#if ARCH_32
+			// Check if we got Int32.MaxValue, which should probably be Int64.MaxValue
+			if (targetTypeHasMaxValue && value == nint.MaxValue)
+				return long.MaxValue;
+#endif
+			return (long) value;
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
+		public static nint ConvertManagedEnumValueToNative (long value)
+		{
+			return (nint) value;
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
+		public static nuint ConvertManagedEnumValueToNative (ulong value)
+		{
+			return (nuint) value;
+		}
 	}
 	
 	internal class IntPtrEqualityComparer : IEqualityComparer<IntPtr>

--- a/src/UIKit/UIEnums.cs
+++ b/src/UIKit/UIEnums.cs
@@ -615,7 +615,11 @@ namespace UIKit {
 	// note: __TVOS_PROHIBITED -> because it uses NSLineBreakMode (but we need this because we don't expose the later)
 	//
 	// NSInteger -> UIStringDrawing.h
+#if __MACCATALYST__
+	[Native (ConvertToNative = "UITextAlignmentExtensions.ToNative", ConvertToManaged = "UITextAlignmentExtensions.ToManaged")]
+#else
 	[Native]
+#endif
 	public enum UITextAlignment : long {
 		Left,
 		Center,
@@ -1230,7 +1234,11 @@ namespace UIKit {
 	}
 
 	// NSInteger -> UIImage.h
+#if __MACCATALYST__
+	[Native (ConvertToNative = "UIImageResizingModeExtensions.ToNative", ConvertToManaged = "UIImageResizingModeExtensions.ToManaged")]
+#else
 	[Native]
+#endif
 	public enum UIImageResizingMode : long {
 		Tile, Stretch
 	}

--- a/src/UIKit/UIEnumsExtensions.cs
+++ b/src/UIKit/UIEnumsExtensions.cs
@@ -8,14 +8,13 @@
 //  Miguel de Icaza
 //
 
-#if IOS
-
 using System;
 using Foundation;
 using ObjCRuntime;
 
 namespace UIKit {
 
+#if IOS
 	public static class UIDeviceOrientationExtensions {
 		public static bool IsPortrait (this UIDeviceOrientation orientation)
 		{
@@ -46,6 +45,76 @@ namespace UIKit {
 				orientation == UIInterfaceOrientation.LandscapeLeft;
 		}
 	}
+#endif // IOS
+
+#if __MACCATALYST__
+	public static class UIImageResizingModeExtensions {
+		public static nint ToNative (UIImageResizingMode value)
+		{
+			// The values we have in managed code corresponds with the ARM64 values.
+			if (!Runtime.IsARM64CallingConvention) {
+				// Stretch and Tile are switched on x64 on Mac Catalyst
+				switch (value) {
+				case (UIImageResizingMode) 0:
+					return 1;
+				case (UIImageResizingMode) 1:
+					return 0;
+				}
+			}
+			return (nint) (long) value;
+		}
+
+		public static UIImageResizingMode ToManaged (nint value)
+		{
+			// The values we have in managed code corresponds with the ARM64 values.
+			if (!Runtime.IsARM64CallingConvention) {
+				// Stretch and Tile are switched on x64 on Mac Catalyst
+				switch (value) {
+				case 0:
+					return (UIImageResizingMode) 1;
+				case 1:
+					return (UIImageResizingMode) 0;
+				}
+			}
+			return (UIImageResizingMode) (long) value;
+		}
+	}
+
+	public static class UITextAlignmentExtensions {
+		public static nint ToNative (UITextAlignment value)
+		{
+			// The values we have in managed code corresponds with the ARM64 values.
+			if (!Runtime.IsARM64CallingConvention) {
+				// Center and Right are switched on x64 on Mac Catalyst
+				switch (value) {
+				case (UITextAlignment) 1:
+					value = (UITextAlignment) 2;
+					break;
+				case (UITextAlignment) 2:
+					value = (UITextAlignment) 1;
+					break;
+				}
+			}
+			return (nint) (long) value;
+		}
+
+		public static UITextAlignment ToManaged (nint value)
+		{
+			// The values we have in managed code corresponds with the ARM64 values.
+			if (!Runtime.IsARM64CallingConvention) {
+				// Center and Right are switched on x64 on Mac Catalyst
+				switch (value) {
+				case 1:
+					value = (nint) 2;
+					break;
+				case 2:
+					value = (nint) 1;
+					break;
+				}
+			}
+			return (UITextAlignment) (long) value;
+		}
+	}
+#endif // __MACCATALYST__
 }
 
-#endif // IOS

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -113,6 +113,7 @@ APPKIT_SOURCES = \
 	AppKit/NSPasteboard.cs \
 	AppKit/NSSharingServiceDelegate.cs \
 	AppKit/NSDocument.cs \
+	AppKit/NSEnumsExtensions.cs \
 	AppKit/NSEvent.cs \
 	AppKit/NSFont.cs \
 	AppKit/NSGestureRecognizer.cs \

--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using Foundation;
 using ObjCRuntime;
 
@@ -50,10 +51,33 @@ public partial class Generator {
 
 		var native = AttributeManager.GetCustomAttribute<NativeAttribute> (type);
 		if (native != null) {
-			if (String.IsNullOrEmpty (native.NativeName))
-				print ("[Native]");
-			else
-				print ("[Native (\"{0}\")]", native.NativeName);
+			var sb = new StringBuilder ();
+			sb.Append ("[Native");
+			var hasNativeName = !string.IsNullOrEmpty (native.NativeName);
+			var hasConvertToManaged = !string.IsNullOrEmpty (native.ConvertToManaged);
+			var hasConvertToNative = !string.IsNullOrEmpty (native.ConvertToNative);
+			if (hasNativeName || hasConvertToManaged || hasConvertToNative ) {
+				sb.Append (" (");
+				if (hasNativeName)
+					sb.Append ('"').Append (native.NativeName).Append ('"');
+				if (hasConvertToManaged) {
+					if (hasNativeName)
+						sb.Append (", ");
+					sb.Append ("ConvertToManaged = \"");
+					sb.Append (native.ConvertToManaged);
+					sb.Append ('"');
+				}
+				if (hasConvertToNative) {
+					if (hasNativeName || hasConvertToManaged)
+						sb.Append (", ");
+					sb.Append ("ConvertToNative = \"");
+					sb.Append (native.ConvertToNative);
+					sb.Append ('"');
+				}
+				sb.Append (")");
+			}
+			sb.Append ("]");
+			print (sb.ToString ());
 		}
 		CopyObsolete (type);
 

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -2104,8 +2104,13 @@ public partial class Generator : IMemberGatherer {
 			throw new BindingException (1029, enumType);
 		}
 
-		preExpression = "(" + renderedEnumType + ") (" + RenderType (underlyingEnumType) + ") ";
-		postExpression = string.Empty;
+		if (!string.IsNullOrEmpty (attrib.ConvertToManaged)) {
+			preExpression = attrib.ConvertToManaged + " (";
+			postExpression = ")";
+		} else {
+			preExpression = "(" + renderedEnumType + ") (" + RenderType (underlyingEnumType) + ") ";
+			postExpression = string.Empty;
+		}
 
 		// Check if we got UInt32.MaxValue, which should probably be UInt64.MaxValue (if the enum
 		// in question actually has that value at least). Same goes for Int32.MinValue/Int64.MinValue.
@@ -2152,8 +2157,13 @@ public partial class Generator : IMemberGatherer {
 			throw new BindingException (1029, enumType);
 		}
 
-		preExpression = "(" + nativeType + ") (" + RenderType (underlyingEnumType) + ") ";
-		postExpression = string.Empty;
+		if (!string.IsNullOrEmpty (attrib.ConvertToNative)) {
+			preExpression = attrib.ConvertToNative + " (";
+			postExpression = ")";
+		} else {
+			preExpression = "(" + nativeType + ") (" + RenderType (underlyingEnumType) + ") ";
+			postExpression = string.Empty;
+		}
 
 		return true;
 	}

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -745,6 +745,7 @@ namespace GeneratorTests
 			bgen.Profile = Profile.iOS;
 			bgen.ProcessEnums = true;
 			bgen.Defines = BGenTool.GetDefaultDefines (bgen.Profile);
+			bgen.Sources = new string [] { Path.Combine (Configuration.SourceRoot, "tests", "generator", "tests", "nativeenum-extensions.cs") }.ToList ();
 			bgen.ApiDefinitions = new string [] { Path.Combine (Configuration.SourceRoot, "tests", "generator", "tests", "nativeenum.cs") }.ToList ();
 			bgen.CreateTemporaryBinding ();
 			bgen.AssertExecute ("build");

--- a/tests/generator/tests/nativeenum-extensions.cs
+++ b/tests/generator/tests/nativeenum-extensions.cs
@@ -1,0 +1,52 @@
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace NS {
+	public class Extensions {
+		public static MyEnum1 ToManaged1 (nint value)
+		{
+			throw new NotImplementedException ();
+		}
+		public static nint ToNative1 (MyEnum1 value)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public static MyEnum2 ToManaged2 (nint value)
+		{
+			throw new NotImplementedException ();
+		}
+		public static nint ToNative2 (MyEnum2 value)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public static MyEnum3 ToManaged3 (nuint value)
+		{
+			throw new NotImplementedException ();
+		}
+		public static nuint ToNative3 (MyEnum3 value)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public static MyEnum4 ToManaged4 (nint value)
+		{
+			throw new NotImplementedException ();
+		}
+		public static nint ToNative4 (MyEnum4 value)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public static MyEnum5 ToManaged5 (nuint value)
+		{
+			throw new NotImplementedException ();
+		}
+		public static nuint ToNative5 (MyEnum5 value)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+}

--- a/tests/generator/tests/nativeenum.cs
+++ b/tests/generator/tests/nativeenum.cs
@@ -3,6 +3,38 @@ using Foundation;
 using ObjCRuntime;
 
 namespace NS {
+	[Native (ConvertToManaged = "Extensions.ToManaged1", ConvertToNative="Extensions.ToNative1")]
+	public enum MyEnum1 : long {
+		Value1,
+		Value2,
+	}
+
+	[Native (ConvertToManaged = "Extensions.ToManaged2", ConvertToNative="Extensions.ToNative2")]
+	public enum MyEnum2 : long {
+		Value1 = long.MinValue,
+		Value2 = long.MaxValue,
+	}
+
+	[Native (ConvertToManaged = "Extensions.ToManaged3", ConvertToNative="Extensions.ToNative3")]
+	public enum MyEnum3 : ulong {
+		Value1 = ulong.MinValue,
+		Value2 = ulong.MaxValue,
+	}
+
+	[Native (ConvertToManaged = "Extensions.ToManaged4", ConvertToNative="Extensions.ToNative4")]
+	public enum MyEnum4 : long {
+		Zero,
+		One,
+		Two
+	}
+
+	[Native (ConvertToManaged = "Extensions.ToManaged5", ConvertToNative="Extensions.ToNative5")]
+	public enum MyEnum5 : ulong {
+		Zero,
+		One,
+		Two
+	}
+
 	[Native]
 	public enum MyEnum6 : long {
 		Value1,
@@ -23,6 +55,27 @@ namespace NS {
 
 	[BaseType (typeof (NSObject))]
 	interface MyClass {
+		[Export ("myProp1")]
+		MyEnum1 MyProp1 { get; set; }
+		[Export ("myMethod1:")]
+		MyEnum1 MyMethod1 (MyEnum1 arg);
+
+		[Export ("myProp2")]
+		MyEnum2 MyProp2 { get; set; }
+		[Export ("myMethod2:")]
+		MyEnum2 MyMethod2 (MyEnum2 arg);
+
+		[Export ("myProp3")]
+		MyEnum3 MyProp3 { get; set; }
+		[Export ("myMethod3:")]
+		MyEnum3 MyMethod3 (MyEnum3 arg);
+
+		[Field ("NIntField", "__Internal")]
+		MyEnum4 FooNIntField { get; set; }
+
+		[Field ("NUIntField", "__Internal")]
+		MyEnum5 FooNUIntField { get; set; }
+
 		[Export ("myProp6")]
 		MyEnum6 MyProp6 { get; set; }
 		[Export ("myMethod6:")]


### PR DESCRIPTION
Augment the Native attribute for enums to support custom conversion functions between
native values and managed values for enums. This makes it possible to have different
values in managed code for an enum compared to native code.

This is necessary to support different native enum values based on the architecture,
because in a few cases Apple has different enum values between x86_64 and ARM64.
Enum values are constants in managed code, and without this support it would be impossible
to translate these correctly to native code.

The updated Native attribute supports two new fields: ConvertToNative and ConvertToManaged,
which are managed functions of a specific signature that the generator will emit
calls to whenever needed to do the appropriate conversion.

Fixes https://github.com/xamarin/xamarin-macios/issues/12111.