### PR TITLE
[ExecutionPolicy] Updates for MacCatalyst

### DIFF
--- a/tests/xtro-sharpie/MacCatalyst-ExecutionPolicy.ignore
+++ b/tests/xtro-sharpie/MacCatalyst-ExecutionPolicy.ignore
@@ -1,3 +1,4 @@
+## EPDeveloperTool and EPExecutionPolicy are both macOS only and no consumers are accessible
 !missing-enum! EPDeveloperToolStatus not bound
 !missing-enum! EPError not bound
 !missing-field! EPErrorDomain not bound


### PR DESCRIPTION
Moved deprecated ExecutionPolicy APIs from .todo to .ignore