### PR TITLE
[ObjCRuntime] Add nullability attributes to the Runtime class + numerous other code updates.

### DIFF
--- a/src/ARKit/ARSkeleton.cs
+++ b/src/ARKit/ARSkeleton.cs
@@ -24,11 +24,11 @@ namespace ARKit {
 #else
 		[SupportedOSPlatform ("ios14.0")]
 #endif
-		public static NSString CreateJointName (NSString recognizedPointKey)
+		public static NSString? CreateJointName (NSString recognizedPointKey)
 		{
-			if (recognizedPointKey == null)
+			if (recognizedPointKey is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (recognizedPointKey));
-			return (NSString) Runtime.GetNSObject (ARSkeletonJointNameForRecognizedPointKey (recognizedPointKey.Handle));
+			return Runtime.GetNSObject<NSString> (ARSkeletonJointNameForRecognizedPointKey (recognizedPointKey.Handle));
 		}
 	}
 }

--- a/src/CoreAnimation/CABasicAnimation.cs
+++ b/src/CoreAnimation/CABasicAnimation.cs
@@ -13,7 +13,7 @@ namespace CoreAnimation {
 	public partial class CABasicAnimation {
 		public T GetFromAs <T> () where T : class, INativeObject
 		{
-			return Runtime.GetINativeObject<T> (_From, false);
+			return Runtime.GetINativeObject<T> (_From, false)!;
 		}
 
 		public void SetFrom (INativeObject value)
@@ -23,7 +23,7 @@ namespace CoreAnimation {
 
 		public T GetToAs <T> () where T : class, INativeObject
 		{
-			return Runtime.GetINativeObject<T> (_To, false);
+			return Runtime.GetINativeObject<T> (_To, false)!;
 		}
 
 		public void SetTo (INativeObject value)
@@ -33,7 +33,7 @@ namespace CoreAnimation {
 
 		public T GetByAs <T> () where T : class, INativeObject
 		{
-			return Runtime.GetINativeObject<T> (_By, false);
+			return Runtime.GetINativeObject<T> (_By, false)!;
 		}
 
 		public void SetBy (INativeObject value)

--- a/src/CoreAnimation/CALayer.cs
+++ b/src/CoreAnimation/CALayer.cs
@@ -114,7 +114,7 @@ namespace CoreAnimation {
 			}
 		}
 
-		public T GetContentsAs <T> () where T : NSObject
+		public T? GetContentsAs <T> () where T : NSObject
 		{
 			return Runtime.GetNSObject<T> (_Contents);
 		}

--- a/src/CoreAnimation/CATextLayer.cs
+++ b/src/CoreAnimation/CATextLayer.cs
@@ -96,7 +96,7 @@ namespace CoreAnimation {
 				else if (type == CFString.GetTypeID ())
 					return CFString.FromHandle (handle);
 #if MONOMAC
-				else return (NSFont) Runtime.GetNSObject (handle);
+				else return Runtime.GetNSObject<NSFont> (handle);
 #else
 				return null;
 #endif

--- a/src/CoreVideo/CVBuffer.cs
+++ b/src/CoreVideo/CVBuffer.cs
@@ -149,7 +149,7 @@ namespace CoreVideo {
 // FIXME: we need to bring the new API to xamcore
 #if !MONOMAC
 		// any CF object can be attached
-		public T GetAttachment<T> (NSString key, out CVAttachmentMode attachmentMode) where T : class, INativeObject
+		public T? GetAttachment<T> (NSString key, out CVAttachmentMode attachmentMode) where T : class, INativeObject
 		{
 			if (key == null)
 				throw new ArgumentNullException ("key");
@@ -162,10 +162,10 @@ namespace CoreVideo {
 			return Runtime.GetINativeObject<T> (CVBufferGetAttachment (handle, key.Handle, out attachmentMode), false);
 		}
 #else
-		public NSObject GetAttachment (NSString key, out CVAttachmentMode attachmentMode)
+		public NSObject? GetAttachment (NSString key, out CVAttachmentMode attachmentMode)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 			if (PlatformHelper.CheckSystemVersion (12, 0))
 				return Runtime.GetNSObject<NSObject> (CVBufferCopyAttachment (handle, key.Handle, out attachmentMode), true);
 			else
@@ -199,7 +199,7 @@ namespace CoreVideo {
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static /* CFDictionaryRef */ IntPtr CVBufferCopyAttachments (/* CVBufferRef */ IntPtr buffer, CVAttachmentMode attachmentMode);
 
-		public NSDictionary GetAttachments (CVAttachmentMode attachmentMode)
+		public NSDictionary? GetAttachments (CVAttachmentMode attachmentMode)
 		{
 #if IOS || __MACCATALYST__ || TVOS
 			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
@@ -214,7 +214,7 @@ namespace CoreVideo {
 
 		// There is some API that needs a more strongly typed version of a NSDictionary
 		// and there is no easy way to downcast from NSDictionary to NSDictionary<TKey, TValue>
-		public NSDictionary<TKey, TValue> GetAttachments<TKey, TValue> (CVAttachmentMode attachmentMode)
+		public NSDictionary<TKey, TValue>? GetAttachments<TKey, TValue> (CVAttachmentMode attachmentMode)
 			where TKey : class, INativeObject
 			where TValue : class, INativeObject
 		{

--- a/src/CoreVideo/CVMetalTexture.cs
+++ b/src/CoreVideo/CVMetalTexture.cs
@@ -72,7 +72,7 @@ namespace CoreVideo {
 			/* float[2] */ IntPtr lowerLeft, /* float[2] */ IntPtr lowerRight, /* float[2] */ IntPtr upperRight, 
 			/* float[2] */ IntPtr upperLeft);
 
-		public IMTLTexture Texture {
+		public IMTLTexture? Texture {
 			get {
 				return Runtime.GetINativeObject<IMTLTexture> (CVMetalTextureGetTexture (handle), owns: false);
 			}

--- a/src/CoreVideo/CVPixelBuffer.cs
+++ b/src/CoreVideo/CVPixelBuffer.cs
@@ -79,7 +79,7 @@ namespace CoreVideo {
 			/* CFArrayRef __nullable */ IntPtr attributes,
 			/* CFDictionaryRef __nullable * __nonnull */ out IntPtr resolvedDictionaryOut);
 
-		public NSDictionary GetAttributes (NSDictionary [] attributes)
+		public NSDictionary? GetAttributes (NSDictionary [] attributes)
 		{
 			CVReturn ret;
 			IntPtr resolvedDictionaryOut;

--- a/src/CoreVideo/CVPixelBufferPool.cs
+++ b/src/CoreVideo/CVPixelBufferPool.cs
@@ -90,7 +90,7 @@ namespace CoreVideo {
 			/* CVPixelBufferPoolRef __nonnull */ IntPtr pool);
 
 		// TODO: Return type is CVPixelBufferAttributes but need different name when this one is not WeakXXXX
-		public NSDictionary PixelBufferAttributes {
+		public NSDictionary? PixelBufferAttributes {
 			get {
 				return Runtime.GetNSObject<NSDictionary> (CVPixelBufferPoolGetPixelBufferAttributes (handle));
 			}
@@ -100,7 +100,7 @@ namespace CoreVideo {
 		extern static /* CFDictionaryRef __nullable */ IntPtr CVPixelBufferPoolGetAttributes (
 			/* CVPixelBufferPoolRef __nonnull */ IntPtr pool);
 
-		public NSDictionary Attributes {
+		public NSDictionary? Attributes {
 			get {
 				return Runtime.GetNSObject<NSDictionary> (CVPixelBufferPoolGetAttributes (handle));
 			}

--- a/src/CoreVideo/CVPixelFormatDescription.cs
+++ b/src/CoreVideo/CVPixelFormatDescription.cs
@@ -158,13 +158,13 @@ namespace CoreVideo {
 			/* CFAllocatorRef __nullable */ IntPtr allocator, int /* OSType = int32_t */ pixelFormat);
 
 #if !XAMCORE_3_0
-		public static NSDictionary Create (int pixelFormat)
+		public static NSDictionary? Create (int pixelFormat)
 		{
 			return Runtime.GetNSObject<NSDictionary> (CVPixelFormatDescriptionCreateWithPixelFormatType (IntPtr.Zero, pixelFormat));
 		}
 #endif
 
-		public static NSDictionary Create (CVPixelFormatType pixelFormat) 
+		public static NSDictionary? Create (CVPixelFormatType pixelFormat) 
 		{
 			return Runtime.GetNSObject<NSDictionary> (CVPixelFormatDescriptionCreateWithPixelFormatType (IntPtr.Zero, (int) pixelFormat));
 		}

--- a/src/HealthKit/HKAppleWalkingSteadiness.cs
+++ b/src/HealthKit/HKAppleWalkingSteadiness.cs
@@ -40,13 +40,13 @@ namespace HealthKit {
 		[DllImport (Constants.HealthKitLibrary)]
 		static extern HKQuantityRef HKAppleWalkingSteadinessMinimumQuantityForClassification (nint classification);
 
-		public static HKQuantity GetMinimumQuantity (HKAppleWalkingSteadinessClassification classification)
+		public static HKQuantity? GetMinimumQuantity (HKAppleWalkingSteadinessClassification classification)
 			=> Runtime.GetNSObject<HKQuantity> (HKAppleWalkingSteadinessMinimumQuantityForClassification ((nint) (long) classification), false); 
 
 		[DllImport (Constants.HealthKitLibrary)]
 		static extern HKQuantityRef HKAppleWalkingSteadinessMaximumQuantityForClassification (nint classification);
 
-		public static HKQuantity GetMaximumQuantity (HKAppleWalkingSteadinessClassification classification)
+		public static HKQuantity? GetMaximumQuantity (HKAppleWalkingSteadinessClassification classification)
 			=> Runtime.GetNSObject<HKQuantity> (HKAppleWalkingSteadinessMaximumQuantityForClassification ((nint) (long) classification), false); 
 	}
 

--- a/src/Metal/MTLCompat.cs
+++ b/src/Metal/MTLCompat.cs
@@ -29,7 +29,7 @@ namespace Metal {
 		[SupportedOSPlatform ("macos10.15")]
 #endif
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		public static IMTLCounterSampleBuffer CreateIMTLCounterSampleBuffer (this IMTLDevice This, MTLCounterSampleBufferDescriptor descriptor, out NSError error)
+		public static IMTLCounterSampleBuffer? CreateIMTLCounterSampleBuffer (this IMTLDevice This, MTLCounterSampleBufferDescriptor descriptor, out NSError? error)
 		{
 			if (descriptor == null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (descriptor));

--- a/src/Metal/MTLDevice.cs
+++ b/src/Metal/MTLDevice.cs
@@ -88,7 +88,7 @@ namespace Metal {
 		[Mac (10, 13)]
 #endif
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		public static IMTLDevice [] GetAllDevices (MTLDeviceNotificationHandler handler, out NSObject observer)
+		public static IMTLDevice [] GetAllDevices (MTLDeviceNotificationHandler handler, out NSObject? observer)
 		{
 			var block_handler = new BlockLiteral ();
 			block_handler.SetupBlockUnsafe (static_notificationHandler, handler);
@@ -110,7 +110,7 @@ namespace Metal {
 #endif
 		[Obsolete ("Use the overload that takes an 'out NSObject' instead.")]
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		public static IMTLDevice [] GetAllDevices (ref NSObject observer, MTLDeviceNotificationHandler handler)
+		public static IMTLDevice [] GetAllDevices (ref NSObject? observer, MTLDeviceNotificationHandler handler)
 		{
 			var rv = GetAllDevices (handler, out var obs);
 			observer = obs;
@@ -125,7 +125,7 @@ namespace Metal {
 			var descriptor = (BlockLiteral*) block;
 			var del = (MTLDeviceNotificationHandler) (descriptor->Target);
 			if (del != null)
-				del ((IMTLDevice) Runtime.GetNSObject (device), (Foundation.NSString) Runtime.GetNSObject (notifyName));
+				del ((IMTLDevice) Runtime.GetNSObject (device)!, (Foundation.NSString) Runtime.GetNSObject (notifyName)!);
 		}
 
 #if !NET
@@ -246,14 +246,13 @@ namespace Metal {
 #if !XAMCORE_4_0
 		[return: Release]
 		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-		public static IMTLLibrary? CreateLibrary (this IMTLDevice This, global::CoreFoundation.DispatchData data, out NSError error)
+		public static IMTLLibrary? CreateLibrary (this IMTLDevice This, global::CoreFoundation.DispatchData data, out NSError? error)
 		{
-			if (data == null)
+			if (data is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 			IntPtr errorValue = IntPtr.Zero;
 
-			IMTLLibrary ret;
-			ret = Runtime.GetINativeObject<IMTLLibrary> (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_ref_IntPtr (This.Handle, Selector.GetHandle ("newLibraryWithData:error:"), data.Handle, ref errorValue), true);
+			var ret = Runtime.GetINativeObject<IMTLLibrary> (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_ref_IntPtr (This.Handle, Selector.GetHandle ("newLibraryWithData:error:"), data.Handle, ref errorValue), true);
 			error = Runtime.GetNSObject<NSError> (errorValue);
 
 			return ret;

--- a/src/Metal/MTLVertexDescriptor.cs
+++ b/src/Metal/MTLVertexDescriptor.cs
@@ -20,7 +20,7 @@ namespace Metal {
 #if !NET
 		[iOS (9,0)]
 #endif
-		public static MTLVertexDescriptor FromModelIO (MDLVertexDescriptor descriptor)
+		public static MTLVertexDescriptor? FromModelIO (MDLVertexDescriptor descriptor)
 		{
 			if (descriptor == null)
 				throw new ArgumentException ("descriptor");
@@ -38,7 +38,7 @@ namespace Metal {
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10,0)]
 #endif
-		public static MTLVertexDescriptor FromModelIO (MDLVertexDescriptor descriptor, out NSError error)
+		public static MTLVertexDescriptor? FromModelIO (MDLVertexDescriptor descriptor, out NSError? error)
 		{
 			if (descriptor == null)
 				throw new ArgumentException ("descriptor");

--- a/src/ModelIO/MDLVertexDescriptor.cs
+++ b/src/ModelIO/MDLVertexDescriptor.cs
@@ -13,10 +13,10 @@ namespace ModelIO {
 		[DllImport (Constants.MetalKitLibrary)]
 		static extern  /* MDLVertexDescriptor __nonnull */ IntPtr MTKModelIOVertexDescriptorFromMetal (/* MTLVertexDescriptor __nonnull */ IntPtr mtlDescriptor);
 
-		public static MDLVertexDescriptor FromMetal (MTLVertexDescriptor descriptor)
+		public static MDLVertexDescriptor? FromMetal (MTLVertexDescriptor descriptor)
 		{
-			if (descriptor == null)
-				throw new ArgumentException ("descriptor");
+			if (descriptor is null)
+				throw new ArgumentException (nameof (descriptor));
 			return Runtime.GetNSObject<MDLVertexDescriptor> (MTKModelIOVertexDescriptorFromMetal (descriptor.Handle));
 		}
 
@@ -31,10 +31,10 @@ namespace ModelIO {
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10,0)]
 #endif
-		public static MDLVertexDescriptor FromMetal (MTLVertexDescriptor descriptor, out NSError error)
+		public static MDLVertexDescriptor? FromMetal (MTLVertexDescriptor descriptor, out NSError? error)
 		{
-			if (descriptor == null)
-				throw new ArgumentException ("descriptor");
+			if (descriptor is null)
+				throw new ArgumentException (nameof (descriptor));
 			IntPtr err;
 			var vd = Runtime.GetNSObject<MDLVertexDescriptor> (MTKModelIOVertexDescriptorFromMetalWithError (descriptor.Handle, out err));
 			error = Runtime.GetNSObject<NSError> (err);

--- a/src/Network/NWConnection.cs
+++ b/src/Network/NWConnection.cs
@@ -548,9 +548,9 @@ namespace Network {
 			return new NWProtocolMetadata (x, owns: true);
 		}
 
-		public T GetProtocolMetadata<T> (NWProtocolDefinition definition) where T : NWProtocolMetadata
+		public T? GetProtocolMetadata<T> (NWProtocolDefinition definition) where T : NWProtocolMetadata
 		{
-			if (definition == null)
+			if (definition is null)
 				throw new ArgumentNullException (nameof (definition));
 
 			var x = nw_connection_copy_protocol_metadata (GetCheckedHandle (), definition.Handle);

--- a/src/Network/NWContentContext.cs
+++ b/src/Network/NWContentContext.cs
@@ -135,9 +135,9 @@ namespace Network {
 			return new NWProtocolMetadata (x, owns: true);
 		}
 
-		public T GetProtocolMetadata<T> (NWProtocolDefinition protocolDefinition) where T : NWProtocolMetadata
+		public T? GetProtocolMetadata<T> (NWProtocolDefinition protocolDefinition) where T : NWProtocolMetadata
 		{
-			if (protocolDefinition == null)
+			if (protocolDefinition is null)
 				throw new ArgumentNullException (nameof (protocolDefinition));
 			var x = nw_content_context_copy_protocol_metadata (GetCheckedHandle (), protocolDefinition.Handle);
 			return Runtime.GetINativeObject<T> (x, owns: true);

--- a/src/Network/NWFramer.cs
+++ b/src/Network/NWFramer.cs
@@ -305,7 +305,7 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		static extern OS_nw_protocol_options nw_framer_create_options (OS_nw_protocol_definition framer_definition);
 
-		public static T CreateOptions<T> (NWProtocolDefinition protocolDefinition) where T: NWProtocolOptions
+		public static T? CreateOptions<T> (NWProtocolDefinition protocolDefinition) where T: NWProtocolOptions
 		{
 			if (protocolDefinition == null)
 				throw new ArgumentNullException (nameof (protocolDefinition));

--- a/src/Network/NWFramerMessage.cs
+++ b/src/Network/NWFramerMessage.cs
@@ -144,7 +144,7 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		static extern IntPtr nw_framer_message_copy_object_value (OS_nw_protocol_metadata message, string key);
 
-		public T GetObject<T> (string key) where T : NSObject
+		public T? GetObject<T> (string key) where T : NSObject
 			=> Runtime.GetNSObject<T> (nw_framer_message_copy_object_value (GetCheckedHandle (), key), owns: true);
 	}
 

--- a/src/ObjCRuntime/ErrorHelper.cs
+++ b/src/ObjCRuntime/ErrorHelper.cs
@@ -19,22 +19,22 @@ namespace Xamarin.Bundler {
 namespace ObjCRuntime {
 #endif
 	static partial class ErrorHelper {
-		public static ProductException CreateError (int code, string message, params object [] args)
+		public static ProductException CreateError (int code, string message, params object? [] args)
 		{
 			return new ProductException (code, true, null, message, args);
 		}
 
-		public static ProductException CreateError (int code, Exception? innerException, string message, params object [] args)
+		public static ProductException CreateError (int code, Exception? innerException, string message, params object? [] args)
 		{
 			return new ProductException (code, true, innerException, message, args);
 		}
 
-		public static ProductException CreateWarning (int code, string message, params object [] args)
+		public static ProductException CreateWarning (int code, string message, params object? [] args)
 		{
 			return new ProductException (code, false, null, message, args);
 		}
 
-		public static ProductException CreateWarning (int code, Exception? innerException, string message, params object [] args)
+		public static ProductException CreateWarning (int code, Exception? innerException, string message, params object? [] args)
 		{
 			return new ProductException (code, false, innerException, message, args);
 		}

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -5,6 +5,9 @@
 //   Miguel de Icaza
 //
 // Copyright 2013 Xamarin Inc.
+
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -27,6 +30,7 @@ namespace ObjCRuntime {
 	
 	public partial class Runtime {
 #if !COREBUILD
+#pragma warning disable 8618 // "Non-nullable field '...' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.": we make sure through other means that these will never be null
 		static Dictionary<IntPtrTypeValueTuple,Delegate> block_to_delegate_cache;
 		static Dictionary<Type, ConstructorInfo> intptr_ctor_cache;
 		static Dictionary<Type, ConstructorInfo> intptr_bool_ctor_cache;
@@ -42,6 +46,7 @@ namespace ObjCRuntime {
 		internal static TypeEqualityComparer TypeEqualityComparer;
 
 		internal static DynamicRegistrar Registrar;
+#pragma warning restore 8618
 
 		internal const uint INVALID_TOKEN_REF = 0xFFFFFFFF;
 
@@ -223,7 +228,7 @@ namespace ObjCRuntime {
 					if (Dlfcn.dladdr (sym2, out info2) == 0) {
 						NSLog ("The native runtime was loaded from {0}", Marshal.PtrToStringAuto (info2.dli_fname));
 					} else if (Dlfcn.dlsym (Dlfcn.RTLD.MainOnly, "xamarin_initialize") != IntPtr.Zero) {
-						byte[] buf = new byte [128];
+						var buf = new byte [128];
 						int length = buf.Length;
 						if (_NSGetExecutablePath (buf, ref length) == -1) {
 							Array.Resize (ref buf, length);
@@ -233,7 +238,7 @@ namespace ObjCRuntime {
 								buf = null;
 							}
 						}
-						if (buf != null) {
+						if (buf is not null) {
 							var str_length = 0;
 							for (int i = 0; i < buf.Length && buf [i] != 0; i++)
 								str_length++;
@@ -333,11 +338,11 @@ namespace ObjCRuntime {
 #endif
 
 #if MONOMAC
-		public static event AssemblyRegistrationHandler AssemblyRegistration;
+		public static event AssemblyRegistrationHandler? AssemblyRegistration;
 
 		static bool OnAssemblyRegistration (AssemblyName assembly_name)
 		{
-			if (AssemblyRegistration != null) {
+			if (AssemblyRegistration is not null) {
 				var args = new AssemblyRegistrationEventArgs
 				{
 					Register = true,
@@ -352,15 +357,15 @@ namespace ObjCRuntime {
 		static MarshalObjectiveCExceptionMode objc_exception_mode;
 		static MarshalManagedExceptionMode managed_exception_mode;
 
-		public static event MarshalObjectiveCExceptionHandler MarshalObjectiveCException;
-		public static event MarshalManagedExceptionHandler MarshalManagedException;
+		public static event MarshalObjectiveCExceptionHandler? MarshalObjectiveCException;
+		public static event MarshalManagedExceptionHandler? MarshalManagedException;
 
 		static MarshalObjectiveCExceptionMode OnMarshalObjectiveCException (IntPtr exception_handle, bool throwManagedAsDefault)
 		{
-			if (throwManagedAsDefault && MarshalObjectiveCException == null)
+			if (throwManagedAsDefault && MarshalObjectiveCException is null)
 				return MarshalObjectiveCExceptionMode.ThrowManagedException;
 			
-			if (MarshalObjectiveCException != null) {
+			if (MarshalObjectiveCException is not null) {
 				var exception = GetNSObject<NSException> (exception_handle);
 				var args = new MarshalObjectiveCExceptionEventArgs ()
 				{
@@ -376,7 +381,7 @@ namespace ObjCRuntime {
 
 		static MarshalManagedExceptionMode OnMarshalManagedException (IntPtr exception_handle)
 		{
-			if (MarshalManagedException != null) {
+			if (MarshalManagedException is not null) {
 				var exception = GCHandle.FromIntPtr (exception_handle).Target as Exception;
 				var args = new MarshalManagedExceptionEventArgs ()
 				{
@@ -399,13 +404,13 @@ namespace ObjCRuntime {
 		// returns: a handle to a native NSString *
 		static IntPtr ConvertSmartEnumToNSString (IntPtr value_handle)
 		{
-			var value = GetGCHandleTarget (value_handle);
+			var value = GetGCHandleTarget (value_handle)!;
 			var smart_type = value.GetType ();
 			MethodBase getConstantMethod, getValueMethod;
 			if (!Registrar.IsSmartEnum (smart_type, out getConstantMethod, out getValueMethod))
 				throw ErrorHelper.CreateError (8024, $"Could not find a valid extension type for the smart enum '{smart_type.FullName}'. Please file a bug at https://github.com/xamarin/xamarin-macios/issues/new.");
-			var rv = (NSString) ((MethodInfo) getConstantMethod).Invoke (null, new object [] { value });
-			if (rv == null)
+			var rv = (NSString?) ((MethodInfo) getConstantMethod).Invoke (null, new object [] { value });
+			if (rv is null)
 				return IntPtr.Zero;
 			rv.DangerousRetain ().DangerousAutorelease ();
 			return rv.Handle;
@@ -416,8 +421,8 @@ namespace ObjCRuntime {
 		// returns: GCHandle to a (smart) enum value. Caller must free the GCHandle.
 		static IntPtr ConvertNSStringToSmartEnum (IntPtr value, IntPtr type)
 		{
-			var smart_type = (Type) GetGCHandleTarget (type);
-			var str = GetNSObject<NSString> (value);
+			var smart_type = (Type) GetGCHandleTarget (type)!;
+			var str = GetNSObject<NSString> (value)!;
 			MethodBase getConstantMethod, getValueMethod;
 			if (!Registrar.IsSmartEnum (smart_type, out getConstantMethod, out getValueMethod))
 				throw ErrorHelper.CreateError (8024, $"Could not find a valid extension type for the smart enum '{smart_type.FullName}'. Please file a bug at https://github.com/xamarin/xamarin-macios/issues/new.");
@@ -428,12 +433,12 @@ namespace ObjCRuntime {
 #region Wrappers for delegate callbacks
 		static void RegisterAssembly (IntPtr a)
 		{
-			RegisterAssembly ((Assembly) GetGCHandleTarget (a));
+			RegisterAssembly ((Assembly) GetGCHandleTarget (a)!);
 		}
 
 		static void RegisterEntryAssembly (IntPtr a)
 		{
-			RegisterEntryAssembly ((Assembly) GetGCHandleTarget (a));
+			RegisterEntryAssembly ((Assembly) GetGCHandleTarget (a)!);
 		}
 
 		static void ThrowNSException (IntPtr ns_exception)
@@ -447,7 +452,7 @@ namespace ObjCRuntime {
 
 		static void RethrowManagedException (IntPtr exception_gchandle)
 		{
-			var e = (Exception) GCHandle.FromIntPtr ((IntPtr) exception_gchandle).Target;
+			var e = (Exception) GCHandle.FromIntPtr ((IntPtr) exception_gchandle).Target!;
 			System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture (e).Throw ();
 		}
 
@@ -455,16 +460,16 @@ namespace ObjCRuntime {
 		{
 			Exception ex;
 #if MONOMAC
-			ex = new ObjCException (Runtime.GetNSObject<NSException> (ns_exception));
+			ex = new ObjCException (Runtime.GetNSObject<NSException> (ns_exception)!);
 #else
-			ex = new MonoTouchException (Runtime.GetNSObject<NSException> (ns_exception));
+			ex = new MonoTouchException (Runtime.GetNSObject<NSException> (ns_exception)!);
 #endif
 			return GCHandle.ToIntPtr (GCHandle.Alloc (ex));
 		}
 
 		static IntPtr CreateRuntimeException (int code, IntPtr message)
 		{
-			var ex = ErrorHelper.CreateError (code, Marshal.PtrToStringAuto (message));
+			var ex = ErrorHelper.CreateError (code, Marshal.PtrToStringAuto (message)!);
 			return GCHandle.ToIntPtr (GCHandle.Alloc (ex));
 		}
 
@@ -476,8 +481,9 @@ namespace ObjCRuntime {
 #else
 			var exc = obj as MonoTouchException;
 #endif
-			if (exc != null) {
-				return exc.NSException.DangerousRetain ().DangerousAutorelease ().Handle;
+			var nsexc = exc?.NSException;
+			if (nsexc is not null) {
+				return nsexc.DangerousRetain ().DangerousAutorelease ().Handle;
 			} else {
 				return IntPtr.Zero;
 			}
@@ -485,22 +491,22 @@ namespace ObjCRuntime {
 
 		static IntPtr GetBlockWrapperCreator (IntPtr method, int parameter)
 		{
-			return AllocGCHandle (GetBlockWrapperCreator ((MethodInfo) GetGCHandleTarget (method), parameter));
+			return AllocGCHandle (GetBlockWrapperCreator ((MethodInfo) GetGCHandleTarget (method)!, parameter));
 		}
 
 		static IntPtr CreateBlockProxy (IntPtr method, IntPtr block)
 		{
-			return AllocGCHandle (CreateBlockProxy ((MethodInfo) GetGCHandleTarget (method), block));
+			return AllocGCHandle (CreateBlockProxy ((MethodInfo) GetGCHandleTarget (method)!, block));
 		}
 			
 		static IntPtr CreateDelegateProxy (IntPtr method, IntPtr @delegate, IntPtr signature, uint token_ref)
 		{
-			return BlockLiteral.GetBlockForDelegate ((MethodInfo) GetGCHandleTarget (method), GetGCHandleTarget (@delegate), token_ref, Marshal.PtrToStringAuto (signature));
+			return BlockLiteral.GetBlockForDelegate ((MethodInfo) GetGCHandleTarget (method)!, GetGCHandleTarget (@delegate), token_ref, Marshal.PtrToStringAuto (signature));
 		}
 
 		static IntPtr GetExceptionMessage (IntPtr exception_gchandle)
 		{
-			var exc = (Exception) GetGCHandleTarget (exception_gchandle);
+			var exc = (Exception) GetGCHandleTarget (exception_gchandle)!;
 			return Marshal.StringToHGlobalAuto (exc.Message);
 		}
 
@@ -518,13 +524,13 @@ namespace ObjCRuntime {
 		{
 			var str = new StringBuilder ();
 			try {
-				var exc = (Exception) GetGCHandleTarget (exception_gchandle);
+				var exc = (Exception) GetGCHandleTarget (exception_gchandle)!;
 
 				int counter = 0;
 				do {
 					PrintException (exc, counter > 0, str);
 					exc = exc.InnerException;
-				} while (counter < 10 && exc != null);
+				} while (counter < 10 && exc is not null);
 			} catch (Exception exception) {
 				str.Append ("Failed to print exception: ").Append (exception);
 			}
@@ -532,12 +538,12 @@ namespace ObjCRuntime {
 			return Marshal.StringToHGlobalAuto (str.ToString ());
 		}
 
-		static unsafe Assembly GetEntryAssembly ()
+		static unsafe Assembly? GetEntryAssembly ()
 		{
 			var asm = Assembly.GetEntryAssembly ();
 #if MONOMAC
-			if (asm == null)
-				asm = Assembly.LoadFile (Marshal.PtrToStringAuto (options->EntryAssemblyPath));
+			if (asm is null)
+				asm = Assembly.LoadFile (Marshal.PtrToStringAuto (options->EntryAssemblyPath)!);
 #endif
 			return asm;
 		}
@@ -562,13 +568,13 @@ namespace ObjCRuntime {
 		//
 		// NOTE: the linker will remove this method when the dynamic registrar has been optimized away (RemoveCode.cs)
 		// and as such cannot be renamed without updating the linker
-		internal static void RegisterEntryAssembly (Assembly entry_assembly)
+		internal static void RegisterEntryAssembly (Assembly? entry_assembly)
 		{
 			var assemblies = new List<Assembly> ();
 
 			assemblies.Add (NSObject.PlatformAssembly); // make sure our platform assembly comes first
 			// Recursively get all assemblies referenced by the entry assembly.
-			if (entry_assembly != null) {
+			if (entry_assembly is not null) {
 				var register_entry_assembly = true;
 #if MONOMAC
 				register_entry_assembly = OnAssemblyRegistration (entry_assembly.GetName ());
@@ -632,8 +638,8 @@ namespace ObjCRuntime {
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static void RegisterAssembly (Assembly a)
 		{
-			if (a == null)
-				throw new ArgumentNullException ("a");
+			if (a is null)
+				throw new ArgumentNullException (nameof (a));
 
 			if (!DynamicRegistrationSupported)
 				throw ErrorHelper.CreateError (8026, "Runtime.RegisterAssembly is not supported when the dynamic registrar has been linked away.");
@@ -646,10 +652,10 @@ namespace ObjCRuntime {
 				string libName = requiredFramework.Name;
 
 				if (libName.Contains (".dylib")) {
-					libPath = ResourcesPath;
+					libPath = ResourcesPath!;
 				}
 				else {
-					libPath = FrameworksPath;
+					libPath = FrameworksPath!;
 					libPath = Path.Combine (libPath, libName);
 					libName = libName.Replace (".frameworks", "");
 				}
@@ -668,7 +674,7 @@ namespace ObjCRuntime {
 			}
 #endif
 
-			if (assemblies == null) {
+			if (assemblies is null) {
 				assemblies = new List <Assembly> ();
 				Class.Register (typeof (NSObject));
 			}
@@ -709,12 +715,12 @@ namespace ObjCRuntime {
 
 		static bool HasNSObject (IntPtr ptr)
 		{
-			return TryGetNSObject (ptr, evenInFinalizerQueue: false) != null;
+			return TryGetNSObject (ptr, evenInFinalizerQueue: false) is not null;
 		}
 
 		static IntPtr GetHandleForINativeObject (IntPtr ptr)
 		{
-			return ((INativeObject) GetGCHandleTarget (ptr)).Handle;
+			return ((INativeObject) GetGCHandleTarget (ptr)!).Handle;
 		}
 
 		static void UnregisterNSObject (IntPtr native_obj, IntPtr managed_obj) 
@@ -725,7 +731,7 @@ namespace ObjCRuntime {
 		static unsafe IntPtr GetMethodFromToken (uint token_ref)
 		{
 			var method = Class.ResolveMethodTokenReference (token_ref);
-			if (method != null)
+			if (method is not null)
 				return AllocGCHandle (method);
 
 			return IntPtr.Zero;
@@ -734,12 +740,12 @@ namespace ObjCRuntime {
 		static unsafe IntPtr GetGenericMethodFromToken (IntPtr obj, uint token_ref)
 		{
 			var method = Class.ResolveMethodTokenReference (token_ref);
-			if (method == null)
+			if (method is null)
 				return IntPtr.Zero;
 
 			var nsobj = GetGCHandleTarget (obj) as NSObject;
-			if (nsobj == null)
-				throw ErrorHelper.CreateError (8023, $"An instance object is required to construct a closed generic method for the open generic method: {method.DeclaringType.FullName}.{method.Name} (token reference: 0x{token_ref:X}). Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new.");
+			if (nsobj is null)
+				throw ErrorHelper.CreateError (8023, $"An instance object is required to construct a closed generic method for the open generic method: {method.DeclaringType!.FullName}.{method.Name} (token reference: 0x{token_ref:X}). Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new.");
 
 			return AllocGCHandle (FindClosedMethod (nsobj.GetType (), method));
 		}
@@ -754,7 +760,7 @@ namespace ObjCRuntime {
 			/*
 			 * This method is called from marshalling bridge (dynamic mode).
 			 */
-			var type = (System.Type) GetGCHandleTarget (type_ptr);
+			var type = (System.Type) GetGCHandleTarget (type_ptr)!;
 			return AllocGCHandle (GetINativeObject (ptr, owns, type));
 		}
 			
@@ -771,19 +777,19 @@ namespace ObjCRuntime {
 
 		static IntPtr GetNSObjectWithType (IntPtr ptr, IntPtr type_ptr, out bool created)
 		{
-			var type = (System.Type) GetGCHandleTarget (type_ptr);
+			var type = (System.Type) GetGCHandleTarget (type_ptr)!;
 			return AllocGCHandle (GetNSObject (ptr, type, MissingCtorResolution.ThrowConstructor1NotFound, true, out created));
 		}
 
 		static void Dispose (IntPtr gchandle)
 		{
-			((IDisposable) GetGCHandleTarget (gchandle)).Dispose ();
+			((IDisposable?) GetGCHandleTarget (gchandle))?.Dispose ();
 		}
 
 		static bool IsParameterTransient (IntPtr info, int parameter)
 		{
 			var minfo = GetGCHandleTarget (info) as MethodInfo;
-			if (minfo == null)
+			if (minfo is null)
 				return false; // might be a ConstructorInfo (bug #15583), but we don't care about that (yet at least).
 			minfo = minfo.GetBaseDefinition ();
 			var parameters = minfo.GetParameters ();
@@ -795,7 +801,7 @@ namespace ObjCRuntime {
 		static bool IsParameterOut (IntPtr info, int parameter)
 		{
 			var minfo = GetGCHandleTarget (info) as MethodInfo;
-			if (minfo == null)
+			if (minfo is null)
 				return false; // might be a ConstructorInfo (bug #15583), but we don't care about that (yet at least).
 			minfo = minfo.GetBaseDefinition ();
 			var parameters = minfo.GetParameters ();
@@ -812,14 +818,14 @@ namespace ObjCRuntime {
 		// If inner_exception_gchandle is provided, it will be freed.
 		static IntPtr CreateProductException (int code, IntPtr inner_exception_gchandle, string msg)
 		{
-			Exception inner_exception = null;
+			Exception? inner_exception = null;
 			if (inner_exception_gchandle != IntPtr.Zero) {
 				GCHandle gchandle = GCHandle.FromIntPtr (inner_exception_gchandle);
-				inner_exception = (Exception) gchandle.Target;
+				inner_exception = (Exception?) gchandle.Target;
 				gchandle.Free ();
 			}
 			Exception ex;
-			if (inner_exception != null) {
+			if (inner_exception is not null) {
 				ex = ErrorHelper.CreateError (code, inner_exception, msg);
 			} else {
 				ex = ErrorHelper.CreateError (code, msg);
@@ -829,13 +835,13 @@ namespace ObjCRuntime {
 
 		static IntPtr TypeGetFullName (IntPtr type) 
 		{	
-			return Marshal.StringToHGlobalAuto (((Type) GetGCHandleTarget (type)).FullName);
+			return Marshal.StringToHGlobalAuto (((Type) GetGCHandleTarget (type)!).FullName);
 		}
 
 		static IntPtr GetObjectTypeFullName (IntPtr gchandle)
 		{
 			var obj = GetGCHandleTarget (gchandle);
-			if (obj == null)
+			if (obj is null)
 				return IntPtr.Zero;
 			return Marshal.StringToHGlobalAuto (obj.GetType ().FullName);
 		}
@@ -846,13 +852,13 @@ namespace ObjCRuntime {
 		}
 #endregion
 
-		static MethodInfo GetBlockProxyAttributeMethod (MethodInfo method, int parameter)
+		static MethodInfo? GetBlockProxyAttributeMethod (MethodInfo method, int parameter)
 		{
 			var attrs = method.GetParameters () [parameter].GetCustomAttributes (typeof (BlockProxyAttribute), true);
 			if (attrs.Length == 1) {
 				try {
 					var attr = attrs [0] as BlockProxyAttribute;
-					return attr.Type.GetMethod ("Create");
+					return attr?.Type?.GetMethod ("Create");
 				} catch {
 					return null;
 				}
@@ -860,10 +866,10 @@ namespace ObjCRuntime {
 			return null;
 		}
 
-		internal static ProtocolMemberAttribute GetProtocolMemberAttribute (Type type, string selector, MethodInfo method)
+		internal static ProtocolMemberAttribute? GetProtocolMemberAttribute (Type type, string selector, MethodInfo method)
 		{
 			var memberAttributes = type.GetCustomAttributes<ProtocolMemberAttribute> ();
-			if (memberAttributes == null)
+			if (memberAttributes is null)
 				return null;
 
 			foreach (var attrib in memberAttributes) {
@@ -883,11 +889,11 @@ namespace ObjCRuntime {
 						var isByRef = paramType.IsByRef;
 						if (isByRef)
 							paramType = paramType.GetElementType ();
-						if (isByRef != attrib.ParameterByRef [i]) {
+						if (isByRef != attrib.ParameterByRef! [i]) {
 							notApplicable = true;
 							break;
 						}
-						if (paramType != attrib.ParameterType [i]) {
+						if (paramType != attrib.ParameterType! [i]) {
 							notApplicable = true;
 							break;
 						}
@@ -908,27 +914,27 @@ namespace ObjCRuntime {
 		// delegate
 		//
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		static MethodInfo GetBlockWrapperCreator (MethodInfo method, int parameter)
+		static MethodInfo? GetBlockWrapperCreator (MethodInfo method, int parameter)
 		{
 			// A mirror of this method is also implemented in StaticRegistrar:FindBlockProxyCreatorMethod
 			// If this method is changed, that method will probably have to be updated too (tests!!!)
 			MethodInfo first = method;
-			MethodInfo last = null;
-			Type[] extensionParameters = null;
+			MethodInfo? last = null;
+			Type[]? extensionParameters = null;
 
 			while (method != last){
 				last = method;
 				var createMethod = GetBlockProxyAttributeMethod (method, parameter);
-				if (createMethod != null)
+				if (createMethod is not null)
 					return createMethod;
 				method = method.GetBaseDefinition ();
 			}
 
-			string selector = null;
+			string? selector = null;
 
 			// Might be the implementation of an interface method, so find the corresponding
 			// MethodInfo for the interface, and check for BlockProxy attributes there as well.
-			foreach (var iface in method.DeclaringType.GetInterfaces ()) {
+			foreach (var iface in method.DeclaringType!.GetInterfaces ()) {
 				if (!iface.IsDefined (typeof (ProtocolAttribute), false))
 					continue;
 
@@ -936,7 +942,7 @@ namespace ObjCRuntime {
 				for (int i = 0; i < map.TargetMethods.Length; i++) {
 					if (map.TargetMethods [i] == first) {
 						var createMethod = GetBlockProxyAttributeMethod (map.InterfaceMethods [i], parameter);
-						if (createMethod != null)
+						if (createMethod is not null)
 							return createMethod;
 					}
 				}
@@ -944,12 +950,12 @@ namespace ObjCRuntime {
 				// We store the BlockProxy type in the ProtocolMemberAttribute, so check those.
 				// We may run into binding assemblies built with earlier versions of the generator,
 				// which means we can't rely on finding the BlockProxy attribute in the ProtocolMemberAttribute.
-				if (selector == null)
+				if (selector is null)
 					selector = GetExportAttribute (method)?.Selector ?? string.Empty;
 				if (!string.IsNullOrEmpty (selector)) {
 					var attrib = GetProtocolMemberAttribute (iface, selector, method);
-					if (attrib != null && attrib.ParameterBlockProxy.Length > parameter && attrib.ParameterBlockProxy [parameter] != null)
-						return attrib.ParameterBlockProxy [parameter].GetMethod ("Create");
+					if (attrib is not null && attrib.ParameterBlockProxy!.Length > parameter && attrib.ParameterBlockProxy [parameter] is not null)
+						return attrib.ParameterBlockProxy [parameter]!.GetMethod ("Create");
 				}
 
 				// Might be an implementation of an optional protocol member.
@@ -959,8 +965,8 @@ namespace ObjCRuntime {
 					extensionName = iface.Namespace + ".";
 				extensionName +=iface.Name.Substring (1) + "_Extensions";
 				var extensionType = iface.Assembly.GetType (extensionName, false);
-				if (extensionType != null) {
-					if (extensionParameters == null) {
+				if (extensionType is not null) {
+					if (extensionParameters is null) {
 						var methodParameters = method.GetParameters ();
 						extensionParameters = new Type [methodParameters.Length + 1];
 						for (int i = 0; i < methodParameters.Length; i++)
@@ -968,9 +974,9 @@ namespace ObjCRuntime {
 					}
 					extensionParameters [0] = iface;
 					var extensionMethod = extensionType.GetMethod (method.Name, BindingFlags.Public | BindingFlags.Static, null, extensionParameters, null);
-					if (extensionMethod != null) {
+					if (extensionMethod is not null) {
 						var createMethod = GetBlockProxyAttributeMethod (extensionMethod, parameter + 1);
-						if (createMethod != null)
+						if (createMethod is not null)
 							return createMethod;
 					}
 				}
@@ -990,18 +996,18 @@ namespace ObjCRuntime {
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		static Delegate CreateBlockProxy (MethodInfo method, IntPtr block)
 		{
-			return (Delegate) method.Invoke (null, new object [] { block } );
+			return (Delegate) method.Invoke (null, new object [] { block } )!;
 		}
 
-		internal static Delegate GetDelegateForBlock (IntPtr methodPtr, Type type)
+		internal static Delegate? GetDelegateForBlock (IntPtr methodPtr, Type type)
 		{
 			// We do not care if there is a race condition and we initialize two caches
 			// since the worst that can happen is that we end up with an extra
 			// delegate->function pointer.
-			Delegate val;
+			Delegate? val;
 			var pair = new IntPtrTypeValueTuple (methodPtr, type);
 			lock (lock_obj) {
-				if (block_to_delegate_cache == null)
+				if (block_to_delegate_cache is null)
 					block_to_delegate_cache = new Dictionary<IntPtrTypeValueTuple, Delegate> ();
 
 				if (block_to_delegate_cache.TryGetValue (pair, out val))
@@ -1018,11 +1024,11 @@ namespace ObjCRuntime {
 
 		unsafe static MethodBase FindMethod (IntPtr typeptr, IntPtr methodptr, int paramCount, IntPtr* paramptr)
 		{
-			var type = Type.GetType (Marshal.PtrToStringAuto (typeptr));
-			var methodName = Marshal.PtrToStringAuto (methodptr);
+			var type = Type.GetType (Marshal.PtrToStringAuto (typeptr)!)!;
+			var methodName = Marshal.PtrToStringAuto (methodptr)!;
 			var parameterTypes = new string [paramCount];
 			for (int i = 0; i < paramCount; i++)
-				parameterTypes [i] = Marshal.PtrToStringAuto (paramptr [i]);
+				parameterTypes [i] = Marshal.PtrToStringAuto (paramptr [i])!;
 
 			MethodBase [] methods;
 			if (methodName == ".ctor") {
@@ -1042,6 +1048,8 @@ namespace ObjCRuntime {
 					var paramType = parameters [i].ParameterType;
 
 					var ptaqn = paramType.AssemblyQualifiedName;
+					if (ptaqn is null)
+						continue;
 					// the condensed string representation needs some fixup if there are generics used
 					if (paramType.IsGenericType) {
 						int s = 0;
@@ -1072,18 +1080,18 @@ namespace ObjCRuntime {
 			}
 		}
 					
-		internal static void NativeObjectHasDied (IntPtr ptr, NSObject managed_obj)
+		internal static void NativeObjectHasDied (IntPtr ptr, NSObject? managed_obj)
 		{
 			lock (lock_obj) {
 				if (object_map.TryGetValue (ptr, out var wr)) {
-					if (managed_obj == null || wr.Target == (object) managed_obj) {
+					if (managed_obj is null || wr.Target == (object) managed_obj) {
 						object_map.Remove (ptr);
 						wr.Free ();
 					}
 
 				}
 
-				if (managed_obj != null)
+				if (managed_obj is not null)
 					managed_obj.ClearHandle ();
 			}
 		}
@@ -1096,12 +1104,12 @@ namespace ObjCRuntime {
 			}
 		}
 
-		internal static PropertyInfo FindPropertyInfo (MethodInfo accessor)
+		internal static PropertyInfo? FindPropertyInfo (MethodInfo accessor)
 		{
 			if (!accessor.IsSpecialName)
 				return null;
 
-			foreach (var pi in accessor.DeclaringType.GetProperties ()) {
+			foreach (var pi in accessor.DeclaringType!.GetProperties ()) {
 				if (pi.GetGetMethod () == accessor)
 					return pi;
 				if (pi.GetSetMethod () == accessor)
@@ -1111,18 +1119,18 @@ namespace ObjCRuntime {
 			return null;
 		}
 
-		internal static ExportAttribute GetExportAttribute (MethodInfo method)
+		internal static ExportAttribute? GetExportAttribute (MethodInfo method)
 		{
 			var attrib = method.GetCustomAttribute<ExportAttribute> ();
-			if (attrib == null) {
+			if (attrib is null) {
 				var pinfo = FindPropertyInfo (method);
-				if (pinfo != null)
+				if (pinfo is not null)
 					attrib = pinfo.GetCustomAttribute<ExportAttribute> ();
 			}
 			return attrib;
 		}
 
-		static NSObject IgnoreConstructionError (IntPtr ptr, IntPtr klass, Type type)
+		static NSObject? IgnoreConstructionError (IntPtr ptr, IntPtr klass, Type type)
 		{
 			return null;
 		}
@@ -1161,32 +1169,32 @@ namespace ObjCRuntime {
 			throw ErrorHelper.CreateError (8027, string.Format (msg, ptr.ToString ("x"), new Class (klass).Name, type.FullName));
 		}
 
-		static NSObject ConstructNSObject (IntPtr ptr, IntPtr klass, MissingCtorResolution missingCtorResolution)
+		static NSObject? ConstructNSObject (IntPtr ptr, IntPtr klass, MissingCtorResolution missingCtorResolution)
 		{
 			Type type = Class.Lookup (klass);
 
-			if (type != null) {
+			if (type is not null) {
 				return ConstructNSObject<NSObject> (ptr, type, missingCtorResolution);
 			} else {
 				return new NSObject (ptr);
 			}
 		}
 
-		internal static T ConstructNSObject<T> (IntPtr ptr) where T: NSObject
+		internal static T? ConstructNSObject<T> (IntPtr ptr) where T: NSObject
 		{
 			return ConstructNSObject<T> (ptr, typeof (T), MissingCtorResolution.ThrowConstructor1NotFound);
 		}
 
 		// The generic argument T is only used to cast the return value.
 		// The 'selector' and 'method' arguments are only used in error messages.
-		static T ConstructNSObject<T> (IntPtr ptr, Type type, MissingCtorResolution missingCtorResolution) where T: class, INativeObject
+		static T? ConstructNSObject<T> (IntPtr ptr, Type type, MissingCtorResolution missingCtorResolution) where T: class, INativeObject
 		{
-			if (type == null)
-				throw new ArgumentNullException ("type");
+			if (type is null)
+				throw new ArgumentNullException (nameof (type));
 
 			var ctor = GetIntPtrConstructor (type);
 
-			if (ctor == null) {
+			if (ctor is null) {
 				MissingCtor (ptr, IntPtr.Zero, type, missingCtorResolution);
 				return null;
 			}
@@ -1195,20 +1203,22 @@ namespace ObjCRuntime {
 		}
 
 		// The generic argument T is only used to cast the return value.
-		static T ConstructINativeObject<T> (IntPtr ptr, bool owns, Type type, MissingCtorResolution missingCtorResolution) where T : class, INativeObject
+		static T? ConstructINativeObject<T> (IntPtr ptr, bool owns, Type type, MissingCtorResolution missingCtorResolution) where T : class, INativeObject
 		{
-			if (type == null)
-				throw new ArgumentNullException ("type");
+			if (type is null)
+				throw new ArgumentNullException (nameof (type));
 
 			if (type.IsByRef)
-				type = type.GetElementType ();
+				type = type.GetElementType ()!;
 
 			var ctor = GetIntPtr_BoolConstructor (type);
 
-			if (ctor == null)
+			if (ctor is null) {
 				MissingCtor (ptr, IntPtr.Zero, type, missingCtorResolution);
+				return null;
+			}
 
-			return (T) ctor.Invoke (new object[] { ptr, owns});
+			return (T?) ctor.Invoke (new object[] { ptr, owns});
 		}
 
 		static IntPtr CreateNSObject (IntPtr type_gchandle, IntPtr handle, NSObject.Flags flags)
@@ -1216,7 +1226,7 @@ namespace ObjCRuntime {
 			return NSObject.CreateNSObject (type_gchandle, handle, flags);
 		}
 
-		static ConstructorInfo GetIntPtrConstructor (Type type)
+		static ConstructorInfo? GetIntPtrConstructor (Type type)
 		{
 			lock (intptr_ctor_cache) {
 				if (intptr_ctor_cache.TryGetValue (type, out var rv))
@@ -1234,7 +1244,7 @@ namespace ObjCRuntime {
 			return null;
 		}
 
-		static ConstructorInfo GetIntPtr_BoolConstructor (Type type)
+		static ConstructorInfo? GetIntPtr_BoolConstructor (Type type)
 		{
 			lock (intptr_bool_ctor_cache) {
 				if (intptr_bool_ctor_cache.TryGetValue (type, out var rv))
@@ -1252,17 +1262,17 @@ namespace ObjCRuntime {
 			return null;
 		}
 
-		public static NSObject TryGetNSObject (IntPtr ptr)
+		public static NSObject? TryGetNSObject (IntPtr ptr)
 		{
 			return TryGetNSObject (ptr, evenInFinalizerQueue: false);
 		}
 
-		internal static NSObject TryGetNSObject (IntPtr ptr, bool evenInFinalizerQueue)
+		internal static NSObject? TryGetNSObject (IntPtr ptr, bool evenInFinalizerQueue)
 		{
 			lock (lock_obj) {
 				if (object_map.TryGetValue (ptr, out var reference)) {
-					var target = (NSObject) reference.Target;
-					if (target == null)
+					var target = (NSObject?) reference.Target;
+					if (target is null)
 						return null;
 
 					if (target.InFinalizerQueue) {
@@ -1290,31 +1300,31 @@ namespace ObjCRuntime {
 			return null;
 		}
 
-		public static NSObject GetNSObject (IntPtr ptr) {
+		public static NSObject? GetNSObject (IntPtr ptr) {
 			return GetNSObject (ptr, MissingCtorResolution.ThrowConstructor1NotFound);
 		}
 
-		internal static NSObject GetNSObject (IntPtr ptr, MissingCtorResolution missingCtorResolution, bool evenInFinalizerQueue = false) {
+		internal static NSObject? GetNSObject (IntPtr ptr, MissingCtorResolution missingCtorResolution, bool evenInFinalizerQueue = false) {
 			if (ptr == IntPtr.Zero)
 				return null;
 
 			var o = TryGetNSObject (ptr, evenInFinalizerQueue);
 
-			if (o != null)
+			if (o is not null)
 				return o;
 
 			return ConstructNSObject (ptr, Class.GetClassForObject (ptr), missingCtorResolution);
 		}
 
-		static public T GetNSObject<T> (IntPtr ptr) where T : NSObject
+		static public T? GetNSObject<T> (IntPtr ptr) where T : NSObject
 		{
 			if (ptr == IntPtr.Zero)
 				return null;
 
-			object obj = TryGetNSObject (ptr, evenInFinalizerQueue: false);
-			T o;
+			var obj = TryGetNSObject (ptr, evenInFinalizerQueue: false);
+			T? o;
 
-			if (obj == null) {
+			if (obj is null) {
 				// Try to get the managed type that correspond to this exact native type
 				IntPtr p = Class.GetClassForObject (ptr);
 				// If unknown then we'll get the Class that Lookup to NSObject even if this is not NSObject.
@@ -1339,14 +1349,14 @@ namespace ObjCRuntime {
 				o = ConstructNSObject<T> (ptr, target_type, MissingCtorResolution.ThrowConstructor1NotFound);
 			} else {
 				o = obj as T;
-				if (o == null)
+				if (o is null)
 					throw new InvalidCastException (string.Format ("Unable to cast object of type '{0}' to type '{1}'", obj.GetType ().FullName, typeof(T).FullName));
 			}
 
 			return o;
 		}
 
-		static public T GetNSObject<T> (IntPtr ptr, bool owns) where T : NSObject
+		static public T? GetNSObject<T> (IntPtr ptr, bool owns) where T : NSObject
 		{
 			var obj = GetNSObject<T> (ptr);
 			if (owns)
@@ -1374,7 +1384,7 @@ namespace ObjCRuntime {
 		//
 
 		// The 'selector' and 'method' arguments are only used in error messages.
-		static NSObject GetNSObject (IntPtr ptr, Type target_type, MissingCtorResolution missingCtorResolution, bool evenInFinalizerQueue, out bool created) {
+		static NSObject? GetNSObject (IntPtr ptr, Type target_type, MissingCtorResolution missingCtorResolution, bool evenInFinalizerQueue, out bool created) {
 			created = false;
 
 			if (ptr == IntPtr.Zero)
@@ -1382,7 +1392,7 @@ namespace ObjCRuntime {
 
 			var o = TryGetNSObject (ptr, evenInFinalizerQueue);
 
-			if (o != null)
+			if (o is not null)
 				return o;
 
 			// Try to get the managed type that correspond to this exact native type
@@ -1409,7 +1419,7 @@ namespace ObjCRuntime {
 			return ConstructNSObject<NSObject> (ptr, target_type, MissingCtorResolution.ThrowConstructor1NotFound);
 		}
 
-		static Type LookupINativeObjectImplementation (IntPtr ptr, Type target_type, Type implementation = null, bool forced_type = false)
+		static Type LookupINativeObjectImplementation (IntPtr ptr, Type target_type, Type? implementation = null, bool forced_type = false)
 		{
 			if (!typeof (NSObject).IsAssignableFrom (target_type)) {
 				// If we're not expecting an NSObject, we can't do a dynamic lookup of the type of ptr,
@@ -1423,7 +1433,7 @@ namespace ObjCRuntime {
 				var p = Class.GetClassForObject (ptr);
 
 				if (p == NSObjectClass) {
-					if (implementation == null)
+					if (implementation is null)
 						implementation = target_type;
 				} else {
 					// only throw if we're not forcing the type we want to expose
@@ -1431,7 +1441,7 @@ namespace ObjCRuntime {
 					// Check if the runtime type can actually be used.
 					if (target_type.IsAssignableFrom (runtime_type)) {
 						implementation = runtime_type;
-					} else if (implementation == null) {
+					} else if (implementation is null) {
 						implementation = target_type;
 					}
 				}
@@ -1444,35 +1454,35 @@ namespace ObjCRuntime {
 				interface_check_type = interface_check_type.GetElementType ();
 #endif
 
-			if (interface_check_type.IsInterface) 
+			if (interface_check_type!.IsInterface) 
 				implementation = FindProtocolWrapperType (implementation);
 
-			return implementation;
+			return implementation!;
 		}
 
-		public static INativeObject GetINativeObject (IntPtr ptr, bool owns, Type target_type)
+		public static INativeObject? GetINativeObject (IntPtr ptr, bool owns, Type target_type)
 		{
 			return GetINativeObject (ptr, owns, target_type, null);
 		}
 
 		// this method is identical in behavior to the generic one.
-		static INativeObject GetINativeObject (IntPtr ptr, bool owns, Type target_type, Type implementation)
+		static INativeObject? GetINativeObject (IntPtr ptr, bool owns, Type target_type, Type? implementation)
 		{
 			if (ptr == IntPtr.Zero)
 				return null;
 
-			NSObject o = TryGetNSObject (ptr, evenInFinalizerQueue: false);
-			if (o != null && target_type.IsAssignableFrom (o.GetType ())) {
+			var o = TryGetNSObject (ptr, evenInFinalizerQueue: false);
+			if (o is not null && target_type.IsAssignableFrom (o.GetType ())) {
 				// found an existing object with the right type.
 				return o;
 			}
 
-			if (o != null) {
+			if (o is not null) {
 				var interface_check_type = target_type;
 #if NET
 				// https://github.com/dotnet/runtime/issues/39068
 				if (interface_check_type.IsByRef)
-					interface_check_type = interface_check_type.GetElementType ();
+					interface_check_type = interface_check_type.GetElementType ()!;
 #endif
 				// found an existing object, but with an incompatible type.
 				if (!interface_check_type.IsInterface) {
@@ -1485,7 +1495,7 @@ namespace ObjCRuntime {
 			implementation = LookupINativeObjectImplementation (ptr, target_type, implementation);
 
 			if (implementation.IsSubclassOf (typeof (NSObject))) {
-				if (o != null) {
+				if (o is not null) {
 					// We already have an instance of an NSObject-subclass for this ptr.
 					// Creating another will break the one-to-one assumption we have between
 					// native objects and NSObject instances.
@@ -1500,19 +1510,19 @@ namespace ObjCRuntime {
 		}
 
 		// this method is identical in behavior to the non-generic one.
-		public static T GetINativeObject<T> (IntPtr ptr, bool owns) where T : class, INativeObject
+		public static T? GetINativeObject<T> (IntPtr ptr, bool owns) where T : class, INativeObject
 		{
 			return GetINativeObject<T> (ptr, false, owns);
 		}
 
-		public static T GetINativeObject<T> (IntPtr ptr, bool forced_type, bool owns) where T : class, INativeObject
+		public static T? GetINativeObject<T> (IntPtr ptr, bool forced_type, bool owns) where T : class, INativeObject
 		{
 			if (ptr == IntPtr.Zero)
 				return null;
 
 			var o = TryGetNSObject (ptr, evenInFinalizerQueue: false);
 			var t = o as T;
-			if (t != null) {
+			if (t is not null) {
 				// found an existing object with the right type.
 				return t;
 			}
@@ -1520,7 +1530,7 @@ namespace ObjCRuntime {
 			// If forced type is true, we ignore any existing instances if the managed type of the existing instance isn't compatible with T.
 			// This may end up creating multiple managed wrapper instances for the same native handle,
 			// which is not optimal, but sometimes the alternative can be worse :/
-			if (o != null && !forced_type) {
+			if (o is not null && !forced_type) {
 				// found an existing object, but with an incompatible type.
 				if (!typeof (T).IsInterface && typeof(NSObject).IsAssignableFrom (typeof (T))) {
 					// if the target type is another NSObject subclass, there's nothing we can do.
@@ -1532,7 +1542,7 @@ namespace ObjCRuntime {
 			var implementation = LookupINativeObjectImplementation (ptr, typeof (T), forced_type: forced_type);
 
 			if (implementation.IsSubclassOf (typeof (NSObject))) {
-				if (o != null && !forced_type) {
+				if (o is not null && !forced_type) {
 					// We already have an instance of an NSObject-subclass for this ptr.
 					// Creating another will break the one-to-one assumption we have between
 					// native objects and NSObject instances.
@@ -1540,26 +1550,28 @@ namespace ObjCRuntime {
 						"because another instance already exists for this native object (of type {3}).",
 						implementation.FullName, ptr.ToString ("x"), Class.class_getName (Class.GetClassForObject (ptr)), o.GetType ().FullName);
 				}
-				return (T) ConstructNSObject<T> (ptr, implementation, MissingCtorResolution.ThrowConstructor1NotFound);
+				return (T?) ConstructNSObject<T> (ptr, implementation, MissingCtorResolution.ThrowConstructor1NotFound);
 			}
 
 			return ConstructINativeObject<T> (ptr, owns, implementation, MissingCtorResolution.ThrowConstructor2NotFound);
 		}
 
-		private static Type FindProtocolWrapperType (Type type)
+		static Type? FindProtocolWrapperType (Type? type)
 		{
+			if (type is null)
+				return null;
 #if NET
 			// https://github.com/dotnet/runtime/issues/39068
 			if (type.IsByRef)
-				type = type.GetElementType ();
+				type = type.GetElementType ()!;
 #endif
-			if (type == null || !type.IsInterface)
+			if (!type.IsInterface)
 				return null;
 
 			// Check if the static registrar knows about this protocol
 			unsafe {
 				var map = options->RegistrationMap;
-				if (map != null) {
+				if (map is not null) {
 					var token = Class.GetTokenReference (type, throw_exception: false);
 					if (token != INVALID_TOKEN_REF) {
 						var wrapper_token = xamarin_find_protocol_wrapper_type (token);
@@ -1572,8 +1584,8 @@ namespace ObjCRuntime {
 			// need to look up the type from the ProtocolAttribute.
 			var a = type.GetCustomAttributes (typeof (Foundation.ProtocolAttribute), false);
 
-			var attr = (Foundation.ProtocolAttribute) (a.Length > 0 ? a [0] : null);
-			if (attr == null || attr.WrapperType == null)
+			var attr = (Foundation.ProtocolAttribute?) (a.Length > 0 ? a [0] : null);
+			if (attr is null || attr.WrapperType is null)
 				throw ErrorHelper.CreateError (4125, "The registrar found an invalid interface '{0}': " +
 					"The interface must have a Protocol attribute specifying its wrapper type.",
 					type.FullName);
@@ -1593,7 +1605,7 @@ namespace ObjCRuntime {
 			// Check if the static registrar knows about this protocol
 			unsafe {
 				var map = options->RegistrationMap;
-				if (map != null && map->protocol_count > 0) {
+				if (map is not null && map->protocol_count > 0) {
 					var token = Class.GetTokenReference (type);
 					var tokens = map->protocol_map.protocol_tokens;
 					for (int i = 0; i < map->protocol_count; i++) {
@@ -1605,7 +1617,7 @@ namespace ObjCRuntime {
 
 			if (type.IsInterface) {
 				var pa = type.GetCustomAttribute<ProtocolAttribute> (false);
-				if (pa != null) {
+				if (pa is not null) {
 					var handle = Protocol.objc_getProtocol (pa.Name);
 					if (handle != IntPtr.Zero)
 						return handle;
@@ -1621,7 +1633,7 @@ namespace ObjCRuntime {
 			var cls = Class.object_getClass (self);
 
 			unsafe {
-				if (options->RegistrationMap != null && options->RegistrationMap->map_count > 0) {
+				if (options->RegistrationMap is not null && options->RegistrationMap->map_count > 0) {
 					var map = options->RegistrationMap->map;
 					var idx = FindUserTypeIndex (map, 0, options->RegistrationMap->map_count - 1, cls);
 					if (idx >= 0)
@@ -1655,8 +1667,8 @@ namespace ObjCRuntime {
 
 		public static void ConnectMethod (Type type, MethodInfo method, Selector selector)
 		{
-			if (selector == null)
-				throw new ArgumentNullException ("selector");
+			if (selector is null)
+				throw new ArgumentNullException (nameof (selector));
 
 			ConnectMethod (type, method, new ExportAttribute (selector.Name));
 		}
@@ -1664,14 +1676,14 @@ namespace ObjCRuntime {
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static void ConnectMethod (Type type, MethodInfo method, ExportAttribute export)
 		{
-			if (type == null)
-				throw new ArgumentNullException ("type");
+			if (type is null)
+				throw new ArgumentNullException (nameof (type));
 
-			if (method == null)
-				throw new ArgumentNullException ("method");
+			if (method is null)
+				throw new ArgumentNullException (nameof (method));
 
-			if (export == null)
-				throw new ArgumentNullException ("export");
+			if (export is null)
+				throw new ArgumentNullException (nameof (export));
 
 			if (!DynamicRegistrationSupported)
 				throw ErrorHelper.CreateError (8026, "Runtime.ConnectMethod is not supported when the dynamic registrar has been linked away.");
@@ -1681,10 +1693,10 @@ namespace ObjCRuntime {
 
 		public static void ConnectMethod (MethodInfo method, Selector selector)
 		{
-			if (method == null)
-				throw new ArgumentNullException ("method");
+			if (method is null)
+				throw new ArgumentNullException (nameof (method));
 
-			ConnectMethod (method.DeclaringType, method, selector);
+			ConnectMethod (method.DeclaringType!, method, selector);
 		}
 
 		[DllImport ("__Internal", CharSet = CharSet.Unicode)]
@@ -1708,7 +1720,7 @@ namespace ObjCRuntime {
 			}
 		}
 
-		internal static void NSLog (string format, params object[] args)
+		internal static void NSLog (string format, params object?[] args)
 		{
 			NSLog (string.Format (format, args));
 		}
@@ -1803,14 +1815,14 @@ namespace ObjCRuntime {
 				return (MethodInfo) open_method;
 
 			// First we need to find the type that declared the open method.
-			Type declaring_closed_type = closed_type;
+			var declaring_closed_type = closed_type;
 			do {
 				if (declaring_closed_type.IsGenericType && declaring_closed_type.GetGenericTypeDefinition () == open_method.DeclaringType) {
 					closed_type = declaring_closed_type;
 					break;
 				}
 				declaring_closed_type = declaring_closed_type.BaseType;
-			} while (declaring_closed_type != null);
+			} while (declaring_closed_type is not null);
 
 			// Find the closed method.
 			foreach (var mi in closed_type.GetMethods (BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly)) {
@@ -1831,12 +1843,12 @@ namespace ObjCRuntime {
 #if MONOMAC
 		public static void ReleaseBlockOnMainThread (IntPtr block)
 		{
-			if (release_block_on_main_thread == null)
+			if (release_block_on_main_thread is null)
 				release_block_on_main_thread = LookupInternalFunction<intptr_func> ("xamarin_release_block_on_main_thread");
 			release_block_on_main_thread (block);
 		}
 		delegate void intptr_func (IntPtr block);
-		static intptr_func release_block_on_main_thread;
+		static intptr_func? release_block_on_main_thread;
 #else
 		[DllImport ("__Internal", EntryPoint = "xamarin_release_block_on_main_thread")]
 		public static extern void ReleaseBlockOnMainThread (IntPtr block);
@@ -1850,7 +1862,7 @@ namespace ObjCRuntime {
 		//     {
 		//     }
 		//
-		internal static T ThrowOnNull<T> (T obj, string name, string message = null) where T : class
+		internal static T ThrowOnNull<T> (T obj, string name, string? message = null) where T : class
 		{
 			return obj ?? throw new ArgumentNullException (name, message);
 		}
@@ -1871,11 +1883,11 @@ namespace ObjCRuntime {
 			IntPtr description; // const char *
 
 			public string Name {
-				get { return Marshal.PtrToStringUTF8 (name); }
+				get { return Marshal.PtrToStringUTF8 (name)!; }
 			}
 
 			public string Description {
-				get { return Marshal.PtrToStringUTF8 (description); }
+				get { return Marshal.PtrToStringUTF8 (description)!; }
 			}
 		}
 
@@ -1896,7 +1908,7 @@ namespace ObjCRuntime {
 		}
 
 		// Get the GCHandle from the IntPtr value and get the wrapped object.
-		internal static object GetGCHandleTarget (IntPtr ptr)
+		internal static object? GetGCHandleTarget (IntPtr ptr)
 		{
 			if (ptr == IntPtr.Zero)
 				return null;
@@ -1904,16 +1916,16 @@ namespace ObjCRuntime {
 		}
 
 		// Allocate a GCHandle and return the IntPtr to it.
-		internal static IntPtr AllocGCHandle (object value)
+		internal static IntPtr AllocGCHandle (object? value)
 		{
 			return GCHandle.ToIntPtr (GCHandle.Alloc (value));
 		}
 
 #if __MACCATALYST__
-		static string _iOSSupportVersion;
+		static string? _iOSSupportVersion;
 		internal static string iOSSupportVersion {
 			get {
-				if (_iOSSupportVersion == null) {
+				if (_iOSSupportVersion is null) {
 					// This is how Apple does it: https://github.com/llvm/llvm-project/blob/62ec4ac90738a5f2d209ed28c822223e58aaaeb7/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm#L100-L105
 					using var dict = NSMutableDictionary.FromFile ("/System/Library/CoreServices/SystemVersion.plist");
 					using var str = (NSString) "iOSSupportVersion";
@@ -1937,7 +1949,7 @@ namespace ObjCRuntime {
 			var exc = handle.Target as Exception;
 			handle.Free ();
 
-			if (exc == null)
+			if (exc is null)
 				return;
 
 			throw exc;
@@ -1992,13 +2004,13 @@ namespace ObjCRuntime {
 
 	internal class TypeEqualityComparer : IEqualityComparer<Type>
 	{
-		public bool Equals (Type x, Type y)
+		public bool Equals (Type? x, Type? y)
 		{
-			return x == y;
+			return (object?) x == (object?) y;
 		}
-		public int GetHashCode (Type obj)
+		public int GetHashCode (Type? obj)
 		{
-			if (obj == null)
+			if (obj is null)
 				return 0;
 			return obj.GetHashCode ();
 		}
@@ -2024,10 +2036,10 @@ namespace ObjCRuntime {
 				item2Comparer.Equals (Item2, other.Item2);
 		}
 
-		public override bool Equals (object obj)
+		public override bool Equals (object? obj)
 		{
-			if (obj is IntPtrTypeValueTuple)
-				return Equals ((IntPtrTypeValueTuple)obj);
+			if (obj is IntPtrTypeValueTuple vt)
+				return Equals (vt);
 
 			return false;
 		}

--- a/src/ObjCRuntime/Runtime.iOS.cs
+++ b/src/ObjCRuntime/Runtime.iOS.cs
@@ -1,4 +1,6 @@
 
+#nullable enable
+
 #if !MONOMAC
 
 using System;
@@ -71,7 +73,7 @@ namespace ObjCRuntime {
 			
 #if TVOS || WATCH || __MACCATALYST__
 		[Advice ("This method is present only to help porting code.")]
-		public static void StartWWAN (Uri uri, Action<Exception> callback)
+		public static void StartWWAN (Uri uri, Action<Exception?> callback)
 		{
 			NSRunLoop.Main.BeginInvokeOnMainThread (() => callback (null));
 		}
@@ -81,11 +83,17 @@ namespace ObjCRuntime {
 		{
 		}
 #else
-		public static void StartWWAN (Uri uri, Action<Exception> callback)
+		public static void StartWWAN (Uri uri, Action<Exception?> callback)
 		{
+			if (uri is null)
+				throw new ArgumentNullException (nameof (uri));
+
+			if (callback is null)
+				throw new ArgumentNullException (nameof (callback));
+
 			DispatchQueue.DefaultGlobalQueue.DispatchAsync (() => 
 			{
-				Exception ex = null;
+				Exception? ex = null;
 				try {
 					StartWWAN (uri);
 				} catch (Exception x) {
@@ -101,8 +109,8 @@ namespace ObjCRuntime {
 
 		public static void StartWWAN (Uri uri)
 		{
-			if (uri == null)
-				throw new ArgumentNullException ("uri");
+			if (uri is null)
+				throw new ArgumentNullException (nameof (uri));
 
 			if (uri.Scheme != "http" && uri.Scheme != "https")
 				throw new ArgumentException ("uri is not a valid http or https uri", uri.ToString ());

--- a/src/ObjCRuntime/Runtime.mac.cs
+++ b/src/ObjCRuntime/Runtime.mac.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 #if MONOMAC
 
 using System;
@@ -40,11 +42,11 @@ namespace ObjCRuntime {
 		internal const string ProductName = "Xamarin.Mac";
 		internal const string AssemblyName = "Xamarin.Mac.dll";
 
-		public static string FrameworksPath {
+		public static string? FrameworksPath {
 			get; set;
 		}
 
-		public static string ResourcesPath {
+		public static string? ResourcesPath {
 			get; set;
 		}
 			
@@ -52,9 +54,9 @@ namespace ObjCRuntime {
 		unsafe delegate sbyte *get_sbyteptr_func ();
 
 		static volatile bool originalWorkingDirectoryIsSet;
-		static string originalWorkingDirectory;
+		static string? originalWorkingDirectory;
 
-		public unsafe static string OriginalWorkingDirectory {
+		public unsafe static string? OriginalWorkingDirectory {
 			get {
 				if (originalWorkingDirectoryIsSet)
 					return originalWorkingDirectory;
@@ -72,7 +74,7 @@ namespace ObjCRuntime {
 
 		public static void ChangeToOriginalWorkingDirectory ()
 		{
-			Directory.SetCurrentDirectory (OriginalWorkingDirectory);
+			Directory.SetCurrentDirectory (OriginalWorkingDirectory!);
 		}
 
 		static IntPtr runtime_library;
@@ -81,13 +83,16 @@ namespace ObjCRuntime {
 		{
 			IntPtr rv;
 
+			if (name is null)
+				throw new ArgumentNullException (nameof (name));
+
 			if (runtime_library == IntPtr.Zero) {
 				runtime_library = new IntPtr (-2 /* RTLD_DEFAULT */);
 				rv = Dlfcn.dlsym (runtime_library, name);
 				if (rv == IntPtr.Zero) {
 					runtime_library = Dlfcn.dlopen ("libxammac.dylib", 0, false);
 					if (runtime_library == IntPtr.Zero)
-						runtime_library = Dlfcn.dlopen (Path.Combine (Path.GetDirectoryName (typeof (NSApplication).Assembly.Location), "libxammac.dylib"), 0, false);
+						runtime_library = Dlfcn.dlopen (Path.Combine (Path.GetDirectoryName (typeof (NSApplication).Assembly.Location)!, "libxammac.dylib"), 0, false);
 					if (runtime_library == IntPtr.Zero)
 						throw new DllNotFoundException ("Could not find the runtime library libxammac.dylib");
 					rv = Dlfcn.dlsym (runtime_library, name);
@@ -118,11 +123,11 @@ namespace ObjCRuntime {
 			// Verify that the system mono we're running against is of a supported version.
 			// Only verify if we're able to get the mono version (we don't want to fail if the Mono.Runtime type was linked away for instance).
 			var type = Type.GetType ("Mono.Runtime");
-			if (type == null)
+			if (type is null)
 				return;
 
 			var displayName = type.GetMethod ("GetDisplayName", BindingFlags.NonPublic | BindingFlags.Static);
-			if (displayName == null)
+			if (displayName is null)
 				return;
 
 			var actual = displayName.Invoke (null, null) as string;
@@ -131,7 +136,7 @@ namespace ObjCRuntime {
 			// The version string looks something like this:
 			// "5.16.0.209 (2018-06/709b46e3338 Wed Oct 31 09:14:07 EDT 2018)"
 			// We only want the first part up until the first space.
-			var spaceIndex = actual.IndexOf (' ');
+			var spaceIndex = actual!.IndexOf (' ');
 			if (spaceIndex > 0)
 				actual = actual.Substring (0, spaceIndex);
 			if (!Version.TryParse (actual, out var actual_version))
@@ -156,7 +161,7 @@ namespace ObjCRuntime {
 			else {
 				basePath = Assembly.GetExecutingAssembly().Location;
 				if(!string.IsNullOrEmpty(basePath)) {
-					basePath = Path.Combine (Path.GetDirectoryName(basePath), "..");
+					basePath = Path.Combine (Path.GetDirectoryName(basePath)!, "..");
 				}
 				else {
 					// The executing assembly location may be null if loaded from
@@ -172,7 +177,7 @@ namespace ObjCRuntime {
 		[Preserve]
 		static IntPtr GetNullableType (IntPtr type)
 		{
-			return AllocGCHandle (Registrar.GetNullableType ((Type) GetGCHandleTarget (type)));
+			return AllocGCHandle (Registrar.GetNullableType ((Type) GetGCHandleTarget (type)!));
 		}
 #endif // !COREBUILD
 	}

--- a/src/ObjCRuntime/RuntimeException.cs
+++ b/src/ObjCRuntime/RuntimeException.cs
@@ -7,22 +7,22 @@ using System.Collections.Generic;
 
 namespace ObjCRuntime {
 	public class RuntimeException : Exception {
-		public RuntimeException (string message, params object[] args)
+		public RuntimeException (string message, params object?[] args)
 			: base (string.Format (message, args))
 		{
 		}
 
-		public RuntimeException (int code, string message, params object[] args) : 
+		public RuntimeException (int code, string message, params object?[] args) : 
 			this (code, false, null, message, args)
 		{
 		}
 		
-		public RuntimeException (int code, bool error, string message, params object[] args) : 
+		public RuntimeException (int code, bool error, string message, params object?[] args) : 
 			this (code, error, null, message, args)
 		{
 		}
 		
-		public RuntimeException (int code, bool error, Exception? innerException, string message, params object[] args) :
+		public RuntimeException (int code, bool error, Exception? innerException, string message, params object?[] args) :
 			base (String.Format (message, args), innerException)
 		{
 			Code = code;

--- a/src/PdfKit/PdfAnnotation.cs
+++ b/src/PdfKit/PdfAnnotation.cs
@@ -10,6 +10,7 @@
 using System;
 using System.Runtime.Versioning;
 
+using CoreFoundation;
 using CoreGraphics;
 using Foundation;
 using ObjCRuntime;
@@ -24,7 +25,7 @@ namespace PdfKit {
 #endif
 		public bool SetValue<T> (T value, PdfAnnotationKey key) where T : class, INativeObject
 		{
-			if (value == null)
+			if (value is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 
 			return _SetValue (value.Handle, key.GetConstant ()!);
@@ -35,11 +36,11 @@ namespace PdfKit {
 #endif
 		public bool SetValue (string str, PdfAnnotationKey key)
 		{
-			var nstr = NSString.CreateNative (str);
+			var nstr = CFString.CreateNative (str);
 			try {
 				return _SetValue (nstr, key.GetConstant ()!);
 			} finally {
-				NSString.ReleaseNative (nstr);
+				CFString.ReleaseNative (nstr);
 			}
 		}
 
@@ -48,7 +49,7 @@ namespace PdfKit {
 #endif
 		public T GetValue<T> (PdfAnnotationKey key) where T : class, INativeObject
 		{
-			return Runtime.GetINativeObject<T> (_GetValue (key.GetConstant ()!), true);
+			return Runtime.GetINativeObject<T> (_GetValue (key.GetConstant ()!), true)!;
 		}
 
 		public PdfAnnotationKey AnnotationType {

--- a/src/SceneKit/SCNCompat.cs
+++ b/src/SceneKit/SCNCompat.cs
@@ -160,7 +160,7 @@ namespace SceneKit {
 		public static SCNAnimationEvent Create (nfloat keyTime, SCNAnimationEventHandler eventHandler)
 		{
 			var handler = new Action<IntPtr, NSObject, bool> ((animationPtr, animatedObject, playingBackward) => {
-				var animation = Runtime.GetINativeObject<AnimationType> (animationPtr, true);
+				var animation = Runtime.GetINativeObject<AnimationType> (animationPtr, true)!;
 				eventHandler (animation, animatedObject, playingBackward);
 			});
 			return Create (keyTime, handler);

--- a/src/SceneKit/SCNSkinner.cs
+++ b/src/SceneKit/SCNSkinner.cs
@@ -22,20 +22,20 @@ namespace SceneKit {
 
 		static SCNMatrix4 []? FromNSArray (NSArray? nsa)
 		{
-			if (nsa == null)
+			if (nsa is null)
 				return null;
 
 			var count = nsa.Count;
 			var ret = new SCNMatrix4 [count];
 			for (nuint i = 0; i < count; i++)
-				ret [i] = Runtime.GetNSObject<NSValue> (nsa.ValueAt (i)).SCNMatrix4Value;
+				ret [i] = Runtime.GetNSObject<NSValue> (nsa.ValueAt (i))!.SCNMatrix4Value;
 
 			return ret;
 		}
 
 		static NSArray ToNSArray (SCNMatrix4 []? items)
 		{
-			if (items == null)
+			if (items is null)
 				return new NSArray ();
 
 			var count = items.Length;

--- a/src/SpriteKit/SKNode.cs
+++ b/src/SpriteKit/SKNode.cs
@@ -11,6 +11,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Versioning;
+
+using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
@@ -23,12 +25,15 @@ namespace SpriteKit
 #if !NET
 		[iOS (8,0), Mac (10,10)]
 #endif
-		public static T FromFile<T> (string file) where T : SKNode
+		public static T? FromFile<T> (string file) where T : SKNode
 		{
-			IntPtr handle;
-			using (var s = new NSString (file))
-				handle = ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (Class.GetHandle(typeof(T)), Selector.GetHandle ("nodeWithFileNamed:"), s.Handle);
-			return Runtime.GetNSObject<T> (handle) ;
+			var fileHandle = CFString.CreateNative (file);
+			try {
+				var handle = ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (Class.GetHandle (typeof (T)), Selector.GetHandle ("nodeWithFileNamed:"), fileHandle);
+				return Runtime.GetNSObject<T> (handle);
+			} finally {
+				CFString.ReleaseNative (fileHandle);
+			}
 		}
 
 		public void Add (SKNode node)

--- a/src/UIKit/UIConfigurationColorTransformer.cs
+++ b/src/UIKit/UIConfigurationColorTransformer.cs
@@ -52,8 +52,8 @@ namespace UIKit {
 		static unsafe IntPtr Invoke (IntPtr block, IntPtr color) {
 			var descriptor = (BlockLiteral *) block;
 			var del = (UIConfigurationColorTransformerHandler) (descriptor->Target);
-			var retval = del (Runtime.GetNSObject<UIColor> (color));
-			return retval != null ? retval.Handle : IntPtr.Zero;
+			var retval = del is null ? null : del (Runtime.GetNSObject<UIColor> (color)!);
+			return retval.GetHandle ();
 		}
 	} /* class SDUIConfigurationColorTransformerHandler */
 	
@@ -79,7 +79,7 @@ namespace UIKit {
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		UIColor Invoke (UIColor color)
 		{
-			return Runtime.GetNSObject<UIColor> (invoker (BlockPointer, color.GetHandle ()));
+			return Runtime.GetNSObject<UIColor> (invoker (BlockPointer, color.GetHandle ()))!;
 		}
 	} /* class NIDUIConfigurationColorTransformerHandler */
 }

--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -205,7 +205,7 @@ public partial class Generator {
 				}
 				print ("}");
 			}
-			print ("return (NSString) Runtime.GetNSObject (ptr);");
+			print ("return (NSString?) Runtime.GetNSObject (ptr);");
 			indent--;
 			print ("}");
 			

--- a/src/generator-filters.cs
+++ b/src/generator-filters.cs
@@ -268,13 +268,13 @@ public partial class Generator {
 		case "CGImage":
 		case "ImageIO.CGImageMetadata":
 		case "CIBarcodeDescriptor":
-			print ("return Runtime.GetINativeObject <{0}> (GetHandle (\"{1}\"), false);", propertyType, propertyName);
+			print ("return Runtime.GetINativeObject <{0}> (GetHandle (\"{1}\"), false)!;", propertyType, propertyName);
 			break;
 		case "AVCameraCalibrationData":
 		case "MLModel":
 		case "NSAttributedString":
 		case "NSData":
-			print ("return Runtime.GetNSObject <{0}> (GetHandle (\"{1}\"), false);", propertyType, propertyName);
+			print ("return Runtime.GetNSObject <{0}> (GetHandle (\"{1}\"), false)!;", propertyType, propertyName);
 			break;
 		case "CIColor":
 		case "CIImage":

--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -200,7 +200,7 @@ namespace NetworkExtension {
 
 		[NoWatch, NoTV, Mac (10,15,4), iOS (13,4)]
 		NWInterface NetworkInterface {
-			[Wrap ("Runtime.GetINativeObject<NWInterface> (WeakNetworkInterface, false)")]
+			[Wrap ("Runtime.GetINativeObject<NWInterface> (WeakNetworkInterface, false)!")]
 			get;
 			[Wrap ("WeakNetworkInterface = value.GetHandle ()")]
 			set;


### PR DESCRIPTION
Add nullability attributes to the Runtime class and fix the code accordingly.

This snowballed a bit, because it ended up requiring changes in multiple other
classes. While at it, I also updated the code to:

* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use CFString.CreateNative/ReleaseNative instead of other means to create
  native strings (the fasets and least memory hungry option).
* Use 'nameof (parameter)' instead of string constants.