### PR TITLE
[src] Adapt some code to work with both C#'s nint/nuint and our custom System.nint/System.nuint types

### DIFF
--- a/src/Accelerate/vImageTypes.cs
+++ b/src/Accelerate/vImageTypes.cs
@@ -61,12 +61,12 @@ namespace Accelerate {
 
 		public int Width {
 			get { return (int) WidthIntPtr; }
-			set { WidthIntPtr = value; }
+			set { WidthIntPtr = (vImagePixelCount) value; }
 		}
 
 		public int Height {
 			get { return (int) HeightIntPtr; }
-			set { HeightIntPtr = value; }
+			set { HeightIntPtr = (vImagePixelCount) value; }
 		}
 	}
 

--- a/src/CoreFoundation/CFStream.cs
+++ b/src/CoreFoundation/CFStream.cs
@@ -532,7 +532,7 @@ namespace CoreFoundation {
 				return;
 			CheckHandle ();
 			if (loop != null) {
-				DoSetClient (null, 0, IntPtr.Zero);
+				DoSetClient (null, (CFIndex) 0, IntPtr.Zero);
 				UnscheduleFromRunLoop (loop, loopMode);
 				loop = null;
 				loopMode = null;

--- a/src/CoreMedia/CMSampleBuffer.cs
+++ b/src/CoreMedia/CMSampleBuffer.cs
@@ -140,9 +140,11 @@ namespace CoreMedia {
 			nint count = timing == null ? 0 : timing.Length;
 			IntPtr handle;
 
-			fixed (CMSampleTimingInfo *t = timing)
-				if ((status = CMSampleBufferCreateCopyWithNewTiming (IntPtr.Zero, original.Handle, count, t, out handle)) != 0)
+			fixed (CMSampleTimingInfo *t = timing) {
+				status = CMSampleBufferCreateCopyWithNewTiming (IntPtr.Zero, original.Handle, count, t, out handle);
+				if (status != (OSStatus) 0)
 					return null;
+			}
 			
 			return new CMSampleBuffer (handle, true);
 		}
@@ -488,12 +490,13 @@ namespace CoreMedia {
 		public unsafe CMSampleTimingInfo [] GetSampleTimingInfo (out OSStatus status) {
 			nint count;
 
-			status = 0;
+			status = default (OSStatus);
 
 			if (handle == IntPtr.Zero)
 				return null;
 
-			if ((status = CMSampleBufferGetSampleTimingInfoArray (handle, 0, null, out count)) != 0)
+			status = CMSampleBufferGetSampleTimingInfoArray (handle, 0, null, out count);
+			if (status != (OSStatus) 0)
 				return null;
 
 			CMSampleTimingInfo [] pInfo = new CMSampleTimingInfo [count];
@@ -501,9 +504,11 @@ namespace CoreMedia {
 			if (count == 0)
 				return pInfo;
 
-			fixed (CMSampleTimingInfo* info = pInfo)
-				if ((status = CMSampleBufferGetSampleTimingInfoArray (handle, count, info, out count)) != 0)
+			fixed (CMSampleTimingInfo* info = pInfo) {
+				status = CMSampleBufferGetSampleTimingInfoArray (handle, count, info, out count);
+				if (status != (OSStatus) 0)
 					return null;
+			}
 
 			return pInfo;
 		}

--- a/src/CoreMidi/MidiThruConnection.cs
+++ b/src/CoreMidi/MidiThruConnection.cs
@@ -148,7 +148,7 @@ namespace CoreMidi {
 				if (totalObjs == 0)
 					return null;
 
-				var basePtr = data.Bytes.ToInt32 ();
+				var basePtr = (int) data.Bytes;
 				var connections = new MidiThruConnection[totalObjs];
 				for (int i = 0; i < totalObjs; i++)
 					connections[i] = new MidiThruConnection ((uint)(basePtr + i * typeSize));

--- a/src/CoreText/CTFontCollection.cs
+++ b/src/CoreText/CTFontCollection.cs
@@ -209,8 +209,9 @@ namespace CoreText {
 			GCHandle c = GCHandle.FromIntPtr (context);
 			var comparer = c.Target as Comparison<CTFontDescriptor>;
 			if (comparer == null)
-				return 0;
-			return comparer (new CTFontDescriptor (first, false), new CTFontDescriptor (second, false));
+				return default (CFIndex);
+			var rv = comparer (new CTFontDescriptor (first, false), new CTFontDescriptor (second, false));
+			return (CFIndex) rv;
 		}
 
 		public CTFontDescriptor[] GetMatchingFontDescriptors (Comparison<CTFontDescriptor> comparer)

--- a/src/Foundation/NSData.cs
+++ b/src/Foundation/NSData.cs
@@ -274,7 +274,7 @@ namespace Foundation {
 			get {
 				if (idx < 0 || (ulong) idx > Length)
 					throw new ArgumentException ("idx");
-				return Marshal.ReadByte (new IntPtr (Bytes.ToInt64 () + idx));
+				return Marshal.ReadByte (new IntPtr (((long) Bytes) + idx));
 			}
 
 			set {

--- a/src/Foundation/NSMutableData.cs
+++ b/src/Foundation/NSMutableData.cs
@@ -20,7 +20,7 @@ namespace Foundation {
 			set {
 				if (idx < 0 || (ulong) idx > Length)
 					throw new ArgumentException ("idx");
-				Marshal.WriteByte (new IntPtr (Bytes.ToInt64 () + idx), value);
+				Marshal.WriteByte (new IntPtr (((long) Bytes) + idx), value);
 			}
 		}
 

--- a/src/ModelIO/MDLAnimatedValueTypes.cs
+++ b/src/ModelIO/MDLAnimatedValueTypes.cs
@@ -755,7 +755,7 @@ namespace ModelIO {
 		static unsafe IntPtr GetAlignedPtrForArray (IntPtr arrptr, int size, bool copy, out IntPtr alignedPtr)
 		{
 			// use the original pointer if it's already aligned on a 16 bytes boundary
-			if (((nuint) arrptr & 15) == 0) {
+			if (((nuint) (ulong) arrptr & 15) == 0) {
 				alignedPtr = arrptr;
 				// nothing to free
 				return IntPtr.Zero;

--- a/src/ObjCRuntime/Dlfcn.cs
+++ b/src/ObjCRuntime/Dlfcn.cs
@@ -291,12 +291,12 @@ namespace ObjCRuntime {
 
 		public static nuint GetNUInt (IntPtr handle, string symbol)
 		{
-			return (nuint)GetIntPtr (handle, symbol);
+			return (nuint) (ulong) GetUIntPtr (handle, symbol);
 		}
 
 		public static void SetNUInt (IntPtr handle, string symbol, nuint value)
 		{
-			SetIntPtr (handle, symbol, (IntPtr) value);
+			SetUIntPtr (handle, symbol, (UIntPtr) (ulong) value);
 		}
 
 		public static nfloat GetNFloat (IntPtr handle, string symbol)
@@ -331,6 +331,22 @@ namespace ObjCRuntime {
 			if (indirect == IntPtr.Zero)
 				return IntPtr.Zero;
 			return Marshal.ReadIntPtr (indirect);
+		}
+
+		public static UIntPtr GetUIntPtr (IntPtr handle, string symbol)
+		{
+			var indirect = dlsym (handle, symbol);
+			if (indirect == IntPtr.Zero)
+				return UIntPtr.Zero;
+			return (UIntPtr) (long) Marshal.ReadIntPtr (indirect);
+		}
+
+		public static void SetUIntPtr (IntPtr handle, string symbol, UIntPtr value)
+		{
+			var indirect = dlsym (handle, symbol);
+			if (indirect == IntPtr.Zero)
+				return;
+			Marshal.WriteIntPtr (indirect, (IntPtr) (ulong) value);
 		}
 
 		public static void SetIntPtr (IntPtr handle, string symbol, IntPtr value)


### PR DESCRIPTION
* Add explicit casts to/from IntPtr and other specific types in a few places
  to avoid relying on implicit conversions (which aren't the same between C#'s
  nint/nuint and our System.nint/nuint types).
* Add Dlfcn.[Get|Set]UIntPtr to match the signed versions (for nuint).