### PR TITLE
[CGPDFContentStream] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreGraphics/CGPDFContentStream.cs
+++ b/src/CoreGraphics/CGPDFContentStream.cs
@@ -6,6 +6,8 @@
 //     
 // Copyright 2014 Xamarin Inc. All rights reserved.
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using Foundation;
@@ -15,7 +17,7 @@ using CoreFoundation;
 namespace CoreGraphics {
 
 	// CGPDFContentStream.h
-	public class CGPDFContentStream : INativeObject, IDisposable {
+	public class CGPDFContentStream : NativeObject {
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGPDFContentStreamRef */ IntPtr CGPDFContentStreamCreateWithPage (/* CGPDFPageRef */ IntPtr page);
@@ -30,82 +32,65 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGPDFContentStreamRelease (/* CGPDFContentStreamRef */ IntPtr cs);
 
+#if !NET
 		public CGPDFContentStream (IntPtr handle)
+			: base (handle, false)
 		{
-			CGPDFContentStreamRetain (handle);
-			Handle = handle;
 		}
+#endif
 
 		[Preserve (Conditional=true)]
 		internal CGPDFContentStream (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (!owns)
-				CGPDFContentStreamRetain (handle);
-
-			Handle = handle;
 		}
 
 		public CGPDFContentStream (CGPDFPage page)
+			: base (CGPDFContentStreamCreateWithPage (Runtime.ThrowOnNull (page, nameof (page)).Handle), true)
 		{
-			if (page == null)
-				throw new ArgumentNullException ("page");
-			Handle = CGPDFContentStreamCreateWithPage (page.Handle);
 		}
 
-		public CGPDFContentStream (CGPDFStream stream, NSDictionary streamResources = null, CGPDFContentStream parent = null)
+		static IntPtr Create (CGPDFStream stream, NSDictionary? streamResources = null, CGPDFContentStream? parent = null)
 		{
-			if (stream == null)
-				throw new ArgumentNullException ("stream");
+			if (stream is null)
+				throw new ArgumentNullException (nameof (stream));
 
-			var dh = streamResources == null ? IntPtr.Zero : streamResources.Handle;
-			var ph = parent == null ? IntPtr.Zero : parent.Handle;
-			Handle = CGPDFContentStreamCreateWithStream (stream.Handle, dh, ph);
+			return CGPDFContentStreamCreateWithStream (stream.Handle, streamResources.GetHandle (), parent.GetHandle ());
 		}
 
-		~CGPDFContentStream ()
+		public CGPDFContentStream (CGPDFStream stream, NSDictionary? streamResources = null, CGPDFContentStream? parent = null)
+			: base (Create (stream, streamResources, parent), true)
 		{
-			Dispose (false);
 		}
 
-		public void Dispose ()
+		protected override void Retain ()
 		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
+			CGPDFContentStreamRetain (GetCheckedHandle ());
 		}
 
-		protected virtual void Dispose (bool disposing)
+		protected override void Release ()
 		{
-			if (Handle != IntPtr.Zero){
-				CGPDFContentStreamRelease (Handle);
-				Handle = IntPtr.Zero;
-			}
+			CGPDFContentStreamRelease (GetCheckedHandle ());
 		}
-
-		public IntPtr Handle { get; private set; }
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CFArrayRef */ IntPtr CGPDFContentStreamGetStreams (/* CGPDFContentStreamRef */ IntPtr cs);
 
-		public CGPDFStream[] GetStreams ()
+		public CGPDFStream?[]? GetStreams ()
 		{
-			using (CFArray a = new CFArray (CGPDFContentStreamGetStreams (Handle))) {
-				var streams = new CGPDFStream [a.Count];
-				for (int i = 0; i < a.Count; i++)
-					streams [i] = new CGPDFStream (a.GetValue (i));
-				return streams;
-				// note: CGPDFStreamRef is weird because it has no retain/release calls unlike other CGPDF* types
-			}
+			var rv = CGPDFContentStreamGetStreams (Handle);
+			return CFArray.ArrayFromHandleFunc (rv, (handle) => new CGPDFStream (handle));
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGPDFObjectRef */ IntPtr CGPDFContentStreamGetResource (/* CGPDFContentStreamRef */ IntPtr cs, /* const char* */ string category, /* const char* */ string name);
 
-		public CGPDFObject GetResource (string category, string name)
+		public CGPDFObject? GetResource (string category, string name)
 		{
-			if (category == null)
-				throw new ArgumentNullException ("category");
-			if (name == null)
-				throw new ArgumentNullException ("name");
+			if (category is null)
+				throw new ArgumentNullException (nameof (category));
+			if (name is null)
+				throw new ArgumentNullException (nameof (name));
 
 			var h = CGPDFContentStreamGetResource (Handle, category, name);
 			return (h == IntPtr.Zero) ? null : new CGPDFObject (h);

--- a/src/CoreGraphics/CGPDFScanner.cs
+++ b/src/CoreGraphics/CGPDFScanner.cs
@@ -90,7 +90,7 @@ namespace CoreGraphics {
 
 		public CGPDFContentStream GetContentStream ()
 		{
-			return new CGPDFContentStream (CGPDFScannerGetContentStream (Handle));
+			return new CGPDFContentStream (CGPDFScannerGetContentStream (Handle), false);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use CFArray.ArrayFromHandleFunc to create managed array from a native CFArray
  instead of doing it manually.
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.
* Remove the (IntPtr) constructor for .NET