### PR TITLE
[generator] Call the (IntPtr, bool) constructor for INativeObjects.

### DIFF
--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -1037,9 +1037,14 @@ namespace AudioUnit
 		public bool IsAtEnd { get { return current == null; }}
 
 		public AURenderEventEnumerator (IntPtr ptr)
+			: this (ptr, false)
 		{
-			Handle = ptr;
-			current = (AURenderEvent *) ptr;
+		}
+
+		internal AURenderEventEnumerator (IntPtr handle, bool owns)
+		{
+			Handle = handle;
+			current = (AURenderEvent *) handle;
 		}
 
 		public void Dispose ()

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1684,7 +1684,7 @@ public partial class Generator : IMemberGatherer {
 
 			if (TypeManager.INativeObject.IsAssignableFrom (pi.ParameterType)) {
 				pars.AppendFormat ("IntPtr {0}", safe_name);
-				invoke.AppendFormat ("new {0} ({1})", pi.ParameterType, safe_name);
+				invoke.AppendFormat ("new {0} ({1}, false)", pi.ParameterType, safe_name);
 				continue;
 			}
 


### PR DESCRIPTION
This is required, because the (IntPtr) constructor will eventually be removed for all types.