### PR TITLE
[CFBundle] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreFoundation/CFArray.cs
+++ b/src/CoreFoundation/CFArray.cs
@@ -119,6 +119,23 @@ namespace CoreFoundation {
 				return CFArrayCreate (IntPtr.Zero, (IntPtr) pv, c, kCFTypeArrayCallbacks_ptr);
 		}
 
+		public static unsafe IntPtr Create (params string [] values)
+		{
+			if (values is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
+			var c = values.Length;
+			var _values = c <= 256 ? stackalloc IntPtr [c] : new IntPtr [c];
+			for (var i = 0; i < c; ++i)
+				_values [i] = values [i] is null ? CFNullHandle : CFString.CreateNative (values [i]);
+			fixed (IntPtr* pv = _values)
+				return CFArrayCreate (IntPtr.Zero, (IntPtr) pv, c, kCFTypeArrayCallbacks_ptr);
+		}
+
+		static public CFArray FromStrings (params string [] items)
+		{
+			return new CFArray (Create (items), true);
+		}
+
 		[DllImport (Constants.CoreFoundationLibrary, EntryPoint="CFArrayGetCount")]
 		internal extern static /* CFIndex */ nint GetCount (/* CFArrayRef */ IntPtr theArray);
 
@@ -133,21 +150,7 @@ namespace CoreFoundation {
 		// identical signature to NSArray API
 		static unsafe public string?[]? StringArrayFromHandle (IntPtr handle)
 		{
-			if (handle == IntPtr.Zero)
-				return null;
-
-			var c = (int) GetCount (handle);
-			if (c == 0)
-				return Array.Empty<string> ();
-
-			var buffer = c <= 256 ? stackalloc IntPtr [c] : new IntPtr [c];
-			fixed (void* ptr = buffer)
-				CFArrayGetValues (handle, new CFRange (0, c), (IntPtr) ptr);
-
-			string?[] ret = new string [c];
-			for (var i = 0; i < c; i++)
-				ret [i] = CFString.FromHandle (buffer [i]);
-			return ret;
+			return ArrayFromHandleFunc (handle, CFString.FromHandle);
 		}
 
 		static unsafe public string?[]? StringArrayFromHandle (IntPtr handle, bool releaseHandle)
@@ -160,6 +163,28 @@ namespace CoreFoundation {
 
 		// identical signature to NSArray API
 		static public T?[]? ArrayFromHandle<T> (IntPtr handle) where T : class, INativeObject
+		{
+			var rv = ArrayFromHandleFunc<T> (handle, DefaultConvert<T>);
+			return rv;
+		}
+
+		static public T?[]? ArrayFromHandle<T> (IntPtr handle, bool releaseHandle) where T : class, INativeObject
+		{
+			var rv = ArrayFromHandle<T> (handle);
+			if (releaseHandle && handle != IntPtr.Zero)
+				CFObject.CFRelease (handle);
+			return rv;
+		}
+
+		static T DefaultConvert<T> (IntPtr handle) where T: class, INativeObject
+		{
+			if (handle != CFNullHandle)
+				return Runtime.GetINativeObject<T> (handle, false)!;
+			return null!;
+		}
+
+		// identical signature to NSArray API
+		static public T[]? ArrayFromHandleFunc<T> (IntPtr handle, Func<IntPtr, T> createObject)
 		{
 			if (handle == IntPtr.Zero)
 				return null;
@@ -174,13 +199,19 @@ namespace CoreFoundation {
 					CFArrayGetValues (handle, new CFRange (0, c), (IntPtr) ptr);
 			}
 
-			T?[] ret = new T [c];
+			var ret = new T [c];
 			for (var i = 0; i < c; i++) {
-				var val = buffer [i];
-				if (val != CFNullHandle)
-					ret [i] = Runtime.GetINativeObject<T> (val, false);
+				ret [i] = createObject (buffer [i]);
 			}
 			return ret;
+		}
+
+		static public T[]? ArrayFromHandleFunc<T> (IntPtr handle, Func<IntPtr, T> createObject, bool releaseHandle)
+		{
+			var rv = ArrayFromHandleFunc<T> (handle, createObject);
+			if (releaseHandle && handle != IntPtr.Zero)
+				CFObject.CFRelease (handle);
+			return rv;
 		}
 	}
 }

--- a/src/CoreFoundation/CFBundle.cs
+++ b/src/CoreFoundation/CFBundle.cs
@@ -1,6 +1,9 @@
 //
 // Copyright 2015 Xamarin Inc
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -11,7 +14,7 @@ using Foundation;
 
 namespace CoreFoundation {
 
-	public partial class CFBundle : INativeObject, IDisposable {
+	public partial class CFBundle : NativeObject {
 
 		public enum PackageType {
 			Application,
@@ -30,79 +33,50 @@ namespace CoreFoundation {
 			public string Creator { get; private set; }
 		}
 
-		IntPtr handle;
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-		
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero) {
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
-		}
-
-		~CFBundle ()
-		{
-			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize(this);
-		}
-
-		internal CFBundle (IntPtr handle) : this (handle, false)
-		{
-		}
-
 		internal CFBundle (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (handle == IntPtr.Zero)
-				throw new ArgumentNullException ("handle");
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (this.handle);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFBundleRef */ IntPtr CFBundleCreate ( /* CFAllocatorRef can be null */ IntPtr allocator, /* CFUrlRef */ IntPtr bundleURL);
 
-		public CFBundle (NSUrl bundleUrl) 
+		static IntPtr Create (NSUrl bundleUrl)
 		{
-			if (bundleUrl == null)
-				throw new ArgumentNullException ("bundleUrl");
-				
-			this.handle = CFBundleCreate (IntPtr.Zero, bundleUrl.Handle);
+			if (bundleUrl is null)
+				throw new ArgumentNullException (nameof (bundleUrl));
+
+			return CFBundleCreate (IntPtr.Zero, bundleUrl.Handle);
+
+		}
+
+		public CFBundle (NSUrl bundleUrl)
+			: base (Create (bundleUrl), true)
+		{
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFArrayRef */ IntPtr CFBundleCreateBundlesFromDirectory (/* CFAllocatorRef can be null */ IntPtr allocator, /* CFUrlRef */ IntPtr directoryURL, /* CFStringRef */ IntPtr bundleType);
 
-		public static CFBundle[] GetBundlesFromDirectory (NSUrl directoryUrl, string bundleType)
+		public static CFBundle[]? GetBundlesFromDirectory (NSUrl directoryUrl, string bundleType)
 		{
-			if (directoryUrl == null) // NSUrl cannot be "" by definition
-				throw new ArgumentNullException ("directoryUrl");
+			if (directoryUrl is null) // NSUrl cannot be "" by definition
+				throw new ArgumentNullException (nameof (directoryUrl));
 			if (String.IsNullOrEmpty (bundleType))
-				throw new ArgumentException ("bundleType");
-			using (var bundleTypeCFSting = new CFString (bundleType))
-			using (var cfBundles = new CFArray (CFBundleCreateBundlesFromDirectory (IntPtr.Zero, directoryUrl.Handle, bundleTypeCFSting.Handle), true)) {
-				var managedBundles = new CFBundle [cfBundles.Count];
-				for (int index = 0; index < cfBundles.Count; index++) {
-					// follow the create rules, therefore we do have ownership of each of the cfbundles
-					managedBundles [index] = new CFBundle (cfBundles.GetValue (index), true);
-				}
-				return managedBundles;
+				throw new ArgumentException (nameof (bundleType));
+			var bundleTypeHandle = CFString.CreateNative (bundleType);
+			try {
+				var rv = CFBundleCreateBundlesFromDirectory (IntPtr.Zero, directoryUrl.Handle, bundleTypeHandle);
+				return CFArray.ArrayFromHandleFunc (rv, (handle) => new CFBundle (handle, true), true);
+			} finally {
+				CFString.ReleaseNative (bundleTypeHandle);
 			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static IntPtr CFBundleGetAllBundles ();
 		
-		public static CFBundle[] GetAll ()
+		public static CFBundle[]? GetAll ()
 		{
 			// as per apple documentation: 
 			// CFBundleGetAllBundles
@@ -115,13 +89,7 @@ namespace CoreFoundation {
 			// in the index or in the bundles returned.
 			using (var cfBundles = new CFArray (CFBundleGetAllBundles ()))
 			using (var cfBundlesCopy = cfBundles.Clone () ) {
-				var bundleCount = cfBundlesCopy.Count; // the property is a C call, calling everytime we loop is not needed
-				var managedBundles = new CFBundle [bundleCount];
-				for (int index = 0; index < bundleCount; index++) {
-					// follow the get rule, we do not own the object
-					managedBundles [index] = new CFBundle (cfBundlesCopy.GetValue (index), false);
-				}
-				return managedBundles;
+				return CFArray.ArrayFromHandleFunc<CFBundle> (cfBundlesCopy.Handle, (handle) => new CFBundle (handle, false), false);
 			}
 		}
 
@@ -129,29 +97,32 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static IntPtr CFBundleGetBundleWithIdentifier (/* CFStringRef */ IntPtr bundleID);
 		
-		public static CFBundle Get (string bundleID)
+		public static CFBundle? Get (string bundleID)
 		{
 			if (String.IsNullOrEmpty (bundleID))
-				throw new ArgumentException ("bundleID");
-			using (var cfBundleId = new CFString (bundleID)) {
-				var cfBundle = CFBundleGetBundleWithIdentifier (cfBundleId.Handle);
+				throw new ArgumentException (nameof (bundleID));
+			var bundleIDHandler = CFString.CreateNative (bundleID);
+			try {
+				var cfBundle = CFBundleGetBundleWithIdentifier (bundleIDHandler);
 				if (cfBundle == IntPtr.Zero)
 					return null;
 				// follow the Get rule and retain the obj
 				return new CFBundle (cfBundle, false);
+			} finally {
+				CFString.ReleaseNative (bundleIDHandler);
 			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static IntPtr CFBundleGetMainBundle ();
 
-		public static CFBundle GetMain ()
+		public static CFBundle? GetMain ()
 		{
 			var cfBundle = CFBundleGetMainBundle ();
 			if (cfBundle == IntPtr.Zero)
 				return null;
 			// follow the get rule and retain
-			return new CFBundle (CFBundleGetMainBundle (), false);
+			return new CFBundle (cfBundle, false);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -159,18 +130,18 @@ namespace CoreFoundation {
 		extern static bool CFBundleIsExecutableLoaded (IntPtr bundle);
 		
 		public bool HasLoadedExecutable {
-			get { return CFBundleIsExecutableLoaded (handle); }
+			get { return CFBundleIsExecutableLoaded (Handle); }
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CFBundlePreflightExecutable (IntPtr bundle, out IntPtr error);
 		
-		public bool PreflightExecutable (out NSError error)
+		public bool PreflightExecutable (out NSError? error)
 		{
 			IntPtr errorPtr = IntPtr.Zero;
 			// follow the create rule, no need to retain
-			var loaded = CFBundlePreflightExecutable (handle, out errorPtr);
+			var loaded = CFBundlePreflightExecutable (Handle, out errorPtr);
 			error = Runtime.GetNSObject<NSError> (errorPtr);
 			return loaded;
 		}
@@ -179,11 +150,11 @@ namespace CoreFoundation {
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CFBundleLoadExecutableAndReturnError (IntPtr bundle, out IntPtr error);
 		
-		public bool LoadExecutable (out NSError error)
+		public bool LoadExecutable (out NSError? error)
 		{
 			IntPtr errorPtr = IntPtr.Zero;
 			// follows the create rule, no need to retain
-			var loaded = CFBundleLoadExecutableAndReturnError (handle, out errorPtr);
+			var loaded = CFBundleLoadExecutableAndReturnError (Handle, out errorPtr);
 			error = Runtime.GetNSObject<NSError> (errorPtr);
 			return loaded;
 		}
@@ -193,85 +164,86 @@ namespace CoreFoundation {
 		
 		public void UnloadExecutable ()
 		{
-			CFBundleUnloadExecutable (handle);
+			CFBundleUnloadExecutable (Handle);
 		}
 		
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFUrlRef */ IntPtr CFBundleCopyAuxiliaryExecutableURL (IntPtr bundle, /* CFStringRef */ IntPtr executableName);
 		
-		public NSUrl GetAuxiliaryExecutableUrl (string executableName)
+		public NSUrl? GetAuxiliaryExecutableUrl (string executableName)
 		{
 			if (String.IsNullOrEmpty (executableName))
-				throw new ArgumentException ("executableName");
-			using (var cfExecutableName = new CFString (executableName)) {
+				throw new ArgumentException (nameof (executableName));
+			var executableNameHandle = CFString.CreateNative (executableName);
+			try {
 				// follows the create rule no need to retain
-				var urlHandle = CFBundleCopyAuxiliaryExecutableURL (handle, cfExecutableName.Handle);
-				if (urlHandle == IntPtr.Zero)
-					return null;
+				var urlHandle = CFBundleCopyAuxiliaryExecutableURL (Handle, executableNameHandle);
 				return Runtime.GetNSObject<NSUrl> (urlHandle, true);
+			} finally {
+				CFString.ReleaseNative (executableNameHandle);
 			}
 		}
 		
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFUrlRef */ IntPtr CFBundleCopyBuiltInPlugInsURL (IntPtr bundle);
 		
-		public NSUrl BuiltInPlugInsUrl {
+		public NSUrl? BuiltInPlugInsUrl {
 			get {
-				return Runtime.GetNSObject<NSUrl> (CFBundleCopyBuiltInPlugInsURL (handle), true);
+				return Runtime.GetNSObject<NSUrl> (CFBundleCopyBuiltInPlugInsURL (Handle), true);
 			}
 		}
 		
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFUrlRef */ IntPtr CFBundleCopyExecutableURL (IntPtr bundle);
 		
-		public NSUrl ExecutableUrl {
+		public NSUrl? ExecutableUrl {
 			get {
-				return Runtime.GetNSObject<NSUrl> (CFBundleCopyExecutableURL (handle), true);
+				return Runtime.GetNSObject<NSUrl> (CFBundleCopyExecutableURL (Handle), true);
 			}
 		}
 		
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFUrlRef */ IntPtr CFBundleCopyPrivateFrameworksURL (IntPtr bundle);
 		
-		public NSUrl PrivateFrameworksUrl {
+		public NSUrl? PrivateFrameworksUrl {
 			get {
-				return Runtime.GetNSObject<NSUrl> (CFBundleCopyPrivateFrameworksURL (handle), true);
+				return Runtime.GetNSObject<NSUrl> (CFBundleCopyPrivateFrameworksURL (Handle), true);
 			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFUrlRef */ IntPtr CFBundleCopyResourcesDirectoryURL (IntPtr bundle);
 		
-		public NSUrl ResourcesDirectoryUrl {
+		public NSUrl? ResourcesDirectoryUrl {
 			get {
-				return Runtime.GetNSObject<NSUrl> (CFBundleCopyResourcesDirectoryURL (handle), true);
+				return Runtime.GetNSObject<NSUrl> (CFBundleCopyResourcesDirectoryURL (Handle), true);
 			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFUrlRef */ IntPtr CFBundleCopySharedFrameworksURL (IntPtr bundle);
 		
-		public NSUrl SharedFrameworksUrl {
+		public NSUrl? SharedFrameworksUrl {
 			get {
-				return Runtime.GetNSObject<NSUrl> (CFBundleCopySharedFrameworksURL (handle), true);
+				return Runtime.GetNSObject<NSUrl> (CFBundleCopySharedFrameworksURL (Handle), true);
 			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFUrlRef */ IntPtr CFBundleCopySharedSupportURL (IntPtr bundle);
 
-		public NSUrl SharedSupportUrl {
+		public NSUrl? SharedSupportUrl {
 			get {
-				return Runtime.GetNSObject<NSUrl> (CFBundleCopySharedSupportURL (handle), true);
+				return Runtime.GetNSObject<NSUrl> (CFBundleCopySharedSupportURL (Handle), true);
 			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFUrlRef */ IntPtr CFBundleCopySupportFilesDirectoryURL (IntPtr bundle);
 		
-		public NSUrl SupportFilesDirectoryUrl {
+		public NSUrl? SupportFilesDirectoryUrl {
 			get {
-				return Runtime.GetNSObject<NSUrl> (CFBundleCopySupportFilesDirectoryURL (handle), true);
+				return Runtime.GetNSObject<NSUrl> (CFBundleCopySupportFilesDirectoryURL (Handle), true);
 			}
 		}
 
@@ -279,88 +251,94 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFUrlRef */ IntPtr CFBundleCopyResourceURL (IntPtr bundle, /* CFStringRef */ IntPtr resourceName, /* CFString */ IntPtr resourceType, /* CFString */ IntPtr subDirName);
 		
-		public NSUrl GetResourceUrl (string resourceName, string resourceType, string subDirName)
+		public NSUrl? GetResourceUrl (string resourceName, string resourceType, string subDirName)
 		{
 			if (String.IsNullOrEmpty (resourceName))
-				throw new ArgumentException ("resourceName");
+				throw new ArgumentException (nameof (resourceName));
 
 			if (String.IsNullOrEmpty (resourceType))
-				throw new ArgumentException ("resourceType");
+				throw new ArgumentException (nameof (resourceType));
 
-			using (CFString cfResourceName = new CFString (resourceName),
-					cfResourceType = new CFString (resourceType),
-					cfDirName = (subDirName == null)? new CFString ("") : new CFString (subDirName)) {
+			var resourceNameHandle = CFString.CreateNative (resourceName);
+			var resourceTypeHandle = CFString.CreateNative (resourceType);
+			var dirNameHandle = CFString.CreateNative (string.IsNullOrEmpty (subDirName) ? null : subDirName);
+			try {
 				// follows the create rules and therefore we do not need to retain
-				var urlHandle = CFBundleCopyResourceURL (handle, cfResourceName.Handle, cfResourceType.Handle,
-								   	 String.IsNullOrEmpty (subDirName) ? IntPtr.Zero : cfDirName.Handle);
+				var urlHandle = CFBundleCopyResourceURL (Handle, resourceNameHandle, resourceTypeHandle, dirNameHandle);
 				return Runtime.GetNSObject<NSUrl> (urlHandle, true);
+			} finally {
+				CFString.ReleaseNative (resourceNameHandle);
+				CFString.ReleaseNative (resourceTypeHandle);
+				CFString.ReleaseNative (dirNameHandle);
 			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFUrlRef */ IntPtr CFBundleCopyResourceURLInDirectory (/* CFUrlRef */ IntPtr bundleURL, /* CFStringRef */ IntPtr resourceName, /* CFStringRef */ IntPtr resourceType, /* CFStringRef */ IntPtr subDirName);
 		
-		public static NSUrl GetResourceUrl (NSUrl bundleUrl, string resourceName, string resourceType, string subDirName)
+		public static NSUrl? GetResourceUrl (NSUrl bundleUrl, string resourceName, string resourceType, string subDirName)
 		{
-			if (bundleUrl == null)
-				throw new ArgumentNullException ("bundleUrl");
+			if (bundleUrl is null)
+				throw new ArgumentNullException (nameof (bundleUrl));
 
 			if (String.IsNullOrEmpty (resourceName))
-				throw new ArgumentException ("resourceName");
+				throw new ArgumentException (nameof (resourceName));
 
 			if (String.IsNullOrEmpty (resourceType))
-				throw new ArgumentException ("resourceType");
+				throw new ArgumentException (nameof (resourceType));
 
-			// follows the create rules and therefore we do not need to retain
-			using (CFString cfResourceName = new CFString (resourceName),
-					cfResourceType = new CFString (resourceType),
-					cfSubDirName = new CFString (subDirName ?? string.Empty)) {
-				var urlHandle = CFBundleCopyResourceURLInDirectory (bundleUrl.Handle, cfResourceName.Handle, cfResourceType.Handle,
-										      String.IsNullOrEmpty (subDirName) ? IntPtr.Zero : cfSubDirName.Handle);
+			var resourceNameHandle = CFString.CreateNative (resourceName);
+			var resourceTypeHandle = CFString.CreateNative (resourceType);
+			var dirNameHandle = CFString.CreateNative (string.IsNullOrEmpty (subDirName) ? null : subDirName);
+			try {
+				// follows the create rules and therefore we do not need to retain
+				var urlHandle = CFBundleCopyResourceURLInDirectory (bundleUrl.Handle, resourceNameHandle, resourceTypeHandle, dirNameHandle);
 				return Runtime.GetNSObject<NSUrl> (urlHandle, true);
+			} finally {
+				CFString.ReleaseNative (resourceNameHandle);
+				CFString.ReleaseNative (resourceTypeHandle);
+				CFString.ReleaseNative (dirNameHandle);
 			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFArray */ IntPtr CFBundleCopyResourceURLsOfType (IntPtr bundle, /* CFStringRef */ IntPtr resourceType, /* CFStringRef */ IntPtr subDirName);
 		
-		public NSUrl[] GetResourceUrls (string resourceType, string subDirName)
+		public NSUrl?[]? GetResourceUrls (string resourceType, string subDirName)
 		{
 			if (String.IsNullOrEmpty (resourceType))
-				throw new ArgumentException ("resourceName");
+				throw new ArgumentException (nameof (resourceType));
 			
-			using (CFString cfResourceType = new CFString (resourceType),
-					cfSubDir = new CFString (subDirName ?? string.Empty))
-			using (var cfArray = new CFArray (CFBundleCopyResourceURLsOfType (handle, cfResourceType.Handle,
-										     String.IsNullOrEmpty (subDirName) ? IntPtr.Zero : cfSubDir.Handle), true)) {
-				var result = new NSUrl [cfArray.Count];
-				for (int index = 0; index < cfArray.Count; index++) {
-					result [index] = Runtime.GetNSObject<NSUrl> (cfArray.GetValue (index), true);
-				}
-				return result;
+			var resourceTypeHandle = CFString.CreateNative (resourceType);
+			var dirNameHandle = CFString.CreateNative (string.IsNullOrEmpty (subDirName) ? null : subDirName);
+			try {
+				var rv = CFBundleCopyResourceURLsOfType (Handle, resourceTypeHandle, dirNameHandle);
+				return CFArray.ArrayFromHandleFunc (rv, (handle) => Runtime.GetNSObject<NSUrl> (handle, true), true);
+			} finally {
+				CFString.ReleaseNative (resourceTypeHandle);
+				CFString.ReleaseNative (dirNameHandle);
 			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFArray */ IntPtr CFBundleCopyResourceURLsOfTypeInDirectory (/* CFUrlRef */ IntPtr bundleURL, /* CFStringRef */ IntPtr resourceType, /* CFStringRef */ IntPtr subDirName);
 
-		public static NSUrl[] GetResourceUrls (NSUrl bundleUrl, string resourceType, string subDirName)
+		public static NSUrl?[]? GetResourceUrls (NSUrl bundleUrl, string resourceType, string subDirName)
 		{
-			if (bundleUrl == null)
-				throw new ArgumentNullException ("bundleUrl");
+			if (bundleUrl is null)
+				throw new ArgumentNullException (nameof (bundleUrl));
 
 			if (String.IsNullOrEmpty (resourceType))
-				throw new ArgumentException ("resourceType");
+				throw new ArgumentException (nameof (resourceType));
 			
-			using (CFString cfResourceType = new CFString (resourceType),
-			                cfSubDir = new CFString (subDirName ?? string.Empty))
-			using (var cfArray = new CFArray (CFBundleCopyResourceURLsOfTypeInDirectory (bundleUrl.Handle, cfResourceType.Handle,
-					                                                        String.IsNullOrEmpty (subDirName) ? IntPtr.Zero : cfSubDir.Handle), true)) {
-				var result = new NSUrl [cfArray.Count];
-				for (int index = 0; index < cfArray.Count; index++) {
-					result [index] = Runtime.GetNSObject<NSUrl> (cfArray.GetValue (index), true);
-				}
-				return result;
+			var resourceTypeHandle = CFString.CreateNative (resourceType);
+			var dirNameHandle = CFString.CreateNative (string.IsNullOrEmpty (subDirName) ? null : subDirName);
+			try {
+				var rv = CFBundleCopyResourceURLsOfTypeInDirectory (bundleUrl.Handle, resourceTypeHandle, dirNameHandle);
+				return CFArray.ArrayFromHandleFunc (rv, (handle) => Runtime.GetNSObject<NSUrl> (handle, true), true);
+			} finally {
+				CFString.ReleaseNative (resourceTypeHandle);
+				CFString.ReleaseNative (dirNameHandle);
 			}
 		}
 
@@ -368,24 +346,29 @@ namespace CoreFoundation {
 		extern static /* CFUrlRef */ IntPtr CFBundleCopyResourceURLForLocalization (IntPtr bundle, /* CFStringRef */ IntPtr resourceName, /* CFStringRef */ IntPtr resourceType, /* CFStringRef */ IntPtr subDirName,
 		                                                                            /* CFStringRef */ IntPtr localizationName);
 		
-		public NSUrl GetResourceUrl (string resourceName, string resourceType, string subDirName, string localizationName)
+		public NSUrl? GetResourceUrl (string resourceName, string resourceType, string subDirName, string localizationName)
 		{
 			if (String.IsNullOrEmpty (resourceName))
-				throw new ArgumentException ("resourceName");
+				throw new ArgumentException (nameof (resourceName));
 
 			if (String.IsNullOrEmpty (resourceType))
-				throw new ArgumentException ("resourceType");
+				throw new ArgumentException (nameof (resourceType));
 			
 			if (String.IsNullOrEmpty (localizationName))
-				throw new ArgumentException ("localizationName");
+				throw new ArgumentException (nameof (localizationName));
 
-			using (CFString cfResourceName = new CFString (resourceName),
-			                cfResourceType = new CFString (resourceType),
-					cfSubDir = new CFString (subDirName ?? string.Empty),
-					cfLocalization = new CFString (localizationName)) {
-				var urlHandle = CFBundleCopyResourceURLForLocalization (handle, cfResourceName.Handle, cfResourceType.Handle,
-											String.IsNullOrEmpty (subDirName) ? IntPtr.Zero : cfSubDir.Handle, cfLocalization.Handle);
+			var resourceNameHandle = CFString.CreateNative (resourceName);
+			var resourceTypeHandle = CFString.CreateNative (resourceType);
+			var dirNameHandle = CFString.CreateNative (string.IsNullOrEmpty (subDirName) ? null : subDirName);
+			var localizationNameHandle = CFString.CreateNative (localizationName);
+			try {
+				var urlHandle = CFBundleCopyResourceURLForLocalization (Handle, resourceNameHandle, resourceTypeHandle, dirNameHandle, localizationNameHandle);
 				return Runtime.GetNSObject<NSUrl> (urlHandle, true);
+			} finally {
+				CFString.ReleaseNative (resourceNameHandle);
+				CFString.ReleaseNative (resourceTypeHandle);
+				CFString.ReleaseNative (dirNameHandle);
+				CFString.ReleaseNative (localizationNameHandle);
 			}
 		}
 		
@@ -393,159 +376,150 @@ namespace CoreFoundation {
 		extern static /* CFArray */ IntPtr CFBundleCopyResourceURLsOfTypeForLocalization (IntPtr bundle, /* CFStringRef */ IntPtr resourceType, /* CFStringRef */ IntPtr subDirName,
 		                                                                                  /* CFStringRef */ IntPtr localizationName);
 		
-		public NSUrl[] GetResourceUrls (string resourceType, string subDirName, string localizationName)
+		public NSUrl?[]? GetResourceUrls (string resourceType, string subDirName, string localizationName)
 		{
 			if (String.IsNullOrEmpty (resourceType))
-				throw new ArgumentException ("resourceType");
+				throw new ArgumentException (nameof (resourceType));
 			
 			if (String.IsNullOrEmpty (localizationName))
-				throw new ArgumentException ("localizationName");
+				throw new ArgumentException (nameof (localizationName));
 			
-			using (CFString cfType = new CFString (resourceType),
-			                cfDirName = new CFString (subDirName ?? string.Empty),
-					cfLocalization = new CFString (localizationName))
-			using (var cfArray = new CFArray (CFBundleCopyResourceURLsOfTypeForLocalization (handle, cfType.Handle,
-													 String.IsNullOrEmpty (subDirName) ? IntPtr.Zero : cfDirName.Handle,
-													 cfLocalization.Handle), true)) {
-				var urls = new NSUrl [cfArray.Count];
-				for (int index = 0; index < cfArray.Count; index++) {
-					urls [index] = Runtime.GetNSObject<NSUrl> (cfArray.GetValue (index), true);
-				}
-				return urls;
+			var resourceTypeHandle = CFString.CreateNative (resourceType);
+			var dirNameHandle = CFString.CreateNative (string.IsNullOrEmpty (subDirName) ? null : subDirName);
+			var localizationNameHandle = CFString.CreateNative (localizationName);
+			try {
+				var rv = CFBundleCopyResourceURLsOfTypeForLocalization (Handle, resourceTypeHandle, dirNameHandle, localizationNameHandle);
+				return CFArray.ArrayFromHandleFunc (rv, (handle) => Runtime.GetNSObject<NSUrl> (handle, true), true);
+			} finally {
+				CFString.ReleaseNative (resourceTypeHandle);
+				CFString.ReleaseNative (dirNameHandle);
+				CFString.ReleaseNative (localizationNameHandle);
 			}
 		}
 		
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFString */ IntPtr CFBundleCopyLocalizedString (IntPtr bundle, /* CFStringRef */ IntPtr key, /* CFStringRef */ IntPtr value, /* CFStringRef */ IntPtr tableName);
 		
-		public string GetLocalizedString (string key, string defaultValue, string tableName)
+		public string? GetLocalizedString (string key, string defaultValue, string? tableName)
 		{
 			if (String.IsNullOrEmpty (key))
-				throw new ArgumentException ("key");
+				throw new ArgumentException (nameof (key));
 
 			if (String.IsNullOrEmpty (tableName))
-				throw new ArgumentException ("tableName");
+				throw new ArgumentException (nameof (tableName));
 
 			// we do allow null and simply use an empty string to avoid the extra check
-			if (defaultValue == null)
+			if (defaultValue is null)
 				defaultValue = string.Empty;
 
-			using (CFString cfKey = new CFString (key),
-					cfValue = new CFString (defaultValue),
-					cfTable = new CFString (tableName)) {
-				return CFString.FromHandle (CFBundleCopyLocalizedString (handle, cfKey.Handle, cfValue.Handle, cfTable.Handle), releaseHandle: true);
+			var keyHandle = CFString.CreateNative (key);
+			var defaultValueHandle = CFString.CreateNative (defaultValue);
+			var tableNameHandle = CFString.CreateNative (tableName);
+			try {
+				var rv = CFBundleCopyLocalizedString (Handle, keyHandle, defaultValueHandle, tableNameHandle);
+				return CFString.FromHandle (rv, releaseHandle: true);
+			} finally {
+				CFString.ReleaseNative (keyHandle);
+				CFString.ReleaseNative (defaultValueHandle);
+				CFString.ReleaseNative (tableNameHandle);
 			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFArray */ IntPtr CFBundleCopyLocalizationsForPreferences (/* CFArrayRef */ IntPtr locArray, /* CFArrayRef */ IntPtr prefArray);
 
-		public static string[] GetLocalizationsForPreferences (string[] locArray, string[] prefArray)
+		public static string?[]? GetLocalizationsForPreferences (string[] locArray, string[] prefArray)
 		{
-			if (locArray == null)
-				throw new ArgumentNullException ("locArray");
-			if (prefArray == null)
-				throw new ArgumentNullException ("prefArray");
+			if (locArray is null)
+				throw new ArgumentNullException (nameof (locArray));
+			if (prefArray is null)
+				throw new ArgumentNullException (nameof (prefArray));
 
-			var cfLocal = new CFString [locArray.Length];
-			for (int index = 0; index < locArray.Length; index++) {
-				cfLocal [index] = new CFString (locArray [index]);
-			}
-			
-			var cfPref = new CFString [prefArray.Length];
-			for (int index = 0; index < prefArray.Length; index++) {
-				cfPref [index] = new CFString (prefArray [index]);
-			}
-			
-			using (CFArray cfLocalArray = CFArray.FromNativeObjects (cfLocal),
-				       cfPrefArray = CFArray.FromNativeObjects (cfPref))
-			using (var cfArray = new CFArray (CFBundleCopyLocalizationsForPreferences (cfLocalArray.Handle, cfPrefArray.Handle), true)) {
-				var cultureInfo = new string [cfArray.Count];
-				for (int index = 0; index < cfArray.Count; index ++) {
-					cultureInfo [index] = CFString.FromHandle (cfArray.GetValue (index));
-				}
-				return cultureInfo;
+			var cfLocalArrayHandle = IntPtr.Zero;
+			var cfPrefArrayHandle = IntPtr.Zero;
+			try {
+				cfLocalArrayHandle = CFArray.Create (locArray);
+				cfPrefArrayHandle = CFArray.Create (prefArray);
+
+				var rv = CFBundleCopyLocalizationsForPreferences (cfLocalArrayHandle, cfPrefArrayHandle);
+				return CFArray.StringArrayFromHandle (rv, true);
+			} finally {
+				if (cfLocalArrayHandle != IntPtr.Zero)
+					CFObject.CFRelease (cfLocalArrayHandle);
+				if (cfPrefArrayHandle != IntPtr.Zero)
+					CFObject.CFRelease (cfPrefArrayHandle);
 			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFArray */ IntPtr CFBundleCopyLocalizationsForURL (/* CFUrlRef */ IntPtr url);
 		
-		public static string[] GetLocalizations (NSUrl bundle)
+		public static string?[]? GetLocalizations (NSUrl bundle)
 		{
-			if (bundle == null)
-				throw new ArgumentNullException ("bundle");
-			using (var cfArray = new CFArray (CFBundleCopyLocalizationsForURL (bundle.Handle), true)) {
-				var cultureInfo = new string [cfArray.Count];
-				for (int index = 0; index < cfArray.Count; index++) {
-					cultureInfo [index] = CFString.FromHandle (cfArray.GetValue (index));
-				}
-				return cultureInfo;
-			}
+			if (bundle is null)
+				throw new ArgumentNullException (nameof (bundle));
+			var rv = CFBundleCopyLocalizationsForURL (bundle.Handle);
+			return CFArray.StringArrayFromHandle (rv, true);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFArray */ IntPtr CFBundleCopyPreferredLocalizationsFromArray (/* CFArrayRef */ IntPtr locArray);
 		
-		public static string[] GetPreferredLocalizations (string[] locArray)
+		public static string?[]? GetPreferredLocalizations (string[] locArray)
 		{
-			if (locArray == null)
-				throw new ArgumentNullException ("locArray");
+			if (locArray is null)
+				throw new ArgumentNullException (nameof (locArray));
 
 			var cfString = new CFString [locArray.Length];
 			for (int index = 0; index < locArray.Length; index++) {
 				cfString [index] = new CFString (locArray [index]);
 			}
-			using (var cfLocArray = CFArray.FromNativeObjects (cfString))
-			using (var cfArray = new CFArray (CFBundleCopyPreferredLocalizationsFromArray (cfLocArray.Handle), true)) {
-				var cultureInfo = new string [cfArray.Count];
-				for (int index = 0; index < cfArray.Count; index++) {
-					cultureInfo [index] = CFString.FromHandle (cfArray.GetValue (index));
-				}
-				return cultureInfo;
+			using (var cfLocArray = CFArray.FromNativeObjects (cfString)) {
+				var rv = CFBundleCopyPreferredLocalizationsFromArray (cfLocArray.Handle);
+				return CFArray.StringArrayFromHandle (rv, true);
 			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFUrlRef */ IntPtr CFBundleCopyBundleURL (IntPtr bundle);
 		
-		public NSUrl Url {
+		public NSUrl? Url {
 			get { 
-				return Runtime.GetNSObject<NSUrl> (CFBundleCopyBundleURL (handle), true);
+				return Runtime.GetNSObject<NSUrl> (CFBundleCopyBundleURL (Handle), true);
 			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFString */ IntPtr CFBundleGetDevelopmentRegion (IntPtr bundle );
 		
-		public string DevelopmentRegion {
-			get { return CFString.FromHandle (CFBundleGetDevelopmentRegion (handle)); }
+		public string? DevelopmentRegion {
+			get { return CFString.FromHandle (CFBundleGetDevelopmentRegion (Handle)); }
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFString */ IntPtr CFBundleGetIdentifier (IntPtr bundle);
 		
-		public string Identifier {
-			get { return CFString.FromHandle (CFBundleGetIdentifier (handle)); }
+		public string? Identifier {
+			get { return CFString.FromHandle (CFBundleGetIdentifier (Handle)); }
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFDictionary */ IntPtr CFBundleGetInfoDictionary (IntPtr bundle ); 
 		
-		public NSDictionary InfoDictionary {
+		public NSDictionary? InfoDictionary {
 			get {
 				// follows the Get rule, we need to retain
-				return Runtime.GetNSObject<NSDictionary> (CFBundleGetInfoDictionary (handle));
+				return Runtime.GetNSObject<NSDictionary> (CFBundleGetInfoDictionary (Handle));
 			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* NSDictionary */ IntPtr CFBundleGetLocalInfoDictionary (IntPtr bundle );	
 		
-		public NSDictionary LocalInfoDictionary {
+		public NSDictionary? LocalInfoDictionary {
 			get {
 				// follows the Get rule, we need to retain
-				return Runtime.GetNSObject<NSDictionary> (CFBundleGetLocalInfoDictionary (handle));
+				return Runtime.GetNSObject<NSDictionary> (CFBundleGetLocalInfoDictionary (Handle));
 			}
 		}
 
@@ -556,10 +530,10 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* NSDictionary */ IntPtr CFBundleCopyInfoDictionaryForURL (/* CFUrlRef */ IntPtr url);
 		
-		public static NSDictionary GetInfoDictionary (NSUrl url)
+		public static NSDictionary? GetInfoDictionary (NSUrl url)
 		{
-			if (url == null)
-				throw new ArgumentNullException ("url");
+			if (url is null)
+				throw new ArgumentNullException (nameof (url));
 			// follow the create rule, no need to retain
 			return Runtime.GetNSObject<NSDictionary> (CFBundleCopyInfoDictionaryForURL (url.Handle));
 		}
@@ -572,7 +546,7 @@ namespace CoreFoundation {
 				uint type = 0;
 				uint creator = 0;
 				
-				CFBundleGetPackageInfo (handle, out type, out creator);
+				CFBundleGetPackageInfo (Handle, out type, out creator);
 				var creatorStr = Runtime.ToFourCCString (creator);
 				switch (type) {
 				case 1095782476: // ""APPL
@@ -589,18 +563,15 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFArray */ IntPtr CFBundleCopyExecutableArchitectures (IntPtr bundle);
 
-		public CFBundle.Architecture[] Architectures {
+		public CFBundle.Architecture[]? Architectures {
 			get {
-				using (var cfArray = new CFArray(CFBundleCopyExecutableArchitectures (handle), true)) {
-					var archs = new CFBundle.Architecture [cfArray.Count];
-					for (int index = 0; index < cfArray.Count; index++) {
-						int value = 0;
-						if (CFDictionary.CFNumberGetValue (cfArray.GetValue (index), /* kCFNumberSInt32Type */ 3, out value)) {
-							archs [index] = (CFBundle.Architecture) value;
-						} 
-					}
-					return archs;
-				}
+				var rv = CFBundleCopyExecutableArchitectures (Handle);
+				return CFArray.ArrayFromHandleFunc (rv,
+					(handle) => {
+						if (CFDictionary.CFNumberGetValue (handle, /* kCFNumberSInt32Type */ 3, out int value))
+							return (CFBundle.Architecture) value;
+						return default (CFBundle.Architecture);
+					}, true);
 			}
 		}
 
@@ -623,12 +594,10 @@ namespace CoreFoundation {
 #endif
 		public static bool IsExecutableLoadable (CFBundle bundle)
 		{
-			if (bundle == null)
+			if (bundle is null)
 				throw new ArgumentNullException (nameof (bundle));
-			if (bundle.Handle == IntPtr.Zero)
-				throw new ObjectDisposedException (nameof (bundle));
 
-			return CFBundleIsExecutableLoadable (bundle.Handle);
+			return CFBundleIsExecutableLoadable (bundle.GetCheckedHandle ());
 		}
 
 #if !NET
@@ -649,7 +618,7 @@ namespace CoreFoundation {
 #endif
 		public static bool IsExecutableLoadable (NSUrl url)
 		{
-			if (url == null)
+			if (url is null)
 				throw new ArgumentNullException (nameof (url));
 
 			return CFBundleIsExecutableLoadableForURL (url.Handle);

--- a/tests/monotouch-test/CoreFoundation/ArrayTest.cs
+++ b/tests/monotouch-test/CoreFoundation/ArrayTest.cs
@@ -1,0 +1,133 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+using CoreFoundation;
+using Foundation;
+using ObjCRuntime;
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.CoreFoundation {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class ArrayTest {
+		static string[] TestArray = new string [] { "a", "b", "??" };
+
+		void VerifyArray (CFArray? a)
+		{
+			Assert.IsNotNull (a, "NotNull");
+			Assert.AreEqual ((nint) 3, a.Count, "Count");
+			for (var i = 0; i < a.Count; i++)
+				Assert.AreEqual (TestArray [i], (string) CFString.FromHandle (a.GetValue (i), false), i.ToString ());
+		}
+
+		void VerifyArray (NSString[]? a)
+		{
+			Assert.IsNotNull (a, "NotNull");
+			Assert.AreEqual (3, a.Length, "Count");
+			for (var i = 0; i < a.Length; i++)
+				Assert.AreEqual (TestArray [i], (string) a [i], i.ToString ());
+		}
+
+		void VerifyArray (string []? a)
+		{
+			Assert.IsNotNull (a, "NotNull");
+			Assert.AreEqual (3, a.Length, "Count");
+			for (var i = 0; i < a.Length; i++)
+				Assert.AreEqual (TestArray [i], (string) a [i], i.ToString ());
+		}
+
+		[Test]
+		public void CreateTest ()
+		{
+			var handle = CFArray.Create (TestArray);
+			using var a = Runtime.GetINativeObject<CFArray> (handle, true);
+			VerifyArray (a);
+			Assert.AreEqual ((nint) 1, CFGetRetainCount (handle), "RC");
+		}
+
+		[Test]
+		public void FromStringsTest ()
+		{
+			using var a = CFArray.FromStrings (TestArray);
+			VerifyArray (a);
+			Assert.AreEqual ((nint) 1, CFGetRetainCount (a.Handle), "RC");
+		}
+
+		[Test]
+		public void ArrayFromHandleTest ()
+		{
+			var handle = CFArray.Create (TestArray);
+			var a = CFArray.ArrayFromHandle<NSString> (handle);
+			VerifyArray (a);
+			Assert.AreEqual ((nint) 1, CFGetRetainCount (handle), "RC");
+			CFRelease (handle);
+		}
+		
+		[Test]
+		public void ArrayFromHandleTest_bool_true ()
+		{
+			var handle = CFArray.Create (TestArray);
+			CFRetain (handle);
+			var a = CFArray.ArrayFromHandle<NSString> (handle, true);
+			VerifyArray (a);
+			Assert.AreEqual ((nint) 1, CFGetRetainCount (handle), "RC");
+			CFRelease (handle);
+		}
+
+		[Test]
+		public void ArrayFromHandleTest_bool_false ()
+		{
+			var handle = CFArray.Create (TestArray);
+			var a = CFArray.ArrayFromHandle<NSString> (handle, false);
+			VerifyArray (a);
+			Assert.AreEqual ((nint) 1, CFGetRetainCount (handle), "RC");
+			CFRelease (handle);
+		}
+
+		[Test]
+		public void ArrayFromHandleFuncTest ()
+		{
+			var handle = CFArray.Create (TestArray);
+			var a = CFArray.ArrayFromHandleFunc<string> (handle, (v) => CFString.FromHandle (v));
+			VerifyArray (a);
+			Assert.AreEqual ((nint) 1, CFGetRetainCount (handle), "RC");
+			CFRelease (handle);
+		}
+
+		[Test]
+		public void ArrayFromHandleFuncTest_bool_true ()
+		{
+			var handle = CFArray.Create (TestArray);
+			CFRetain (handle);
+			var a = CFArray.ArrayFromHandleFunc<string> (handle, (v) => CFString.FromHandle (v), true);
+			VerifyArray (a);
+			Assert.AreEqual ((nint) 1, CFGetRetainCount (handle), "RC");
+			CFRelease (handle);
+		}
+
+		[Test]
+		public void ArrayFromHandleFuncTest_bool_false ()
+		{
+			var handle = CFArray.Create (TestArray);
+			var a = CFArray.ArrayFromHandleFunc<string> (handle, (v) => CFString.FromHandle (v), false);
+			VerifyArray (a);
+			Assert.AreEqual ((nint) 1, CFGetRetainCount (handle), "RC");
+			CFRelease (handle);
+		}
+
+		[DllImport (Constants.CoreFoundationLibrary)]
+		extern static nint CFGetRetainCount (IntPtr handle);
+
+		[DllImport (Constants.CoreFoundationLibrary)]
+		extern static void CFRetain (IntPtr obj);
+
+		[DllImport (Constants.CoreFoundationLibrary)]
+		extern static void CFRelease (IntPtr obj);
+	}
+}


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use CFString.CreateNative/ReleaseNative instead of other means to create native
  strings (the fastest and least memory hungry option).
* Use 'nameof (parameter)' instead of string constants.
* Call 'GetCheckedHandle ()' (which will throw an ObjectDisposedException if
  Handle  == IntPtr.Zero) instead of manually checking for IntPtr.Zero and throwing
  ObjectDisposedException.
* Use CFArray helper methods to create arrays (and implement some helper methods
  that didn't exist).
* Add a few tests for the new CFArray helper methods.