### PR TITLE
Fixing Main: Invalid Obsolete Message

### DIFF
--- a/src/AudioUnit/AudioComponentDescription.cs
+++ b/src/AudioUnit/AudioComponentDescription.cs
@@ -125,7 +125,7 @@ namespace AudioUnit
 #if IOS
 		[Obsolete ("Starting with ios13.0 use 'AudioTypeConverter.NewTimePitch' instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #elif TVOS
-		[Obsolete ("Starting with tvos13.0 use 'AudioTypeConverter.NewTimePitch' instead.'", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
+		[Obsolete ("Starting with tvos13.0 use 'AudioTypeConverter.NewTimePitch' instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif // if !NET
 		AUiPodTime=0x6970746d, // 'iptm'


### PR DESCRIPTION
I know we have a test to check other deprecated messages. I'll see if we can extend that to check these dotnet obsoletes as well.