### PR TITLE
[Makefile] Prevent people from bulding in the wrong dir.

### DIFF
--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -785,6 +785,18 @@ function check_osx_version () {
 	ok "Found OSX $ACTUAL_OSX_VERSION (at least $MIN_OSX_BUILD_VERSION is required)"
 }
 
+function check_checkout_dir () {
+	# use apple script to get the possibily translated special folders and check that we are not a subdir
+	for special in documents downloads desktop; do
+		path=$(osascript -e "set result to POSIX path of (path to $special folder as string)")
+		if [[ $PWD == $path* ]]; then
+			fail "Your checkout is under $path which is a special path. This can result in problems runnign the tests."
+		fi
+	done
+	ok "Checkout will not result in test problems."
+}
+
+
 function install_cmake () {
 	if ! brew --version >& /dev/null; then
 		fail "Asked to install cmake, but brew is not installed."
@@ -1045,6 +1057,7 @@ function check_dotnet ()
 echo "Checking system..."
 
 check_osx_version
+check_checkout_dir
 check_xcode
 check_homebrew
 check_autotools

--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -793,7 +793,7 @@ function check_checkout_dir () {
 			fail "Your checkout is under $path which is a special path. This can result in problems running the tests."
 		fi
 	done
-	ok "Checkout will not result in test problems."
+	ok "Checkout location will not result in test problems."
 }
 
 

--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -786,7 +786,7 @@ function check_osx_version () {
 }
 
 function check_checkout_dir () {
-	# use apple script to get the possibily translated special folders and check that we are not a subdir
+	# use apple script to get the possibly translated special folders and check that we are not a subdir
 	for special in documents downloads desktop; do
 		path=$(osascript -e "set result to POSIX path of (path to $special folder as string)")
 		if [[ $PWD == $path* ]]; then

--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -790,7 +790,7 @@ function check_checkout_dir () {
 	for special in documents downloads desktop; do
 		path=$(osascript -e "set result to POSIX path of (path to $special folder as string)")
 		if [[ $PWD == $path* ]]; then
-			fail "Your checkout is under $path which is a special path. This can result in problems runnign the tests."
+			fail "Your checkout is under $path which is a special path. This can result in problems running the tests."
 		fi
 	done
 	ok "Checkout will not result in test problems."


### PR DESCRIPTION
Special paths are protected by the OS. These paths are problematic
becasue the xpcproxy_sim might not have access to them, resulting in the
simulator tests failing (the process cannot return the PID used to
launch the app).

The problem with special folders.. is that they could be or not
translated or changed so we cannot hardcode them, yet we can use a small
apple script to return the path of the ones we know about (documents,
downloads, etc), get them and check if pwd is a substring.

The following is the example of a make all under the documents path:
```
 make all
Touch.Unit is up-to-date.
opentk is up-to-date.
Xamarin.MacDev is up-to-date.
macios-binaries is up-to-date.
ikvm-fork is up-to-date.
maccore is up-to-date.
ios-api-docs is up-to-date.
mac-api-docs is up-to-date.
xamarin-analysis is up-to-date.
All dependent modules up to date
Checking system...
    Found OSX 11.4 (at least 11.0 is required)
    Your checkout is under /Users/mandel/Documents/ which is a special path. This can result in problems runnign the tests.
    Checkout will not result in test problems.
    Found Xcode 13.0 in /Applications/Xcode_13.0.0-beta5.app
        Found CoreSimulator.framework 776.1 (exactly 776.1 is recommended)
    Found Homebrew (Homebrew 3.2.8-12-g6f41861)
    Found autoconf (GNU Autoconf) 2.71 (no specific version is required)
    Found glibtool (GNU libtool) 2.4.6 (no specific version is required)
    Found automake (GNU automake) 1.16.4 (no specific version is required)
    Found Python 3.9.6 (no specific version is required)
    Found Mono 6.12.0.145 (at least 6.12.0.145 and not more than 6.12.99 is required)
    Found Visual Studio 8.10.0.1773 (at least 8.4.4.8 and not more than 8.10.99 is required)
    Found CMake 3.21.1 (at least 2.8.8 is required)
    Found 7z (no specific version is required)
    Found Objective Sharpie 3.5.46 (at least 3.5.46 and not more than 3.5.99 is recommended)
    Found all extra simulators: com.apple.pkg.iPhoneSimulatorSDK11_4, com.apple.pkg.iPhoneSimulatorSDK12_0, com.apple.pkg.AppleTVSimulatorSDK11_4, com.apple.pkg.WatchSimulatorSDK6_0
    Found dotnet 5.0.200 in /usr/local/share/dotnet/sdk/5.0.200 (exactly 5.0.200 is required).
    Installed .NET SDKs:
        1.0.0-preview2-003121 [/usr/local/share/dotnet/sdk]
        1.0.4 [/usr/local/share/dotnet/sdk]
        2.0.0 [/usr/local/share/dotnet/sdk]
        2.1.4 [/usr/local/share/dotnet/sdk]
        2.1.301 [/usr/local/share/dotnet/sdk]
        2.1.302 [/usr/local/share/dotnet/sdk]
        2.1.503 [/usr/local/share/dotnet/sdk]
        2.1.504 [/usr/local/share/dotnet/sdk]
        2.1.505 [/usr/local/share/dotnet/sdk]
        2.1.700 [/usr/local/share/dotnet/sdk]
        2.1.809 [/usr/local/share/dotnet/sdk]
        2.2.203 [/usr/local/share/dotnet/sdk]
        3.0.100 [/usr/local/share/dotnet/sdk]
        3.1.100 [/usr/local/share/dotnet/sdk]
        3.1.101 [/usr/local/share/dotnet/sdk]
        3.1.102 [/usr/local/share/dotnet/sdk]
        3.1.200 [/usr/local/share/dotnet/sdk]
        3.1.201 [/usr/local/share/dotnet/sdk]
        3.1.402 [/usr/local/share/dotnet/sdk]
        3.1.404 [/usr/local/share/dotnet/sdk]
        3.1.406 [/usr/local/share/dotnet/sdk]
        3.1.407 [/usr/local/share/dotnet/sdk]
        3.1.408 [/usr/local/share/dotnet/sdk]
        3.1.409 [/usr/local/share/dotnet/sdk]
        5.0.100-preview.3.20216.6 [/usr/local/share/dotnet/sdk]
        5.0.100-preview.5.20256.10 [/usr/local/share/dotnet/sdk]
        5.0.100-preview.6.20265.2 [/usr/local/share/dotnet/sdk]
        5.0.100-preview.7.20317.11 [/usr/local/share/dotnet/sdk]
        5.0.100-preview.8.20359.11 [/usr/local/share/dotnet/sdk]
        5.0.100-rc.1.20426.3 [/usr/local/share/dotnet/sdk]
        5.0.100-rc.2.20459.1 [/usr/local/share/dotnet/sdk]
        5.0.101 [/usr/local/share/dotnet/sdk]
        5.0.103 [/usr/local/share/dotnet/sdk]
        5.0.200 [/usr/local/share/dotnet/sdk]
        5.0.201 [/usr/local/share/dotnet/sdk]
        5.0.202 [/usr/local/share/dotnet/sdk]
        5.0.203 [/usr/local/share/dotnet/sdk]
        6.0.100-preview.3.21202.5 [/usr/local/share/dotnet/sdk]
        6.0.100-preview.5.21302.13 [/usr/local/share/dotnet/sdk]
System check failed
make: *** [check-system] Error 1
```