### PR TITLE
[tools] Pass the right arguments to the AOT compiler for Mac Catalyst. Fixes #12484.

### DIFF
--- a/tests/monotouch-test/dotnet/MacCatalyst/Makefile
+++ b/tests/monotouch-test/dotnet/MacCatalyst/Makefile
@@ -1,1 +1,7 @@
 include ../shared.mk
+
+llvm:
+	$(Q) $(MAKE) build BUILD_ARGUMENTS="/p:RuntimeIdentifier=maccatalyst-arm64 /p:MtouchUseLlvm=true /p:MtouchLink=SdkOnly /p:Configuration=Release-llvm /bl:$@.binlog"
+
+run-llvm:
+	$(Q) $(MAKE) build BUILD_ARGUMENTS="/p:RuntimeIdentifier=maccatalyst-arm64 /p:MtouchUseLlvm=true /p:MtouchLink=SdkOnly /p:Configuration=Release-llvm /bl:$@.binlog /t:Run"

--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -132,6 +132,8 @@ namespace Xharness.Jenkins {
 							yield return new TestData { Variation = "Debug (static registrar)", MonoBundlingExtraArgs = "--registrar:static", Debug = true, Undefines = "DYNAMIC_REGISTRAR", Ignored = !jenkins.IncludeMac, };
 							yield return new TestData { Variation = "Debug (static registrar, ARM64)", MonoBundlingExtraArgs = "--registrar:static", Debug = true, Undefines = "DYNAMIC_REGISTRAR", Profiling = false, Ignored = !jenkins.IncludeMac || !mac_supports_arm64, RuntimeIdentifier = arm64_runtime_identifier, };
 						}
+						if (test.Platform == TestPlatform.MacCatalyst)
+							yield return new TestData { Variation = "Release (ARM64, LLVM)", Debug = false, UseLlvm = true, Ignored = !jenkins.IncludeMacCatalyst || !mac_supports_arm64, RuntimeIdentifier = arm64_runtime_identifier };
 					}
 					break;
 				case "xammac tests":

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -1483,7 +1483,11 @@ namespace Xamarin.Bundler {
 			if (app.AotOtherArguments != null)
 				processArguments.AddRange (app.AotOtherArguments);
 			aotArguments = new List<string> ();
-			aotArguments.Add ($"--aot=mtriple={(enable_thumb ? arch.Replace ("arm", "thumb") : arch)}-ios");
+			if (Platform == ApplePlatform.MacCatalyst) {
+				aotArguments.Add ($"--aot=mtriple={arch}-apple-ios{DeploymentTarget}-macabi");
+			} else {
+				aotArguments.Add ($"--aot=mtriple={(enable_thumb ? arch.Replace ("arm", "thumb") : arch)}-ios");
+			}
 			aotArguments.Add ($"data-outfile={dataFile}");
 			aotArguments.Add ("static");
 			aotArguments.Add ("asmonly");


### PR DESCRIPTION
Mac Catalyst is just special.

Also add an xharness test variation and update a test amkefile.

Fixes https://github.com/xamarin/xamarin-macios/issues/12484.