### PR TITLE
[GithubActions] Remove Debug Dumps

### DIFF
--- a/.github/workflows/label-checker.yml
+++ b/.github/workflows/label-checker.yml
@@ -9,11 +9,6 @@ jobs:
     name: Labels verification
 
     steps:
-    - run: echo "$GITHUB_CONTEXT"
-      name: 'Debug context'
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-
     - run: exit 0
       name: 'Monojenkins PR'
       # always happy if monojenkins

--- a/.github/workflows/pong.yml
+++ b/.github/workflows/pong.yml
@@ -15,11 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: 'Debug context'
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-
       - name: 'Add remotes'
         run: |
           git remote add public "http://$Env:GITHUB_TOKEN@github.com/xamarin/xamarin-macios.git"


### PR DESCRIPTION
We will be receiving debugging logs from Github for all of our Github Actions using [this](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-runner-diagnostic-logging) so these dumps will not be needed!