### PR TITLE
[build] Change the .NET version suffix to 'preview.9'.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -75,7 +75,7 @@ endif
 
 # For release branches, modify the following variables to hardcode a version name
 # Set the NUGET_HARDCODED_PRERELEASE_IDENTIFIER variable to the prerelease identifer you want (say "preview.5." (the trailing dot is important)
-NUGET_HARDCODED_PRERELEASE_IDENTIFIER=rc.2.
+NUGET_HARDCODED_PRERELEASE_IDENTIFIER=preview.9.
 # Set the NUGET_HARDCODED_PRERELEASE_BRANCH variable to the exact name for the branch the above variable should apply to (so that any other branches won't pick it up by accident).
 # For the previous example, this would be "release/6.0.1xx-preview5"
 # When creating a release branch from main, this must be changed from "main" to the new release branch.

--- a/Make.versions
+++ b/Make.versions
@@ -66,11 +66,11 @@ MAC_PACKAGE_VERSION=7.99.0.$(MAC_COMMIT_DISTANCE)
 # WARNING: Do **not** use versions higher than the available Xcode SDK or else we will have issues with mtouch (See https://github.com/xamarin/xamarin-macios/issues/7705)
 # When bumping the major macOS version in MACOS_NUGET_VERSION also update the macOS version where we execute on bots in jenkins/Jenkinsfile (in the 'node' element)
 
-IOS_NUGET_VERSION=15.0.100
-TVOS_NUGET_VERSION=15.0.100
-WATCHOS_NUGET_VERSION=8.0.100
-MACOS_NUGET_VERSION=12.0.100
-MACCATALYST_NUGET_VERSION=15.0.100
+IOS_NUGET_VERSION=15.0.101
+TVOS_NUGET_VERSION=15.0.101
+WATCHOS_NUGET_VERSION=8.0.101
+MACOS_NUGET_VERSION=12.0.101
+MACCATALYST_NUGET_VERSION=15.0.101
 
 
 # Defines the default platform version if it's not specified in the TFM. The default should not change for a given .NET version:


### PR DESCRIPTION
.NET MAUI (and underlying SDKs) will be in a "preview" status until Q2 2022.

Going forward in xamarin-macios our version numbers will be
[8|12|15].0.101-preview.9.*.

We need to bump the patch version to 101, so the version number will be higher
than the currently released [8|12|15].0.100-rc.1.*.

Ref: https://devblogs.microsoft.com/dotnet/update-on-dotnet-maui/
Ref: https://github.com/xamarin/xamarin-android/pull/6299
Ref: https://github.com/dotnet/maui/pull/2497