### PR TITLE
[msbuild] Share the OptimizeImage and OptimizePropertyList tasks and targets between iOS and macOS.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/OptimizeImageTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/OptimizeImageTaskBase.cs
@@ -4,9 +4,7 @@ using System.IO;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 
-using Xamarin.MacDev.Tasks;
-
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	public abstract class OptimizeImageTaskBase : XamarinToolTask
 	{

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/OptimizeImage.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/OptimizeImage.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	public class OptimizeImage : OptimizeImageTaskBase, ITaskCallback
 	{

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/OptimizePropertyList.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/OptimizePropertyList.cs
@@ -1,10 +1,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Framework;
-using Xamarin.MacDev.Tasks;
 using Xamarin.Messaging.Build.Client;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	public class OptimizePropertyList : OptimizePropertyListTaskBase, ITaskCallback
 	{

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -58,8 +58,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.Metal" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.MetalLib" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.MTouch" AssemblyFile="$(_TaskAssemblyName)" />
-	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.OptimizeImage" AssemblyFile="$(_TaskAssemblyName)" />
-	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.OptimizePropertyList" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.ParseDeviceSpecificBuildInformation" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.PrepareNativeReferences" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Condition="'$(_PlatformName)' != 'macOS'" TaskName="Xamarin.iOS.Tasks.ResolveNativeWatchApp" AssemblyFile="$(_TaskAssemblyName)" />
@@ -111,6 +109,8 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetFullPath" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetPropertyListValue" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.IBTool" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.OptimizeImage" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.OptimizePropertyList" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.PackLibraryResources" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.ParseBundlerArguments" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.PrepareResourceRules" AssemblyFile="$(_TaskAssemblyName)" />
@@ -128,6 +128,12 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
+
+	<ItemDefinitionGroup>
+		<_BundleResourceWithLogicalName>
+			<Optimize />
+		</_BundleResourceWithLogicalName>
+	</ItemDefinitionGroup>
 
 	<!--
 		@(NativeReference) are not safe to use as an Input to a task, as frameworks are a directory and will appears unbuilt every time.
@@ -958,6 +964,146 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<_CreateAppManifest>$(_CanOutputAppBundle)</_CreateAppManifest>
 			<_TemporaryAppManifest>$(DeviceSpecificIntermediateOutputPath)AppManifest.plist</_TemporaryAppManifest>
 		</PropertyGroup>
+	</Target>
+
+
+	<!-- Optimize png images -->
+
+	<PropertyGroup>
+		<OptimizePngImagesDependsOn>
+			_CollectPngImages;
+			_CoreOptimizePngImages;
+			_AfterCoreOptimizePngImages
+		</OptimizePngImagesDependsOn>
+	</PropertyGroup>
+
+	<Target Name="_OptimizePngImages" DependsOnTargets="$(OptimizePngImagesDependsOn)" />
+
+	<Target Name="_CollectPngImages" DependsOnTargets="_CollectBundleResources">
+		<CreateItem Include="@(_BundleResourceWithLogicalName)" Condition="'%(_BundleResourceWithLogicalName.Extension)' == '.png' And '%(_BundleResourceWithLogicalName.Optimize)' == 'true'">
+			<Output TaskParameter="Include" ItemName="_PngImage" />
+		</CreateItem>
+	</Target>
+
+	<Target Name="_CoreOptimizePngImages"
+		DependsOnTargets="_CollectPngImages;_DetectSdkLocations"
+		Inputs="@(_PngImage)"
+		Outputs="@(_PngImage -> '$(DeviceSpecificIntermediateOutputPath)optimized\%(LogicalName)')">
+
+		<OptimizeImage
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			ToolExe="$(PngCrushExe)"
+			ToolPath="$(PngCrushPath)"
+			SdkDevPath="$(_SdkDevPath)"
+			InputImages="@(_PngImage)"
+			OutputImages="@(_PngImage -> '$(DeviceSpecificIntermediateOutputPath)optimized\%(LogicalName)')">
+			<Output TaskParameter="OutputImages" ItemName="FileWrites" />
+		</OptimizeImage>
+	</Target>
+
+	<Target Name="_AfterCoreOptimizePngImages" Condition="'@(_PngImage)' != ''">
+		<ItemGroup>
+			<_BundleResourceWithLogicalName Remove="@(_PngImage)" />
+		</ItemGroup>
+
+		<CreateItem Include="$(DeviceSpecificIntermediateOutputPath)optimized\%(_PngImage.LogicalName)" AdditionalMetadata="LogicalName=%(_PngImage.LogicalName);Optimize='false';ResourceTags=%(_PngImage.ResourceTags)">
+			<Output TaskParameter="Include" ItemName="_BundleResourceWithLogicalName" />
+		</CreateItem>
+	</Target>
+
+	<!-- Optimize property lists -->
+
+	<PropertyGroup>
+		<OptimizePropertyListsDependsOn>
+			_CollectPropertyLists;
+			_CoreOptimizePropertyLists;
+			_AfterCoreOptimizePropertyLists
+		</OptimizePropertyListsDependsOn>
+	</PropertyGroup>
+
+	<Target Name="_OptimizePropertyLists" DependsOnTargets="$(OptimizePropertyListsDependsOn)" />
+
+	<Target Name="_CollectPropertyLists" DependsOnTargets="_CollectBundleResources">
+		<CreateItem Include="@(_BundleResourceWithLogicalName)" Condition="'%(_BundleResourceWithLogicalName.Extension)' == '.plist' And '%(_BundleResourceWithLogicalName.Optimize)' == 'true'">
+			<Output TaskParameter="Include" ItemName="_PropertyList" />
+		</CreateItem>
+		<ItemGroup>
+			<FileWrites Include="$(DeviceSpecificIntermediateOutputPath)optimized\%(_PropertyList.LogicalName)" />
+		</ItemGroup>
+	</Target>
+
+	<Target Name="_CoreOptimizePropertyLists"
+		DependsOnTargets="_CollectPropertyLists;_DetectSdkLocations"
+		Inputs="@(_PropertyList)"
+		Outputs="$(DeviceSpecificIntermediateOutputPath)optimized\%(_PropertyList.LogicalName)"
+		>
+
+		<OptimizePropertyList
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			ToolExe="$(PlUtilExe)"
+			ToolPath="$(PlUtilPath)"
+			Input="%(_PropertyList.Identity)"
+			Output="$(DeviceSpecificIntermediateOutputPath)optimized\%(_PropertyList.LogicalName)">
+		</OptimizePropertyList>
+	</Target>
+
+	<Target Name="_AfterCoreOptimizePropertyLists" Condition="'@(_PropertyList)' != ''">
+		<ItemGroup>
+			<_BundleResourceWithLogicalName Remove="@(_PropertyList)" />
+		</ItemGroup>
+
+		<CreateItem Include="$(DeviceSpecificIntermediateOutputPath)optimized\%(_PropertyList.LogicalName)" AdditionalMetadata="LogicalName=%(_PropertyList.LogicalName);Optimize='false'">
+			<Output TaskParameter="Include" ItemName="_BundleResourceWithLogicalName" />
+		</CreateItem>
+	</Target>
+
+	<!-- Optimize localization files (*.strings) -->
+
+	<PropertyGroup>
+		<OptimizeLocalizationFilesDependsOn>
+			_CollectLocalizationFiles;
+			_CoreOptimizeLocalizationFiles;
+			_AfterCoreOptimizeLocalizationFiles
+		</OptimizeLocalizationFilesDependsOn>
+	</PropertyGroup>
+
+	<Target Name="_OptimizeLocalizationFiles" DependsOnTargets="$(OptimizeLocalizationFilesDependsOn)" />
+
+	<Target Name="_CollectLocalizationFiles" DependsOnTargets="_CollectBundleResources">
+		<CreateItem Include="@(_BundleResourceWithLogicalName)" Condition="'%(_BundleResourceWithLogicalName.Extension)' == '.strings' And '%(_BundleResourceWithLogicalName.Optimize)' == 'true'">
+			<Output TaskParameter="Include" ItemName="_LocalizationFile" />
+		</CreateItem>
+		<ItemGroup>
+			<FileWrites Include="$(DeviceSpecificIntermediateOutputPath)optimized\%(_LocalizationFile.LogicalName)" />
+		</ItemGroup>
+	</Target>
+
+	<Target Name="_CoreOptimizeLocalizationFiles"
+		DependsOnTargets="_CollectLocalizationFiles;_DetectSdkLocations"
+		Inputs="@(_LocalizationFile)"
+		Outputs="$(DeviceSpecificIntermediateOutputPath)optimized\%(_LocalizationFile.LogicalName)"
+		>
+
+		<OptimizePropertyList
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			ToolExe="$(PlUtilExe)"
+			ToolPath="$(PlUtilPath)"
+			Input="%(_LocalizationFile.Identity)"
+			Output="$(DeviceSpecificIntermediateOutputPath)optimized\%(_LocalizationFile.LogicalName)">
+		</OptimizePropertyList>
+	</Target>
+
+	<Target Name="_AfterCoreOptimizeLocalizationFiles" Condition="'@(_LocalizationFile)' != ''">
+		<ItemGroup>
+			<_BundleResourceWithLogicalName Remove="@(_LocalizationFile)" />
+		</ItemGroup>
+
+		<CreateItem Include="$(DeviceSpecificIntermediateOutputPath)optimized\%(_LocalizationFile.LogicalName)" AdditionalMetadata="LogicalName=%(_LocalizationFile.LogicalName);Optimize='false'">
+			<Output TaskParameter="Include" ItemName="_BundleResourceWithLogicalName" />
+		</CreateItem>
 	</Target>
 
 	<PropertyGroup Condition="'$(IsBindingProject)' == 'true'">

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -41,13 +41,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<_AppBundleName>$(AssemblyName)</_AppBundleName>
 	</PropertyGroup>
 
-	<ItemDefinitionGroup>
-		<!-- MSBuild will honor this default metadata, but xbuild will not, so we still need to use CreateItem -->
-		<_BundleResourceWithLogicalName>
-			<Optimize />
-		</_BundleResourceWithLogicalName>
-	</ItemDefinitionGroup>
-
 	<!-- Insert our app bundle generation step -->
 	<PropertyGroup Condition="'$(UsingAppleNETSdk)' != 'true'">
 		<BuildDependsOn>
@@ -74,36 +67,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			_CleanUploaded;
 		</CleanDependsOn>
 	</PropertyGroup>
-
-	<PropertyGroup>
-		<OptimizePngImagesDependsOn>
-			_CollectPngImages;
-			_CoreOptimizePngImages;
-			_AfterCoreOptimizePngImages
-		</OptimizePngImagesDependsOn>
-	</PropertyGroup>
-
-	<Target Name="_OptimizePngImages" DependsOnTargets="$(OptimizePngImagesDependsOn)" />
-
-	<PropertyGroup>
-		<OptimizePropertyListsDependsOn>
-			_CollectPropertyLists;
-			_CoreOptimizePropertyLists;
-			_AfterCoreOptimizePropertyLists
-		</OptimizePropertyListsDependsOn>
-	</PropertyGroup>
-
-	<Target Name="_OptimizePropertyLists" DependsOnTargets="$(OptimizePropertyListsDependsOn)" />
-
-	<PropertyGroup>
-		<OptimizeLocalizationFilesDependsOn>
-			_CollectLocalizationFiles;
-			_CoreOptimizeLocalizationFiles;
-			_AfterCoreOptimizeLocalizationFiles
-		</OptimizeLocalizationFilesDependsOn>
-	</PropertyGroup>
-
-	<Target Name="_OptimizeLocalizationFiles" DependsOnTargets="$(OptimizeLocalizationFilesDependsOn)" />
 
 	<PropertyGroup Condition="'$(UsingAppleNETSdk)' != 'true'">
 		<CreateAppBundleDependsOn>
@@ -371,109 +334,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			>
 		</CreateDebugConfiguration>
-	</Target>
-
-	<Target Name="_CollectPngImages" DependsOnTargets="_CollectBundleResources">
-		<CreateItem Include="@(_BundleResourceWithLogicalName)" Condition="'%(_BundleResourceWithLogicalName.Extension)' == '.png' And '%(_BundleResourceWithLogicalName.Optimize)' == 'true'">
-			<Output TaskParameter="Include" ItemName="_PngImage" />
-		</CreateItem>
-	</Target>
-
-	<Target Name="_CoreOptimizePngImages"
-		DependsOnTargets="_CollectPngImages;_DetectSdkLocations"
-		Inputs="@(_PngImage)"
-		Outputs="@(_PngImage -> '$(DeviceSpecificIntermediateOutputPath)optimized\%(LogicalName)')">
-
-		<OptimizeImage
-			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true'"
-			ToolExe="$(PngCrushExe)"
-			ToolPath="$(PngCrushPath)"
-			SdkDevPath="$(_SdkDevPath)"
-			InputImages="@(_PngImage)"
-			OutputImages="@(_PngImage -> '$(DeviceSpecificIntermediateOutputPath)optimized\%(LogicalName)')">
-			<Output TaskParameter="OutputImages" ItemName="FileWrites" />
-		</OptimizeImage>
-	</Target>
-
-	<Target Name="_AfterCoreOptimizePngImages" Condition="'@(_PngImage)' != ''">
-		<ItemGroup>
-			<_BundleResourceWithLogicalName Remove="@(_PngImage)" />
-		</ItemGroup>
-
-		<CreateItem Include="$(DeviceSpecificIntermediateOutputPath)optimized\%(_PngImage.LogicalName)" AdditionalMetadata="LogicalName=%(_PngImage.LogicalName);Optimize='false';ResourceTags=%(_PngImage.ResourceTags)">
-			<Output TaskParameter="Include" ItemName="_BundleResourceWithLogicalName" />
-		</CreateItem>
-	</Target>
-
-	<Target Name="_CollectPropertyLists" DependsOnTargets="_CollectBundleResources">
-		<CreateItem Include="@(_BundleResourceWithLogicalName)" Condition="'%(_BundleResourceWithLogicalName.Extension)' == '.plist' And '%(_BundleResourceWithLogicalName.Optimize)' == 'true'">
-			<Output TaskParameter="Include" ItemName="_PropertyList" />
-		</CreateItem>
-		<ItemGroup>
-			<FileWrites Include="$(DeviceSpecificIntermediateOutputPath)optimized\%(_PropertyList.LogicalName)" />
-		</ItemGroup>
-	</Target>
-
-	<Target Name="_CoreOptimizePropertyLists"
-		DependsOnTargets="_CollectPropertyLists;_DetectSdkLocations"
-		Inputs="@(_PropertyList)"
-		Outputs="$(DeviceSpecificIntermediateOutputPath)optimized\%(_PropertyList.LogicalName)"
-		>
-
-		<OptimizePropertyList
-			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true'"
-			ToolExe="$(PlUtilExe)"
-			ToolPath="$(PlUtilPath)"
-			Input="%(_PropertyList.Identity)"
-			Output="$(DeviceSpecificIntermediateOutputPath)optimized\%(_PropertyList.LogicalName)">
-		</OptimizePropertyList>
-	</Target>
-
-	<Target Name="_AfterCoreOptimizePropertyLists" Condition="'@(_PropertyList)' != ''">
-		<ItemGroup>
-			<_BundleResourceWithLogicalName Remove="@(_PropertyList)" />
-		</ItemGroup>
-
-		<CreateItem Include="$(DeviceSpecificIntermediateOutputPath)optimized\%(_PropertyList.LogicalName)" AdditionalMetadata="LogicalName=%(_PropertyList.LogicalName);Optimize='false'">
-			<Output TaskParameter="Include" ItemName="_BundleResourceWithLogicalName" />
-		</CreateItem>
-	</Target>
-
-	<Target Name="_CollectLocalizationFiles" DependsOnTargets="_CollectBundleResources">    
-		<CreateItem Include="@(_BundleResourceWithLogicalName)" Condition="'%(_BundleResourceWithLogicalName.Extension)' == '.strings' And '%(_BundleResourceWithLogicalName.Optimize)' == 'true'">
-			<Output TaskParameter="Include" ItemName="_LocalizationFile" />
-		</CreateItem>
-		<ItemGroup>
-			<FileWrites Include="$(DeviceSpecificIntermediateOutputPath)optimized\%(_LocalizationFile.LogicalName)" />
-		</ItemGroup>
-	</Target>
-
-	<Target Name="_CoreOptimizeLocalizationFiles"
-		DependsOnTargets="_CollectLocalizationFiles;_DetectSdkLocations"
-		Inputs="@(_LocalizationFile)"
-		Outputs="$(DeviceSpecificIntermediateOutputPath)optimized\%(_LocalizationFile.LogicalName)"
-		>
-
-		<OptimizePropertyList
-			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true'"
-			ToolExe="$(PlUtilExe)"
-			ToolPath="$(PlUtilPath)"
-			Input="%(_LocalizationFile.Identity)"
-			Output="$(DeviceSpecificIntermediateOutputPath)optimized\%(_LocalizationFile.LogicalName)">
-		</OptimizePropertyList>
-	</Target>
-
-	<Target Name="_AfterCoreOptimizeLocalizationFiles" Condition="'@(_LocalizationFile)' != ''">
-		<ItemGroup>
-			<_BundleResourceWithLogicalName Remove="@(_LocalizationFile)" />
-		</ItemGroup>
-
-		<CreateItem Include="$(DeviceSpecificIntermediateOutputPath)optimized\%(_LocalizationFile.LogicalName)" AdditionalMetadata="LogicalName=%(_LocalizationFile.LogicalName);Optimize='false'">
-			<Output TaskParameter="Include" ItemName="_BundleResourceWithLogicalName" />
-		</CreateItem>
 	</Target>
 
 	<PropertyGroup>


### PR DESCRIPTION
This brings .png and .plist optimization to macOS (but no behavior is changed,
because it's already disabled by default).