### PR TITLE
[CV[Image|Pixel[Buffer] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreVideo/CVBuffer.cs
+++ b/src/CoreVideo/CVBuffer.cs
@@ -25,6 +25,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -40,63 +43,29 @@ namespace CoreVideo {
 #if !NET
 	[Watch (4,0)]
 #endif
-	public partial class CVBuffer : INativeObject
+	public partial class CVBuffer : NativeObject
+	{
 #if !COREBUILD
-		, IDisposable
-#endif
-		{
-#if !COREBUILD
-		internal IntPtr handle;
-
-		internal CVBuffer ()
-		{
-		}
-
-		internal CVBuffer (IntPtr handle)
-		{
-			if (handle == IntPtr.Zero)
-				throw new Exception ("Invalid parameters to context creation");
-
-			CVBufferRetain (handle);
-			this.handle = handle;
-		}
-
 		[Preserve (Conditional=true)]
 		internal CVBuffer (IntPtr handle, bool owns)
+			: base (handle, owns, verify: true)
 		{
-			if (!owns)
-				CVBufferRetain (handle);
-
-			this.handle = handle;
 		}
 
-		~CVBuffer ()
-		{
-			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-	
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static void CVBufferRelease (/* CVBufferRef */ IntPtr buffer);
 		
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static /* CVBufferRef */ IntPtr CVBufferRetain (/* CVBufferRef */ IntPtr buffer);
-		
-		protected virtual void Dispose (bool disposing)
+
+		protected override void Retain ()
 		{
-			if (handle != IntPtr.Zero){
-				CVBufferRelease (handle);
-				handle = IntPtr.Zero;
-			}
+			CVBufferRetain (GetCheckedHandle ());
+		}
+
+		protected override void Release ()
+		{
+			CVBufferRelease (GetCheckedHandle ());
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
@@ -104,7 +73,7 @@ namespace CoreVideo {
 
 		public void RemoveAllAttachments ()
 		{
-			CVBufferRemoveAllAttachments (handle);
+			CVBufferRemoveAllAttachments (Handle);
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
@@ -112,10 +81,10 @@ namespace CoreVideo {
 
 		public void RemoveAttachment (NSString key)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
-			CVBufferRemoveAttachment (handle, key.Handle);
+			CVBufferRemoveAttachment (Handle, key.Handle);
 		}
 
 #if !NET
@@ -151,15 +120,15 @@ namespace CoreVideo {
 		// any CF object can be attached
 		public T? GetAttachment<T> (NSString key, out CVAttachmentMode attachmentMode) where T : class, INativeObject
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 #if IOS || __MACCATALYST__ || TVOS
 			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
 #elif WATCH
 			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (8, 0))
 #endif
-				return Runtime.GetINativeObject<T> (CVBufferCopyAttachment (handle, key.Handle, out attachmentMode), true);
-			return Runtime.GetINativeObject<T> (CVBufferGetAttachment (handle, key.Handle, out attachmentMode), false);
+				return Runtime.GetINativeObject<T> (CVBufferCopyAttachment (Handle, key.Handle, out attachmentMode), true);
+			return Runtime.GetINativeObject<T> (CVBufferGetAttachment (Handle, key.Handle, out attachmentMode), false);
 		}
 #else
 		public NSObject? GetAttachment (NSString key, out CVAttachmentMode attachmentMode)
@@ -167,9 +136,9 @@ namespace CoreVideo {
 			if (key is null)
 				throw new ArgumentNullException (nameof (key));
 			if (PlatformHelper.CheckSystemVersion (12, 0))
-				return Runtime.GetNSObject<NSObject> (CVBufferCopyAttachment (handle, key.Handle, out attachmentMode), true);
+				return Runtime.GetNSObject<NSObject> (CVBufferCopyAttachment (Handle, key.Handle, out attachmentMode), true);
 			else
-				return Runtime.GetNSObject<NSObject> (CVBufferGetAttachment (handle, key.Handle, out attachmentMode), false);
+				return Runtime.GetNSObject<NSObject> (CVBufferGetAttachment (Handle, key.Handle, out attachmentMode), false);
 		}
 #endif
 
@@ -208,8 +177,8 @@ namespace CoreVideo {
 #elif MONOMAC
 			if (PlatformHelper.CheckSystemVersion (12, 0))
 #endif
-				return Runtime.GetINativeObject<NSDictionary> (CVBufferCopyAttachments (handle, attachmentMode), true);
-			return Runtime.GetNSObject<NSDictionary> (CVBufferGetAttachments (handle, attachmentMode), false);
+				return Runtime.GetINativeObject<NSDictionary> (CVBufferCopyAttachments (Handle, attachmentMode), true);
+			return Runtime.GetNSObject<NSDictionary> (CVBufferGetAttachments (Handle, attachmentMode), false);
 		}
 
 		// There is some API that needs a more strongly typed version of a NSDictionary
@@ -218,7 +187,7 @@ namespace CoreVideo {
 			where TKey : class, INativeObject
 			where TValue : class, INativeObject
 		{
-			return Runtime.GetNSObject<NSDictionary<TKey, TValue>> (CVBufferGetAttachments (handle, attachmentMode));
+			return Runtime.GetNSObject<NSDictionary<TKey, TValue>> (CVBufferGetAttachments (Handle, attachmentMode));
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
@@ -226,10 +195,10 @@ namespace CoreVideo {
 
 		public void PropogateAttachments (CVBuffer destinationBuffer)
 		{
-			if (destinationBuffer == null)
-				throw new ArgumentNullException ("destinationBuffer");
+			if (destinationBuffer is null)
+				throw new ArgumentNullException (nameof (destinationBuffer));
 
-			CVBufferPropagateAttachments (handle, destinationBuffer.Handle);
+			CVBufferPropagateAttachments (Handle, destinationBuffer.Handle);
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
@@ -237,11 +206,11 @@ namespace CoreVideo {
 
 		public void SetAttachment (NSString key, INativeObject @value, CVAttachmentMode attachmentMode)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
-			if (@value == null)
-				throw new ArgumentNullException ("value");
-			CVBufferSetAttachment (handle, key.Handle, @value.Handle, attachmentMode);
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
+			if (@value is null)
+				throw new ArgumentNullException (nameof (value));
+			CVBufferSetAttachment (Handle, key.Handle, @value.Handle, attachmentMode);
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
@@ -249,9 +218,9 @@ namespace CoreVideo {
 
 		public void SetAttachments (NSDictionary theAttachments, CVAttachmentMode attachmentMode)
 		{
-			if (theAttachments == null)
-				throw new ArgumentNullException ("theAttachments");
-			CVBufferSetAttachments (handle, theAttachments.Handle, attachmentMode);
+			if (theAttachments is null)
+				throw new ArgumentNullException (nameof (theAttachments));
+			CVBufferSetAttachments (Handle, theAttachments.Handle, attachmentMode);
 		}
 
 #if !NET
@@ -278,7 +247,7 @@ namespace CoreVideo {
 		{
 			if (key is null)
 				throw new ArgumentNullException (nameof (key));
-			return CVBufferHasAttachment (handle, key.Handle);
+			return CVBufferHasAttachment (Handle, key.Handle);
 		}
 
 #endif // !COREBUILD

--- a/src/CoreVideo/CVImageBuffer.cs
+++ b/src/CoreVideo/CVImageBuffer.cs
@@ -43,14 +43,9 @@ namespace CoreVideo {
 #endif
 	public partial class CVImageBuffer : CVBuffer {
 #if !COREBUILD
-		internal CVImageBuffer (IntPtr handle) : base (handle)
-		{
-		}
-
-		internal CVImageBuffer () {}
-		
 		[Preserve (Conditional=true)]
-		internal CVImageBuffer (IntPtr handle, bool owns) : base (handle, owns)
+		internal CVImageBuffer (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
 		}
 		
@@ -59,7 +54,7 @@ namespace CoreVideo {
 
 		public CGRect CleanRect {
 			get {
-				return CVImageBufferGetCleanRect (handle);
+				return CVImageBufferGetCleanRect (Handle);
 			}
 		}
 
@@ -68,7 +63,7 @@ namespace CoreVideo {
 
 		public CGSize DisplaySize {
 			get {
-				return CVImageBufferGetDisplaySize (handle);
+				return CVImageBufferGetDisplaySize (Handle);
 			}
 		}
 
@@ -77,7 +72,7 @@ namespace CoreVideo {
 
 		public CGSize EncodedSize {
 			get {
-				return CVImageBufferGetDisplaySize (handle);
+				return CVImageBufferGetDisplaySize (Handle);
 			}
 		}
 
@@ -87,7 +82,7 @@ namespace CoreVideo {
 		
 		public bool IsFlipped {
 			get {
-				return CVImageBufferIsFlipped (handle);
+				return CVImageBufferIsFlipped (Handle);
 			}
 		}
 
@@ -105,8 +100,8 @@ namespace CoreVideo {
 #endif
 		public CGColorSpace? ColorSpace {
 			get {
-				var h = CVImageBufferGetColorSpace (handle);
-				return h == IntPtr.Zero ? null : new CGColorSpace (h);
+				var h = CVImageBufferGetColorSpace (Handle);
+				return h == IntPtr.Zero ? null : new CGColorSpace (h, false);
 			}
 		}
 #elif !XAMCORE_3_0
@@ -133,10 +128,10 @@ namespace CoreVideo {
 
 		public static CGColorSpace? CreateFrom (NSDictionary attachments)
 		{
-			if (attachments == null)
-				throw new ArgumentNullException ("attachments");
+			if (attachments is null)
+				throw new ArgumentNullException (nameof (attachments));
 			var h = CVImageBufferCreateColorSpaceFromAttachments (attachments.Handle);
-			return h == IntPtr.Zero ? null : new CGColorSpace (h);
+			return h == IntPtr.Zero ? null : new CGColorSpace (h, true);
 		}
 #endif
 

--- a/src/CoreVideo/CVPixelBuffer.cs
+++ b/src/CoreVideo/CVPixelBuffer.cs
@@ -6,7 +6,6 @@
 // Copyright 2010 Novell, Inc
 // Copyright 2011-2014 Xamarin Inc
 //
-
 using System;
 using System.Runtime.InteropServices;
 using CoreFoundation;

--- a/src/CoreVideo/CVPixelBuffer.cs
+++ b/src/CoreVideo/CVPixelBuffer.cs
@@ -6,6 +6,7 @@
 // Copyright 2010 Novell, Inc
 // Copyright 2011-2014 Xamarin Inc
 //
+
 using System;
 using System.Runtime.InteropServices;
 using CoreFoundation;
@@ -30,10 +31,6 @@ namespace CoreVideo {
 		[DllImport (Constants.CoreVideoLibrary, EntryPoint = "CVPixelBufferGetTypeID")]
 		public extern static /* CFTypeID */ nint GetTypeID ();
 
-		internal CVPixelBuffer (IntPtr handle) : base (handle)
-		{
-		}
-
 		[Preserve (Conditional=true)]
 		internal CVPixelBuffer (IntPtr handle, bool owns) : base (handle, owns)
 		{
@@ -57,20 +54,26 @@ namespace CoreVideo {
 		{
 		}
 
-		[Advice ("Use constructor with CVPixelBufferAttributes")]
-		CVPixelBuffer (nint width, nint height, CVPixelFormatType pixelFormatType, NSDictionary? pixelBufferAttributes)
+		static IntPtr Create (nint width, nint height, CVPixelFormatType pixelFormatType, NSDictionary? pixelBufferAttributes)
 		{
 			if (width <= 0)
-				throw new ArgumentOutOfRangeException ("width");
+				throw new ArgumentOutOfRangeException (nameof (width));
 
 			if (height <= 0)
-				throw new ArgumentOutOfRangeException ("height");
+				throw new ArgumentOutOfRangeException (nameof (height));
 
-			CVReturn ret = CVPixelBufferCreate (IntPtr.Zero, width, height, pixelFormatType,
-				pixelBufferAttributes == null ? IntPtr.Zero : pixelBufferAttributes.Handle, out handle);
+			var ret = CVPixelBufferCreate (IntPtr.Zero, width, height, pixelFormatType, pixelBufferAttributes.GetHandle (), out var handle);
 
 			if (ret != CVReturn.Success)
 				throw new ArgumentException (ret.ToString ());
+
+			return handle;
+		}
+
+		[Advice ("Use constructor with CVPixelBufferAttributes")]
+		CVPixelBuffer (nint width, nint height, CVPixelFormatType pixelFormatType, NSDictionary? pixelBufferAttributes)
+			: base (Create (width, height, pixelFormatType, pixelBufferAttributes), true)
+		{
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
@@ -79,7 +82,7 @@ namespace CoreVideo {
 			/* CFArrayRef __nullable */ IntPtr attributes,
 			/* CFDictionaryRef __nullable * __nonnull */ out IntPtr resolvedDictionaryOut);
 
-		public NSDictionary? GetAttributes (NSDictionary [] attributes)
+		public NSDictionary? GetAttributes (NSDictionary []? attributes)
 		{
 			CVReturn ret;
 			IntPtr resolvedDictionaryOut;
@@ -87,7 +90,7 @@ namespace CoreVideo {
 				ret = CVPixelBufferCreateResolvedAttributesDictionary (IntPtr.Zero, IntPtr.Zero, out resolvedDictionaryOut);
 			} else {
 				using (var array = NSArray.FromNSObjects (attributes)) {
-					ret = CVPixelBufferCreateResolvedAttributesDictionary (IntPtr.Zero, array.Handle, out resolvedDictionaryOut);
+					ret = CVPixelBufferCreateResolvedAttributesDictionary (IntPtr.Zero, array!.Handle, out resolvedDictionaryOut);
 				}
 			}
 			if (ret != CVReturn.Success)
@@ -115,8 +118,10 @@ namespace CoreVideo {
 		[Watch (8,0), TV (15,0), Mac (12,0), iOS (15,0), NoMacCatalyst]
 #endif
 		public CVPixelBufferAttributes? GetPixelBufferCreationAttributes () {
-			var attrs = CVPixelBufferCopyCreationAttributes (handle);
-			return (attrs == IntPtr.Zero) ? null : new CVPixelBufferAttributes (new NSDictionary (attrs));
+			var attrs = Runtime.GetNSObject<NSDictionary> (CVPixelBufferCopyCreationAttributes (Handle), true);
+			if (attrs is null)
+				return null;
+			return new CVPixelBufferAttributes (attrs);
 		}
 #endif
 
@@ -289,7 +294,7 @@ namespace CoreVideo {
 		public void GetExtendedPixels (ref nuint extraColumnsOnLeft, ref nuint extraColumnsOnRight,
 			ref nuint extraRowsOnTop, ref nuint extraRowsOnBottom)
 		{
-			CVPixelBufferGetExtendedPixels (handle, ref extraColumnsOnLeft, ref extraColumnsOnRight, 
+			CVPixelBufferGetExtendedPixels (Handle, ref extraColumnsOnLeft, ref extraColumnsOnRight, 
 				ref extraRowsOnTop, ref extraRowsOnBottom);
 		}
 
@@ -298,7 +303,7 @@ namespace CoreVideo {
 
 		public CVReturn FillExtendedPixels ()
 		{
-			return CVPixelBufferFillExtendedPixels (handle);
+			return CVPixelBufferFillExtendedPixels (Handle);
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
@@ -307,7 +312,7 @@ namespace CoreVideo {
 
 		public IntPtr BaseAddress {
 			get {
-				return CVPixelBufferGetBaseAddress (handle);
+				return CVPixelBufferGetBaseAddress (Handle);
 			}
 		}
 
@@ -317,7 +322,7 @@ namespace CoreVideo {
 
 		public nint BytesPerRow {
 			get {
-				return CVPixelBufferGetBytesPerRow (handle);
+				return CVPixelBufferGetBytesPerRow (Handle);
 			}
 		}
 
@@ -327,7 +332,7 @@ namespace CoreVideo {
 
 		public nint DataSize {
 			get {
-				return CVPixelBufferGetDataSize (handle);
+				return CVPixelBufferGetDataSize (Handle);
 			}
 		}
 
@@ -336,7 +341,7 @@ namespace CoreVideo {
 
 		public nint Height {
 			get {
-				return CVPixelBufferGetHeight (handle);
+				return CVPixelBufferGetHeight (Handle);
 			}
 		}
 
@@ -345,7 +350,7 @@ namespace CoreVideo {
 
 		public nint Width {
 			get {
-				return CVPixelBufferGetWidth (handle);
+				return CVPixelBufferGetWidth (Handle);
 			}
 		}
 
@@ -355,7 +360,7 @@ namespace CoreVideo {
 
 		public nint PlaneCount {
 			get {
-				return CVPixelBufferGetPlaneCount (handle);
+				return CVPixelBufferGetPlaneCount (Handle);
 			}
 		}
 
@@ -365,7 +370,7 @@ namespace CoreVideo {
 
 		public bool IsPlanar {
 			get {
-				return CVPixelBufferIsPlanar (handle);
+				return CVPixelBufferIsPlanar (Handle);
 			}
 		}
 
@@ -375,7 +380,7 @@ namespace CoreVideo {
 
 		public CVPixelFormatType PixelFormatType {
 			get {
-				return CVPixelBufferGetPixelFormatType (handle);
+				return CVPixelBufferGetPixelFormatType (Handle);
 			}
 		}
 
@@ -385,7 +390,7 @@ namespace CoreVideo {
 
 		public IntPtr GetBaseAddress (nint planeIndex)
 		{
-			return CVPixelBufferGetBaseAddressOfPlane (handle, planeIndex);
+			return CVPixelBufferGetBaseAddressOfPlane (Handle, planeIndex);
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
@@ -394,7 +399,7 @@ namespace CoreVideo {
 
 		public nint GetBytesPerRowOfPlane (nint planeIndex)
 		{
-			return CVPixelBufferGetBytesPerRowOfPlane (handle, planeIndex);
+			return CVPixelBufferGetBytesPerRowOfPlane (Handle, planeIndex);
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
@@ -403,7 +408,7 @@ namespace CoreVideo {
 
 		public nint GetHeightOfPlane (nint planeIndex)
 		{
-			return CVPixelBufferGetHeightOfPlane (handle, planeIndex);
+			return CVPixelBufferGetHeightOfPlane (Handle, planeIndex);
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
@@ -412,7 +417,7 @@ namespace CoreVideo {
 
 		public nint GetWidthOfPlane (nint planeIndex)
 		{
-			return CVPixelBufferGetWidthOfPlane (handle, planeIndex);
+			return CVPixelBufferGetWidthOfPlane (Handle, planeIndex);
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
@@ -423,13 +428,13 @@ namespace CoreVideo {
 		[Obsolete ("Use 'Lock (CVPixelBufferLock)' instead.")]
 		public CVReturn Lock (CVOptionFlags lockFlags)
 		{
-			return CVPixelBufferLockBaseAddress (handle, (CVPixelBufferLock) lockFlags);
+			return CVPixelBufferLockBaseAddress (Handle, (CVPixelBufferLock) lockFlags);
 		}
 #endif
 
 		public CVReturn Lock (CVPixelBufferLock lockFlags)
 		{
-			return CVPixelBufferLockBaseAddress (handle, lockFlags);
+			return CVPixelBufferLockBaseAddress (Handle, lockFlags);
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
@@ -440,13 +445,13 @@ namespace CoreVideo {
 		[Obsolete ("Use 'Unlock (CVPixelBufferLock)'.")]
 		public CVReturn Unlock (CVOptionFlags unlockFlags)
 		{
-			return CVPixelBufferUnlockBaseAddress (handle, (CVPixelBufferLock) unlockFlags);
+			return CVPixelBufferUnlockBaseAddress (Handle, (CVPixelBufferLock) unlockFlags);
 		}
 #endif
 
 		public CVReturn Unlock (CVPixelBufferLock unlockFlags)
 		{
-			return CVPixelBufferUnlockBaseAddress (handle, unlockFlags);
+			return CVPixelBufferUnlockBaseAddress (Handle, unlockFlags);
 		}
 #endif // !COREBUILD
 	}


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.
* Remove the internal (IntPtr) and default constructor.