### PR TITLE
[ci] Push .NET 6 packages to dnceng dotnet6 feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,8 +8,6 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="Dotnet arcade" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-    <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
-    <add key="xamarin-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
     <add key="macios-dependencies" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/macios-dependencies/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>

--- a/dotnet/package/common.csproj
+++ b/dotnet/package/common.csproj
@@ -119,7 +119,7 @@
     <Error Condition="'@(BuildArtifacts)' == ''" Text="No packages to create manifest from." />
 
     <ItemGroup>
-      <ManifestBuildData Include="InitialAssetsLocation=https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
+      <ManifestBuildData Include="InitialAssetsLocation=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
       <ManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
       <ManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
       <ManifestBuildData Include="AzureDevOpsProject=$(SYSTEM_TEAMPROJECT)" />

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -51,12 +51,27 @@ stages:
           *.nupkg
 
     - task: NuGetCommand@2
-      displayName: Publish Nugets to xamarin-impl
+      displayName: Publish Nugets to dotnet6
       inputs:
         command: push
         packagesToPush: $(Build.SourcesDirectory)/package/*.nupkg
         nuGetFeedType: external
-        publishFeedCredentials: xamarin-impl public feed
+        publishFeedCredentials: dnceng-dotnet6
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: vs-msi-nugets
+        downloadPath: $(Build.SourcesDirectory)/vs-msi-nugets
+        patterns: |
+          *.nupkg
+
+    - task: NuGetCommand@2
+      displayName: Publish Nugets to dotnet6
+      inputs:
+        command: push
+        packagesToPush: $(Build.SourcesDirectory)/vs-msi-nugets/*.nupkg
+        nuGetFeedType: external
+        publishFeedCredentials: dnceng-dotnet6
 
 # Check - "xamarin-macios (VS Insertion Wait For Approval)"
 # Check - "xamarin-macios (VS Insertion Create VS Drop and Open PR)"


### PR DESCRIPTION
We should now have the ability to push to the `dotnet6` feed that
contains the rest of the .NET 6 SDK Workload packages.  This should help
simplify workload acquisition.  The .nupkg files containing .msi the
.msi installers used for VS insertions will also now be pushed to this
feed.