### PR TITLE
[CGLPixelFormat] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/OpenGL/CGLPixelFormat.cs
+++ b/src/OpenGL/CGLPixelFormat.cs
@@ -25,12 +25,16 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Collections.Generic;
+
+using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
-using System.Runtime.Versioning;
 
 namespace OpenGL {
 #if !NET
@@ -41,44 +45,28 @@ namespace OpenGL {
 	[Obsolete ("Starting with macos10.14 Use 'Metal' Framework instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif
-	public class CGLPixelFormat : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CGLPixelFormat : NativeObject {
+#if !NET
 		public CGLPixelFormat (IntPtr handle)
+			: base (handle, false, verify: true)
 		{
-			if (handle == IntPtr.Zero)
-				throw new Exception ("Invalid parameters to context creation");
+		}
+#endif
 
-			CGLRetainPixelFormat (handle);
-			this.handle = handle;
+		protected override void Retain ()
+		{
+			CGLRetainPixelFormat (GetCheckedHandle ());
 		}
 
-		internal CGLPixelFormat ()
+		protected override void Release ()
 		{
+			CGLReleasePixelFormat (GetCheckedHandle ());
 		}
 
 		[Preserve (Conditional=true)]
 		internal CGLPixelFormat (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (!owns)
-				CGLRetainPixelFormat (handle);
-
-			this.handle = handle;
-		}
-
-		~CGLPixelFormat ()
-		{
-			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
 		}
 
 		[DllImport (Constants.OpenGLLibrary)]
@@ -87,25 +75,17 @@ namespace OpenGL {
 		[DllImport (Constants.OpenGLLibrary)]
 		extern static void CGLReleasePixelFormat (IntPtr handle);
 
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CGLReleasePixelFormat (handle);
-				handle = IntPtr.Zero;
-			}
-		}
-
 		[DllImport (Constants.OpenGLLibrary)]
 		extern static CGLErrorCode CGLChoosePixelFormat (CGLPixelFormatAttribute[] attributes, out IntPtr /* CGLPixelFormatObj* */ pix, out int /* GLint* */ npix);
 		public CGLPixelFormat (CGLPixelFormatAttribute[] attributes, out int npix)
+			: base (Create (attributes, out npix), true)
 		{
-			Initialize (attributes, out npix);
 		}
 
-		void Initialize (CGLPixelFormatAttribute[] attributes, out int npix)
+		static IntPtr Create (CGLPixelFormatAttribute[] attributes, out int npix)
 		{
-			if (attributes == null)
-				throw new ArgumentNullException ("attributes");
+			if (attributes is null)
+				throw new ArgumentNullException (nameof (attributes));
 			IntPtr pixelFormatOut;
 			var marshalAttribs = new CGLPixelFormatAttribute [attributes.Length + 1];
 
@@ -117,13 +97,12 @@ namespace OpenGL {
 				throw new Exception ("CGLChoosePixelFormat returned: " + ret);
 			}
 
-			this.handle = pixelFormatOut;
+			return pixelFormatOut;
 		}
 
 		public CGLPixelFormat (params object [] attributes)
+			: base (Create (ConvertToAttributes (attributes), out _), true)
 		{
-			int ignored;
-			Initialize (ConvertToAttributes (attributes), out ignored);
 		}
 
 		public CGLPixelFormat (out int npix, params object [] attributes) : this (ConvertToAttributes (attributes), out npix)


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.
* Remove the (IntPtr) constructor for NET