### PR TITLE
Make the NuGet version code a bit more consistent.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -74,8 +74,8 @@ PULL_REQUEST_ID=$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)
 endif
 
 # For release branches, modify the following variables to hardcode a version name
-# Set the NUGET_HARDCODED_PRERELEASE_IDENTIFIER variable to the prerelease identifer you want (say "preview.5." (the trailing dot is important)
-NUGET_HARDCODED_PRERELEASE_IDENTIFIER=preview.10.
+# Set the NUGET_HARDCODED_PRERELEASE_IDENTIFIER variable to the prerelease identifer you want (say "preview.10")
+NUGET_HARDCODED_PRERELEASE_IDENTIFIER=preview.10
 # Set the NUGET_HARDCODED_PRERELEASE_BRANCH variable to the exact name for the branch the above variable should apply to (so that any other branches won't pick it up by accident).
 # For the previous example, this would be "release/6.0.1xx-preview5"
 # When creating a release branch from main, this must be changed from "main" to the new release branch.
@@ -89,7 +89,7 @@ NUGET_HARDCODED_PRERELEASE_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%
 ifneq ($(PULL_REQUEST_ID),)
 NUGET_PRERELEASE_IDENTIFIER=ci.pr.gh$(PULL_REQUEST_ID).
 else ifeq ($(NUGET_HARDCODED_PRERELEASE_BRANCH_ALPHANUMERIC),$(CURRENT_BRANCH_ALPHANUMERIC))
-NUGET_PRERELEASE_IDENTIFIER=$(NUGET_HARDCODED_PRERELEASE_IDENTIFIER)
+NUGET_PRERELEASE_IDENTIFIER=$(NUGET_HARDCODED_PRERELEASE_IDENTIFIER).
 else
 NUGET_PRERELEASE_IDENTIFIER=ci.$(CURRENT_BRANCH_ALPHANUMERIC).
 endif


### PR DESCRIPTION
Some code branches had names with dot at the end, some code paths didn't.

Now they're all dotted in the same place.