### PR TITLE
Generated msi files for all packages

### DIFF
--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -79,10 +79,5 @@ stages:
   parameters:
     dependsOn: prepare_release
     symbolArtifactName: nuget-signed
-    symbolArtifactPatterns: |
-      Microsoft.NET.Sdk.iOS.Manifest*.nupkg
-      Microsoft.NET.Sdk.MacCatalyst.Manifest*.nupkg
-      Microsoft.iOS*.nupkg
-      Microsoft.MacCatalyst*.nupkg
     symbolConversionFilters: '*mlaunch.app*'
     condition: eq(variables.IsPRBuild, 'False')


### PR DESCRIPTION
Since both tvOS and macOS are needed on Windows, we also need the .msi versions.