### PR TITLE
[avkit] Fix `VideoCallSupport` category failure on MacCatalyst 15

### DIFF
--- a/src/avkit.cs
+++ b/src/avkit.cs
@@ -842,15 +842,18 @@ namespace AVKit {
 
 		// interface AVPictureInPictureControllerContentSource_VideoCallSupport
 		[NoWatch, NoTV, NoMac]
+		[NoMacCatalyst] // doc as available, intro fails on macOS 12 beta 6
 		[Export ("initWithActiveVideoCallSourceView:contentViewController:")]
 		IntPtr Constructor (UIView sourceView, AVPictureInPictureVideoCallViewController contentViewController);
 
 		[NullAllowed]
 		[NoWatch, NoTV, NoMac]
+		[NoMacCatalyst] // doc as available, intro fails on macOS 12 beta 6
 		[Export ("activeVideoCallSourceView", ArgumentSemantic.Weak)]
 		UIView ActiveVideoCallSourceView { get; }
 
 		[NoWatch, NoTV, NoMac]
+		[NoMacCatalyst] // doc as available, intro fails on macOS 12 beta 6
 		[Export ("activeVideoCallContentViewController")]
 		AVPictureInPictureVideoCallViewController ActiveVideoCallContentViewController { get; }
 

--- a/tests/xtro-sharpie/MacCatalyst-AVKit.ignore
+++ b/tests/xtro-sharpie/MacCatalyst-AVKit.ignore
@@ -5,3 +5,8 @@
 !extra-enum-value! Managed value -1100 for AVKitError.ContentRatingUnknown not found in native headers
 !extra-enum-value! Managed value -1101 for AVKitError.ContentDisallowedByPasscode not found in native headers
 !extra-enum-value! Managed value -1102 for AVKitError.ContentDisallowedByProfile not found in native headers
+
+## `VideoCallSupport` category introspection failures on MacCatalyst 15
+!missing-selector! AVPictureInPictureControllerContentSource::activeVideoCallContentViewController not bound
+!missing-selector! AVPictureInPictureControllerContentSource::activeVideoCallSourceView not bound
+!missing-selector! AVPictureInPictureControllerContentSource::initWithActiveVideoCallSourceView:contentViewController: not bound


### PR DESCRIPTION
Web documentation mention them to be available. Introspection disagree.

Since they are all related to a single `VideoCallSupport` category, this
feature is likely not available to Catalyst.