### PR TITLE
[CoreGraphics] Rename a P/Invoke to not overload on nint vs IntPtr.

### DIFF
--- a/src/CoreGraphics/CGPDFObject.cs
+++ b/src/CoreGraphics/CGPDFObject.cs
@@ -53,7 +53,7 @@ namespace CoreGraphics {
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFObjectGetValue (/* CGPDFObjectRef */IntPtr pdfobj, CGPDFObjectType type, /* void* */ out byte value);
 
-		[DllImport (Constants.CoreGraphicsLibrary)]
+		[DllImport (Constants.CoreGraphicsLibrary, EntryPoint = "CGPDFObjectGetValue")]
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFObjectGetNIntValue (/* CGPDFObjectRef */IntPtr pdfobj, CGPDFObjectType type, /* void* */ out nint value);
 


### PR DESCRIPTION
It would result in the same signature when using C# nints, and a failed build.