### PR TITLE
Bump maccore.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 3e591cbcb15081d34a9512ca39d9df55c331bdbd
+NEEDED_MACCORE_VERSION := efad4f0baec567c7937ce0a87b2fc94ee0094a2b
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@efad4f0bae [Xamarin.Hosting] Fix a few compiler warnings. (xamarin/maccore#2512)
* xamarin/maccore@55087e093a [Xamarin.Hosting] Fix detecting app exit on device. (#2511)
* xamarin/maccore@ffefee386c [Xamarin.Hosting] Add support for launching with debugserver on iOS/tvOS 14+. (#2510)
* xamarin/maccore@e203814d08 [tests] Fix .ipa path for iOSCoolApp now that it's a fat app. (#2509)
* xamarin/maccore@c2531ff702 Update the provisionator script. (#2505)
* xamarin/maccore@2bfa5fa12b [submission] Add a fat Mac Catalyst test app. (#2508)

Diff: https://github.com/xamarin/maccore/compare/3e591cbcb15081d34a9512ca39d9df55c331bdbd..efad4f0baec567c7937ce0a87b2fc94ee0094a2b