### PR TITLE
[tests] Move deletion of existing temporary directory to the background.

### DIFF
--- a/tests/mtouch/Cache.cs
+++ b/tests/mtouch/Cache.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Xamarin
 {
@@ -18,8 +19,25 @@ namespace Xamarin
 		static Cache ()
 		{
 			root = Path.Combine (Path.GetDirectoryName (System.Reflection.Assembly.GetExecutingAssembly ().Location), "tmp-test-dir");
-			if (Directory.Exists (root))
-				Directory.Delete (root, true);
+			if (Directory.Exists (root)) {
+				var movedRoot = root + DateTime.UtcNow.Ticks.ToString () + "-deletion-in-progress";
+				// The temporary directory can be big, and it can take a while to clean it out.
+				// So move it to a different name (which should be fast), and then do the deletion on a different thread.
+				// This should speed up startup in some cases.
+				if (!Directory.Exists (movedRoot)) {
+					try {
+						Directory.Move (root, movedRoot);
+						ThreadPool.QueueUserWorkItem ((v) => {
+							Directory.Delete (movedRoot, true);
+						});
+					} catch (Exception e) {
+						// Just delete the root if we can't move the temporary directory.
+						Directory.Delete (root, true);
+					}
+				} else {
+					Directory.Delete (root, true);
+				}
+			}
 			Directory.CreateDirectory (root);
 		}
 

--- a/tests/xharness/.gitignore
+++ b/tests/xharness/.gitignore
@@ -1,4 +1,4 @@
 xharness.csproj.inc
-tmp-test-dir
+tmp-test-dir*
 
 /xharness.exe.config

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -8,6 +8,7 @@ using System.Xml;
 using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
+using Xamarin;
 using Xharness.Jenkins.TestTasks;
 
 namespace Xharness {
@@ -87,7 +88,7 @@ namespace Xharness {
 
 		async Task CreateCopyAsync (ILog log, IProcessManager processManager, ITestTask test, string rootDirectory, Dictionary<string, TestProject> allProjectReferences)
 		{
-			var directory = DirectoryUtilities.CreateTemporaryDirectory (test?.TestName ?? System.IO.Path.GetFileNameWithoutExtension (Path));
+			var directory = Cache.CreateTemporaryDirectory (test?.TestName ?? System.IO.Path.GetFileNameWithoutExtension (Path));
 			Directory.CreateDirectory (directory);
 			var original_path = Path;
 			Path = System.IO.Path.Combine (directory, System.IO.Path.GetFileName (Path));

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -180,6 +180,9 @@
     <Compile Include="..\..\tools\common\StringUtils.cs">
       <Link>StringUtils.cs</Link>
     </Compile>
+    <Compile Include="..\mtouch\Cache.cs">
+      <Link>Cache.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\tools\common\SdkVersions.cs">


### PR DESCRIPTION
Improve Cache.CreateTemporaryDirectory to move the deletion of the previous
root temporary directory to a background thread. In some cases this directory
can have a lot of files and directories, and deleting it synchronously can
cause a significant startup delay when running tests locally.