### PR TITLE
[tests] Add a test to verify that AppDomain.CurrentDomain.BaseDirectory is always something. Fixes #12687.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -857,5 +857,11 @@ Additional information:
 #endif
 			Assert.AreEqual (expectedDirectory, actualDirectory, "Current directory at launch");
 		}
+
+		[Test]
+		public void CurrentDomain_BaseDirectory_Test ()
+		{
+			Assert.That (AppDomain.CurrentDomain.BaseDirectory, Is.Not.Null.And.Not.Empty, "AppDomain.CurrentDomain.BaseDirectory");
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/12687.