### PR TITLE
[xcode13.1] [msbuild] Create the directory for the .stamp file for the _CreateBindingResourcePackage target before trying to create the .stamp file.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -181,6 +181,12 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			>
 		</CreateBindingResourcePackage>
 
+		<MakeDir
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			Directories="$([System.IO.Path]::GetDirectoryName($(BindingResourcePath)))"
+		/>
+
 		<Touch
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1426870.


Backport of #13179
