### PR TITLE
[Policy] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreFoundation/NativeObject.cs
+++ b/src/CoreFoundation/NativeObject.cs
@@ -40,7 +40,18 @@ namespace CoreFoundation {
 		}
 
 		protected NativeObject (IntPtr handle, bool owns)
+			: this (handle, owns, false)
 		{
+		}
+
+		protected NativeObject (IntPtr handle, bool owns, bool verify)
+		{
+#if !COREBUILD
+			if (verify && handle == IntPtr.Zero && Class.ThrowOnInitFailure)
+				throw new Exception ($"Could not initialize an instance of the type '{GetType ().FullName}': handle is null.\n" +
+					"It is possible to ignore this condition by setting ObjCRuntime.Class.ThrowOnInitFailure to false.");
+#endif
+
 			Handle = handle;
 			if (!owns)
 				Retain ();


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* This needed another constructor overload in NativeObject that validates that
  the handle is valid, since the Policy class verifies that.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use CFString.CreateNative/ReleaseNative instead of other means to create
  native strings (the fastest and least memory hungry option).
* Remove the (IntPtr) constructor for XAMCORE_4_0.