### PR TITLE
[CGEventSource] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreGraphics/CGEventSource.cs
+++ b/src/CoreGraphics/CGEventSource.cs
@@ -8,14 +8,14 @@
  *    Miguel de Icaza
  */
 
+#nullable enable
+
 #if MONOMAC || __MACCATALYST__
 
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-#if !NO_SYSTEM_DRAWING
-using System.Drawing;
-#endif
+
 using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
@@ -26,52 +26,29 @@ namespace CoreGraphics {
 #else
 	[SupportedOSPlatform ("maccatalyst15.0")]
 #endif
-	public sealed class CGEventSource : IDisposable, INativeObject {
-		IntPtr handle;
+	public sealed class CGEventSource : NativeObject {
+#if !XAMCORE_4_0
+		public CGEventSource (IntPtr handle)
+			: base (handle, false)
+		{
+		}
+#endif
 
-#region Lifecycle
-		public CGEventSource (IntPtr handle) : this (handle, false)
+#if XAMCORE_4_0
+		internal CGEventSource (IntPtr handle, bool owns)
+#else
+		public CGEventSource (IntPtr handle, bool owns)
+#endif
+			: base (handle, owns)
 		{
 		}
 
-		public CGEventSource (IntPtr handle, bool ownsHandle)
-		{
-			if (!ownsHandle)
-				CFObject.CFRetain (handle);
-			this.handle = handle;
-		}
-
-		~CGEventSource ()
-		{
-			Dispose (false);
-		}
-
-		public IntPtr Handle {
-			get {
-				return handle;
-			}
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero) {
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
-		}
-#endregion
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary)]
 		extern static IntPtr CGEventSourceCreate (CGEventSourceStateID stateID);
 	
 		public CGEventSource (CGEventSourceStateID stateID)
+			: base (CGEventSourceCreate (stateID), true)
 		{
-			handle = CGEventSourceCreate (stateID);
 		}
 
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary)]
@@ -82,10 +59,10 @@ namespace CoreGraphics {
 
 		public int KeyboardType  {
 			get {
-				return CGEventSourceGetKeyboardType (handle);
+				return CGEventSourceGetKeyboardType (Handle);
 			}
 			set {
-				CGEventSourceSetKeyboardType (handle, value);
+				CGEventSourceSetKeyboardType (Handle, value);
 			}
 		}
 
@@ -94,7 +71,7 @@ namespace CoreGraphics {
 		
 		public CGEventSourceStateID StateID {
 			get {
-				return CGEventSourceGetSourceStateID (handle);
+				return CGEventSourceGetSourceStateID (Handle);
 			}
 		}
 
@@ -107,10 +84,10 @@ namespace CoreGraphics {
 		
 		public double PixelsPerLine {
 			get {
-				return CGEventSourceGetPixelsPerLine (handle);
+				return CGEventSourceGetPixelsPerLine (Handle);
 			}
 			set {
-				CGEventSourceSetPixelsPerLine (handle, value);
+				CGEventSourceSetPixelsPerLine (Handle, value);
 			}
 		}
 
@@ -139,10 +116,10 @@ namespace CoreGraphics {
 
 		public long UserData {
 			get {
-				return CGEventSourceGetUserData (handle);
+				return CGEventSourceGetUserData (Handle);
 			}
 			set {
-				CGEventSourceSetUserData (handle, value);
+				CGEventSourceSetUserData (Handle, value);
 			}
 		}
 
@@ -152,7 +129,7 @@ namespace CoreGraphics {
 
 		public void SetLocalEventsFilterDuringSupressionState (CGEventFilterMask filter, CGEventSuppressionState state)
 		{
-			CGEventSourceSetLocalEventsFilterDuringSuppressionState (handle, filter, state);
+			CGEventSourceSetLocalEventsFilterDuringSuppressionState (Handle, filter, state);
 		}
 		
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary)]
@@ -160,7 +137,7 @@ namespace CoreGraphics {
 
 		public CGEventFilterMask GetLocalEventsFilterDuringSupressionState (CGEventSuppressionState state)
 		{
-			return CGEventSourceGetLocalEventsFilterDuringSuppressionState (handle, state);
+			return CGEventSourceGetLocalEventsFilterDuringSuppressionState (Handle, state);
 		}
 		
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary)]
@@ -171,10 +148,10 @@ namespace CoreGraphics {
 
 		public double LocalEventsSupressionInterval {
 			get {
-				return CGEventSourceGetLocalEventsSuppressionInterval (handle);
+				return CGEventSourceGetLocalEventsSuppressionInterval (Handle);
 			}
 			set {
-				CGEventSourceSetLocalEventsSuppressionInterval (handle, value);
+				CGEventSourceSetLocalEventsSuppressionInterval (Handle, value);
 			}
 		}
 		


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Remove the (IntPtr) constructor for XAMCORE_4_0.
* Make the (IntPtr, bool) constructor internal for XAMCORE_4_0.