### PR TITLE
Bump maccore.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 62e6757515dc46b3a99bfbc348932f25861f27bd
+NEEDED_MACCORE_VERSION := 3e591cbcb15081d34a9512ca39d9df55c331bdbd
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@62e6757515 [provisioning-profiles] Show more output from fetching the latest provisioning profiles. (#2504)
* xamarin/maccore@d9dcac2172 [submissions] Add ported samples. (#2503)
* xamarin/maccore@9473912ea3 [submission] Use a different bundle identifier for FSharpMacCoolApp to not clash with another test app. (#2502)
* xamarin/maccore@f235bd6454 Update vseng-xamarin-mac-devices.p12 (#2499)
* xamarin/maccore@2fba9b0761 [submissions] Fix string interpolation. (#2501)
* xamarin/maccore@32acd3aa82 [certificates] Update la_dev_apple.p12, la_distr_apple.p12 and la_mac_installer_distr.p12. (#2500)

Diff: https://github.com/xamarin/maccore/compare/8bb7dc6c38f40cab45fd916f082d794313b0855d..62e6757515dc46b3a99bfbc348932f25861f27bd