### PR TITLE
[dotnet] Support SupportedOSPlatformVersion. Fixes #12336.

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/template.json
@@ -31,10 +31,10 @@
     },
     "minOSVersion": {
       "type": "parameter",
-      "description": "Overrides LSMinimumSystemVersion in the Info.plist",
+      "description": "Overrides SupportedOSPlatformVersion in the project file",
       "replaces": "minOSVersion",
       "datatype": "string",
-      "defaultValue": "10.15.1"
+      "defaultValue": "14.2"
     }
   },
   "defaultName": "MacCatalystApp1"

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/Info.plist
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/Info.plist
@@ -10,8 +10,6 @@
     <string>1.0</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
-    <key>LSMinimumSystemVersion</key>
-        <string>minOSVersion</string>
     <key>UIDeviceFamily</key>
     <array>
         <integer>2</integer>

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/MacCatalystApp1.csproj
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/MacCatalystApp1.csproj
@@ -6,5 +6,6 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
+    <SupportedOSPlatformVersion>minOSVersion</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/template.json
@@ -31,7 +31,7 @@
       },
       "minOSVersion": {
         "type": "parameter",
-        "description": "Overrides MinimumOSVersion in the Info.plist",
+        "description": "Overrides SupportedOSPlatformVersion in the project file",
         "replaces": "minOSVersion",
         "datatype": "string",
         "defaultValue": "11.2"

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/Info.plist
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/Info.plist
@@ -12,8 +12,6 @@
     <string>1.0</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
-    <key>MinimumOSVersion</key>
-        <string>minOSVersion</string>
     <key>UIDeviceFamily</key>
     <array>
         <!--#if((deviceFamily == "iphone") || (deviceFamily == "universal"))

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/iOSApp1.csproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/iOSApp1.csproj
@@ -5,5 +5,6 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
+    <SupportedOSPlatformVersion>minOSVersion</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/template.json
@@ -31,7 +31,7 @@
       },
       "minOSVersion": {
         "type": "parameter",
-        "description": "Overrides LSMinimumSystemVersion in the Info.plist",
+        "description": "Overrides SupportedOSPlatformVersion in the project file",
         "replaces": "minOSVersion",
         "datatype": "string",
         "defaultValue": "10.14"

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/Info.plist
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/Info.plist
@@ -10,8 +10,6 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>minOSVersion</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/macOSApp1.csproj
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/macOSApp1.csproj
@@ -5,5 +5,6 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
+    <SupportedOSPlatformVersion>minOSVersion</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/template.json
@@ -31,10 +31,10 @@
     },
     "minOSVersion": {
       "type": "parameter",
-      "description": "Overrides MinimumOSVersion in the Info.plist",
+      "description": "Overrides SupportedOSPlatformVersion in the project file",
       "replaces": "minOSVersion",
       "datatype": "string",
-      "defaultValue": "11.2"
+      "defaultValue": "14.0"
     }
   },
   "defaultName": "tvOSApp1"

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/template.json
@@ -34,7 +34,7 @@
       "description": "Overrides SupportedOSPlatformVersion in the project file",
       "replaces": "minOSVersion",
       "datatype": "string",
-      "defaultValue": "14.0"
+      "defaultValue": "11.2"
     }
   },
   "defaultName": "tvOSApp1"

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/Info.plist
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/Info.plist
@@ -10,8 +10,6 @@
     <string>1.0</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
-    <key>MinimumOSVersion</key>
-        <string>minOSVersion</string>
     <key>UIDeviceFamily</key>
     <array>
         <integer>3</integer>

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/tvOSApp1.csproj
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/tvOSApp1.csproj
@@ -5,5 +5,6 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
+    <SupportedOSPlatformVersion>minOSVersion</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -1904,6 +1904,15 @@ namespace Xamarin.Localization.MSBuild {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The {0} value in the Info.plist ({1}) does not match the SupportedOSPlatformVersion value in the project file ({2})..
+        /// </summary>
+        public static string E7082 {
+            get {
+                return ResourceManager.GetString("E7082", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid framework: {0}.
         /// </summary>
         public static string InvalidFramework {

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1308,4 +1308,13 @@
             {0}: the path to the compiler
         </comment>
     </data>
+
+    <data name="E7082" xml:space="preserve">
+        <value>The {0} value in the Info.plist ({1}) does not match the SupportedOSPlatformVersion value in the project file ({2}).</value>
+        <comment>
+            {0}: the name of a value from the Info.plist file the message talks about (either 'MinimumOSVersion' or 'LSMinimumSystemVersion').
+            {1}: the value from the Info.plist.
+            {2}: the value from the project file.
+        </comment>
+    </data>
 </root>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -183,7 +183,7 @@ namespace Xamarin.MacDev.Tasks
 				return false;
 			} else if (!string.IsNullOrEmpty (convertedSupportedOSPlatformVersion) && convertedSupportedOSPlatformVersion != minimumOSVersionInManifest) {
 				// SupportedOSPlatformVersion and the value in the Info.plist are not the same. This is an error.
-				Log.LogError (null, null, null, AppManifest, 0, 0, 0, 0, "The {0} value in the Info.plist ({1}) does not match the SupportedOSPlatformVersion value in the project file ({2}).", minimumVersionKey, minimumOSVersionInManifest, SupportedOSPlatformVersion); // FIXME: add tests + translated string.
+				Log.LogError (null, null, null, AppManifest, 0, 0, 0, 0, MSBStrings.E7082, minimumVersionKey, minimumOSVersionInManifest, SupportedOSPlatformVersion);
 				return false;
 			} else {
 				minimumOSVersion = minimumOSVersionInManifest;

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -336,6 +336,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			SdkPlatform="$(_SdkPlatform)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			SdkVersion="$(_SdkVersion)"
+			SupportedOSPlatformVersion="$(SupportedOSPlatformVersion)"
 			DebugIPAddresses="$(_DebugIPAddresses)"
 			Validate="$(_CreateAppManifest)"
 			>

--- a/tests/common/TestProjects/AppWithExtraArgumentThatOverrides/AppWithExtraArgumentThatOverrides.dotnet.csproj
+++ b/tests/common/TestProjects/AppWithExtraArgumentThatOverrides/AppWithExtraArgumentThatOverrides.dotnet.csproj
@@ -5,6 +5,7 @@
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <MtouchLink>None</MtouchLink>
+    <SupportedOSPlatformVersion>11.4</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/common/TestProjects/Bug60536/Bug60536.dotnet.csproj
+++ b/tests/common/TestProjects/Bug60536/Bug60536.dotnet.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>10.3</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/My Spaced App/My Spaced App.dotnet.csproj
+++ b/tests/common/TestProjects/My Spaced App/My Spaced App.dotnet.csproj
@@ -7,6 +7,7 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>MySpacedApp</AssemblyName>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyActionExtension/MyActionExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyActionExtension/MyActionExtension.dotnet.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyAppWithPackageReference/MyAppWithPackageReference.dotnet.csproj
+++ b/tests/common/TestProjects/MyAppWithPackageReference/MyAppWithPackageReference.dotnet.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyCoreMLApp/MyCoreMLApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyCoreMLApp/MyCoreMLApp.dotnet.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyDocumentPickerExtension/MyDocumentPickerExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyDocumentPickerExtension/MyDocumentPickerExtension.dotnet.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyExtensionWithPackageReference/MyExtensionWithPackageReference.dotnet.csproj
+++ b/tests/common/TestProjects/MyExtensionWithPackageReference/MyExtensionWithPackageReference.dotnet.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyIBToolLinkTest/MyIBToolLinkTest.dotnet.csproj
+++ b/tests/common/TestProjects/MyIBToolLinkTest/MyIBToolLinkTest.dotnet.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyKeyboardExtension/MyKeyboardExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyKeyboardExtension/MyKeyboardExtension.dotnet.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
+    <SupportedOSPlatformVersion>9.3</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyLinkedAssets/MyLinkedAssets.dotnet.csproj
+++ b/tests/common/TestProjects/MyLinkedAssets/MyLinkedAssets.dotnet.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>10.2</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <!-- No automatic inclusion since these files are outside of the project directory -->

--- a/tests/common/TestProjects/MyMasterDetailApp/MyMasterDetailApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyMasterDetailApp/MyMasterDetailApp.dotnet.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyMetalGame/MyMetalGame.dotnet.csproj
+++ b/tests/common/TestProjects/MyMetalGame/MyMetalGame.dotnet.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyOpenGLApp/MyOpenGLApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyOpenGLApp/MyOpenGLApp.dotnet.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>8.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyPhotoEditingExtension/MyPhotoEditingExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyPhotoEditingExtension/MyPhotoEditingExtension.dotnet.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyReleaseBuild/MyReleaseBuild.dotnet.csproj
+++ b/tests/common/TestProjects/MyReleaseBuild/MyReleaseBuild.dotnet.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MySceneKitApp/MySceneKitApp.dotnet.csproj
+++ b/tests/common/TestProjects/MySceneKitApp/MySceneKitApp.dotnet.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyShareExtension/MyShareExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyShareExtension/MyShareExtension.dotnet.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MySingleView/MySingleView.dotnet.csproj
+++ b/tests/common/TestProjects/MySingleView/MySingleView.dotnet.csproj
@@ -6,6 +6,7 @@
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <DefaultItemExcludes>$(DefaultItemExcludes);MyLibrary\**</DefaultItemExcludes>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MySpriteKitGame/MySpriteKitGame.dotnet.csproj
+++ b/tests/common/TestProjects/MySpriteKitGame/MySpriteKitGame.dotnet.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyTVApp/MyTVApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyTVApp/MyTVApp.dotnet.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0-tvos</TargetFramework>
     <RuntimeIdentifier>tvossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyTVMetalGame/MyTVMetalGame.dotnet.csproj
+++ b/tests/common/TestProjects/MyTVMetalGame/MyTVMetalGame.dotnet.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net6.0-tvos</TargetFramework>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifier>tvossimulator-x64</RuntimeIdentifier>
+    <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyTVServicesExtension/MyTVServicesExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyTVServicesExtension/MyTVServicesExtension.dotnet.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net6.0-tvos</TargetFramework>
     <RuntimeIdentifier>tvossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyTabbedApplication/MyTabbedApplication.dotnet.csproj
+++ b/tests/common/TestProjects/MyTabbedApplication/MyTabbedApplication.dotnet.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyTodayExtension/MyTodayExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyTodayExtension/MyTodayExtension.dotnet.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
+    <SupportedOSPlatformVersion>8.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyWatch2Container/MyWatch2Container.dotnet.csproj
+++ b/tests/common/TestProjects/MyWatch2Container/MyWatch2Container.dotnet.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>9.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyWebViewApp/MyWebViewApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyWebViewApp/MyWebViewApp.dotnet.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyXamarinFormsApp/MyXamarinFormsApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyXamarinFormsApp/MyXamarinFormsApp.dotnet.csproj
@@ -5,6 +5,7 @@
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/common/TestProjects/MyiOSAppWithBinding/MyiOSAppWithBinding.dotnet.csproj
+++ b/tests/common/TestProjects/MyiOSAppWithBinding/MyiOSAppWithBinding.dotnet.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -7,6 +7,8 @@
 	<PropertyGroup Condition="$(TargetFramework.EndsWith('-ios'))">
 		<AssetTargetFallback>xamarinios10;$(AssetTargetFallback)</AssetTargetFallback>
 		<NativeLibName>ios-fat</NativeLibName>
+		<!-- We need this because we'd otherwise default to the latest OS version we support, and we'll want to execute on earlier versions -->
+		<SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 	<ItemGroup Condition="'$(_PlatformName)' == 'iOS'">
 		<PackageReference Include="MonoTouch.Dialog" Version="2.0.0-pre1" />
@@ -17,6 +19,7 @@
 		<DefineConstants>$(DefineConstants);XAMCORE_3_0</DefineConstants>
 		<AssetTargetFallback>xamarintvos10;$(AssetTargetFallback)</AssetTargetFallback>
 		<NativeLibName>tvos-fat</NativeLibName>
+		<SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 	<ItemGroup Condition="$(TargetFramework.EndsWith('-tvos'))">
 		<PackageReference Include="MonoTouch.Dialog" Version="2.0.0-pre1" />
@@ -26,12 +29,14 @@
 	<PropertyGroup Condition="$(TargetFramework.EndsWith('-macos'))">
 		<DefineConstants>$(DefineConstants);MONOMAC</DefineConstants>
 		<NativeLibName>macos-fat</NativeLibName>
+		<SupportedOSPlatformVersion>10.15</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
 	<!-- Logic for Mac Catalyst -->
 	<PropertyGroup Condition="$(TargetFramework.EndsWith('-maccatalyst'))">
 		<AssetTargetFallback>xamarinios10;$(AssetTargetFallback)</AssetTargetFallback>
 		<NativeLibName>maccatalyst-fat</NativeLibName>
+		<SupportedOSPlatformVersion>13.3</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
 	<!-- Logic for all test suites -->

--- a/tests/dotnet/MyCatalystApp/Info.plist
+++ b/tests/dotnet/MyCatalystApp/Info.plist
@@ -14,8 +14,6 @@
 	</array>
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.15</string>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
 </dict>

--- a/tests/dotnet/MyCatalystApp/MyCatalystApp.csproj
+++ b/tests/dotnet/MyCatalystApp/MyCatalystApp.csproj
@@ -8,5 +8,6 @@
     <ApplicationTitle>MyCatalystApp</ApplicationTitle>
     <ApplicationId>com.xamarin.mycatalystapp</ApplicationId>
     <ApplicationVersion>3.14</ApplicationVersion>
+    <SupportedOSPlatformVersion>13.1</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/dotnet/MyCocoaApp/Info.plist
+++ b/tests/dotnet/MyCocoaApp/Info.plist
@@ -10,8 +10,6 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.14</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/tests/dotnet/MyCocoaApp/MyCocoaApp.csproj
+++ b/tests/dotnet/MyCocoaApp/MyCocoaApp.csproj
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0-macos</TargetFramework>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/dotnet/MySimpleApp/MacCatalyst/Info.plist
+++ b/tests/dotnet/MySimpleApp/MacCatalyst/Info.plist
@@ -2,8 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- We need this because we'd otherwise default to the latest macOS version we support (currently 12.0), and we'll want to execute on earlier versions -->
-	<key>LSMinimumSystemVersion</key>
-	<string>11.0</string>
 </dict>
 </plist>

--- a/tests/dotnet/MySimpleApp/iOS/Info.plist
+++ b/tests/dotnet/MySimpleApp/iOS/Info.plist
@@ -2,7 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- We need this because some tests will build this project for 32-bit targets -->
-	<key>MinimumOSVersion</key>
-	<string>10.0</string></dict>
+</dict>
 </plist>

--- a/tests/dotnet/MySimpleApp/macOS/Info.plist
+++ b/tests/dotnet/MySimpleApp/macOS/Info.plist
@@ -2,8 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- We need this because we'd otherwise default to the latest macOS version we support (currently 12.0), and we'll want to execute on earlier versions -->
-	<key>LSMinimumSystemVersion</key>
-	<string>11.0</string>
 </dict>
 </plist>

--- a/tests/dotnet/MySimpleApp/shared.csproj
+++ b/tests/dotnet/MySimpleApp/shared.csproj
@@ -8,6 +8,8 @@
 		<ApplicationVersion>3.14</ApplicationVersion>
 	</PropertyGroup>
 
+	<Import Project="../../common/shared-dotnet.csproj" />
+
 	<ItemGroup>
 		<Compile Include="../*.cs" />
 		<None Include="Info.plist" />

--- a/tests/dotnet/MySingleView/Info.plist
+++ b/tests/dotnet/MySingleView/Info.plist
@@ -12,8 +12,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
 	<key>XSLaunchImageAssets</key>

--- a/tests/dotnet/MySingleView/MySingleView.csproj
+++ b/tests/dotnet/MySingleView/MySingleView.csproj
@@ -7,5 +7,6 @@
     <ApplicationTitle>MySingleTitle</ApplicationTitle>
     <ApplicationId>com.xamarin.mysingletitle</ApplicationId>
     <ApplicationVersion>3.14</ApplicationVersion>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/dotnet/MyTVApp/Info.plist
+++ b/tests/dotnet/MyTVApp/Info.plist
@@ -14,8 +14,6 @@
 	</array>
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>MyTVApp</string>
 	<key>CFBundleIdentifier</key>

--- a/tests/dotnet/MyTVApp/MyTVApp.csproj
+++ b/tests/dotnet/MyTVApp/MyTVApp.csproj
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0-tvos</TargetFramework>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/dotnet/MyXamarinFormsApp/Info.plist
+++ b/tests/dotnet/MyXamarinFormsApp/Info.plist
@@ -20,8 +20,6 @@
         <string>UIInterfaceOrientationLandscapeLeft</string>
         <string>UIInterfaceOrientationLandscapeRight</string>
     </array>
-    <key>MinimumOSVersion</key>
-    <string>10.0</string>
     <key>CFBundleDisplayName</key>
     <string>MyXamarinFormsApp</string>
     <key>CFBundleIdentifier</key>

--- a/tests/dotnet/MyXamarinFormsApp/MyXamarinFormsApp.csproj
+++ b/tests/dotnet/MyXamarinFormsApp/MyXamarinFormsApp.csproj
@@ -5,6 +5,7 @@
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/iOS/Info.plist
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/iOS/Info.plist
@@ -2,7 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 </dict>
 </plist>

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/macOS/Info.plist
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/macOS/Info.plist
@@ -2,7 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>LSMinimumSystemVersion</key>
-	<string>11.0</string>
 </dict>
 </plist>

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/shared.csproj
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/shared.csproj
@@ -8,6 +8,8 @@
 		<ApplicationVersion>1.0</ApplicationVersion>
 	</PropertyGroup>
 
+	<Import Project="../../common/shared-dotnet.csproj" />
+
 	<ItemGroup>
 		<NativeReference Include="..\..\..\test-libraries\.libs\$(FatName)\libtest.dylib" Kind="Dynamic" />
 	</ItemGroup>

--- a/tests/dotnet/NativeFileReferencesApp/iOS/Info.plist
+++ b/tests/dotnet/NativeFileReferencesApp/iOS/Info.plist
@@ -2,7 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 </dict>
 </plist>

--- a/tests/dotnet/NativeFileReferencesApp/macOS/Info.plist
+++ b/tests/dotnet/NativeFileReferencesApp/macOS/Info.plist
@@ -2,7 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>LSMinimumSystemVersion</key>
-	<string>11.0</string>
 </dict>
 </plist>

--- a/tests/dotnet/NativeFileReferencesApp/shared.csproj
+++ b/tests/dotnet/NativeFileReferencesApp/shared.csproj
@@ -8,6 +8,8 @@
 		<ApplicationVersion>1.0</ApplicationVersion>
 	</PropertyGroup>
 
+	<Import Project="../../common/shared-dotnet.csproj" />
+
 	<ItemGroup>
 		<NativeReference Include="..\..\..\test-libraries\.libs\$(FatName)\libtest.a" Kind="Static" />
 		<NativeReference Include="..\..\..\test-libraries\.libs\$(FatName)\libtest2.a" Kind="Static" />

--- a/tests/dotnet/NativeFrameworkReferencesApp/iOS/Info.plist
+++ b/tests/dotnet/NativeFrameworkReferencesApp/iOS/Info.plist
@@ -2,7 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 </dict>
 </plist>

--- a/tests/dotnet/NativeFrameworkReferencesApp/macOS/Info.plist
+++ b/tests/dotnet/NativeFrameworkReferencesApp/macOS/Info.plist
@@ -2,7 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>LSMinimumSystemVersion</key>
-	<string>11.0</string>
 </dict>
 </plist>

--- a/tests/dotnet/NativeFrameworkReferencesApp/shared.csproj
+++ b/tests/dotnet/NativeFrameworkReferencesApp/shared.csproj
@@ -8,6 +8,8 @@
 		<ApplicationVersion>1.0</ApplicationVersion>
 	</PropertyGroup>
 
+	<Import Project="../../common/shared-dotnet.csproj" />
+
 	<ItemGroup>
 		<NativeReference Include="..\..\..\test-libraries\.libs\$(FatName)\XTest.framework" Kind="Framework" />
 		<NativeReference Include="..\..\..\test-libraries\.libs\$(FatName)\XStaticArTest.framework" Kind="Framework" CopyToAppBundle="false" />

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/iOS/Info.plist
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/iOS/Info.plist
@@ -2,7 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 </dict>
 </plist>

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/macOS/Info.plist
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/macOS/Info.plist
@@ -2,7 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>LSMinimumSystemVersion</key>
-	<string>11.0</string>
 </dict>
 </plist>

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/shared.csproj
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/shared.csproj
@@ -8,6 +8,8 @@
 		<ApplicationVersion>1.0</ApplicationVersion>
 	</PropertyGroup>
 
+	<Import Project="../../common/shared-dotnet.csproj" />
+
 	<ItemGroup>
 		<NativeReference Include="..\..\..\test-libraries\.libs\XTest.xcframework" Kind="Framework" />
 	</ItemGroup>

--- a/tests/dotnet/SimpleAppWithOldReferences/MacCatalyst/Info.plist
+++ b/tests/dotnet/SimpleAppWithOldReferences/MacCatalyst/Info.plist
@@ -2,8 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- We need this because we'd otherwise default to the latest macOS version we support (currently 12.0), and we'll want to execute on earlier versions -->
-	<key>LSMinimumSystemVersion</key>
-	<string>11.0</string>
 </dict>
 </plist>

--- a/tests/dotnet/SimpleAppWithOldReferences/iOS/Info.plist
+++ b/tests/dotnet/SimpleAppWithOldReferences/iOS/Info.plist
@@ -2,6 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string></dict>
+</dict>
 </plist>

--- a/tests/dotnet/SimpleAppWithOldReferences/macOS/Info.plist
+++ b/tests/dotnet/SimpleAppWithOldReferences/macOS/Info.plist
@@ -2,8 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- We need this because we'd otherwise default to the latest macOS version we support (currently 12.0), and we'll want to execute on earlier versions -->
-	<key>LSMinimumSystemVersion</key>
-	<string>11.0</string>
 </dict>
 </plist>

--- a/tests/dotnet/SimpleAppWithOldReferences/shared.csproj
+++ b/tests/dotnet/SimpleAppWithOldReferences/shared.csproj
@@ -8,6 +8,8 @@
 		<ApplicationVersion>1.0</ApplicationVersion>
 	</PropertyGroup>
 
+	<Import Project="../../common/shared-dotnet.csproj" />
+
 	<ItemGroup>
 		<Compile Include="../*.cs" />
 		<None Include="Info.plist" />

--- a/tests/dotnet/size-comparison/MySingleView/dotnet/MySingleView.csproj
+++ b/tests/dotnet/size-comparison/MySingleView/dotnet/MySingleView.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../AppDelegate.cs" />

--- a/tests/framework-test/dotnet/MacCatalyst/Info.plist
+++ b/tests/framework-test/dotnet/MacCatalyst/Info.plist
@@ -8,7 +8,5 @@
 		<string>com.xamarin.framework-test</string>
 		<key>CFBundleName</key>
 		<string>framework-test</string>
-		<key>LSMinimumSystemVersion</key>
-		<string>10.15</string>
 	</dict>
 </plist>

--- a/tests/framework-test/dotnet/iOS/Info.plist
+++ b/tests/framework-test/dotnet/iOS/Info.plist
@@ -8,7 +8,5 @@
 		<string>com.xamarin.framework-test</string>
 		<key>CFBundleName</key>
 		<string>framework-test</string>
-		<key>MinimumOSVersion</key>
-		<string>10.0</string>
 	</dict>
 </plist>

--- a/tests/framework-test/dotnet/macOS/Info.plist
+++ b/tests/framework-test/dotnet/macOS/Info.plist
@@ -8,7 +8,5 @@
 		<string>com.xamarin.framework-test</string>
 		<key>CFBundleName</key>
 		<string>framework-test</string>
-		<key>LSMinimumSystemVersion</key>
-		<string>10.14</string>
 	</dict>
 </plist>

--- a/tests/framework-test/dotnet/tvOS/Info.plist
+++ b/tests/framework-test/dotnet/tvOS/Info.plist
@@ -8,7 +8,5 @@
 		<string>com.xamarin.framework-test</string>
 		<key>CFBundleName</key>
 		<string>framework-test</string>
-		<key>MinimumOSVersion</key>
-		<string>10.0</string>
 	</dict>
 </plist>

--- a/tests/fsharp/dotnet/MacCatalyst/Info.plist
+++ b/tests/fsharp/dotnet/MacCatalyst/Info.plist
@@ -4,7 +4,5 @@
 <dict>
 	<key>CFBundleIdentifier</key>
 	<string>com.xamarin.fsharp</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.15</string>
 </dict>
 </plist>

--- a/tests/fsharp/dotnet/iOS/Info.plist
+++ b/tests/fsharp/dotnet/iOS/Info.plist
@@ -4,7 +4,5 @@
   <dict>
     <key>CFBundleIdentifier</key>
     <string>com.xamarin.fsharp</string>
-    <key>MinimumOSVersion</key>
-    <string>10.0</string>
   </dict>
 </plist>

--- a/tests/fsharp/dotnet/macOS/Info.plist
+++ b/tests/fsharp/dotnet/macOS/Info.plist
@@ -4,7 +4,5 @@
 <dict>
 	<key>CFBundleIdentifier</key>
 	<string>com.xamarin.fsharp</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.14</string>
 </dict>
 </plist>

--- a/tests/fsharp/dotnet/tvOS/Info.plist
+++ b/tests/fsharp/dotnet/tvOS/Info.plist
@@ -4,7 +4,5 @@
   <dict>
     <key>CFBundleIdentifier</key>
     <string>com.xamarin.fsharp</string>
-    <key>MinimumOSVersion</key>
-    <string>10.0</string>
   </dict>
 </plist>

--- a/tests/interdependent-binding-projects/dotnet/MacCatalyst/Info.plist
+++ b/tests/interdependent-binding-projects/dotnet/MacCatalyst/Info.plist
@@ -8,7 +8,5 @@
 		<string>com.xamarin.dotnet.interdependentbindingprojects</string>
 		<key>CFBundleName</key>
 		<string>InterdependentBindingProject</string>
-		<key>LSMinimumSystemVersion</key>
-		<string>10.15</string>
 	</dict>
 </plist>

--- a/tests/interdependent-binding-projects/dotnet/iOS/Info.plist
+++ b/tests/interdependent-binding-projects/dotnet/iOS/Info.plist
@@ -8,8 +8,6 @@
 		<string>com.xamarin.dotnet.interdependentbindingprojects</string>
 		<key>CFBundleName</key>
 		<string>InterdependentBindingProject</string>
-		<key>MinimumOSVersion</key>
-		<string>10.0</string>
 		<key>UIDeviceFamily</key>
 		<array>
 			<integer>1</integer>

--- a/tests/interdependent-binding-projects/dotnet/macOS/Info.plist
+++ b/tests/interdependent-binding-projects/dotnet/macOS/Info.plist
@@ -8,7 +8,5 @@
 		<string>com.xamarin.dotnet.interdependentbindingprojects</string>
 		<key>CFBundleName</key>
 		<string>InterdependentBindingProject</string>
-		<key>LSMinimumSystemVersion</key>
-		<string>10.14</string>
 	</dict>
 </plist>

--- a/tests/interdependent-binding-projects/dotnet/tvOS/Info.plist
+++ b/tests/interdependent-binding-projects/dotnet/tvOS/Info.plist
@@ -8,8 +8,6 @@
 		<string>com.xamarin.dotnet.interdependentbindingprojects</string>
 		<key>CFBundleName</key>
 		<string>InterdependentBindingProject</string>
-		<key>MinimumOSVersion</key>
-		<string>10.0</string>
 		<key>UIDeviceFamily</key>
 		<array>
 			<integer>3</integer>

--- a/tests/introspection/dotnet/MacCatalyst/Info.plist
+++ b/tests/introspection/dotnet/MacCatalyst/Info.plist
@@ -10,8 +10,6 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.15</string>
 	<key>NSAppleMusicUsageDescription</key>
 	<string>Testing tastes</string>
 	<key>NSHomeKitUsageDescription</key>

--- a/tests/introspection/dotnet/iOS/Info.plist
+++ b/tests/introspection/dotnet/iOS/Info.plist
@@ -10,8 +10,6 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 	<key>NSAppleMusicUsageDescription</key>
 	<string>Testing tastes</string>
 	<key>NSHomeKitUsageDescription</key>

--- a/tests/introspection/dotnet/macOS/Info.plist
+++ b/tests/introspection/dotnet/macOS/Info.plist
@@ -8,8 +8,6 @@
 	<string>com.xamarin.introspection</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.14</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>LSApplicationCategoryType</key>

--- a/tests/introspection/dotnet/tvOS/Info.plist
+++ b/tests/introspection/dotnet/tvOS/Info.plist
@@ -10,8 +10,6 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 	<key>NSAppleMusicUsageDescription</key>
 	<string>Testing tastes</string>
 	<key>NSHomeKitUsageDescription</key>

--- a/tests/linker/ios/dont link/dotnet/MacCatalyst/Info.plist
+++ b/tests/linker/ios/dont link/dotnet/MacCatalyst/Info.plist
@@ -6,7 +6,5 @@
     <string>DontLinkTest</string>
     <key>CFBundleIdentifier</key>
     <string>com.xamarin.dontlink</string>
-    <key>LSMinimumSystemVersion</key>
-    <string>10.15</string>
   </dict>
 </plist>

--- a/tests/linker/ios/dont link/dotnet/iOS/Info.plist
+++ b/tests/linker/ios/dont link/dotnet/iOS/Info.plist
@@ -6,8 +6,6 @@
     <string>DontLinkTest</string>
     <key>CFBundleIdentifier</key>
     <string>com.xamarin.dontlink</string>
-    <key>MinimumOSVersion</key>
-    <string>10.0</string>
     <key>UIDeviceFamily</key>
     <array>
       <integer>1</integer>

--- a/tests/linker/ios/dont link/dotnet/macOS/Info.plist
+++ b/tests/linker/ios/dont link/dotnet/macOS/Info.plist
@@ -8,7 +8,5 @@
 		<string>com.xamarin.dontlink</string>
 		<key>CFBundleName</key>
 		<string>DontLinkTest</string>
-		<key>LSMinimumSystemVersion</key>
-		<string>10.14</string>
 	</dict>
 </plist>

--- a/tests/linker/ios/dont link/dotnet/tvOS/Info.plist
+++ b/tests/linker/ios/dont link/dotnet/tvOS/Info.plist
@@ -6,8 +6,6 @@
     <string>DontLinkTest</string>
     <key>CFBundleIdentifier</key>
     <string>com.xamarin.dontlink</string>
-    <key>MinimumOSVersion</key>
-    <string>10.0</string>
     <key>UIDeviceFamily</key>
     <array>
       <integer>3</integer>

--- a/tests/linker/ios/link all/dotnet/MacCatalyst/Info.plist
+++ b/tests/linker/ios/link all/dotnet/MacCatalyst/Info.plist
@@ -6,7 +6,5 @@
 		<string>LinkAll</string>
 		<key>CFBundleIdentifier</key>
 		<string>com.xamarin.linkall</string>
-		<key>LSMinimumSystemVersion</key>
-		<string>10.15</string>
 	</dict>
 </plist>

--- a/tests/linker/ios/link all/dotnet/iOS/Info.plist
+++ b/tests/linker/ios/link all/dotnet/iOS/Info.plist
@@ -8,8 +8,6 @@
 	<string>com.xamarin.linkall</string>
 	<key>CFBundleName</key>
 	<string>LinkAll</string>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/tests/linker/ios/link all/dotnet/macOS/Info.plist
+++ b/tests/linker/ios/link all/dotnet/macOS/Info.plist
@@ -8,7 +8,5 @@
 		<string>com.xamarin.linkall</string>
 		<key>CFBundleName</key>
 		<string>LinkAllTest</string>
-		<key>LSMinimumSystemVersion</key>
-		<string>10.14</string>
 	</dict>
 </plist>

--- a/tests/linker/ios/link all/dotnet/tvOS/Info.plist
+++ b/tests/linker/ios/link all/dotnet/tvOS/Info.plist
@@ -8,8 +8,6 @@
     <string>com.xamarin.linkall</string>
     <key>CFBundleName</key>
     <string>LinkAll</string>
-    <key>MinimumOSVersion</key>
-    <string>10.0</string>
     <key>UIDeviceFamily</key>
     <array>
       <integer>3</integer>

--- a/tests/linker/ios/link sdk/dotnet/MacCatalyst/Info.plist
+++ b/tests/linker/ios/link sdk/dotnet/MacCatalyst/Info.plist
@@ -6,7 +6,5 @@
 		<string>LinkSdkTest</string>
 		<key>CFBundleIdentifier</key>
 		<string>com.xamarin.linksdk</string>
-		<key>LSMinimumSystemVersion</key>
-		<string>10.15</string>
 	</dict>
 </plist>

--- a/tests/linker/ios/link sdk/dotnet/iOS/Info.plist
+++ b/tests/linker/ios/link sdk/dotnet/iOS/Info.plist
@@ -6,8 +6,6 @@
 	<string>LinkSdkTest</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.xamarin.linksdk</string>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/tests/linker/ios/link sdk/dotnet/macOS/Info.plist
+++ b/tests/linker/ios/link sdk/dotnet/macOS/Info.plist
@@ -8,7 +8,5 @@
 		<string>com.xamarin.linksdk</string>
 		<key>CFBundleName</key>
 		<string>LinkSdkTest</string>
-		<key>LSMinimumSystemVersion</key>
-		<string>10.14</string>
 	</dict>
 </plist>

--- a/tests/linker/ios/link sdk/dotnet/tvOS/Info.plist
+++ b/tests/linker/ios/link sdk/dotnet/tvOS/Info.plist
@@ -6,8 +6,6 @@
     <string>LinkSdkTest</string>
     <key>CFBundleIdentifier</key>
     <string>com.xamarin.linksdk</string>
-    <key>MinimumOSVersion</key>
-    <string>10.0</string>
     <key>UIDeviceFamily</key>
     <array>
       <integer>3</integer>

--- a/tests/monotouch-test/dotnet/MacCatalyst/Info.plist
+++ b/tests/monotouch-test/dotnet/MacCatalyst/Info.plist
@@ -8,8 +8,6 @@
 	<string>com.xamarin.monotouch-test</string>
 	<key>CFBundleName</key>
 	<string>MonoTouchTest</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.15</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/tests/monotouch-test/dotnet/iOS/Info.plist
+++ b/tests/monotouch-test/dotnet/iOS/Info.plist
@@ -8,8 +8,6 @@
 	<string>com.xamarin.monotouch-test</string>
 	<key>CFBundleName</key>
 	<string>MonoTouchTest</string>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/tests/monotouch-test/dotnet/macOS/Info.plist
+++ b/tests/monotouch-test/dotnet/macOS/Info.plist
@@ -8,8 +8,6 @@
 	<string>com.xamarin.monotouch-test</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.14</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>LSUIElement</key>

--- a/tests/monotouch-test/dotnet/tvOS/Info.plist
+++ b/tests/monotouch-test/dotnet/tvOS/Info.plist
@@ -8,8 +8,6 @@
     <string>com.xamarin.monotouch-test</string>
     <key>CFBundleName</key>
     <string>MonoTouchTest</string>
-    <key>MinimumOSVersion</key>
-    <string>10.0</string>
     <key>NSAppTransportSecurity</key>
     <dict>
       <key>NSAllowsArbitraryLoads</key>

--- a/tests/xcframework-test/dotnet/MacCatalyst/Info.plist
+++ b/tests/xcframework-test/dotnet/MacCatalyst/Info.plist
@@ -8,7 +8,5 @@
 		<string>com.xamarin.xcframework-test</string>
 		<key>CFBundleName</key>
 		<string>xcframework-test</string>
-		<key>LSMinimumSystemVersion</key>
-		<string>10.15</string>
 	</dict>
 </plist>

--- a/tests/xcframework-test/dotnet/iOS/Info.plist
+++ b/tests/xcframework-test/dotnet/iOS/Info.plist
@@ -8,7 +8,5 @@
 		<string>com.xamarin.xcframework-test</string>
 		<key>CFBundleName</key>
 		<string>xcframework-test</string>
-		<key>MinimumOSVersion</key>
-		<string>10.0</string>
 	</dict>
 </plist>

--- a/tests/xcframework-test/dotnet/macOS/Info.plist
+++ b/tests/xcframework-test/dotnet/macOS/Info.plist
@@ -8,7 +8,5 @@
 		<string>com.xamarin.xcframework-test</string>
 		<key>CFBundleName</key>
 		<string>xcframework-test</string>
-		<key>LSMinimumSystemVersion</key>
-		<string>10.14</string>
 	</dict>
 </plist>

--- a/tests/xcframework-test/dotnet/tvOS/Info.plist
+++ b/tests/xcframework-test/dotnet/tvOS/Info.plist
@@ -8,7 +8,5 @@
 		<string>com.xamarin.xcframework-test</string>
 		<key>CFBundleName</key>
 		<string>xcframework-test</string>
-		<key>MinimumOSVersion</key>
-		<string>10.0</string>
 	</dict>
 </plist>


### PR DESCRIPTION
* Add support for the SupportedOSPlatformVersion MSBuild property, and write
  it to the Info.plist for the corresponding minimum OS version.
* If there are any minimum OS version in the Info.plist, we'll now show an
  error if it doesn't match SupportedOSPlatformVersion.

This unfortunately means that if there's any minimum OS version in any
Info.plist, then that will most likely have to be moved to the
SupportedOSPlatformVersion property (or removed entirely if that's the right
choice), since it's unlikely to match the default value for
SupportedOSPlatformVersion. However, this was deemed to be the best option for
the future (it's a one-time pain during migration).

Also add new tests, update existing tests, and update the templates.

Fixes https://github.com/xamarin/xamarin-macios/issues/12336.