### PR TITLE
[tests] Adjust a few introspection checks to work on iOS 11.4.1

### DIFF
--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -45,6 +45,14 @@ namespace Introspection {
 			case "MTLCounterSet":
 				return true; // Incorrectly bound, will be fixed for XAMCORE_4_0.
 #endif
+			case "MPSImageLaplacianPyramid":
+			case "MPSImageLaplacianPyramidSubtract":
+			case "MPSImageLaplacianPyramidAdd":
+			case "MPSCnnYoloLossNode":
+				// The presence of these seem to depend on hardware capabilities, and not only OS version.
+				// Unfortunately I couldn't find any documentation related to determining exactly which
+				// hardware capability these need (or how to detect them), so just ignore them.
+				return true;
 			default:
 				return SkipDueToAttribute (type);
 			}

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -849,6 +849,14 @@ namespace Introspection {
 				if (selectorName == "waitUntilExit")
 					return true;
 				break;
+			case "MPSImageDescriptor":
+				switch (selectorName) {
+				case "copyWithZone:":
+					if (!TestRuntime.CheckXcodeVersion (10, 0))
+						return true;
+					break;
+				}
+				break;
 			}
 
 			// old binding mistake

--- a/tests/introspection/Mac/MacApiProtocolTest.cs
+++ b/tests/introspection/Mac/MacApiProtocolTest.cs
@@ -34,10 +34,6 @@ namespace Introspection {
 				return true;
 			case "AVCaptureSynchronizedDataCollection":
 			case "AVCaptureSynchronizedData":
-			case "MPSImageLaplacianPyramid":
-			case "MPSImageLaplacianPyramidSubtract":
-			case "MPSImageLaplacianPyramidAdd":
-			case "MPSCnnYoloLossNode":
 			case "CXProvider":
 				return TestRuntime.IsVM; // skip only on vms
 			case "NSMenuView": // not longer supported

--- a/tests/introspection/Mac/MacApiSelectorTest.cs
+++ b/tests/introspection/Mac/MacApiSelectorTest.cs
@@ -186,10 +186,6 @@ namespace Introspection {
 					if (!Mac.CheckSystemVersion (10, 9))
 						return true;
 					break;
-				case "MPSImageDescriptor":
-					if (!Mac.CheckSystemVersion (10, 14)) // Likely to be fixed when we do MPS binding
-						return true;
-					break;
 				case "SFSafariPage":
 				case "SFSafariTab":
 				case "SFSafariToolbarItem":


### PR DESCRIPTION
I ran into these failures when running on an iOS 11.4.1 device (iPhone 7 / A1778).