### PR TITLE
[tests] Bump our generic min macOS version to 10.14 for .NET tests.

### DIFF
--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -29,7 +29,7 @@
 	<PropertyGroup Condition="$(TargetFramework.EndsWith('-macos'))">
 		<DefineConstants>$(DefineConstants);MONOMAC</DefineConstants>
 		<NativeLibName>macos-fat</NativeLibName>
-		<SupportedOSPlatformVersion>10.15</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
 	<!-- Logic for Mac Catalyst -->


### PR DESCRIPTION
Fixes this when running our test suites on macOS 10.14:

    dyld: Library not loaded: /System/Library/Frameworks/AuthenticationServices.framework/Versions/A/AuthenticationServices
      Referenced from: /Users/runner/work/1/s/artifacts/mac-test-package/tests/./introspection/dotnet/macOS/bin/Debug/net6.0-macos/osx-x64/introspection.app/Contents/MacOS/introspection
      Reason: image not found
    make[2]: *** [exec-mac-dotnet-x64-introspection] Abort trap: 6