### PR TITLE
[msbuild] Augment the CreateBindingResourcePackage to support creating a zipped binding resource package.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -2546,5 +2546,14 @@ namespace Xamarin.Localization.MSBuild {
                 return ResourceManager.GetString("W7085", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expected a &apos;manifest&apos; file in the directory {0}..
+        /// </summary>
+        public static string W7087 {
+            get {
+                return ResourceManager.GetString("W7087", resourceCulture);
+            }
+        }
     }
 }

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -1931,6 +1931,15 @@ namespace Xamarin.Localization.MSBuild {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The value &apos;{0}&apos; is invalid for the Compress property. Valid values: &apos;true&apos;, &apos;false&apos; or &apos;auto&apos;..
+        /// </summary>
+        public static string E7086 {
+            get {
+                return ResourceManager.GetString("E7086", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid framework: {0}.
         /// </summary>
         public static string InvalidFramework {
@@ -2526,6 +2535,15 @@ namespace Xamarin.Localization.MSBuild {
         public static string W0176 {
             get {
                 return ResourceManager.GetString("W0176", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Creating a compressed binding resource package because there are symlinks in the input..
+        /// </summary>
+        public static string W7085 {
+            get {
+                return ResourceManager.GetString("W7085", resourceCulture);
             }
         }
     }

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1338,4 +1338,9 @@
         <value>The value '{0}' is invalid for the Compress property. Valid values: 'true', 'false' or 'auto'.</value>
         <comment>The following are literal names and should not be translated: Compress, true, false, auto.</comment>
     </data>
+
+    <data name="W7087" xml:space="preserve">
+        <value>Expected a 'manifest' file in the directory {0}.</value>
+        <comment>The following are literal names and should not be translated: manifest</comment>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1329,4 +1329,13 @@
             {0}: the target directory (in the app bundle) for the font file
         </comment>
     </data>
+
+    <data name="W7085" xml:space="preserve">
+        <value>Creating a compressed binding resource package because there are symlinks in the input.</value>
+    </data>
+
+    <data name="E7086" xml:space="preserve">
+        <value>The value '{0}' is invalid for the Compress property. Valid values: 'true', 'false' or 'auto'.</value>
+        <comment>The following are literal names and should not be translated: Compress, true, false, auto.</comment>
+    </data>
 </root>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateBindingResourcePackageBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateBindingResourcePackageBase.cs
@@ -53,6 +53,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			if (compress) {
 				var zipFile = Path.GetFullPath (BindingResourcePath + ".zip");
+				Log.LogMessage (MSBStrings.M0121, zipFile);
 				if (File.Exists (zipFile))
 					File.Delete (zipFile);
 				Directory.CreateDirectory (Path.GetDirectoryName (zipFile));
@@ -74,6 +75,7 @@ namespace Xamarin.MacDev.Tasks {
 				}
 			} else {
 				var bindingResourcePath = BindingResourcePath;
+				Log.LogMessage (MSBStrings.M0121, bindingResourcePath);
 				Directory.CreateDirectory (bindingResourcePath);
 				foreach (var nativeRef in NativeReferences)
 					Xamarin.Bundler.FileCopier.UpdateDirectory (nativeRef.ItemSpec, bindingResourcePath);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateBindingResourcePackageBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateBindingResourcePackageBase.cs
@@ -41,9 +41,9 @@ namespace Xamarin.MacDev.Tasks {
 			} else if (string.Equals (Compress, "auto", StringComparison.OrdinalIgnoreCase)) {
 				compress = ContainsSymlinks (NativeReferences);
 				if (compress)
-					Log.LogMessage (MessageImportance.Low, "Creating a compressed binding resource package because there are symlinks in the input."); // FIXME: localize
+					Log.LogMessage (MessageImportance.Low, MSBStrings.W7085 /* "Creating a compressed binding resource package because there are symlinks in the input." */);
 			} else {
-				Log.LogError ("The value '{0}' is invalid for the Compress property. Valid values: 'true', 'false' or 'auto'.", Compress); // FIXME: localize
+				Log.LogError (MSBStrings.E7086 /* "The value '{0}' is invalid for the Compress property. Valid values: 'true', 'false' or 'auto'." */, Compress);
 			}
 
 			Directory.CreateDirectory (compress ? IntermediateOutputPath : BindingResourcePath);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
@@ -85,7 +85,7 @@ namespace Xamarin.MacDev.Tasks {
 			return PlatformFrameworkHelper.GetSdkPlatform (Platform, isSimulator);
 		}
 
-		protected async System.Threading.Tasks.Task<Execution> ExecuteAsync (string fileName, IList<string> arguments, string sdkDevPath = null, Dictionary<string, string> environment = null, bool mergeOutput = true, bool showErrorIfFailure = true)
+		protected async System.Threading.Tasks.Task<Execution> ExecuteAsync (string fileName, IList<string> arguments, string sdkDevPath = null, Dictionary<string, string> environment = null, bool mergeOutput = true, bool showErrorIfFailure = true, string workingDirectory = null)
 		{
 			// Create a new dictionary if we're given one, to make sure we don't change the caller's dictionary.
 			var launchEnvironment = environment == null ? new Dictionary<string, string> () : new Dictionary<string, string> (environment);
@@ -93,7 +93,7 @@ namespace Xamarin.MacDev.Tasks {
 				launchEnvironment ["DEVELOPER_DIR"] = sdkDevPath;
 
 			Log.LogMessage (MessageImportance.Normal, MSBStrings.M0001, fileName, StringUtils.FormatArguments (arguments));
-			var rv = await Execution.RunAsync (fileName, arguments, environment: launchEnvironment, mergeOutput: mergeOutput);
+			var rv = await Execution.RunAsync (fileName, arguments, environment: launchEnvironment, mergeOutput: mergeOutput, workingDirectory: workingDirectory);
 			Log.LogMessage (rv.ExitCode == 0 ? MessageImportance.Low : MessageImportance.High, MSBStrings.M0002, fileName, rv.ExitCode);
 
 			// Show the output

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -145,6 +145,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' And '$(IsBindingProject)' != 'true'"
 			Architectures="$(TargetArchitectures)"
+			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
 			NativeReferences="@(_XCFrameworkNativeReference);@(_FrameworkNativeReference)"
 			References="@(ReferencePath)"
 			SdkIsSimulator="$(_SdkIsSimulator)"

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -161,15 +161,36 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<Target Name="_CreateBindingResourcePackage" Condition="'$(DesignTimeBuild)' != 'true'"
 		DependsOnTargets="_ExpandNativeReferences"
 		Inputs="$(MSBuildAllProjects);$(MSBuildProjectFullPath);@(ObjcBindingApiDefinition);@(ObjcBindingCoreSource);@(ReferencePath);@(ObjcBindingNativeLibrary);@(_FrameworkNativeReference);@(_FileNativeReference)"
-		Outputs="$(BindingResourcePath)/manifest">
+		Outputs="$(BindingResourcePath).stamp">
+
+		<!-- CompressBindingResourcePackage specifies whether the package should be compressed (zipped) or not
+			true: compressed (we produce an Assembly.resources directory)
+			false: not compressed (we produce an Assembly.resources.zip file)
+			auto: compressed if there are any symlinks
+			The default is 'false' for legacy Xamarin projects (for compatibility) and 'auto' for .NET projects (NuGet doesn't handle symlinks properly, so this way it's not necessary to set this property to create NuGets that work)
+		-->
+		<PropertyGroup Condition="'$(CompressBindingResourcePackage)' == ''">
+			<CompressBindingResourcePackage Condition="'$(UsingAppleNETSdk)' == 'true'">auto</CompressBindingResourcePackage>
+			<CompressBindingResourcePackage Condition="'$(UsingAppleNETSdk)' != 'true'">false</CompressBindingResourcePackage>
+		</PropertyGroup>
+
 		<CreateBindingResourcePackage Condition="'$(IsMacEnabled)' == 'true' And '$(NoBindingEmbedding)' == 'true' And '$(SkipBindingResourcePackage)' != 'true'"
 			SessionId="$(BuildSessionId)"
-			OutputPath="$(OutputPath)"
 			NativeReferences="@(NativeReference)"
-			ProjectDir="$(MSBuildProjectDirectory)"
-			BindingAssembly="@(IntermediateAssembly)">
-			<Output TaskParameter="Manifest" ItemName="_BundleResourceManifest" />
+			BindingResourcePath="$(BindingResourcePath)"
+			Compress="$(CompressBindingResourcePackage)"
+			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
+			>
 		</CreateBindingResourcePackage>
+
+		<Touch
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			AlwaysCreate="true"
+			Files="$(BindingResourcePath).stamp"
+			>
+			<Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
+		</Touch>
 	</Target>
 
 	<!-- Cleaning via FileWrites leaves empty framework directories on disk, so nuke via RemoveDir -->

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CreateBindingResourceTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CreateBindingResourceTaskTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using NUnit.Framework;
+
+using Xamarin.iOS.Tasks;
+using Xamarin.Utils;
+
+namespace Xamarin.MacDev.Tasks {
+	[TestFixture]
+	public class CreateBindingResourceTaskTests : TestBase {
+		CreateBindingResourcePackage ExecuteTask (string compress, bool symlinks, out string tmpdir)
+		{
+			tmpdir = Cache.CreateTemporaryDirectory ();
+			var task = CreateTask<CreateBindingResourcePackage> ();
+			task.Compress = compress;
+			task.BindingResourcePath = Path.Combine (tmpdir, "CreateBindingResourceTaskTest");
+			task.IntermediateOutputPath = Path.Combine (tmpdir, "IntermediateOutputPath");
+			task.NativeReferences = CreateNativeReferences (tmpdir, symlinks);
+
+			var currentDir = Environment.CurrentDirectory;
+			try {
+				Environment.CurrentDirectory = tmpdir;
+				Assert.IsTrue (task.Execute (), "Execute");
+			} finally {
+				Environment.CurrentDirectory = currentDir;
+			}
+
+			return task;
+		}
+
+		[Test]
+		[TestCase (true)]
+		[TestCase (false)]
+		public void Compressed (bool symlinks)
+		{
+			var task = ExecuteTask ("true", symlinks, out var tmpdir);
+
+			var zipFile = task.BindingResourcePath + ".zip";
+			Assert.That (zipFile, Does.Exist, "Zip existence");
+
+			var extracted = Path.Combine (tmpdir, "Extracted");
+			Extract (zipFile, extracted);
+			AssertResourceDirectory (extracted, symlinks);
+		}
+
+		[Test]
+		[TestCase (true)]
+		[TestCase (false)]
+		public void Uncompressed (bool symlinks)
+		{
+			var task = ExecuteTask ("false", symlinks, out var tmpdir);
+
+			AssertResourceDirectory (task.BindingResourcePath, symlinks);
+		}
+
+		[Test]
+		[TestCase (true)]
+		[TestCase (false)]
+		public void Auto (bool symlinks)
+		{
+			var task = ExecuteTask ("auto", symlinks, out var tmpdir);
+
+			string extracted;
+			if (symlinks) {
+				var zipFile = task.BindingResourcePath + ".zip";
+				Assert.That (zipFile, Does.Exist, "Zip existence");
+
+				extracted = Path.Combine (tmpdir, "Extracted");
+				Extract (zipFile, extracted);
+			} else {
+				extracted = task.BindingResourcePath;
+			}
+			AssertResourceDirectory (extracted, symlinks);
+		}
+
+		void Extract (string zipArchive, string targetDirectory)
+		{
+			var unzipArguments = new List<string> ();
+			unzipArguments.Add ("-d");
+			unzipArguments.Add (targetDirectory);
+			unzipArguments.Add (zipArchive);
+			var output = new StringBuilder ();
+			var rv = Execution.RunWithStringBuildersAsync ("unzip", unzipArguments, standardOutput: output, standardError: output).Result;
+			Assert.AreEqual (0, rv.ExitCode, "ExitCode\n" + output.ToString ());
+		}
+
+		void AssertResourceDirectory (string directory, bool symlinks)
+		{
+			var allFiles = Directory.GetFileSystemEntries (directory, "*", SearchOption.AllDirectories).OrderBy (v => v).Select (v => v.Substring (directory.Length + 1)).ToArray ();
+			foreach (var file in allFiles)
+				Console.WriteLine (file);
+			if (symlinks) {
+				Assert.AreEqual (7, allFiles.Length, "Length");
+			} else {
+				Assert.AreEqual (5, allFiles.Length, "Length");
+			}
+			Assert.AreEqual ("ABCDEFGHIJKLMAAA", File.ReadAllText (Path.Combine (directory, "A.txt")), "A.txt");
+			Assert.AreEqual ("ABCDEFGHIJKLMBBB", File.ReadAllText (Path.Combine (directory, "B.txt")), "B.txt");
+			Assert.AreEqual ("ABCDEFGHIJKLMCCC", File.ReadAllText (Path.Combine (directory, "C.framework/C.txt")), "C.txt");
+			if (symlinks) {
+				var linkToCPath = Path.Combine (directory, "C.framework/LinkToC.txt");
+				Assert.AreEqual ("ABCDEFGHIJKLMCCC", File.ReadAllText (linkToCPath), "LinkToC.txt");
+				Assert.IsTrue (PathUtils.IsSymlink (linkToCPath), "LinkToC.txt - IsSymlink");
+				Assert.AreEqual ("C.txt", PathUtils.GetSymlinkTarget (linkToCPath), "LinkToC.txt - IsSymlink target");
+
+				var linkToNowherePath = Path.Combine (directory, "C.framework/LinkToNowhere.txt");
+				Assert.Throws<FileNotFoundException> (() => File.ReadAllText (linkToNowherePath), "LinkToNowhere.txt");
+				Assert.AreEqual ("Nowhere.txt", PathUtils.GetSymlinkTarget (linkToNowherePath), "LinkToNowhere.txt - IsSymlink target");
+			}
+
+			var manifest = @"<BindingAssembly>
+	<NativeReference Name=""A.txt"">
+		<Kind></Kind>
+		<ForceLoad></ForceLoad>
+		<SmartLink></SmartLink>
+		<Frameworks></Frameworks>
+		<WeakFrameworks></WeakFrameworks>
+		<LinkerFlags></LinkerFlags>
+		<NeedsGccExceptionHandling></NeedsGccExceptionHandling>
+		<IsCxx></IsCxx>
+	</NativeReference>
+	<NativeReference Name=""B.txt"">
+		<Kind></Kind>
+		<ForceLoad></ForceLoad>
+		<SmartLink></SmartLink>
+		<Frameworks></Frameworks>
+		<WeakFrameworks></WeakFrameworks>
+		<LinkerFlags></LinkerFlags>
+		<NeedsGccExceptionHandling></NeedsGccExceptionHandling>
+		<IsCxx></IsCxx>
+	</NativeReference>
+	<NativeReference Name=""C.framework"">
+		<Kind></Kind>
+		<ForceLoad></ForceLoad>
+		<SmartLink></SmartLink>
+		<Frameworks></Frameworks>
+		<WeakFrameworks></WeakFrameworks>
+		<LinkerFlags></LinkerFlags>
+		<NeedsGccExceptionHandling></NeedsGccExceptionHandling>
+		<IsCxx></IsCxx>
+	</NativeReference>
+</BindingAssembly>";
+			Assert.AreEqual (manifest, File.ReadAllText (Path.Combine (directory, "manifest")), "Manifest");
+		}
+
+		ITaskItem[] CreateNativeReferences (string tmpdir, bool symlinks)
+		{
+			var rv = new List<ITaskItem> ();
+
+			// Full path
+			var fn = Path.Combine (tmpdir, "A.txt");
+			File.WriteAllText (fn, "ABCDEFGHIJKLMAAA");
+			rv.Add (new TaskItem (fn));
+
+			// Relative path
+			fn = Path.Combine (tmpdir, "B.txt");
+			File.WriteAllText (fn, "ABCDEFGHIJKLMBBB");
+			rv.Add (new TaskItem (Path.GetFileName (fn)));
+
+			// Directory with symlink
+			var dir = Path.Combine (tmpdir, "C.framework");
+			Directory.CreateDirectory (dir);
+			rv.Add (new TaskItem (dir));
+			File.WriteAllText (Path.Combine (dir, "C.txt"), "ABCDEFGHIJKLMCCC");
+			if (symlinks) {
+				PathUtils.CreateSymlink (Path.Combine (dir, "LinkToC.txt"), "C.txt");
+				PathUtils.CreateSymlink (Path.Combine (dir, "LinkToNowhere.txt"), "Nowhere.txt");
+			}
+
+			return rv.ToArray ();
+		}
+
+	}
+}
+

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/TestEngine.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/TestEngine.cs
@@ -27,20 +27,30 @@ namespace Xamarin.iOS.Tasks
 			throw new NotImplementedException ();
 		}
 
+		bool Verbose => true; // change to true while debugging output
+
 		public void LogCustomEvent (CustomBuildEventArgs e)
 		{
+			if (Verbose)
+				Console.WriteLine (e.Message);
 			Logger.CustomEvents.Add (e);
 		}
 		public void LogErrorEvent (BuildErrorEventArgs e)
 		{
+			if (Verbose)
+				Console.WriteLine (e.Message);
 			Logger.ErrorEvents.Add (e);
 		}
 		public void LogMessageEvent (BuildMessageEventArgs e)
 		{
+			if (Verbose)
+				Console.WriteLine (e.Message);
 			Logger.MessageEvents.Add (e);
 		}
 		public void LogWarningEvent (BuildWarningEventArgs e)
 		{
+			if (Verbose)
+				Console.WriteLine (e.Message);
 			Logger.WarningsEvents.Add (e);
 		}
 

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/TestEngine.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/TestEngine.cs
@@ -27,7 +27,7 @@ namespace Xamarin.iOS.Tasks
 			throw new NotImplementedException ();
 		}
 
-		bool Verbose => true; // change to true while debugging output
+		bool Verbose => false; // change to true while debugging output
 
 		public void LogCustomEvent (CustomBuildEventArgs e)
 		{

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -161,6 +161,15 @@ namespace Xamarin.Bundler {
 				return;
 
 			string resourceBundlePath = Path.ChangeExtension (FullPath, ".resources");
+			if (!Directory.Exists (resourceBundlePath)) {
+				var zipPath = resourceBundlePath + ".zip";
+				if (File.Exists (zipPath)) {
+					string path = Path.Combine (App.Cache.Location, Path.GetFileName (resourceBundlePath));
+					if (Driver.RunCommand ("/usr/bin/unzip", "-u", "-o", "-d", path, zipPath) != 0)
+						throw ErrorHelper.CreateError (1306, Errors.MX1306 /* Could not decompress the file '{0}'. Please review the build log for more information from the native 'unzip' command. */, zipPath);
+					resourceBundlePath = path;
+				}
+			}
 			string manifestPath = Path.Combine (resourceBundlePath, "manifest");
 			if (File.Exists (manifestPath)) {
 				foreach (NativeReferenceMetadata metadata in ReadManifest (manifestPath)) {

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -164,7 +164,7 @@ namespace Xamarin.Bundler {
 			if (!Directory.Exists (resourceBundlePath)) {
 				var zipPath = resourceBundlePath + ".zip";
 				if (File.Exists (zipPath)) {
-					string path = Path.Combine (App.Cache.Location, Path.GetFileName (resourceBundlePath));
+					var path = Path.Combine (App.Cache.Location, Path.GetFileName (resourceBundlePath));
 					if (Driver.RunCommand ("/usr/bin/unzip", "-u", "-o", "-d", path, zipPath) != 0)
 						throw ErrorHelper.CreateError (1306, Errors.MX1306 /* Could not decompress the file '{0}'. Please review the build log for more information from the native 'unzip' command. */, zipPath);
 					resourceBundlePath = path;

--- a/tools/common/PathUtils.cs
+++ b/tools/common/PathUtils.cs
@@ -220,8 +220,10 @@ namespace Xamarin.Utils
 			if (!Directory.Exists (directoryOrFile))
 				return false;
 
-			foreach (var entry in Directory.EnumerateFileSystemEntries (directoryOrFile))
-				return IsSymlinkOrContainsSymlinks (entry);
+			foreach (var entry in Directory.EnumerateFileSystemEntries (directoryOrFile)) {
+				if (IsSymlinkOrContainsSymlinks (entry))
+					return true;
+			}
 
 			return false;
 		}

--- a/tools/common/PathUtils.cs
+++ b/tools/common/PathUtils.cs
@@ -211,5 +211,19 @@ namespace Xamarin.Utils
 			const int S_IFLNK = 40960;
 			return (buf.st_mode & S_IFLNK) == S_IFLNK;
 		}
+
+		public static bool IsSymlinkOrContainsSymlinks (string directoryOrFile)
+		{
+			if (IsSymlink (directoryOrFile))
+				return true;
+
+			if (!Directory.Exists (directoryOrFile))
+				return false;
+
+			foreach (var entry in Directory.EnumerateFileSystemEntries (directoryOrFile))
+				return IsSymlinkOrContainsSymlinks (entry);
+
+			return false;
+		}
 	}
 }

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -3786,6 +3786,15 @@ namespace Xamarin.Bundler {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not decompress the file &apos;{0}&apos;. Please review the build log for more information from the native &apos;unzip&apos; command..
+        /// </summary>
+        public static string MX1306 {
+            get {
+                return ResourceManager.GetString("MX1306", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to One or more reference(s) to type &apos;{0}&apos; already exists inside &apos;{1}&apos; before linking
         ///		.
         /// </summary>

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -1015,6 +1015,10 @@
 		</value>
 	</data>
 
+	<data name="MX1306" xml:space="preserve">
+		<value>Could not decompress the file '{0}'. Please review the build log for more information from the native 'unzip' command.</value>
+	</data>
+
 	<data name="MM1401" xml:space="preserve">
 		<value>The required 'Xamarin.Mac.dll' assembly is missing from the references
 		</value>


### PR DESCRIPTION
Augment the CreateBindingResourcePackage to support creating a zipped binding
resource package (which is just a zipped version of the binding resource
package). This can either be manually chosen by the new 'Compressed' property,
or automatically detected (create a zipped version when there's a symlink in
the binding resource package).

The default is to not create a zipped version in legacy Xamarin, and
automatically detect for .NET.

The problem this is trying to solve is when creating a NuGet package - NuGet
doesn't handle symlinks correctly and it's not possible to create a NuGet with
symlinks. Instead we need to create a zipfile with all the binding resources.
The default has been chosen so that we automatically create a zip file when
it's required for .NET, while still maintaining old behavior with legacy
Xamarin.