### PR TITLE
[CFRunLoop] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreFoundation/CFProxySupport.cs
+++ b/src/CoreFoundation/CFProxySupport.cs
@@ -647,7 +647,7 @@ namespace CoreFoundation {
 				pacCbData.ErrorPtr = error;
 			}
 			// stop the CFRunLoop
-			var runLoop = new CFRunLoop (pacCbData.CFRunLoopPtr);
+			var runLoop = new CFRunLoop (pacCbData.CFRunLoopPtr, false);
 			Marshal.StructureToPtr (pacCbData, client, false);
 			runLoop.Stop ();
 		}
@@ -673,7 +673,7 @@ namespace CoreFoundation {
 					var clientContext = new CFStreamClientContext ();
 					clientContext.Info = pacDataPtr;
 
-					using (var loopSource = new CFRunLoopSource (factory (ExecutePacCallback, ref clientContext)))
+					using (var loopSource = new CFRunLoopSource (factory (ExecutePacCallback, ref clientContext), false))
 					using (var mode = new NSString ("Xamarin.iOS.Proxy")) {
 
 						if (cancellationToken.IsCancellationRequested)
@@ -729,7 +729,7 @@ namespace CoreFoundation {
 				var clientContext = new CFStreamClientContext ();
 				clientContext.Info = pacDataPtr;
 
-				using (var loopSource = new CFRunLoopSource (factory (ExecutePacCallback, ref clientContext)))
+				using (var loopSource = new CFRunLoopSource (factory (ExecutePacCallback, ref clientContext), false))
 				using (var mode = new NSString ("Xamarin.iOS.Proxy")) {
 					runLoop.AddSource (loopSource, mode);
 					runLoop.RunInMode (mode, double.MaxValue, false);

--- a/src/CoreFoundation/CFRunLoop.cs
+++ b/src/CoreFoundation/CFRunLoop.cs
@@ -28,6 +28,8 @@
 //
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -61,30 +63,21 @@ namespace CoreFoundation {
 		public IntPtr Perform;
 	}
 
-	public class CFRunLoopSource : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CFRunLoopSource : NativeObject {
+#if !NET
 		public CFRunLoopSource (IntPtr handle)
-			: this (handle, false)
+			: base (handle, false)
 		{
 		}
+#endif
 
-		public CFRunLoopSource (IntPtr handle, bool ownsHandle)
+#if NET
+		internal CFRunLoopSource (IntPtr handle, bool owns)
+#else
+		public CFRunLoopSource (IntPtr handle, bool owns)
+#endif
+			: base (handle, owns)
 		{
-			if (!ownsHandle)
-				CFObject.CFRetain (handle);
-			this.handle = handle;
-		}
-
-		~CFRunLoopSource ()
-		{
-			Dispose (false);
-		}
-
-		public IntPtr Handle {
-			get {
-				return handle;
-			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -92,7 +85,7 @@ namespace CoreFoundation {
 
 		public nint Order {
 			get {
-				return CFRunLoopSourceGetOrder (handle);
+				return CFRunLoopSourceGetOrder (Handle);
 			}
 		}
 
@@ -101,7 +94,7 @@ namespace CoreFoundation {
 
 		public void Invalidate ()
 		{
-			CFRunLoopSourceInvalidate (handle);
+			CFRunLoopSourceInvalidate (Handle);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -110,7 +103,7 @@ namespace CoreFoundation {
 
 		public bool IsValid {
 			get {
-				return CFRunLoopSourceIsValid (handle);
+				return CFRunLoopSourceIsValid (Handle);
 			}
 		}
 
@@ -119,21 +112,7 @@ namespace CoreFoundation {
 
 		public void Signal ()
 		{
-			CFRunLoopSourceSignal (handle);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero) {
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
+			CFRunLoopSourceSignal (Handle);
 		}
 	}
 
@@ -142,12 +121,12 @@ namespace CoreFoundation {
 		GCHandle gch;
 
 		[DllImport (Constants.CoreFoundationLibrary)]
-		extern static /* CFRunLoopSourceRef */ IntPtr CFRunLoopSourceCreate (/* CFAllocatorRef */ IntPtr allocator, /* CFIndex */ nint order, /* CFRunLoopSourceContext* */ IntPtr context);
+		extern static /* CFRunLoopSourceRef */ IntPtr CFRunLoopSourceCreate (/* CFAllocatorRef */ IntPtr allocator, /* CFIndex */ nint order, /* CFRunLoopSourceContext* */ ref CFRunLoopSourceContext context);
 
 		static ScheduleCallback ScheduleDelegate = (ScheduleCallback) Schedule;
 		static CancelCallback CancelDelegate = (CancelCallback) Cancel;
 		static PerformCallback PerformDelegate = (PerformCallback) Perform;
-		
+
 		protected CFRunLoopSourceCustom ()
 			: base (IntPtr.Zero, true)
 		{
@@ -158,16 +137,8 @@ namespace CoreFoundation {
 			ctx.Cancel = Marshal.GetFunctionPointerForDelegate (CancelDelegate);
 			ctx.Perform = Marshal.GetFunctionPointerForDelegate (PerformDelegate);
 
-			var ptr = Marshal.AllocHGlobal (Marshal.SizeOf (typeof(CFRunLoopSourceContext)));
-			try {
-				Marshal.StructureToPtr (ctx, ptr, false);
-				handle = CFRunLoopSourceCreate (IntPtr.Zero, 0, ptr);
-			} finally {
-				Marshal.FreeHGlobal (ptr);
-			}
-
-			if (handle == IntPtr.Zero)
-				throw new NotSupportedException ();
+			var handle = CFRunLoopSourceCreate (IntPtr.Zero, 0, ref ctx);
+			InitializeHandle (handle);
 		}
 
 		delegate void ScheduleCallback (IntPtr info, IntPtr runLoop, IntPtr mode);
@@ -176,8 +147,10 @@ namespace CoreFoundation {
 		static void Schedule (IntPtr info, IntPtr runLoop, IntPtr mode)
 		{
 			var source = GCHandle.FromIntPtr (info).Target as CFRunLoopSourceCustom;
+			if (source is null)
+				return;
 
-			using (var loop = new CFRunLoop (runLoop))
+			using (var loop = new CFRunLoop (runLoop, false))
 			using (var mstring = new NSString (mode)) {
 				source.OnSchedule (loop, mstring);
 			}
@@ -191,8 +164,10 @@ namespace CoreFoundation {
 		static void Cancel (IntPtr info, IntPtr runLoop, IntPtr mode)
 		{
 			var source = GCHandle.FromIntPtr (info).Target as CFRunLoopSourceCustom;
+			if (source is null)
+				return;
 
-			using (var loop = new CFRunLoop (runLoop))
+			using (var loop = new CFRunLoop (runLoop, false))
 			using (var mstring = new NSString (mode)) {
 				source.OnCancel (loop, mstring);
 			}
@@ -206,6 +181,9 @@ namespace CoreFoundation {
 		static void Perform (IntPtr info)
 		{
 			var source = GCHandle.FromIntPtr (info).Target as CFRunLoopSourceCustom;
+			if (source is null)
+				return;
+
 			source.OnPerform ();
 		}
 
@@ -222,20 +200,15 @@ namespace CoreFoundation {
 	}
 #endif
 
-	public partial class CFRunLoop
-#if !COREBUILD
-		: INativeObject, IDisposable
-#endif
+	public partial class CFRunLoop : NativeObject
 	{
 #if !COREBUILD
-		internal IntPtr handle;
-
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFRunLoopRef */ IntPtr CFRunLoopGetCurrent ();
 
 		static public CFRunLoop Current {
 			get {
-				return new CFRunLoop (CFRunLoopGetCurrent ());
+				return new CFRunLoop (CFRunLoopGetCurrent (), false);
 			}
 		}
 
@@ -244,7 +217,7 @@ namespace CoreFoundation {
 		
 		static public CFRunLoop Main {
 			get {
-				return new CFRunLoop (CFRunLoopGetMain ());
+				return new CFRunLoop (CFRunLoopGetMain (), false);
 			}
 		}
 
@@ -261,7 +234,7 @@ namespace CoreFoundation {
 
 		public void Stop ()
 		{
-			CFRunLoopStop (handle);
+			CFRunLoopStop (Handle);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -269,7 +242,7 @@ namespace CoreFoundation {
 
 		public void WakeUp ()
 		{
-			CFRunLoopWakeUp (handle);
+			CFRunLoopWakeUp (Handle);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -278,21 +251,21 @@ namespace CoreFoundation {
 
 		public bool IsWaiting {
 			get {
-				return CFRunLoopIsWaiting (handle);
+				return CFRunLoopIsWaiting (Handle);
 			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
-		extern static int /* SInt32 */ CFRunLoopRunInMode (/* CFStringRef */ IntPtr mode, 
+		extern static CFRunLoopExitReason /* SInt32 */ CFRunLoopRunInMode (/* CFStringRef */ IntPtr mode, 
 			/* CFTimeInterval */ double seconds, 
 			/* Boolean */ [MarshalAs (UnmanagedType.I1)] bool returnAfterSourceHandled);
 
 		public CFRunLoopExitReason RunInMode (NSString mode, double seconds, bool returnAfterSourceHandled)
 		{
-			if (mode == null)
-				throw new ArgumentNullException ("mode");
+			if (mode is null)
+				throw new ArgumentNullException (nameof (mode));
 
-			return (CFRunLoopExitReason) CFRunLoopRunInMode (mode.Handle, seconds, returnAfterSourceHandled);
+			return CFRunLoopRunInMode (mode.Handle, seconds, returnAfterSourceHandled);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -300,12 +273,12 @@ namespace CoreFoundation {
 
 		public void AddSource (CFRunLoopSource source, NSString mode)
 		{
-			if (source == null)
-				throw new ArgumentNullException ("source");
-			if (mode == null)
-				throw new ArgumentNullException ("mode");
+			if (source is null)
+				throw new ArgumentNullException (nameof (source));
+			if (mode is null)
+				throw new ArgumentNullException (nameof (mode));
 
-			CFRunLoopAddSource (handle, source.Handle, mode.Handle);
+			CFRunLoopAddSource (Handle, source.Handle, mode.Handle);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -314,12 +287,12 @@ namespace CoreFoundation {
 
 		public bool ContainsSource (CFRunLoopSource source, NSString mode)
 		{
-			if (source == null)
-				throw new ArgumentNullException ("source");
-			if (mode == null)
-				throw new ArgumentNullException ("mode");
+			if (source is null)
+				throw new ArgumentNullException (nameof (source));
+			if (mode is null)
+				throw new ArgumentNullException (nameof (mode));
 
-			return CFRunLoopContainsSource (handle, source.Handle, mode.Handle);
+			return CFRunLoopContainsSource (Handle, source.Handle, mode.Handle);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -327,50 +300,18 @@ namespace CoreFoundation {
 
 		public void RemoveSource (CFRunLoopSource source, NSString mode)
 		{
-			if (source == null)
-				throw new ArgumentNullException ("source");
-			if (mode == null)
-				throw new ArgumentNullException ("mode");
+			if (source is null)
+				throw new ArgumentNullException (nameof (source));
+			if (mode is null)
+				throw new ArgumentNullException (nameof (mode));
 
-			CFRunLoopRemoveSource (handle, source.Handle, mode.Handle);
-		}
-
-		internal CFRunLoop (IntPtr handle)
-			: this (handle, false)
-		{
+			CFRunLoopRemoveSource (Handle, source.Handle, mode.Handle);
 		}
 
 		[Preserve (Conditional = true)]
 		internal CFRunLoop (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (!owns)
-				CFObject.CFRetain (handle);
-			this.handle = handle;
-		}
-
-		~CFRunLoop ()
-		{
-			Dispose (false);
-		}
-
-		public IntPtr Handle {
-			get {
-				return handle;
-			}
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 		public static bool operator == (CFRunLoop a, CFRunLoop b)
@@ -385,16 +326,16 @@ namespace CoreFoundation {
 
 		public override int GetHashCode ()
 		{
-			return handle.GetHashCode ();
+			return Handle.GetHashCode ();
 		}
 
-		public override bool Equals (object other)
+		public override bool Equals (object? other)
 		{
-			CFRunLoop cfother = other as CFRunLoop;
-			if (cfother == null)
+			var cfother = other as CFRunLoop;
+			if (cfother is null)
 				return false;
 
-			return cfother.Handle == handle;
+			return cfother.Handle == Handle;
 		}
 #endif // !COREBUILD
 	}

--- a/src/CoreFoundation/CFSocket.cs
+++ b/src/CoreFoundation/CFSocket.cs
@@ -326,7 +326,7 @@ namespace CoreFoundation {
 				throw new CFSocketException (CFSocketError.Error);
 			gch = GCHandle.Alloc (this);
 
-			var source = new CFRunLoopSource (CFSocketCreateRunLoopSource (IntPtr.Zero, handle, 0));
+			var source = new CFRunLoopSource (CFSocketCreateRunLoopSource (IntPtr.Zero, handle, 0), true);
 			loop.AddSource (source, CFRunLoop.ModeDefault);
 		}
 
@@ -350,7 +350,7 @@ namespace CoreFoundation {
 			if (handle == IntPtr.Zero)
 				throw new CFSocketException (CFSocketError.Error);
 
-			var source = new CFRunLoopSource (CFSocketCreateRunLoopSource (IntPtr.Zero, handle, 0));
+			var source = new CFRunLoopSource (CFSocketCreateRunLoopSource (IntPtr.Zero, handle, 0), true);
 			var loop = CFRunLoop.Current;
 			loop.AddSource (source, CFRunLoop.ModeDefault);
 		}
@@ -360,7 +360,7 @@ namespace CoreFoundation {
 			this.handle = handle;
 			gch = GCHandle.Alloc (this);
 
-			var source = new CFRunLoopSource (CFSocketCreateRunLoopSource (IntPtr.Zero, handle, 0));
+			var source = new CFRunLoopSource (CFSocketCreateRunLoopSource (IntPtr.Zero, handle, 0), true);
 			var loop = CFRunLoop.Current;
 			loop.AddSource (source, CFRunLoop.ModeDefault);
 		}

--- a/src/CoreFoundation/CFSocket.cs
+++ b/src/CoreFoundation/CFSocket.cs
@@ -306,6 +306,7 @@ namespace CoreFoundation {
 				loop.AddSource (source, CFRunLoop.ModeDefault);
 			} catch {
 				gch.Free ();
+				throw;
 			}
 		}
 

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -1225,7 +1225,7 @@ namespace Foundation {
 			{
 				status = NSStreamStatus.NotOpen;
 				stream = inputStream;
-				source = new CFRunLoopSource (Handle);
+				source = new CFRunLoopSource (Handle, false);
 			}
 
 			public override NSStreamStatus Status => status;


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.
* Remove the (IntPtr) constructor for .NET
* Make the (IntPtr, bool) constructor internal for .NET
* Make the CFRunLoopSourceCreate P/Invoke take a ref parameter to avoid manual
  memory handling.