### PR TITLE
[msbuild] Make the CompileAppManifestTaskBase.AppManifest property an ITaskItem.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -94,7 +94,7 @@ namespace Xamarin.MacDev.Tasks
 		{
 			PDictionary plist = null;
 
-			var appManifest = AppManifest.ItemSpec;
+			var appManifest = AppManifest?.ItemSpec;
 			if (File.Exists (appManifest)) {
 				try {
 					plist = PDictionary.FromFile (appManifest);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -30,7 +30,8 @@ namespace Xamarin.MacDev.Tasks
 		[Required]
 		public string AppBundleName { get; set; }
 
-		public string AppManifest { get; set; }
+		// This must be an ITaskItem to copy the file to Windows for remote builds.
+		public ITaskItem AppManifest { get; set; }
 
 		[Required]
 		public string AssemblyName { get; set; }
@@ -93,11 +94,12 @@ namespace Xamarin.MacDev.Tasks
 		{
 			PDictionary plist = null;
 
-			if (File.Exists (AppManifest)) {
+			var appManifest = AppManifest.ItemSpec;
+			if (File.Exists (appManifest)) {
 				try {
-					plist = PDictionary.FromFile (AppManifest);
+					plist = PDictionary.FromFile (appManifest);
 				} catch (Exception ex) {
-					LogAppManifestError (MSBStrings.E0010, AppManifest, ex.Message);
+					LogAppManifestError (MSBStrings.E0010, appManifest, ex.Message);
 					return false;
 				}
 			} else {

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -240,11 +240,11 @@ namespace Xamarin.MacDev.Tasks
 					minimumOSVersion = SdkVersion;
 				}
 			} else if (!IAppleSdkVersion_Extensions.TryParse (minimumOSVersionInManifest, out var _)) {
-				Log.LogError (null, null, null, AppManifest, 0, 0, 0, 0, MSBStrings.E0011, minimumOSVersionInManifest);
+				LogAppManifestError (MSBStrings.E0011, minimumOSVersionInManifest);
 				return false;
 			} else if (!string.IsNullOrEmpty (convertedSupportedOSPlatformVersion) && convertedSupportedOSPlatformVersion != minimumOSVersionInManifest) {
 				// SupportedOSPlatformVersion and the value in the Info.plist are not the same. This is an error.
-				Log.LogError (null, null, null, AppManifest, 0, 0, 0, 0, MSBStrings.E7082, minimumVersionKey, minimumOSVersionInManifest, SupportedOSPlatformVersion);
+				LogAppManifestError (MSBStrings.E7082, minimumVersionKey, minimumOSVersionInManifest, SupportedOSPlatformVersion);
 				return false;
 			} else {
 				minimumOSVersion = minimumOSVersionInManifest;
@@ -261,13 +261,22 @@ namespace Xamarin.MacDev.Tasks
 		protected void LogAppManifestError (string format, params object[] args)
 		{
 			// Log an error linking to the Info.plist file
-			Log.LogError (null, null, null, AppManifest, 0, 0, 0, 0, format, args);
+			if (AppManifest != null) {
+				Log.LogError (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, format, args);
+			} else {
+				Log.LogError (format, args);
+			}
+
 		}
 
 		protected void LogAppManifestWarning (string format, params object[] args)
 		{
 			// Log a warning linking to the Info.plist file
-			Log.LogWarning (null, null, null, AppManifest, 0, 0, 0, 0, format, args);
+			if (AppManifest != null) {
+				Log.LogWarning (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, format, args);
+			} else {
+				Log.LogWarning (format, args);
+			}
 		}
 
 		protected void SetValue (PDictionary dict, string key, string value)

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
@@ -52,7 +52,7 @@ namespace Xamarin.iOS.Tasks {
 			main.SetMinimumOSVersion ("14.0");
 			main.Save (mainPath);
 
-			task.AppManifest = mainPath;
+			task.AppManifest = new TaskItem (mainPath);
 
 			ExecuteTask (task);
 
@@ -77,7 +77,7 @@ namespace Xamarin.iOS.Tasks {
 			partial.SetMinimumOSVersion ("13.0");
 			partial.Save (partialPath);
 
-			task.AppManifest = mainPath;
+			task.AppManifest = new TaskItem (mainPath);
 			task.PartialAppManifests = new [] { new TaskItem (partialPath) };
 
 			ExecuteTask (task);
@@ -96,7 +96,7 @@ namespace Xamarin.iOS.Tasks {
 			plist.SetMinimumOSVersion ("10.0");
 			var manifest = Path.Combine (dir, "Info.plist");
 			plist.Save (manifest);
-			task.AppManifest = manifest;
+			task.AppManifest = new TaskItem (manifest);
 			task.SupportedOSPlatformVersion = "11.0";
 
 			ExecuteTask (task, expectedErrorCount: 1);

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
@@ -38,14 +38,14 @@ namespace Xamarin.iOS.Tasks
 			Task.AppBundleName = appBundleName;
 			Task.CompiledAppManifest = new TaskItem (Path.Combine (Cache.CreateTemporaryDirectory (), "AppBundlePath", "Info.plist"));
 			Task.AssemblyName = assemblyName;
-			Task.AppManifest = CreateTempFile ("foo.plist");
+			Task.AppManifest = new TaskItem (CreateTempFile ("foo.plist"));
 			Task.SdkPlatform = "iPhoneSimulator";
 			Task.SdkVersion = "10.0";
 
 			Plist = new PDictionary ();
 			Plist ["CFBundleDisplayName"] = displayName;
 			Plist ["CFBundleIdentifier"] = bundleIdentifier;
-			Plist.Save (Task.AppManifest);
+			Plist.Save (Task.AppManifest.ItemSpec);
 		}
 
 		public override void Setup ()
@@ -62,7 +62,7 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void PlistMissing ()
 		{
-			File.Delete (Task.AppManifest);
+			File.Delete (Task.AppManifest.ItemSpec);
 			Assert.IsTrue (Task.Execute (), "#1");
 			Assert.That (Task.CompiledAppManifest.ItemSpec, Does.Exist, "#2");
 		}
@@ -79,7 +79,7 @@ namespace Xamarin.iOS.Tasks
 		public void MissingBundleIdentifier ()
 		{
 			Plist.Remove ("CFBundleIdentifier");
-			Plist.Save (Task.AppManifest);
+			Plist.Save (Task.AppManifest.ItemSpec);
 			Assert.IsTrue (Task.Execute (), "#1");
 		}
 
@@ -87,7 +87,7 @@ namespace Xamarin.iOS.Tasks
 		public void MissingDisplayName ()
 		{
 			Plist.Remove ("CFBundleDisplayName");
-			Plist.Save (Task.AppManifest);
+			Plist.Save (Task.AppManifest.ItemSpec);
 			Assert.IsTrue (Task.Execute (), "#1");
 		}
 


### PR DESCRIPTION
So that any input app manifest is copied to Windows when doing remote builds.