### PR TITLE
[CI] M1 - Mac Big Sur (11.5): Agent pool update

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -104,7 +104,10 @@ parameters:
       statusContext: 'M1 - Mac Big Sur (11.5)',
       demands: [
         "Agent.OS -equals Darwin",
-        "macOS.Architecture -equals arm64"
+        "macOS.Name -equals BigSur",
+        "macOS.Architecture -equals arm64",
+        "Agent.HasDevices -equals False",
+        "Agent.IsPaired -equals False"
       ]
     }]
 


### PR DESCRIPTION
Target the `VSEng-VSMac-Xamarin-Shared` (untrusted) agent pool instead of `VSEng-VSMac-Xamarin-Shared-Trusted`
Update agent demands to ensure the appropriate machine is chosen