### PR TITLE
[tests] Fix a thread synchronization issue in the generator tests.

### DIFF
--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -440,9 +440,11 @@ namespace Xamarin.Tests
 
 		public TextWriter CurrentWriter {
 			get {
-				if (current_writer == null)
-					return original_stdout;
-				return current_writer;
+				lock (lock_obj) {
+					if (current_writer == null)
+						return original_stdout;
+					return current_writer;
+				}
 			}
 		}
 


### PR DESCRIPTION
Properly synchronize access to the current writer in the generator tests'
ThreadStaticTextWriter class.

Should fix this random failure:

    Error Message:
     System.NullReferenceException : Object reference not set to an instance of an object.
    Stack Trace:
       at Xamarin.Tests.ThreadStaticTextWriter.WriteLine(String value) in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/generator/BGenTool.cs:line 478
     at System.IO.TextWriter.SyncTextWriter.WriteLine(Object value)
     at System.Console.WriteLine(Object value)
     at Xamarin.Tests.BGenTool.Execute() in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/generator/BGenTool.cs:line 235
     at Xamarin.Tests.BGenTool.AssertExecute(String message) in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/generator/BGenTool.cs:line 207
     at GeneratorTests.BGenTests.BuildFile(Profile profile, Boolean nowarnings, Boolean processEnums, IEnumerable`1 references, String[] filenames) in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/generator/BGenTests.cs:line 780
     at GeneratorTests.BGenTests.BuildFile(Profile profile, Boolean nowarnings, Boolean processEnums, String[] filenames) in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/generator/BGenTests.cs:line 766
     at GeneratorTests.BGenTests.BuildFile(Profile profile, String[] filenames) in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/generator/BGenTests.cs:line 756
     at GeneratorTests.BGenTests.VSTS970507() in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/generator/BGenTests.cs:line 650