### PR TITLE
[objcruntime] Directly call the `Runtime.TryGetNSObject(IntPtr,bool)`

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -709,7 +709,7 @@ namespace ObjCRuntime {
 
 		static bool HasNSObject (IntPtr ptr)
 		{
-			return TryGetNSObject (ptr) != null;
+			return TryGetNSObject (ptr, evenInFinalizerQueue: false) != null;
 		}
 
 		static IntPtr GetHandleForINativeObject (IntPtr ptr)
@@ -1254,10 +1254,10 @@ namespace ObjCRuntime {
 
 		public static NSObject TryGetNSObject (IntPtr ptr)
 		{
-			return TryGetNSObject (ptr, false);
+			return TryGetNSObject (ptr, evenInFinalizerQueue: false);
 		}
 
-		internal static NSObject TryGetNSObject (IntPtr ptr, bool evenInFinalizerQueue = false)
+		internal static NSObject TryGetNSObject (IntPtr ptr, bool evenInFinalizerQueue)
 		{
 			lock (lock_obj) {
 				if (object_map.TryGetValue (ptr, out var reference)) {
@@ -1311,7 +1311,7 @@ namespace ObjCRuntime {
 			if (ptr == IntPtr.Zero)
 				return null;
 
-			object obj = TryGetNSObject (ptr);
+			object obj = TryGetNSObject (ptr, evenInFinalizerQueue: false);
 			T o;
 
 			if (obj == null) {
@@ -1461,7 +1461,7 @@ namespace ObjCRuntime {
 			if (ptr == IntPtr.Zero)
 				return null;
 
-			NSObject o = TryGetNSObject (ptr);
+			NSObject o = TryGetNSObject (ptr, evenInFinalizerQueue: false);
 			if (o != null && target_type.IsAssignableFrom (o.GetType ())) {
 				// found an existing object with the right type.
 				return o;
@@ -1510,7 +1510,7 @@ namespace ObjCRuntime {
 			if (ptr == IntPtr.Zero)
 				return null;
 
-			var o = TryGetNSObject (ptr);
+			var o = TryGetNSObject (ptr, evenInFinalizerQueue: false);
 			var t = o as T;
 			if (t != null) {
 				// found an existing object with the right type.


### PR DESCRIPTION
instead of the helper without the `bool` argument.

This way we can avoid the extra call (likely optimized), it's code and
metadata inside applications.

```diff
--- a.cs	2021-09-14 18:52:23.000000000 -0400
+++ b.cs	2021-09-14 18:52:26.000000000 -0400
@@ -1299,7 +1299,7 @@

 		private static bool HasNSObject(IntPtr P_0)
 		{
-			return TryGetNSObject(P_0) != null;
+			return TryGetNSObject(P_0, false) != null;
 		}

 		private static IntPtr GetHandleForINativeObject(IntPtr P_0)
@@ -1654,12 +1654,7 @@
 			return null;
 		}

-		public static NSObject TryGetNSObject(IntPtr P_0)
-		{
-			return TryGetNSObject(P_0, false);
-		}
-
-		internal static NSObject TryGetNSObject(IntPtr P_0, bool P_1 = false)
+		internal static NSObject TryGetNSObject(IntPtr P_0, bool P_1)
 		{
 			lock (lock_obj)
 			{
@@ -1712,7 +1707,7 @@
 			{
 				return null;
 			}
-			object obj = TryGetNSObject(P_0);
+			object obj = TryGetNSObject(P_0, false);
 			T val;
 			if (obj == null)
 			{
@@ -1839,7 +1834,7 @@
 			{
 				return null;
 			}
-			NSObject nSObject = TryGetNSObject(P_0);
+			NSObject nSObject = TryGetNSObject(P_0, false);
 			if (nSObject != null && P_2.IsAssignableFrom(nSObject.GetType()))
 			{
 				return nSObject;
@@ -1879,7 +1874,7 @@
 			{
 				return null;
 			}
-			NSObject nSObject = TryGetNSObject(P_0);
+			NSObject nSObject = TryGetNSObject(P_0, false);
 			T val = nSObject as T;
 			if (val != null)
 			{
```