### PR TITLE
[CFDictionary] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreFoundation/CFDictionary.cs
+++ b/src/CoreFoundation/CFDictionary.cs
@@ -28,6 +28,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using Foundation;
@@ -35,45 +37,17 @@ using ObjCRuntime;
 
 namespace CoreFoundation {
 
-	class CFDictionary : INativeObject, IDisposable {
-		public IntPtr Handle { get; private set; }
-	
+	class CFDictionary : NativeObject {
 		public static IntPtr KeyCallbacks;
 		public static IntPtr ValueCallbacks;
 
-		public CFDictionary (IntPtr handle)
-			: this (handle, false)
+		internal CFDictionary (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-		}
-
-		public CFDictionary (IntPtr handle, bool owns)
-		{
-			if (!owns)
-				CFObject.CFRetain (handle);
-			this.Handle = handle;
 		}
 		
 		[DllImport (Constants.CoreFoundationLibrary, EntryPoint="CFDictionaryGetTypeID")]
 		public extern static nint GetTypeID ();
-
-		~CFDictionary ()
-		{
-			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (Handle != IntPtr.Zero){
-				CFObject.CFRelease (Handle);
-				Handle = IntPtr.Zero;
-			}
-		}
 
 		static CFDictionary ()
 		{
@@ -89,11 +63,11 @@ namespace CoreFoundation {
 		
 		public static CFDictionary FromObjectsAndKeys (INativeObject[] objects, INativeObject[] keys)
 		{
-			if (objects == null)
-				throw new ArgumentNullException ("objects");
+			if (objects is null)
+				throw new ArgumentNullException (nameof (objects));
 
-			if (keys == null)
-				throw new ArgumentNullException ("keys");
+			if (keys is null)
+				throw new ArgumentNullException (nameof (keys));
 
 			if (objects.Length != keys.Length)
 				throw new ArgumentException ("The length of both arrays must be the same");
@@ -144,52 +118,70 @@ namespace CoreFoundation {
 			return CFBoolean.GetValue (value);
 		}
 		
-		public string GetStringValue (string key)
+		public string? GetStringValue (string key)
 		{
-			using (var str = new CFString (key)) {
-				return CFString.FromHandle (CFDictionaryGetValue (Handle, str.Handle));
+			var keyHandle = CFString.CreateNative (key);
+			try {
+				return CFString.FromHandle (CFDictionaryGetValue (Handle, keyHandle));
+			} finally {
+				CFString.ReleaseNative (keyHandle);
 			}
 		}
 
 		public int GetInt32Value (string key)
 		{
 			int value = 0;
-			using (var str = new CFString (key)) {
-				if (!CFNumberGetValue (CFDictionaryGetValue (Handle, str.Handle), /* kCFNumberSInt32Type */ 3, out value))
+			var keyHandle = CFString.CreateNative (key);
+			try {
+				if (!CFNumberGetValue (CFDictionaryGetValue (Handle, keyHandle), /* kCFNumberSInt32Type */ 3, out value))
 					throw new System.Collections.Generic.KeyNotFoundException (string.Format ("Key {0} not found", key));
 				return value;
+			} finally {
+				CFString.ReleaseNative (keyHandle);
 			}
 		}
 
 		public long GetInt64Value (string key)
 		{
 			long value = 0;
-			using (var str = new CFString (key)) {
-				if (!CFNumberGetValue (CFDictionaryGetValue (Handle, str.Handle), /* kCFNumberSInt64Type */ 4, out value))
+			var keyHandle = CFString.CreateNative (key);
+			try {
+				if (!CFNumberGetValue (CFDictionaryGetValue (Handle, keyHandle), /* kCFNumberSInt64Type */ 4, out value))
 					throw new System.Collections.Generic.KeyNotFoundException (string.Format ("Key {0} not found", key));
 				return value;
+			} finally {
+				CFString.ReleaseNative (keyHandle);
 			}
 		}
 
 		public IntPtr GetIntPtrValue (string key)
 		{
-			using (var str = new CFString (key)) {
-				return CFDictionaryGetValue (Handle, str.Handle);
+			var keyHandle = CFString.CreateNative (key);
+			try {
+				return CFDictionaryGetValue (Handle, keyHandle);
+			} finally {
+				CFString.ReleaseNative (keyHandle);
 			}
 		}
 
-		public CFDictionary GetDictionaryValue (string key)
+		public CFDictionary? GetDictionaryValue (string key)
 		{
-			using (var str = new CFString (key)) {
-				var ptr = CFDictionaryGetValue (Handle, str.Handle);
-				return ptr == IntPtr.Zero ? null : new CFDictionary (ptr);
+			var keyHandle = CFString.CreateNative (key);
+			try {
+				var ptr = CFDictionaryGetValue (Handle, keyHandle);
+				return ptr == IntPtr.Zero ? null : new CFDictionary (ptr, false);
+			} finally {
+				CFString.ReleaseNative (keyHandle);
 			}
 		}
 
 		public bool ContainsKey (string key)
 		{
-			using (var str = new CFString (key)) {
-				return CFDictionaryContainsKey (Handle, str.Handle);
+			var keyHandle = CFString.CreateNative (key);
+			try {
+				return CFDictionaryContainsKey (Handle, keyHandle);
+			} finally {
+				CFString.ReleaseNative (keyHandle);
 			}
 		}
 


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use CFString.CreateNative/ReleaseNative instead of other means to create
  native strings (the fastest and least memory hungry option).
* Use 'nameof (parameter)' instead of string constants.
* Remove the (IntPtr) constructor (which is not a breaking change because the type isn't public).
* Make the (IntPtr, bool) constructor internal (which is not a breaking change because the type isn't public).