### PR TITLE
[msbuild] Don't require an Info.plist for .NET builds.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -960,7 +960,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			Items="@(Content)">
 			<Output TaskParameter="Item" PropertyName="_AppManifest" />
 		</FindItemWithLogicalName>
-		<Error Condition="'$(_AppManifest)' == '' And '$(_CanOutputAppBundle)' == 'true'" Text="Info.plist not found."/>
+		<Error Condition="'$(_AppManifest)' == '' And '$(_CanOutputAppBundle)' == 'true' And '$(UsingAppleNETSdk)' != 'true'" Text="Info.plist not found."/>
 		<PropertyGroup>
 			<_AppBundleManifest>$(_AppBundlePath)$(_AppBundleManifestRelativePath)Info.plist</_AppBundleManifest>
 			<!-- We should only write out a compiled app manifest if we're creating an app bundle -->

--- a/tests/dotnet/MyInterpretedApp/Info.plist
+++ b/tests/dotnet/MyInterpretedApp/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/MyInterpretedApp/shared.csproj
+++ b/tests/dotnet/MyInterpretedApp/shared.csproj
@@ -12,8 +12,5 @@
 
   <ItemGroup>
     <Compile Include="../*.cs" />
-    <None Include="../Info.plist">
-      <Link>Info.plist</Link>
-    </None>
   </ItemGroup>
 </Project>

--- a/tests/dotnet/MyPartialAppManifestApp/MacCatalyst/Info.plist
+++ b/tests/dotnet/MyPartialAppManifestApp/MacCatalyst/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/MyPartialAppManifestApp/iOS/Info.plist
+++ b/tests/dotnet/MyPartialAppManifestApp/iOS/Info.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<!-- We need this because some tests will build this project for 32-bit targets -->
-	<key>MinimumOSVersion</key>
-	<string>10.0</string></dict>
-</plist>

--- a/tests/dotnet/MyPartialAppManifestApp/macOS/Info.plist
+++ b/tests/dotnet/MyPartialAppManifestApp/macOS/Info.plist
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<!-- We need this because we'd otherwise default to the latest macOS version we support (currently 12.0), and we'll want to execute on earlier versions -->
-	<key>LSMinimumSystemVersion</key>
-	<string>11.0</string>
-</dict>
-</plist>

--- a/tests/dotnet/MyPartialAppManifestApp/shared.csproj
+++ b/tests/dotnet/MyPartialAppManifestApp/shared.csproj
@@ -8,9 +8,10 @@
 		<ApplicationVersion>3.14</ApplicationVersion>
 	</PropertyGroup>
 
+	<Import Project="../../common/shared-dotnet.csproj" />
+
 	<ItemGroup>
 		<Compile Include="../*.cs" />
-		<None Include="Info.plist" />
 		<PartialAppManifest Include="../Partial.plist" />
 	</ItemGroup>
 </Project>

--- a/tests/dotnet/MyPartialAppManifestApp/tvOS/Info.plist
+++ b/tests/dotnet/MyPartialAppManifestApp/tvOS/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/MySimpleApp/MacCatalyst/Info.plist
+++ b/tests/dotnet/MySimpleApp/MacCatalyst/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/MySimpleApp/iOS/Info.plist
+++ b/tests/dotnet/MySimpleApp/iOS/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/MySimpleApp/macOS/Info.plist
+++ b/tests/dotnet/MySimpleApp/macOS/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/MySimpleApp/shared.csproj
+++ b/tests/dotnet/MySimpleApp/shared.csproj
@@ -12,6 +12,5 @@
 
 	<ItemGroup>
 		<Compile Include="../*.cs" />
-		<None Include="Info.plist" />
 	</ItemGroup>
 </Project>

--- a/tests/dotnet/MySimpleApp/tvOS/Info.plist
+++ b/tests/dotnet/MySimpleApp/tvOS/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/iOS/Info.plist
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/iOS/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/macOS/Info.plist
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/macOS/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/shared.csproj
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/shared.csproj
@@ -16,8 +16,5 @@
 
 	<ItemGroup>
 		<Compile Include="../*.cs" />
-		<None Include="../Info.plist">
-			<Link>Info.plist</Link>
-		</None>
 	</ItemGroup>
 </Project>

--- a/tests/dotnet/NativeFileReferencesApp/iOS/Info.plist
+++ b/tests/dotnet/NativeFileReferencesApp/iOS/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/NativeFileReferencesApp/macOS/Info.plist
+++ b/tests/dotnet/NativeFileReferencesApp/macOS/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/NativeFileReferencesApp/shared.csproj
+++ b/tests/dotnet/NativeFileReferencesApp/shared.csproj
@@ -17,8 +17,5 @@
 
 	<ItemGroup>
 		<Compile Include="../*.cs" />
-		<None Include="../Info.plist">
-			<Link>Info.plist</Link>
-		</None>
 	</ItemGroup>
 </Project>

--- a/tests/dotnet/NativeFrameworkReferencesApp/iOS/Info.plist
+++ b/tests/dotnet/NativeFrameworkReferencesApp/iOS/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/NativeFrameworkReferencesApp/macOS/Info.plist
+++ b/tests/dotnet/NativeFrameworkReferencesApp/macOS/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/NativeFrameworkReferencesApp/shared.csproj
+++ b/tests/dotnet/NativeFrameworkReferencesApp/shared.csproj
@@ -18,8 +18,5 @@
 
 	<ItemGroup>
 		<Compile Include="../*.cs" />
-		<None Include="../Info.plist">
-			<Link>Info.plist</Link>
-		</None>
 	</ItemGroup>
 </Project>

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/iOS/Info.plist
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/iOS/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/macOS/Info.plist
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/macOS/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/shared.csproj
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/shared.csproj
@@ -16,8 +16,5 @@
 
 	<ItemGroup>
 		<Compile Include="../*.cs" />
-		<None Include="../Info.plist">
-			<Link>Info.plist</Link>
-		</None>
 	</ItemGroup>
 </Project>

--- a/tests/dotnet/SimpleAppWithOldReferences/MacCatalyst/Info.plist
+++ b/tests/dotnet/SimpleAppWithOldReferences/MacCatalyst/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/SimpleAppWithOldReferences/iOS/Info.plist
+++ b/tests/dotnet/SimpleAppWithOldReferences/iOS/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/SimpleAppWithOldReferences/macOS/Info.plist
+++ b/tests/dotnet/SimpleAppWithOldReferences/macOS/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>

--- a/tests/dotnet/SimpleAppWithOldReferences/shared.csproj
+++ b/tests/dotnet/SimpleAppWithOldReferences/shared.csproj
@@ -12,7 +12,6 @@
 
 	<ItemGroup>
 		<Compile Include="../*.cs" />
-		<None Include="Info.plist" />
 		<Reference Include="../dotnet45assembly/dotnet45assembly.dll" />
 	</ItemGroup>
 

--- a/tests/dotnet/SimpleAppWithOldReferences/tvOS/Info.plist
+++ b/tests/dotnet/SimpleAppWithOldReferences/tvOS/Info.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>


### PR DESCRIPTION
We either have defaults or MSBuild properties for the most important values that
were previously required to be in the Info.plist, so now it doesn't make sense anymore
to require an Info.plist, when for simple cases it will just be an empty file.

This allows us to simplify some of our test projects and remove a few empty Info.plist files.