### PR TITLE
[tests] Add an Xcode 13.1 version check in WKPreferencesTest.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -300,6 +300,18 @@ partial class TestRuntime
 #else
 				throw new NotImplementedException ();
 #endif
+			case 1:
+#if __WATCHOS__
+				return CheckWatchOSSystemVersion (8, 1);
+#elif __TVOS__
+				return ChecktvOSSystemVersion (15, 1);
+#elif __IOS__
+				return CheckiOSSystemVersion (15, 1);
+#elif MONOMAC
+				return CheckMacSystemVersion (12, 0);
+#else
+				throw new NotImplementedException ();
+#endif
 			default:
 				throw new NotImplementedException ();
 			}

--- a/tests/monotouch-test/WebKit/WKPreferencesTest.cs
+++ b/tests/monotouch-test/WebKit/WKPreferencesTest.cs
@@ -14,6 +14,7 @@ namespace MonoTouchFixtures.WebKit {
 		[Test]
 		public void TextInteractionEnabledTest ()
 		{
+			TestRuntime.AssertXcodeVersion (13, 1);
 			using var preferences = new WKPreferences ();
 			// ignore the OS version, the property should always work
 			Assert.DoesNotThrow (() => preferences.TextInteractionEnabled = true, "Getter");


### PR DESCRIPTION
Fixes this test failure on macOS 10.14:

    MonoTouchFixtures.WebKit.WKPreferencesTest
        [FAIL] TextInteractionEnabledTest :   Getter
            Expected: No Exception to be thrown
            But was:  <Foundation.ObjCException: NSInvalidArgumentException: -[WKPreferences setTextInteractionEnabled:]: unrecognized selector sent to instance 0x7fa228f12640
                at (wrapper managed-to-native) ObjCRuntime.Messaging.void_objc_msgSend_bool(intptr,intptr,bool)
                at WebKit.WKPreferences.set__OldTextInteractionEnabled (System.Boolean value) [0x0002c] in /Users/builder/azdo/_work/1/s/xamarin-macios/src/build/mac/mobile/WebKit/WKPreferences.g.cs:482
                at WebKit.WKPreferences.set_TextInteractionEnabled (System.Boolean value) [0x00000] in /Users/builder/azdo/_work/1/s/xamarin-macios/src/WKWebKit/WKPreferences.cs:32
                at MonoTouchFixtures.WebKit.WKPreferencesTest+<>c__DisplayClass0_0.<TextInteractionEnabledTest>b__0 () [0x00000] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/WebKit/WKPreferencesTest.cs:19
                at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
                at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs:395
                --- End of stack trace from previous location where exception was thrown ---
                at NUnit.Framework.Internal.ExceptionHelper.Rethrow (System.Exception exception) [0x00006] in <d392db2fb3d64f4fa564a7b744fc7801>:0
                at NUnit.Framework.Internal.Reflect.DynamicInvokeWithTransparentExceptions (System.Delegate delegate) [0x00013] in <d392db2fb3d64f4fa564a7b744fc7801>:0
                at NUnit.Framework.Internal.ExceptionHelper.RecordException (System.Delegate parameterlessDelegate, System.String parameterName) [0x00067] in <d392db2fb3d64f4fa564a7b744fc7801>:0 >