### PR TITLE
[src] Ignore warning due to obsolete method.

### DIFF
--- a/src/CFNetwork/CFHTTPMessage.cs
+++ b/src/CFNetwork/CFHTTPMessage.cs
@@ -147,7 +147,11 @@ namespace CoreServices {
 			CFUrl urlRef = null;
 			NSString methodRef = null;
 
+			// the method is obsolete, but EscapeDataString does not work the same way. We could get the components
+			// of the Uri and then EscapeDataString, but this might introduce bugs, so for now we will ignore the warning
+#pragma warning disable SYSLIB0001
 			var escaped = Uri.EscapeUriString (uri.ToString ());
+#pragma warning restore SYSLIB0001
 
 			try {
 				urlRef = CFUrl.FromUrlString (escaped, null);


### PR DESCRIPTION
The warning is new from .net 5 but the code is old and the change of the
method is not direct, EscapeDataString does not work as EscapeUriString.