### PR TITLE
[objcruntime] Do not pre-compute the `Selector.Name` property

### DIFF
--- a/src/ObjCRuntime/Selector.cs
+++ b/src/ObjCRuntime/Selector.cs
@@ -42,7 +42,7 @@ namespace ObjCRuntime {
 #endif
 
 		IntPtr handle;
-		string name;
+		string? name;
 
 		public Selector (IntPtr sel)
 		{
@@ -50,7 +50,6 @@ namespace ObjCRuntime {
 				ObjCRuntime.ThrowHelper.ThrowArgumentException (nameof (sel), "Not a selector handle.");
 
 			this.handle = sel;
-			name = GetName (sel);
 		}
 
 		// this .ctor is required, like for any INativeObject implementation
@@ -59,7 +58,6 @@ namespace ObjCRuntime {
 		internal Selector (IntPtr handle, bool /* unused */ owns)
 		{
 			this.handle = handle;
-			name = GetName (handle);
 		}
 
 		public Selector (string name)
@@ -73,7 +71,11 @@ namespace ObjCRuntime {
 		}
 
 		public string Name {
-			get { return name; }
+			get {
+				if (name == null)
+					name = GetName (handle);
+				return name;
+			}
 		}
 
 		public static bool operator!= (Selector left, Selector right) {


### PR DESCRIPTION
it's not often required.

Delaying it's retrieval allows the linker to remove additional code (and
lower the memory for each selector) if the app's code never uses the
selector name.

```diff
@@ -2990,8 +2985,6 @@
 	{
 		private IntPtr handle;

-		private string name;
-
 		public IntPtr Handle => handle;

 		public Selector(IntPtr P_0)
@@ -3001,13 +2994,11 @@
 				ThrowHelper.ThrowArgumentException("sel", "Not a selector handle.");
 			}
 			handle = P_0;
-			name = GetName(P_0);
 		}

 		internal Selector(IntPtr P_0, bool P_1)
 		{
 			handle = P_0;
-			name = GetName(P_0);
 		}

 		public sealed override bool Equals(object? P_0)
@@ -3029,14 +3020,6 @@
 			return handle.GetHashCode();
 		}

-		internal static string GetName(IntPtr P_0)
-		{
-			return Marshal.PtrToStringAuto(sel_getName(P_0));
-		}
-
-		[DllImport("/usr/lib/libobjc.dylib")]
-		private static extern IntPtr sel_getName(IntPtr P_0);
-
 		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "sel_registerName")]
 		public static extern IntPtr GetHandle(string P_0);

```