### PR TITLE
[introspection] Skip VideoToolbox classes in the ApiCMAttachmentTest on tvOS devices.

### DIFF
--- a/tests/introspection/ApiCMAttachmentTest.cs
+++ b/tests/introspection/ApiCMAttachmentTest.cs
@@ -231,6 +231,16 @@ namespace Introspection {
 			case "SecIdentity2": // same (dupe logic)
 			case "Authorization":
 				return true;
+			case "VTCompressionSession":
+			case "VTSession":
+			case "VTFrameSilo":
+			case "VTMultiPassStorage":
+#if __TVOS__
+				// Causes a crash in a background thread.
+				return true;
+#else
+				return false;
+#endif
 			default:
  				return false;
 			}

--- a/tests/introspection/ApiCMAttachmentTest.cs
+++ b/tests/introspection/ApiCMAttachmentTest.cs
@@ -237,10 +237,10 @@ namespace Introspection {
 			case "VTMultiPassStorage":
 #if __TVOS__
 				// Causes a crash in a background thread.
-				return true;
-#else
-				return false;
+				if (Runtime.Arch == Arch.DEVICE)
+					return true;
 #endif
+				return false;
 			default:
  				return false;
 			}


### PR DESCRIPTION
They crash on device.