### PR TITLE
[tools] Keep passing 'direct-icalls' to the AOT compiler for legacy Xamarin. Fixes #12810.

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -1491,7 +1491,7 @@ namespace Xamarin.Bundler {
 			aotArguments.Add ($"data-outfile={dataFile}");
 			aotArguments.Add ("static");
 			aotArguments.Add ("asmonly");
-			if (app.LibMonoLinkMode == AssemblyBuildTarget.StaticObject)
+			if (app.LibMonoLinkMode == AssemblyBuildTarget.StaticObject || !Driver.IsDotNet)
 				aotArguments.Add ("direct-icalls");
 			aotArguments.AddRange (app.AotArguments);
 			if (llvm_only)


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/12810.
Fixes https://github.com/mono/mono/issues/21210.