### PR TITLE
[CGContext] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -26,72 +26,48 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
+using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
 namespace CoreGraphics {
 
-	public class CGContext : INativeObject
-#if !COREBUILD
-		, IDisposable
-#endif
+	public class CGContext : NativeObject
 	{
 #if !COREBUILD
-		IntPtr handle;
-
+#if !XAMCORE_4_0
 		public CGContext (IntPtr handle)
-			: this (handle, false)
+			: base (handle, false)
 		{
 		}
+#endif
 
-		internal CGContext ()
-		{
-		}
-		
 		[Preserve (Conditional=true)]
 		internal CGContext (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			Handle = handle;
-			if (!owns)
-				CGContextRetain (handle);
 		}
 
-		~CGContext ()
-		{
-			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-			internal set {
-				if (value == IntPtr.Zero)
-					throw new Exception ("Invalid parameters to context creation");
-				handle = value;
-			}
-		}
-	
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextRelease (/* CGContextRef */ IntPtr c);
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGContextRef */ IntPtr CGContextRetain (/* CGContextRef */ IntPtr c);
-		
-		protected virtual void Dispose (bool disposing)
+
+		protected override void Retain ()
 		{
-			if (handle != IntPtr.Zero){
-				CGContextRelease (handle);
-				handle = IntPtr.Zero;
-			}
+			CGContextRetain (GetCheckedHandle ());
+		}
+
+		protected override void Release ()
+		{
+			CGContextRelease (GetCheckedHandle ());
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -102,12 +78,12 @@ namespace CoreGraphics {
 		
 		public void SaveState ()
 		{
-			CGContextSaveGState (handle);
+			CGContextSaveGState (Handle);
 		}
 
 		public void RestoreState ()
 		{
-			CGContextRestoreGState (handle);
+			CGContextRestoreGState (Handle);
 		}
 
 		//
@@ -119,7 +95,7 @@ namespace CoreGraphics {
 
 		public void ScaleCTM (nfloat sx, nfloat sy)
 		{
-			CGContextScaleCTM (handle, sx, sy);
+			CGContextScaleCTM (Handle, sx, sy);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -127,7 +103,7 @@ namespace CoreGraphics {
 
 		public void TranslateCTM (nfloat tx, nfloat ty)
 		{
-			CGContextTranslateCTM (handle, tx, ty);
+			CGContextTranslateCTM (Handle, tx, ty);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -135,7 +111,7 @@ namespace CoreGraphics {
 
 		public void RotateCTM (nfloat angle)
 		{
-			CGContextRotateCTM (handle, angle);
+			CGContextRotateCTM (Handle, angle);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -143,7 +119,7 @@ namespace CoreGraphics {
 
 		public void ConcatCTM (CGAffineTransform transform)
 		{
-			CGContextConcatCTM (handle, transform);
+			CGContextConcatCTM (Handle, transform);
 		}
 
 		// Settings
@@ -152,7 +128,7 @@ namespace CoreGraphics {
 
 		public void SetLineWidth (nfloat w)
 		{
-			CGContextSetLineWidth (handle, w);
+			CGContextSetLineWidth (Handle, w);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -160,7 +136,7 @@ namespace CoreGraphics {
 
 		public void SetLineCap (CGLineCap cap)
 		{
-			CGContextSetLineCap (handle, cap);
+			CGContextSetLineCap (Handle, cap);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -168,7 +144,7 @@ namespace CoreGraphics {
 
 		public void SetLineJoin (CGLineJoin join)
 		{
-			CGContextSetLineJoin (handle, join);
+			CGContextSetLineJoin (Handle, join);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -176,25 +152,25 @@ namespace CoreGraphics {
 
 		public void SetMiterLimit (nfloat limit)
 		{
-			CGContextSetMiterLimit (handle, limit);
+			CGContextSetMiterLimit (Handle, limit);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextSetLineDash (/* CGContextRef */ IntPtr c, /* CGFloat */ nfloat phase, /* CGFloat[] */ nfloat [] lengths, /* size_t */ nint count);
+		extern static void CGContextSetLineDash (/* CGContextRef */ IntPtr c, /* CGFloat */ nfloat phase, /* CGFloat[] */ nfloat []? lengths, /* size_t */ nint count);
 
-		public void SetLineDash (nfloat phase, nfloat [] lengths)
+		public void SetLineDash (nfloat phase, nfloat []? lengths)
 		{
-			int n = lengths == null ? 0 : lengths.Length;
-			CGContextSetLineDash (handle, phase, lengths, n);
+			int n = lengths is null ? 0 : lengths.Length;
+			CGContextSetLineDash (Handle, phase, lengths, n);
 		}
 
-		public void SetLineDash (nfloat phase, nfloat [] lengths, int n)
+		public void SetLineDash (nfloat phase, nfloat []? lengths, int n)
 		{
-			if (lengths == null)
+			if (lengths is null)
 				n = 0;
 			else if (n < 0 || n > lengths.Length)
-				throw new ArgumentException ("n");
-			CGContextSetLineDash (handle, phase, lengths, n);
+				throw new ArgumentException (nameof (n));
+			CGContextSetLineDash (Handle, phase, lengths, n);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -202,7 +178,7 @@ namespace CoreGraphics {
 
 		public void SetFlatness (nfloat flatness)
 		{
-			CGContextSetFlatness (handle, flatness);
+			CGContextSetFlatness (Handle, flatness);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -210,7 +186,7 @@ namespace CoreGraphics {
 
 		public void SetAlpha (nfloat alpha)
 		{
-			CGContextSetAlpha (handle, alpha);
+			CGContextSetAlpha (Handle, alpha);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -218,7 +194,7 @@ namespace CoreGraphics {
 
 		public void SetBlendMode (CGBlendMode mode)
 		{
-			CGContextSetBlendMode (handle, mode);
+			CGContextSetBlendMode (Handle, mode);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -226,7 +202,7 @@ namespace CoreGraphics {
 
 		public CGAffineTransform GetCTM ()
 		{
-			return CGContextGetCTM (handle);
+			return CGContextGetCTM (Handle);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -234,7 +210,7 @@ namespace CoreGraphics {
 
 		public void BeginPath ()
 		{
-			CGContextBeginPath (handle);
+			CGContextBeginPath (Handle);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -242,7 +218,7 @@ namespace CoreGraphics {
 
 		public void MoveTo (nfloat x, nfloat y)
 		{
-			CGContextMoveToPoint (handle, x, y);
+			CGContextMoveToPoint (Handle, x, y);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -250,7 +226,7 @@ namespace CoreGraphics {
 
 		public void AddLineToPoint (nfloat x, nfloat y)
 		{
-			CGContextAddLineToPoint (handle, x, y);
+			CGContextAddLineToPoint (Handle, x, y);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -258,7 +234,7 @@ namespace CoreGraphics {
 
 		public void AddCurveToPoint (nfloat cp1x, nfloat cp1y, nfloat cp2x, nfloat cp2y, nfloat x, nfloat y)
 		{
-			CGContextAddCurveToPoint (handle, cp1x, cp1y, cp2x, cp2y, x, y);
+			CGContextAddCurveToPoint (Handle, cp1x, cp1y, cp2x, cp2y, x, y);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -266,7 +242,7 @@ namespace CoreGraphics {
 
 		public void AddQuadCurveToPoint (nfloat cpx, nfloat cpy, nfloat x, nfloat y)
 		{
-			CGContextAddQuadCurveToPoint (handle, cpx, cpy, x, y);
+			CGContextAddQuadCurveToPoint (Handle, cpx, cpy, x, y);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -274,7 +250,7 @@ namespace CoreGraphics {
 
 		public void ClosePath ()
 		{
-			CGContextClosePath (handle);
+			CGContextClosePath (Handle);
 		}
 			
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -282,7 +258,7 @@ namespace CoreGraphics {
 
 		public void AddRect (CGRect rect)
 		{
-			CGContextAddRect (handle, rect);
+			CGContextAddRect (Handle, rect);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -290,18 +266,18 @@ namespace CoreGraphics {
 
 		public void AddRects (CGRect [] rects)
 		{
-			if (rects == null)
-				throw new ArgumentNullException ("rects");
-			CGContextAddRects (handle, rects, rects.Length);
+			if (rects is null)
+				throw new ArgumentNullException (nameof (rects));
+			CGContextAddRects (Handle, rects, rects.Length);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextAddLines (/* CGContextRef */ IntPtr c, CGPoint [] points, /* size_t */ nint count);
 		public void AddLines (CGPoint [] points)
 		{
-			if (points == null)
-				throw new ArgumentNullException ("points");
-			CGContextAddLines (handle, points, points.Length);
+			if (points is null)
+				throw new ArgumentNullException (nameof (points));
+			CGContextAddLines (Handle, points, points.Length);
 		}
 			
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -309,7 +285,7 @@ namespace CoreGraphics {
 
 		public void AddEllipseInRect (CGRect rect)
 		{
-			CGContextAddEllipseInRect (handle, rect);
+			CGContextAddEllipseInRect (Handle, rect);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -317,7 +293,7 @@ namespace CoreGraphics {
 
 		public void AddArc (nfloat x, nfloat y, nfloat radius, nfloat startAngle, nfloat endAngle, bool clockwise)
 		{
-			CGContextAddArc (handle, x, y, radius, startAngle, endAngle, clockwise ? 1 : 0);
+			CGContextAddArc (Handle, x, y, radius, startAngle, endAngle, clockwise ? 1 : 0);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -325,7 +301,7 @@ namespace CoreGraphics {
 
 		public void AddArcToPoint (nfloat x1, nfloat y1, nfloat x2, nfloat y2, nfloat radius)
 		{
-			CGContextAddArcToPoint (handle, x1, y1, x2, y2, radius);
+			CGContextAddArcToPoint (Handle, x1, y1, x2, y2, radius);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -333,9 +309,9 @@ namespace CoreGraphics {
 
 		public void AddPath (CGPath path)
 		{
-			if (path == null)
-				throw new ArgumentNullException ("path");
-			CGContextAddPath (handle, path.handle);
+			if (path is null)
+				throw new ArgumentNullException (nameof (path));
+			CGContextAddPath (Handle, path.Handle);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -343,7 +319,7 @@ namespace CoreGraphics {
 
 		public void ReplacePathWithStrokedPath ()
 		{
-			CGContextReplacePathWithStrokedPath (handle);
+			CGContextReplacePathWithStrokedPath (Handle);
 		}
 
 		
@@ -353,7 +329,7 @@ namespace CoreGraphics {
 
 		public bool IsPathEmpty ()
 		{
-			return CGContextIsPathEmpty (handle);
+			return CGContextIsPathEmpty (Handle);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -361,7 +337,7 @@ namespace CoreGraphics {
 
 		public CGPoint GetPathCurrentPoint ()
 		{
-			return CGContextGetPathCurrentPoint (handle);
+			return CGContextGetPathCurrentPoint (Handle);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -369,7 +345,7 @@ namespace CoreGraphics {
 
 		public CGRect GetPathBoundingBox ()
 		{
-			return CGContextGetPathBoundingBox (handle);
+			return CGContextGetPathBoundingBox (Handle);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -378,7 +354,7 @@ namespace CoreGraphics {
 
 		public bool PathContainsPoint (CGPoint point, CGPathDrawingMode mode)
 		{
-			return CGContextPathContainsPoint (handle, point, mode);
+			return CGContextPathContainsPoint (Handle, point, mode);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -386,7 +362,7 @@ namespace CoreGraphics {
 
 		public void DrawPath (CGPathDrawingMode mode)
 		{
-			CGContextDrawPath (handle, mode);
+			CGContextDrawPath (Handle, mode);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -394,7 +370,7 @@ namespace CoreGraphics {
 
 		public void FillPath ()
 		{
-			CGContextFillPath (handle);
+			CGContextFillPath (Handle);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -402,7 +378,7 @@ namespace CoreGraphics {
 
 		public void EOFillPath ()
 		{
-			CGContextEOFillPath (handle);
+			CGContextEOFillPath (Handle);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -410,7 +386,7 @@ namespace CoreGraphics {
 
 		public void StrokePath ()
 		{
-			CGContextStrokePath (handle);
+			CGContextStrokePath (Handle);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -418,7 +394,7 @@ namespace CoreGraphics {
 
 		public void FillRect (CGRect rect)
 		{
-			CGContextFillRect (handle, rect);
+			CGContextFillRect (Handle, rect);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -426,9 +402,9 @@ namespace CoreGraphics {
 
 		public void ContextFillRects (CGRect [] rects)
 		{
-			if (rects == null)
-				throw new ArgumentNullException ("rects");
-			CGContextFillRects (handle, rects, rects.Length);
+			if (rects is null)
+				throw new ArgumentNullException (nameof (rects));
+			CGContextFillRects (Handle, rects, rects.Length);
 		}
 			
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -436,7 +412,7 @@ namespace CoreGraphics {
 
 		public void StrokeRect (CGRect rect)
 		{
-			CGContextStrokeRect (handle, rect);
+			CGContextStrokeRect (Handle, rect);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -444,7 +420,7 @@ namespace CoreGraphics {
 
 		public void StrokeRectWithWidth (CGRect rect, nfloat width)
 		{
-			CGContextStrokeRectWithWidth (handle, rect, width);
+			CGContextStrokeRectWithWidth (Handle, rect, width);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -452,7 +428,7 @@ namespace CoreGraphics {
 
 		public void ClearRect (CGRect rect)
 		{
-			CGContextClearRect (handle, rect);
+			CGContextClearRect (Handle, rect);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -460,7 +436,7 @@ namespace CoreGraphics {
 
 		public void FillEllipseInRect (CGRect rect)
 		{
-			CGContextFillEllipseInRect (handle, rect);
+			CGContextFillEllipseInRect (Handle, rect);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -468,17 +444,17 @@ namespace CoreGraphics {
 
 		public void StrokeEllipseInRect (CGRect rect)
 		{
-			CGContextStrokeEllipseInRect (handle, rect);
+			CGContextStrokeEllipseInRect (Handle, rect);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextStrokeLineSegments (/* CGContextRef __nullable */ IntPtr c, 
-			/* const CGPoint* __nullable */ CGPoint [] points,
+			/* const CGPoint* __nullable */ CGPoint []? points,
 			/* size_t */ nint count);
 
-		public void StrokeLineSegments (CGPoint [] points)
+		public void StrokeLineSegments (CGPoint []? points)
 		{
-			CGContextStrokeLineSegments (handle, points, points == null ? 0 : points.Length);
+			CGContextStrokeLineSegments (Handle, points, points is null ? 0 : points.Length);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -486,7 +462,7 @@ namespace CoreGraphics {
 
 		public void Clip ()
 		{
-			CGContextClip (handle);
+			CGContextClip (Handle);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -494,7 +470,7 @@ namespace CoreGraphics {
 
 		public void EOClip ()
 		{
-			CGContextEOClip (handle);
+			CGContextEOClip (Handle);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -514,16 +490,16 @@ namespace CoreGraphics {
 #endif
 		public void ResetClip ()
 		{
-			CGContextResetClip (handle);
+			CGContextResetClip (Handle);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextClipToMask (/* CGContextRef */ IntPtr c, CGRect rect, 
 			/* CGImageRef __nullable */ IntPtr mask);
 
-		public void ClipToMask (CGRect rect, CGImage mask)
+		public void ClipToMask (CGRect rect, CGImage? mask)
 		{
-			CGContextClipToMask (handle, rect, mask == null ? IntPtr.Zero : mask.handle);
+			CGContextClipToMask (Handle, rect, mask.GetHandle ());
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -531,7 +507,7 @@ namespace CoreGraphics {
 
 		public CGRect GetClipBoundingBox ()
 		{
-			return CGContextGetClipBoundingBox (handle);
+			return CGContextGetClipBoundingBox (Handle);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -539,7 +515,7 @@ namespace CoreGraphics {
 
 		public void ClipToRect (CGRect rect)
 		{
-			CGContextClipToRect (handle, rect);
+			CGContextClipToRect (Handle, rect);
 		}
 		       
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -547,16 +523,16 @@ namespace CoreGraphics {
 
 		public void ClipToRects (CGRect [] rects)
 		{
-			if (rects == null)
-				throw new ArgumentNullException ("rects");
-			CGContextClipToRects (handle, rects, rects.Length);
+			if (rects is null)
+				throw new ArgumentNullException (nameof (rects));
+			CGContextClipToRects (Handle, rects, rects.Length);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetFillColorWithColor (/* CGContextRef */ IntPtr c,
 			/* CGColorRef __nullable */ IntPtr color);
 
-		public void SetFillColor (CGColor color)
+		public void SetFillColor (CGColor? color)
 		{
 			CGContextSetFillColorWithColor (Handle, color.GetHandle ());
 		}
@@ -565,7 +541,7 @@ namespace CoreGraphics {
 		extern static void CGContextSetStrokeColorWithColor (/* CGContextRef */ IntPtr c,
 			/* CGColorRef __nullable */ IntPtr color);
 
-		public void SetStrokeColor (CGColor color)
+		public void SetStrokeColor (CGColor? color)
 		{
 			CGContextSetStrokeColorWithColor (Handle, color.GetHandle ());
 		}
@@ -574,54 +550,54 @@ namespace CoreGraphics {
 		extern static void CGContextSetFillColorSpace (/* CGContextRef */ IntPtr context,
 			/* CGColorSpaceRef __nullable */ IntPtr space);
 
-		public void SetFillColorSpace (CGColorSpace space)
+		public void SetFillColorSpace (CGColorSpace? space)
 		{
-			CGContextSetFillColorSpace (handle, space.GetHandle ());
+			CGContextSetFillColorSpace (Handle, space.GetHandle ());
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetStrokeColorSpace (/* CGContextRef */ IntPtr context,
 			/* CGColorSpaceRef __nullable */ IntPtr space);
 
-		public void SetStrokeColorSpace (CGColorSpace space)
+		public void SetStrokeColorSpace (CGColorSpace? space)
 		{
-			CGContextSetStrokeColorSpace (handle, space.GetHandle ());
+			CGContextSetStrokeColorSpace (Handle, space.GetHandle ());
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetFillColor (/* CGContextRef */ IntPtr context,
-			/* const CGFloat * __nullable */ nfloat [] components);
+			/* const CGFloat * __nullable */ nfloat []? components);
 
-		public void SetFillColor (nfloat [] components)
+		public void SetFillColor (nfloat []? components)
 		{
-			CGContextSetFillColor (handle, components);
+			CGContextSetFillColor (Handle, components);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetStrokeColor (/* CGContextRef */ IntPtr context,
-			/* const CGFloat * __nullable */ nfloat [] components);
+			/* const CGFloat * __nullable */ nfloat []? components);
 
-		public void SetStrokeColor (nfloat [] components)
+		public void SetStrokeColor (nfloat []? components)
 		{
-			CGContextSetStrokeColor (handle, components);
+			CGContextSetStrokeColor (Handle, components);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetFillPattern (/* CGContextRef */ IntPtr context,
-			/* CGPatternRef __nullable */ IntPtr pattern, /* const CGFloat * __nullable */ nfloat [] components);
+			/* CGPatternRef __nullable */ IntPtr pattern, /* const CGFloat * __nullable */ nfloat []? components);
 
-		public void SetFillPattern (CGPattern pattern, nfloat [] components)
+		public void SetFillPattern (CGPattern pattern, nfloat []? components)
 		{
-			CGContextSetFillPattern (handle, pattern.GetHandle (), components);
+			CGContextSetFillPattern (Handle, pattern.GetHandle (), components);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetStrokePattern (/* CGContextRef */ IntPtr context,
-			/* CGPatternRef __nullable */ IntPtr pattern, /* const CGFloat * __nullable */ nfloat [] components);
+			/* CGPatternRef __nullable */ IntPtr pattern, /* const CGFloat * __nullable */ nfloat []? components);
 
-		public void SetStrokePattern (CGPattern pattern, nfloat [] components)
+		public void SetStrokePattern (CGPattern? pattern, nfloat []? components)
 		{
-			CGContextSetStrokePattern (handle, pattern.GetHandle (), components);
+			CGContextSetStrokePattern (Handle, pattern.GetHandle (), components);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -629,7 +605,7 @@ namespace CoreGraphics {
 
 		public void SetPatternPhase (CGSize phase)
 		{
-			CGContextSetPatternPhase (handle, phase);
+			CGContextSetPatternPhase (Handle, phase);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -637,7 +613,7 @@ namespace CoreGraphics {
 
 		public void SetFillColor (nfloat gray, nfloat alpha)
 		{
-			CGContextSetGrayFillColor (handle, gray, alpha);
+			CGContextSetGrayFillColor (Handle, gray, alpha);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -645,7 +621,7 @@ namespace CoreGraphics {
 
 		public void SetStrokeColor (nfloat gray, nfloat alpha)
 		{
-			CGContextSetGrayStrokeColor (handle, gray, alpha);
+			CGContextSetGrayStrokeColor (Handle, gray, alpha);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -653,7 +629,7 @@ namespace CoreGraphics {
 
 		public void SetFillColor (nfloat red, nfloat green, nfloat blue, nfloat alpha)
 		{
-			CGContextSetRGBFillColor (handle, red, green, blue, alpha);
+			CGContextSetRGBFillColor (Handle, red, green, blue, alpha);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -661,7 +637,7 @@ namespace CoreGraphics {
 
 		public void SetStrokeColor (nfloat red, nfloat green, nfloat blue, nfloat alpha)
 		{
-			CGContextSetRGBStrokeColor (handle, red, green, blue, alpha);
+			CGContextSetRGBStrokeColor (Handle, red, green, blue, alpha);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -669,7 +645,7 @@ namespace CoreGraphics {
 
 		public void SetFillColor (nfloat cyan, nfloat magenta, nfloat yellow, nfloat black, nfloat alpha)
 		{
-			CGContextSetCMYKFillColor (handle, cyan, magenta, yellow, black, alpha);
+			CGContextSetCMYKFillColor (Handle, cyan, magenta, yellow, black, alpha);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -677,7 +653,7 @@ namespace CoreGraphics {
 
 		public void SetStrokeColor (nfloat cyan, nfloat magenta, nfloat yellow, nfloat black, nfloat alpha)
 		{
-			CGContextSetCMYKStrokeColor (handle, cyan, magenta, yellow, black, alpha);
+			CGContextSetCMYKStrokeColor (Handle, cyan, magenta, yellow, black, alpha);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -685,25 +661,25 @@ namespace CoreGraphics {
 
 		public void SetRenderingIntent (CGColorRenderingIntent intent)
 		{
-			CGContextSetRenderingIntent (handle, intent);
+			CGContextSetRenderingIntent (Handle, intent);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextDrawImage (/* CGContextRef */ IntPtr c, CGRect rect,
 			/* CGImageRef __nullable */ IntPtr image);
 
-		public void DrawImage (CGRect rect, CGImage image)
+		public void DrawImage (CGRect rect, CGImage? image)
 		{
-			CGContextDrawImage (handle, rect, image == null ? IntPtr.Zero : image.Handle);
+			CGContextDrawImage (Handle, rect, image.GetHandle ());
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextDrawTiledImage (/* CGContextRef */ IntPtr c, CGRect rect,
 			/* CGImageRef __nullable */ IntPtr image);
 
-		public void DrawTiledImage (CGRect rect, CGImage image)
+		public void DrawTiledImage (CGRect rect, CGImage? image)
 		{
-			CGContextDrawTiledImage (handle, rect, image == null ? IntPtr.Zero : image.Handle);
+			CGContextDrawTiledImage (Handle, rect, image.GetHandle ());
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -714,11 +690,11 @@ namespace CoreGraphics {
 		
 		public CGInterpolationQuality  InterpolationQuality {
 			get {
-				return CGContextGetInterpolationQuality (handle);
+				return CGContextGetInterpolationQuality (Handle);
 			}
 
 			set {
-				CGContextSetInterpolationQuality (handle, value);
+				CGContextSetInterpolationQuality (Handle, value);
 			}
 		}
 		
@@ -729,7 +705,7 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetShadow (IntPtr context, CGSize offset, nfloat blur);
 
-		public void SetShadow (CGSize offset, nfloat blur, CGColor color = null)
+		public void SetShadow (CGSize offset, nfloat blur, CGColor? color = null)
 		{
 			if (color is null)
 				CGContextSetShadow (Handle, offset, blur);
@@ -742,9 +718,9 @@ namespace CoreGraphics {
 			/* CGGradientRef __nullable */ IntPtr gradient, CGPoint startPoint, CGPoint endPoint,
 			CGGradientDrawingOptions options);
 
-		public void DrawLinearGradient (CGGradient gradient, CGPoint startPoint, CGPoint endPoint, CGGradientDrawingOptions options)
+		public void DrawLinearGradient (CGGradient? gradient, CGPoint startPoint, CGPoint endPoint, CGGradientDrawingOptions options)
 		{
-			CGContextDrawLinearGradient (handle, gradient == null ? IntPtr.Zero : gradient.handle, startPoint, endPoint, options);
+			CGContextDrawLinearGradient (Handle, gradient.GetHandle (), startPoint, endPoint, options);
 		}
 			
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -753,18 +729,18 @@ namespace CoreGraphics {
 			CGPoint startCenter, /* CGFloat */ nfloat startRadius,
 			CGPoint endCenter, /* CGFloat */ nfloat endRadius, CGGradientDrawingOptions options);
 
-		public void DrawRadialGradient (CGGradient gradient, CGPoint startCenter, nfloat startRadius, CGPoint endCenter, nfloat endRadius, CGGradientDrawingOptions options)
+		public void DrawRadialGradient (CGGradient? gradient, CGPoint startCenter, nfloat startRadius, CGPoint endCenter, nfloat endRadius, CGGradientDrawingOptions options)
 		{
-			CGContextDrawRadialGradient (handle, gradient == null ? IntPtr.Zero : gradient.handle, startCenter, startRadius, endCenter, endRadius, options);
+			CGContextDrawRadialGradient (Handle, gradient.GetHandle (), startCenter, startRadius, endCenter, endRadius, options);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextDrawShading (/* CGContextRef */ IntPtr context,
 			/* CGShadingRef __nullable */ IntPtr shading);
 
-		public void DrawShading (CGShading shading)
+		public void DrawShading (CGShading? shading)
 		{
-			CGContextDrawShading (handle, shading == null ? IntPtr.Zero : shading.handle);
+			CGContextDrawShading (Handle, shading.GetHandle ());
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -772,7 +748,7 @@ namespace CoreGraphics {
 
 		public void SetCharacterSpacing (nfloat spacing)
 		{
-			CGContextSetCharacterSpacing (handle, spacing);
+			CGContextSetCharacterSpacing (Handle, spacing);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -783,10 +759,10 @@ namespace CoreGraphics {
 
 		public CGPoint TextPosition {
 			get {
-				return CGContextGetTextPosition (handle);
+				return CGContextGetTextPosition (Handle);
 			}
 			set {
-				CGContextSetTextPosition (handle, value.X, value.Y);
+				CGContextSetTextPosition (Handle, value.X, value.Y);
 			}
 		}
 
@@ -798,10 +774,10 @@ namespace CoreGraphics {
 
 		public CGAffineTransform TextMatrix {
 			get {
-				return CGContextGetTextMatrix (handle);
+				return CGContextGetTextMatrix (Handle);
 			}
 			set {
-				CGContextSetTextMatrix (handle, value);
+				CGContextSetTextMatrix (Handle, value);
 			}
 		}
 
@@ -810,15 +786,15 @@ namespace CoreGraphics {
 
 		public void SetTextDrawingMode (CGTextDrawingMode mode)
 		{
-			CGContextSetTextDrawingMode (handle, mode);
+			CGContextSetTextDrawingMode (Handle, mode);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetFont (/* CGContextRef */ IntPtr c, /* CGFontRef __nullable */ IntPtr font);
 
-		public void SetFont (CGFont font)
+		public void SetFont (CGFont? font)
 		{
-			CGContextSetFont (handle, font == null ? IntPtr.Zero : font.handle);
+			CGContextSetFont (Handle, font.GetHandle ());
 		}
 			
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -826,7 +802,7 @@ namespace CoreGraphics {
 
 		public void SetFontSize (nfloat size)
 		{
-			CGContextSetFontSize (handle, size);
+			CGContextSetFontSize (Handle, size);
 		}
 
 #if !NET
@@ -838,7 +814,7 @@ namespace CoreGraphics {
 #endif
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSelectFont (/* CGContextRef */ IntPtr c,
-			/* const char* __nullable */ string name, /* CGFloat */ nfloat size, CGTextEncoding textEncoding);
+			/* const char* __nullable */ string? name, /* CGFloat */ nfloat size, CGTextEncoding textEncoding);
 
 #if !NET
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
@@ -852,23 +828,23 @@ namespace CoreGraphics {
 		[Obsolete ("Starting with macos10.9 use the 'CoreText' API instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif
-		public void SelectFont (string name, nfloat size, CGTextEncoding textEncoding)
+		public void SelectFont (string? name, nfloat size, CGTextEncoding textEncoding)
 		{
-			CGContextSelectFont (handle, name, size, textEncoding);
+			CGContextSelectFont (Handle, name, size, textEncoding);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowGlyphsAtPositions (/* CGContextRef __nullable */ IntPtr context,
-			/* const CGGlyph * __nullable */ ushort [] glyphs,
-			/* const CGPoint * __nullable */ CGPoint [] positions, /* size_t */ nint count);
+			/* const CGGlyph * __nullable */ ushort []? glyphs,
+			/* const CGPoint * __nullable */ CGPoint []? positions, /* size_t */ nint count);
 
-		public void ShowGlyphsAtPositions (ushort [] glyphs, CGPoint [] positions, int count = -1)
+		public void ShowGlyphsAtPositions (ushort []? glyphs, CGPoint []? positions, int count = -1)
 		{
-			if (glyphs == null)
+			if (glyphs is null)
 				count = 0;
 			else if (count < 0)
 				count = glyphs.Length;
-			CGContextShowGlyphsAtPositions (handle, glyphs, positions, count);
+			CGContextShowGlyphsAtPositions (Handle, glyphs, positions, count);
 		}
 
 #if !NET
@@ -879,7 +855,7 @@ namespace CoreGraphics {
 		[UnsupportedOSPlatform ("macos10.9")]
 #endif
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextShowText (/* CGContextRef */ IntPtr c, /* const char* __nullable */ string s, /* size_t */ nint length);
+		extern static void CGContextShowText (/* CGContextRef */ IntPtr c, /* const char* __nullable */ string? s, /* size_t */ nint length);
 
 #if !NET
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
@@ -893,13 +869,13 @@ namespace CoreGraphics {
 		[Obsolete ("Starting with macos10.9 use the 'CoreText' API instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif
-		public void ShowText (string str, int count)
+		public void ShowText (string? str, int count)
 		{
-			if (str == null)
+			if (str is null)
 				count = 0;
 			else if (count > str.Length)
-				throw new ArgumentException ("count");
-			CGContextShowText (handle, str, count);
+				throw new ArgumentException (nameof (count));
+			CGContextShowText (Handle, str, count);
 		}
 
 #if !NET
@@ -914,9 +890,9 @@ namespace CoreGraphics {
 		[Obsolete ("Starting with macos10.9 use the 'CoreText' API instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif
-		public void ShowText (string str)
+		public void ShowText (string? str)
 		{
-			CGContextShowText (handle, str, str == null ? 0 : str.Length);
+			CGContextShowText (Handle, str, str is null ? 0 : str.Length);
 		}
 
 #if !NET
@@ -927,7 +903,7 @@ namespace CoreGraphics {
 		[UnsupportedOSPlatform ("macos10.9")]
 #endif
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextShowText (/* CGContextRef */ IntPtr c, /* const char* __nullable */ byte[] bytes, /* size_t */ nint length);
+		extern static void CGContextShowText (/* CGContextRef */ IntPtr c, /* const char* __nullable */ byte[]? bytes, /* size_t */ nint length);
 
 #if !NET
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
@@ -941,13 +917,13 @@ namespace CoreGraphics {
 		[Obsolete ("Starting with macos10.9 use the 'CoreText' API instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif
-		public void ShowText (byte[] bytes, int count)
+		public void ShowText (byte[]? bytes, int count)
 		{
-			if (bytes == null)
+			if (bytes is null)
 				count = 0;
 			else if (count > bytes.Length)
-				throw new ArgumentException ("count");
-			CGContextShowText (handle, bytes, count);
+				throw new ArgumentException (nameof (count));
+			CGContextShowText (Handle, bytes, count);
 		}
 		
 #if !NET
@@ -962,9 +938,9 @@ namespace CoreGraphics {
 		[Obsolete ("Starting with macos10.9 use the 'CoreText' API instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif
-		public void ShowText (byte[] bytes)
+		public void ShowText (byte[]? bytes)
 		{
-			CGContextShowText (handle, bytes, bytes == null ? 0 : bytes.Length);
+			CGContextShowText (Handle, bytes, bytes is null ? 0 : bytes.Length);
 		}
 
 #if !NET
@@ -976,7 +952,7 @@ namespace CoreGraphics {
 #endif
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowTextAtPoint (/* CGContextRef __nullable */ IntPtr c, /* CGFloat */ nfloat x, 
-			/* CGFloat */ nfloat y, /* const char* __nullable */ string str, /* size_t */ nint length);
+			/* CGFloat */ nfloat y, /* const char* __nullable */ string? str, /* size_t */ nint length);
 
 #if !NET
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
@@ -990,9 +966,9 @@ namespace CoreGraphics {
 		[Obsolete ("Starting with macos10.9 use the 'CoreText' API instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif
-		public void ShowTextAtPoint (nfloat x, nfloat y, string str, int length)
+		public void ShowTextAtPoint (nfloat x, nfloat y, string? str, int length)
 		{
-			CGContextShowTextAtPoint (handle, x, y, str, length);
+			CGContextShowTextAtPoint (Handle, x, y, str, length);
 		}
 
 #if !NET
@@ -1007,9 +983,9 @@ namespace CoreGraphics {
 		[Obsolete ("Starting with macos10.9 use the 'CoreText' API instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif
-		public void ShowTextAtPoint (nfloat x, nfloat y, string str)
+		public void ShowTextAtPoint (nfloat x, nfloat y, string? str)
 		{
-			CGContextShowTextAtPoint (handle, x, y, str, str == null ? 0 : str.Length);
+			CGContextShowTextAtPoint (Handle, x, y, str, str is null ? 0 : str.Length);
 		}
 
 #if !NET
@@ -1020,16 +996,16 @@ namespace CoreGraphics {
 		[UnsupportedOSPlatform ("macos10.9")]
 #endif
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextShowTextAtPoint (/* CGContextRef */ IntPtr c, /* CGFloat */ nfloat x, /* CGFloat */ nfloat y, /* const char* */ byte[] bytes, /* size_t */ nint length);
+		extern static void CGContextShowTextAtPoint (/* CGContextRef */ IntPtr c, /* CGFloat */ nfloat x, /* CGFloat */ nfloat y, /* const char* */ byte[]? bytes, /* size_t */ nint length);
 
-		public void ShowTextAtPoint (nfloat x, nfloat y, byte[] bytes, int length)
+		public void ShowTextAtPoint (nfloat x, nfloat y, byte[]? bytes, int length)
 		{
-			CGContextShowTextAtPoint (handle, x, y, bytes, length);
+			CGContextShowTextAtPoint (Handle, x, y, bytes, length);
 		}
 		
-		public void ShowTextAtPoint (nfloat x, nfloat y, byte[] bytes)
+		public void ShowTextAtPoint (nfloat x, nfloat y, byte[]? bytes)
 		{
-			CGContextShowTextAtPoint (handle, x, y, bytes, bytes == null ? 0 : bytes.Length);
+			CGContextShowTextAtPoint (Handle, x, y, bytes, bytes is null ? 0 : bytes.Length);
 		}
 
 #if !NET
@@ -1041,7 +1017,7 @@ namespace CoreGraphics {
 #endif
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowGlyphs (/* CGContextRef __nullable */ IntPtr c,
-			/* const CGGlyph * __nullable */ ushort [] glyphs, /* size_t */ nint count);
+			/* const CGGlyph * __nullable */ ushort []? glyphs, /* size_t */ nint count);
 
 #if !NET
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
@@ -1055,9 +1031,9 @@ namespace CoreGraphics {
 		[Obsolete ("Starting with macos10.9 use the 'CoreText' API instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif
-		public void ShowGlyphs (ushort [] glyphs)
+		public void ShowGlyphs (ushort []? glyphs)
 		{
-			CGContextShowGlyphs (handle, glyphs, glyphs == null ? 0 : glyphs.Length);
+			CGContextShowGlyphs (Handle, glyphs, glyphs is null ? 0 : glyphs.Length);
 		}
 
 #if !NET
@@ -1072,13 +1048,13 @@ namespace CoreGraphics {
 		[Obsolete ("Starting with macos10.9 use the 'CoreText' API instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif
-		public void ShowGlyphs (ushort [] glyphs, int count)
+		public void ShowGlyphs (ushort []? glyphs, int count)
 		{
-			if (glyphs == null)
+			if (glyphs is null)
 				count = 0;
 			else if (count > glyphs.Length)
-				throw new ArgumentException ("count");
-			CGContextShowGlyphs (handle, glyphs, count);
+				throw new ArgumentException (nameof (count));
+			CGContextShowGlyphs (Handle, glyphs, count);
 		}
 		
 #if !NET
@@ -1090,7 +1066,7 @@ namespace CoreGraphics {
 #endif
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowGlyphsAtPoint (/* CGContextRef */ IntPtr context, /* CGFloat */ nfloat x,
-			/* CGFloat */ nfloat y, /* const CGGlyph * __nullable */ ushort [] glyphs, /* size_t */ nint count);
+			/* CGFloat */ nfloat y, /* const CGGlyph * __nullable */ ushort []? glyphs, /* size_t */ nint count);
 
 #if !NET
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
@@ -1104,13 +1080,13 @@ namespace CoreGraphics {
 		[Obsolete ("Starting with macos10.9 use the 'CoreText' API instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif
-		public void ShowGlyphsAtPoint (nfloat x, nfloat y, ushort [] glyphs, int count)
+		public void ShowGlyphsAtPoint (nfloat x, nfloat y, ushort []? glyphs, int count)
 		{
-			if (glyphs == null)
+			if (glyphs is null)
 				count = 0;
 			else if (count > glyphs.Length)
-				throw new ArgumentException ("count");
-			CGContextShowGlyphsAtPoint (handle, x, y, glyphs, count);
+				throw new ArgumentException (nameof (count));
+			CGContextShowGlyphsAtPoint (Handle, x, y, glyphs, count);
 		}
 
 #if !NET
@@ -1125,9 +1101,9 @@ namespace CoreGraphics {
 		[Obsolete ("Starting with macos10.9 use the 'CoreText' API instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif
-		public void ShowGlyphsAtPoint (nfloat x, nfloat y, ushort [] glyphs)
+		public void ShowGlyphsAtPoint (nfloat x, nfloat y, ushort []? glyphs)
 		{
-			CGContextShowGlyphsAtPoint (handle, x, y, glyphs, glyphs == null ? 0 : glyphs.Length);
+			CGContextShowGlyphsAtPoint (Handle, x, y, glyphs, glyphs is null ? 0 : glyphs.Length);
 		}
 
 #if !NET
@@ -1139,8 +1115,8 @@ namespace CoreGraphics {
 #endif
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowGlyphsWithAdvances (/* CGContextRef __nullable */ IntPtr c,
-			/* const CGGlyph * __nullable */ ushort [] glyphs,
-			/* const CGSize * __nullable */ CGSize [] advances, /* size_t */ nint count);
+			/* const CGGlyph * __nullable */ ushort []? glyphs,
+			/* const CGSize * __nullable */ CGSize []? advances, /* size_t */ nint count);
 
 #if !NET
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
@@ -1154,22 +1130,22 @@ namespace CoreGraphics {
 		[Obsolete ("Starting with macos10.9 use the 'CoreText' API instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif
-		public void ShowGlyphsWithAdvances (ushort [] glyphs, CGSize [] advances, int count)
+		public void ShowGlyphsWithAdvances (ushort []? glyphs, CGSize []? advances, int count)
 		{
-			if (glyphs == null)
+			if (glyphs is null)
 				count = 0;
-			if (count > glyphs.Length || count > advances.Length)
-				throw new ArgumentException ("count");
-			CGContextShowGlyphsWithAdvances (handle, glyphs, advances, count);
+			if (count > (glyphs?.Length ?? 0) || count > (advances?.Length ?? 0))
+				throw new ArgumentException (nameof (count));
+			CGContextShowGlyphsWithAdvances (Handle, glyphs, advances, count);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextDrawPDFPage (/* CGContextRef __nullable */ IntPtr c,
 			/* CGPDFPageRef __nullable */ IntPtr page);
 
-		public void DrawPDFPage (CGPDFPage page)
+		public void DrawPDFPage (CGPDFPage? page)
 		{
-			CGContextDrawPDFPage (handle, page == null ? IntPtr.Zero : page.handle);
+			CGContextDrawPDFPage (Handle, page.GetHandle ());
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1180,9 +1156,9 @@ namespace CoreGraphics {
 		{
 			if (rect.HasValue){
 				CGRect v = rect.Value;
-				CGContextBeginPage (handle, &v);
+				CGContextBeginPage (Handle, &v);
 			} else {
-				CGContextBeginPage (handle, null);
+				CGContextBeginPage (Handle, null);
 			}
 		}
 		
@@ -1191,7 +1167,7 @@ namespace CoreGraphics {
 
 		public void EndPage ()
 		{
-			CGContextEndPage (handle);
+			CGContextEndPage (Handle);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1199,7 +1175,7 @@ namespace CoreGraphics {
 
 		public void Flush ()
 		{
-			CGContextFlush (handle);
+			CGContextFlush (Handle);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1207,7 +1183,7 @@ namespace CoreGraphics {
 
 		public void Synchronize ()
 		{
-			CGContextSynchronize (handle);
+			CGContextSynchronize (Handle);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1215,14 +1191,14 @@ namespace CoreGraphics {
 
 		public void SetShouldAntialias (bool shouldAntialias)
 		{
-			CGContextSetShouldAntialias (handle, shouldAntialias);
+			CGContextSetShouldAntialias (Handle, shouldAntialias);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetAllowsAntialiasing (/* CGContextRef */ IntPtr context, [MarshalAs (UnmanagedType.I1)] bool allowsAntialiasing);
 		public void SetAllowsAntialiasing (bool allowsAntialiasing)
 		{
-			CGContextSetAllowsAntialiasing (handle, allowsAntialiasing);
+			CGContextSetAllowsAntialiasing (Handle, allowsAntialiasing);
 		}
 			
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1230,7 +1206,7 @@ namespace CoreGraphics {
 
 		public void SetShouldSmoothFonts (bool shouldSmoothFonts)
 		{
-			CGContextSetShouldSmoothFonts (handle, shouldSmoothFonts);
+			CGContextSetShouldSmoothFonts (Handle, shouldSmoothFonts);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1238,7 +1214,7 @@ namespace CoreGraphics {
 
 		public CGAffineTransform GetUserSpaceToDeviceSpaceTransform ()
 		{
-			return CGContextGetUserSpaceToDeviceSpaceTransform (handle);
+			return CGContextGetUserSpaceToDeviceSpaceTransform (Handle);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1246,7 +1222,7 @@ namespace CoreGraphics {
 
 		public CGPoint PointToDeviceSpace (CGPoint point)
 		{
-			return CGContextConvertPointToDeviceSpace (handle, point);
+			return CGContextConvertPointToDeviceSpace (Handle, point);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1254,7 +1230,7 @@ namespace CoreGraphics {
 
 		public CGPoint ConvertPointToUserSpace (CGPoint point)
 		{
-			return CGContextConvertPointToUserSpace (handle, point);
+			return CGContextConvertPointToUserSpace (Handle, point);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1262,7 +1238,7 @@ namespace CoreGraphics {
 
 		public CGSize ConvertSizeToDeviceSpace (CGSize size)
 		{
-			return CGContextConvertSizeToDeviceSpace (handle, size);
+			return CGContextConvertSizeToDeviceSpace (Handle, size);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1270,7 +1246,7 @@ namespace CoreGraphics {
 
 		public CGSize ConvertSizeToUserSpace (CGSize size)
 		{
-			return CGContextConvertSizeToUserSpace (handle, size);
+			return CGContextConvertSizeToUserSpace (Handle, size);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1278,7 +1254,7 @@ namespace CoreGraphics {
 
 		public CGRect ConvertRectToDeviceSpace (CGRect rect)
 		{
-			return CGContextConvertRectToDeviceSpace (handle, rect);
+			return CGContextConvertRectToDeviceSpace (Handle, rect);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1286,7 +1262,7 @@ namespace CoreGraphics {
 
 		public CGRect ConvertRectToUserSpace (CGRect rect)
 		{
-			return CGContextConvertRectToUserSpace (handle, rect);
+			return CGContextConvertRectToUserSpace (Handle, rect);
 		}
 
 		// CGLayer.h
@@ -1295,9 +1271,9 @@ namespace CoreGraphics {
 
 		public void DrawLayer (CGLayer layer, CGRect rect)
 		{
-			if (layer == null)
-				throw new ArgumentNullException ("layer");
-			CGContextDrawLayerInRect (handle, rect, layer.Handle);
+			if (layer is null)
+				throw new ArgumentNullException (nameof (layer));
+			CGContextDrawLayerInRect (Handle, rect, layer.Handle);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1305,9 +1281,9 @@ namespace CoreGraphics {
 
 		public void DrawLayer (CGLayer layer, CGPoint point)
 		{
-			if (layer == null)
-				throw new ArgumentNullException ("layer");
-			CGContextDrawLayerAtPoint (handle, point, layer.Handle);
+			if (layer is null)
+				throw new ArgumentNullException (nameof (layer));
+			CGContextDrawLayerAtPoint (Handle, point, layer.Handle);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1315,7 +1291,7 @@ namespace CoreGraphics {
 
 		public CGPath CopyPath ()
 		{
-			var r = CGContextCopyPath (handle);
+			var r = CGContextCopyPath (Handle);
 			return new CGPath (r, true);
 		}
 
@@ -1324,7 +1300,7 @@ namespace CoreGraphics {
 
 		public void SetAllowsFontSmoothing (bool allows)
 		{
-			CGContextSetAllowsFontSmoothing (handle, allows);
+			CGContextSetAllowsFontSmoothing (Handle, allows);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1332,7 +1308,7 @@ namespace CoreGraphics {
 
 		public void SetAllowsSubpixelPositioning (bool allows)
 		{
-			CGContextSetAllowsFontSubpixelPositioning (handle, allows);
+			CGContextSetAllowsFontSubpixelPositioning (Handle, allows);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1340,7 +1316,7 @@ namespace CoreGraphics {
 
 		public void SetAllowsFontSubpixelQuantization (bool allows)
 		{
-			CGContextSetAllowsFontSubpixelQuantization (handle, allows);
+			CGContextSetAllowsFontSubpixelQuantization (Handle, allows);
 		}
 			
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1348,7 +1324,7 @@ namespace CoreGraphics {
 
 		public void SetShouldSubpixelPositionFonts (bool shouldSubpixelPositionFonts)
 		{
-			CGContextSetShouldSubpixelPositionFonts (handle, shouldSubpixelPositionFonts);
+			CGContextSetShouldSubpixelPositionFonts (Handle, shouldSubpixelPositionFonts);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1356,23 +1332,23 @@ namespace CoreGraphics {
 
 		public void ShouldSubpixelQuantizeFonts (bool shouldSubpixelQuantizeFonts)
 		{
-			CGContextSetShouldSubpixelQuantizeFonts (handle, shouldSubpixelQuantizeFonts);
+			CGContextSetShouldSubpixelQuantizeFonts (Handle, shouldSubpixelQuantizeFonts);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextBeginTransparencyLayer (/* CGContextRef */ IntPtr context, /* CFDictionaryRef __nullable */ IntPtr auxiliaryInfo);
 
-		public void BeginTransparencyLayer (NSDictionary auxiliaryInfo = null)
+		public void BeginTransparencyLayer (NSDictionary? auxiliaryInfo = null)
 		{
-			CGContextBeginTransparencyLayer (handle, auxiliaryInfo == null ? IntPtr.Zero : auxiliaryInfo.Handle);
+			CGContextBeginTransparencyLayer (Handle, auxiliaryInfo.GetHandle ());
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextBeginTransparencyLayerWithRect (/* CGContextRef */ IntPtr context, CGRect rect, /* CFDictionaryRef __nullable */ IntPtr auxiliaryInfo);
 
-		public void BeginTransparencyLayer (CGRect rectangle, NSDictionary auxiliaryInfo = null)
+		public void BeginTransparencyLayer (CGRect rectangle, NSDictionary? auxiliaryInfo = null)
 		{
-			CGContextBeginTransparencyLayerWithRect (handle, rectangle, auxiliaryInfo == null ? IntPtr.Zero : auxiliaryInfo.Handle);
+			CGContextBeginTransparencyLayerWithRect (Handle, rectangle, auxiliaryInfo.GetHandle ());
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -1380,7 +1356,7 @@ namespace CoreGraphics {
 
 		public void EndTransparencyLayer ()
 		{
-			CGContextEndTransparencyLayer (handle);
+			CGContextEndTransparencyLayer (Handle);
 		}
 
 		public CGBitmapContext AsBitmapContext ()

--- a/src/CoreGraphics/CGContextPDF.cs
+++ b/src/CoreGraphics/CGContextPDF.cs
@@ -149,10 +149,15 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		unsafe extern static /* CGContextRef */ IntPtr CGPDFContextCreate (/* CGDataConsumerRef */ IntPtr consumer, CGRect *mediaBox, /* CFDictionaryRef */ IntPtr auxiliaryInfo);
 
-		unsafe CGContextPDF (CGDataConsumer dataConsumer, CGRect *mediaBox, CGPDFInfo info)
+		static unsafe IntPtr Create (CGDataConsumer dataConsumer, CGRect *mediaBox, CGPDFInfo info)
 		{
-			using (var dict = info == null ? null : info.ToDictionary ())
-				Handle = CGPDFContextCreate (dataConsumer.GetHandle (), mediaBox, dict.GetHandle ());
+			using (var dict = info?.ToDictionary ())
+				return CGPDFContextCreate (dataConsumer.GetHandle (), mediaBox, dict.GetHandle ());
+		}
+
+		unsafe CGContextPDF (CGDataConsumer dataConsumer, CGRect *mediaBox, CGPDFInfo info)
+			: base (Create (dataConsumer, mediaBox, info), true)
+		{
 		}
 
 		public unsafe CGContextPDF (CGDataConsumer dataConsumer, CGRect mediaBox, CGPDFInfo info) :
@@ -175,10 +180,15 @@ namespace CoreGraphics {
 		{
 		}
 
-		unsafe CGContextPDF (NSUrl url, CGRect *mediaBox, CGPDFInfo info)
+		static unsafe IntPtr Create (NSUrl url, CGRect *mediaBox, CGPDFInfo info)
 		{
-			using (var dict = info == null ? null : info.ToDictionary ())
-				Handle = CGPDFContextCreateWithURL (url.GetHandle (), mediaBox, dict.GetHandle ());
+			using (var dict = info?.ToDictionary ())
+				return CGPDFContextCreateWithURL (url.GetHandle (), mediaBox, dict.GetHandle ());
+		}
+
+		unsafe CGContextPDF (NSUrl url, CGRect *mediaBox, CGPDFInfo info)
+			: base (Create (url, mediaBox, info), true)
+		{
 		}
 
 		public unsafe CGContextPDF (NSUrl url, CGRect mediaBox, CGPDFInfo info) :


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.
* Call 'GetCheckedHandle ()' (which will throw an ObjectDisposedException if
  Handle == IntPtr.Zero) instead of manually checking for IntPtr.Zero and
  throwing ObjectDisposedException.
* Remove the (IntPtr) constructor for XAMCORE_4_0.