### PR TITLE
[release/6.0.1xx-rc.1] Generated msi files for all packages

### DIFF
--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -26,11 +26,6 @@ stages:
       yamlResourceName: templates
       dependsOn: signing
       artifactName: nuget-signed
-      artifactPatterns: |
-        Microsoft.NET.Sdk.iOS.Manifest*.nupkg
-        Microsoft.NET.Sdk.MacCatalyst.Manifest*.nupkg
-        Microsoft.iOS*.nupkg
-        Microsoft.MacCatalyst*.nupkg
       propsArtifactName: package
       signType: Real
 


### PR DESCRIPTION
Since both tvOS and macOS are needed on Windows, we also need the .msi versions.

tvOS and macOS are needed on Windows so that we can built multi-targeted libraries.

This also needs to go to RC 1


Backport of #12581
