### PR TITLE
[CFData] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreFoundation/CFData.cs
+++ b/src/CoreFoundation/CFData.cs
@@ -26,6 +26,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using Foundation;
@@ -33,46 +35,14 @@ using ObjCRuntime;
 
 namespace CoreFoundation {
 
-	class CFData : INativeObject, IDisposable {
-		internal IntPtr handle;
-
-		public CFData (IntPtr handle)
-			: this (handle, false)
+	class CFData : NativeObject {
+		internal CFData (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
 		}
 
-		public CFData (IntPtr handle, bool owns)
-		{
-			if (!owns)
-				CFObject.CFRetain (handle);
-			this.handle = handle;
-		}
-
-		~CFData ()
-		{
-			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-		
 		[DllImport (Constants.CoreFoundationLibrary, EntryPoint="CFDataGetTypeID")]
 		public extern static /* CFTypeID */ nint GetTypeID ();
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
-		}
 
 #if !COREBUILD
 		public static CFData FromDataNoCopy (IntPtr buffer, nint length)
@@ -85,7 +55,7 @@ namespace CoreFoundation {
 #endif
 
 		public nint Length {
-			get { return CFDataGetLength (handle); }
+			get { return CFDataGetLength (Handle); }
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -94,7 +64,7 @@ namespace CoreFoundation {
 		public byte[] GetBuffer ()
 		{
 			var buffer = new byte [Length];
-			var ptr = CFDataGetBytePtr (handle);
+			var ptr = CFDataGetBytePtr (Handle);
 			Marshal.Copy (ptr, buffer, 0, buffer.Length);
 			return buffer;
 		}
@@ -106,7 +76,7 @@ namespace CoreFoundation {
 		 * Exposes a read-only pointer to the underlying storage.
 		 */
 		public IntPtr Bytes {
-			get { return CFDataGetBytePtr (handle); }
+			get { return CFDataGetBytePtr (Handle); }
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.