### PR TITLE
[msbuild] Remove dead property (AotScope).

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -46,7 +46,6 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 		<HttpClientHandler Condition="'$(HttpClientHandler)' == ''">HttpClientHandler</HttpClientHandler>
 		<I18n Condition="'$(I18n)' == ''"></I18n>
 		<IncludeMonoRuntime Condition="'$(IncludeMonoRuntime)' == ''">true</IncludeMonoRuntime>
-		<AotScope Condition="'$(AotScope)' == ''">None</AotScope>
 		<Profiling Condition="'$(Profiling)' == '' And '$(MtouchProfiling)' != ''">$(MtouchProfiling)</Profiling>
 		<Profiling Condition="'$(Profiling)' == ''">False</Profiling>
 	</PropertyGroup>


### PR DESCRIPTION
All the other code related to this property was removed a long time ago
(659a74cc369395958b9c00d107281ef94873d57d).