### PR TITLE
[foundation] Enable nullability on NSString manual bindings

### DIFF
--- a/src/Foundation/NSString2.cs
+++ b/src/Foundation/NSString2.cs
@@ -27,6 +27,8 @@ using System;
 using System.Runtime.InteropServices;
 using ObjCRuntime;
 
+#nullable enable
+
 namespace Foundation {
 
 	public partial class NSString : IComparable<NSString> {
@@ -45,11 +47,11 @@ namespace Foundation {
 #endif
 		}
 
-		public static NSString FromData (NSData data, NSStringEncoding encoding)
+		public static NSString? FromData (NSData data, NSStringEncoding encoding)
 		{
-			if (data == null) 
-				throw new ArgumentNullException ("data");
-			NSString ret = null;
+			if (data is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
+			NSString? ret = null;
 			try { 
 				ret = new NSString (data, encoding);
 			} catch (Exception) {
@@ -58,8 +60,11 @@ namespace Foundation {
 			return ret;
 		}
 
-		public int CompareTo (NSString other)
+		public int CompareTo (NSString? other)
 		{
+			// `compare:` behavior is undefined if `nil` is provided, so we need to handle that case.
+			if (other is null)
+				return -1;
 			return (int)Compare (other);
 		}
 


### PR DESCRIPTION
Also fix `compare:` undefined behavior if used with `nil`.

ref: https://github.com/xamarin/xamarin-macios/wiki/Nullability