### PR TITLE
[dotnet] Updates the path to illink when building from Windows

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -314,7 +314,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 
 		<PropertyGroup>
 			<!-- We need to use net5.0 because when building from VS it sets MSBuildRuntimeType to Core and will pick net472 (which doesn't contain the illink assembly) -->
-			<_RemoteILLinkPath>$(ILLinkTasksAssembly.Replace('$(NetCoreRoot)', '$(_DotNetRootRemoteDirectory)').Replace('net472', 'net5.0').Replace('$([System.IO.Path]::GetFileName('$(ILLinkTasksAssembly)'))', 'illink.dll'))</_RemoteILLinkPath>
+			<_RemoteILLinkPath>$(ILLinkTasksAssembly.Replace('$(NetCoreRoot)', '$(_DotNetRootRemoteDirectory)').Replace('net472', 'net6.0').Replace('$([System.IO.Path]::GetFileName('$(ILLinkTasksAssembly)'))', 'illink.dll'))</_RemoteILLinkPath>
 		</PropertyGroup>
 
 		<ItemGroup>


### PR DESCRIPTION
The directory that contains illink.dll was renamed to net6.0