### PR TITLE
[msbuild] Sign the localization assembly as well.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
+++ b/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../../product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>


### PR DESCRIPTION
Fixes this problem:

    error MSB4018: The "FindItemWithLogicalName" task failed unexpectedly.
    error MSB4018: System.IO.FileLoadException: Could not load file or assembly 'Xamarin.Localization.MSBuild, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. A strongly-named assembly is required. (Exception from HRESULT: 0x80131044)
    error MSB4018: File name: 'Xamarin.Localization.MSBuild, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'
    error MSB4018: at Xamarin.MacDev.Tasks.FindItemWithLogicalNameTaskBase.Execute()
    error MSB4018: at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
    error MSB4018: at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()