### PR TITLE
[monotouch-test] Ignore several HttpMessageTest test cases in CI in case of network failures.

### DIFF
--- a/tests/monotouch-test/CoreServices/HttpMessageTest.cs
+++ b/tests/monotouch-test/CoreServices/HttpMessageTest.cs
@@ -98,6 +98,9 @@ namespace MonoTouchFixtures.CoreServices {
 					}
 				}
 			}, () => done);
+			if (!done)
+				TestRuntime.IgnoreInCI ("Transient network failure - ignore in CI");
+			Assert.IsTrue (done, "Network request completed");
 			using (var auth = CFHTTPAuthentication.CreateFromResponse (response)) {
 				Assert.NotNull (auth, "Null Auth");
 				Assert.IsTrue (auth.IsValid, "Auth is valid");

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -252,6 +252,9 @@ namespace MonoTests.System.Net.Http
 				}
 			}, () => completed);
 
+			if (!completed)
+				TestRuntime.IgnoreInCI ("Transient network failure - ignore in CI");
+			Assert.IsTrue (completed, "Network request completed");
 			Assert.IsNull (ex, "Exception");
 			Assert.IsNotNull (nativeSetCookieResult, "Native set-cookies result");
 			Assert.IsNotNull (nativeCookieResult, "Native cookies result");
@@ -295,6 +298,9 @@ namespace MonoTests.System.Net.Http
 				}
 			}, () => completed);
 
+			if (!completed)
+				TestRuntime.IgnoreInCI ("Transient network failure - ignore in CI");
+			Assert.IsTrue (completed, "Network request completed");
 			Assert.IsNull (ex, "Exception");
 			Assert.IsNotNull (nativeSetCookieResult, "Native set-cookies result");
 			Assert.IsNotNull (nativeCookieResult, "Native cookies result");

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -120,6 +120,9 @@ namespace MonoTests.System.Net.Http
 				}
 			}, () => completed);
 
+			if (!completed)
+				TestRuntime.IgnoreInCI ("Transient network failure - ignore in CI");
+			Assert.IsTrue (completed, "Network request completed");
 			Assert.IsNull (ex, "Exception");
 			Assert.IsTrue (managedCookieResult, $"Failed to get managed cookies");
 			Assert.IsTrue (nativeCookieResult, $"Failed to get native cookies");
@@ -167,6 +170,9 @@ namespace MonoTests.System.Net.Http
 				}
 			}, () => completed);
 
+			if (!completed)
+				TestRuntime.IgnoreInCI ("Transient network failure - ignore in CI");
+			Assert.IsTrue (completed, "Network request completed");
 			Assert.IsNull (ex, "Exception");
 			Assert.IsNotNull (managedCookieResult, "Managed cookies result");
 			Assert.IsNotNull (nativeCookieResult, "Native cookies result");
@@ -201,6 +207,9 @@ namespace MonoTests.System.Net.Http
 				}
 			}, () => completed);
 
+			if (!completed)
+				TestRuntime.IgnoreInCI ("Transient network failure - ignore in CI");
+			Assert.IsTrue (completed, "Network request completed");
 			Assert.IsNull (ex, "Exception");
 			Assert.IsNotNull (nativeCookieResult, "Native cookies result");
 			var cookiesFromServer = cookieContainer.GetCookies (new Uri (url));
@@ -534,6 +543,8 @@ namespace MonoTests.System.Net.Http
 			if (!done) { // timeouts happen in the bots due to dns issues, connection issues etc.. we do not want to fail
 				Assert.Inconclusive ("Request timedout.");
 			} else {
+				if (httpStatus == HttpStatusCode.BadGateway)
+					TestRuntime.IgnoreInCI ("Transient network failure - ignore in CI");
 				Assert.IsNull (ex, "Exception not null");
 				Assert.AreEqual (expectedStatus, httpStatus, "Status not ok");
 			}
@@ -572,6 +583,8 @@ namespace MonoTests.System.Net.Http
 			if (!done) { // timeouts happen in the bots due to dns issues, connection issues etc.. we do not want to fail
 				Assert.Inconclusive ("First request timedout.");
 			} else {
+				if (httpStatus == HttpStatusCode.BadGateway)
+					TestRuntime.IgnoreInCI ("Transient network failure - ignore in CI");
 				Assert.IsNull (ex, "First request exception not null");
 				Assert.AreEqual (HttpStatusCode.OK, httpStatus, "First status not ok");
 			}
@@ -601,6 +614,8 @@ namespace MonoTests.System.Net.Http
 			if (!done) { // timeouts happen in the bots due to dns issues, connection issues etc.. we do not want to fail
 				Assert.Inconclusive ("Second request timedout.");
 			} else {
+				if (httpStatus == HttpStatusCode.BadGateway)
+					TestRuntime.IgnoreInCI ("Transient network failure - ignore in CI");
 				Assert.IsNull (ex, "Second request exception not null");
 				Assert.AreEqual (HttpStatusCode.Unauthorized, httpStatus, "Second status not ok");
 			}


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/2160.
Fixes https://github.com/xamarin/maccore/issues/2491.
Fixes https://github.com/xamarin/maccore/issues/2493.
Fixes https://github.com/xamarin/maccore/issues/2304.