### PR TITLE
[CGFunction] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreGraphics/CGFunction.cs
+++ b/src/CoreGraphics/CGFunction.cs
@@ -25,18 +25,21 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
+using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
 namespace CoreGraphics {
 
 	// CGFunction.h
-	public class CGFunction : INativeObject, IDisposable {
-		IntPtr handle;
-		CGFunctionEvaluate evaluate;
+	public class CGFunction : NativeObject {
+		CGFunctionEvaluate? evaluate;
 
 		static CGFunctionCallbacks cbacks;
 
@@ -47,36 +50,20 @@ namespace CoreGraphics {
 			cbacks.release = new CGFunctionReleaseCallback (ReleaseCallback);
 		}
 
-		// invoked by marshallers
+#if !XAMCORE_4_0
 		internal CGFunction (IntPtr handle)
-			: this (handle, false)
+			: base (handle, false)
 		{
 		}
+#endif
 
 		[Preserve (Conditional=true)]
 		internal CGFunction (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			this.handle = handle;
-			if (!owns)
-				CGFunctionRetain (handle);
-		}
-		
-		~CGFunction ()
-		{
-			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
 		}
 
-		public IntPtr Handle {
-			get { return handle; }
-		}
-	
-		public CGFunctionEvaluate EvaluateFunction {
+		public CGFunctionEvaluate? EvaluateFunction {
 			get {
 				return evaluate;
 			}
@@ -90,13 +77,15 @@ namespace CoreGraphics {
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGFunctionRef */ IntPtr CGFunctionRetain (/* CGFunctionRef */ IntPtr function);
-		
-		protected virtual void Dispose (bool disposing)
+
+		protected override void Retain ()
 		{
-			if (handle != IntPtr.Zero){
-				CGFunctionRelease (handle);
-				handle = IntPtr.Zero;
-			}
+			CGFunctionRetain (GetCheckedHandle ());
+		}
+
+		protected override void Release ()
+		{
+			CGFunctionRelease (GetCheckedHandle ());
 		}
 
 		// Apple's documentation says 'float', the header files say 'CGFloat'
@@ -106,32 +95,34 @@ namespace CoreGraphics {
 		[StructLayout (LayoutKind.Sequential)]
 		struct CGFunctionCallbacks {
 			public /* unsigned int */ uint version;
-			public CGFunctionEvaluateCallback evaluate;
-			public CGFunctionReleaseCallback release;
+			public CGFunctionEvaluateCallback? evaluate;
+			public CGFunctionReleaseCallback? release;
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static IntPtr CGFunctionCreate (/* void* */ IntPtr data, /* size_t */ nint domainDimension, /* CGFloat* */ nfloat [] domain, nint rangeDimension, /* CGFloat* */ nfloat [] range, ref CGFunctionCallbacks callbacks);
+		extern static IntPtr CGFunctionCreate (/* void* */ IntPtr data, /* size_t */ nint domainDimension, /* CGFloat* */ nfloat []? domain, nint rangeDimension, /* CGFloat* */ nfloat []? range, ref CGFunctionCallbacks callbacks);
 		
 		unsafe public delegate void CGFunctionEvaluate (nfloat *data, nfloat *outData);
 
-		public unsafe CGFunction (nfloat [] domain, nfloat [] range, CGFunctionEvaluate callback)
+
+		public unsafe CGFunction (nfloat []? domain, nfloat []? range, CGFunctionEvaluate callback)
 		{
-			if (domain != null){
+			if (domain is not null) {
 				if ((domain.Length % 2) != 0)
-					throw new ArgumentException ("The domain array must consist of pairs of values", "domain");
+					throw new ArgumentException ("The domain array must consist of pairs of values", nameof (domain));
 			}
-			if (range != null) {
+			if (range is not null) {
 				if ((range.Length % 2) != 0)
-					throw new ArgumentException ("The range array must consist of pairs of values", "range");
+					throw new ArgumentException ("The range array must consist of pairs of values", nameof (range));
 			}
-			if (callback == null)
-				throw new ArgumentNullException ("callback");
+			if (callback is null)
+				throw new ArgumentNullException (nameof (callback));
 
 			this.evaluate = callback;
 
 			var gch = GCHandle.Alloc (this);
-			handle = CGFunctionCreate (GCHandle.ToIntPtr (gch), domain != null ? domain.Length/2 : 0, domain, range != null ? range.Length/2 : 0, range, ref cbacks);
+			var handle = CGFunctionCreate (GCHandle.ToIntPtr (gch), domain != null ? domain.Length / 2 : 0, domain, range != null ? range.Length / 2 : 0, range, ref cbacks);
+			InitializeHandle (handle);
 		}
 
 #if !MONOMAC
@@ -148,9 +139,9 @@ namespace CoreGraphics {
 		unsafe static void EvaluateCallback (IntPtr info, nfloat *input, nfloat *output)
 		{
 			GCHandle lgc = GCHandle.FromIntPtr (info);
-			CGFunction container = (CGFunction) lgc.Target;
+			var container = lgc.Target as CGFunction;
 
-			container.evaluate?.Invoke (input, output);
+			container?.evaluate?.Invoke (input, output);
 		}
 	}
 }


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.
* Call 'GetCheckedHandle ()' (which will throw an ObjectDisposedException if
  Handle == IntPtr.Zero) instead of manually checking for IntPtr.Zero and
  throwing ObjectDisposedException.
* Remove the (IntPtr) constructor for XAMCORE_4_0.