### PR TITLE
[mailkit] Disable some selector not working on macOS 12 beta 6

### DIFF
--- a/src/mailkit.cs
+++ b/src/mailkit.cs
@@ -108,6 +108,7 @@ namespace MailKit {
 		[Export ("markAsUnreadAction")]
 		MEMessageAction MarkAsUnread { get; }
 
+#if false // does not respond (nor work in ObjC) with macOS 12 beta 6
 		[Static]
 		[Export ("flagAction")]
 		MEMessageAction Flag { get; }
@@ -119,6 +120,7 @@ namespace MailKit {
 		[Static]
 		[Export ("setColorActionWithColor:")]
 		MEMessageAction SetColor (MEMessageActionMessageColor color);
+#endif
 	}
 
 	[NoWatch, NoTV, NoiOS, NoMacCatalyst, Mac (12,0)]

--- a/tests/xtro-sharpie/macOS-MailKit.ignore
+++ b/tests/xtro-sharpie/macOS-MailKit.ignore
@@ -1,0 +1,4 @@
+# does not respond on macOS 12 beta 6 (same when using Xcode / ObjC)
+!missing-selector! +MEMessageAction::flagAction not bound
+!missing-selector! +MEMessageAction::setColorActionWithColor: not bound
+!missing-selector! +MEMessageAction::unflagAction not bound


### PR DESCRIPTION
The framework is only available on macOS 12.

It's possible (my guess) that the selectors were renamed after Xcode 13
beta 5 was released. In that case a future (RC?) Xcode will have the
updated headers.

Most selectors are working as expected

```
NSLog (@"%@", [MEMessageAction markAsReadAction]);

Message Action: Destination: (null), Read Status: 1, Flag Change: (null), Message Color: 0
```

while the last 3 do not work, even from an ObjC application

```
NSLog (@"%@", [MEMessageAction flagAction]);

+[MEMessageAction flagAction]: unrecognized selector sent to class 0x7ffa601fc5d8
```

```
NSLog (@"%@", [MEMessageAction unflagAction]);

+[MEMessageAction unflagAction]: unrecognized selector sent to class 0x7ffa601fc5d8
```

```
NSLog (@"%@", [MEMessageAction setColorActionWithColor:(MEMessageActionMessageColorRed) ]);

+[MEMessageAction setColorActionWithColor:]: unrecognized selector sent to class 0x7ffa601fc5d8
```