### PR TITLE
[CI] Build pipeline: Agent-Cleanser: yaml-template step

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -128,7 +128,7 @@ resources:
   - repository: templates
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/dev/bond/provisionator-cache    # UNDONE: TEST: DO NOT MERGE TO MAIN. Agent-Cleanser test
     endpoint: xamarin
 
   - repository: maccore

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -128,7 +128,7 @@ resources:
   - repository: templates
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/dev/bond/provisionator-cache    # UNDONE: TEST: DO NOT MERGE TO MAIN. Agent-Cleanser test
+    ref: refs/heads/main
     endpoint: xamarin
 
   - repository: maccore

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -103,6 +103,8 @@ steps:
     MacDeveloper: $(mac-developer)
     HostedMacKeychainPassword: ${{ parameters.keyringPass }}
 
+- template: agent-cleanser/v1.yml@templates   # Uninstalls mono, Xamarin.Mac (if installed) plus cleanses the Provisionator Xcode cache
+
 - task: xamops.azdevex.provisionator-task.provisionator@2
   displayName: 'Provision Brew components'
   inputs:


### PR DESCRIPTION
Include the Agent-Cleanser template from `yaml-templates` to help keep disk space in check on the build agents.  iOS builds currently run against the following pools:
[VSEng-Xamarin-RedmondMacBuildPool-iOS-Trusted](https://devdiv.visualstudio.com/_settings/agentpools?poolId=367&view=agents)
[VSEng-Xamarin-RedmondMacBuildPool-iOS-Untrusted](https://devdiv.visualstudio.com/_settings/agentpools?poolId=366&view=agents)


Related PR: https://github.com/xamarin/yaml-templates/pull/129