### PR TITLE
[CGImageSource] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/ImageIO/CGImageSource.cs
+++ b/src/ImageIO/CGImageSource.cs
@@ -290,9 +290,9 @@ namespace ImageIO {
 		[DllImport (Constants.ImageIOLibrary)]
 		extern static /* CGImageRef */ IntPtr CGImageSourceCreateThumbnailAtIndex (/* CGImageSourceRef */ IntPtr isrc, /* size_t */ nint index, /* CFDictionaryRef */ IntPtr options);
 
-		public CGImage CreateThumbnail (int index, CGImageThumbnailOptions options)
+		public CGImage CreateThumbnail (int index, CGImageThumbnailOptions? options)
 		{
-			using (var dict = options.ToDictionary ()) {
+			using (var dict = options?.ToDictionary ()) {
 				var ret = CGImageSourceCreateThumbnailAtIndex (Handle, index, dict.GetHandle ());
 				return new CGImage (ret, true);
 			}

--- a/src/ImageIO/CGImageSource.iOS.cs
+++ b/src/ImageIO/CGImageSource.iOS.cs
@@ -5,6 +5,8 @@
 // Copyright 2013-2014 Xamarin Inc
 //
 
+#nullable enable
+
 #if !MONOMAC
 
 using System;
@@ -14,8 +16,6 @@ using System.Runtime.Versioning;
 
 using ObjCRuntime;
 using Foundation;
-using CoreFoundation;
-using CoreGraphics;
 
 namespace ImageIO {
 	
@@ -31,25 +31,19 @@ namespace ImageIO {
 #if !NET
 		[iOS (7,0)]
 #endif
-		public CGImageMetadata CopyMetadata (nint index, NSDictionary options)
+		public CGImageMetadata? CopyMetadata (nint index, NSDictionary? options)
 		{
-			IntPtr o = options == null ? IntPtr.Zero : options.Handle;
-			IntPtr result = CGImageSourceCopyMetadataAtIndex (Handle, index, o);
-			return (result == IntPtr.Zero) ? null : new CGImageMetadata (result);
+			var result = CGImageSourceCopyMetadataAtIndex (Handle, index, options.GetHandle ());
+			return (result == IntPtr.Zero) ? null : new CGImageMetadata (result, true);
 		}
 
 #if !NET
 		[iOS (7,0)]
 #endif
-		public CGImageMetadata CopyMetadata (nint index, CGImageOptions options)
+		public CGImageMetadata? CopyMetadata (nint index, CGImageOptions? options)
 		{
-			NSDictionary o = null;
-			if (options != null)
-				o = options.ToDictionary ();
-			var result = CopyMetadata (index, o);
-			if (options != null)
-				o.Dispose ();
-			return result;
+			using var o = options?.ToDictionary ();
+			return CopyMetadata (index, o);
 		}
 
 		// CGImageSource.h


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.
* Use the 'Runtime.GetNSObject<T> (IntPtr, bool)' overload to specify handle
  ownership, to avoid having to call NSObject.DangerousRelease manually later.
* Use Array.Empty<T> instead of creating an empty array manually.
* Remove the internal (IntPtr) constructor.