### PR TITLE
Bump maccore.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := efad4f0baec567c7937ce0a87b2fc94ee0094a2b
+NEEDED_MACCORE_VERSION := 6f0bf5e2f40be0afe10b23995604808a5bc48959
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@6f0bf5e2f4 [Dotnet] Update the bundle to hold the dotnet assemblies
* xamarin/maccore@c36eb31d43 Update net6 submission file path

Diff: https://github.com/xamarin/maccore/compare/efad4f0baec567c7937ce0a87b2fc94ee0094a2b..6f0bf5e2f40be0afe10b23995604808a5bc48959