### PR TITLE
[PrintCore] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/PrintCore/PrintCore.cs
+++ b/src/PrintCore/PrintCore.cs
@@ -6,6 +6,9 @@
 //
 // Copyright 2016 Microsoft Inc
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -18,51 +21,26 @@ using PMObject=System.IntPtr;
 using OSStatus=System.Int32;
 
 namespace PrintCore {
-	class NativeInvoke {
+	public class PMPrintCoreBase : NativeObject {
+		internal PMPrintCoreBase (IntPtr handle, bool owns)
+			: base (handle, owns)
+		{
+		}
+
 		[DllImport (Constants.PrintCoreLibrary)]
 		internal extern static OSStatus PMRetain (PMObject obj);
 
 		[DllImport (Constants.PrintCoreLibrary)]
 		internal extern static OSStatus PMRelease (PMObject obj);
 
-		
-	}
-	
-	public class PMPrintCoreBase : IDisposable, INativeObject {
-		internal IntPtr handle;
-
-		internal PMPrintCoreBase ()
+		protected override void Retain ()
 		{
-			// For delayed initialization cases.
-		}
-		
-		internal PMPrintCoreBase (IntPtr handle) : this (handle, false) {}
-		internal PMPrintCoreBase (IntPtr handle, bool owns)
-		{
-			if (!owns)
-				NativeInvoke.PMRetain (handle);
-			this.handle = handle;
+			PMRetain (Handle);
 		}
 
-		~PMPrintCoreBase ()
+		protected override void Release ()
 		{
-			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle => handle;
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				NativeInvoke.PMRelease (handle);
-				handle = IntPtr.Zero;
-			}
+			PMRelease (Handle);
 		}
 	}
 
@@ -75,18 +53,21 @@ namespace PrintCore {
 		extern static PMStatusCode PMCreateSession (out IntPtr session);
 
 		internal PMPrintSession (IntPtr handle, bool owns) : base (handle, owns) {}
-		
-		public PMPrintSession ()
+
+		static IntPtr Create ()
 		{
-			IntPtr value;
-			var code = PMCreateSession (out value);
+			var code = PMCreateSession (out var value);
 			if (code == PMStatusCode.Ok)
-				handle = value;
-			else
-				throw new PMPrintException (code);
+				return value;
+			throw new PMPrintException (code);
 		}
 
-		public static PMStatusCode TryCreate (out PMPrintSession session)
+		public PMPrintSession ()
+			: base (Create (), true)
+		{
+		}
+
+		public static PMStatusCode TryCreate (out PMPrintSession? session)
 		{
 			IntPtr value;
 			var code = PMCreateSession (out value);
@@ -105,10 +86,10 @@ namespace PrintCore {
 		
 		public PMStatusCode SessionError {
 			get {
-				return PMSessionError (handle);
+				return PMSessionError (Handle);
 			}
 			set {
-				PMSessionSetError (handle, value);
+				PMSessionSetError (Handle, value);
 			}
 		}
 		
@@ -117,9 +98,9 @@ namespace PrintCore {
 
 		public void AssignDefaultSettings (PMPrintSettings settings)
 		{
-			if (settings == null)
+			if (settings is null)
 				throw new ArgumentNullException (nameof (settings));
-			PMSessionDefaultPrintSettings (handle, settings.handle);
+			PMSessionDefaultPrintSettings (Handle, settings.Handle);
 		}
 
 		[DllImport (Constants.PrintCoreLibrary)]
@@ -127,40 +108,24 @@ namespace PrintCore {
 		
 		public void AssignDefaultPageFormat (PMPageFormat pageFormat)
 		{
-			if (pageFormat == null)
+			if (pageFormat is null)
 				throw new ArgumentNullException (nameof (pageFormat));
-			PMSessionDefaultPageFormat (handle, pageFormat.Handle);
+			PMSessionDefaultPageFormat (Handle, pageFormat.Handle);
 		}
 		
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMSessionCreatePrinterList (IntPtr printSession, out IntPtr printerListArray, out int index, out IntPtr printer);
-
-		internal static string [] FetchArray (IntPtr cfArrayString, bool owns)
+				
+		public PMStatusCode CreatePrinterList (out string? []? printerList, out int index, out PMPrinter? printer)
 		{
-			string [] ret;
-			// Fetc the values from the array that we own.
-			var arr = new CFArray (cfArrayString, owns: owns);
-			int c = (int) arr.Count;
-			ret = new string [c];
-			for (int i = 0; i < c; i++)
-				ret [i] = CFString.FromHandle (arr.GetValue (i));
-			arr.Dispose ();
-
-			return ret;
-		}
-		
-		public PMStatusCode CreatePrinterList (out string [] printerList, out int index, out PMPrinter printer)
-		{
-			IntPtr array, printerHandle;
-			var code = PMSessionCreatePrinterList (handle, out array, out index, out printerHandle);
+			var code = PMSessionCreatePrinterList (Handle, out var array, out index, out var printerHandle);
 			if (code != PMStatusCode.Ok){
 				printerList = null;
 				printer = null;
 				return code;
 			}
 
-			printerList = CFArray.StringArrayFromHandle (array);
-			CFObject.CFRelease (array);
+			printerList = CFArray.StringArrayFromHandle (array, true);
 			if (printerHandle != IntPtr.Zero){
 				// Now get the printer, we do not own it, so retain.
 				printer = new PMPrinter (printerHandle, owns: false);
@@ -175,11 +140,10 @@ namespace PrintCore {
 		
 		public PMStatusCode ValidatePrintSettings (PMPrintSettings settings, out bool changed)
 		{
-			if (settings == null)
+			if (settings is null)
 				throw new ArgumentNullException (nameof (settings));
 			
-			byte c;
-			var code = PMSessionValidatePrintSettings (handle, settings.handle, out c);
+			var code = PMSessionValidatePrintSettings (Handle, settings.Handle, out var c);
 			if (code != PMStatusCode.Ok){
 				changed = false;
 				return code;
@@ -193,18 +157,25 @@ namespace PrintCore {
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMCreatePrintSettings (out IntPtr session);
 		
-		internal PMPrintSettings (IntPtr handle, bool owns) : base (handle, owns) {}
-		public PMPrintSettings ()
+		internal PMPrintSettings (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			IntPtr value;
-			var code = PMCreatePrintSettings (out value);
-			if (code == PMStatusCode.Ok)
-				handle = value;
-			else
-				throw new PMPrintException (code);
 		}
 
-		public static PMStatusCode TryCreate (out PMPrintSettings settings)
+		static IntPtr Create ()
+		{
+			var code = PMCreatePrintSettings (out var value);
+			if (code == PMStatusCode.Ok)
+				return value;
+			throw new PMPrintException (code);
+		}
+
+		public PMPrintSettings ()
+			: base (Create (), true)
+		{
+		}
+
+		public static PMStatusCode TryCreate (out PMPrintSettings? settings)
 		{
 			IntPtr value;
 			var code = PMCreatePrintSettings (out value);
@@ -222,12 +193,11 @@ namespace PrintCore {
 		extern static PMStatusCode PMSetFirstPage (IntPtr handle, uint first, byte lockb);
 		public uint FirstPage {
 			get {
-				uint val = 0;
-				PMGetFirstPage (handle, out val);
+				PMGetFirstPage (Handle, out var val);
 				return val;
 			}
 			set {
-				PMSetFirstPage (handle, value, 0);
+				PMSetFirstPage (Handle, value, 0);
 			}
 		}
 
@@ -237,12 +207,11 @@ namespace PrintCore {
 		extern static PMStatusCode PMSetLastPage (IntPtr handle, uint last, byte lockb);
 		public uint LastPage {
 			get {
-				uint val = 0;
-				PMGetLastPage (handle, out val);
+				PMGetLastPage (Handle, out var val);
 				return val;
 			}
 			set {
-				PMSetLastPage (handle, value, 0);
+				PMSetLastPage (Handle, value, 0);
 			}
 		}
 
@@ -252,12 +221,12 @@ namespace PrintCore {
 		extern static PMStatusCode PMSetPageRange (IntPtr handle, uint minPage, uint maxPage);
 		public PMStatusCode GetPageRange (out uint minPage, out uint maxPage)
 		{
-			return PMGetPageRange (handle, out minPage, out maxPage);
+			return PMGetPageRange (Handle, out minPage, out maxPage);
 		}
 
 		public PMStatusCode SetPageRange (uint minPage, uint maxPage)
 		{
-			return PMSetPageRange (handle, minPage, maxPage);
+			return PMSetPageRange (Handle, minPage, maxPage);
 		}
 		
 			
@@ -266,9 +235,9 @@ namespace PrintCore {
 		
 		public PMStatusCode CopySettings (PMPrintSettings destination)
 		{
-			if (destination == null)
+			if (destination is null)
 				throw new ArgumentNullException (nameof (destination));
-			return PMCopyPrintSettings (handle, destination.handle);
+			return PMCopyPrintSettings (Handle, destination.Handle);
 		}
 
 		[DllImport (Constants.PrintCoreLibrary)]
@@ -278,14 +247,13 @@ namespace PrintCore {
 
 		public uint Copies {
 			get {
-				uint c;
-				if (PMGetCopies (handle, out c) == PMStatusCode.Ok)
+				if (PMGetCopies (Handle, out var c) == PMStatusCode.Ok)
 					return c;
 				else
 					return 0;
 			}
 			set {
-				PMSetCopies (handle, value, 0);
+				PMSetCopies (Handle, value, 0);
 			}
 		}
 
@@ -296,14 +264,13 @@ namespace PrintCore {
 
 		public bool Collate {
 			get {
-				byte c;
-				if (PMGetCollate (handle, out c) == PMStatusCode.Ok)
+				if (PMGetCollate (Handle, out var c) == PMStatusCode.Ok)
 					return c != 0;
 				else
 					return false;
 			}
 			set {
-				PMSetCollate (handle, (byte) (value ? 1 : 0));
+				PMSetCollate (Handle, (byte) (value ? 1 : 0));
 			}
 		}
 
@@ -314,14 +281,13 @@ namespace PrintCore {
 
 		public PMDuplexMode DuplexMode {
 			get {
-				PMDuplexMode c;
-				if (PMGetDuplex (handle, out c) == PMStatusCode.Ok)
+				if (PMGetDuplex (Handle, out var c) == PMStatusCode.Ok)
 					return c;
 				else
 					return PMDuplexMode.None;
 			}
 			set {
-				PMSetDuplex (handle, value);
+				PMSetDuplex (Handle, value);
 			}
 		}
 
@@ -332,14 +298,13 @@ namespace PrintCore {
 
 		public double Scale {
 			get {
-				double c;
-				if (PMGetScale (handle, out c) == PMStatusCode.Ok)
+				if (PMGetScale (Handle, out var c) == PMStatusCode.Ok)
 					return c;
 				else
 					return 100;
 			}
 			set {
-				PMSetScale (handle, value);
+				PMSetScale (Handle, value);
 			}
 		}
 		
@@ -352,28 +317,33 @@ namespace PrintCore {
 		extern static PMStatusCode PMCreatePageFormatWithPMPaper (out IntPtr handle, IntPtr paper);
 
 		internal PMPageFormat (IntPtr handle, bool owns): base (handle, owns) {}
-		
-		public PMPageFormat (PMPaper paper = null)
+
+		static IntPtr Create (PMPaper? paper = null)
 		{
 			IntPtr value;
 			PMStatusCode code;
-			if (paper == null)
+			if (paper is null) {
 				code = PMCreatePageFormat (out value);
-			else
+			} else {
 				code = PMCreatePageFormatWithPMPaper (out value, paper.Handle);
-			
+			}
 			if (code == PMStatusCode.Ok)
-				handle = value;
-			else
-				throw new PMPrintException (code);
+				return value;
+
+			throw new PMPrintException (code);
 		}
 
-		public static PMStatusCode TryCreate (out PMPageFormat pageFormat, PMPaper paper = null)
+		public PMPageFormat (PMPaper? paper = null)
+			: base (Create (paper), true)
+		{
+		}
+
+		public static PMStatusCode TryCreate (out PMPageFormat? pageFormat, PMPaper? paper = null)
 		{
 			PMStatusCode code;
 			IntPtr value;
 			
-			if (paper == null)
+			if (paper is null)
 				code = PMCreatePageFormat (out value);
 			else
 				code = PMCreatePageFormatWithPMPaper (out value, paper.Handle);
@@ -393,14 +363,13 @@ namespace PrintCore {
 
 		public PMOrientation Orientation {
 			get {
-				PMOrientation o;
-				if (PMGetOrientation (handle, out o) == PMStatusCode.Ok)
+				if (PMGetOrientation (Handle, out var o) == PMStatusCode.Ok)
 					return o;
 				else
 					return PMOrientation.Portrait;
 			}
 			set {
-				PMSetOrientation (handle, value, 0);
+				PMSetOrientation (Handle, value, 0);
 			}
 		}
 
@@ -408,8 +377,7 @@ namespace PrintCore {
 		extern static PMStatusCode PMGetAdjustedPageRect (IntPtr pageFormat, out PMRect pageRect);
 		public PMRect AdjustedPageRect {
 			get {
-				PMRect rect;
-				if (PMGetAdjustedPageRect (handle, out rect) == PMStatusCode.Ok)
+				if (PMGetAdjustedPageRect (Handle, out var rect) == PMStatusCode.Ok)
 					return rect;
 				return new PMRect (0, 0, 0, 0);
 			}
@@ -419,8 +387,7 @@ namespace PrintCore {
 		extern static PMStatusCode PMGetAdjustedPaperRect (IntPtr pageFormat, out PMRect pageRect);
 		public PMRect AdjustedPaperRect {
 			get {
-				PMRect rect;
-				if (PMGetAdjustedPaperRect (handle, out rect) == PMStatusCode.Ok)
+				if (PMGetAdjustedPaperRect (Handle, out var rect) == PMStatusCode.Ok)
 					return rect;
 				return new PMRect (0, 0, 0, 0);
 			}
@@ -440,10 +407,9 @@ namespace PrintCore {
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMPaperCreateLocalizedName (IntPtr handle, IntPtr printer, out IntPtr name);
 		
-		public string ID {
+		public string? ID {
 			get {
-				IntPtr s;
-				var code = PMPaperGetID (handle, out s);
+				var code = PMPaperGetID (Handle, out var s);
 				if (code != PMStatusCode.Ok)
 					return null;
 				return CFString.FromHandle (s);
@@ -452,8 +418,7 @@ namespace PrintCore {
 
 		public double Width {
 			get {
-				double s; 
-				var code = PMPaperGetWidth (handle, out s);
+				var code = PMPaperGetWidth (Handle, out var s);
 				if (code != PMStatusCode.Ok)
 					return 0;
 				return s;
@@ -462,8 +427,7 @@ namespace PrintCore {
 			
 		public double Height {
 			get {
-				double s; 
-				var code = PMPaperGetHeight (handle, out s);
+				var code = PMPaperGetHeight (Handle, out var s);
 				if (code != PMStatusCode.Ok)
 					return 0;
 				return s;
@@ -472,25 +436,21 @@ namespace PrintCore {
 
 		public PMPaperMargins? Margins {
 			get {
-				PMPaperMargins margins;
-				var code = PMPaperGetMargins (handle, out margins);
+				var code = PMPaperGetMargins (Handle, out var margins);
 				if (code != PMStatusCode.Ok)
 					return null;
 				return margins;
 			}
 		}
 
-		public string GetLocalizedName (PMPrinter printer)
+		public string? GetLocalizedName (PMPrinter printer)
 		{
-			if (printer == null)
+			if (printer is null)
 				throw new ArgumentNullException (nameof (printer));
-			IntPtr name;
-			var code = PMPaperCreateLocalizedName (handle, printer.handle, out name);
+			var code = PMPaperCreateLocalizedName (Handle, printer.Handle, out var name);
 			if (code != PMStatusCode.Ok)
 				return null;
-			var str = CFString.FromHandle (name);
-			CFObject.CFRelease (name);
-			return str;
+			return CFString.FromHandle (name, true);
 		}
 		
 	}
@@ -503,28 +463,42 @@ namespace PrintCore {
 		extern static IntPtr PMPrinterCreateFromPrinterID (IntPtr id);
 
 		internal PMPrinter (IntPtr handle, bool owns) : base (handle, owns) {}
-		public PMPrinter ()
+
+		static IntPtr Create ()
 		{
-			IntPtr value;
-			var code = PMCreateGenericPrinter (out value);
+			var code = PMCreateGenericPrinter (out var value);
 			if (code == PMStatusCode.Ok)
-				handle = value;
-			else
-				throw new PMPrintException (code);
+				return value;
+			throw new PMPrintException (code);
+		}
+
+		public PMPrinter ()
+			: base (Create (), true)
+		{
+		}
+
+		static IntPtr Create (string printerId)
+		{
+			if (printerId is null)
+				throw new ArgumentNullException (nameof (printerId));
+
+			var printerIdHandle = CFString.CreateNative (printerId);
+			try {
+				var value = PMPrinterCreateFromPrinterID (printerIdHandle);
+				if (value == IntPtr.Zero)
+					throw new PMPrintException (PMStatusCode.InvalidPrinter);
+				return value;
+			} finally {
+				CFString.ReleaseNative (printerIdHandle);
+			}
 		}
 
 		public PMPrinter (string printerId)
+			: base (Create (printerId), true)
 		{
-			using (var idf = new CFString (printerId)){
-				var value = PMPrinterCreateFromPrinterID (idf.Handle);
-				if (value == IntPtr.Zero)
-					throw new PMPrintException (PMStatusCode.InvalidPrinter);
-					
-				handle = value;
-			}
 		}
 		
-		public static PMStatusCode TryCreate (out PMPrinter printer)
+		public static PMStatusCode TryCreate (out PMPrinter? printer)
 		{
 			IntPtr value;
 			var code = PMCreateGenericPrinter (out value);
@@ -536,7 +510,7 @@ namespace PrintCore {
 			return code;
 		}
 
-		public static PMPrinter TryCreate (string printerId)
+		public static PMPrinter? TryCreate (string printerId)
 		{
 			using (var idf = new CFString (printerId)){
 				var h = PMPrinterCreateFromPrinterID (idf.Handle);
@@ -548,16 +522,14 @@ namespace PrintCore {
 
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static IntPtr PMPrinterGetName (IntPtr handle);
-		public string Name => CFString.FromHandle (PMPrinterGetName (handle));
+		public string? Name => CFString.FromHandle (PMPrinterGetName (Handle));
 
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMPrinterCopyDeviceURI (IntPtr handle, out IntPtr url);
 
-		public PMStatusCode TryGetDeviceUrl (out NSUrl url)
+		public PMStatusCode TryGetDeviceUrl (out NSUrl? url)
 		{
-			IntPtr urlH;
-			
-			var code = PMPrinterCopyDeviceURI (handle, out urlH);
+			var code = PMPrinterCopyDeviceURI (Handle, out var urlH);
 			if (code != PMStatusCode.Ok){
 				url = null;
 				return code;
@@ -566,11 +538,9 @@ namespace PrintCore {
 			return PMStatusCode.Ok;
 		}
 
-		public NSUrl DeviceUrl {
+		public NSUrl? DeviceUrl {
 			get {
-				IntPtr urlH;
-			
-				var code = PMPrinterCopyDeviceURI (handle, out urlH);
+				var code = PMPrinterCopyDeviceURI (Handle, out var urlH);
 				if (code != PMStatusCode.Ok)
 					return null;
 
@@ -581,10 +551,9 @@ namespace PrintCore {
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMPrinterGetMakeAndModelName(IntPtr printer, out IntPtr makeAndModel);
 
-		public string MakeAndModel {
+		public string? MakeAndModel {
 			get {
-				IntPtr v;
-				if (PMPrinterGetMakeAndModelName (handle, out v) == PMStatusCode.Ok){
+				if (PMPrinterGetMakeAndModelName (Handle, out var v) == PMStatusCode.Ok) {
 					return CFString.FromHandle (v);
 				}
 				return null;
@@ -597,8 +566,7 @@ namespace PrintCore {
 		// Return is overloaded - if negative, a PMStatusCode.
 		public PMPrinterState PrinterState {
 			get {
-				PMPrinterState s;
-				var code = PMPrinterGetState (handle, out s);
+				var code = PMPrinterGetState (Handle, out var s);
 				if (code == PMStatusCode.Ok)
 					return s;
 
@@ -609,10 +577,9 @@ namespace PrintCore {
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMPrinterGetMimeTypes (IntPtr printer, IntPtr settings, out IntPtr arrayStr);
 
-		public PMStatusCode TryGetMimeTypes (PMPrintSettings settings, out string [] mimeTypes)
+		public PMStatusCode TryGetMimeTypes (PMPrintSettings settings, out string? []? mimeTypes)
 		{
-			IntPtr m;
-			var code = PMPrinterGetMimeTypes (handle, settings == null ? IntPtr.Zero : settings.Handle, out m);
+			var code = PMPrinterGetMimeTypes (Handle, settings.GetHandle (), out var m);
 			if (code != PMStatusCode.Ok){
 				mimeTypes = null;
 				return code;
@@ -623,67 +590,60 @@ namespace PrintCore {
 
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMPrinterGetPaperList (IntPtr printer, out IntPtr arrayStr);
-		public PMStatusCode TryGetPaperList (out PMPaper [] paperList)
+		public PMStatusCode TryGetPaperList (out PMPaper []? paperList)
 		{
-			IntPtr m;
-			var code = PMPrinterGetPaperList (handle, out m);
+			var code = PMPrinterGetPaperList (Handle, out var m);
 			if (code != PMStatusCode.Ok){
 				paperList = null;
 				return code;
 			}
-			int c = (int) CFArray.GetCount (m);
-			paperList = new PMPaper [c];
-			for (int i = 0; i < c; i++)
-				paperList [i] = new PMPaper (CFArray.CFArrayGetValueAtIndex (m, i), owns: false);
-
+			paperList = (PMPaper []) CFArray.ArrayFromHandleFunc<PMPaper> (m, (handle) => new PMPaper (handle, false))!;
 			return PMStatusCode.Ok;
 		}
 
 		public PMPaper [] PaperList {
 			get {
-				IntPtr m;
-				if (PMPrinterGetPaperList (handle, out m) != PMStatusCode.Ok)
-					return new PMPaper [0];
+				if (PMPrinterGetPaperList (Handle, out var m) != PMStatusCode.Ok)
+					return Array.Empty<PMPaper> ();
 
-				int c = (int) CFArray.GetCount (m);
-				var paperList = new PMPaper [c];
-				for (int i = 0; i < c; i++)
-					paperList [i] = new PMPaper (CFArray.CFArrayGetValueAtIndex (m, i), owns: false);
-
-				return paperList;
+				return (PMPaper []) CFArray.ArrayFromHandleFunc<PMPaper> (m, (handle) => new PMPaper (handle, false))!;
 			}
 		}
 
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMPrinterPrintWithFile (IntPtr handle, IntPtr settings, IntPtr pageFormat, IntPtr strMimeType, IntPtr fileUrl);
 
-		public PMStatusCode TryPrintFile (PMPrintSettings settings, PMPageFormat pageFormat, NSUrl fileUrl, string mimeType = null)
+		public PMStatusCode TryPrintFile (PMPrintSettings settings, PMPageFormat? pageFormat, NSUrl fileUrl, string? mimeType = null)
 		{
-			if (settings == null)
+			if (settings is null)
 				throw new ArgumentNullException (nameof (settings));
-			if (fileUrl == null)
+			if (fileUrl is null)
 				throw new ArgumentNullException (nameof (fileUrl));
 				    
 			IntPtr mime = CFString.CreateNative (mimeType);
-			var code = PMPrinterPrintWithFile (handle, settings.handle, pageFormat == null ? IntPtr.Zero : pageFormat.handle, mime, fileUrl.Handle);
-			CFString.ReleaseNative (mime);
-			return code;
+			try {
+				return PMPrinterPrintWithFile (Handle, settings.Handle, pageFormat.GetHandle (), mime, fileUrl.Handle);
+			} finally {
+				CFString.ReleaseNative (mime);
+			}
 		}
 
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMPrinterPrintWithProvider (IntPtr printer, IntPtr settings, IntPtr pageFormat, IntPtr strMimeType, IntPtr cgDataProvider);
 
-		public PMStatusCode TryPrintFromProvider (PMPrintSettings settings, PMPageFormat pageFormat, CGDataProvider provider, string mimeType = null)
+		public PMStatusCode TryPrintFromProvider (PMPrintSettings settings, PMPageFormat? pageFormat, CGDataProvider provider, string? mimeType = null)
 		{
-			if (settings == null)
+			if (settings is null)
 				throw new ArgumentNullException (nameof (settings));
-			if (provider == null)
+			if (provider is null)
 				throw new ArgumentNullException (nameof (provider));
 				    
 			IntPtr mime = CFString.CreateNative (mimeType);
-			var code = PMPrinterPrintWithProvider (handle, settings.handle, pageFormat == null ? IntPtr.Zero : pageFormat.handle, mime, provider.Handle);
-			CFString.ReleaseNative (mime);
-			return code;
+			try {
+				return PMPrinterPrintWithProvider (Handle, settings.Handle, pageFormat.GetHandle (), mime, provider.Handle);
+			} finally {
+				CFString.ReleaseNative (mime);
+			}
 		}
 
 		[DllImport (Constants.PrintCoreLibrary)]
@@ -693,20 +653,19 @@ namespace PrintCore {
 
 		public PMResolution GetOutputResolution (PMPrintSettings settings)
 		{
-			if (settings == null)
+			if (settings is null)
 				throw new ArgumentNullException (nameof (settings));
 
-			PMResolution res;
-			if (PMPrinterGetOutputResolution (handle, settings.Handle, out res) == PMStatusCode.Ok)
+			if (PMPrinterGetOutputResolution (Handle, settings.Handle, out var res) == PMStatusCode.Ok)
 				return res;
 			return new PMResolution (0, 0);
 		}
 
 		public void SetOutputResolution (PMPrintSettings settings, PMResolution res)
 		{
-			if (settings == null)
+			if (settings is null)
 				throw new ArgumentNullException (nameof (settings));
-			PMPrinterSetOutputResolution (handle, settings.Handle, ref res);
+			PMPrinterSetOutputResolution (Handle, settings.Handle, ref res);
 		}
 
 		[DllImport (Constants.PrintCoreLibrary)]
@@ -714,27 +673,26 @@ namespace PrintCore {
 
 		public PMStatusCode SetDefault ()
 		{
-			return PMPrinterSetDefault (handle);
+			return PMPrinterSetDefault (Handle);
 		}
 
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static byte PMPrinterIsFavorite (IntPtr printer);
-		public bool IsFavorite => PMPrinterIsFavorite (handle) != 0;
+		public bool IsFavorite => PMPrinterIsFavorite (Handle) != 0;
 		
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static byte PMPrinterIsDefault (IntPtr printer);
-		public bool IsDefault => PMPrinterIsDefault (handle) != 0;
+		public bool IsDefault => PMPrinterIsDefault (Handle) != 0;
 
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static byte PMPrinterIsPostScriptCapable (IntPtr printer);
-		public bool IsPostScriptCapable => PMPrinterIsPostScriptCapable (handle) != 0;
+		public bool IsPostScriptCapable => PMPrinterIsPostScriptCapable (Handle) != 0;
 
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMPrinterIsPostScriptPrinter  (IntPtr printer, out byte isps);
 		public bool IsPostScriptPrinter {
 			get {
-				byte r;
-				if (PMPrinterIsPostScriptPrinter (handle, out r) == PMStatusCode.Ok)
+				if (PMPrinterIsPostScriptPrinter (Handle, out var r) == PMStatusCode.Ok)
 					return r != 0;
 				return false;
 			}
@@ -744,8 +702,7 @@ namespace PrintCore {
 		extern static PMStatusCode PMPrinterIsRemote  (IntPtr printer, out byte isrem);
 		public bool IsRemote {
 			get {
-				byte r;
-				if (PMPrinterIsRemote (handle, out r) == PMStatusCode.Ok)
+				if (PMPrinterIsRemote (Handle, out var r) == PMStatusCode.Ok)
 					return r != 0;
 				return false;
 			}
@@ -754,18 +711,18 @@ namespace PrintCore {
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static IntPtr PMPrinterGetID (IntPtr printer);
 
-		public string Id {
+		public string? Id {
 			get {
-				return CFString.FromHandle (PMPrinterGetID (handle));
+				return CFString.FromHandle (PMPrinterGetID (Handle));
 			}
 		}
 
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMPrinterCopyHostName (IntPtr printer, out IntPtr hostName);
 
-		public string HostName {
+		public string? HostName {
 			get {
-				PMStatusCode code = PMPrinterCopyHostName (handle, out IntPtr hostName);
+				PMStatusCode code = PMPrinterCopyHostName (Handle, out var hostName);
 				if (code != PMStatusCode.Ok)
 					return null;
 				return CFString.FromHandle (hostName, true);
@@ -774,7 +731,11 @@ namespace PrintCore {
 	}
 
 	public class PMServer : PMPrintCoreBase {
-		PMServer () {}
+		// A private constructor so that nobody can create an instance of this class.
+		PMServer ()
+			: base (IntPtr.Zero, true)
+		{
+		}
 
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMServerLaunchPrinterBrowser (IntPtr server, IntPtr dictFutureUse);
@@ -786,20 +747,14 @@ namespace PrintCore {
 
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMServerCreatePrinterList (IntPtr server, out IntPtr printerListArray);
-		public static PMStatusCode CreatePrinterList (out PMPrinter [] printerList)
+		public static PMStatusCode CreatePrinterList (out PMPrinter []? printerList)
 		{
-			IntPtr arr;
-			var code = PMServerCreatePrinterList (IntPtr.Zero /* ServerLocal */, out arr);
+			var code = PMServerCreatePrinterList (IntPtr.Zero /* ServerLocal */, out var arr);
 			if (code != PMStatusCode.Ok){
 				printerList = null;
 				return code;
 			}
-			int c = (int) CFArray.GetCount (arr);
-			printerList = new PMPrinter [c];
-			for (int i = 0; i < c; i++)
-				printerList [i] = new PMPrinter (CFArray.CFArrayGetValueAtIndex (arr, i), owns: false);
-
-			CFObject.CFRelease (arr);
+			printerList = CFArray.ArrayFromHandleFunc<PMPrinter> (arr, (handle) => new PMPrinter (handle, false), true);
 			return PMStatusCode.Ok;
 		}
 	}

--- a/src/PrintCore/PrintCore.cs
+++ b/src/PrintCore/PrintCore.cs
@@ -115,7 +115,6 @@ namespace PrintCore {
 		
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMSessionCreatePrinterList (IntPtr printSession, out IntPtr printerListArray, out int index, out IntPtr printer);
-				
 		public PMStatusCode CreatePrinterList (out string? []? printerList, out int index, out PMPrinter? printer)
 		{
 			var code = PMSessionCreatePrinterList (Handle, out var array, out index, out var printerHandle);


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.ç
* Remove the PrintCore.NativeInvoke class and put the P/Invokes in the
  PMPrintCoreBase class - no need for a separate class for the P/Invokes in
  this class.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use CFString.CreateNative/ReleaseNative instead of other means to create
  native strings (the fastest and least memory hungry option).
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.
* Use Array.Empty<T> instead of creating an empty array manually.