### PR TITLE
Pin the signing plugin task to 3.3.11

### DIFF
--- a/tools/devops/automation/templates/build/sign-and-notarized.yml
+++ b/tools/devops/automation/templates/build/sign-and-notarized.yml
@@ -88,7 +88,7 @@ steps:
   condition: and(${{ parameters.condition }}, contains(variables['configuration.BuildPkgs'], 'True'))
   timeoutInMinutes: 180
 
-- task: MicroBuildSigningPlugin@3
+- task: MicroBuildSigningPlugin@3.3.11
   displayName: 'Install Signing Plugin'
   inputs:
     signType: '${{ parameters.signatureType }}'


### PR DESCRIPTION
Pinning the sign plugin task to 3.3.11 to workaround current issue.