### PR TITLE
[release/6.0.1xx-rc.1] [ci] Only sign and push on release branches

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -257,8 +257,8 @@ stages:
         xqaCertPass: $(xqa--certificates--password)
         enableDotnet: ${{ parameters.enableDotnet }}
 
-# .NET 6 Release Prep and VS Insertion Stages, only execute them when the build reason is not a PR or a schedule build from OneLoc
-- ${{ if and(ne(variables['Build.Reason'], 'Schedule'), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual'))) }}:
+# .NET 6 Release Prep and VS Insertion Stages, only execute them when the build comes from an official branch and is not a schedule build from OneLoc
+- ${{ if and(ne(variables['Build.Reason'], 'Schedule'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
   - template: templates/release/vs-insertion-prep.yml
 
 # Test stages


### PR DESCRIPTION
The `templates/release/vs-insertion-prep.yml` template which includes
package signing and feed publishing should only run against official
branches.  The condition has been updated to check the branch name for
`main` or `release/` before running.


Backport of #12531
