### PR TITLE
[xcode13.1] [WebKit] Add methods removed by Apple.

### DIFF
--- a/src/WKWebKit/WKCompat.cs
+++ b/src/WKWebKit/WKCompat.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Threading.Tasks;
+using System.Runtime.Versioning;
 
 using Foundation;
+using ObjCRuntime;
 
 #nullable enable
 
@@ -13,6 +16,131 @@ namespace WebKit {
 		public WKWebsiteDataStore ()
 		{
 		}
+	}
+
+	public partial class WKWebView {
+
+#if !NET
+		[Mac (11,3), iOS (14,5), MacCatalyst (14,5)]
+#else
+		[SupportedOSPlatform ("ios14.5"), SupportedOSPlatform ("macos11.3"), SupportedOSPlatform ("maccatalyst14.5")]
+#endif
+		[Obsolete ("Use 'CloseAllMediaPresentations (Action completionHandler)' instead.")]
+		public virtual void CloseAllMediaPresentations () {
+#if IOS || __MACCATALYST__
+ 				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+#elif MONOMAC
+ 				if (PlatformHelper.CheckSystemVersion (12, 0))
+#endif
+					CloseAllMediaPresentationsAsync ().Wait();
+				else
+					_OldCloseAllMediaPresentations ();
+		}
+
+#if !NET
+		[Mac (11,3), iOS (14,5), MacCatalyst (14,5)]
+#else
+		[SupportedOSPlatform ("ios14.5"), SupportedOSPlatform ("macos11.3"), SupportedOSPlatform ("maccatalyst14.5")]
+#endif
+ 		public virtual void PauseAllMediaPlayback (Action? completionHandler)
+		{
+#if IOS || __MACCATALYST__
+ 				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+#elif MONOMAC
+ 				if (PlatformHelper.CheckSystemVersion (12, 0))
+#endif
+					_NewPauseAllMediaPlayback (completionHandler);
+				else
+					_OldPauseAllMediaPlayback (completionHandler);
+		}
+
+#if !NET
+		[Mac (11,3), iOS (14,5), MacCatalyst (14,5)]
+#else
+		[SupportedOSPlatform ("ios14.5"), SupportedOSPlatform ("macos11.3"), SupportedOSPlatform ("maccatalyst14.5")]
+#endif
+ 		public virtual Task PauseAllMediaPlaybackAsync ()
+		{
+#if IOS || __MACCATALYST__
+ 				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+#elif MONOMAC
+ 				if (PlatformHelper.CheckSystemVersion (12, 0))
+#endif
+					return _NewPauseAllMediaPlaybackAsync ();
+				else
+					return _OldPauseAllMediaPlaybackAsync ();
+		}
+
+#if !NET
+		[Mac (11,3), iOS (14,5), MacCatalyst (14,5)]
+#else
+		[SupportedOSPlatform ("ios14.5"), SupportedOSPlatform ("macos11.3"), SupportedOSPlatform ("maccatalyst14.5")]
+#endif
+		[Obsolete ("Use 'SetAllMediaPlaybackSuspended' instead.")]
+ 		public virtual void SuspendAllMediaPlayback (Action? completionHandler)
+		{
+#if IOS || __MACCATALYST__
+ 				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+#elif MONOMAC
+ 				if (PlatformHelper.CheckSystemVersion (12, 0))
+#endif
+					SetAllMediaPlaybackSuspended (true, completionHandler);
+				else
+					_OldSuspendAllMediaPlayback (completionHandler);
+		}
+
+#if !NET
+		[Mac (11,3), iOS (14,5), MacCatalyst (14,5)]
+#else
+		[SupportedOSPlatform ("ios14.5"), SupportedOSPlatform ("macos11.3"), SupportedOSPlatform ("maccatalyst14.5")]
+#endif
+ 		public virtual Task SuspendAllMediaPlaybackAsync ()
+		{
+#if IOS || __MACCATALYST__
+ 				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+#elif MONOMAC
+ 				if (PlatformHelper.CheckSystemVersion (12, 0))
+#endif
+					return SetAllMediaPlaybackSuspendedAsync (true);
+				else
+					return _OldSuspendAllMediaPlaybackAsync ();
+		}
+
+#if !NET
+		[Mac (11,3), iOS (14,5), MacCatalyst (14,5)]
+#else
+		[SupportedOSPlatform ("ios14.5"), SupportedOSPlatform ("macos11.3"), SupportedOSPlatform ("maccatalyst14.5")]
+#endif
+		[Obsolete ("Use 'SetAllMediaPlaybackSuspended' instead.")]
+ 		public virtual void ResumeAllMediaPlayback (Action? completionHandler)
+		{
+#if IOS || __MACCATALYST__
+ 				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+#elif MONOMAC
+ 				if (PlatformHelper.CheckSystemVersion (12, 0))
+#endif
+					SetAllMediaPlaybackSuspended (false, completionHandler);
+				else
+					_OldResumeAllMediaPlayback (completionHandler);
+		}
+
+#if !NET
+		[Mac (11,3), iOS (14,5), MacCatalyst (14,5)]
+#else
+		[SupportedOSPlatform ("ios14.5"), SupportedOSPlatform ("macos11.3"), SupportedOSPlatform ("maccatalyst14.5")]
+#endif
+ 		public virtual Task ResumeAllMediaPlaybackAsync ()
+		{
+#if IOS || __MACCATALYST__
+ 				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+#elif MONOMAC
+ 				if (PlatformHelper.CheckSystemVersion (12, 0))
+#endif
+					return SetAllMediaPlaybackSuspendedAsync (false);
+				else
+					return _OldResumeAllMediaPlaybackAsync ();
+		}
+
 	}
 #endif
 }

--- a/src/wkwebkit.cs
+++ b/src/wkwebkit.cs
@@ -897,32 +897,48 @@ namespace WebKit
 		NSPrintOperation GetPrintOperation (NSPrintInfo printInfo);
 
 		// Apple renamed those API since Xcode 12.5
-
-		// [Mac (11,3)][iOS (14,5)]
-		// [MacCatalyst (14,5)]
-		// [Export ("closeAllMediaPresentations")]
-		// void CloseAllMediaPresentations ();
+		[Internal]
+		[Mac (11,3)][iOS (14,5)]
+		[MacCatalyst (14,5)]
+ 		[Export ("closeAllMediaPresentations")]
+ 		void _OldCloseAllMediaPresentations ();
 
 		[Async]
 		[Mac (12,0), iOS (15,0), MacCatalyst (15,0), NoTV]
 		[Export ("closeAllMediaPresentationsWithCompletionHandler:")]
 		void CloseAllMediaPresentations ([NullAllowed] Action completionHandler);
 
+		[Internal]
+		[Mac (11,3)][iOS (14,5)]
+ 		[MacCatalyst (14,5)]
+ 		[Async]
+ 		[Export ("pauseAllMediaPlayback:")]
+ 		void _OldPauseAllMediaPlayback ([NullAllowed] Action completionHandler);
+
+		[Internal]
 		[Async]
 		[Mac (12,0), iOS (15,0), MacCatalyst (15,0), NoTV]
 		[Export ("pauseAllMediaPlaybackWithCompletionHandler:")]
-		void PauseAllMediaPlayback ([NullAllowed] Action completionHandler);
+		void _NewPauseAllMediaPlayback ([NullAllowed] Action completionHandler);
+
+		[Internal]
+		[Mac (11,3)][iOS (14,5)]
+ 		[MacCatalyst (14,5)]
+ 		[Async]
+ 		[Export ("suspendAllMediaPlayback:")]
+ 		void _OldSuspendAllMediaPlayback ([NullAllowed] Action completionHandler);
+
+		[Internal]
+		[Mac (11,3)][iOS (14,5)]
+ 		[MacCatalyst (14,5)]
+ 		[Async]
+ 		[Export ("resumeAllMediaPlayback:")]
+ 		void _OldResumeAllMediaPlayback ([NullAllowed] Action completionHandler);
 
 		[Async]
 		[Mac (12,0), iOS (15,0), MacCatalyst (15,0), NoTV]
 		[Export ("setAllMediaPlaybackSuspended:completionHandler:")]
 		void SetAllMediaPlaybackSuspended (bool suspended, [NullAllowed] Action completionHandler);
-
-		// [Mac (11,3)][iOS (14,5)]
-		// [MacCatalyst (14,5)]
-		// [Async]
-		// [Export ("resumeAllMediaPlayback:")]
-		// void ResumeAllMediaPlayback ([NullAllowed] Action completionHandler);
 
 		[Async]
 		[Mac (12,0), iOS (15,0), MacCatalyst (15,0), NoTV]

--- a/tests/xtro-sharpie/common-WebKit.ignore
+++ b/tests/xtro-sharpie/common-WebKit.ignore
@@ -1,8 +1,4 @@
 # added and removed in the same version.
-!missing-selector! WKWebView::closeAllMediaPresentations not bound
 !missing-selector! WKWebView::loadSimulatedRequest:withResponse:responseData: not bound
 !missing-selector! WKWebView::loadSimulatedRequest:withResponseHTMLString: not bound
-!missing-selector! WKWebView::pauseAllMediaPlayback: not bound
 !missing-selector! WKWebView::requestMediaPlaybackState: not bound
-!missing-selector! WKWebView::resumeAllMediaPlayback: not bound
-!missing-selector! WKWebView::suspendAllMediaPlayback: not bound


### PR DESCRIPTION
Apple removed methods without deprecating and did not add them back
after a rdar was reported. We can implement those methofs using the new
ones.


Backport of #13133
