### PR TITLE
[release/6.0.1xx-preview9] [msbuild/tools] Add a better error message for when we fail to convert between iOS and macOS versions for Mac Catalyst.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -1089,7 +1089,7 @@ namespace Xamarin.Localization.MSBuild {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not map the macOS version {0} to a corresponding iOS version.
+        ///   Looks up a localized string similar to Could not map the macOS version {0} to a corresponding Mac Catalyst version. Valid macOS versions are: {1}.
         /// </summary>
         public static string E0187 {
             get {
@@ -1098,7 +1098,7 @@ namespace Xamarin.Localization.MSBuild {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not map the iOS version {0} to a corresponding macOS version.
+        ///   Looks up a localized string similar to Could not map the Mac Catalyst version {0} to a corresponding macOS version. Valid Mac Catalyst versions are: {1}.
         /// </summary>
         public static string E0188 {
             get {

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -881,11 +881,11 @@
     </data>
     
     <data name="E0187" xml:space="preserve">
-        <value>Could not map the macOS version {0} to a corresponding iOS version</value>
+        <value>Could not map the macOS version {0} to a corresponding Mac Catalyst version. Valid macOS versions are: {1}</value>
     </data>
 
     <data name="E0188" xml:space="preserve">
-        <value>Could not map the iOS version {0} to a corresponding macOS version</value>
+        <value>Could not map the Mac Catalyst version {0} to a corresponding macOS version. Valid Mac Catalyst versions are: {1}</value>
     </data>
 
     <data name="E7001" xml:space="preserve">

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -212,8 +212,8 @@ namespace Xamarin.MacDev.Tasks
 			if (Platform == ApplePlatform.MacCatalyst && !string.IsNullOrEmpty (SupportedOSPlatformVersion)) {
 				// SupportedOSPlatformVersion is the iOS version for Mac Catalyst.
 				// But we need to store the macOS version in the app manifest, so convert it to the macOS version here.
-				if (!MacCatalystSupport.TryGetMacOSVersion (Sdks.GetAppleSdk (Platform).GetSdkPath (SdkVersion, false), SupportedOSPlatformVersion, out var convertedVersion))
-					Log.LogError (MSBStrings.E0188, SupportedOSPlatformVersion);
+				if (!MacCatalystSupport.TryGetMacOSVersion (Sdks.GetAppleSdk (Platform).GetSdkPath (SdkVersion, false), SupportedOSPlatformVersion, out var convertedVersion, out var knowniOSVersions))
+					Log.LogError (MSBStrings.E0188, SupportedOSPlatformVersion, string.Join (", ", knowniOSVersions));
 				convertedSupportedOSPlatformVersion = convertedVersion;
 			} else {
 				convertedSupportedOSPlatformVersion = SupportedOSPlatformVersion;
@@ -224,8 +224,8 @@ namespace Xamarin.MacDev.Tasks
 				var minimumiOSVersionInManifest = plist?.Get<PString> (ManifestKeys.MinimumOSVersion)?.Value;
 				if (!string.IsNullOrEmpty (minimumiOSVersionInManifest)) {
 					// Convert to the macOS version
-					if (!MacCatalystSupport.TryGetMacOSVersion (Sdks.GetAppleSdk (Platform).GetSdkPath (SdkVersion, false), minimumiOSVersionInManifest, out var convertedVersion))
-						Log.LogError (MSBStrings.E0188, minimumiOSVersionInManifest);
+					if (!MacCatalystSupport.TryGetMacOSVersion (Sdks.GetAppleSdk (Platform).GetSdkPath (SdkVersion, false), minimumiOSVersionInManifest, out var convertedVersion, out var knowniOSVersions))
+						Log.LogError (MSBStrings.E0188, minimumiOSVersionInManifest, string.Join (", ", knowniOSVersions));
 					minimumOSVersionInManifest = convertedVersion;
 				}
 			}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ReadAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ReadAppManifestTaskBase.cs
@@ -70,8 +70,8 @@ namespace Xamarin.MacDev.Tasks {
 			if (Platform == ApplePlatform.MacCatalyst) {
 				// The minimum version in the Info.plist is the macOS version. However, the rest of our tooling
 				// expects the iOS version, so expose that.
-				if (!MacCatalystSupport.TryGetiOSVersion (Sdks.GetAppleSdk (Platform).GetSdkPath (SdkVersion, false), MinimumOSVersion, out var convertedVersion))
-					Log.LogError (MSBStrings.E0187, MinimumOSVersion);
+				if (!MacCatalystSupport.TryGetiOSVersion (Sdks.GetAppleSdk (Platform).GetSdkPath (SdkVersion, false), MinimumOSVersion!, out var convertedVersion, out var knownMacOSVersions))
+					Log.LogError (MSBStrings.E0187, MinimumOSVersion, string.Join (", ", knownMacOSVersions));
 				MinimumOSVersion = convertedVersion;
 			}
 

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
@@ -135,7 +135,7 @@ namespace Xamarin.iOS.Tasks {
 			task.SupportedOSPlatformVersion = "10.0";
 
 			ExecuteTask (task, expectedErrorCount: 1);
-			Assert.AreEqual ("Could not map the iOS version 10.0 to a corresponding macOS version", Engine.Logger.ErrorEvents [0].Message);
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.StartWith ("Could not map the Mac Catalyst version 10.0 to a corresponding macOS version. Valid Mac Catalyst versions are:"));
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ReadAppManifestTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ReadAppManifestTaskTests.cs
@@ -47,7 +47,7 @@ namespace Xamarin.MacDev.Tasks {
 				plist.SetMinimumSystemVersion ("10.0");
 			});
 			ExecuteTask (task, expectedErrorCount: 1);
-			Assert.AreEqual ("Could not map the macOS version 10.0 to a corresponding iOS version", Engine.Logger.ErrorEvents [0].Message);
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.StartWith ("Could not map the macOS version 10.0 to a corresponding Mac Catalyst version. Valid macOS versions are:"));
 		}
 	}
 }

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -439,16 +439,16 @@ namespace Xamarin.Bundler {
 
 		public Version GetMacCatalystmacOSVersion (Version iOSVersion)
 		{
-			if (!MacCatalystSupport.TryGetMacOSVersion (Driver.GetFrameworkDirectory (this), iOSVersion, out var value))
-				throw ErrorHelper.CreateError (183, Errors.MX0183 /* Could not map the iOS version {0} to a macOS version for Mac Catalyst */, iOSVersion.ToString ());
+			if (!MacCatalystSupport.TryGetMacOSVersion (Driver.GetFrameworkDirectory (this), iOSVersion, out var value, out var knowniOSVersions))
+				throw ErrorHelper.CreateError (183, Errors.MX0183 /* Could not map the Mac Catalyst version {0} to a corresponding macOS version. Valid Mac Catalyst versions are: {1} */, iOSVersion.ToString (), string.Join (", ", knowniOSVersions));
 
 			return value;
 		}
 
 		public Version GetMacCatalystiOSVersion (Version macOSVersion)
 		{
-			if (!MacCatalystSupport.TryGetiOSVersion (Driver.GetFrameworkDirectory (this), macOSVersion, out var value))
-				throw ErrorHelper.CreateError (184, Errors.MX0184 /* Could not map the macOS version {0} to a corresponding iOS version for Mac Catalyst */, macOSVersion.ToString ());
+			if (!MacCatalystSupport.TryGetiOSVersion (Driver.GetFrameworkDirectory (this), macOSVersion, out var value, out var knownMacOSVersions))
+				throw ErrorHelper.CreateError (184, Errors.MX0184 /* Could not map the macOS version {0} to a corresponding Mac Catalyst version. Valid macOS versions are: {1} */, macOSVersion.ToString (), string.Join (", ", knownMacOSVersions));
 
 			return value;
 		}

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -3749,7 +3749,7 @@ namespace Xamarin.Bundler {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not map the iOS version {0} to a macOS version for Mac Catalyst.
+        ///   Looks up a localized string similar to Could not map the Mac Catalyst version {0} to a corresponding macOS version. Valid Mac Catalyst versions are: {1}.
         /// </summary>
         public static string MX0183 {
             get {
@@ -3758,7 +3758,7 @@ namespace Xamarin.Bundler {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not map the macOS version {0} to a corresponding iOS version for Mac Catalyst.
+        ///   Looks up a localized string similar to Could not map the macOS version {0} to a corresponding Mac Catalyst version. Valid macOS versions are: {1}.
         /// </summary>
         public static string MX0184 {
             get {

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -924,11 +924,11 @@
 	</data>
     
     <data name="MX0183" xml:space="preserve">
-        <value>Could not map the iOS version {0} to a macOS version for Mac Catalyst</value>
+        <value>Could not map the Mac Catalyst version {0} to a corresponding macOS version. Valid Mac Catalyst versions are: {1}</value>
     </data>
     
     <data name="MX0184" xml:space="preserve">
-        <value>Could not map the macOS version {0} to a corresponding iOS version for Mac Catalyst</value>
+        <value>Could not map the macOS version {0} to a corresponding Mac Catalyst version. Valid macOS versions are: {1}</value>
     </data>
 
 	<data name="MX0185" xml:space="preserve">


### PR DESCRIPTION
New commits in xamarin/Xamarin.MacDev:

* xamarin/Xamarin.MacDev@9e6e29f [Xamarin.MacDev] Return valid iOS/macOS versions when converting betweeen iOS and macOS versions for Mac Catalyst.

Diff: https://github.com/xamarin/Xamarin.MacDev/compare/41d91e0de0354f648a2c5e09d627d0ec1bd8a873..9e6e29f2a4e89b140cb37575168faccc70c45d5f


Backport of #12767
