### PR TITLE
[Metal] Fix a few issues in MTLDevice.

### DIFF
--- a/src/Metal/MTLDevice.cs
+++ b/src/Metal/MTLDevice.cs
@@ -61,42 +61,48 @@ namespace Metal {
 		public static IMTLDevice [] GetAllDevices ()
 		{
 			var rv = MTLCopyAllDevices ();
-			return NSArray.ArrayFromHandle<IMTLDevice> (rv);
+			var devices = NSArray.ArrayFromHandle<IMTLDevice> (rv);
+			NSObject.DangerousRelease (rv);
+			return devices;
 		}
 
 #if !NET
 		[Mac (10, 13)]
 #endif
 		[DllImport (Constants.MetalLibrary)]
-		unsafe static extern IntPtr MTLCopyAllDevicesWithObserver (ref IntPtr observer, void* handler);
+		static extern IntPtr MTLCopyAllDevicesWithObserver (out IntPtr observer, ref BlockLiteral handler);
 
 #if !NET
 		[Mac (10, 13)]
 #endif
 		[BindingImpl (BindingImplOptions.Optimizable)]
+		public static IMTLDevice [] GetAllDevices (MTLDeviceNotificationHandler handler, out NSObject observer)
+		{
+			var block_handler = new BlockLiteral ();
+			block_handler.SetupBlockUnsafe (static_notificationHandler, handler);
+
+			var rv = MTLCopyAllDevicesWithObserver (out var observer_handle, ref block_handler);
+			var obj = NSArray.ArrayFromHandle<IMTLDevice> (rv);
+			NSObject.DangerousRelease (rv);
+
+			block_handler.CleanupBlock ();
+
+			observer = Runtime.GetNSObject (observer_handle);
+			NSObject.DangerousRelease (observer_handle); // Apple's documentation says "The observer out parameter is returned with a +1 retain count [...]."
+
+			return obj;
+		}
+
+#if !NET
+		[Mac (10, 13)]
+#endif
+		[Obsolete ("Use the overload that takes an 'out NSObject' instead.")]
+		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static IMTLDevice [] GetAllDevices (ref NSObject observer, MTLDeviceNotificationHandler handler)
 		{
-			if (observer == null)
-				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (observer));
-
-			IntPtr handle = observer.Handle;
-
-			unsafe
-			{
-				BlockLiteral* block_ptr_handler;
-				BlockLiteral block_handler;
-				block_handler = new BlockLiteral ();
-				block_ptr_handler = &block_handler;
-				block_handler.SetupBlockUnsafe (static_notificationHandler, handler);
-
-				var rv = MTLCopyAllDevicesWithObserver (ref handle, (void*) block_ptr_handler);
-				var obj = NSArray.ArrayFromHandle<IMTLDevice> (rv);
-
-				if (handle != observer.Handle)
-					observer = Runtime.GetNSObject (handle);
-
-				return obj;
-			}
+			var rv = GetAllDevices (handler, out var obs);
+			observer = obs;
+			return rv;
 		}
 
 		internal delegate void InnerNotification (IntPtr block, IntPtr device, IntPtr notifyName);

--- a/tests/monotouch-test/Metal/MTLDeviceTests.cs
+++ b/tests/monotouch-test/Metal/MTLDeviceTests.cs
@@ -36,6 +36,18 @@ namespace MonoTouchFixtures.Metal {
 				MTLDevice.RemoveObserver (refObj);
 			});
 		}
+
+		[Test]
+		public void GetAllDevicesTestOutObserver ()
+		{
+			var devices = MTLDevice.GetAllDevices ((IMTLDevice device, NSString notifyName) => { }, out var observer);
+
+			// It's possible to run on a system that does not support metal,
+			// in which case we'll get an empty array of devices.
+			Assert.IsNotNull (devices, "MTLDevices.GetAllDevices not null");
+
+			MTLDevice.RemoveObserver (observer);
+		}
 #endif
 
 		[Test]


### PR DESCRIPTION
* MTLCopyAllDevices returns a retained object, so we need to release it.
* MTLCopyAllDevicesWithObserver returns an observer (no need to provide one). This
  means we can obsolete the 'ref NSObject' overload (the API doesn't make sense),
  and instead add an 'out NSObject' overload.
* The returned observer from MTLCopyAllDevicesWithObserver is retained, so we must
  release it.
* The returned array from MTLCopyAllDevicesWithObserver is a retained object, so
  we need to release it.
* Simpify the supporting block code for the calls to MTLCopyAllDevicesWithObserver.
* Clean up the block we passed to MTLCopyAllDevicesWithObserver.