### PR TITLE
[CI] Cannot use condition.

### DIFF
--- a/tools/devops/automation/templates/release/publish-nugets.yml
+++ b/tools/devops/automation/templates/release/publish-nugets.yml
@@ -18,11 +18,11 @@ steps:
     ${{ else }}:
       VAR_NAME: 'NUGET_PRIVATE_FEED'
 
-- task: NuGetAuthenticate@0
-  displayName: 'Authenticate dotnet-tool feed'
-  inputs:
-    nuGetServiceConnections: $(ConfigureNuget.Credential)
-  condition: contains (variables['Build.DefinitionName'], 'private')
+- ${{ if not(contains(variables['Build.DefinitionName'], 'private')) }}:
+  - task: NuGetAuthenticate@0
+    displayName: 'Authenticate dotnet-tool feed'
+    inputs:
+      nuGetServiceConnections: $(ConfigureNuget.Credential)
 
 - task: DownloadPipelineArtifact@2
   inputs:


### PR DESCRIPTION
Using a condition will result in the template being generated which
results in the security check to run. We need to use a template and not
a condition to avoid it.