### PR TITLE
[CGPath] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -25,10 +25,14 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
+using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
@@ -63,69 +67,43 @@ namespace CoreGraphics {
 		public CGPoint Point3;
 	}
 	
-	public class CGPath : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CGPath : NativeObject {
+#if !COREBUILD
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGMutablePathRef */ IntPtr CGPathCreateMutable ();
 
 		public CGPath ()
+			: base (CGPathCreateMutable (), true)
 		{
-			handle = CGPathCreateMutable ();
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGMutablePathRef */ IntPtr CGPathCreateMutableCopyByTransformingPath (/* CGPathRef */ IntPtr path, /* const CGAffineTransform* */ ref CGAffineTransform transform);
 
 		public CGPath (CGPath reference, CGAffineTransform transform)
+			: base (CGPathCreateMutableCopyByTransformingPath (Runtime.ThrowOnNull (reference, nameof (reference)).Handle, ref transform), true)
 		{
-			if (reference == null)
-				throw new ArgumentNullException ("reference");
-			handle = CGPathCreateMutableCopyByTransformingPath (reference.Handle, ref transform);
 		}
 	
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGMutablePathRef */ IntPtr CGPathCreateMutableCopy (/* CGPathRef */ IntPtr path);
 
 		public CGPath (CGPath basePath)
+			: base (CGPathCreateMutableCopy (Runtime.ThrowOnNull (basePath, nameof (basePath)).Handle), true)
 		{
-			if (basePath == null)
-				throw new ArgumentNullException ("basePath");
-			handle = CGPathCreateMutableCopy (basePath.handle);
 		}
 
-		//
-		// For use by marshallrs
-		//
+#if !XAMCORE_4_0
 		public CGPath (IntPtr handle)
+			: base (handle, false)
 		{
-			CGPathRetain (handle);
-			this.handle = handle;
 		}
+#endif
 
-		// Indicates that we own it `owns'
 		[Preserve (Conditional=true)]
 		internal CGPath (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (!owns)
-				CGPathRetain (handle);
-			
-			this.handle = handle;
-		}
-		
-		~CGPath ()
-		{
-			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
 		}
 	
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -133,16 +111,17 @@ namespace CoreGraphics {
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGPathRef */ IntPtr CGPathRetain (/* CGPathRef */ IntPtr path);
-		
-		protected virtual void Dispose (bool disposing)
+
+		protected override void Retain ()
 		{
-			if (handle != IntPtr.Zero){
-				CGPathRelease (handle);
-				handle = IntPtr.Zero;
-			}
+			CGPathRetain (GetCheckedHandle ());
 		}
 
-#if !COREBUILD
+		protected override void Release ()
+		{
+			CGPathRelease (GetCheckedHandle ());
+		}
+
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPathEqualToPath (/* CGPathRef */ IntPtr path1, /* CGPathRef */ IntPtr path2);
@@ -159,16 +138,16 @@ namespace CoreGraphics {
 
 		public override int GetHashCode ()
 		{
-			return handle.GetHashCode ();
+			return Handle.GetHashCode ();
 		}
 
-		public override bool Equals (object o)
+		public override bool Equals (object? o)
 		{
-			CGPath other = o as CGPath;
-			if (other == null)
+			var other = o as CGPath;
+			if (other is null)
 				return false;
 
-			return CGPathEqualToPath (this.handle, other.handle);
+			return CGPathEqualToPath (this.Handle, other.Handle);
 		}
        
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -176,22 +155,22 @@ namespace CoreGraphics {
 
 		public unsafe void MoveToPoint (nfloat x, nfloat y)
 		{
-			CGPathMoveToPoint (handle, null, x, y);
+			CGPathMoveToPoint (Handle, null, x, y);
 		}
 
 		public unsafe void MoveToPoint (CGPoint point)
 		{
-			CGPathMoveToPoint (handle, null, point.X, point.Y);
+			CGPathMoveToPoint (Handle, null, point.X, point.Y);
 		}
 		
 		public unsafe void MoveToPoint (CGAffineTransform transform, nfloat x, nfloat y)
 		{
-			CGPathMoveToPoint (handle, &transform, x, y);
+			CGPathMoveToPoint (Handle, &transform, x, y);
 		}
 
 		public unsafe void MoveToPoint (CGAffineTransform transform, CGPoint point)
 		{
-			CGPathMoveToPoint (handle, &transform, point.X, point.Y);
+			CGPathMoveToPoint (Handle, &transform, point.X, point.Y);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -199,22 +178,22 @@ namespace CoreGraphics {
 
 		public unsafe void AddLineToPoint (nfloat x, nfloat y)
 		{
-			CGPathAddLineToPoint (handle, null, x, y);
+			CGPathAddLineToPoint (Handle, null, x, y);
 		}
 
 		public unsafe void AddLineToPoint (CGPoint point)
 		{
-			CGPathAddLineToPoint (handle, null, point.X, point.Y);
+			CGPathAddLineToPoint (Handle, null, point.X, point.Y);
 		}
 
 		public unsafe void AddLineToPoint (CGAffineTransform transform, nfloat x, nfloat y)
 		{
-			CGPathAddLineToPoint (handle, &transform, x, y);
+			CGPathAddLineToPoint (Handle, &transform, x, y);
 		}
 
 		public unsafe void AddLineToPoint (CGAffineTransform transform, CGPoint point)
 		{
-			CGPathAddLineToPoint (handle, &transform, point.X, point.Y);
+			CGPathAddLineToPoint (Handle, &transform, point.X, point.Y);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -222,12 +201,12 @@ namespace CoreGraphics {
 
 		public unsafe void AddQuadCurveToPoint (nfloat cpx, nfloat cpy, nfloat x, nfloat y)
 		{
-			CGPathAddQuadCurveToPoint (handle, null, cpx, cpy, x, y);
+			CGPathAddQuadCurveToPoint (Handle, null, cpx, cpy, x, y);
 		}
 
 		public unsafe void AddQuadCurveToPoint (CGAffineTransform transform, nfloat cpx, nfloat cpy, nfloat x, nfloat y)
 		{
-			CGPathAddQuadCurveToPoint (handle, &transform, cpx, cpy, x, y);
+			CGPathAddQuadCurveToPoint (Handle, &transform, cpx, cpy, x, y);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -235,22 +214,22 @@ namespace CoreGraphics {
 
 		public unsafe void AddCurveToPoint (CGAffineTransform transform, nfloat cp1x, nfloat cp1y, nfloat cp2x, nfloat cp2y, nfloat x, nfloat y)
 		{
-			CGPathAddCurveToPoint (handle, &transform, cp1x, cp1y, cp2x, cp2y, x, y);
+			CGPathAddCurveToPoint (Handle, &transform, cp1x, cp1y, cp2x, cp2y, x, y);
 		}
 
 		public unsafe void AddCurveToPoint (CGAffineTransform transform, CGPoint cp1, CGPoint cp2, CGPoint point)
 		{
-			CGPathAddCurveToPoint (handle, &transform, cp1.X, cp1.Y, cp2.X, cp2.Y, point.X, point.Y);
+			CGPathAddCurveToPoint (Handle, &transform, cp1.X, cp1.Y, cp2.X, cp2.Y, point.X, point.Y);
 		}
 
 		public unsafe void AddCurveToPoint (nfloat cp1x, nfloat cp1y, nfloat cp2x, nfloat cp2y, nfloat x, nfloat y)
 		{
-			CGPathAddCurveToPoint (handle, null, cp1x, cp1y, cp2x, cp2y, x, y);
+			CGPathAddCurveToPoint (Handle, null, cp1x, cp1y, cp2x, cp2y, x, y);
 		}
 			
 		public unsafe void AddCurveToPoint (CGPoint cp1, CGPoint cp2, CGPoint point)
 		{
-			CGPathAddCurveToPoint (handle, null, cp1.X, cp1.Y, cp2.X, cp2.Y, point.X, point.Y);
+			CGPathAddCurveToPoint (Handle, null, cp1.X, cp1.Y, cp2.X, cp2.Y, point.X, point.Y);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -258,7 +237,7 @@ namespace CoreGraphics {
 
 		public void CloseSubpath ()
 		{
-			CGPathCloseSubpath (handle);
+			CGPathCloseSubpath (Handle);
 		}
 			
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -266,12 +245,12 @@ namespace CoreGraphics {
 
 		public unsafe void AddRect (CGAffineTransform transform, CGRect rect)
 		{
-			CGPathAddRect (handle, &transform, rect);
+			CGPathAddRect (Handle, &transform, rect);
 		}
 
 		public unsafe void AddRect (CGRect rect)
 		{
-			CGPathAddRect (handle, null, rect);
+			CGPathAddRect (Handle, null, rect);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -279,34 +258,34 @@ namespace CoreGraphics {
 
 		public unsafe void AddRects (CGAffineTransform m, CGRect [] rects)
 		{
-			if (rects == null)
-				throw new ArgumentNullException ("rects");
-			CGPathAddRects (handle, &m, rects, rects.Length);
+			if (rects is null)
+				throw new ArgumentNullException (nameof (rects));
+			CGPathAddRects (Handle, &m, rects, rects.Length);
 		}
 
 		public unsafe void AddRects (CGAffineTransform m, CGRect [] rects, int count)
 		{
-			if (rects == null)
-				throw new ArgumentNullException ("rects");
+			if (rects is null)
+				throw new ArgumentNullException (nameof (rects));
 			if (count > rects.Length)
-				throw new ArgumentException ("count");
-			CGPathAddRects (handle, &m, rects, count);
+				throw new ArgumentException (nameof (count));
+			CGPathAddRects (Handle, &m, rects, count);
 		}
 		
 		public unsafe void AddRects (CGRect [] rects)
 		{
-			if (rects == null)
-				throw new ArgumentNullException ("rects");
-			CGPathAddRects (handle, null, rects, rects.Length);
+			if (rects is null)
+				throw new ArgumentNullException (nameof (rects));
+			CGPathAddRects (Handle, null, rects, rects.Length);
 		}
 
 		public unsafe void AddRects (CGRect [] rects, int count)
 		{
-			if (rects == null)
-				throw new ArgumentNullException ("rects");
+			if (rects is null)
+				throw new ArgumentNullException (nameof (rects));
 			if (count > rects.Length)
-				throw new ArgumentException ("count");
-			CGPathAddRects (handle, null, rects, count);
+				throw new ArgumentException (nameof (count));
+			CGPathAddRects (Handle, null, rects, count);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -314,34 +293,34 @@ namespace CoreGraphics {
 
 		public unsafe void AddLines (CGAffineTransform m, CGPoint [] points)
 		{
-			if (points == null)
-				throw new ArgumentNullException ("points");
-			CGPathAddLines (handle, &m, points, points.Length);
+			if (points is null)
+				throw new ArgumentNullException (nameof (points));
+			CGPathAddLines (Handle, &m, points, points.Length);
 		}
 
 		public unsafe void AddLines (CGAffineTransform m, CGPoint [] points, int count)
 		{
-			if (points == null)
-				throw new ArgumentNullException ("points");
+			if (points is null)
+				throw new ArgumentNullException (nameof (points));
 			if (count > points.Length)
-				throw new ArgumentException ("count");
-			CGPathAddLines (handle, &m, points, count);
+				throw new ArgumentException (nameof (count));
+			CGPathAddLines (Handle, &m, points, count);
 		}
 
 		public unsafe void AddLines (CGPoint [] points)
 		{
-			if (points == null)
-				throw new ArgumentNullException ("points");
-			CGPathAddLines (handle, null, points, points.Length);
+			if (points is null)
+				throw new ArgumentNullException (nameof (points));
+			CGPathAddLines (Handle, null, points, points.Length);
 		}
 
 		public unsafe void AddLines (CGPoint [] points, int count)
 		{
-			if (points == null)
-				throw new ArgumentNullException ("points");
+			if (points is null)
+				throw new ArgumentNullException (nameof (points));
 			if (count > points.Length)
-				throw new ArgumentException ("count");
-			CGPathAddLines (handle, null, points, count);
+				throw new ArgumentException (nameof (count));
+			CGPathAddLines (Handle, null, points, count);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -349,12 +328,12 @@ namespace CoreGraphics {
 
 		public unsafe void AddEllipseInRect (CGAffineTransform m, CGRect rect)
 		{
-			CGPathAddEllipseInRect (handle, &m, rect);
+			CGPathAddEllipseInRect (Handle, &m, rect);
 		}
 		
 		public unsafe void AddEllipseInRect (CGRect rect)
 		{
-			CGPathAddEllipseInRect (handle, null, rect);
+			CGPathAddEllipseInRect (Handle, null, rect);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -362,12 +341,12 @@ namespace CoreGraphics {
 
 		public unsafe void AddArc (CGAffineTransform m, nfloat x, nfloat y, nfloat radius, nfloat startAngle, nfloat endAngle, bool clockwise)
 		{
-			CGPathAddArc (handle, &m, x, y, radius, startAngle, endAngle, clockwise);
+			CGPathAddArc (Handle, &m, x, y, radius, startAngle, endAngle, clockwise);
 		}
 		
 		public unsafe void AddArc (nfloat x, nfloat y, nfloat radius, nfloat startAngle, nfloat endAngle, bool clockwise)
 		{
-			CGPathAddArc (handle, null, x, y, radius, startAngle, endAngle, clockwise);
+			CGPathAddArc (Handle, null, x, y, radius, startAngle, endAngle, clockwise);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -375,12 +354,12 @@ namespace CoreGraphics {
 
 		public unsafe void AddArcToPoint (CGAffineTransform m, nfloat x1, nfloat y1, nfloat x2, nfloat y2, nfloat radius)
 		{
-			CGPathAddArcToPoint (handle, &m, x1, y1, x2, y2, radius);
+			CGPathAddArcToPoint (Handle, &m, x1, y1, x2, y2, radius);
 		}
 		
 		public unsafe void AddArcToPoint (nfloat x1, nfloat y1, nfloat x2, nfloat y2, nfloat radius)
 		{
-			CGPathAddArcToPoint (handle, null, x1, y1, x2, y2, radius);
+			CGPathAddArcToPoint (Handle, null, x1, y1, x2, y2, radius);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -388,12 +367,12 @@ namespace CoreGraphics {
 
 		public unsafe void AddRelativeArc (CGAffineTransform m, nfloat x, nfloat y, nfloat radius, nfloat startAngle, nfloat delta)
 		{
-			CGPathAddRelativeArc (handle, &m, x, y, radius, startAngle, delta);
+			CGPathAddRelativeArc (Handle, &m, x, y, radius, startAngle, delta);
 		}
 
 		public unsafe void AddRelativeArc (nfloat x, nfloat y, nfloat radius, nfloat startAngle, nfloat delta)
 		{
-			CGPathAddRelativeArc (handle, null, x, y, radius, startAngle, delta);
+			CGPathAddRelativeArc (Handle, null, x, y, radius, startAngle, delta);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -401,16 +380,16 @@ namespace CoreGraphics {
 
 		public unsafe void AddPath (CGAffineTransform t, CGPath path2)
 		{
-			if (path2 == null)
-				throw new ArgumentNullException ("path2");
-			CGPathAddPath (handle, &t, path2.handle);
+			if (path2 is null)
+				throw new ArgumentNullException (nameof (path2));
+			CGPathAddPath (Handle, &t, path2.Handle);
 		}
 		
 		public unsafe void AddPath (CGPath path2)
 		{
-			if (path2 == null)
-				throw new ArgumentNullException ("path2");
-			CGPathAddPath (handle, null, path2.handle);
+			if (path2 is null)
+				throw new ArgumentNullException (nameof (path2));
+			CGPathAddPath (Handle, null, path2.Handle);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -419,7 +398,7 @@ namespace CoreGraphics {
 
 		public bool IsEmpty {
 			get {
-				return CGPathIsEmpty (handle);
+				return CGPathIsEmpty (Handle);
 			}
 		}
 			
@@ -429,7 +408,7 @@ namespace CoreGraphics {
 
 		public bool IsRect (out CGRect rect)
 		{
-			return CGPathIsRect (handle, out rect);
+			return CGPathIsRect (Handle, out rect);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -437,7 +416,7 @@ namespace CoreGraphics {
 
 		public CGPoint CurrentPoint {
 			get {
-				return CGPathGetCurrentPoint (handle);
+				return CGPathGetCurrentPoint (Handle);
 			}
 		}
 
@@ -446,7 +425,7 @@ namespace CoreGraphics {
 
 		public CGRect BoundingBox {
 			get {
-				return CGPathGetBoundingBox (handle);
+				return CGPathGetBoundingBox (Handle);
 			}
 		}
 
@@ -455,7 +434,7 @@ namespace CoreGraphics {
 
 		public CGRect PathBoundingBox {
 			get {
-				return CGPathGetPathBoundingBox (handle);
+				return CGPathGetPathBoundingBox (Handle);
 			}
 		}
 		
@@ -465,12 +444,12 @@ namespace CoreGraphics {
 
 		public unsafe bool ContainsPoint (CGAffineTransform m, CGPoint point, bool eoFill)
 		{
-			return CGPathContainsPoint (handle, &m, point, eoFill);
+			return CGPathContainsPoint (Handle, &m, point, eoFill);
 		}
 		
 		public unsafe bool ContainsPoint (CGPoint point, bool eoFill)
 		{
-			return CGPathContainsPoint (handle, null, point, eoFill);
+			return CGPathContainsPoint (Handle, null, point, eoFill);
 		}
 
 		public delegate void ApplierFunction (CGPathElement element);
@@ -485,7 +464,9 @@ namespace CoreGraphics {
 			GCHandle gch = GCHandle.FromIntPtr (info);
 			// note: CGPathElementType is an untyped enum, always 32bits
 			CGPathElement element = new CGPathElement (Marshal.ReadInt32(element_ptr, 0));
-			ApplierFunction func = (ApplierFunction) gch.Target;
+			var func = gch.Target as ApplierFunction;
+			if (func is null)
+				return;
 
 			IntPtr ptr = Marshal.ReadIntPtr (element_ptr, IntPtr.Size);
 			int ptsize = Marshal.SizeOf (typeof (CGPoint));
@@ -496,18 +477,18 @@ namespace CoreGraphics {
 
 			case CGPathElementType.MoveToPoint:
 			case CGPathElementType.AddLineToPoint:
-				element.Point1 = (CGPoint) Marshal.PtrToStructure (ptr, typeof (CGPoint));
+				element.Point1 = Marshal.PtrToStructure<CGPoint> (ptr)!;
 				break;
 
 			case CGPathElementType.AddQuadCurveToPoint:
-				element.Point1 = (CGPoint) Marshal.PtrToStructure (ptr, typeof (CGPoint));
-				element.Point2 = (CGPoint) Marshal.PtrToStructure (((IntPtr) (((long)ptr) + ptsize)), typeof (CGPoint));
+				element.Point1 = Marshal.PtrToStructure<CGPoint> (ptr)!;
+				element.Point2 = Marshal.PtrToStructure<CGPoint> (((IntPtr) (((long)ptr) + ptsize)))!;
 				break;
 
 			case CGPathElementType.AddCurveToPoint:
-				element.Point1 = (CGPoint) Marshal.PtrToStructure (ptr, typeof (CGPoint));
-				element.Point2 = (CGPoint) Marshal.PtrToStructure (((IntPtr) (((long)ptr) + ptsize)), typeof (CGPoint));
-				element.Point3 = (CGPoint) Marshal.PtrToStructure (((IntPtr) (((long)ptr) + (2*ptsize))), typeof (CGPoint));
+				element.Point1 = Marshal.PtrToStructure<CGPoint> (ptr)!;
+				element.Point2 = Marshal.PtrToStructure<CGPoint> (((IntPtr) (((long)ptr) + ptsize)))!;
+				element.Point3 = Marshal.PtrToStructure<CGPoint> (((IntPtr) (((long)ptr) + (2*ptsize))))!;
 				break;
 			}
 
@@ -521,7 +502,7 @@ namespace CoreGraphics {
 		public void Apply (ApplierFunction func)
 		{
 			GCHandle gch = GCHandle.Alloc (func);
-			CGPathApply (handle, GCHandle.ToIntPtr (gch), ApplierCallback);
+			CGPathApply (Handle, GCHandle.ToIntPtr (gch), ApplierCallback);
 			gch.Free ();
 		}
 
@@ -546,7 +527,7 @@ namespace CoreGraphics {
 
 		public unsafe CGPath CopyByDashingPath (CGAffineTransform transform, nfloat [] lengths, nfloat phase)
 		{
-			return MakeMutable (CGPathCreateCopyByDashingPath (handle, &transform, phase, lengths, lengths == null ? 0 : lengths.Length));
+			return MakeMutable (CGPathCreateCopyByDashingPath (Handle, &transform, phase, lengths, lengths is null ? 0 : lengths.Length));
 		}
 
 		public CGPath CopyByDashingPath (nfloat [] lengths)
@@ -556,13 +537,13 @@ namespace CoreGraphics {
 
 		public unsafe CGPath CopyByDashingPath (nfloat [] lengths, nfloat phase)
 		{
-			var path = CGPathCreateCopyByDashingPath (handle, null, phase, lengths, lengths == null ? 0 : lengths.Length);
+			var path = CGPathCreateCopyByDashingPath (Handle, null, phase, lengths, lengths is null ? 0 : lengths.Length);
 			return MakeMutable (path);
 		}
 
 		public unsafe CGPath Copy ()
 		{
-			return MakeMutable (handle);
+			return MakeMutable (Handle);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -570,12 +551,12 @@ namespace CoreGraphics {
 
 		public unsafe CGPath CopyByStrokingPath (CGAffineTransform transform, nfloat lineWidth, CGLineCap lineCap, CGLineJoin lineJoin, nfloat miterLimit)
 		{
-			return MakeMutable (CGPathCreateCopyByStrokingPath (handle, &transform, lineWidth, lineCap, lineJoin, miterLimit));
+			return MakeMutable (CGPathCreateCopyByStrokingPath (Handle, &transform, lineWidth, lineCap, lineJoin, miterLimit));
 		}
 
 		public unsafe CGPath CopyByStrokingPath (nfloat lineWidth, CGLineCap lineCap, CGLineJoin lineJoin, nfloat miterLimit)
 		{
-			return MakeMutable (CGPathCreateCopyByStrokingPath (handle, null, lineWidth, lineCap, lineJoin, miterLimit));
+			return MakeMutable (CGPathCreateCopyByStrokingPath (Handle, null, lineWidth, lineCap, lineJoin, miterLimit));
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -583,7 +564,7 @@ namespace CoreGraphics {
 
 		public CGPath CopyByTransformingPath (CGAffineTransform transform)
 		{
-			return MakeMutable (CGPathCreateCopyByTransformingPath (handle, ref transform));
+			return MakeMutable (CGPathCreateCopyByTransformingPath (Handle, ref transform));
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -618,9 +599,9 @@ namespace CoreGraphics {
 		static unsafe CGPath _FromRoundedRect (CGRect rectangle, nfloat cornerWidth, nfloat cornerHeight, CGAffineTransform *transform)
 		{
 			if ((cornerWidth < 0) || (2 * cornerWidth > rectangle.Width))
-				throw new ArgumentException ("cornerWidth");
+				throw new ArgumentException (nameof (cornerWidth));
 			if ((cornerHeight < 0) || (2 * cornerHeight > rectangle.Height))
-				throw new ArgumentException ("cornerHeight");
+				throw new ArgumentException (nameof (cornerHeight));
 			return MakeMutable (CGPathCreateWithRoundedRect (rectangle, cornerWidth, cornerHeight, transform));
 		}
 
@@ -648,7 +629,7 @@ namespace CoreGraphics {
 #endif
 		public unsafe void AddRoundedRect (CGAffineTransform transform, CGRect rect, nfloat cornerWidth, nfloat cornerHeight)
 		{
-			CGPathAddRoundedRect (handle, &transform, rect, cornerWidth, cornerHeight);
+			CGPathAddRoundedRect (Handle, &transform, rect, cornerWidth, cornerHeight);
 		}
 
 #if !NET
@@ -656,7 +637,7 @@ namespace CoreGraphics {
 #endif
 		public unsafe void AddRoundedRect (CGRect rect, nfloat cornerWidth, nfloat cornerHeight)
 		{
-			CGPathAddRoundedRect (handle, null, rect, cornerWidth, cornerHeight);
+			CGPathAddRoundedRect (Handle, null, rect, cornerWidth, cornerHeight);
 		}
 #endif // !COREBUILD
 	}


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.
* Remove the (IntPtr) constructor for XAMCORE_4_0.
* Fix constructor chain invocation for the (IntPtr, bool) constructor to
  actually pass on the 'owns' parameter.