### PR TITLE
[dotnet] Implement support for the MtouchFloat32 MSBuild property. Fixes #12524.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -424,6 +424,7 @@
 				MarshalManagedExceptionMode=$(_MarshalManagedExceptionMode)
 				MarshalObjectiveCExceptionMode=$(_MarshalObjectiveCExceptionMode)
 				@(_MonoLibrary -> 'MonoLibrary=%(Identity)')
+				MtouchFloat32=$(MtouchFloat32)
 				Optimize=$(_BundlerOptimize)
 				PartialStaticRegistrarLibrary=$(_LibPartialStaticRegistrar)
 				Platform=$(_PlatformName)

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
@@ -25,7 +25,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<MtouchProfiling Condition="'$(MtouchProfiling)' == ''">False</MtouchProfiling>
 		<MtouchLinkerDumpDependencies Condition="'$(MtouchLinkerDumpDependencies)' == ''">False</MtouchLinkerDumpDependencies>
 		<MtouchUseLlvm Condition="'$(MtouchUseLlvm)' == ''">False</MtouchUseLlvm>
-		<MtouchFloat32 Condition="'$(MtouchFloat32)' == ''">False</MtouchFloat32>
+		<MtouchFloat32 Condition="'$(MtouchFloat32)' == '' And '$(UsingAppleNETSdk)' != 'true'">False</MtouchFloat32>
 		<MtouchEnableBitcode Condition="'$(MtouchEnableBitcode)' == ''">False</MtouchEnableBitcode>
 		<MtouchUseThumb Condition="'$(MtouchUseThumb)' == ''">False</MtouchUseThumb>
 		<MtouchProjectDirectory>$(MSBuildProjectDirectory)</MtouchProjectDirectory>

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -74,6 +74,7 @@ namespace Xamarin.Bundler {
 		// The AOT arguments are currently not used for macOS, but they could eventually be used there as well (there's no mmp option to set these yet).
 		public List<string> AotArguments = new List<string> ();
 		public List<string> AotOtherArguments = null;
+		public bool? AotFloat32 = null;
 
 		public DlsymOptions DlsymOptions;
 		public List<Tuple<string, bool>> DlsymAssemblies;
@@ -1482,6 +1483,8 @@ namespace Xamarin.Bundler {
 				processArguments.Add ("-O=gsharedvt");
 			if (app.AotOtherArguments != null)
 				processArguments.AddRange (app.AotOtherArguments);
+			if (app.AotFloat32.HasValue)
+				processArguments.Add (app.AotFloat32.Value ? "-O=float32" : "-O=-float32");
 			aotArguments = new List<string> ();
 			if (Platform == ApplePlatform.MacCatalyst) {
 				aotArguments.Add ($"--aot=mtriple={arch}-apple-ios{DeploymentTarget}-macabi");

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -184,6 +184,10 @@ namespace Xamarin.Linker {
 				case "MonoLibrary":
 					Application.MonoLibraries.Add (value);
 					break;
+				case "MtouchFloat32":
+					if (!TryParseOptionalBoolean (value, out Application.AotFloat32))
+						throw new InvalidOperationException ($"Unable to parse the {key} value: {value} in {linker_file}");
+					break;
 				case "Optimize":
 					user_optimize_flags = value;
 					break;
@@ -319,6 +323,26 @@ namespace Xamarin.Linker {
 
 			Application.InitializeCommon ();
 			Application.Initialize ();
+		}
+
+		bool TryParseOptionalBoolean (string input, out bool? value)
+		{
+			value = null;
+
+			if (string.IsNullOrEmpty (input))
+				return true;
+
+			if (string.Equals (input, "true", StringComparison.OrdinalIgnoreCase)) {
+				value = true;
+				return true;
+			}
+
+			if (string.Equals (input, "false", StringComparison.OrdinalIgnoreCase)) {
+				value = false;
+				return true;
+			}
+
+			return false;
 		}
 
 		AssemblyBuildTarget ParseLinkMode (string value, string variableName)


### PR DESCRIPTION
Implement support for the MtouchFloat32 MSBuild property, and do so in a way
that allows us to change the default in the future, if we so wish.

Fixes https://github.com/xamarin/xamarin-macios/issues/12524.