### PR TITLE
[runtime/tools] Change the 'xamarin_runtime_libraries' array to contain only the names of the runtime library in question.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2575,12 +2575,26 @@ xamarin_is_native_library (const char *libraryName)
 	if (xamarin_runtime_libraries == NULL)
 		return false;
 
+	size_t libraryNameLength = strlen (libraryName);
+	// The libraries in xamarin_runtime_libraries are extension-less, so we need to
+	// remove any .dylib extension for the library name we're comparing with too.
+	if (libraryNameLength > 6 && strcmp (libraryName + libraryNameLength - 6, ".dylib") == 0)
+		libraryNameLength -= 6;
+
+	bool rv = false;
 	for (int i = 0; xamarin_runtime_libraries [i] != NULL; i++) {
-		if (!strcmp (xamarin_runtime_libraries [i], libraryName))
-			return true;
+		// Check if the start of the current xamarin_runtime_libraries entry matches libraryName
+		if (!strncmp (xamarin_runtime_libraries [i], libraryName, libraryNameLength)) {
+			// The start matches, now check if that's all there is
+			if (xamarin_runtime_libraries [i] [libraryNameLength] == 0) {
+				// If so, we've got a match
+				rv = true;
+				break;
+			}
+		}
 	}
 
-	return false;
+	return rv;
 }
 
 void*

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -749,7 +749,7 @@ namespace Xamarin.Bundler {
 			if (app.MonoNativeMode != MonoNativeMode.None) {
 				sw.WriteLine ("static const char *xamarin_runtime_libraries_array[] = {");
 				foreach (var lib in app.MonoLibraries)
-					sw.WriteLine ($"\t\"{Path.GetFileName (lib)}\",");
+					sw.WriteLine ($"\t\"{Path.GetFileNameWithoutExtension (lib)}\",");
 				sw.WriteLine ($"\tNULL");
 				sw.WriteLine ("};");
 			}


### PR DESCRIPTION
P/Invokes may point to a dylib, while the actual library linked into the .app
might be a static library, so make sure to compare without the extension.

This fixes an issue when linking with the static version of the runtime libraries.