### PR TITLE
[mlaunch] Make sure to install mlaunch when the 'install' target is executed.

### DIFF
--- a/tools/mlaunch/Makefile
+++ b/tools/mlaunch/Makefile
@@ -25,6 +25,8 @@ else
 build-and-install:
 	$(Q) $(CP) -R $(MACIOS_BINARIES_PATH)/mlaunch/bin/mlaunch $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin
 	$(Q) $(CP) -R $(MACIOS_BINARIES_PATH)/mlaunch/lib/mlaunch $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib
+
+install-local:: build-and-install
 endif
 
 all-local:: build-and-install


### PR DESCRIPTION
When we create a package, we only execute 'make install' with a custom install
directory (and not 'make all'). This means that we have to make sure 'make
install' actually copies mlaunch to the install directory, otherwise it won't
end up in the package.

So make sure to do this when we're using mlaunch from macios-binaries (it's
already handled correctly in maccore/tools/mlaunch when building mlaunch from
source).