### PR TITLE
[tests] Import nunit.framework.targets in more .NET test projects.

### DIFF
--- a/tests/introspection/dotnet/shared.csproj
+++ b/tests/introspection/dotnet/shared.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
 
   <Import Project="$(RootTestsDirectory)/common/shared-dotnet.csproj" />
+  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
 
   <ItemGroup>
     <PackageReference Include="NUnitLite" Version="3.12.0" />

--- a/tests/linker/ios/dont link/dotnet/shared.csproj
+++ b/tests/linker/ios/dont link/dotnet/shared.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <Import Project="$(RootTestsDirectory)/common/shared-dotnet.csproj" />
+  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
 
   <ItemGroup>
     <PackageReference Include="NUnitLite" Version="3.12.0" />

--- a/tests/linker/ios/link all/dotnet/shared.csproj
+++ b/tests/linker/ios/link all/dotnet/shared.csproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <Import Project="$(RootTestsDirectory)/common/shared-dotnet.csproj" />
+  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
 
   <!-- We use configurations like Debug64 and Release64, which doesn't work with the default logic we and .NET have -->
   <PropertyGroup Condition="$(Configuration.Contains('Debug'))">

--- a/tests/linker/ios/link sdk/dotnet/shared.csproj
+++ b/tests/linker/ios/link sdk/dotnet/shared.csproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <Import Project="$(RootTestsDirectory)/common/shared-dotnet.csproj" />
+  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
 
   <ItemGroup>
     <Reference Include="support">


### PR DESCRIPTION
This is to set the -dlsym:-nunit.framework.dll option, because nunit.framework.dll
contains a P/Invoke to a function that doesn't exist.

For some reason this is more of a problem in tvOS projects than iOS projects
(although it happens for iOS projects as well).