### PR TITLE
[generator] Fix the return type for blocks returning a type we've bound as an INativeObject.

### DIFF
--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -751,6 +751,19 @@ namespace GeneratorTests
 			bgen.AssertExecute ("build");
 		}
 
+		[Test]
+		public void DelegateWithINativeObjectReturnType ()
+		{
+			var bgen = BuildFile (Profile.iOS, "tests/delegate-with-inativeobject-return-type.cs");
+			bgen.AssertExecute ("build");
+
+			// Assert that the return type from the delegate is IntPtr
+			var type = bgen.ApiAssembly.MainModule.GetType ("ObjCRuntime", "Trampolines").NestedTypes.First (v => v.Name == "DMyHandler");
+			Assert.NotNull (type, "DMyHandler");
+			var method = type.Methods.First (v => v.Name == "Invoke");
+			Assert.AreEqual ("System.IntPtr", method.ReturnType.FullName, "Return type");
+		}
+
 		BGenTool BuildFile (Profile profile, params string [] filenames)
 		{
 			return BuildFile (profile, true, false, filenames);

--- a/tests/generator/tests/delegate-with-inativeobject-return-type.cs
+++ b/tests/generator/tests/delegate-with-inativeobject-return-type.cs
@@ -1,0 +1,20 @@
+using System;
+using CoreGraphics;
+using Foundation;
+
+namespace DelegateWithINativeObjectReturnType {
+
+	delegate CGPDFDocument MyHandler ();
+	delegate NSObject MyHandler2 ();
+
+	[BaseType (typeof (NSObject))]
+	interface FooObject {
+
+		[Export ("createWithBlock2:")]
+		void CreateWithBlock2 (MyHandler2 handler);
+
+		[Export ("createWithBlock:")]
+		void CreateWithBlock (MyHandler handler);
+
+	}
+}


### PR DESCRIPTION
* Create all INativeObject subclasses using 'Runtime.GetINativeObject<T>' instead
  of 'new T ()'. Although it's somewhat slower, it automatically handles any IntPtr.Zero
  handles, and it also makes the generator code simpler. If something turns out to
  be a performance problem, we can always add custom static creation methods (like
  some of the existing types already have).

* This makes it so that the zero pointer check logic in the generator isn't necessary
  anymore.

* The most important part is where we use IntPtr as the marshalling type for returned
  INativeObjects in blocks (instead of the INativeObject class - which doesn't make
  sense really, because I have no idea how that's marshalled).

Example:

```diff
diff --git a/build/dotnet/ios/generated-sources/ObjCRuntime/Trampolines.g.cs b/build-new/dotnet/ios/generated-sources/ObjCRuntime/Trampolines.g.cs
index 97e58f3a91b..8a40748de8b 100644
--- a/build/dotnet/ios/generated-sources/ObjCRuntime/Trampolines.g.cs
+++ b/build-new/dotnet/ios/generated-sources/ObjCRuntime/Trampolines.g.cs
@@ -214,7 +214,7 @@ namespace ObjCRuntime {
    } /* class NIDAVAudioEngineManualRenderingBlock */
    [UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
    [UserDelegateType (typeof (global::AVFoundation.AVAudioIONodeInputBlock))]
-   internal delegate global::AudioToolbox.AudioBuffers DAVAudioIONodeInputBlock (IntPtr block, uint frameCount);
+   internal delegate IntPtr DAVAudioIONodeInputBlock (IntPtr block, uint frameCount);
    //
    // This class bridges native block invocations that call into C#
    //
@@ -223,11 +223,11 @@ namespace ObjCRuntime {
      [Preserve (Conditional = true)]
      [global::System.Diagnostics.CodeAnalysis.DynamicDependency ("Handler")]
      [MonoPInvokeCallback (typeof (DAVAudioIONodeInputBlock))]
-     static unsafe global::AudioToolbox.AudioBuffers Invoke (IntPtr block, uint frameCount) {
+     static unsafe IntPtr Invoke (IntPtr block, uint frameCount) {
        var descriptor = (BlockLiteral *) block;
        var del = (global::AVFoundation.AVAudioIONodeInputBlock) (descriptor->Target);
        AudioToolbox.AudioBuffers retval = del (frameCount);
-       return retval;
+       return retval.GetHandle ();
      }
    } /* class SDAVAudioIONodeInputBlock */
    internal sealed class NIDAVAudioIONodeInputBlock : TrampolineBlockBase {
@@ -249,7 +249,7 @@ namespace ObjCRuntime {
      [BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
      unsafe global::AudioToolbox.AudioBuffers Invoke (uint frameCount)
      {
-       var ret = invoker (BlockPointer, frameCount);
+       var ret = Runtime.GetINativeObject<global::AudioToolbox.AudioBuffers> (invoker (BlockPointer, frameCount), false);
        return ret!;
      }
    } /* class NIDAVAudioIONodeInputBlock */
```