### PR TITLE
[audiounit] remove duplicate `using System.Runtime.Versioning;` to avoid build warnings

### DIFF
--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -39,7 +39,6 @@ using AudioToolbox;
 using ObjCRuntime;
 using CoreFoundation;
 using Foundation;
-using System.Runtime.Versioning;
 
 namespace AudioUnit
 {


### PR DESCRIPTION
```
AudioUnit/AudioUnit.cs(42,7): warning CS0105: The using directive for 'System.Runtime.Versioning' appeared previously in this namespace
```