### PR TITLE
[SecIdentity] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/Security/SecIdentity.cs
+++ b/src/Security/SecIdentity.cs
@@ -7,6 +7,8 @@
 // Copyright 2013 Xamarin Inc.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using ObjCRuntime;
@@ -23,7 +25,7 @@ namespace Security {
 		public SecKey PrivateKey {
 			get {
 				IntPtr p;
-				SecStatusCode result = SecIdentityCopyPrivateKey (handle, out p);
+				SecStatusCode result = SecIdentityCopyPrivateKey (Handle, out p);
 				if (result != SecStatusCode.Success)
 					throw new InvalidOperationException (result.ToString ());
 				return new SecKey (p, true);

--- a/src/Security/Trust.cs
+++ b/src/Security/Trust.cs
@@ -235,7 +235,7 @@ namespace Security {
 				if ((index < 0) || (index >= Count))
 					throw new ArgumentOutOfRangeException (nameof (index));
 
-				return new SecCertificate (SecTrustGetCertificateAtIndex (GetCheckedHandle (), index));
+				return new SecCertificate (SecTrustGetCertificateAtIndex (GetCheckedHandle (), index), false);
 			}
 		}
 

--- a/tests/introspection/ApiCMAttachmentTest.cs
+++ b/tests/introspection/ApiCMAttachmentTest.cs
@@ -395,7 +395,7 @@ namespace Introspection {
 					var result = SecImportExport.ImportPkcs12 (farscape_pfx, options, out array);
 					if (result != SecStatusCode.Success)
 						throw new InvalidOperationException (string.Format ("Could not create the new instance for type {0} due to {1}.", t.Name, result));
-					return new SecIdentity (array [0].LowlevelObjectForKey (SecImportExport.Identity.Handle));
+					return Runtime.GetINativeObject<SecIdentity> (array [0].LowlevelObjectForKey (SecImportExport.Identity.Handle), false);
 				}
 			case "SecTrust":
 				X509Certificate x = new X509Certificate (mail_google_com);
@@ -462,7 +462,7 @@ namespace Introspection {
 					var result = SecImportExport.ImportPkcs12 (farscape_pfx, options, out array);
 					if (result != SecStatusCode.Success)
 						throw new InvalidOperationException (string.Format ("Could not create the new instance for type {0} due to {1}.", t.Name, result));
-					return new SecIdentity2 (new SecIdentity (array [0].LowlevelObjectForKey (SecImportExport.Identity.Handle)));
+					return new SecIdentity2 (Runtime.GetINativeObject<SecIdentity> (array [0].LowlevelObjectForKey (SecImportExport.Identity.Handle), false));
 				}
 				
 			case "SecKey":

--- a/tests/monotouch-test/Security/IdentityTest.cs
+++ b/tests/monotouch-test/Security/IdentityTest.cs
@@ -10,6 +10,7 @@
 
 using System;
 using Foundation;
+using ObjCRuntime;
 using Security;
 using NUnit.Framework;
 
@@ -26,7 +27,7 @@ namespace MonoTouchFixtures.Security {
 				NSDictionary[] array;
 				if (SecImportExport.ImportPkcs12 (ImportExportTest.farscape_pfx, options, out array) != SecStatusCode.Success)
 					Assert.Fail ("ImportPkcs12");
-				return new SecIdentity (array [0].LowlevelObjectForKey (SecImportExport.Identity.Handle));
+				return Runtime.GetINativeObject<SecIdentity> (array [0].LowlevelObjectForKey (SecImportExport.Identity.Handle), false);
 			}
 		}
 


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.
* Call 'GetCheckedHandle ()' (which will throw an ObjectDisposedException if
  Handle == IntPtr.Zero) instead of manually checking for IntPtr.Zero and
  throwing ObjectDisposedException.
* Use the 'Runtime.GetNSObject<T> (IntPtr, bool)' overload to specify handle
  ownership, to avoid having to call CFObject.CFRelease manually later.
* Use Array.Empty<T> instead of creating an empty array manually.
* Remove the (IntPtr) constructor for .NET.