### PR TITLE
[CGLayer] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreGraphics/CGLayer.cs
+++ b/src/CoreGraphics/CGLayer.cs
@@ -26,68 +26,41 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
+using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
 namespace CoreGraphics {
 
 	// CGLayer.h
-	public class CGLayer : INativeObject
-#if !COREBUILD
-		, IDisposable
-#endif
+	public class CGLayer : NativeObject
 	{
 #if !COREBUILD
-		IntPtr handle;
-
-		internal CGLayer (IntPtr handle)
-		{
-			if (handle == IntPtr.Zero)
-				throw new Exception ("Invalid parameters to layer creation");
-					
-			this.handle = handle;
-			CGLayerRetain (handle);
-		}
-
 		[Preserve (Conditional=true)]
 		internal CGLayer (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (!owns)
-				CGLayerRetain (handle);
-
-			this.handle = handle;
 		}
 
-		~CGLayer ()
-		{
-			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-	
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGLayerRelease (/* CGLayerRef */ IntPtr layer);
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGLayerRef */ IntPtr CGLayerRetain (/* CGLayerRef */ IntPtr layer);
 		
-		protected virtual void Dispose (bool disposing)
+		protected override void Retain ()
 		{
-			if (handle != IntPtr.Zero){
-				CGLayerRelease (handle);
-				handle = IntPtr.Zero;
-			}
+			CGLayerRetain (GetCheckedHandle ());
+		}
+
+		protected override void Release ()
+		{
+			CGLayerRelease (GetCheckedHandle ());
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -95,7 +68,7 @@ namespace CoreGraphics {
 
 		public CGSize Size {
 			get {
-				return CGLayerGetSize (handle);
+				return CGLayerGetSize (Handle);
 			}
 		}
 		
@@ -104,17 +77,17 @@ namespace CoreGraphics {
 
 		public CGContext Context {
 			get {
-				return new CGContext (CGLayerGetContext (handle));
+				return new CGContext (CGLayerGetContext (Handle));
 			}
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGLayerRef */ IntPtr CGLayerCreateWithContext (/* CGContextRef */ IntPtr context, CGSize size, /* CFDictionaryRef */ IntPtr auxiliaryInfo);
 
-		public static CGLayer Create (CGContext context, CGSize size)
+		public static CGLayer Create (CGContext? context, CGSize size)
 		{
 			// note: auxiliaryInfo is reserved and should be null
-			return new CGLayer (CGLayerCreateWithContext (context == null ? IntPtr.Zero : context.Handle, size, IntPtr.Zero), true);
+			return new CGLayer (CGLayerCreateWithContext (context.GetHandle (), size, IntPtr.Zero), true);
 		}
 #endif
 	}


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Remove the internal (IntPtr) constructor.