### PR TITLE
[CGShading] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -764,7 +764,7 @@ namespace CoreGraphics {
 
 		public void DrawShading (CGShading shading)
 		{
-			CGContextDrawShading (handle, shading == null ? IntPtr.Zero : shading.handle);
+			CGContextDrawShading (Handle, shading.GetHandle ());
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.
* Call 'GetCheckedHandle ()' (which will throw an ObjectDisposedException if
  Handle == IntPtr.Zero) instead of manually checking for IntPtr.Zero and
  throwing ObjectDisposedException.
* Remove the (IntPtr) constructor for XAMCORE_4_0.