### PR TITLE
[release/6.0.1xx-rc.1] Import .NET 6 property page targets path in iOS sdk targets

### DIFF
--- a/dotnet/Microsoft.iOS.Windows.Sdk/targets/Microsoft.iOS.Windows.Sdk.targets
+++ b/dotnet/Microsoft.iOS.Windows.Sdk/targets/Microsoft.iOS.Windows.Sdk.targets
@@ -16,7 +16,7 @@
   -->
 
   <PropertyGroup Condition="'$(XamarinIOSDesignTimeTargetsPath)' == ''">
-    <XamarinIOSDesignTimeTargetsPath>$(MSBuildEXtensionsPath)\Microsoft\VisualStudio\Xamarin\iOS\Xamarin.iOS.DesignTime.targets</XamarinIOSDesignTimeTargetsPath>
+    <XamarinIOSDesignTimeTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Xamarin\iOS\Xamarin.iOS.DesignTime.targets</XamarinIOSDesignTimeTargetsPath>
   </PropertyGroup>
 
   <Import Project="$(XamarinIOSDesignTimeTargetsPath)" Condition="Exists('$(XamarinIOSDesignTimeTargetsPath)')" />

--- a/dotnet/Microsoft.iOS.Windows.Sdk/targets/Microsoft.iOS.Windows.Sdk.targets
+++ b/dotnet/Microsoft.iOS.Windows.Sdk/targets/Microsoft.iOS.Windows.Sdk.targets
@@ -15,4 +15,10 @@
 
   -->
 
+  <PropertyGroup Condition="'$(XamarinIOSDesignTimeTargetsPath)' == ''">
+    <XamarinIOSDesignTimeTargetsPath>$(MSBuildEXtensionsPath)\Microsoft\VisualStudio\Xamarin\iOS\Xamarin.iOS.DesignTime.targets</XamarinIOSDesignTimeTargetsPath>
+  </PropertyGroup>
+
+  <Import Project="$(XamarinIOSDesignTimeTargetsPath)" Condition="Exists('$(XamarinIOSDesignTimeTargetsPath)')" />
+
 </Project>


### PR DESCRIPTION
The .NET 6 iOS projects will use the [dotnet-project system property pages](https://github.com/dotnet/project-system/tree/main/docs/repo/property-pages) system which requires the authored .xaml pages to be imported as MEF components. I'm hooking into the _Microsoft.iOS.Windows.Sdk.targets_ file to import [Xamarin.iOS.DesignTime.targets](https://github.com/xamarin/XamarinVS/blob/feature/dotnetpropertypages/src/Features/VisualStudio.Properties/VisualStudio.iOS.DotNetProperties/DesignTimeTargets/Xamarin.iOS.DesignTime.targets) which will import each .xaml property page as a _PropertyPageSchema_.

The property pages will be placed in the same directory as the designtime targets file.


Backport of #12556
