### PR TITLE
[xcode13-ios] [tests] Ignore TemplateProjectTest.CreateAppBundleDependsOnTest when the specified platform isn't included in the build.

### DIFF
--- a/tests/dotnet/UnitTests/TemplateProjectTest.cs
+++ b/tests/dotnet/UnitTests/TemplateProjectTest.cs
@@ -37,6 +37,7 @@ class MainClass {
 		[TestCase (ApplePlatform.MacOSX)]
 		public void CreateAppBundleDependsOnTest (ApplePlatform platform)
 		{
+			Configuration.IgnoreIfIgnoredPlatform (platform);
 			var magic = Guid.NewGuid ().ToString ();
 			var csproj = $@"<Project Sdk=""Microsoft.NET.Sdk"">
 <PropertyGroup>


### PR DESCRIPTION



Backport of #12933
