### PR TITLE
[dotnet/Templates] Add preview language

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/template.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "macOS", "Catalyst" ],
+  "classifications": [ "macOS", "Mac Catalyst" ],
   "identity": "Microsoft.MacCatalyst.MacCatalystApp",
-  "name": "MacCatalyst Application",
-  "description": "A project for creating an MacCatalyst application",
+  "name": "MacCatalyst Application (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst application",
   "shortName": "maccatalyst",
   "tags": {
     "language": "C#",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/template.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json.schemastore.org/template",
     "author": "Microsoft",
-    "classifications": [ "iOS" ],
+    "classifications": [ "iOS", "Mobile" ],
     "name": "iOS Controller template",
     "description": "An iOS Controller class",
     "tags": {

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/template.json
@@ -1,10 +1,10 @@
 {
     "$schema": "http://json.schemastore.org/template",
     "author": "Microsoft",
-    "classifications": [ "iOS" ],
+    "classifications": [ "iOS", "Mobile" ],
     "identity": "Microsoft.iOS.iOSApp",
-    "name": "iOS Application",
-    "description": "A project for creating an iOS application",
+    "name": "iOS Application (Preview)",
+    "description": "A project for creating a .NET 6 iOS application",
     "shortName": "ios",
     "tags": {
       "language": "C#",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/template.json
@@ -1,10 +1,10 @@
 ﻿{
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "iOS" ],
+  "classifications": [ "iOS", "Mobile" ],
   "identity": "Microsoft.iOS.iOSLib",
-  "name": "iOS Class library",
-  "description": "A project for creating an iOS class library",
+  "name": "iOS Class Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS class library",
   "shortName": "ioslib",
   "tags": {
     "language": "C#",

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/template.json
@@ -3,8 +3,8 @@
     "author": "Microsoft",
     "classifications": [ "macOS" ],
     "identity": "Microsoft.macOS.macOSApp",
-    "name": "macOS Application",
-    "description": "A project for creating an macOS application",
+    "name": "macOS Application (Preview)",
+    "description": "A project for creating a .NET 6 macOS application",
     "shortName": "macos",
     "tags": {
       "language": "C#",

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/template.json
@@ -1,10 +1,10 @@
 ﻿{
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "tvOS" ],
+  "classifications": [ "tvOS", "Mobile" ],
   "identity": "Microsoft.tvOS.tvOSApp",
-  "name": "tvOS Application",
-  "description": "A project for creating an tvOS application",
+  "name": "tvOS Application (Preview)",
+  "description": "A project for creating a .NET 6 tvOS application",
   "shortName": "tvos",
   "tags": {
     "language": "C#",


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-macios/issues/12955

Update the .NET 6 project templates to include "(Preview)" in the title
and include the "Mobile" classification where applicable. The phrase
".NET 6" has also been added to the description to help them stand out
from the regular Xamarin templates.