### PR TITLE
[CFMessagePort] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreFoundation/CFMessagePort.cs
+++ b/src/CoreFoundation/CFMessagePort.cs
@@ -6,6 +6,9 @@
 //
 // Copyright 2015 Xamarin Inc
 //
+
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -30,14 +33,14 @@ namespace CoreFoundation {
 
 	internal class CFMessagePortContext {
 
-		public Func<INativeObject> Retain { get; set; }
+		public Func<INativeObject>? Retain { get; set; }
 
-		public Action Release { get; set; }
+		public Action? Release { get; set; }
 
-		public Func<NSString> CopyDescription { get; set; }
+		public Func<NSString>? CopyDescription { get; set; }
 	}
 
-	public class CFMessagePort : INativeObject, IDisposable {
+	public class CFMessagePort : NativeObject {
 
 		// CFMessagePortContext
 		[StructLayout (LayoutKind.Sequential)]
@@ -57,57 +60,47 @@ namespace CoreFoundation {
 
 		static Dictionary <IntPtr, CFMessagePortCallBack> outputHandles = new Dictionary <IntPtr, CFMessagePortCallBack> (Runtime.IntPtrEqualityComparer);
 
-		static Dictionary <IntPtr, Action> invalidationHandles = new Dictionary <IntPtr, Action> (Runtime.IntPtrEqualityComparer);
+		static Dictionary <IntPtr, Action?> invalidationHandles = new Dictionary <IntPtr, Action?> (Runtime.IntPtrEqualityComparer);
 
-		static Dictionary <IntPtr, CFMessagePortContext> messagePortContexts = new Dictionary <IntPtr, CFMessagePortContext> (Runtime.IntPtrEqualityComparer);
+		static Dictionary <IntPtr, CFMessagePortContext?> messagePortContexts = new Dictionary <IntPtr, CFMessagePortContext?> (Runtime.IntPtrEqualityComparer);
 
 		static CFMessagePortCallBackProxy messageOutputCallback = new CFMessagePortCallBackProxy (MessagePortCallback);
 
 		static CFMessagePortInvalidationCallBackProxy messageInvalidationCallback = new CFMessagePortInvalidationCallBackProxy (MessagePortInvalidationCallback);
 
-		IntPtr handle;
 		IntPtr contextHandle = IntPtr.Zero;
-
-		public IntPtr Handle {
-			get {
-				return handle;
-			}
-		}
 
 		public bool IsRemote {
 			get {
-				Check ();
-				return CFMessagePortIsRemote (handle);
+				return CFMessagePortIsRemote (GetCheckedHandle ());
 			}
 		}
 
-		public string Name {
+		public string? Name {
 			get {
-				Check ();
-				return CFString.FromHandle (CFMessagePortGetName (handle));
+				return CFString.FromHandle (CFMessagePortGetName (GetCheckedHandle ()));
 			}
 			set {
-				Check ();
-				IntPtr n = NSString.CreateNative (value);
-				CFMessagePortSetName (handle, n);
-				NSString.ReleaseNative (n);
+				var n = CFString.CreateNative (value);
+				try {
+					CFMessagePortSetName (GetCheckedHandle (), n);
+				} finally {
+					CFString.ReleaseNative (n);
+				}
 			}
 		}
 
 		public bool IsValid {
 			get {
-				Check ();
-				return CFMessagePortIsValid (handle);
+				return CFMessagePortIsValid (GetCheckedHandle ());
 			}
 		}
 
-		internal CFMessagePortContext Context {
+		internal CFMessagePortContext? Context {
 			get {
-				Check ();
-
-				CFMessagePortContext result;
+				CFMessagePortContext? result;
 				ContextProxy context = new ContextProxy ();
-				CFMessagePortGetContext (handle, ref context);
+				CFMessagePortGetContext (GetCheckedHandle (), ref context);
 
 				if (context.info == IntPtr.Zero)
 					return null;
@@ -119,63 +112,41 @@ namespace CoreFoundation {
 			}
 		}
 
-		public Action InvalidationCallback {
+		public Action? InvalidationCallback {
 			get {
-				Check ();
-				Action result;
-
-				lock (invalidationHandles)
-					invalidationHandles.TryGetValue (handle, out result);
-
-				return result;
+				lock (invalidationHandles) {
+					invalidationHandles.TryGetValue (GetCheckedHandle (), out var result);
+					return result;
+				}
 			}
 			set {
-				Check ();
-
 				lock (invalidationHandles) {
-					if (value == null)
-						invalidationHandles [handle] = null;
+					if (value is null)
+						invalidationHandles [GetCheckedHandle ()] = null;
 					else
-						invalidationHandles.Add (handle, value);
+						invalidationHandles.Add (GetCheckedHandle (), value);
 				}
 
-				CFMessagePortSetInvalidationCallBack (handle, messageInvalidationCallback);
+				CFMessagePortSetInvalidationCallBack (Handle, messageInvalidationCallback);
 			}
-		}
-
-		internal CFMessagePort (IntPtr handle) : this (handle, false)
-		{
 		}
 
 		[Preserve (Conditional = true)]
 		internal CFMessagePort (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
 		}
 
-		~CFMessagePort ()
+		protected override void Dispose (bool disposing)
 		{
-			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero) {
+			if (Handle != IntPtr.Zero) {
 
 				lock (outputHandles)
-					outputHandles.Remove (handle);
+					outputHandles.Remove (Handle);
 
 				lock (invalidationHandles) {
-					if (invalidationHandles.ContainsKey (handle))
-						invalidationHandles.Remove (handle);
+					if (invalidationHandles.ContainsKey (Handle))
+						invalidationHandles.Remove (Handle);
 				}
 
 				lock (messagePortContexts) {
@@ -183,10 +154,10 @@ namespace CoreFoundation {
 						invalidationHandles.Remove (contextHandle);
 				}
 
-				CFObject.CFRelease (handle);
 				contextHandle = IntPtr.Zero;
-				handle = IntPtr.Zero;
 			}
+
+			base.Dispose (disposing);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -202,7 +173,7 @@ namespace CoreFoundation {
 		static extern IntPtr CFMessagePortCreateRunLoopSource (/* CFAllocatorRef */ IntPtr allocator, /* CFMessagePortRef */ IntPtr local, /* CFIndex */ nint order);
 
 		[DllImport (Constants.CoreFoundationLibrary)]
-		static extern /* SInt32 */ CFMessagePortSendRequestStatus CFMessagePortSendRequest (/* CFMessagePortRef */ IntPtr remote, /* SInt32 */ int msgid, /* CFDataRef */ IntPtr data, /* CFTiemInterval */ double sendTimeout, /* CFTiemInterval */ double rcvTimeout, /* CFStringRef */ IntPtr replyMode, /* CFDataRef* */ ref IntPtr returnData);
+		static extern /* SInt32 */ CFMessagePortSendRequestStatus CFMessagePortSendRequest (/* CFMessagePortRef */ IntPtr remote, /* SInt32 */ int msgid, /* CFDataRef */ IntPtr data, /* CFTiemInterval */ double sendTimeout, /* CFTiemInterval */ double rcvTimeout, /* CFStringRef */ IntPtr replyMode, /* CFDataRef* */ out IntPtr returnData);
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
@@ -231,18 +202,17 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		static extern IntPtr CFMessagePortGetInvalidationCallBack (/* CFMessagePortRef */ IntPtr ms);
 
-		public static CFMessagePort CreateLocalPort (string name, CFMessagePortCallBack callback, CFAllocator allocator = null)
+		public static CFMessagePort? CreateLocalPort (string? name, CFMessagePortCallBack callback, CFAllocator? allocator = null)
 		{
-			if (callback == null)
-				throw new ArgumentNullException ("callback");
+			if (callback is null)
+				throw new ArgumentNullException (nameof (callback));
 			
 			return CreateLocalPort (allocator, name, callback, context: null);
 		}
 		
-		internal static CFMessagePort CreateLocalPort (CFAllocator allocator, string name, CFMessagePortCallBack callback, CFMessagePortContext context)
+		internal static CFMessagePort? CreateLocalPort (CFAllocator? allocator, string? name, CFMessagePortCallBack callback, CFMessagePortContext? context)
 		{
-			IntPtr a = allocator == null ? IntPtr.Zero : allocator.Handle;
-			IntPtr n = NSString.CreateNative (name);
+			var n = CFString.CreateNative (name);
 			bool shouldFreeInfo = false;
 			var contextProxy = new ContextProxy ();
 
@@ -251,12 +221,12 @@ namespace CoreFoundation {
 			// original context defined by developer
 			var shortHandle = GCHandle.Alloc (contextProxy);
 
-			if (context != null) {
-				if (context.Retain != null)
+			if (context is not null) {
+				if (context.Retain is not null)
 					contextProxy.retain = RetainProxy;
-				if (context.Release != null)
+				if (context.Release is not null)
 					contextProxy.release = ReleaseProxy;
-				if (context.CopyDescription != null)
+				if (context.CopyDescription is not null)
 					contextProxy.copyDescription = CopyDescriptionProxy;
 				contextProxy.info = (IntPtr)shortHandle;
 				lock (messagePortContexts)
@@ -264,21 +234,18 @@ namespace CoreFoundation {
 			}
 
 			try {
-				var portHandle = CFMessagePortCreateLocal (a, n, messageOutputCallback, ref contextProxy, ref shouldFreeInfo);
-
-				// we won't need short GCHandle after the Create call
-				shortHandle.Free ();
+				var portHandle = CFMessagePortCreateLocal (allocator.GetHandle (), n, messageOutputCallback, ref contextProxy, ref shouldFreeInfo);
 
 				// TODO handle should free info
 				if (portHandle == IntPtr.Zero)
 					return null;
 
-				var result = new CFMessagePort (portHandle);
+				var result = new CFMessagePort (portHandle, true);
 
 				lock (outputHandles)
 					outputHandles.Add (portHandle, callback);
 				
-				if (context != null) {
+				if (context is not null) {
 					lock (messagePortContexts) {
 						messagePortContexts.Remove (contextProxy.info);
 						CFMessagePortGetContext (portHandle, ref contextProxy);
@@ -290,7 +257,10 @@ namespace CoreFoundation {
 			
 				return result;
 			} finally {
-				NSString.ReleaseNative (n);
+				CFString.ReleaseNative (n);
+
+				// we won't need short GCHandle after the Create call
+				shortHandle.Free ();
 			}
 		}
 
@@ -300,44 +270,44 @@ namespace CoreFoundation {
 		[MonoPInvokeCallback (typeof (Func<IntPtr, IntPtr>))]
 		static IntPtr RetainProxy (IntPtr info)
 		{
-			INativeObject result = null;
-			CFMessagePortContext context;
+			INativeObject? result = null;
+			CFMessagePortContext? context;
 
 			lock (messagePortContexts) {
 				messagePortContexts.TryGetValue (info, out context);
 			}
 			
-			if (context != null && context.Retain != null)
+			if (context?.Retain is not null)
 				result = context.Retain ();
 
-			return result == null ? IntPtr.Zero : result.Handle;
+			return result.GetHandle ();
 		}
 
 		[MonoPInvokeCallback (typeof (Action<IntPtr>))]
 		static void ReleaseProxy (IntPtr info)
 		{
-			CFMessagePortContext context;
+			CFMessagePortContext? context;
 
 			lock (messagePortContexts)
 				messagePortContexts.TryGetValue (info, out context);
 
-			if (context != null && context.Release != null)
+			if (context?.Release is not null)
 				context.Release ();
 		}
 
 		[MonoPInvokeCallback (typeof (Func<IntPtr, IntPtr>))]
 		static IntPtr CopyDescriptionProxy (IntPtr info)
 		{
-			NSString result = null;
-			CFMessagePortContext context;
+			NSString? result = null;
+			CFMessagePortContext? context;
 
 			lock (messagePortContexts)
 				messagePortContexts.TryGetValue (info, out context);
 
-			if (context != null && context.CopyDescription != null)
+			if (context?.CopyDescription is not null)
 				result = context.CopyDescription ();
 
-			return result == null ? IntPtr.Zero : result.Handle;
+			return result.GetHandle ();
 		}
 
 		[MonoPInvokeCallback (typeof (CFMessagePortCallBackProxy))]
@@ -348,21 +318,21 @@ namespace CoreFoundation {
 			lock (outputHandles)
 				callback = outputHandles [local];
 
-			if (callback == null)
+			if (callback is null)
 				return IntPtr.Zero;
 			
-			using (var managedData = Runtime.GetNSObject<NSData> (data)) {
+			using (var managedData = Runtime.GetNSObject<NSData> (data)!) {
 				var result = callback.Invoke (msgid, managedData);
 				// System will release returned CFData
 				result?.DangerousRetain ();
-				return result == null ? IntPtr.Zero : result.Handle;
+				return result.GetHandle ();
 			}
 		}
 
 		[MonoPInvokeCallback (typeof (CFMessagePortInvalidationCallBackProxy))]
 		static void MessagePortInvalidationCallback (IntPtr messagePort, IntPtr info)
 		{
-			Action callback;
+			Action? callback;
 
 			lock (invalidationHandles)
 				invalidationHandles.TryGetValue (messagePort, out callback);
@@ -371,37 +341,28 @@ namespace CoreFoundation {
 				callback.Invoke ();
 		}
 
-		public static CFMessagePort CreateRemotePort (CFAllocator allocator, string name)
+		public static CFMessagePort? CreateRemotePort (CFAllocator? allocator, string name)
 		{
-			if (name == null)
-				throw new ArgumentNullException ("name");
+			if (name is null)
+				throw new ArgumentNullException (nameof (name));
 
-			IntPtr a = allocator == null ? IntPtr.Zero : allocator.Handle;
-			IntPtr n = NSString.CreateNative (name);
-
+			var n = CFString.CreateNative (name);
 			try {
-				var portHandle = CFMessagePortCreateRemote (a, n);
-				return portHandle == IntPtr.Zero ? null : new CFMessagePort (portHandle);
+				var portHandle = CFMessagePortCreateRemote (allocator.GetHandle (), n);
+				return portHandle == IntPtr.Zero ? null : new CFMessagePort (portHandle, true);
 			} finally {
-				NSString.ReleaseNative (n);
+				CFString.ReleaseNative (n);
 			}
 		}
 
 		public void Invalidate ()
 		{
-			Check ();
-			CFMessagePortInvalidate (handle);
+			CFMessagePortInvalidate (GetCheckedHandle ());
 		}
 
-		public CFMessagePortSendRequestStatus SendRequest (int msgid, NSData data, double sendTimeout, double rcvTimeout, NSString replyMode, out NSData returnData)
+		public CFMessagePortSendRequestStatus SendRequest (int msgid, NSData? data, double sendTimeout, double rcvTimeout, NSString? replyMode, out NSData? returnData)
 		{
-			Check ();
-
-			IntPtr replyModeHandle = replyMode == null ? IntPtr.Zero : replyMode.Handle;
-			IntPtr returnDataHandle = IntPtr.Zero;
-			IntPtr dataHandle = data == null ? IntPtr.Zero : data.Handle;
-
-			var result = CFMessagePortSendRequest (handle, msgid, dataHandle, sendTimeout, rcvTimeout, replyModeHandle, ref returnDataHandle);
+			var result = CFMessagePortSendRequest (GetCheckedHandle (), msgid, data.GetHandle (), sendTimeout, rcvTimeout, replyMode.GetHandle (), out var returnDataHandle);
 
 			returnData = Runtime.GetINativeObject<NSData> (returnDataHandle, false);
 
@@ -411,22 +372,13 @@ namespace CoreFoundation {
 		public CFRunLoopSource CreateRunLoopSource ()
 		{
 			// note: order is currently ignored by CFMessagePort object run loop sources. Pass 0 for this value.
-			var runLoopHandle = CFMessagePortCreateRunLoopSource (IntPtr.Zero, handle, 0);
+			var runLoopHandle = CFMessagePortCreateRunLoopSource (IntPtr.Zero, Handle, 0);
 			return new CFRunLoopSource (runLoopHandle, false);
 		}
 
-		public void SetDispatchQueue (DispatchQueue queue)
+		public void SetDispatchQueue (DispatchQueue? queue)
 		{
-			IntPtr q = queue == null ? IntPtr.Zero : queue.Handle;
-
-			Check ();
-			CFMessagePortSetDispatchQueue (handle, q);
-		}
-
-		protected void Check ()
-		{
-			if (handle == IntPtr.Zero)
-				throw new ObjectDisposedException (GetType ().ToString ());
+			CFMessagePortSetDispatchQueue (GetCheckedHandle (), queue.GetHandle ());
 		}
 	}
 }


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use CFString.CreateNative/ReleaseNative instead of other means to create
  native strings (the fastest and least memory hungry option).
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.
* Call 'GetCheckedHandle ()' (which will throw an ObjectDisposedException if
  Handle == IntPtr.Zero) instead of manually checking for IntPtr.Zero and
  throwing ObjectDisposedException.
* Remove the (IntPtr) constructor..