### PR TITLE
[runtime] Use the correct underlying types for our own nfloat/n(u)int types.

### DIFF
--- a/runtime/bindings.h
+++ b/runtime/bindings.h
@@ -16,15 +16,9 @@ extern "C" {
 void * xamarin_IntPtr_objc_msgSend_IntPtr (id self, SEL sel, void *a);
 void * xamarin_IntPtr_objc_msgSendSuper_IntPtr (struct objc_super *super, SEL sel, void *a);
 
-#if defined(__i386__)
-typedef float xm_nfloat_t;
-typedef int32_t xm_nint_t;
-typedef uint32_t xm_nuint_t;
-#else
-typedef double xm_nfloat_t;
-typedef int64_t xm_nint_t;
-typedef uint64_t xm_nuint_t;
-#endif
+typedef CGFloat xm_nfloat_t;
+typedef NSInteger xm_nint_t;
+typedef NSUInteger xm_nuint_t;
 
 typedef float (*float_send) (id self, SEL sel);
 typedef float (*float_sendsuper) (struct objc_super *super, SEL sel);


### PR DESCRIPTION
Defining xm_nint_t to be 32-bit sized only on i386 is not the right thing to do for armv7.

Strangely enough this caused just a single test failure:

    MonoTouchFixtures.Foundation.CalendarTest
        [FAIL] TestFindNextDateAfterDateMatching :   Expected: <Foundation.MonoTouchException>
            But was:  null
            at MonoTouchFixtures.Foundation.CalendarTest.TestFindNextDateAfterDateMatching()

and that happened because:

1. We use a wrapper function around objc_msgSend:

    ```c
    void *
    xamarin_IntPtr_objc_msgSend_IntPtr_IntPtr_nuint_exception (id self, SEL sel, void * p0, void * p1, xm_nuint_t p2, GCHandle *exception_gchandle)
    {
    	@try {
    		return ((func_xamarin_IntPtr_objc_msgSend_IntPtr_IntPtr_nuint_exception) objc_msgSend) (self, sel, p0, p1, p2);
    	} @catch (NSException *e) {
    		xamarin_process_nsexception_using_mode (e, true, exception_gchandle);
    		return NULL;
    	}
    }
    ```

2. Note that the second to last argument is an 'xm_nuint_t'. We told the
   native compiler this was a 64-bit value, when the managed P/Invoke would
   give it a 32-bit value. This had no effect on the 'p2' parameter, but it
   meant that clang would thing the next argument, 'exception_gchandle', would
   be somewhere it wasn't (the managed function would pass two 32-bit values,
   'p2' and 'exception_gchandle', which clang would merge into a single 64-bit
   'p2' argument, and then read random stuff for 'exception_gchandle').

3. Finally things would go sideways when we caught the exception and passed
   'exception_gchandle' to xamarin_process_nsexception_using_mode. In effect
   we'd ask xamarin_process_nsexception_using_mode to store the resulting
   gchandle in random memory. Amazingly it only resulted in a test failure
   (because upon return the managed location for the 'exception_gchandle'
   wasn't touched, and would have its initial value of 0, thus managed code
   would think no exception occurred).

So fix this to use the correct underlying types, instead of trying to figure
out the correct #if condition.

I'm not sure why we're using our own types here anyways, but this fix is the
smallest.