### PR TITLE
[ApiDiffs] Creating Api Diffs for the Dotnet Assemblies

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -41,6 +41,7 @@ APIDIFF_REFERENCES_DOTNET_iOS=https://bosstoragemirror.blob.core.windows.net/wre
 APIDIFF_REFERENCES_DOTNET_tvOS=https://bosstoragemirror.blob.core.windows.net/wrench/main/3c2c3d062daedd66ccd06ecb68192767ddf8e3c4/5315390/package/bundle.zip
 APIDIFF_REFERENCES_DOTNET_macOS=https://bosstoragemirror.blob.core.windows.net/wrench/main/3c2c3d062daedd66ccd06ecb68192767ddf8e3c4/5315390/package/bundle.zip
 APIDIFF_REFERENCES_DOTNET_MacCatalyst=https://bosstoragemirror.blob.core.windows.net/wrench/main/3c2c3d062daedd66ccd06ecb68192767ddf8e3c4/5315390/package/bundle.zip
+
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 
 #

--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -603,3 +603,4 @@ jenkins-api-diff:
 	$(Q) mkdir -p $(JENKINS_RESULTS_DIRECTORY)/api-diff
 	$(Q) $(CP) *.html $(JENKINS_RESULTS_DIRECTORY)/api-diff
 	$(Q) $(CP) *.md $(JENKINS_RESULTS_DIRECTORY)/api-diff
+	$(Q) $(CP) -R diff $(JENKINS_RESULTS_DIRECTORY)/api-diff


### PR DESCRIPTION
This PR creates the Api Diffs for the Dotnet Assemblies for three different scenarios:
* New Dotnet assemblies vs. Stable Dotnet assemblies
* New Dotnet assemblies vs. Stable Legacy assemblies
* New Dotnet iOS assembly vs. New Dotnet MacCatalyst assembly

Task is found here: https://github.com/xamarin/xamarin-macios/issues/10210

Next part of this is to include these new diffs into the CI!