### PR TITLE
[xharness] Set the EnableSGenConc value for all project configurations.

### DIFF
--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -231,7 +231,7 @@ namespace Xharness.Jenkins {
 							MonoNativeHelper.AddProjectDefines (clone.Xml, mono_native_link);
 						}
 						if (test_data.EnableSGenConc)
-							clone.Xml.SetNode ("MtouchEnableSGenConc", "true", task.ProjectPlatform, configuration);
+							clone.Xml.SetTopLevelPropertyGroupValue ("EnableSGenConc", "true");
 						if (test_data.UseThumb) // no need to check the platform, already done at the data iterator
 							clone.Xml.SetNode ("MtouchUseThumb", "true", task.ProjectPlatform, configuration);
 						if (use_llvm)


### PR DESCRIPTION
* Update to use EnableSGenConc instead of MtouchEnableSGenConc (either works,
  the former is the new future).
* Set EnableSGenConc as a top-level property, so we make sure it's set no
  matter how the project is executed.

This makes it so that this setting work for .NET projects, where we're not using project configurations.