### PR TITLE
[FSEvents] Fix compiler warning about nullability.

### DIFF
--- a/src/CoreServices/FSEvents.cs
+++ b/src/CoreServices/FSEvents.cs
@@ -104,7 +104,7 @@ namespace CoreServices
 				return Guid.Empty;
 			}
 
-			return (Guid)Marshal.PtrToStructure (uuidRef, typeof (Guid));
+			return (Guid)Marshal.PtrToStructure (uuidRef, typeof (Guid))!;
 		}
 
 		[DllImport (Constants.CoreServicesLibrary)]


### PR DESCRIPTION
Fixes this warning:

    CoreServices/FSEvents.cs(107,11): warning CS8605: Unboxing a possibly null value.