### PR TITLE
[tests] Modify a few test directories with multiple projects to have the projects in subfolders.

### DIFF
--- a/tests/bindings-framework-test/iOS/bindings-framework-test.csproj
+++ b/tests/bindings-framework-test/iOS/bindings-framework-test.csproj
@@ -15,7 +15,7 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>bindings-framework-test</AssemblyName>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>..\..\..\product.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants></DefineConstants>
@@ -48,43 +48,43 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
-    <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+    <ObjcBindingApiDefinition Include="..\ApiDefinition.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ObjcBindingCoreSource Include="StructsAndEnums.cs" />
+    <ObjcBindingCoreSource Include="..\StructsAndEnums.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.ObjCBinding.CSharp.targets" />
   <PropertyGroup>
-    <TestLibrariesDirectory>..\..\tests\test-libraries</TestLibrariesDirectory>
+    <TestLibrariesDirectory>..\..\..\tests\test-libraries</TestLibrariesDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="..\..\tests\test-libraries\libframework.m">
+    <None Include="..\..\..\tests\test-libraries\libframework.m">
       <Link>libframework.m</Link>
     </None>
-    <None Include="..\..\tests\test-libraries\libframework.h">
+    <None Include="..\..\..\tests\test-libraries\libframework.h">
       <Link>libframework.h</Link>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <TestLibrariesInput Include="..\..\tests\test-libraries\libframework.m" />
-    <TestLibrariesOutput Include="..\..\tests\test-libraries\.libs\ios-fat\XTest.framework" />
-    <TestLibrariesOutput Include="..\..\tests\test-libraries\.libs\ios-fat\XSharedObjectTest.framework" />
-    <TestLibrariesOutput Include="..\..\tests\test-libraries\.libs\ios-fat\XSharedARTest.framework" />
+    <TestLibrariesInput Include="..\..\..\tests\test-libraries\libframework.m" />
+    <TestLibrariesOutput Include="..\..\..\tests\test-libraries\.libs\ios-fat\XTest.framework" />
+    <TestLibrariesOutput Include="..\..\..\tests\test-libraries\.libs\ios-fat\XSharedObjectTest.framework" />
+    <TestLibrariesOutput Include="..\..\..\tests\test-libraries\.libs\ios-fat\XSharedARTest.framework" />
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\..\tests\test-libraries\.libs\ios-fat\XStaticArTest.framework">
+    <NativeReference Include="..\..\..\tests\test-libraries\.libs\ios-fat\XStaticArTest.framework">
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
       <Frameworks Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'">CoreLocation ModelIO</Frameworks>
       <Frameworks Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.WatchOS'">CoreLocation</Frameworks>
     </NativeReference>
-    <NativeReference Include="..\..\tests\test-libraries\.libs\ios-fat\XStaticObjectTest.framework">
+    <NativeReference Include="..\..\..\tests\test-libraries\.libs\ios-fat\XStaticObjectTest.framework">
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
       <Frameworks Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'">CoreLocation ModelIO</Frameworks>
       <Frameworks Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.WatchOS'">CoreLocation</Frameworks>
     </NativeReference>
-    <NativeReference Include="..\..\tests\test-libraries\.libs\ios-fat\XTest.framework">
+    <NativeReference Include="..\..\..\tests\test-libraries\.libs\ios-fat\XTest.framework">
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
       <Frameworks Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'">CoreLocation ModelIO</Frameworks>

--- a/tests/bindings-framework-test/macOS/bindings-framework-test.csproj
+++ b/tests/bindings-framework-test/macOS/bindings-framework-test.csproj
@@ -13,9 +13,9 @@
    <OutputType>Library</OutputType>
     <RootNamespace>bindingstest</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <AssemblyName>bindings-xcframework-test</AssemblyName>
+    <AssemblyName>bindings-framework-test</AssemblyName>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>..\..\..\product.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants></DefineConstants>
@@ -26,7 +26,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\Any CPU\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DEBUG;FRAMEWORK_TEST;XCFRAMEWORK;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DEBUG;FRAMEWORK_TEST;;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -35,7 +35,7 @@
     <DebugType>none</DebugType>
     <Optimize>True</Optimize>
     <OutputPath>bin\Any CPU\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DO_NOT_REMOVE;FRAMEWORK_TEST;XCFRAMEWORK;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DO_NOT_REMOVE;FRAMEWORK_TEST;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -48,33 +48,29 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
-    <ObjcBindingApiDefinition Include="..\bindings-framework-test\ApiDefinition.cs">
-      <Link>ApiDefinition.cs</Link>
-    </ObjcBindingApiDefinition>
+    <ObjcBindingApiDefinition Include="..\ApiDefinition.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ObjcBindingCoreSource Include="..\bindings-framework-test\StructsAndEnums.cs">
-      <Link>StructsAndEnums.cs</Link>
-    </ObjcBindingCoreSource>
+    <ObjcBindingCoreSource Include="..\StructsAndEnums.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.ObjCBinding.CSharp.targets" />
   <PropertyGroup>
-    <TestLibrariesDirectory>..\..\tests\test-libraries</TestLibrariesDirectory>
+    <TestLibrariesDirectory>..\..\..\tests\test-libraries</TestLibrariesDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="..\..\tests\test-libraries\libframework.m">
+    <None Include="..\..\..\tests\test-libraries\libframework.m">
       <Link>libframework.m</Link>
     </None>
-    <None Include="..\..\tests\test-libraries\libframework.h">
+    <None Include="..\..\..\tests\test-libraries\libframework.h">
       <Link>libframework.h</Link>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <TestLibrariesInput Include="..\..\tests\test-libraries\libframework.m" />
-    <TestLibrariesOutput Include="..\..\tests\test-libraries\.libs\XTest.xcframework" />
+    <TestLibrariesInput Include="..\..\..\tests\test-libraries\libframework.m" />
+    <TestLibrariesOutput Include="..\..\..\tests\test-libraries\.libs\macos\XTest.framework" />
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\test-libraries\.libs\XTest.xcframework">
+    <NativeReference Include="..\..\..\tests\test-libraries\.libs\macos\XTest.framework">
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
       <Frameworks>CoreLocation ModelIO</Frameworks>

--- a/tests/bindings-xcframework-test/iOS/bindings-xcframework-test.csproj
+++ b/tests/bindings-xcframework-test/iOS/bindings-xcframework-test.csproj
@@ -15,7 +15,7 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>bindings-xcframework-test</AssemblyName>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>..\..\..\product.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)</IntermediateOutputPath>
     <DefineConstants></DefineConstants>
@@ -49,32 +49,32 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.ObjCBinding.CSharp.targets" />
   <PropertyGroup>
-    <TestLibrariesDirectory>..\..\tests\test-libraries</TestLibrariesDirectory>
+    <TestLibrariesDirectory>..\..\..\tests\test-libraries</TestLibrariesDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="..\..\tests\test-libraries\libframework.m">
+    <None Include="..\..\..\tests\test-libraries\libframework.m">
       <Link>libframework.m</Link>
     </None>
-    <None Include="..\..\tests\test-libraries\libframework.h">
+    <None Include="..\..\..\tests\test-libraries\libframework.h">
       <Link>libframework.h</Link>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ObjcBindingApiDefinition Include="..\bindings-framework-test\ApiDefinition.cs">
+    <ObjcBindingApiDefinition Include="..\..\bindings-framework-test\ApiDefinition.cs">
       <Link>ApiDefinition.cs</Link>
     </ObjcBindingApiDefinition>
   </ItemGroup>
   <ItemGroup>
-    <ObjcBindingCoreSource Include="..\bindings-framework-test\StructsAndEnums.cs">
+    <ObjcBindingCoreSource Include="..\..\bindings-framework-test\StructsAndEnums.cs">
       <Link>StructsAndEnums.cs</Link>
     </ObjcBindingCoreSource>
   </ItemGroup>
   <ItemGroup>
-    <TestLibrariesInput Include="..\..\tests\test-libraries\libframework.m" />
-    <TestLibrariesOutput Include="..\..\tests\test-libraries\.libs\XTest.xcframework" />
+    <TestLibrariesInput Include="..\..\..\tests\test-libraries\libframework.m" />
+    <TestLibrariesOutput Include="..\..\..\tests\test-libraries\.libs\XTest.xcframework" />
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\test-libraries\.libs\XTest.xcframework">
+    <NativeReference Include="..\..\test-libraries\.libs\XTest.xcframework">
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
 	  <Frameworks Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'">CoreLocation ModelIO</Frameworks>

--- a/tests/bindings-xcframework-test/macOS/bindings-xcframework-test.csproj
+++ b/tests/bindings-xcframework-test/macOS/bindings-xcframework-test.csproj
@@ -13,9 +13,9 @@
    <OutputType>Library</OutputType>
     <RootNamespace>bindingstest</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <AssemblyName>bindings-framework-test</AssemblyName>
+    <AssemblyName>bindings-xcframework-test</AssemblyName>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>..\..\..\product.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants></DefineConstants>
@@ -26,7 +26,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\Any CPU\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DEBUG;FRAMEWORK_TEST;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DEBUG;FRAMEWORK_TEST;XCFRAMEWORK;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -35,7 +35,7 @@
     <DebugType>none</DebugType>
     <Optimize>True</Optimize>
     <OutputPath>bin\Any CPU\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DO_NOT_REMOVE;FRAMEWORK_TEST;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DO_NOT_REMOVE;FRAMEWORK_TEST;XCFRAMEWORK;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -48,29 +48,33 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
-    <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+    <ObjcBindingApiDefinition Include="..\..\bindings-framework-test\ApiDefinition.cs">
+      <Link>ApiDefinition.cs</Link>
+    </ObjcBindingApiDefinition>
   </ItemGroup>
   <ItemGroup>
-    <ObjcBindingCoreSource Include="StructsAndEnums.cs" />
+    <ObjcBindingCoreSource Include="..\..\bindings-framework-test\StructsAndEnums.cs">
+      <Link>StructsAndEnums.cs</Link>
+    </ObjcBindingCoreSource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.ObjCBinding.CSharp.targets" />
   <PropertyGroup>
-    <TestLibrariesDirectory>..\..\tests\test-libraries</TestLibrariesDirectory>
+    <TestLibrariesDirectory>..\..\..\tests\test-libraries</TestLibrariesDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="..\..\tests\test-libraries\libframework.m">
+    <None Include="..\..\..\tests\test-libraries\libframework.m">
       <Link>libframework.m</Link>
     </None>
-    <None Include="..\..\tests\test-libraries\libframework.h">
+    <None Include="..\..\..\tests\test-libraries\libframework.h">
       <Link>libframework.h</Link>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <TestLibrariesInput Include="..\..\tests\test-libraries\libframework.m" />
-    <TestLibrariesOutput Include="..\..\tests\test-libraries\.libs\macos\XTest.framework" />
+    <TestLibrariesInput Include="..\..\..\tests\test-libraries\libframework.m" />
+    <TestLibrariesOutput Include="..\..\..\tests\test-libraries\.libs\XTest.xcframework" />
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\..\tests\test-libraries\.libs\macos\XTest.framework">
+    <NativeReference Include="..\..\test-libraries\.libs\XTest.xcframework">
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
       <Frameworks>CoreLocation ModelIO</Frameworks>

--- a/tests/framework-test/iOS/framework-test-ios.csproj
+++ b/tests/framework-test/iOS/framework-test-ios.csproj
@@ -169,7 +169,7 @@
   <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
-    <ProjectReference Include="..\..\..\tests\bindings-framework-test\bindings-framework-test.csproj">
+    <ProjectReference Include="..\..\..\tests\bindings-framework-test\iOS\bindings-framework-test.csproj">
       <Project>{E40B0B77-3467-4891-9117-7AF8F248E306}</Project>
       <Name>bindings-framework-test</Name>
     </ProjectReference>

--- a/tests/framework-test/macOS/framework-test-mac.csproj
+++ b/tests/framework-test/macOS/framework-test-mac.csproj
@@ -79,7 +79,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <ItemGroup>
-    <ProjectReference Include="$(RootTestsDirectory)\bindings-framework-test\bindings-framework-test-mac.csproj">
+    <ProjectReference Include="$(RootTestsDirectory)\bindings-framework-test\macOS\bindings-framework-test.csproj">
       <Project>{E40B0B77-3467-4891-9117-7AF8F248E306}</Project>
       <Name>bindings-framework-test-mac</Name>
     </ProjectReference>

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2027,11 +2027,11 @@ public class TestApp {
 
 		static string GetFrameworksBindingLibrary (Profile profile)
 		{
-			// Path.Combine (Configuration.SourceRoot, "tests/bindings-framework-test/bin/Any CPU/Debug-unified/bindings-framework-test.dll"),
-			var fn = Path.Combine (Configuration.SourceRoot, "tests", "bindings-framework-test", "bin", "Any CPU", GetConfiguration (profile), "bindings-framework-test.dll");
+			// Path.Combine (Configuration.SourceRoot, "tests/bindings-framework-test/iOS/bin/Any CPU/Debug-unified/bindings-framework-test.dll"),
+			var fn = Path.Combine (Configuration.SourceRoot, "tests", "bindings-framework-test", GetPlatformSimpleName (profile), "bin", "Any CPU", GetConfiguration (profile), "bindings-framework-test.dll");
 
 			if (!File.Exists (fn)) {
-				var csproj = Path.Combine (Configuration.SourceRoot, "tests", "bindings-framework-test", "bindings-framework-test" + GetProjectSuffix (profile) + ".csproj");
+				var csproj = Path.Combine (Configuration.SourceRoot, "tests", "bindings-framework-test", GetPlatformSimpleName (profile), "bindings-framework-test.csproj");
 				XBuild.BuildXI (csproj, platform: "AnyCPU");
 			}
 

--- a/tests/tests-mac.sln
+++ b/tests/tests-mac.sln
@@ -19,7 +19,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Touch.Client-macOS-mobile",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Touch.Client-macOS-full", "..\external\Touch.Unit\Touch.Client\macOS\full\Touch.Client-macOS-full.csproj", "{A1209F3A-3876-4EAC-ADA7-99F660002AB6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bindings-framework-test-mac", "bindings-framework-test\bindings-framework-test-mac.csproj", "{E40B0B77-3467-4891-9117-7AF8F248E306}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bindings-framework-test-mac", "bindings-framework-test\macOS\bindings-framework-test.csproj", "{E40B0B77-3467-4891-9117-7AF8F248E306}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/tests/tests.sln
+++ b/tests/tests.sln
@@ -13,7 +13,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EmbeddedResources", "Embedd
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bindings-test", "bindings-test\iOS\bindings-test.csproj", "{D6667423-EDD8-4B50-9D98-1AC5D8A8A4EA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bindings-framework-test", "bindings-framework-test\bindings-framework-test.csproj", "{E40B0B77-3467-4891-9117-7AF8F248E306}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bindings-framework-test", "bindings-framework-test\iOS\bindings-framework-test.csproj", "{E40B0B77-3467-4891-9117-7AF8F248E306}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "fsharplibrary", "fsharplibrary\fsharplibrary.fsproj", "{C7212169-BA46-413B-91CD-A32C52AD5E0D}"
 EndProject
@@ -55,7 +55,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Touch.Client-iOS", "..\exte
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xcframework-test", "xcframework-test\iOS\xcframework-test-ios.csproj", "{2ECCE3D0-AAD1-46B9-B190-B567249DCF9D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bindings-xcframework-test", "bindings-xcframework-test\bindings-xcframework-test.csproj", "{E40B0B77-3467-4891-9117-7AF8F248E307}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bindings-xcframework-test", "bindings-xcframework-test\iOS\bindings-xcframework-test.csproj", "{E40B0B77-3467-4891-9117-7AF8F248E307}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/tests/xcframework-test/iOS/xcframework-test-ios.csproj
+++ b/tests/xcframework-test/iOS/xcframework-test-ios.csproj
@@ -160,7 +160,7 @@
       <Project>{F611ED96-54B5-4975-99BB-12F50AF95936}</Project>
       <Name>Touch.Client-iOS</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\bindings-xcframework-test\bindings-xcframework-test.csproj">
+    <ProjectReference Include="..\..\bindings-xcframework-test\iOS\bindings-xcframework-test.csproj">
       <Project>{E40B0B77-3467-4891-9117-7AF8F248E307}</Project>
       <Name>bindings-xcframework-test</Name>
       <ReferenceSourceTarget>ProjectReference</ReferenceSourceTarget>

--- a/tests/xcframework-test/macOS/xcframework-test-mac.csproj
+++ b/tests/xcframework-test/macOS/xcframework-test-mac.csproj
@@ -79,7 +79,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <ItemGroup>
-    <ProjectReference Include="$(RootTestsDirectory)\bindings-xcframework-test\bindings-xcframework-test-mac.csproj">
+    <ProjectReference Include="$(RootTestsDirectory)\bindings-xcframework-test\macOS\bindings-xcframework-test.csproj">
       <Project>{E40B0B77-3467-4891-9117-7AF8F248E306}</Project>
       <Name>bindings-xcframework-test-mac</Name>
     </ProjectReference>

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -443,7 +443,7 @@ namespace Xharness {
 
 		void AutoConfigureIOS ()
 		{
-			var library_projects = new string [] { "BundledResources", "EmbeddedResources", "bindings-test2", "bindings-framework-test", "bindings-xcframework-test" };
+			var library_projects = new string [] { "BundledResources", "EmbeddedResources", "bindings-test2" };
 			var fsharp_test_suites = new string [] { "fsharp" };
 			var fsharp_library_projects = new string [] { "fsharplibrary" };
 
@@ -458,6 +458,12 @@ namespace Xharness {
 			foreach (var p in fsharp_library_projects)
 				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".fsproj")), false) { Name = p });
 
+			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bindings-framework-test", "iOS", "bindings-framework-test.csproj"))) {
+				Name = "bindings-framework-test",
+			});
+			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bindings-xcframework-test", "iOS", "bindings-xcframework-test.csproj"))) {
+				Name = "bindings-xcframework-test",
+			});
 			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "framework-test", "iOS", "framework-test-ios.csproj"))) {
 				Name = "framework-test",
 			});

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -458,10 +458,10 @@ namespace Xharness {
 			foreach (var p in fsharp_library_projects)
 				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".fsproj")), false) { Name = p });
 
-			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bindings-framework-test", "iOS", "bindings-framework-test.csproj"))) {
+			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bindings-framework-test", "iOS", "bindings-framework-test.csproj")), false) {
 				Name = "bindings-framework-test",
 			});
-			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bindings-xcframework-test", "iOS", "bindings-xcframework-test.csproj"))) {
+			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bindings-xcframework-test", "iOS", "bindings-xcframework-test.csproj")), false) {
 				Name = "bindings-xcframework-test",
 			});
 			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "framework-test", "iOS", "framework-test-ios.csproj"))) {


### PR DESCRIPTION
This fixes a problem where the build from the different projects could stomp
on eachother in the obj/bin folders. It's technically possible to make this
work by setting up custom [Base][Intermediate][OutputPath] properties in the
project files, but the simplest solution is to just make sure there's no more
than a single project per directory.