### PR TITLE
[devops] Set a 1h timeout on cleanup duties.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -87,6 +87,7 @@ steps:
   env:
     BUILD_REVISION: 'jenkins'
   continueOnError: true
+  timeoutInMinutes: 60
 
 - bash: |
     security set-key-partition-list -S apple-tool:,apple: -s -k $OSX_KEYCHAIN_PASS login.keychain

--- a/tools/devops/automation/templates/devices/build.yml
+++ b/tools/devops/automation/templates/devices/build.yml
@@ -54,6 +54,7 @@ steps:
   env:
     BUILD_REVISION: 'jenkins'
   continueOnError: true
+  timeoutInMinutes: 60
 
 - bash: cd $(System.DefaultWorkingDirectory)/xamarin-macios/ && git clean -xdf
   displayName: 'Clean workspace'

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -65,6 +65,7 @@ steps:
   env:
     BUILD_REVISION: 'jenkins'
   continueOnError: true
+  timeoutInMinutes: 60
 
 # Use a cmdlet to check if the space available in the devices root system is larger than 50 gb. If there is not
 # enough space available it:


### PR DESCRIPTION
If cleaning takes longer than 1h then something is stuck somewhere, so let's
just ignore it and hope for the best for the rest of the test run.