### PR TITLE
[MediaLibrary] Update MacCatalyst Support

### DIFF
--- a/tests/xtro-sharpie/MacCatalyst-MediaLibrary.ignore
+++ b/tests/xtro-sharpie/MacCatalyst-MediaLibrary.ignore
@@ -1,3 +1,4 @@
+## Deprecated and not used in Catalyst
 !missing-enum! MLMediaSourceType not bound
 !missing-enum! MLMediaType not bound
 !missing-field! MLApertureAllPhotosTypeIdentifier not bound


### PR DESCRIPTION
Moved MediaLibrary APIs that were deprecated and not used in Catalyst from. .todo to .ignore