### PR TITLE
Correct Xamarin.Mac profiling properties

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -47,7 +47,8 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 		<I18n Condition="'$(I18n)' == ''"></I18n>
 		<IncludeMonoRuntime Condition="'$(IncludeMonoRuntime)' == ''">true</IncludeMonoRuntime>
 		<AotScope Condition="'$(AotScope)' == ''">None</AotScope>
-		<Profiling Condition="'$(MtouchProfiling)' == ''">False</Profiling>
+		<Profiling Condition="'$(Profiling)' == '' And '$(MtouchProfiling)' != ''">$(MtouchProfiling)</Profiling>
+		<Profiling Condition="'$(Profiling)' == ''">$(False)</Profiling>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFrameworkName)' == 'Full'">

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -48,7 +48,7 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 		<IncludeMonoRuntime Condition="'$(IncludeMonoRuntime)' == ''">true</IncludeMonoRuntime>
 		<AotScope Condition="'$(AotScope)' == ''">None</AotScope>
 		<Profiling Condition="'$(Profiling)' == '' And '$(MtouchProfiling)' != ''">$(MtouchProfiling)</Profiling>
-		<Profiling Condition="'$(Profiling)' == ''">$(False)</Profiling>
+		<Profiling Condition="'$(Profiling)' == ''">False</Profiling>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFrameworkName)' == 'Full'">


### PR DESCRIPTION
Seems like it was broken as of https://github.com/xamarin/xamarin-macios/commit/7c15428fc20d9ebecb48f999654b701707461c72

If MtouchProfiling is not set for Xamarin.Mac apps, it would not have a value. This behavioural change was also not replicated in the IDE, which still sets `Profiling`.

Change the property so it inherits MtouchProfiling if Profiling is not set and detauls to false.