### PR TITLE
[LocalAuthenticationEmbeddedUI] Update bindings for Xcode 13.0 beta 2 and 3

### DIFF
--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1975,6 +1975,7 @@ MAC_FRAMEWORKS =            \
 	JavaScriptCore          \
 	LinkPresentation        \
 	LocalAuthentication     \
+	LocalAuthenticationEmbeddedUI	\
 	MailKit                 \
 	MapKit                  \
 	MediaAccessibility      \

--- a/src/localauthenticationembeddedui.cs
+++ b/src/localauthenticationembeddedui.cs
@@ -1,0 +1,38 @@
+//
+// LocalAuthenticationEmbeddedUI C# bindings
+//
+// Authors:
+//	Rachel Kang  <rachelkang@microsoft.com>
+//
+// Copyright 2021 Microsoft Corporation All rights reserved.
+//
+
+using System;
+using ObjCRuntime;
+using Foundation;
+using AppKit;
+using CoreGraphics;
+using LocalAuthentication;
+
+namespace LocalAuthenticationEmbeddedUI {
+    
+    [NoWatch, NoTV, NoiOS, NoMacCatalyst, Mac (12,0)]
+    [BaseType (typeof(NSView))]
+    interface LAAuthenticationView
+    {
+        [Export ("initWithFrame:")]
+        IntPtr Constructor (CGRect frameRect);
+
+        [Export ("initWithContext:")]
+        IntPtr Constructor (LAContext context);
+
+        [Export ("initWithContext:controlSize:")]
+        IntPtr Constructor (LAContext context, NSControlSize controlSize);
+
+        [Export ("context")]
+        LAContext Context { get; }
+
+        [Export ("controlSize")]
+        NSControlSize ControlSize { get; }
+    }
+}

--- a/src/localauthenticationembeddedui.cs
+++ b/src/localauthenticationembeddedui.cs
@@ -17,7 +17,7 @@ using LocalAuthentication;
 namespace LocalAuthenticationEmbeddedUI {
     
     [NoWatch, NoTV, NoiOS, NoMacCatalyst, Mac (12,0)]
-    [BaseType (typeof(NSView))]
+    [BaseType (typeof (NSView))]
     interface LAAuthenticationView
     {
         [Export ("initWithFrame:")]

--- a/tests/xtro-sharpie/MacCatalyst-LocalAuthenticationEmbeddedUI.ignore
+++ b/tests/xtro-sharpie/MacCatalyst-LocalAuthenticationEmbeddedUI.ignore
@@ -1,3 +1,4 @@
+## No LocalAuthentication support for Catalyst
 !missing-selector! LAAuthenticationView::context not bound
 !missing-selector! LAAuthenticationView::controlSize not bound
 !missing-selector! LAAuthenticationView::initWithContext: not bound

--- a/tests/xtro-sharpie/macOS-LocalAuthenticationEmbeddedUI.todo
+++ b/tests/xtro-sharpie/macOS-LocalAuthenticationEmbeddedUI.todo
@@ -1,5 +1,0 @@
-!missing-selector! LAAuthenticationView::context not bound
-!missing-selector! LAAuthenticationView::controlSize not bound
-!missing-selector! LAAuthenticationView::initWithContext: not bound
-!missing-selector! LAAuthenticationView::initWithContext:controlSize: not bound
-!missing-type! LAAuthenticationView not bound

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -262,6 +262,7 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "AdServices", "AdServices", 11,1 },
 
 					{ "Chip", "CHIP", 12, 0 },
+					{ "LocalAuthenticationEmbeddedUI", "LocalAuthenticationEmbeddedUI", 12, 0 },
 					{ "MailKit", "MailKit", 12, 0 },
 					{ "MetricKit", 12, 0 },
 					{ "Phase", "PHASE", 12, 0 },


### PR DESCRIPTION
No diffs for betas 1, 4, 5

Should I transfer the MacCatalyst.todo to .ignore? AFAICT, this framework doesn't have catalyst availability.