### PR TITLE
[msbuild] Ignore CS8002 for the Xamarin.iOS.Tasks and Xamarin.Mac.Tasks projects.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -5,6 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../product.snk</AssemblyOriginatorKeyFile>
+    <NoWarn>$(NoWarn);8002</NoWarn> <!-- Referenced projects aren't signed: this doesn't matter, because we use ILMerge to merge into a single assembly which we sign -->
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Messaging.Build.Client" Version="$(MessagingVersion)" />

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -6,6 +6,7 @@
     <IncludeMSBuildAssets Condition="'$(IncludeMSBuildAssets)' == ''">compile</IncludeMSBuildAssets>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../product.snk</AssemblyOriginatorKeyFile>
+    <NoWarn>$(NoWarn);8002</NoWarn> <!-- Referenced projects aren't signed: this doesn't matter, because we use ILMerge to merge into a single assembly which we sign -->
   </PropertyGroup>
 
   <Import Project="..\..\eng\Versions.props" />


### PR DESCRIPTION
Fixes these warnings, which we don't care about:

    CSC : warning CS8002: Referenced assembly 'Xamarin.MacDev.Tasks.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' does not have a strong name. [(...)/xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    CSC : warning CS8002: Referenced assembly 'Xamarin.iOS.Tasks.Core, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' does not have a strong name. [(...)/xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    CSC : warning CS8002: Referenced assembly 'Xamarin.MacDev.Tasks, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' does not have a strong name. [(...)/xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    CSC : warning CS8002: Referenced assembly 'Xamarin.Localization.MSBuild, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' does not have a strong name. [(...)/xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    CSC : warning CS8002: Referenced assembly 'Xamarin.MacDev.Tasks.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' does not have a strong name. [(...)/xamarin-macios/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj]
    CSC : warning CS8002: Referenced assembly 'Xamarin.Mac.Tasks.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' does not have a strong name. [(...)/xamarin-macios/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj]