### PR TITLE
[build] Add missing Hot Restart symbol files.

### DIFF
--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -479,7 +479,9 @@ MSBUILD_PRODUCTS += $(DOTNET_TARGETS)
 DOTNET_IOS_WINDOWS_OUTPUT_FILES =                                \
 	$(foreach dll,$(IOS_WINDOWS_TASK_ASSEMBLIES),$(dll).*)       \
 	$(foreach dll,$(IOS_WINDOWS_DEPENDENCIES),$(dll).*)          \
+	iSign.Core.pdb                                               \
 	System.Diagnostics.Tracer.pdb                                \
+	Xamarin.iOS.Windows.Client.pdb                               \
 	Broker.zip                                                   \
 	Build.zip                                                    \
 	Xamarin.PreBuilt.iOS.app.zip

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Xamarin.Messaging.Build.Client" Version="$(MessagingVersion)" IncludeAssets="contentFiles" />
     <PackageReference Include="Xamarin.Messaging.Core" Version="$(MessagingVersion)" IncludeAssets="build" />
     <PackageReference Include="Xamarin.Messaging.Server" Version="$(MessagingVersion)" IncludeAssets="contentFiles" />
-    <PackageReference Include="Xamarin.iOS.HotRestart.Client" Version="$(HotRestartVersion)" />
+    <PackageReference Include="Xamarin.iOS.HotRestart.Client" Version="$(HotRestartVersion)" GeneratePathProperty="true" />
     <PackageReference Include="System.Diagnostics.Tracer" Version="2.0.8" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
@@ -34,6 +34,8 @@
       <Link>Xamarin.PreBuilt.iOS.app.zip</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="$(PkgXamarin_iOS_HotRestart_Client)\lib\netstandard2.0\iSign.Core.pdb" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(PkgXamarin_iOS_HotRestart_Client)\lib\netstandard2.0\Xamarin.iOS.Windows.Client.pdb" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(PkgSystem_Diagnostics_Tracer)\lib\netstandard1.3\System.Diagnostics.Tracer.pdb" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Commit 91c6517f missed a few symbol files because it was tested against
a version of Hot Restart assemblies that had already been inserted into
VS.  The Hot Restart package version bump in commit fbbaa7fc triggered
a couple of new SymbolCheck issues that can be fixed by bringing in the
previously missed pdbs.