### PR TITLE
Generate msi files and VS setup authoring for all .NET 6 platforms

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -137,6 +137,8 @@ $(DOTNET_NUPKG_DIR)/vs-workload.props: Workloads/vs-workload.template.props
 		$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),-e "s/@$(platform)_WORKLOAD_VERSION@/$($(platform)_NUGET_VERSION).$($(platform)_NUGET_COMMIT_DISTANCE)/g") \
 		-e "s/@PACK_VERSION_LONG@/$(IOS_NUGET_VERSION_NO_METADATA)/g" \
 		-e "s/@PACK_VERSION_SHORT@/$(IOS_NUGET_VERSION).$(IOS_NUGET_COMMIT_DISTANCE)/g" \
+		-e "s/@MACOS_PACK_VERSION_LONG@/$(MACOS_NUGET_VERSION_NO_METADATA)/g" \
+		-e "s/@MACOS_PACK_VERSION_SHORT@/$(MACOS_NUGET_VERSION).$(MACOS_NUGET_COMMIT_DISTANCE)/g" \
 		$< > $@.tmp
 	$(Q) mv $@.tmp $@
 

--- a/dotnet/Workloads/vs-workload.template.props
+++ b/dotnet/Workloads/vs-workload.template.props
@@ -12,9 +12,6 @@
     <ShortNames Include="Microsoft.MacCatalyst.Runtime.maccatalyst">
       <Replacement>Microsoft.MacCatalyst.Runtime</Replacement>
     </ShortNames>
-    <ShortNames Include="Microsoft.NET.Sdk.MacCatalyst.Manifest">
-      <Replacement>Microsoft.MacCatalyst.Manifest</Replacement>
-    </ShortNames>
     <ComponentResources Include="ios" Version="@IOS_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for iOS" Description=".NET SDK Workload for building iOS applications."/>
     <ComponentResources Include="maccatalyst" Version="@MACCATALYST_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for Mac Catalyst" Description=".NET SDK Workload for building macOS applications with Mac Catalyst."/>
     <ComponentResources Include="macos" Version="@MACOS_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for macOS" Description=".NET SDK Workload for building macOS applications."/>

--- a/dotnet/Workloads/vs-workload.template.props
+++ b/dotnet/Workloads/vs-workload.template.props
@@ -12,6 +12,9 @@
     <ShortNames Include="Microsoft.MacCatalyst.Runtime.maccatalyst">
       <Replacement>Microsoft.MacCatalyst.Runtime</Replacement>
     </ShortNames>
+      <ShortNames Include="Microsoft.NET.Sdk.MacCatalyst.Manifest">
+        <Replacement>Microsoft.MacCatalyst.Manifest</Replacement>
+      </ShortNames>
     <ComponentResources Include="ios" Version="@IOS_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for iOS" Description=".NET SDK Workload for building iOS applications."/>
     <ComponentResources Include="maccatalyst" Version="@MACCATALYST_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for Mac Catalyst" Description=".NET SDK Workload for building macOS applications with Mac Catalyst."/>
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.iOS.Manifest*.nupkg" Version="@IOS_WORKLOAD_VERSION@" />

--- a/dotnet/Workloads/vs-workload.template.props
+++ b/dotnet/Workloads/vs-workload.template.props
@@ -18,6 +18,9 @@
     <ShortNames Include="Microsoft.NET.Sdk.MacCatalyst.Manifest">
       <Replacement>Microsoft.MacCatalyst.Manifest</Replacement>
     </ShortNames>
+    <ShortNames Include="Microsoft.tvOS.Runtime.tvossimulator">
+      <Replacement>Microsoft.tvOS.Runtime</Replacement>
+    </ShortNames>
     <ComponentResources Include="ios" Version="@IOS_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for iOS" Description=".NET SDK Workload for building iOS applications."/>
     <ComponentResources Include="maccatalyst" Version="@MACCATALYST_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for Mac Catalyst" Description=".NET SDK Workload for building macOS applications with Mac Catalyst."/>
     <ComponentResources Include="macos" Version="@MACOS_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for macOS" Description=".NET SDK Workload for building macOS applications."/>

--- a/dotnet/Workloads/vs-workload.template.props
+++ b/dotnet/Workloads/vs-workload.template.props
@@ -12,9 +12,9 @@
     <ShortNames Include="Microsoft.MacCatalyst.Runtime.maccatalyst">
       <Replacement>Microsoft.MacCatalyst.Runtime</Replacement>
     </ShortNames>
-      <ShortNames Include="Microsoft.NET.Sdk.MacCatalyst.Manifest">
-        <Replacement>Microsoft.MacCatalyst.Manifest</Replacement>
-      </ShortNames>
+    <ShortNames Include="Microsoft.NET.Sdk.MacCatalyst.Manifest">
+      <Replacement>Microsoft.MacCatalyst.Manifest</Replacement>
+    </ShortNames>
     <ComponentResources Include="ios" Version="@IOS_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for iOS" Description=".NET SDK Workload for building iOS applications."/>
     <ComponentResources Include="maccatalyst" Version="@MACCATALYST_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for Mac Catalyst" Description=".NET SDK Workload for building macOS applications with Mac Catalyst."/>
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.iOS.Manifest*.nupkg" Version="@IOS_WORKLOAD_VERSION@" />

--- a/dotnet/Workloads/vs-workload.template.props
+++ b/dotnet/Workloads/vs-workload.template.props
@@ -12,6 +12,9 @@
     <ShortNames Include="Microsoft.MacCatalyst.Runtime.maccatalyst">
       <Replacement>Microsoft.MacCatalyst.Runtime</Replacement>
     </ShortNames>
+    <ShortNames Include="Microsoft.NET.Sdk.MacCatalyst.Manifest">
+      <Replacement>Microsoft.MacCatalyst.Manifest</Replacement>
+    </ShortNames>
     <ComponentResources Include="ios" Version="@IOS_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for iOS" Description=".NET SDK Workload for building iOS applications."/>
     <ComponentResources Include="maccatalyst" Version="@MACCATALYST_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for Mac Catalyst" Description=".NET SDK Workload for building macOS applications with Mac Catalyst."/>
     <ComponentResources Include="macos" Version="@MACOS_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for macOS" Description=".NET SDK Workload for building macOS applications."/>

--- a/dotnet/Workloads/vs-workload.template.props
+++ b/dotnet/Workloads/vs-workload.template.props
@@ -9,6 +9,9 @@
     <ShortNames Include="@PACK_VERSION_LONG@">
       <Replacement>@PACK_VERSION_SHORT@</Replacement>
     </ShortNames>
+    <ShortNames Include="@MACOS_PACK_VERSION_LONG@">
+      <Replacement>@MACOS_PACK_VERSION_SHORT@</Replacement>
+    </ShortNames>
     <ShortNames Include="Microsoft.MacCatalyst.Runtime.maccatalyst">
       <Replacement>Microsoft.MacCatalyst.Runtime</Replacement>
     </ShortNames>

--- a/dotnet/Workloads/vs-workload.template.props
+++ b/dotnet/Workloads/vs-workload.template.props
@@ -17,7 +17,11 @@
     </ShortNames>
     <ComponentResources Include="ios" Version="@IOS_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for iOS" Description=".NET SDK Workload for building iOS applications."/>
     <ComponentResources Include="maccatalyst" Version="@MACCATALYST_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for Mac Catalyst" Description=".NET SDK Workload for building macOS applications with Mac Catalyst."/>
+    <ComponentResources Include="macos" Version="@MACOS_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for macOS" Description=".NET SDK Workload for building macOS applications."/>
+    <ComponentResources Include="tvos" Version="@TVOS_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for tvOS" Description=".NET SDK Workload for building tvOS applications."/>
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.iOS.Manifest*.nupkg" Version="@IOS_WORKLOAD_VERSION@" />
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.MacCatalyst.Manifest*.nupkg" Version="@MACCATALYST_WORKLOAD_VERSION@" />
+    <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.macOS.Manifest*.nupkg" Version="@MACOS_WORKLOAD_VERSION@" />
+    <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.tvOS.Manifest*.nupkg" Version="@TVOS_WORKLOAD_VERSION@" />
   </ItemGroup>
 </Project>

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -128,7 +128,7 @@ resources:
   - repository: templates
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/pjc/shorten-manifests
     endpoint: xamarin
 
   - repository: maccore

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -8,7 +8,7 @@
 parameters:
 - name: runTests
   type: boolean
-  default: true
+  default: false
 
 - name: runDeviceTests
   type: boolean
@@ -258,7 +258,7 @@ stages:
         enableDotnet: ${{ parameters.enableDotnet }}
 
 # .NET 6 Release Prep and VS Insertion Stages, only execute them when the build comes from an official branch and is not a schedule build from OneLoc
-- ${{ if and(ne(variables['Build.Reason'], 'Schedule'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
+- ${{ if and(ne(variables['Build.Reason'], 'Schedule'), or(eq(variables['Build.SourceBranch'], 'refs/heads/mattleibow/tvos-msi'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
   - template: templates/release/vs-insertion-prep.yml
 
 # Test stages

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -8,7 +8,7 @@
 parameters:
 - name: runTests
   type: boolean
-  default: false
+  default: true
 
 - name: runDeviceTests
   type: boolean

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -128,7 +128,7 @@ resources:
   - repository: templates
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/pjc/shorten-manifests
+    ref: refs/heads/main
     endpoint: xamarin
 
   - repository: maccore
@@ -258,7 +258,7 @@ stages:
         enableDotnet: ${{ parameters.enableDotnet }}
 
 # .NET 6 Release Prep and VS Insertion Stages, only execute them when the build comes from an official branch and is not a schedule build from OneLoc
-- ${{ if and(ne(variables['Build.Reason'], 'Schedule'), or(eq(variables['Build.SourceBranch'], 'refs/heads/mattleibow/tvos-msi'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
+- ${{ if and(ne(variables['Build.Reason'], 'Schedule'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
   - template: templates/release/vs-insertion-prep.yml
 
 # Test stages

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -74,10 +74,5 @@ stages:
   parameters:
     dependsOn: prepare_release
     symbolArtifactName: nuget-signed
-    symbolArtifactPatterns: |
-      Microsoft.NET.Sdk.iOS.Manifest*.nupkg
-      Microsoft.NET.Sdk.MacCatalyst.Manifest*.nupkg
-      Microsoft.iOS*.nupkg
-      Microsoft.MacCatalyst*.nupkg
     symbolConversionFilters: '*mlaunch.app*'
     condition: eq(variables.IsPRBuild, 'False')

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -17,7 +17,7 @@ stages:
   - template: sign-artifacts/jobs/v2.yml@templates
     parameters:
       artifactName: package
-      signType: Real
+      signType: Test
       usePipelineArtifactTasks: true
 
   # Check - "xamarin-macios (Prepare Release Convert NuGet to MSI)"
@@ -27,12 +27,13 @@ stages:
       dependsOn: signing
       artifactName: nuget-signed
       propsArtifactName: package
-      signType: Real
+      signType: Test
 
   # Check - "xamarin-macios (Prepare Release Push NuGets)"
   - job: push_signed_nugets
     displayName: Push NuGets
     dependsOn: nuget_convert
+    condition: false
     variables:
       skipNugetSecurityAnalysis: true
     pool:
@@ -75,4 +76,5 @@ stages:
     dependsOn: prepare_release
     symbolArtifactName: nuget-signed
     symbolConversionFilters: '*mlaunch.app*'
+    createVSPR: false
     condition: eq(variables.IsPRBuild, 'False')

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -33,7 +33,6 @@ stages:
   - job: push_signed_nugets
     displayName: Push NuGets
     dependsOn: nuget_convert
-    condition: false
     variables:
       skipNugetSecurityAnalysis: true
     pool:
@@ -76,5 +75,4 @@ stages:
     dependsOn: prepare_release
     symbolArtifactName: nuget-signed
     symbolConversionFilters: '*mlaunch.app*'
-    createVSPR: false
     condition: eq(variables.IsPRBuild, 'False')

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -26,11 +26,6 @@ stages:
       yamlResourceName: templates
       dependsOn: signing
       artifactName: nuget-signed
-      artifactPatterns: |
-        Microsoft.NET.Sdk.iOS.Manifest*.nupkg
-        Microsoft.NET.Sdk.MacCatalyst.Manifest*.nupkg
-        Microsoft.iOS*.nupkg
-        Microsoft.MacCatalyst*.nupkg
       propsArtifactName: package
       signType: Real
 

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -17,7 +17,7 @@ stages:
   - template: sign-artifacts/jobs/v2.yml@templates
     parameters:
       artifactName: package
-      signType: Test
+      signType: Real
       usePipelineArtifactTasks: true
 
   # Check - "xamarin-macios (Prepare Release Convert NuGet to MSI)"
@@ -27,7 +27,7 @@ stages:
       dependsOn: signing
       artifactName: nuget-signed
       propsArtifactName: package
-      signType: Test
+      signType: Real
 
   # Check - "xamarin-macios (Prepare Release Push NuGets)"
   - job: push_signed_nugets


### PR DESCRIPTION
Since both tvOS and macOS are needed on Windows, we also need the .msi versions.

tvOS and macOS are needed on Windows so that we can built multi-targeted libraries.

This also needs to go to RC 1