### PR TITLE
[msbuild/dotnet] Don't use the built-in publishing logic in .NET to copy frameworks to the app bundle. Fixes #12369.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -232,6 +232,7 @@
 			_LinkNativeExecutable;
 			_ComputePublishLocation;
 			CopyFilesToPublishDirectory;
+			_CopyFrameworksToBundle;
 			_CopyAppExtensionsToBundle;
 		</CreateAppBundleDependsOn>
 
@@ -560,28 +561,37 @@
 		<WriteLinesToFile SessionId="$(BuildSessionId)" File="$(_CustomLinkerOptionsFile)" Lines="$(_CustomLinkerOptions)" Overwrite="true" />
 	</Target>
 
-	<!-- Look in the NativeReference items for frameworks that need to be added to the app bundle, and add all those frameworks to ResolvedFileToPublish (as separate files) -->
+	<!-- Look in the _FrameworkNativeReference items for frameworks that need to be added to the app bundle, and add all those frameworks to _FrameworkToPublish -->
 	<Target Name="_ComputeFrameworkFilesToPublish" DependsOnTargets="_ExpandNativeReferences;_ComputeVariables;_LoadLinkerOutput">
 		<ItemGroup>
-			<!-- Expand each framework (which are directories) into all the files in the framework -->
-			<!-- Support a 'CopyToAppBundle' metadata that can be set to 'false' to avoid copying a framework to the app bundle -->
-			<_FrameworkFilesToPublish Include="%(_FrameworkNativeReference.RootDir)%(_FrameworkNativeReference.Directory)/**/*" Condition="'%(_FrameworkNativeReference.Kind)' == 'Framework' And '%(_FrameworkNativeReference.CopyToAppBundle)' != 'false'">
-				<_FrameworkIdentity>%(RootDir)%(Directory)</_FrameworkIdentity>
-				<_FrameworkPath>$(_AppBundleFrameworksDir)\%(Filename).framework</_FrameworkPath>
-				<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-			</_FrameworkFilesToPublish>
+			<!-- Collect the list of frameworks to publish from _FrameworkNativeReference. The ExtractBindingLibrariesStep in the linker might also add frameworks to _FrameworkToPublish -->
+			<_FrameworkToPublish Include="@(_FrameworkNativeReference)" Condition="'%(_FrameworkNativeReference.Kind)' == 'Framework' And '%(_FrameworkNativeReference.CopyToAppBundle)' != 'false'" />
 
-			<!-- Compute the relative path of each file in the framework relative to the framework directory -->
-			<_FrameworkFilesToPublish Update="@(_FrameworkFilesToPublish)">
-				<_FrameworkRelativePath>$([System.String]::Copy('%(Identity)').Substring($([System.String]::Copy('%(_FrameworkIdentity)').Length)))</_FrameworkRelativePath>
-			</_FrameworkFilesToPublish>
-
-			<!-- Add all the framework files to ResolvedFileToPublish -->
-			<ResolvedFileToPublish Include="@(_FrameworkFilesToPublish)">
-				<RelativePath>%(_FrameworkFilesToPublish._FrameworkPath)\%(_FrameworkFilesToPublish._FrameworkRelativePath)</RelativePath>
-				<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-			</ResolvedFileToPublish>
+			<!-- Set TargetDirectory and SourceDirectory for all frameworks we have to publish -->
+			<_FrameworkToPublish Update="@(_FrameworkToPublish)">
+				<TargetDirectory>$(PublishDir)$(_AppBundleFrameworksDir)\%(Filename).framework</TargetDirectory>
+				<SourceDirectory>%(RootDir)%(Directory)</SourceDirectory>
+			</_FrameworkToPublish>
 		</ItemGroup>
+	</Target>
+
+	<Target Name="_CopyFrameworksToBundle"
+		DependsOnTargets="_ComputeFrameworkFilesToPublish"
+		Inputs="@(_FrameworkToPublish)"
+		Outputs="@(_FrameworkToPublish -> '%(TargetDirectory)%(Filename)')"
+		>
+		<!-- We specifically do *not* use the publishing logic in .NET to (ResolvedFileToPublish) copy frameworks to the app bundle, because symlinks aren't handled correctly.
+			 In particular, MSBuild can't handle symlinks to directories: https://github.com/dotnet/msbuild/issues/6821.
+			 So we have a custom item group (_FrameworkToPublish), which we copy ourselves.
+		-->
+		<Ditto
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			ToolExe="$(DittoExe)"
+			ToolPath="$(DittoPath)"
+			Source="%(_FrameworkToPublish.SourceDirectory)"
+			Destination="%(_FrameworkToPublish.TargetDirectory)"
+		/>
 	</Target>
 
 	<!-- Look in the NativeReference items for dylibs that need to be added to the app bundle, and add all those frameworks to ResolvedFileToPublish (as separate files) -->
@@ -641,9 +651,9 @@
 		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_AssembliesToAOT.items" Condition="Exists('$(_LinkerItemsDirectory)/_AssembliesToAOT.items')">
 			<Output TaskParameter="Items" ItemName="_AssembliesToAOT" />
 		</ReadItemsFromFile>
-		<!-- Load _FrameworkFilesToPublish -->
-		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_FrameworkFilesToPublish.items" Condition="Exists('$(_LinkerItemsDirectory)/_FrameworkFilesToPublish.items')">
-			<Output TaskParameter="Items" ItemName="_FrameworkFilesToPublish" />
+		<!-- Load _FrameworkToPublish -->
+		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_FrameworkToPublish.items" Condition="Exists('$(_LinkerItemsDirectory)/_FrameworkToPublish.items')">
+			<Output TaskParameter="Items" ItemName="_FrameworkToPublish" />
 		</ReadItemsFromFile>
 		<!-- Load _DynamicLibraryToPublish -->
 		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_DynamicLibraryToPublish.items" Condition="Exists('$(_LinkerItemsDirectory)/_DynamicLibraryToPublish.items')">

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -569,7 +569,7 @@
 
 			<!-- Set TargetDirectory and SourceDirectory for all frameworks we have to publish -->
 			<_FrameworkToPublish Update="@(_FrameworkToPublish)">
-				<TargetDirectory>$(PublishDir)$(_AppBundleFrameworksDir)\%(Filename).framework</TargetDirectory>
+				<TargetDirectory>$(_RelativePublishDir)$(_AppBundleFrameworksDir)\%(Filename).framework</TargetDirectory>
 				<SourceDirectory>%(RootDir)%(Directory)</SourceDirectory>
 			</_FrameworkToPublish>
 		</ItemGroup>
@@ -732,6 +732,8 @@
 			<!-- Take into account that 'PublishDir' may or may not be an absolute path to begin with -->
 			<_AbsolutePublishDir>$(PublishDir)</_AbsolutePublishDir>
 			<_AbsolutePublishDir Condition="!$([System.IO.Path]::IsPathRooted ('$(_AbsolutePublishDir)'))">$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\$(PublishDir)'))</_AbsolutePublishDir>
+			<!-- Compute the relative path to the publish directory ('PublishDir' is by default a relative path, but the developer might use an absolute path) -->
+			<_RelativePublishDir>$([MSBuild]::MakeRelative($(MSBuildProjectDirectory),$(_AbsolutePublishDir)))</_RelativePublishDir>
 			<!-- Compute the relative path of the app bundle relative to the publish directory. The _AppBundlePath is relative to the project directory, so to compute this we need to have both app bundle path and the publish directory as absolute paths first. -->
 			<_RelativeAppBundlePath>$([MSBuild]::MakeRelative($(_AbsolutePublishDir),$(MSBuildProjectDirectory)/$(_AppBundlePath)))</_RelativeAppBundlePath>
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -146,12 +146,14 @@ namespace Xamarin.MacDev.Tasks
 			// signing a framework and a file inside a framework is not *always* identical
 			// on macOS apps {item.ItemSpec} can be a symlink to `Versions/Current/{item.ItemSpec}`
 			// and `Current` also a symlink to `A`... and `_CodeSignature` will be found there
-			var path = PathUtils.ResolveSymbolicLinks (item.ItemSpec);
+			var path = item.ItemSpec;
 			var parent = Path.GetDirectoryName (path);
       
 			// so do not don't sign `A.framework/A`, sign `A.framework` which will always sign the *bundle*
 			if ((Path.GetExtension (parent) == ".framework") && (Path.GetFileName (path) == Path.GetFileNameWithoutExtension (parent)))
 				path = parent;
+
+			path = PathUtils.ResolveSymbolicLinks (path);
 			args.Add (Path.GetFullPath (path));
 
 			return args;

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -34,11 +34,19 @@ $(GENERATED_FILES_PATTERN): testgenerator.exe
 libtest-object.m libtest-ar.m:
 	$(Q) ln -fhs libtest.m $@
 
+MACOS_INFO_PLIST_INFIX=/Versions/A/Resources
+MACOS_BINARY_INFIX=/Versions/A
+MACCATALYST_INFO_PLIST_INFIX=/Versions/A/Resources
+MACCATALYST_BINARY_INFIX=/Versions/A
+
 define Template
 
+$(1)_XTEST_TARGETS += \
+	.libs/$(1)/XTest.framework$($(2)_BINARY_INFIX)/XTest \
+	.libs/$(1)/XTest.framework$($(2)_INFO_PLIST_INFIX)/Info.plist \
+
 $(2)_TARGETS = \
-	.libs/$(1)/XTest.framework/XTest \
-	.libs/$(1)/XTest.framework/Info.plist \
+	$$($(1)_XTEST_TARGETS) \
 	.libs/$(1)/XStaticObjectTest.framework/XStaticObjectTest \
 	.libs/$(1)/XStaticArTest.framework/XStaticArTest \
 	.libs/$(1)/libtest.dylib \
@@ -50,8 +58,12 @@ $(2)_TARGETS = \
 	$$(foreach arch,$(3),.libs/$(1)/libtest-object.$$(arch).a) \
 	$$(foreach arch,$(3),.libs/$(1)/libtest-ar.$$(arch).a) \
 	.libs/$(1)/XTest.framework \
+	.libs/$(1)/XTest.framework.stamp \
 
 all-local:: $$($(2)_TARGETS) $(GENERATED_FILES)
+
+.libs/$(1)/XTest.framework.stamp: $($(1)_XTEST_TARGETS)
+	$$(Q) touch $$@
 
 clean-$(1):
 	rm -Rf .libs/$(1)
@@ -99,11 +111,11 @@ COMMON_DYLIB_ARGS=-g -dynamiclib -gdwarf-2 -fms-extensions libframework.m -o $$@
 	$$(call Q_2,LIPO   [$(1)]) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo $$^ -create -output $$@
 
 # XTest is a framework where the binary code is a (fat) dynamic library
-.libs/$(1)/XTest.framework/XTest: .libs/$(1)/libtest.dylib | .libs/$(1)/XTest.framework
+.libs/$(1)/XTest.framework$($(2)_BINARY_INFIX)/XTest: .libs/$(1)/libtest.dylib | .libs/$(1)/XTest.framework$($(2)_BINARY_INFIX)
 	$$(Q) $(CP) $$^ $$@
 	$$(Q) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool -id @rpath/XTest.framework/XTest $$@
 
-.libs/$(1)/XTest.framework/Info.plist: XTest-Info.plist | .libs/$(1)/XTest.framework
+.libs/$(1)/XTest.framework$($(2)_INFO_PLIST_INFIX)/Info.plist: XTest-Info-$(1).plist | .libs/$(1)/XTest.framework$($(2)_INFO_PLIST_INFIX)
 	$$(Q) $(CP) $$^ $$@
 
 # XStaticObjectTest is a framework where the binary code is a (fat) object file
@@ -142,6 +154,34 @@ $(eval $(call Template,macos,MACOS,x86_64 arm64,MacOSX,-mmacosx-version-min=$(MI
 endif
 ifdef INCLUDE_MACCATALYST
 $(eval $(call Template,maccatalyst,MACCATALYST,x86_64 arm64,MacCatalyst,$(MACCATALYST_COMMON_CFLAGS)))
+endif
+
+define SymlinksTemplate
+
+$(1)_XTEST_TARGETS += \
+	.libs/$(1)/XTest.framework/XTest \
+	.libs/$(1)/XTest.framework/Resources \
+	.libs/$(1)/XTest.framework/Versions/Current \
+	.libs/$(1)/XTest.framework/Versions/A/Resources/Info.plist \
+
+.libs/$(1)/XTest.framework$($(2)_BINARY_INFIX) .libs/$(1)/XTest.framework$($(2)_INFO_PLIST_INFIX):
+	$$(Q) mkdir -p $$@
+
+.libs/$(1)/XTest.framework/XTest:
+	$$(Q) ln -fs Versions/A/XTest $$@
+
+.libs/$(1)/XTest.framework/Resources:
+	$$(Q) ln -fs Versions/Current/Resources $$@
+
+.libs/$(1)/XTest.framework/Versions/Current:
+	$$(Q) ln -fs A $$@
+
+endef
+ifdef INCLUDE_MAC
+$(eval $(call SymlinksTemplate,macos,MACOS))
+endif
+ifdef INCLUDE_MACCATALYST
+$(eval $(call SymlinksTemplate,maccatalyst,MACCATALYST))
 endif
 
 .libs/ios-fat .libs/tvos-fat .libs/watchos-fat .libs/maccatalyst-fat .libs/macos-fat:
@@ -185,11 +225,11 @@ define FatFrameworkTemplate
 	$(Q) mkdir -p $$(dir $$@)
 	$(Q) lipo -create -output $$@ $$^
 
-.libs/$(1)/XTest.framework/XTest: .libs/$(2)/XTest.framework/XTest .libs/$(3)/XTest.framework/XTest | .libs/$(1)
+.libs/$(1)/XTest.framework$($(4)_BINARY_INFIX)/XTest: .libs/$(2)/XTest.framework$($(4)_BINARY_INFIX)/XTest .libs/$(3)/XTest.framework$($(4)_BINARY_INFIX)/XTest | .libs/$(1)
 	$(Q) mkdir -p $$(dir $$@)
 	$(Q) lipo -create -output $$@ $$^
 
-.libs/$(1)/XTest.framework/Info.plist: .libs/$(2)/XTest.framework/Info.plist .libs/$(3)/XTest.framework/Info.plist
+.libs/$(1)/XTest.framework$($(4)_INFO_PLIST_INFIX)/Info.plist: .libs/$(2)/XTest.framework$($(4)_INFO_PLIST_INFIX)/Info.plist .libs/$(3)/XTest.framework$($(4)_INFO_PLIST_INFIX)/Info.plist
 	$(Q) mkdir -p $$(dir $$@)
 ifneq ($(2),$(3))
 	@# Check if the Info.plists are identical
@@ -208,7 +248,8 @@ endif
 	$(Q) lipo -create -output $$@ $$^
 
 $(3)_TARGETS += \
-	.libs/$(1)/XTest.framework/XTest .libs/$(1)/XTest.framework/Info.plist \
+	.libs/$(1)/XTest.framework$($(4)_BINARY_INFIX)/XTest \
+	.libs/$(1)/XTest.framework$($(4)_INFO_PLIST_INFIX)/Info.plist \
 	.libs/$(1)/XStaticObjectTest.framework/XStaticObjectTest \
 	.libs/$(1)/XStaticArTest.framework/XStaticArTest \
 	.libs/$(1)/libtest.dylib \
@@ -218,18 +259,46 @@ $(3)_TARGETS += \
 all-local:: $$($(3)_TARGETS)
 endef
 
-$(eval $(call FatFrameworkTemplate,ios-fat,iphoneos,iphonesimulator))
+$(eval $(call FatFrameworkTemplate,ios-fat,iphoneos,iphonesimulator,IPHONESIMULATOR))
 ifdef INCLUDE_TVOS
-$(eval $(call FatFrameworkTemplate,tvos-fat,tvos,tvsimulator))
+$(eval $(call FatFrameworkTemplate,tvos-fat,tvos,tvsimulator,TVSIMULATOR))
 endif
 ifdef INCLUDE_WATCH
-$(eval $(call FatFrameworkTemplate,watchos-fat,watchos,watchsimulator))
+$(eval $(call FatFrameworkTemplate,watchos-fat,watchos,watchsimulator,WATCHSIMULATOR))
 endif
 ifdef INCLUDE_MACCATALYST
-$(eval $(call FatFrameworkTemplate,maccatalyst-fat,maccatalyst,maccatalyst))
+$(eval $(call FatFrameworkTemplate,maccatalyst-fat,maccatalyst,maccatalyst,MACCATALYST))
 endif
 ifdef INCLUDE_MAC
-$(eval $(call FatFrameworkTemplate,macos-fat,macos,macos))
+$(eval $(call FatFrameworkTemplate,macos-fat,macos,macos,MACOS))
+endif
+
+define FatFrameworkSymlinksTemplate
+.libs/$(1)/XTest.framework/XTest: | .libs/$(1)
+	$(Q) mkdir -p $$(dir $$@)
+	$(Q) ln -fs Versions/A/XTest $$@
+
+.libs/$(1)/XTest.framework/Resources: | .libs/$(1)
+	$(Q) mkdir -p $$(dir $$@)
+	$(Q) ln -fs Versions/A/Resources $$@
+
+.libs/$(1)/XTest.framework/Versions/Current: | .libs/$(1)
+	$(Q) mkdir -p $$(dir $$@)
+	$(Q) ln -fs A $$@
+
+$(3)_TARGETS += \
+	.libs/$(1)/XTest.framework/XTest \
+	.libs/$(1)/XTest.framework/Resources \
+	.libs/$(1)/XTest.framework/Versions/Current \
+
+all-local:: $$($(3)_TARGETS)
+endef
+
+ifdef INCLUDE_MACCATALYST
+$(eval $(call FatFrameworkSymlinksTemplate,maccatalyst-fat,maccatalyst,maccatalyst,MACCATALYST))
+endif
+ifdef INCLUDE_MAC
+$(eval $(call FatFrameworkSymlinksTemplate,macos-fat,macos,macos,MACOS))
 endif
 
 ifdef INCLUDE_IOS
@@ -250,8 +319,7 @@ endif
 
 XTEST_XCFRAMEWORKS += $(foreach platform,$(XCPLATFORMS),.libs/$(platform)/XTest.framework)
 XTEST_XCTARGETS += \
-	$(foreach platform,$(XCPLATFORMS),.libs/$(platform)/XTest.framework/XTest) \
-	$(foreach platform,$(XCPLATFORMS),.libs/$(platform)/XTest.framework/Info.plist) \
+	$(foreach platform,$(XCPLATFORMS),.libs/$(platform)/XTest.framework.stamp) \
 
 .libs/XTest.xcframework: $(XTEST_XCTARGETS) Makefile
 	$(Q) rm -rf $@

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -128,7 +128,13 @@ COMMON_DYLIB_ARGS=-g -dynamiclib -gdwarf-2 -fms-extensions libframework.m -o $$@
 	$(Q) rm -f $$@
 	$$(call Q_2,LIPO   [$(1)]) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo $$^ -create -output $$@
 
-.libs/$(1)/XTest.framework .libs/$(1)/XStaticObjectTest.framework .libs/$(1)/XStaticArTest.framework:
+$(1)_DIRECTORIES = \
+	.libs/$(1)/XTest.framework \
+	.libs/$(1)/XTest.framework/Versions \
+	.libs/$(1)/XStaticObjectTest.framework \
+	.libs/$(1)/XStaticArTest.framework \
+
+$$($(1)_DIRECTORIES):
 	$$(Q) mkdir -p $$@
 
 endef

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -39,6 +39,37 @@ MACOS_BINARY_INFIX=/Versions/A
 MACCATALYST_INFO_PLIST_INFIX=/Versions/A/Resources
 MACCATALYST_BINARY_INFIX=/Versions/A
 
+define SymlinksTemplate
+
+$(1)_XTEST_TARGETS += \
+	.libs/$(1)/XTest.framework/XTest \
+	.libs/$(1)/XTest.framework/Resources \
+	.libs/$(1)/XTest.framework/Versions/Current \
+	.libs/$(1)/XTest.framework/Versions/A/Resources/Info.plist \
+
+.libs/$(1)/XTest.framework$($(2)_BINARY_INFIX) .libs/$(1)/XTest.framework$($(2)_INFO_PLIST_INFIX):
+	$$(Q) mkdir -p $$@
+
+.libs/$(1)/XTest.framework/XTest: | .libs/$(1)/XTest.framework
+	$$(Q) ln -fs Versions/A/XTest $$@
+
+.libs/$(1)/XTest.framework/Resources: | .libs/$(1)/XTest.framework
+	$$(Q) ln -fs Versions/Current/Resources $$@
+
+.libs/$(1)/XTest.framework/Versions/Current: | .libs/$(1)/XTest.framework/Versions
+	$$(Q) ln -fs A $$@
+
+x::
+	@echo $(1)_XTEST_TARGETS=$$($(1)_XTEST_TARGETS)
+
+endef
+ifdef INCLUDE_MAC
+$(eval $(call SymlinksTemplate,macos,MACOS))
+endif
+ifdef INCLUDE_MACCATALYST
+$(eval $(call SymlinksTemplate,maccatalyst,MACCATALYST))
+endif
+
 define Template
 
 $(1)_XTEST_TARGETS += \
@@ -160,34 +191,6 @@ $(eval $(call Template,macos,MACOS,x86_64 arm64,MacOSX,-mmacosx-version-min=$(MI
 endif
 ifdef INCLUDE_MACCATALYST
 $(eval $(call Template,maccatalyst,MACCATALYST,x86_64 arm64,MacCatalyst,$(MACCATALYST_COMMON_CFLAGS)))
-endif
-
-define SymlinksTemplate
-
-$(1)_XTEST_TARGETS += \
-	.libs/$(1)/XTest.framework/XTest \
-	.libs/$(1)/XTest.framework/Resources \
-	.libs/$(1)/XTest.framework/Versions/Current \
-	.libs/$(1)/XTest.framework/Versions/A/Resources/Info.plist \
-
-.libs/$(1)/XTest.framework$($(2)_BINARY_INFIX) .libs/$(1)/XTest.framework$($(2)_INFO_PLIST_INFIX):
-	$$(Q) mkdir -p $$@
-
-.libs/$(1)/XTest.framework/XTest:
-	$$(Q) ln -fs Versions/A/XTest $$@
-
-.libs/$(1)/XTest.framework/Resources:
-	$$(Q) ln -fs Versions/Current/Resources $$@
-
-.libs/$(1)/XTest.framework/Versions/Current:
-	$$(Q) ln -fs A $$@
-
-endef
-ifdef INCLUDE_MAC
-$(eval $(call SymlinksTemplate,macos,MACOS))
-endif
-ifdef INCLUDE_MACCATALYST
-$(eval $(call SymlinksTemplate,maccatalyst,MACCATALYST))
 endif
 
 .libs/ios-fat .libs/tvos-fat .libs/watchos-fat .libs/maccatalyst-fat .libs/macos-fat:

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -62,7 +62,7 @@ $(2)_TARGETS = \
 
 all-local:: $$($(2)_TARGETS) $(GENERATED_FILES)
 
-.libs/$(1)/XTest.framework.stamp: $($(1)_XTEST_TARGETS)
+.libs/$(1)/XTest.framework.stamp: $$($(1)_XTEST_TARGETS)
 	$$(Q) touch $$@
 
 clean-$(1):

--- a/tests/test-libraries/XTest-Info-iphoneos.plist
+++ b/tests/test-libraries/XTest-Info-iphoneos.plist
@@ -9,7 +9,7 @@
         <key>CFBundleInfoDictionaryVersion</key>
         <string>6.0</string>
         <key>CFBundleName</key>
-        <string>Mono</string>
+        <string>XTest</string>
         <key>CFBundlePackageType</key>
         <string>FMWK</string>
         <key>CFBundleShortVersionString</key>
@@ -22,7 +22,6 @@
         <string></string>
         <key>CFBundleExecutable</key>
         <string>XTest</string>
-
         <key>BuildMachineOSBuild</key>
         <string>13F34</string>
         <key>CFBundleDevelopmentRegion</key>

--- a/tests/test-libraries/XTest-Info-iphonesimulator.plist
+++ b/tests/test-libraries/XTest-Info-iphonesimulator.plist
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleIdentifier</key>
+        <string>xamarin.ios.xtest</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>XTest</string>
+        <key>CFBundlePackageType</key>
+        <string>FMWK</string>
+        <key>CFBundleShortVersionString</key>
+        <string>1.0</string>
+        <key>CFBundleSignature</key>
+        <string>????</string>
+        <key>CFBundleVersion</key>
+        <string>3.12</string>
+        <key>NSPrincipalClass</key>
+        <string></string>
+        <key>CFBundleExecutable</key>
+        <string>XTest</string>
+        <key>BuildMachineOSBuild</key>
+        <string>13F34</string>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleSupportedPlatforms</key>
+        <array>
+                <string>iPhoneOS</string>
+        </array>
+        <key>DTCompiler</key>
+        <string>com.apple.compilers.llvm.clang.1_0</string>
+        <key>DTPlatformBuild</key>
+        <string>12D508</string>
+        <key>DTPlatformName</key>
+        <string>iphoneos</string>
+        <key>DTPlatformVersion</key>
+        <string>8.2</string>
+        <key>DTSDKBuild</key>
+        <string>12D508</string>
+        <key>DTSDKName</key>
+        <string>iphoneos8.2</string>
+        <key>DTXcode</key>
+        <string>0620</string>
+        <key>DTXcodeBuild</key>
+        <string>6C131e</string>
+        <key>MinimumOSVersion</key>
+        <string>8.1</string>
+        <key>UIDeviceFamily</key>
+        <array>
+                <integer>1</integer>
+                <integer>2</integer>
+        </array>
+</dict>
+</plist>

--- a/tests/test-libraries/XTest-Info-maccatalyst.plist
+++ b/tests/test-libraries/XTest-Info-maccatalyst.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleIdentifier</key>
+        <string>xamarin.ios.xtest</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>XTest</string>
+        <key>CFBundlePackageType</key>
+        <string>FMWK</string>
+        <key>CFBundleShortVersionString</key>
+        <string>1.0</string>
+        <key>CFBundleSignature</key>
+        <string>????</string>
+        <key>CFBundleVersion</key>
+        <string>3.12</string>
+        <key>NSPrincipalClass</key>
+        <string></string>
+        <key>CFBundleExecutable</key>
+        <string>XTest</string>
+        <key>BuildMachineOSBuild</key>
+        <string>13F34</string>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>DTCompiler</key>
+        <string>com.apple.compilers.llvm.clang.1_0</string>
+        <key>DTPlatformBuild</key>
+        <string>12D508</string>
+        <key>DTPlatformName</key>
+        <string>macosx</string>
+        <key>DTPlatformVersion</key>
+        <string>10.15</string>
+        <key>DTSDKBuild</key>
+        <string>12D508</string>
+        <key>DTSDKName</key>
+        <string>macosx10.15</string>
+        <key>DTXcode</key>
+        <string>0620</string>
+        <key>DTXcodeBuild</key>
+        <string>6C131e</string>
+        <key>LSMinimumSystemVersion</key>
+        <string>10.15</string>
+</dict>
+</plist>

--- a/tests/test-libraries/XTest-Info-macos.plist
+++ b/tests/test-libraries/XTest-Info-macos.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleIdentifier</key>
+        <string>xamarin.ios.xtest</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>XTest</string>
+        <key>CFBundlePackageType</key>
+        <string>FMWK</string>
+        <key>CFBundleShortVersionString</key>
+        <string>1.0</string>
+        <key>CFBundleSignature</key>
+        <string>????</string>
+        <key>CFBundleVersion</key>
+        <string>3.12</string>
+        <key>NSPrincipalClass</key>
+        <string></string>
+        <key>CFBundleExecutable</key>
+        <string>XTest</string>
+        <key>BuildMachineOSBuild</key>
+        <string>13F34</string>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>DTCompiler</key>
+        <string>com.apple.compilers.llvm.clang.1_0</string>
+        <key>DTPlatformBuild</key>
+        <string>12D508</string>
+        <key>DTPlatformName</key>
+        <string>macosx</string>
+        <key>DTPlatformVersion</key>
+        <string>10.9</string>
+        <key>DTSDKBuild</key>
+        <string>12D508</string>
+        <key>DTSDKName</key>
+        <string>macosx10.9</string>
+        <key>DTXcode</key>
+        <string>0620</string>
+        <key>DTXcodeBuild</key>
+        <string>6C131e</string>
+        <key>LSMinimumSystemVersion</key>
+        <string>10.9</string>
+</dict>
+</plist>

--- a/tests/test-libraries/XTest-Info-tvos.plist
+++ b/tests/test-libraries/XTest-Info-tvos.plist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleIdentifier</key>
+        <string>xamarin.ios.xtest</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>XTest</string>
+        <key>CFBundlePackageType</key>
+        <string>FMWK</string>
+        <key>CFBundleShortVersionString</key>
+        <string>1.0</string>
+        <key>CFBundleSignature</key>
+        <string>????</string>
+        <key>CFBundleVersion</key>
+        <string>3.12</string>
+        <key>NSPrincipalClass</key>
+        <string></string>
+        <key>CFBundleExecutable</key>
+        <string>XTest</string>
+        <key>BuildMachineOSBuild</key>
+        <string>13F34</string>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleSupportedPlatforms</key>
+        <array>
+                <string>AppleTVOS</string>
+        </array>
+        <key>DTCompiler</key>
+        <string>com.apple.compilers.llvm.clang.1_0</string>
+        <key>DTPlatformBuild</key>
+        <string>12D508</string>
+        <key>DTPlatformName</key>
+        <string>appletvos</string>
+        <key>DTPlatformVersion</key>
+        <string>9.0</string>
+        <key>DTSDKBuild</key>
+        <string>12D508</string>
+        <key>DTSDKName</key>
+        <string>appletvos9.0</string>
+        <key>DTXcode</key>
+        <string>0620</string>
+        <key>DTXcodeBuild</key>
+        <string>6C131e</string>
+        <key>MinimumOSVersion</key>
+        <string>9.0</string>
+        <key>UIDeviceFamily</key>
+        <array>
+                <integer>3</integer>
+        </array>
+</dict>
+</plist>

--- a/tests/test-libraries/XTest-Info-tvsimulator.plist
+++ b/tests/test-libraries/XTest-Info-tvsimulator.plist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleIdentifier</key>
+        <string>xamarin.ios.xtest</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>XTest</string>
+        <key>CFBundlePackageType</key>
+        <string>FMWK</string>
+        <key>CFBundleShortVersionString</key>
+        <string>1.0</string>
+        <key>CFBundleSignature</key>
+        <string>????</string>
+        <key>CFBundleVersion</key>
+        <string>3.12</string>
+        <key>NSPrincipalClass</key>
+        <string></string>
+        <key>CFBundleExecutable</key>
+        <string>XTest</string>
+        <key>BuildMachineOSBuild</key>
+        <string>13F34</string>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleSupportedPlatforms</key>
+        <array>
+                <string>AppleTVOS</string>
+        </array>
+        <key>DTCompiler</key>
+        <string>com.apple.compilers.llvm.clang.1_0</string>
+        <key>DTPlatformBuild</key>
+        <string>12D508</string>
+        <key>DTPlatformName</key>
+        <string>appletvos</string>
+        <key>DTPlatformVersion</key>
+        <string>9.0</string>
+        <key>DTSDKBuild</key>
+        <string>12D508</string>
+        <key>DTSDKName</key>
+        <string>appletvos9.0</string>
+        <key>DTXcode</key>
+        <string>0620</string>
+        <key>DTXcodeBuild</key>
+        <string>6C131e</string>
+        <key>MinimumOSVersion</key>
+        <string>9.0</string>
+        <key>UIDeviceFamily</key>
+        <array>
+                <integer>3</integer>
+        </array>
+</dict>
+</plist>

--- a/tests/test-libraries/XTest-Info-watchos.plist
+++ b/tests/test-libraries/XTest-Info-watchos.plist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleIdentifier</key>
+        <string>xamarin.ios.xtest</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>XTest</string>
+        <key>CFBundlePackageType</key>
+        <string>FMWK</string>
+        <key>CFBundleShortVersionString</key>
+        <string>1.0</string>
+        <key>CFBundleSignature</key>
+        <string>????</string>
+        <key>CFBundleVersion</key>
+        <string>3.12</string>
+        <key>NSPrincipalClass</key>
+        <string></string>
+        <key>CFBundleExecutable</key>
+        <string>XTest</string>
+        <key>BuildMachineOSBuild</key>
+        <string>13F34</string>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleSupportedPlatforms</key>
+        <array>
+                <string>WatchOS</string>
+        </array>
+        <key>DTCompiler</key>
+        <string>com.apple.compilers.llvm.clang.1_0</string>
+        <key>DTPlatformBuild</key>
+        <string>12D508</string>
+        <key>DTPlatformName</key>
+        <string>watchos</string>
+        <key>DTPlatformVersion</key>
+        <string>2.0</string>
+        <key>DTSDKBuild</key>
+        <string>12D508</string>
+        <key>DTSDKName</key>
+        <string>watchos2.0</string>
+        <key>DTXcode</key>
+        <string>0620</string>
+        <key>DTXcodeBuild</key>
+        <string>6C131e</string>
+        <key>MinimumOSVersion</key>
+        <string>2.0</string>
+        <key>UIDeviceFamily</key>
+        <array>
+                <integer>4</integer>
+        </array>
+</dict>
+</plist>

--- a/tests/test-libraries/XTest-Info-watchsimulator.plist
+++ b/tests/test-libraries/XTest-Info-watchsimulator.plist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleIdentifier</key>
+        <string>xamarin.ios.xtest</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>XTest</string>
+        <key>CFBundlePackageType</key>
+        <string>FMWK</string>
+        <key>CFBundleShortVersionString</key>
+        <string>1.0</string>
+        <key>CFBundleSignature</key>
+        <string>????</string>
+        <key>CFBundleVersion</key>
+        <string>3.12</string>
+        <key>NSPrincipalClass</key>
+        <string></string>
+        <key>CFBundleExecutable</key>
+        <string>XTest</string>
+        <key>BuildMachineOSBuild</key>
+        <string>13F34</string>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleSupportedPlatforms</key>
+        <array>
+                <string>WatchOS</string>
+        </array>
+        <key>DTCompiler</key>
+        <string>com.apple.compilers.llvm.clang.1_0</string>
+        <key>DTPlatformBuild</key>
+        <string>12D508</string>
+        <key>DTPlatformName</key>
+        <string>watchos</string>
+        <key>DTPlatformVersion</key>
+        <string>2.0</string>
+        <key>DTSDKBuild</key>
+        <string>12D508</string>
+        <key>DTSDKName</key>
+        <string>watchos2.0</string>
+        <key>DTXcode</key>
+        <string>0620</string>
+        <key>DTXcodeBuild</key>
+        <string>6C131e</string>
+        <key>MinimumOSVersion</key>
+        <string>2.0</string>
+        <key>UIDeviceFamily</key>
+        <array>
+                <integer>4</integer>
+        </array>
+</dict>
+</plist>

--- a/tools/dotnet-linker/Steps/ExtractBindingLibrariesStep.cs
+++ b/tools/dotnet-linker/Steps/ExtractBindingLibrariesStep.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Linker {
 			}
 			Configuration.WriteOutputForMSBuild ("_BindingLibraryFrameworks", frameworks);
 
-			var frameworkFilesToPublish = new List<MSBuildItem> ();
+			var frameworksToPublish = new List<MSBuildItem> ();
 			foreach (var asm in Configuration.Target.Assemblies) {
 				var fwks = new HashSet<string> ();
 				fwks.UnionWith (asm.Frameworks);
@@ -70,19 +70,15 @@ namespace Xamarin.Linker {
 					if (!Configuration.Application.VerifyDynamicFramework (fwk))
 						continue;
 
-					foreach (var file in Directory.GetFiles (fwk, "*", SearchOption.AllDirectories)) {
-						var item = new MSBuildItem {
-							Include = file,
-							Metadata = new Dictionary<string, string> {
-								{ "_FrameworkIdentity", fwk },
-								{ "_FrameworkPath", Path.Combine (Configuration.RelativeAppBundlePath, Configuration.Application.RelativeFrameworksPath, Path.GetFileName (fwk)) },
-							},
-						};
-						frameworkFilesToPublish.Add (item);
-					}
+					var executable = Path.Combine (fwk, Path.GetFileNameWithoutExtension (fwk));
+
+					var item = new MSBuildItem {
+						Include = executable,
+					};
+					frameworksToPublish.Add (item);
 				}
 			}
-			Configuration.WriteOutputForMSBuild ("_FrameworkFilesToPublish", frameworkFilesToPublish);
+			Configuration.WriteOutputForMSBuild ("_FrameworkToPublish", frameworksToPublish);
 
 			var dynamicLibraryToPublish = new List<MSBuildItem> ();
 			foreach (var asm in Configuration.Target.Assemblies) {


### PR DESCRIPTION
.NET/MSBuild don't handle symlinks properly [1], which means that we can't ask
.NET to copy frameworks to the app bundle, since frameworks may contain
symlinks.

In our case, the symptom was that instead of copying symlinks, the file the
symlink pointed to was copied instead, and then codesign complained about
invalid bundle format when we tried to sign the framework.

We fix this by having our own target (_CopyFrameworksToBundle) to copy
frameworks to the app bundle (instead of adding all the files in the
frameworks to the ResolvedFileToPublish item group), and then using 'ditto' to
copy the frameworks.

In order to create a test case for this, I also made the macOS and Mac
Catalyst versions of the XTest framework use symlinks:

* Create a proper XTest framework bundle hierarchy for macOS and Mac Catalyst
  by using the typical symlink structure (actual files in the Versions/A
  subdirectory, and then symlinks pointing into that directory).
* Create a separate Info.plist for each platform for XTest.framework, since
  using an otherwise correct framework makes tooling (such as codesign)
  complain if the Info.plist isn't correct too.

This made our existing tests show the bug.

Finally I had to fix signing frameworks where the executable is a symlink.

We were first resolving symlinks for the input - say we had an
Example.framework/Example symlink to Example.framework/Versions/A/Example -
and then checking the parent directory if it's a framework. The parent
directory of 'Example.framework/Versions/A/Example' is 'A', which did not meet
our framewrok condition (if it ends with '.framework').

The fix is to adjust the logic to resolve symlinks after checking if the input
is a framework or not.

[1]: https://github.com/dotnet/msbuild/issues/6821

Fixes https://github.com/xamarin/xamarin-macios/issues/12369.