### PR TITLE
[ci] Opt in to symbol archiving during VS insertion (#12547)

### DIFF
--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -479,6 +479,7 @@ MSBUILD_PRODUCTS += $(DOTNET_TARGETS)
 DOTNET_IOS_WINDOWS_OUTPUT_FILES =                                \
 	$(foreach dll,$(IOS_WINDOWS_TASK_ASSEMBLIES),$(dll).*)       \
 	$(foreach dll,$(IOS_WINDOWS_DEPENDENCIES),$(dll).*)          \
+	System.Diagnostics.Tracer.pdb                                \
 	Broker.zip                                                   \
 	Build.zip                                                    \
 	Xamarin.PreBuilt.iOS.app.zip

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Xamarin.Messaging.Core" Version="$(MessagingVersion)" IncludeAssets="build" />
     <PackageReference Include="Xamarin.Messaging.Server" Version="$(MessagingVersion)" IncludeAssets="contentFiles" />
     <PackageReference Include="Xamarin.iOS.HotRestart.Client" Version="$(HotRestartVersion)" />
+    <PackageReference Include="System.Diagnostics.Tracer" Version="2.0.8" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messaging\Xamarin.Messaging.Build\Xamarin.Messaging.Build.csproj">
@@ -33,6 +34,7 @@
       <Link>Xamarin.PreBuilt.iOS.app.zip</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="$(PkgSystem_Diagnostics_Tracer)\lib\netstandard1.3\System.Diagnostics.Tracer.pdb" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Tasks\" />

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -29,6 +29,7 @@ $(DOTNET_DESTDIR)/%.Sdk/tools/bin/bgen: bgen/bgen.dotnet | $(DOTNET_DESTDIR)/%.S
 
 $(DOTNET_DESTDIR)/%.Sdk/tools/lib/Xamarin.Apple.BindingAttributes.dll: $(DOTNET_BUILD_DIR)/Xamarin.Apple.BindingAttributes.dll | $(DOTNET_DESTDIR)/%.Sdk/tools/lib
 	$(Q) $(CP) $< $@
+	$(Q) $(CP) $(<:.dll=.pdb) $(@:.dll=.pdb)
 
 DOTNET_TARGETS += \
 	$(DOTNET_BUILD_DIR)/bgen/bgen \

--- a/src/bgen/bgen.csproj
+++ b/src/bgen/bgen.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+    <PackageReference Include="Mono.Options" Version="6.12.0.148" GeneratePathProperty="true" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="4.7.2" />
     <!--<PackageReference Include="XliffTasks" Version="1.0.0-beta.19607.1" PrivateAssets="all" />-->
   </ItemGroup>
@@ -68,6 +68,7 @@
     <Compile Include="..\..\tools\common\SdkVersions.cs">
       <Link>SdkVersions.cs</Link>
     </Compile>
+    <None Include="$(PkgMono_Options)\lib\netstandard2.0\Mono.Options.pdb" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\Resources.resx">

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -78,4 +78,11 @@ stages:
 - template: vs-insertion/stage/v1.yml@templates
   parameters:
     dependsOn: prepare_release
+    symbolArtifactName: nuget-signed
+    symbolArtifactPatterns: |
+      Microsoft.NET.Sdk.iOS.Manifest*.nupkg
+      Microsoft.NET.Sdk.MacCatalyst.Manifest*.nupkg
+      Microsoft.iOS*.nupkg
+      Microsoft.MacCatalyst*.nupkg
+    symbolConversionFilters: '*mlaunch.app*'
     condition: eq(variables.IsPRBuild, 'False')


### PR DESCRIPTION
Backport of: https://github.com/xamarin/xamarin-macios/pull/12547
Context: https://github.com/xamarin/yaml-templates/pull/131

Enables conversion and archiving of symbol files during the VS insertion
stage.  Symbol archiving steps will only run if both the
`symbolArtifactName` parameter is provided, and `archiveSymbols` is set
to true.  The `symbolConversionFilters` parameter can be used to filter
out paths of symbol files that should not be converted/archived.