### PR TITLE
[UIKit] Updates for Catalyst

### DIFF
--- a/tests/xtro-sharpie/MacCatalyst-UIKit.ignore
+++ b/tests/xtro-sharpie/MacCatalyst-UIKit.ignore
@@ -39,3 +39,10 @@
 
 ## Grouped nint constants
 !unknown-native-enum! UIFocusGroupPriority bound
+
+## Selectors documented in web docs but not in header files
+!missing-selector! +NSToolbarItem::itemWithItemIdentifier:barButtonItem: not bound
+!missing-selector! NSSharingServicePickerToolbarItem::activityItemsConfiguration not bound
+!missing-selector! NSSharingServicePickerToolbarItem::setActivityItemsConfiguration: not bound
+!missing-selector! NSSharingServicePickerTouchBarItem::activityItemsConfiguration not bound
+!missing-selector! NSSharingServicePickerTouchBarItem::setActivityItemsConfiguration: not bound

--- a/tests/xtro-sharpie/MacCatalyst-UIKit.todo
+++ b/tests/xtro-sharpie/MacCatalyst-UIKit.todo
@@ -430,17 +430,12 @@
 !missing-protocol-member! NSCollectionLayoutVisibleItem::transform not found
 !missing-requires-super! UIControl::contextMenuInteraction:willDisplayMenuForConfiguration:animator: is missing an [RequiresSuper] attribute
 !missing-requires-super! UIControl::contextMenuInteraction:willEndForConfiguration:animator: is missing an [RequiresSuper] attribute
-!missing-selector! +NSToolbarItem::itemWithItemIdentifier:barButtonItem: not bound
 !missing-selector! NSDiffableDataSourceSectionTransaction::difference not bound
 !missing-selector! NSDiffableDataSourceTransaction::difference not bound
 !missing-selector! NSObject::accessibilityDragSourceDescriptors not bound
 !missing-selector! NSObject::accessibilityDropPointDescriptors not bound
 !missing-selector! NSObject::setAccessibilityDragSourceDescriptors: not bound
 !missing-selector! NSObject::setAccessibilityDropPointDescriptors: not bound
-!missing-selector! NSSharingServicePickerToolbarItem::activityItemsConfiguration not bound
-!missing-selector! NSSharingServicePickerToolbarItem::setActivityItemsConfiguration: not bound
-!missing-selector! NSSharingServicePickerTouchBarItem::activityItemsConfiguration not bound
-!missing-selector! NSSharingServicePickerTouchBarItem::setActivityItemsConfiguration: not bound
 !missing-selector! UIAlertView::initWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles: not bound
 !missing-selector! UIBarAppearance::copy not bound
 !missing-selector! UIBarButtonItemAppearance::copy not bound


### PR DESCRIPTION
Moved some of the .todo to .ignore as the selectors don't exist in the header files
Only moved the ones caught by @chamons' cat_compare script and left the rest in .todo

