### PR TITLE
[CFType] Enable nullability + a few other code updates

### DIFF
--- a/src/CoreFoundation/CFType.cs
+++ b/src/CoreFoundation/CFType.cs
@@ -1,6 +1,9 @@
 //
 // Copyright 2012-2014 Xamarin
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using ObjCRuntime;
@@ -13,13 +16,12 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static IntPtr CFCopyDescription (IntPtr ptr);
 
-		public string GetDescription (IntPtr handle)
+		public string? GetDescription (IntPtr handle)
 		{
 			if (handle == IntPtr.Zero)
-				throw new ArgumentNullException ("handle");
+				throw new ArgumentNullException (nameof (handle));
 			
-			using (var s = new CFString (CFCopyDescription (handle)))
-				return s.ToString ();
+			return CFString.FromHandle (CFCopyDescription (handle));
 		}
 		
 		[DllImport (Constants.CoreFoundationLibrary, EntryPoint="CFEqual")]


### PR DESCRIPTION
* Enable nullability and fix code accordingly.
* Use CFString.CreateNative/ReleaseNative instead of other means to create
  native strings (the fastest and least memory hungry option).
* Use 'nameof (parameter)' instead of string constants.