### PR TITLE
[dotnet-linker] Mark protocol interfaces when using the dynamic registrar. Fixes #12644.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -522,6 +522,7 @@
 			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Condition="'$(_LinkMode)' != 'None'" Type="Xamarin.Linker.Steps.PreserveBlockCodeHandler" />
 			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Condition="'$(_LinkMode)' != 'None'" Type="Xamarin.Linker.OptimizeGeneratedCodeHandler" />
 			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Condition="'$(_LinkMode)' != 'None'" Type="Xamarin.Linker.BackingFieldDelayHandler" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Condition="'$(_LinkMode)' != 'None'" Type="Xamarin.Linker.MarkIProtocolHandler" />
 			<!-- MarkDispatcher substeps will run for all marked assemblies. -->
 			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Condition="'$(_LinkMode)' != 'None'" Type="Xamarin.Linker.Steps.MarkDispatcher" />
 			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Condition="'$(_LinkMode)' != 'None'" Type="Xamarin.Linker.Steps.PreserveSmartEnumConversionsHandler" />

--- a/tools/dotnet-linker/MarkIProtocolHandler.cs
+++ b/tools/dotnet-linker/MarkIProtocolHandler.cs
@@ -1,0 +1,42 @@
+using System;
+
+using Mono.Cecil;
+using Mono.Linker;
+using Mono.Linker.Steps;
+
+namespace Xamarin.Linker {
+	public class MarkIProtocolHandler : ConfigurationAwareMarkHandler {
+
+		protected override string Name { get; } = "IProtocol Marker";
+		protected override int ErrorCode { get; } = 2420;
+
+		public override void Initialize (LinkContext context, MarkContext markContext)
+		{
+			base.Initialize (context);
+
+			if (LinkContext.App.Registrar == Bundler.RegistrarMode.Dynamic) {
+				markContext.RegisterMarkTypeAction (ProcessType);
+			}
+		}
+
+		protected override void Process (TypeDefinition type)
+		{
+			if (!type.HasInterfaces)
+				return;
+
+			foreach (var iface in type.Interfaces) {
+				var resolvedInterfaceType = iface.InterfaceType.Resolve ();
+				// If we're using the dynamic registrar, we need to mark interfaces that represent protocols
+				// even if it doesn't look like the interfaces are used, since we need them at runtime.
+				var isProtocol = type.IsNSObject (LinkContext) && resolvedInterfaceType.HasCustomAttribute (LinkContext, Namespaces.Foundation, "ProtocolAttribute");
+				if (isProtocol) {
+					// Mark only if not already marked.
+					// otherwise we might enqueue something everytime and never get an empty queue
+					if (!LinkContext.Annotations.IsMarked (resolvedInterfaceType)) {
+						LinkContext.Annotations.Mark (resolvedInterfaceType);
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes this test failure when running monotouch-test with the dynamic registrar and
linking has been enabled:

    MonoTouchFixtures.ObjCRuntime.RegistrarTest
        [FAIL] TestProtocolRegistration :   UIApplicationDelegate/17669
            Expected: True
            But was:  False

This is a port of what we do during linking for legacy Xamarin apps.

Ref: 682f54da87db7b2cc0b6e699751fde2e45a3346c

Fixes https://github.com/xamarin/xamarin-macios/issues/12644.