### PR TITLE
[CFHTTPMessage] Indirectly subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CFNetwork/CFHTTPStream.cs
+++ b/src/CFNetwork/CFHTTPStream.cs
@@ -60,7 +60,7 @@ namespace CoreServices {
 				throw new InvalidCastException ();
 			}
 
-			return new CFHTTPMessage (handle);
+			return new CFHTTPMessage (handle, true);
 		}
 
 		public CFHTTPMessage GetResponseHeader ()
@@ -73,7 +73,7 @@ namespace CoreServices {
 				CFObject.CFRelease (handle);
 				throw new InvalidCastException ();
 			}
-			return new CFHTTPMessage (handle);
+			return new CFHTTPMessage (handle, true);
 		}
 
 		public bool AttemptPersistentConnection {

--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -33,6 +33,7 @@
 //
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 using ObjCRuntime;
@@ -196,16 +197,23 @@ namespace CoreFoundation {
 			return s;
 		}
 
-		public static implicit operator string? (CFString x)
+		public static implicit operator string? (CFString? x)
 		{
+			if (x is null)
+				return null;
+
 			if (x.str == null)
 				x.str = FromHandle (x.Handle);
 			
 			return x.str;
 		}
 
-		public static implicit operator CFString (string s)
+		[return: NotNullIfNotNull ("s")]
+		public static implicit operator CFString? (string? s)
 		{
+			if (s is null)
+				return null;
+
 			return new CFString (s);
 		}
 


### PR DESCRIPTION
* The base class CFType now subclasses NativeObject, so we can remove a lot of unnecessary code.
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use CFString.CreateNative/ReleaseNative instead of other means to create
  native strings (the fastest and least memory hungry option).
* Use 'nameof (parameter)' instead of string constants.
* Remove the internal (IntPtr) constructor.
* Adjust the string<->CFString conversion operators to allow for null input
  (and thus null output), and annotate the operators accordingly when
  possible.