### PR TITLE
[msbuild] Make the ParseBundlerArgumentsTaskBase take the verbosity as input as well.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ParseBundlerArgumentsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ParseBundlerArgumentsTaskBase.cs
@@ -34,6 +34,7 @@ namespace Xamarin.MacDev.Tasks {
 		[Output]
 		public string Registrar { get; set; }
 
+		// This is input too
 		[Output]
 		public int Verbosity { get; set; }
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1050,6 +1050,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			ExtraArgs="$(_BundlerArguments)"
 			NoSymbolStrip="$(_NoSymbolStrip)"
 			NoDSymUtil="$(_NoDSymUtil)"
+			Verbosity="$(_BundlerVerbosity)"
 			>
 			<Output TaskParameter="CustomBundleName" PropertyName="_CustomBundleName" />
 			<Output TaskParameter="DlSym" ItemName="_BundlerDlsym" />


### PR DESCRIPTION
This way we'll honor a _BundlerVerbosity value passed on the command line.

This fixes an inconvenience when we have when we want to increase verbosity
for a test run, which can be done by setting 'MtouchExtraArgs=-v'. This works
fine until the test we want to run wants to use MtouchExtraArgs for its own
purposes (1). If we set MtouchExtraArgs on the command line, then that value
will be global and won't be able to be overridden by the test, and the test
will fail.

With this fix we can pass _BundlerVerbosity=1 directly when building the test
to avoid the whole problem.

1. For instance, most tests pass an argument in MtouchExtraArgs to use
dlsym for NUnit.Framework.dll, which contains a P/Invoke to a native function
that doesn't exist - see the tests/nunit.framework.targets file.