### PR TITLE
[tests] Remove assert that fails on M1 on Rosetta.

### DIFF
--- a/tests/monotouch-test/CoreFoundation/BundleTest.cs
+++ b/tests/monotouch-test/CoreFoundation/BundleTest.cs
@@ -371,8 +371,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 			bool loadable_arm64 = CFBundle.IsArchitectureLoadable (CFBundle.Architecture.ARM64);
 			if (isArm64Executable)
 				Assert.IsTrue (loadable_arm64, "arm64 Expected => true");
-			else
-				Assert.IsFalse (loadable_arm64, "arm64 Expected => false");
+			// Due to Rosetta, we can't determine whether ARM64 is loadable or not if we're an X64 executable ourselves.
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes this error when running on M1 (and Rosetta):

    MonoTouchFixtures.CoreFoundation.BundleTest.TestGetBundleIdNull : 0.9134 ms
        [FAIL] TestIsArchitectureLoadable :   arm64 Expected => false
            Expected: False
            But was:  True
                at MonoTouchFixtures.CoreFoundation.BundleTest.TestIsArchitectureLoadable() in xamarin-macios/tests/monotouch-test/CoreFoundation/BundleTest.cs:line 375