### PR TITLE
[CGDataConsumer] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreGraphics/CGDataConsumer.cs
+++ b/src/CoreGraphics/CGDataConsumer.cs
@@ -25,46 +25,31 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
+using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
 namespace CoreGraphics {
 
 	// CGDataConsumer.h
-	public partial class CGDataConsumer : INativeObject, IDisposable {
-		internal IntPtr handle;
-
-		// invoked by marshallers
+	public partial class CGDataConsumer : NativeObject {
+#if !XAMCORE_4_0
 		public CGDataConsumer (IntPtr handle)
-			: this (handle, false)
+			: base (handle, false)
 		{
-			this.handle = handle;
 		}
+#endif
 
 		[Preserve (Conditional=true)]
 		internal CGDataConsumer (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			this.handle = handle;
-			if (!owns)
-				CGDataConsumerRetain (handle);
-		}
-
-		~CGDataConsumer ()
-		{
-			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -73,34 +58,46 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGDataConsumerRef */ IntPtr CGDataConsumerRetain (/* CGDataConsumerRef */ IntPtr consumer);
 
-		protected virtual void Dispose (bool disposing)
+		protected override void Retain ()
 		{
-			if (handle != IntPtr.Zero){
-				CGDataConsumerRelease (handle);
-				handle = IntPtr.Zero;
-			}
+			CGDataConsumerRetain (GetCheckedHandle ());
+		}
+
+		protected override void Release ()
+		{
+			CGDataConsumerRelease (GetCheckedHandle ());
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGDataConsumerRef */ IntPtr CGDataConsumerCreateWithCFData (/* CFMutableDataRef __nullable */ IntPtr data);
 
-		public CGDataConsumer (NSMutableData data)
+		static IntPtr Create (NSMutableData data)
 		{
 			// not it's a __nullable parameter but it would return nil (see unit tests) and create an invalid instance
-			if (data == null)
-				throw new ArgumentNullException ("data");
-			handle = CGDataConsumerCreateWithCFData (data.Handle);
+			if (data is null)
+				throw new ArgumentNullException (nameof (data));
+			return CGDataConsumerCreateWithCFData (data.Handle);
+		}
+
+		public CGDataConsumer (NSMutableData data)
+			: base (Create (data), true)
+		{
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGDataConsumerRef */ IntPtr CGDataConsumerCreateWithURL (/* CFURLRef __nullable */ IntPtr url);
 
-		public CGDataConsumer (NSUrl url)
+		static IntPtr Create (NSUrl url)
 		{
 			// not it's a __nullable parameter but it would return nil (see unit tests) and create an invalid instance
-			if (url == null)
-				throw new ArgumentNullException ("url");
-			handle = CGDataConsumerCreateWithURL (url.Handle);
+			if (url is null)
+				throw new ArgumentNullException (nameof (url));
+			return CGDataConsumerCreateWithURL (url.Handle);
+		}
+
+		public CGDataConsumer (NSUrl url)
+			: base (Create (url), true)
+		{
 		}
 	}
 }


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use CFString.CreateNative/ReleaseNative instead of other means to create
  native strings (the fastest and least memory hungry option).
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.