### PR TITLE
[tests] Add perf test for calling Marshal.AllocHGlobal/FreeHGlobal.

### DIFF
--- a/tests/perftest/ManagedRuntime.cs
+++ b/tests/perftest/ManagedRuntime.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Runtime.InteropServices;
+
+using BenchmarkDotNet.Attributes;
+
+namespace PerfTest {
+
+	public class ManagedRuntime {
+		[Benchmark]
+		public void AllocHGlobal ()
+		{
+			Marshal.FreeHGlobal (Marshal.AllocHGlobal (1));
+		}
+	}
+}

--- a/tests/perftest/dotnet/perftest.csproj
+++ b/tests/perftest/dotnet/perftest.csproj
@@ -7,6 +7,7 @@
     <MonoBundlingExtraArgs>--marshal-objectivec-exceptions:disable --registrar:static</MonoBundlingExtraArgs>
     <LinkMode>None</LinkMode> <!-- never link -->
     <Optimize>true</Optimize> <!-- always optimize -->
+    <SupportedOSPlatformVersion>10.15</SupportedOSPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />


### PR DESCRIPTION
Also add a 'SupportedOSPlatformVersion' value to the .NET perftest project
file, to cope with recent changes in our .NET support.

Ref: https://github.com/dotnet/runtime/issues/58939.