### PR TITLE
[dotnet] rename $(AppleShortVersion) to $(ApplicationDisplayVersion)

### DIFF
--- a/dotnet/SingleProject.md
+++ b/dotnet/SingleProject.md
@@ -10,16 +10,23 @@ For our Apple platforms this means we're mapping the following MSBuild
 properties to Info.plist keys (this mapping will only take place if the
 Info.plist in the project doesn't already contain entries for these keys):
 
-| MSBuild Property    | Info.plist key             | Notes                                     |
-| --------------------|----------------------------|-------------------------------------------|
-| ApplicationId       | CFBundleIdentifier         |                                           |
-| ApplicationTitle    | CFBundleDisplayName        |                                           |
-| ApplicationVersion  | CFBundleVersion            |                                           |
-| AppleShortVersion   | CFBundleShortVersionString | Defaults to ApplicationVersion when blank |
+| MSBuild Property          | Info.plist key             | Notes                                     |
+| --------------------------|----------------------------|-------------------------------------------|
+| ApplicationId             | CFBundleIdentifier         |                                           |
+| ApplicationTitle          | CFBundleDisplayName        |                                           |
+| ApplicationVersion        | CFBundleVersion            |                                           |
+| ApplicationDisplayVersion | CFBundleShortVersionString | Defaults to ApplicationVersion when blank |
 
 This is only enabled if the `GenerateApplicationManifest` is set to `true`
 (which is the default for `.NET 6`, and not for "legacy"
 Xamarin.iOS/Xamarin.Mac)
+
+Additionally, `$(ApplicationDisplayVersion)` will overwrite the value for `$(Version)`,
+so the following properties will be set with the same value:
+
+* `$(AssemblyVersion)`
+* `$(FileVersion)`
+* `$(InformationalVersion)`
 
 Ref: [Issue #10473][2]
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -4,6 +4,7 @@
 	<PropertyGroup>
 		<!-- Use single-project MSBuild properties to generate the application manifest by default -->
 		<GenerateApplicationManifest Condition="'$(GenerateApplicationManifest)' == ''">true</GenerateApplicationManifest>
+		<Version Condition="'$(GenerateApplicationManifest)' == 'true' and '$(ApplicationDisplayVersion)' != ''">$(ApplicationDisplayVersion)</Version>
 	</PropertyGroup>
 
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.CompileNativeCode" AssemblyFile="$(_XamarinTaskAssembly)" />

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -18,7 +18,7 @@ namespace Xamarin.MacDev.Tasks
 		public string ApplicationId { get; set; }
 
 		// Single-project property that maps to CFBundleShortVersionString for Apple platforms
-		public string AppleShortVersion { get; set; }
+		public string ApplicationDisplayVersion { get; set; }
 
 		// Single-project property that maps to CFBundleDisplayName for Apple platforms
 		public string ApplicationTitle { get; set; }
@@ -116,8 +116,8 @@ namespace Xamarin.MacDev.Tasks
 
 			string defaultBundleShortVersion = null;
 			if (GenerateApplicationManifest) {
-				if (!string.IsNullOrEmpty (AppleShortVersion))
-					defaultBundleShortVersion = AppleShortVersion;
+				if (!string.IsNullOrEmpty (ApplicationDisplayVersion))
+					defaultBundleShortVersion = ApplicationDisplayVersion;
 				else if (!string.IsNullOrEmpty (ApplicationVersion))
 					defaultBundleShortVersion = ApplicationVersion;
 			}

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -314,10 +314,10 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<CompileAppManifest
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
-			AppleShortVersion="$(AppleShortVersion)"
 			ApplicationId="$(ApplicationId)"
 			ApplicationTitle="$(ApplicationTitle)"
 			ApplicationVersion="$(ApplicationVersion)"
+			ApplicationDisplayVersion="$(ApplicationDisplayVersion)"
 			AppBundleName="$(_AppBundleName)"
 			AppManifest="$(_AppManifest)"
 			AssemblyName="$(AssemblyName)"


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/1662
Context: https://github.com/xamarin/xamarin-android/pull/6139

Previously:

* `$(ApplicationVersion)` mapped to `CFBundleVersion`
* `$(AppleShortVersion)` mapped to `CFBundleShortVersionString`

To be able to leverage identical property names on iOS/Android,
we're changing this to:

* `$(ApplicationVersion)` maps to `CFBundleVersion`
* `$(ApplicationDisplayVersion)` maps to `CFBundleShortVersionString`

Lastly, let's allow `$(ApplicationDisplayVersion)` to set `$(Version)`,
so the various C# assembly-level attributes are all set to the same value.