### PR TITLE
[Draft] Generate many duplicate availability attributes due to NET6 semantic differences 

### DIFF
--- a/src/PassKit/PKPaymentRequest.cs
+++ b/src/PassKit/PKPaymentRequest.cs
@@ -42,8 +42,13 @@ namespace PassKit {
 
 	public partial class PKPaymentRequest {
 
+	// XXX - This is a single set of examples of what would need to be done for every manual code with availability attributes
 #if NET
 		[SupportedOSPlatform ("ios11.0")]
+		[SupportedOSPlatform ("watchos4.0")]
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst")]
 #else
 		[Watch (4,0)][iOS (11,0)]
 #endif
@@ -54,6 +59,10 @@ namespace PassKit {
 
 #if NET
 		[SupportedOSPlatform ("ios11.0")]
+		[SupportedOSPlatform ("watchos4.0")]
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst")]
 #else
 		[Watch (4,0)][iOS (11,0)]
 #endif

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3368,7 +3368,7 @@ public partial class Generator : IMemberGatherer {
 		if (attr.Version is null) {
 			switch (attr.AvailabilityKind) {
 				case AvailabilityKind.Introduced:
-					return new IntroducedAttribute(platform, attr.Architecture, attr.Message);
+					return new IntroducedAttribute (platform, attr.Architecture, attr.Message);
 				case AvailabilityKind.Deprecated:
 					return new DeprecatedAttribute(platform, attr.Architecture, attr.Message);
 				case AvailabilityKind.Obsoleted:

--- a/tests/cecil-tests/AttributeTest.cs
+++ b/tests/cecil-tests/AttributeTest.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using NUnit.Framework;
+
+using Mono.Cecil;
+
+#nullable enable
+
+namespace Cecil.Tests {
+
+	[TestFixture]
+	public class AttributeTest {
+		// https://github.com/xamarin/xamarin-macios/issues/10170
+		// Every binding class that has net6 availability attributes on a method/property
+		// must have one matching every platform listed on the availabilities of the class
+		//
+		// Example:
+		// [SupportedOSPlatform("ios1.0")]
+		// [SupportedOSPlatform("maccatalyst1.0")]
+		// class TestType
+		// {
+		//     public static void Original () { }
+		//
+		//     [SupportedOSPlatform(""ios2.0"")]
+		//     public static void Extension () { }
+		// }
+		//
+		// In this example, Extension is _not_ considered part of maccatalyst1.0
+		// Because having _any_ SupportedOSPlatform implies only the set explicitly set on that member
+		//
+		// This test should find Extension, note that it has an ios attribute,
+		// and insist that some maccatalyst must also be set.
+		[TestCaseSource (typeof (Helper), "Net6PlatformAssemblies")]
+		public void AvailabilityForAllPlatforms (string assemblyPath)
+		{
+			var assembly = Helper.GetAssembly (assemblyPath);
+			if (assembly == null) {
+				Assert.Ignore ("{assemblyPath} could not be found (might be disabled in build)");
+				return; // just to help nullability
+			}
+			Console.WriteLine(assemblyPath);
+
+			// Make a list of Availabilty on parent. If iOS that implies Catalyst. Ignore NotSupported here.
+			// Each child must have an attribute for each availability (Either NotSupported or Supported)
+			HashSet<string> found = new HashSet<string> ();
+			int count = 0;
+			foreach (var prop in Helper.FilterProperties(assembly, a => HasAnyAvailabilityAttribute(a, includeUnsupported: true))) {
+				var parentAvailability = GetParentAvailabilityAttributes(prop, includeUnsupported: false).ToList();
+				// iOS implies maccatalyst, but only for parent scope
+				if (parentAvailability.Contains("ios") && !parentAvailability.Contains("maccatalyst")) {
+					parentAvailability.Append("maccatalyst");
+				}
+				var myAvailability = GetAvailabilityAttributes(prop, includeUnsupported: true);
+				if (!FirstContainsAllOfSecond (myAvailability, parentAvailability)) {
+					if (count < 10) {
+						Console.WriteLine (prop.FullName);
+						Console.WriteLine ("Parent: " + string.Join(" ", parentAvailability));
+						Console.WriteLine ("Mine: " + string.Join(" ", myAvailability));
+						Console.WriteLine ();
+						count += 1;
+					}
+					found.Add(prop.FullName);
+				}
+			}
+			foreach (var meth in Helper.FilterMethods(assembly, a => HasAnyAvailabilityAttribute(a, includeUnsupported: true))) {
+				var parentAvailability = GetParentAvailabilityAttributes(meth, includeUnsupported: false).ToList();
+				// iOS implies maccatalyst, but only for parent scope
+				if (parentAvailability.Contains("ios") && !parentAvailability.Contains("maccatalyst")) {
+					parentAvailability.Append("maccatalyst");
+				}
+				var myAvailability = GetAvailabilityAttributes(meth, includeUnsupported: true);
+				if (!FirstContainsAllOfSecond (myAvailability, parentAvailability)) {
+					if (count < 10) {
+						Console.WriteLine (meth.FullName);
+						Console.WriteLine ("Parent: " + string.Join(" ", parentAvailability));
+						Console.WriteLine ("Mine: " + string.Join(" ", myAvailability));
+						Console.WriteLine ();
+						count += 1;
+					}
+					found.Add(meth.FullName);
+				}
+			}
+			Console.WriteLine(found.Count);
+			//Assert.That (found, Is.Empty, string.Join (", ", found));
+		}
+
+		bool FirstContainsAllOfSecond<T> (IEnumerable<T> first, IEnumerable<T> second)
+		{
+			HashSet<T> firstSet = new HashSet<T>(first);
+			return second.All(s => firstSet.Contains(s));
+		}
+
+		IEnumerable<string> GetParentAvailabilityAttributes(PropertyDefinition prop, bool includeUnsupported) => GetAvailabilityAttributes(prop.DeclaringType, includeUnsupported);
+		IEnumerable<string> GetParentAvailabilityAttributes(MethodDefinition meth, bool includeUnsupported) => GetAvailabilityAttributes(meth.DeclaringType, includeUnsupported);
+
+		IEnumerable<string> GetAvailabilityAttributes(TypeDefinition definition, bool includeUnsupported) => GetAvailabilityAttributes(definition.CustomAttributes, includeUnsupported);
+		IEnumerable<string> GetAvailabilityAttributes(PropertyDefinition prop, bool includeUnsupported) => GetAvailabilityAttributes(prop.CustomAttributes, includeUnsupported);
+		IEnumerable<string> GetAvailabilityAttributes(MethodDefinition meth, bool includeUnsupported) => GetAvailabilityAttributes(meth.CustomAttributes, includeUnsupported);
+
+		IEnumerable<string> GetAvailabilityAttributes(IEnumerable<CustomAttribute> attributes, bool includeUnsupported)
+		{
+			var availability = new List<string>();
+			foreach (var attribute in attributes.Where(a => IsAvailabilityAttribute(a, includeUnsupported))) {
+				var kind = FindAvailabilityKind (attribute);
+				if (kind != null) {
+					availability.Add(kind);
+				}
+			}
+			return availability;
+		}
+
+		string? FindAvailabilityKind (CustomAttribute attribute)
+		{
+			if (attribute.ConstructorArguments.Count == 1 && attribute.ConstructorArguments[0].Type.Name == "String") {
+				string full = (string)attribute.ConstructorArguments[0].Value;
+				switch (full) {
+					case string s when full.StartsWith("ios"):
+						return "ios";
+					case string s when full.StartsWith("watchos"):
+						return "watchos";
+					case string s when full.StartsWith("tvos"):
+						return "tvos";
+					case string s when full.StartsWith("macos"):
+						return "macos";
+					case string s when full.StartsWith("maccatalyst"):
+						return "maccatalyst";
+					default:
+						throw new System.NotImplementedException($"Unknown platform kind: {full}");
+				}
+			}
+			return null;
+		}
+
+		bool HasAnyAvailabilityAttribute (PropertyDefinition prop, bool includeUnsupported) => HasAnyAvailabilityAttribute(prop.CustomAttributes, includeUnsupported);
+		bool HasAnyAvailabilityAttribute (MethodDefinition meth, bool includeUnsupported) => HasAnyAvailabilityAttribute(meth.CustomAttributes, includeUnsupported);
+
+		bool HasAnyAvailabilityAttribute (IEnumerable<CustomAttribute> attributes, bool includeUnsupported) => attributes.Any (a => IsAvailabilityAttribute(a, includeUnsupported));
+
+		bool IsAvailabilityAttribute (CustomAttribute attribute, bool includeUnsupported)
+		{
+			return attribute.AttributeType.Name == "SupportedOSPlatformAttribute" ||
+				(includeUnsupported && attribute.AttributeType.Name == "UnsupportedOSPlatformAttribute");
+		}
+	}
+}

--- a/tests/cecil-tests/Helper.cs
+++ b/tests/cecil-tests/Helper.cs
@@ -80,7 +80,7 @@ namespace Cecil.Tests {
 		{
 			if (type.HasProperties) {
 				foreach (var property in type.Properties) {
-					if ((filter == null) || filter (property))
+					if ((filter is null) || filter (property))
 						yield return property;
 				}
 			}

--- a/tests/cecil-tests/Helper.cs
+++ b/tests/cecil-tests/Helper.cs
@@ -65,6 +65,34 @@ namespace Cecil.Tests {
 			yield break;
 		}
 
+		public static IEnumerable<PropertyDefinition> FilterProperties (AssemblyDefinition assembly, Func<PropertyDefinition, bool>? filter)
+		{
+			foreach (var module in assembly.Modules) {
+				foreach (var type in module.Types) {
+					foreach (var property in FilterProperties (type, filter))
+						yield return property;
+				}
+			}
+			yield break;
+		}
+
+		static IEnumerable<PropertyDefinition> FilterProperties (TypeDefinition type, Func<PropertyDefinition, bool>? filter)
+		{
+			if (type.HasProperties) {
+				foreach (var property in type.Properties) {
+					if ((filter == null) || filter (property))
+						yield return property;
+				}
+			}
+			if (type.HasNestedTypes) {
+				foreach (var nested in type.NestedTypes) {
+					foreach (var property in FilterProperties (nested, filter))
+						yield return property;
+				}
+			}
+			yield break;
+		}
+
 		public static string GetBCLDirectory (string assembly)
 		{
 			var rv = string.Empty;
@@ -80,6 +108,7 @@ namespace Cecil.Tests {
 				rv = Path.GetDirectoryName (Configuration.XamarinTVOSDll);
 				break;
 			case "Xamarin.Mac.dll":
+			case "Xamarin.MacCatalyst.dll":
 				rv = Path.GetDirectoryName (assembly);
 				break;
 			default:
@@ -102,6 +131,15 @@ namespace Cecil.Tests {
 
 				yield return new TestCaseData (Configuration.XamarinMacMobileDll);
 				yield return new TestCaseData (Configuration.XamarinMacFullDll);
+			}
+		}
+
+		public static IEnumerable Net6PlatformAssemblies {
+			get {
+				yield return new TestCaseData (Path.Combine (Configuration.GetDotNetRoot(), "Microsoft.iOS.Ref", "ref", "net6.0", "Xamarin.iOS.dll"));
+				yield return new TestCaseData (Path.Combine (Configuration.GetDotNetRoot(), "Microsoft.tvOS.Ref", "ref", "net6.0", "Xamarin.TVOS.dll"));
+				yield return new TestCaseData (Path.Combine (Configuration.GetDotNetRoot(), "Microsoft.macOS.Ref", "ref", "net6.0", "Xamarin.Mac.dll"));
+				yield return new TestCaseData (Path.Combine (Configuration.GetDotNetRoot(), "Microsoft.MacCatalyst.Ref", "ref", "net6.0", "Xamarin.MacCatalyst.dll"));
 			}
 		}
 

--- a/tests/cecil-tests/Makefile
+++ b/tests/cecil-tests/Makefile
@@ -8,7 +8,7 @@ build:
 	$(SYSTEM_MSBUILD) /r
 
 run-tests: build
-	$(TOP)/tools/nunit3-console-3.11.1 $(abspath $(TOP)/tests/cecil-tests/bin/Debug/net472/cecil-tests.dll)
+	$(TOP)/tools/nunit3-console-3.11.1 $(abspath $(TOP)/tests/cecil-tests/bin/Debug/net472/cecil-tests.dll) $(TEST_FILTER)
 
 clean:
 	rm -rf bin/ obj/ TestResult.xml


### PR DESCRIPTION
This is the start of https://github.com/xamarin/xamarin-macios/issues/10170

# The Problem

As noted in that issue, NET 6 style SupportedOSPlatform/UnsupportedOSPlatform attributes have some rather unfortunate (for us) semantics:

1 - Any attributes on a member prevents "recursing up" to parent class
- By default, for a property/method if it does not have any attributes look at the containing class.
- However, if we have a single attribute defined, do not "recurse up" to the container. Assume that all attributes on the member are all that is.

This means for example:

```csharp
	[SupportedOSPlatform ("ios9.0")]
	[SupportedOSPlatform ("tvos12.0")]
        public class Foo
        {
              public void A () {}
	
              [SupportedOSPlatform ("ios10.0")]
              public void B () {} 
        }
```

That Foo:B() is only available on iOS 10 and *not tvos12*. This is very different than our existing Xamarin attributes.

2 - iOS attributes imply maccatalyst of the same version. 

Due to behavior 1, this will overwrite any existing maccatalyst attribute on the parent class.

# Potential Solution

Working under the assumption that the net6 availability attributes and analyzers are frozen in behavior we must:

1. Create an automated test to detect cases where attribute behavior would differ from current legacy based upon what we know today
2. Update our code generate to instance the large number of attributes in generated code
3. Update manual code and enable the test to prevent future regressions
4. (Optional) Work on additional cecil tests to increase confidence such as [this one](https://github.com/xamarin/xamarin-macios/issues/12544)

This draft PR takes us past the 2nd checkpoint.

# This PR

It reduces the number of errors found by the cecil tests from 5-7k to 300-700 (depending on assembly in question) roughly. 

I spot checked a handful and those were all in manual code (step 3). 

I do not have confidence that this solution is complete and correct, nor that it is the optimal path forward, thus the draft PR state. 

I suspect there are bugs, but it's enough to start the discussion if we want me to run this over the finish line. 

Here is a diff of the generated code:
https://gist.github.com/chamons/b0dbdd9b8d389bcb76306caffe6d3e59

All comments welcome.