### PR TITLE
[CMBufferQueue] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreMedia/CMBufferQueue.cs
+++ b/src/CoreMedia/CMBufferQueue.cs
@@ -7,6 +7,9 @@
 // Copyright 2012-2016 Xamarin Inc. All rights reserved.
 //
 //
+
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -15,10 +18,6 @@ using Foundation;
 using CoreFoundation;
 using ObjCRuntime;
 using OSStatus = System.Int32;
-
-// FIXME64: this will change on 64 bit builds
-//
-using CMItemCount = System.Int32;
 
 namespace CoreMedia {
 	
@@ -31,21 +30,17 @@ namespace CoreMedia {
 #endif
 	public delegate nint   CMBufferGetSize (INativeObject buffer);
 
-	public class CMBufferQueue : INativeObject
-#if !COREBUILD
-		, IDisposable
-#endif
+	public class CMBufferQueue : NativeObject
 		{
 #if !COREBUILD
 		GCHandle gch;
 		Dictionary<IntPtr, INativeObject> queueObjects;
-		internal IntPtr handle;
-		CMBufferGetTime getDecodeTimeStamp;
-		CMBufferGetTime getPresentationTimeStamp;
-		CMBufferGetTime getDuration;
-		CMBufferGetBool isDataReady;
-		CMBufferCompare compare;
-		CMBufferGetSize getTotalSize;
+		CMBufferGetTime? getDecodeTimeStamp;
+		CMBufferGetTime? getPresentationTimeStamp;
+		CMBufferGetTime? getDuration;
+		CMBufferGetBool? isDataReady;
+		CMBufferCompare? compare;
+		CMBufferGetSize? getTotalSize;
 		
 		delegate CMTime BufferGetTimeCallback (/* CMBufferRef */ IntPtr buf, /* void* */ IntPtr refcon);
 		[return: MarshalAs (UnmanagedType.I1)]
@@ -57,13 +52,13 @@ namespace CoreMedia {
 		struct CMBufferCallbacks {
 			internal uint version;
 			internal IntPtr refcon;
-			internal BufferGetTimeCallback XgetDecodeTimeStamp;
-			internal BufferGetTimeCallback XgetPresentationTimeStamp;
-			internal BufferGetTimeCallback XgetDuration;
-			internal BufferGetBooleanCallback XisDataReady;
-			internal BufferCompareCallback Xcompare;
+			internal BufferGetTimeCallback? XgetDecodeTimeStamp;
+			internal BufferGetTimeCallback? XgetPresentationTimeStamp;
+			internal BufferGetTimeCallback? XgetDuration;
+			internal BufferGetBooleanCallback? XisDataReady;
+			internal BufferCompareCallback? Xcompare;
 			internal IntPtr cfStringPtr_dataBecameReadyNotification;
-			internal BufferGetSizeCallback XgetSize;
+			internal BufferGetSizeCallback? XgetSize;
 		}
 
 		// A version with no delegates, just native pointers
@@ -79,31 +74,13 @@ namespace CoreMedia {
 			internal IntPtr cfStringPtr_dataBecameReadyNotification;
 			internal IntPtr XgetSize;
 		}
-
-		~CMBufferQueue ()
-		{
-			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
 	
-		protected virtual void Dispose (bool disposing)
+		protected override void Dispose (bool disposing)
 		{
-			queueObjects = null;
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
+			queueObjects.Clear ();
 			if (gch.IsAllocated)
 				gch.Free ();
+			base.Dispose (disposing);
 		}
 
 		// CMItemCount -> CMBase.h (looks weird but it's 4 bytes in 32bits and 8 bytes in 64bits, x86_64 and ARM64)
@@ -114,34 +91,40 @@ namespace CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static OSStatus CMBufferQueueCreate (/* CFAllocatorRef */ IntPtr allocator, /* CMItemCount */ nint capacity, /* CMBufferCallbacks */ IntPtr cbacks, /* CMBufferQueueRef* */ out IntPtr result);
 
-		internal CMBufferQueue (int count)
+		CMBufferQueue (IntPtr handle, bool owns, int count)
+			: base (handle, owns)
 		{
-			queueObjects = new Dictionary<IntPtr,INativeObject> (count, Runtime.IntPtrEqualityComparer);
+			queueObjects = new Dictionary<IntPtr, INativeObject> (count, Runtime.IntPtrEqualityComparer);
 			gch = GCHandle.Alloc (this);
 		}
 
+		CMBufferQueue (int count)
+			: this (IntPtr.Zero, true, count)
+		{
+		}
+
 		// for compatibility with 7.0 and earlier
-		public static CMBufferQueue FromCallbacks (int count, CMBufferGetTime getDecodeTimeStamp, CMBufferGetTime getPresentationTimeStamp, CMBufferGetTime getDuration,
-			CMBufferGetBool isDataReady, CMBufferCompare compare, NSString dataBecameReadyNotification)
+		public static CMBufferQueue? FromCallbacks (int count, CMBufferGetTime? getDecodeTimeStamp, CMBufferGetTime? getPresentationTimeStamp, CMBufferGetTime? getDuration,
+			CMBufferGetBool? isDataReady, CMBufferCompare? compare, NSString dataBecameReadyNotification)
 		{
 			return FromCallbacks (count, getDecodeTimeStamp, getPresentationTimeStamp, getDuration, isDataReady, 
 				compare, dataBecameReadyNotification, null);
 		}
 
-		public static CMBufferQueue FromCallbacks (int count, CMBufferGetTime getDecodeTimeStamp, CMBufferGetTime getPresentationTimeStamp, CMBufferGetTime getDuration,
-			CMBufferGetBool isDataReady, CMBufferCompare compare, NSString dataBecameReadyNotification, CMBufferGetSize getTotalSize)
+		public static CMBufferQueue? FromCallbacks (int count, CMBufferGetTime? getDecodeTimeStamp, CMBufferGetTime? getPresentationTimeStamp, CMBufferGetTime? getDuration,
+			CMBufferGetBool? isDataReady, CMBufferCompare? compare, NSString dataBecameReadyNotification, CMBufferGetSize? getTotalSize)
 		{
 			var bq = new CMBufferQueue (count);
 			var cbacks = new CMBufferCallbacks () {
 				version = (uint) (getTotalSize == null ? 0 : 1),
 				refcon = GCHandle.ToIntPtr (bq.gch),
-				XgetDecodeTimeStamp = getDecodeTimeStamp == null ? (BufferGetTimeCallback) null : GetDecodeTimeStamp,
-				XgetPresentationTimeStamp = getPresentationTimeStamp == null ? (BufferGetTimeCallback) null : GetPresentationTimeStamp,
-				XgetDuration = getDuration == null ? (BufferGetTimeCallback) null : GetDuration,
-				XisDataReady = isDataReady == null ? (BufferGetBooleanCallback) null : GetDataReady,
-				Xcompare = compare == null ? (BufferCompareCallback) null : Compare,
+				XgetDecodeTimeStamp = getDecodeTimeStamp == null ? (BufferGetTimeCallback?) null : GetDecodeTimeStamp,
+				XgetPresentationTimeStamp = getPresentationTimeStamp == null ? (BufferGetTimeCallback?) null : GetPresentationTimeStamp,
+				XgetDuration = getDuration == null ? (BufferGetTimeCallback?) null : GetDuration,
+				XisDataReady = isDataReady == null ? (BufferGetBooleanCallback?) null : GetDataReady,
+				Xcompare = compare == null ? (BufferCompareCallback?) null : Compare,
 				cfStringPtr_dataBecameReadyNotification = dataBecameReadyNotification == null ? IntPtr.Zero : dataBecameReadyNotification.Handle,
-				XgetSize = getTotalSize == null ? (BufferGetSizeCallback) null : GetTotalSize
+				XgetSize = getTotalSize == null ? (BufferGetSizeCallback?) null : GetTotalSize
 			};
 
 			bq.getDecodeTimeStamp = getDecodeTimeStamp;
@@ -151,8 +134,10 @@ namespace CoreMedia {
 			bq.compare = compare;
 			bq.getTotalSize = getTotalSize;
 
-			if (CMBufferQueueCreate (IntPtr.Zero, count, cbacks, out bq.handle) == 0)
+			if (CMBufferQueueCreate (IntPtr.Zero, count, cbacks, out var handle) == 0) {
+				bq.InitializeHandle (handle);
 				return bq;
+			}
 
 			bq.Dispose ();
 			return null;
@@ -161,18 +146,17 @@ namespace CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		unsafe extern static /* CMBufferCallbacks */ IntPtr CMBufferQueueGetCallbacksForUnsortedSampleBuffers ();
 		
-		public static CMBufferQueue CreateUnsorted (int count)
+		public static CMBufferQueue? CreateUnsorted (int count)
 		{
-			var bq = new CMBufferQueue (count);
 			// note: different version of iOS can return a different (size) structure, e.g. iOS 7.1,
 			// that structure might not map to our `CMBufferCallbacks2` managed representation
 			// and can cause a crash, e.g. bug #17330
 			// since we don't need the managed bcallbacks (it's the native callback that will be used for this queue)
 			// then we can simply use an IntPtr to represent them (no GCHandle)
 			var callbacks = CMBufferQueueGetCallbacksForUnsortedSampleBuffers ();
-			
-			if (CMBufferQueueCreate (IntPtr.Zero, count, callbacks, out bq.handle) == 0)
-				return bq;
+
+			if (CMBufferQueueCreate (IntPtr.Zero, count, callbacks, out var handle) == 0)
+				return new CMBufferQueue (handle, true, count);
 
 			return null;
 		}
@@ -185,11 +169,11 @@ namespace CoreMedia {
 		//
 		public void Enqueue (INativeObject cftypeBuffer)
 		{
-			if (cftypeBuffer == null)
-				throw new ArgumentNullException ("cftypeBuffer");
+			if (cftypeBuffer is null)
+				throw new ArgumentNullException (nameof (cftypeBuffer));
 			lock (queueObjects){
 				var cfh = cftypeBuffer.Handle;
-				CMBufferQueueEnqueue (handle, cfh);
+				CMBufferQueueEnqueue (Handle, cfh);
 				if (!queueObjects.ContainsKey (cfh))
 					queueObjects [cfh] = cftypeBuffer;
 			}
@@ -198,7 +182,7 @@ namespace CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMBufferRef */ IntPtr CMBufferQueueDequeueAndRetain (/* CMBufferQueueRef */ IntPtr queue);
 
-		public INativeObject Dequeue ()
+		public INativeObject? Dequeue ()
 		{
 			//
 			// Our managed objects already take a reference on the object,
@@ -206,7 +190,7 @@ namespace CoreMedia {
 			// dictionary, we kept the reference alive.   So we need to
 			// release the newly acquired reference
 			//
-			var oHandle = CMBufferQueueDequeueAndRetain (handle);
+			var oHandle = CMBufferQueueDequeueAndRetain (Handle);
 			if (oHandle == IntPtr.Zero)
 				return null;
 
@@ -221,7 +205,7 @@ namespace CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMBufferRef */ IntPtr CMBufferQueueDequeueIfDataReadyAndRetain (/* CMBufferQueueRef */ IntPtr queue);
 		
-		public INativeObject DequeueIfDataReady ()
+		public INativeObject? DequeueIfDataReady ()
 		{
 			//
 			// Our managed objects already take a reference on the object,
@@ -229,7 +213,7 @@ namespace CoreMedia {
 			// dictionary, we kept the reference alive.   So we need to
 			// release the newly acquired reference
 			//
-			var oHandle = CMBufferQueueDequeueIfDataReadyAndRetain (handle);
+			var oHandle = CMBufferQueueDequeueIfDataReadyAndRetain (Handle);
 			if (oHandle == IntPtr.Zero)
 				return null;
 
@@ -245,7 +229,7 @@ namespace CoreMedia {
 		extern static byte CMBufferQueueIsEmpty (/* CMBufferQueueRef */ IntPtr queue);
 		public bool IsEmpty {
 			get {
-				return CMBufferQueueIsEmpty (handle) != 0;
+				return CMBufferQueueIsEmpty (Handle) != 0;
 			}
 		}
 
@@ -254,14 +238,14 @@ namespace CoreMedia {
 		extern static OSStatus CMBufferQueueMarkEndOfData (/* CMBufferQueueRef */ IntPtr queue);
 		public int MarkEndOfData ()
 		{
-			return CMBufferQueueMarkEndOfData (handle);
+			return CMBufferQueueMarkEndOfData (Handle);
 		}
 
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static byte CMBufferQueueContainsEndOfData (/* CMBufferQueueRef */ IntPtr queue);
 		public bool ContainsEndOfData {
 			get {
-				return CMBufferQueueContainsEndOfData (handle) != 0;
+				return CMBufferQueueContainsEndOfData (Handle) != 0;
 			}
 		}
 
@@ -269,7 +253,7 @@ namespace CoreMedia {
 		extern static byte CMBufferQueueIsAtEndOfData (/* CMBufferQueueRef */ IntPtr queue);
 		public bool IsAtEndOfData {
 			get {
-				return CMBufferQueueIsAtEndOfData (handle) != 0;
+				return CMBufferQueueIsAtEndOfData (Handle) != 0;
 			}
 		}
 
@@ -277,14 +261,14 @@ namespace CoreMedia {
 		extern static OSStatus CMBufferQueueReset (/* CMBufferQueueRef */ IntPtr queue);
 		public OSStatus Reset ()
 		{
-			return CMBufferQueueReset (handle);
+			return CMBufferQueueReset (Handle);
 		}
 
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static nint CMBufferQueueGetBufferCount (/* CMBufferQueueRef */ IntPtr queue);
 		public nint BufferCount {
 			get {
-				return CMBufferQueueGetBufferCount (handle);
+				return CMBufferQueueGetBufferCount (Handle);
 			}
 		}
 
@@ -292,7 +276,7 @@ namespace CoreMedia {
 		extern static CMTime CMBufferQueueGetDuration (/* CMBufferQueueRef */ IntPtr queue);
 		public CMTime Duration {
 			get {
-				return CMBufferQueueGetDuration (handle);
+				return CMBufferQueueGetDuration (Handle);
 			}
 		}
 		
@@ -308,7 +292,7 @@ namespace CoreMedia {
 #endif
 		public nint GetTotalSize ()
 		{
-			return CMBufferQueueGetTotalSize (handle);
+			return CMBufferQueueGetTotalSize (Handle);
 		}
 
 
@@ -323,7 +307,9 @@ namespace CoreMedia {
 #endif
 		static CMTime GetDecodeTimeStamp (IntPtr buffer, IntPtr refcon)
 		{
-			var queue = (CMBufferQueue) GCHandle.FromIntPtr (refcon).Target;
+			var queue = (CMBufferQueue?) GCHandle.FromIntPtr (refcon).Target;
+			if (queue?.getDecodeTimeStamp is null)
+				return default (CMTime);
 			return queue.getDecodeTimeStamp (queue.Surface (buffer));
 		}
 
@@ -332,7 +318,9 @@ namespace CoreMedia {
 #endif
 		static CMTime GetPresentationTimeStamp (IntPtr buffer, IntPtr refcon)
 		{
-			var queue = (CMBufferQueue) GCHandle.FromIntPtr (refcon).Target;
+			var queue = (CMBufferQueue?) GCHandle.FromIntPtr (refcon).Target;
+			if (queue?.getPresentationTimeStamp is null)
+				return default (CMTime);
 			return queue.getPresentationTimeStamp (queue.Surface (buffer));
 		}
 
@@ -341,7 +329,9 @@ namespace CoreMedia {
 #endif
 		static CMTime GetDuration (IntPtr buffer, IntPtr refcon)
 		{
-			var queue = (CMBufferQueue) GCHandle.FromIntPtr (refcon).Target;
+			var queue = (CMBufferQueue?) GCHandle.FromIntPtr (refcon).Target;
+			if (queue?.getDuration is null)
+				return default (CMTime);
 			return queue.getDuration (queue.Surface (buffer));
 		}
 
@@ -350,7 +340,9 @@ namespace CoreMedia {
 #endif
 		static bool GetDataReady (IntPtr buffer, IntPtr refcon)
 		{
-			var queue = (CMBufferQueue) GCHandle.FromIntPtr (refcon).Target;
+			var queue = (CMBufferQueue?) GCHandle.FromIntPtr (refcon).Target;
+			if (queue?.isDataReady is null)
+				return false;
 			return queue.isDataReady (queue.Surface (buffer));
 		}
 
@@ -359,7 +351,9 @@ namespace CoreMedia {
 #endif
 		static int Compare (IntPtr buffer1, IntPtr buffer2, IntPtr refcon)
 		{
-			var queue = (CMBufferQueue) GCHandle.FromIntPtr (refcon).Target;
+			var queue = (CMBufferQueue?) GCHandle.FromIntPtr (refcon).Target;
+			if (queue?.compare is null)
+				return 0;
 			return queue.compare (queue.Surface (buffer1), queue.Surface (buffer2));
 		}
 
@@ -368,7 +362,9 @@ namespace CoreMedia {
 #endif
 		static nint GetTotalSize (IntPtr buffer, IntPtr refcon)
 		{
-			var queue = (CMBufferQueue) GCHandle.FromIntPtr (refcon).Target;
+			var queue = (CMBufferQueue?) GCHandle.FromIntPtr (refcon).Target;
+			if (queue?.getTotalSize is null)
+				return 0;
 			return queue.getTotalSize (queue.Surface (buffer));
 		}
 #endif // !COREBUILD


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.