### PR TITLE
[dotnet-linker] Improve output when we report an error we raised ourselves.

### DIFF
--- a/tools/dotnet-linker/Steps/ConfigurationAwareStep.cs
+++ b/tools/dotnet-linker/Steps/ConfigurationAwareStep.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Mono.Cecil;
 using Mono.Linker.Steps;
@@ -66,18 +67,71 @@ namespace Xamarin.Linker {
 
 		// failure overrides, with defaults
 
+		bool CollectProductExceptions (Exception e, out List<ProductException> productExceptions)
+		{
+			if (e is ProductException pe) {
+				productExceptions = new List<ProductException> ();
+				productExceptions.Add (pe);
+				return true;
+			}
+
+			if (e is AggregateException ae && ae.InnerExceptions.All (v => v is ProductException)) {
+				productExceptions = new List<ProductException> (ae.InnerExceptions.Cast<ProductException> ());
+				return true;
+			}
+
+			productExceptions = null;
+			return false;
+		}
+
 		protected virtual Exception Fail (AssemblyDefinition assembly, Exception e)
 		{
+			// Detect if we're reporting one or more ProductExceptions (and no other exceptions), and in that case
+			// report the product exceptions as top-level exceptions + the step-specific exception at the end,
+			// instead of the step-specific exception with all the other exceptions as an inner exception.
+			// This makes the errors show up nicer in the output.
+			if (CollectProductExceptions (e, out var productExceptions)) {
+				// don't add inner exception
+				var ex = ErrorHelper.CreateError (ErrorCode, Errors.MX_ConfigurationAwareStepWithAssembly, Name, assembly?.FullName, e.Message);
+				// instead return an aggregate exception with the original exception and all the ProductExceptions we're reporting.
+				productExceptions.Add (ex);
+				return new AggregateException (productExceptions);
+			}
+
 			return ErrorHelper.CreateError (ErrorCode, e, Errors.MX_ConfigurationAwareStepWithAssembly, Name, assembly?.FullName, e.Message);
 		}
 
 		protected virtual Exception Fail (Exception e)
 		{
+			// Detect if we're reporting one or more ProductExceptions (and no other exceptions), and in that case
+			// report the product exceptions as top-level exceptions + the step-specific exception at the end,
+			// instead of the step-specific exception with all the other exceptions as an inner exception.
+			// This makes the errors show up nicer in the output.
+			if (CollectProductExceptions (e, out var productExceptions)) {
+				// don't add inner exception
+				var ex = ErrorHelper.CreateError (ErrorCode | 1, Errors.MX_ConfigurationAwareStep, Name, e.Message);
+				// instead return an aggregate exception with the original exception and all the ProductExceptions we're reporting.
+				productExceptions.Add (ex);
+				return new AggregateException (productExceptions);
+			}
+
 			return ErrorHelper.CreateError (ErrorCode | 1, e, Errors.MX_ConfigurationAwareStep, Name, e.Message);
 		}
 
 		protected virtual Exception FailEnd (Exception e)
 		{
+			// Detect if we're reporting one or more ProductExceptions (and no other exceptions), and in that case
+			// report the product exceptions as top-level exceptions + the step-specific exception at the end,
+			// instead of the step-specific exception with all the other exceptions as an inner exception.
+			// This makes the errors show up nicer in the output.
+			if (CollectProductExceptions (e, out var productExceptions)) {
+				// don't add inner exception
+				var ex = ErrorHelper.CreateError (ErrorCode | 2, Errors.MX_ConfigurationAwareStep, Name, e.Message);
+				// instead return an aggregate exception with the original exception and all the ProductExceptions we're reporting.
+				productExceptions.Add (ex);
+				return new AggregateException (productExceptions);
+			}
+
 			return ErrorHelper.CreateError (ErrorCode | 2, e, Errors.MX_ConfigurationAwareStep, Name, e.Message);
 		}
 


### PR DESCRIPTION
Instead of something like this:

    ILLINK : error MT2362: The linker step 'Registrar' failed during processing: One or more errors occurred. (The registrar cannot build a signature for type `Bindings.Test.Sf' in method `Sf()`.
        ) (The registrar cannot build a signature for type `Bindings.Test.Sf' in method `Sf_invoke()`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sdldl' in method `get_PSdldl()`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sdldl' in method `Bindings.Test.ObjCRegistrarTest.set_PSdldl`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sf' in method `get_PSf()`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sf' in method `Bindings.Test.ObjCRegistrarTest.set_PSf`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sff' in method `get_PSff()`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sff' in method `Bindings.Test.ObjCRegistrarTest.set_PSff`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sfff' in method `get_PSfff()`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sfff' in method `Bindings.Test.ObjCRegistrarTest.set_PSfff`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sffff' in method `get_PSffff()`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sffff' in method `Bindings.Test.ObjCRegistrarTest.set_PSffff`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sfffff' in method `get_PSfffff()`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sfffff' in method `Bindings.Test.ObjCRegistrarTest.set_PSfffff`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sfi' in method `get_PSfi()`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sfi' in method `Bindings.Test.ObjCRegistrarTest.set_PSfi`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sfifi' in method `get_PSfifi()`. (TaskId:208)
        ) (The registrar cannot build a signature for type `Bindings.Test.Sfifi' in method `Bindings.Test.ObjCRegistrarTest.set_PSfifi`. (TaskId:208)

we now get this:

    /Users/rolf/work/maccore/dotnet-devicetests/xamarin-macios/tests/bindings-test/dotnet/iOS/obj/Debug/net6.0-ios/iOS/Bindings.Test/ObjCRegistrarTest.g.cs(3072): error MT4111: The registrar cannot build a signature for type `Bindings.Test.Sf' in method `Sf()`.
    /Users/rolf/work/maccore/dotnet-devicetests/xamarin-macios/tests/bindings-test/dotnet/iOS/obj/Debug/net6.0-ios/iOS/Bindings.Test/ObjCRegistrarTest.g.cs(3100): error MT4111: The registrar cannot build a signature for type `Bindings.Test.Sf' in method `Sf_invoke()`.
    /Users/rolf/work/maccore/dotnet-devicetests/xamarin-macios/tests/bindings-test/dotnet/iOS/obj/Debug/net6.0-ios/iOS/Bindings.Test/ObjCRegistrarTest.g.cs(6112): error MT4111: The registrar cannot build a signature for type `Bindings.Test.Sdldl' in method `get_PSdldl()`.
    /Users/rolf/work/maccore/dotnet-devicetests/xamarin-macios/tests/bindings-test/dotnet/iOS/obj/Debug/net6.0-ios/iOS/Bindings.Test/ObjCRegistrarTest.g.cs(6138): error MT4111: The registrar cannot build a signature for type `Bindings.Test.Sdldl' in method `Bindings.Test.ObjCRegistrarTest.set_PSdldl`.
    /Users/rolf/work/maccore/dotnet-devicetests/xamarin-macios/tests/bindings-test/dotnet/iOS/obj/Debug/net6.0-ios/iOS/Bindings.Test/ObjCRegistrarTest.g.cs(6149): error MT4111: The registrar cannot build a signature for type `Bindings.Test.Sf' in method `get_PSf()`.
    ILLINK : error MT2362: The linker step 'Registrar' failed during processing: One or more errors occurred.

and in addition we'll get stack traces for each inner exception as well
whenever we have verbose mtouch logging enabled.