### PR TITLE
[release/6.0.1xx-rc.1] [ci] Authenticode sign Mono.Options.dll

### DIFF
--- a/dotnet/Workloads/SignList.xml
+++ b/dotnet/Workloads/SignList.xml
@@ -1,7 +1,6 @@
 <Project>
   <!-- Do not sign files that already have a signature -->
   <ItemGroup>
-    <Skip Include="Mono.Options.dll" />
     <Skip Include="System.Reflection.MetadataLoadContext.dll" />
     <!-- Microsoft.iOS.Windows.Sdk content -->
     <Skip Include="tools\msbuild\iOS\Microsoft.Win32.Registry.dll" />
@@ -49,6 +48,7 @@
   <ItemGroup>
     <FirstParty Include="bgen.dll" />
     <FirstParty Include="dotnet-linker.dll" />
+    <FirstParty Include="Mono.Options.dll" />
     <FirstParty Include="Xamarin.*.dll" />
     <!-- mlaunch.app MonoBundle content-->
     <FirstParty Include="mlaunch.exe" />


### PR DESCRIPTION
Commit 91c6517f bumped to a new Mono.Options package version that
included symbol files, however it appears to be missing a Microsoft
digital signature.  We can fix this by signing the file ourselves rather
than skipping it.


Backport of #12585
