### PR TITLE
[vs-insertion] Push packs to "shipping" feed

### DIFF
--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -75,4 +75,7 @@ stages:
     dependsOn: prepare_release
     symbolArtifactName: nuget-signed
     symbolConversionFilters: '*mlaunch.app*'
+    pushToShippingFeed: true
+    nupkgArtifactName: nuget-signed
+    msiNupkgArtifactName: vs-msi-nugets
     condition: eq(variables.IsPRBuild, 'False')


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/134

The .NET 6 packs will now also be pushed to a public xamarin
`net6-maui-shipping` feed during the `VS Insertion` stage.