### PR TITLE
[Github Actions] Get rid of annoying failure emails

### DIFF
--- a/.github/workflows/localization_branch_sync.yml
+++ b/.github/workflows/localization_branch_sync.yml
@@ -13,7 +13,7 @@ jobs:
   replaceLocalizationBranch:
     name: 'Replace Localization Branch'
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.merged == true && github.event.pull_request.user.login == 'github-actions[bot]' && contains(github.event.pull_request.labels.*.name, 'localization_bot') }}
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.user.login == 'github-actions[bot]' && contains(github.event.pull_request.labels.*.name, 'localization_bot') }}
     steps:
     - uses: dawidd6/action-delete-branch@v3
       name: 'delete'


### PR DESCRIPTION
When merging something to main from a fork, this github action gets a little salty and results in emails being sent about it failing when we use `exit 1`

![image](https://user-images.githubusercontent.com/50846373/137948564-747c8b7a-4eb2-47b0-af1b-9e370c036749.png)
![image](https://user-images.githubusercontent.com/50846373/137957572-4037d886-6dd9-4586-834f-a49f9a494dd4.png)

Let's just use `success ()` conditionals to continue running the github action or stop running the github action as needed.

