### PR TITLE
[CFHTTPAuthentication] Indirectly subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CFNetwork/CFHTTPAuthentication.cs
+++ b/src/CFNetwork/CFHTTPAuthentication.cs
@@ -7,6 +7,8 @@
 // Copyright 2012-2014 Xamarin Inc. (http://www.xamarin.com)
 //
 
+#nullable enable
+
 using System;
 using System.Net;
 using System.Runtime.InteropServices;
@@ -21,63 +23,22 @@ namespace CFNetwork {
 namespace CoreServices {
 #endif
 
-	public class CFHTTPAuthentication : CFType, INativeObject, IDisposable {
-		internal IntPtr handle;
-
-		internal CFHTTPAuthentication (IntPtr handle)
-			: this (handle, false)
-		{
-		}
-
+	public class CFHTTPAuthentication : CFType {
 		internal CFHTTPAuthentication (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (!owns)
-				CFObject.CFRetain (handle);
-			this.handle = handle;
 		}
 
 		[DllImport (Constants.CFNetworkLibrary, EntryPoint="CFHTTPAuthenticationGetTypeID")]
 		public extern static /* CFTypeID */ nint GetTypeID ();
 
-		~CFHTTPAuthentication ()
-		{
-			Dispose (false);
-		}
-		
-		protected void CheckHandle ()
-		{
-			if (handle == IntPtr.Zero)
-				throw new ObjectDisposedException (GetType ().Name);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get {
-				CheckHandle ();
-				return handle;
-			}
-		}
-		
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero) {
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
-		}
-
 		[DllImport (Constants.CFNetworkLibrary)]
 		extern static /* CFHTTPAuthenticationRef */ IntPtr CFHTTPAuthenticationCreateFromResponse (/* CFAllocatorRef */ IntPtr alloc, /* CFHTTPMessageRef */ IntPtr response);
 
-		public static CFHTTPAuthentication CreateFromResponse (CFHTTPMessage response)
+		public static CFHTTPAuthentication? CreateFromResponse (CFHTTPMessage response)
 		{
-			if (response == null)
-				throw new ArgumentNullException ("response");
+			if (response is null)
+				throw new ArgumentNullException (nameof (response));
 
 			if (response.IsRequest)
 				throw new InvalidOperationException ();
@@ -103,8 +64,8 @@ namespace CoreServices {
 
 		public bool AppliesToRequest (CFHTTPMessage request)
 		{
-			if (request == null)
-				throw new ArgumentNullException ("request");
+			if (request is null)
+				throw new ArgumentNullException (nameof (request));
 
 			if (!request.IsRequest)
 				throw new InvalidOperationException ();
@@ -139,13 +100,10 @@ namespace CoreServices {
 		[DllImport (Constants.CFNetworkLibrary)]
 		extern static /* CFString */ IntPtr CFHTTPAuthenticationCopyMethod (/* CFHTTPAuthenticationRef */ IntPtr auth);
 
-		public string GetMethod ()
+		public string? GetMethod ()
 		{
 			var ptr = CFHTTPAuthenticationCopyMethod (Handle);
-			if (ptr == IntPtr.Zero)
-				return null;
-			using (var method = new CFString (ptr))
-				return method;
+			return CFString.FromHandle (ptr, true);
 		}
 	}
 }


### PR DESCRIPTION
* The base class CFType now subclasses NativeObject, so we can remove a lot of unnecessary code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.
* Remove the internal (IntPtr) constructor.