### PR TITLE
[apidiff] Fix rule to download reference assemblies.

### DIFF
--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -365,7 +365,8 @@ $$(UNZIP_STAMP_DOTNET_$(1)): $$(BUNDLE_ZIP_DOTNET_$(1))
 	$$(Q_GEN) unzip -q -d $$(UNZIP_DIR_DOTNET_$(1)) $$(BUNDLE_ZIP_DOTNET_$(1))
 	$$(Q) touch $$@
 
-$$(UNZIP_DIR_DOTNET_$(1))/%.dll: $$(UNZIP_STAMP_DOTNET_$(1))
+$$(UNZIP_DIR_DOTNET_$(1))/%.dll: $$(UNZIP_STAMP_DOTNET_$(1)) ;
+
 endef
 
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call DotNetUnzipBundle,$(platform))))


### PR DESCRIPTION
Make seems to ignore pattern rules without a recipe, so just add an empty
recipe for this pattern rule.

Fixes:

> make: *** No rule to make target `temp/downloads/dotnet-iOS-5315390/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.dll', needed by `references/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.xml'.  Stop.