### PR TITLE
[xcode13-ios] [Foundation] Remove warning due to the Equals accepting a null value.

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -13775,7 +13775,7 @@ namespace Foundation
 		NSHost _FromAddress (string address);
 
 		[Export ("isEqualToHost:")]
-		bool Equals (NSHost host);
+		bool Equals ([NullAllowed] NSHost host);
 
 		[Export ("name")]
 		string Name { get; }

--- a/tests/monotouch-test/Foundation/NSHostTest.cs
+++ b/tests/monotouch-test/Foundation/NSHostTest.cs
@@ -1,0 +1,22 @@
+#if __MACOS__
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using Foundation;
+
+#nullable  enable
+
+namespace MonoTouchFixtures.Foundation {
+	public class NSHostTest {
+
+		public void EqualsNullAllowed ()
+		{
+			using var host = NSHost.FromAddress ("http://microsoft.com");
+			Assert.False (host.Equals (null));
+		}
+	}
+}
+#endif

--- a/tests/xtro-sharpie/macOS-Foundation.ignore
+++ b/tests/xtro-sharpie/macOS-Foundation.ignore
@@ -834,3 +834,6 @@
 !missing-null-allowed! 'System.Void Foundation.NSUserNotification::set_Subtitle(System.String)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void Foundation.NSUserNotification::set_Title(System.String)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void Foundation.NSUserNotification::set_UserInfo(Foundation.NSDictionary)' is missing an [NullAllowed] on parameter #0
+
+# added because the method does the right thing yet it was not marked by apple, there is a test for it
+!extra-null-allowed! 'System.Boolean Foundation.NSHost::Equals(Foundation.NSHost)' has a extraneous [NullAllowed] on parameter #0


### PR DESCRIPTION
Removes the following warning during the builds:

```
warning CS8767: Nullability of reference types in type of parameter 'host' of 'bool NSHost.Equals(NSHost host)' doesn't match implicitly implemented member 'bool IEquatable<NSHost>.Equals(NSHost? other)' (possibly because of nullability attributes)
```

Test was added to ensure that we did not throw an exception.


Backport of #12839
