### PR TITLE
[xcode13-ios] [mtouch] Make 'MonoTouch.Dialog-1' and 'MonoTouch.NUnitLite' SDK assemblies, not product assemblies. Fixes #12862.

### DIFF
--- a/tools/linker/MobileProfile.cs
+++ b/tools/linker/MobileProfile.cs
@@ -44,6 +44,8 @@ namespace Xamarin.Linker {
 			"Mono.Security",
 			"OpenTK",
 			"OpenTK-1.0",
+			"MonoTouch.Dialog-1",
+			"MonoTouch.NUnitLite",
 			// Facades assemblies (PCL)
 			"Microsoft.Win32.Primitives",
 			"Microsoft.Win32.Registry.AccessControl",

--- a/tools/linker/MonoTouch.Tuner/MonoTouchProfile.cs
+++ b/tools/linker/MonoTouch.Tuner/MonoTouchProfile.cs
@@ -8,14 +8,7 @@ namespace MonoTouch.Tuner {
 
 		protected override bool IsProduct (string assemblyName)
 		{
-			switch (assemblyName) {
-			case "MonoTouch.Dialog-1":
-			case "MonoTouch.NUnitLite":
-			case "Xamarin.iOS": // The Xamarin.iOS.dll implementation assembly for Mac Catalyst.
-				return true;
-			default:
-				return assemblyName == product_assembly;
-			}
+			return assemblyName == product_assembly;
 		}
 
 		public override string ProductAssembly { 


### PR DESCRIPTION
The "product assembly" is supposed to be Xamarin.iOS.dll, Xamarin.Mac.dll,
etc., not other assemblies, so fix the implementation to reflect this. The
original commit where MonoTouch.Dialog-1 and MonoTouch.NUnitLite were
introduced as platform assemblies is quite old [1], and doesn't explain much,
but I believe the intention was to make us treat these assemblies as *SDK*
assemblies and link them accordingly, so I made these assemblies SDK assemblies now.

Additionally remove "Xamarin.iOS" as a hardcoded platform assembly for Mac
Catalyst, because this particular code is exclusive to legacy Xamarin, and Mac
Catalyst support will only be included in our .NET release, which means this
code does not have any purpose here, and might even break something one day.

[1]: https://github.com/xamarin/maccore/commit/0349f8d47f64c07c1345c9f0fa4a6e8a739910e7

Fixes https://github.com/xamarin/xamarin-macios/issues/12862.


Backport of #12919
