### PR TITLE
[foundation] Allow the optimization of `NSAutoreleasePool` bindings

### DIFF
--- a/src/Foundation/NSAutoreleasePool.cs
+++ b/src/Foundation/NSAutoreleasePool.cs
@@ -42,16 +42,15 @@ namespace Foundation {
 #if !COREBUILD
 		public override IntPtr ClassHandle { get { return Class.GetHandle ("NSAutoreleasePool"); } }
 
+		[BindingImpl (BindingImplOptions.Optimizable)]
 		[Export ("init")]
 		public NSAutoreleasePool () : base (NSObjectFlag.Empty)
 		{
-			IsDirectBinding = GetType () == typeof (NSAutoreleasePool);
 			if (IsDirectBinding) {
 				Handle = Messaging.IntPtr_objc_msgSend (this.Handle, Selector.GetHandle ("init"));
 			} else {
 				Handle = Messaging.IntPtr_objc_msgSendSuper (this.SuperHandle, Selector.GetHandle ("init"));
 			}
-
 		}
 
 #if XAMCORE_4_0


### PR DESCRIPTION
For historical reason `NSAutoreleasePool` is bound manually. However it
can still be optimized, which is nice since it's not a type that is
likely to be subclassed.

The default `IsDirectBinding`, from `NSObject`, does the right job.

Optimized code, inside app, will look like:

```csharp
[Export("init")]
public NSAutoreleasePool()
	: base(NSObjectFlag.Empty)
{
	base.Handle = Messaging.IntPtr_objc_msgSend(base.Handle, Selector.GetHandle("init"));
}

```