### PR TITLE
[tests] Fix the name of monotouchtest.

### DIFF
--- a/tests/common/shared-dotnet.mk
+++ b/tests/common/shared-dotnet.mk
@@ -6,7 +6,9 @@ unexport MSBUILD_EXE_PATH
 
 BINLOG_TIMESTAMP:=$(shell date +%Y-%m-%d-%H%M%S)
 
+ifeq ($(TESTNAME),)
 TESTNAME:=$(notdir $(shell dirname "$(shell dirname "$(CURDIR)")"))
+endif
 
 prepare:
 	$(Q) $(MAKE) -C $(TOP)/tests/dotnet copy-dotnet-config

--- a/tests/monotouch-test/dotnet/shared.mk
+++ b/tests/monotouch-test/dotnet/shared.mk
@@ -1,3 +1,4 @@
 TOP=../../../..
 
+TESTNAME=monotouchtest
 include $(TOP)/tests/common/shared-dotnet.mk


### PR DESCRIPTION
Fix the name of monotouchtest, so that the app/executable is found by the
makefile when trying to execute the test.