### PR TITLE
[msbuild/dotnet] Include font files by default in .NET apps, and implement a way to automatically register them. Fixes #12536.

### DIFF
--- a/dotnet/DefaultCompilationIncludes.md
+++ b/dotnet/DefaultCompilationIncludes.md
@@ -56,3 +56,8 @@ etc.) in the binding project directory which should be compiled as binding
 source code, and not as normal C# source code.
 
 [1]: https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#default-compilation-includes-in-net-core-projects
+
+## Font files
+
+All \*.ttf, \*.ttc and \*.otf files anywhere inside the Resources/
+subdirectory are included by default (as `BundleResource` items).

--- a/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
+++ b/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
@@ -78,4 +78,12 @@
 			<IsDefaultItem>true</IsDefaultItem>
 		</SceneKitAsset>
 	</ItemGroup>
+
+	<!-- Default font files inclusion -->
+	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
+		<BundleResource Include="$(_ResourcePrefix)\**\*.ttf;$(_ResourcePrefix)\**\*.otf;$(_ResourcePrefix)\**\*.ttc" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
+			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
+			<IsDefaultItem>true</IsDefaultItem>
+		</BundleResource>
+	</ItemGroup>
 </Project>

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -1913,6 +1913,24 @@ namespace Xamarin.Localization.MSBuild {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to All font files must be located in the same directory in the app bundle. The following font files have different target directories in the app bundle:.
+        /// </summary>
+        public static string E7083 {
+            get {
+                return ResourceManager.GetString("E7083", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The target directory is {0}.
+        /// </summary>
+        public static string E7084 {
+            get {
+                return ResourceManager.GetString("E7084", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid framework: {0}.
         /// </summary>
         public static string InvalidFramework {

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1317,4 +1317,16 @@
             {2}: the value from the project file.
         </comment>
     </data>
+
+    <data name="E7083" xml:space="preserve">
+        <value>All font files must be located in the same directory in the app bundle. The following font files have different target directories in the app bundle:</value>
+        <comment>This error message will be followed by E7084 error messages listing the target directory for each font file</comment>
+    </data>
+
+    <data name="E7084" xml:space="preserve">
+        <value>The target directory is {0}</value>
+        <comment>See E7082 as well.
+            {0}: the target directory (in the app bundle) for the font file
+        </comment>
+    </data>
 </root>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -317,6 +317,10 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		Outputs="$(_TemporaryAppManifest)"
 		>
 
+		<ItemGroup>
+			<_FontFilesToRegister Include="@(BundleResource)" Condition="'%(BundleResource.RegisterFont)' == 'true'" />
+		</ItemGroup>
+
 		<CompileAppManifest
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
@@ -330,12 +334,15 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			CompiledAppManifest="$(_TemporaryAppManifest)"
 			Debug="$(_BundlerDebug)"
 			DefaultSdkVersion="$(_SdkVersion)"
+			FontFilesToRegister="@(_FontFilesToRegister)"
 			GenerateApplicationManifest="$(GenerateApplicationManifest)"
 			IsAppExtension="$(IsAppExtension)"
 			IsWatchApp="$(IsWatchApp)"
 			IsWatchExtension="$(IsWatchExtension)"
 			IsXPCService="$(IsXPCService)"
 			PartialAppManifests="@(PartialAppManifest)"
+			ProjectDir="$(MSBuildProjectDirectory)"
+			ResourcePrefix="$(_ResourcePrefix)"
 			ResourceRules="$(_PreparedResourceRules)"
 			TargetArchitectures="$(TargetArchitectures)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"

--- a/tests/dotnet/AppWithResources/AppDelegate.cs
+++ b/tests/dotnet/AppWithResources/AppDelegate.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+namespace MySimpleApp
+{
+	public class Program
+	{
+		static int Main (string[] args)
+		{
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+
+			return args.Length;
+		}
+	}
+}

--- a/tests/dotnet/AppWithResources/MacCatalyst/AppWithResources.csproj
+++ b/tests/dotnet/AppWithResources/MacCatalyst/AppWithResources.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithResources/MacCatalyst/Makefile
+++ b/tests/dotnet/AppWithResources/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithResources/MacCatalyst/Resources/A.ttc
+++ b/tests/dotnet/AppWithResources/MacCatalyst/Resources/A.ttc
@@ -1,0 +1,1 @@
+I am a font!

--- a/tests/dotnet/AppWithResources/MacCatalyst/Resources/B.otf
+++ b/tests/dotnet/AppWithResources/MacCatalyst/Resources/B.otf
@@ -1,0 +1,1 @@
+I am a font too!

--- a/tests/dotnet/AppWithResources/MacCatalyst/Resources/C.ttf
+++ b/tests/dotnet/AppWithResources/MacCatalyst/Resources/C.ttf
@@ -1,0 +1,1 @@
+Even I am a font!

--- a/tests/dotnet/AppWithResources/iOS/AppWithResources.csproj
+++ b/tests/dotnet/AppWithResources/iOS/AppWithResources.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-ios</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithResources/iOS/Makefile
+++ b/tests/dotnet/AppWithResources/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithResources/iOS/Resources/A.ttc
+++ b/tests/dotnet/AppWithResources/iOS/Resources/A.ttc
@@ -1,0 +1,1 @@
+I am a font!

--- a/tests/dotnet/AppWithResources/iOS/Resources/B.otf
+++ b/tests/dotnet/AppWithResources/iOS/Resources/B.otf
@@ -1,0 +1,1 @@
+I am a font too!

--- a/tests/dotnet/AppWithResources/iOS/Resources/C.ttf
+++ b/tests/dotnet/AppWithResources/iOS/Resources/C.ttf
@@ -1,0 +1,1 @@
+Even I am a font!

--- a/tests/dotnet/AppWithResources/macOS/AppWithResources.csproj
+++ b/tests/dotnet/AppWithResources/macOS/AppWithResources.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-macos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithResources/macOS/Makefile
+++ b/tests/dotnet/AppWithResources/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithResources/macOS/Resources/A.ttc
+++ b/tests/dotnet/AppWithResources/macOS/Resources/A.ttc
@@ -1,0 +1,1 @@
+I am a font!

--- a/tests/dotnet/AppWithResources/macOS/Resources/B.otf
+++ b/tests/dotnet/AppWithResources/macOS/Resources/B.otf
@@ -1,0 +1,1 @@
+I am a font too!

--- a/tests/dotnet/AppWithResources/macOS/Resources/C.ttf
+++ b/tests/dotnet/AppWithResources/macOS/Resources/C.ttf
@@ -1,0 +1,1 @@
+Even I am a font!

--- a/tests/dotnet/AppWithResources/shared.csproj
+++ b/tests/dotnet/AppWithResources/shared.csproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+
+		<ApplicationTitle>AppWithResources</ApplicationTitle>
+		<ApplicationId>com.xamarin.appwithresources</ApplicationId>
+	</PropertyGroup>
+
+	<Import Project="../../common/shared-dotnet.csproj" />
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+
+		<BundleResource Update="$(_ResourcePrefix)/B.otf" RegisterFont="true" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/AppWithResources/shared.mk
+++ b/tests/dotnet/AppWithResources/shared.mk
@@ -1,0 +1,26 @@
+TOP=../../../..
+include $(TOP)/Make.config
+
+prepare:
+	$(Q) $(MAKE) -C $(TOP)/tests/dotnet copy-dotnet-config
+
+reload:
+	$(Q) $(MAKE) -C $(TOP)/tests/dotnet reload
+	$(Q) git clean -xfdq
+
+reload-and-build:
+	$(Q) $(MAKE) reload
+	$(Q) $(MAKE) build
+
+reload-and-run:
+	$(Q) $(MAKE) reload
+	$(Q) $(MAKE) run
+
+build: prepare
+	$(Q) $(DOTNET6) build /bl *.csproj $(MSBUILD_VERBOSITY) $(BUILD_ARGUMENTS)
+
+run: prepare
+	$(Q) $(DOTNET6) build /bl *.csproj $(MSBUILD_VERBOSITY) $(BUILD_ARGUMENTS) -t:Run
+
+diag: prepare
+	$(Q) $(DOTNET6) build /v:diag msbuild.binlog

--- a/tests/dotnet/AppWithResources/tvOS/AppWithResources.csproj
+++ b/tests/dotnet/AppWithResources/tvOS/AppWithResources.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-tvos</TargetFramework>
+  </PropertyGroup>
+  <Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithResources/tvOS/Makefile
+++ b/tests/dotnet/AppWithResources/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithResources/tvOS/Resources/A.ttc
+++ b/tests/dotnet/AppWithResources/tvOS/Resources/A.ttc
@@ -1,0 +1,1 @@
+I am a font!

--- a/tests/dotnet/AppWithResources/tvOS/Resources/B.otf
+++ b/tests/dotnet/AppWithResources/tvOS/Resources/B.otf
@@ -1,0 +1,1 @@
+I am a font too!

--- a/tests/dotnet/AppWithResources/tvOS/Resources/C.ttf
+++ b/tests/dotnet/AppWithResources/tvOS/Resources/C.ttf
@@ -1,0 +1,1 @@
+Even I am a font!

--- a/tests/dotnet/Makefile
+++ b/tests/dotnet/Makefile
@@ -34,6 +34,10 @@ run-unit-tests:
 
 all-local:: $(TARGETS)
 
+reload: $(TARGETS)
+	$(Q) $(MAKE) -C $(TOP) -j8 all
+	$(Q) $(MAKE) -C $(TOP) -j8 install
+
 compare compare-size: $(TARGETS)
 	rm -rf packages
 	cd size-comparison && git clean -xfdq

--- a/tests/dotnet/UnitTests/TestBaseClass.cs
+++ b/tests/dotnet/UnitTests/TestBaseClass.cs
@@ -117,5 +117,36 @@ namespace Xamarin.Tests {
 			}
 		}
 
+		protected string GetNativeExecutable (ApplePlatform platform, string app_directory)
+		{
+			var executableName = Path.GetFileNameWithoutExtension (app_directory);
+			switch (platform) {
+			case ApplePlatform.iOS:
+			case ApplePlatform.TVOS:
+			case ApplePlatform.WatchOS:
+				return Path.Combine (app_directory, executableName);
+			case ApplePlatform.MacOSX:
+			case ApplePlatform.MacCatalyst:
+				return Path.Combine (app_directory, "Contents", "MacOS", executableName);
+			default:
+				throw new NotImplementedException ($"Unknown platform: {platform}");
+			}
+		}
+
+		protected string GetResourcesDirectory (ApplePlatform platform, string app_directory)
+		{
+			switch (platform) {
+			case ApplePlatform.iOS:
+			case ApplePlatform.TVOS:
+			case ApplePlatform.WatchOS:
+				return app_directory;
+			case ApplePlatform.MacOSX:
+			case ApplePlatform.MacCatalyst:
+				return Path.Combine (app_directory, "Contents", "Resources");
+			default:
+				throw new NotImplementedException ($"Unknown platform: {platform}");
+			}
+		}
+
 	}
 }


### PR DESCRIPTION
* Automatically include *.ttf, *.ttc and *.otf in .NET projects as BundleResource
  items (if these files are found within the Resources/ subdirectory).
* Add support for a 'RegisterFont' metadata on BundleResource items, where if set
  to 'true', we'll register the font file in the Info.plist as required by the target
  platform.
* Add tests.

Fixes https://github.com/xamarin/xamarin-macios/issues/12536.