### PR TITLE
[xharness] Don't copy xharness.[css|js] to the output directory when they're already in the output directory.

### DIFF
--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -184,10 +184,10 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="xharness.js">
+    <Content Include="xharness.js" Condition="'$(OutputPath)' != '.'">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="xharness.css">
+    <Content Include="xharness.css" Condition="'$(OutputPath)' != '.'">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
The problem is that cleaning the project would then clean these files, which
would break the next build.