### PR TITLE
[Maccore] Bump maccore to bring the feed config.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 6f0bf5e2f40be0afe10b23995604808a5bc48959
+NEEDED_MACCORE_VERSION := 0be9399a534a1b7d28275a1629d95ed092fbfaa8
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
Commits: 
 * [Make] Set the nuget feeds to use in CI as a make variable. (#2522)

Diff: https://github.com/xamarin/maccore/compare/6f0bf5e2f40be0afe10b23995604808a5bc48959..0be9399a534a1b7d28275a1629d95ed092fbfaa8
