### PR TITLE
[introspection] Skip verifying the objc_msgSend[Super]_stret on all platforms.

### DIFF
--- a/tests/introspection/ApiPInvokeTest.cs
+++ b/tests/introspection/ApiPInvokeTest.cs
@@ -124,6 +124,13 @@ namespace Introspection
 
 		protected virtual bool Skip (string symbolName)
 		{
+			switch (symbolName) {
+			// it's not needed for ARM64/ARM64_32 and Apple does not have stubs for them in libobjc.dylib
+			// also the linker normally removes them (unreachable due to other optimizations)
+			case "objc_msgSend_stret":
+			case "objc_msgSendSuper_stret":
+				return true;
+			}
 			return false;
 		}
 

--- a/tests/introspection/iOS/iOSApiPInvokeTest.cs
+++ b/tests/introspection/iOS/iOSApiPInvokeTest.cs
@@ -59,10 +59,6 @@ namespace Introspection {
 			case "CVPixelBufferGetIOSurface":
 			case "CVPixelBufferCreateWithIOSurface":
 				return simulator && !TestRuntime.CheckXcodeVersion (11, 0);
-			// it's not needed for ARM64/ARM64_32 and Apple does not have stubs for them in libobjc.dylib
-			case "objc_msgSend_stret":
-			case "objc_msgSendSuper_stret":
-				return !simulator;
 
 			default:
 				// MLCompute not available in simulator as of Xcode 12 beta 3


### PR DESCRIPTION
Now that macOS runs on AMR64 (and also the simulators soon), we need to have to same logic for all platforms.

Fixes:

    Introspection.iOSApiPInvokeTest
        [FAIL] Could not find the field 'objc_msgSend_stret' in /usr/lib/libobjc.dylib
        [FAIL] Could not find the field 'objc_msgSendSuper_stret' in /usr/lib/libobjc.dylib
        [FAIL] SymbolExists :   2 errors found in 5300 functions validated: objc_msgSend_stret, objc_msgSendSuper_stret
            Expected: 0
            But was:  2
                at Introspection.ApiPInvokeTest.SymbolExists() in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/introspection/ApiPInvokeTest.cs:line 182