### PR TITLE
[VTFrameSilo] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/VideoToolbox/VTFrameSilo.cs
+++ b/src/VideoToolbox/VTFrameSilo.cs
@@ -7,6 +7,8 @@
 // Copyright 2015 Xamarin Inc.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -23,45 +25,18 @@ namespace VideoToolbox {
 #else
 	[Mac (10,10), iOS (8,0), TV (10,2)]
 #endif
-	public class VTFrameSilo : INativeObject, IDisposable {
-		IntPtr handle;
-
-		/* invoked by marshallers */
+	public class VTFrameSilo : NativeObject {
+#if !XAMCORE_4_0
 		protected internal VTFrameSilo (IntPtr handle)
+			: base (handle, false)
 		{
-			this.handle = handle;
-			CFObject.CFRetain (this.handle);
 		}
-
-		public IntPtr Handle {
-			get {return handle; }
-		}
+#endif
 
 		[Preserve (Conditional=true)]
 		internal VTFrameSilo (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (this.handle);
-		}
-
-		~VTFrameSilo ()
-		{
-			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 		[DllImport (Constants.VideoToolboxLibrary)]
@@ -72,15 +47,14 @@ namespace VideoToolbox {
 			/* CFDictionaryRef */ IntPtr options, /* Reserved, always null */
 			/* VTFrameSiloRef */ out IntPtr siloOut);
 
-		public static VTFrameSilo Create (NSUrl fileUrl = null, CMTimeRange? timeRange = null)
+		public static VTFrameSilo? Create (NSUrl? fileUrl = null, CMTimeRange? timeRange = null)
 		{
-			IntPtr ret;
 			var status = VTFrameSiloCreate (
 				IntPtr.Zero,
-				fileUrl == null ? IntPtr.Zero : fileUrl.Handle, 
+				fileUrl.GetHandle (),
 				timeRange ?? CMTimeRange.InvalidRange, 
 				IntPtr.Zero, 
-				out ret);
+				out var ret);
 
 			if (status != VTStatus.Ok)
 				return null;
@@ -95,11 +69,10 @@ namespace VideoToolbox {
 
 		public VTStatus AddSampleBuffer (CMSampleBuffer sampleBuffer)
 		{
-			if (sampleBuffer == null)
-				throw new ArgumentNullException ("sampleBuffer");
+			if (sampleBuffer is null)
+				throw new ArgumentNullException (nameof (sampleBuffer));
 
-			var status = VTFrameSiloAddSampleBuffer (handle, sampleBuffer.Handle);
-			return status;
+			return VTFrameSiloAddSampleBuffer (Handle, sampleBuffer.Handle);
 		}
 
 		[DllImport (Constants.VideoToolboxLibrary)]
@@ -110,15 +83,15 @@ namespace VideoToolbox {
 
 		public unsafe VTStatus SetTimeRangesForNextPass (CMTimeRange[] ranges)
 		{
-			if (ranges == null)
-				throw new ArgumentNullException ("ranges");
+			if (ranges is null)
+				throw new ArgumentNullException (nameof (ranges));
 
 			if (ranges.Length > 0)
 				fixed (CMTimeRange *first = &ranges [0]) {
-					return VTFrameSiloSetTimeRangesForNextPass (handle, ranges.Length, (IntPtr)first);
+					return VTFrameSiloSetTimeRangesForNextPass (Handle, ranges.Length, (IntPtr)first);
 				}
 			else
-				return VTFrameSiloSetTimeRangesForNextPass (handle, ranges.Length, IntPtr.Zero);
+				return VTFrameSiloSetTimeRangesForNextPass (Handle, ranges.Length, IntPtr.Zero);
 		}
 
 		[DllImport (Constants.VideoToolboxLibrary)]
@@ -128,7 +101,7 @@ namespace VideoToolbox {
 
 		public VTStatus GetProgressOfCurrentPass (out float progress)
 		{
-			return VTFrameSiloGetProgressOfCurrentPass (handle, out progress);
+			return VTFrameSiloGetProgressOfCurrentPass (Handle, out progress);
 		}
 
 #if !NET
@@ -147,7 +120,9 @@ namespace VideoToolbox {
 		static VTStatus BufferCallback (IntPtr callbackInfo, IntPtr sampleBufferPtr)
 		{
 			var gch = GCHandle.FromIntPtr (callbackInfo);
-			var func = (Func<CMSampleBuffer, VTStatus>) gch.Target;
+			var func = gch.Target as Func<CMSampleBuffer, VTStatus>;
+			if (func is null)
+				return (VTStatus) 1; // return non-zero to abort iteration early.
 			var sampleBuffer = new CMSampleBuffer (sampleBufferPtr, false);
 			return func (sampleBuffer);
 		}
@@ -167,9 +142,9 @@ namespace VideoToolbox {
 		{
 			var callbackHandle = GCHandle.Alloc (callback);
 #if NET
-			var foreachResult = VTFrameSiloCallFunctionForEachSampleBuffer (handle, range ?? CMTimeRange.InvalidRange, GCHandle.ToIntPtr (callbackHandle), &BufferCallback);
+			var foreachResult = VTFrameSiloCallFunctionForEachSampleBuffer (Handle, range ?? CMTimeRange.InvalidRange, GCHandle.ToIntPtr (callbackHandle), &BufferCallback);
 #else
-			var foreachResult = VTFrameSiloCallFunctionForEachSampleBuffer (handle, range ?? CMTimeRange.InvalidRange, GCHandle.ToIntPtr (callbackHandle), static_EachSampleBufferCallback);
+			var foreachResult = VTFrameSiloCallFunctionForEachSampleBuffer (Handle, range ?? CMTimeRange.InvalidRange, GCHandle.ToIntPtr (callbackHandle), static_EachSampleBufferCallback);
 #endif
 			callbackHandle.Free ();
 			return foreachResult;


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.