### PR TITLE
[CoreVideo/XKit] Add missing availability attributes.

### DIFF
--- a/src/CoreVideo/CVMetalTextureCache.cs
+++ b/src/CoreVideo/CVMetalTextureCache.cs
@@ -24,6 +24,10 @@ namespace CoreVideo {
 
 #if !NET
 	[iOS (8,0), Mac (10,15), MacCatalyst (15,0)]
+#else
+	[SupportedOSPlatform ("ios8.0")]
+	[SupportedOSPlatform ("macos10.15")]
+	[SupportedOSPlatform ("maccatalyst15.0")]
 #endif
 	public partial class CVMetalTextureCache : INativeObject, IDisposable {
 		internal IntPtr handle;

--- a/src/corevideo.cs
+++ b/src/corevideo.cs
@@ -506,7 +506,7 @@ namespace CoreVideo {
 		[Field ("kCVMetalTextureCacheMaximumTextureAgeKey")]
 		IntPtr MaxTextureAge { get; }
 
-		[TV (13,0), NoWatch, iOS (13,0), Mac (10,15)]
+		[TV (13,0), NoWatch, iOS (13,0)]
 		[Field ("kCVMetalTextureStorageMode")]
 		NSString StorageMode { get; }
 	}


### PR DESCRIPTION
Fixes introspection on macOS 10.14.