### PR TITLE
[CVDisplayLink] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreVideo/CVDisplayLink.cs
+++ b/src/CoreVideo/CVDisplayLink.cs
@@ -30,6 +30,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
+using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 using OpenGL;
@@ -37,26 +38,20 @@ using OpenGL;
 #nullable enable
 
 namespace CoreVideo {
-	public class CVDisplayLink : INativeObject, IDisposable {
-		IntPtr handle;
+	public class CVDisplayLink : NativeObject {
 		GCHandle callbackHandle;
 		
+#if !NET
 		public CVDisplayLink (IntPtr handle)
+			: base (handle, false, true)
 		{
-			if (handle == IntPtr.Zero)
-				throw new Exception ("Invalid parameters to display link creation");
-
-			CVDisplayLinkRetain (handle);
-			this.handle = handle;
 		}
+#endif
 
 		[Preserve (Conditional=true)]
 		internal CVDisplayLink (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (!owns)
-				CVDisplayLinkRetain (handle);
-
-			this.handle = handle;
 		}
 
 #if !NET
@@ -119,7 +114,7 @@ namespace CoreVideo {
 #endif
 		public static CVDisplayLink? CreateFromDisplayIds (uint[] displayIds, out CVReturn error)
 		{
-			if (displayIds == null)
+			if (displayIds is null)
 				throw new ArgumentNullException (nameof (displayIds));
 			error = 0;
 			IntPtr handle = IntPtr.Zero;
@@ -180,93 +175,88 @@ namespace CoreVideo {
 		public static CVDisplayLink? CreateFromOpenGLMask (uint mask)
 			=> CreateFromOpenGLMask (mask, out var _);
 
-		~CVDisplayLink ()
-		{
-			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-	
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static void CVDisplayLinkRetain (IntPtr handle);
 		
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static void CVDisplayLinkRelease (IntPtr handle);
 		
-		protected virtual void Dispose (bool disposing)
+		protected override void Retain ()
+		{
+			CVDisplayLinkRetain (GetCheckedHandle ());
+		}
+
+		protected override void Release ()
+		{
+			CVDisplayLinkRelease (GetCheckedHandle ());
+		}
+
+		protected override void Dispose (bool disposing)
 		{
 			if (callbackHandle.IsAllocated) {
 				callbackHandle.Free();
 			}
 
-			if (handle != IntPtr.Zero){
-				CVDisplayLinkRelease (handle);
-				handle = IntPtr.Zero;
-			}
+			base.Dispose (disposing);
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static CVReturn CVDisplayLinkCreateWithActiveCGDisplays (out IntPtr displayLinkOut);
-		public CVDisplayLink ()
+		static IntPtr Create ()
 		{
-			IntPtr displayLinkOut;
-		
-			CVReturn ret = CVDisplayLinkCreateWithActiveCGDisplays (out displayLinkOut);
-	
+			var ret = CVDisplayLinkCreateWithActiveCGDisplays (out var handle);
+
 			if (ret != CVReturn.Success)
 				throw new Exception ("CVDisplayLink returned: " + ret);
-	
-			this.handle = displayLinkOut;
+
+			return handle;
+
+		}
+		public CVDisplayLink ()
+			: base (Create (), true)
+		{
 		}		
 
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static CVReturn CVDisplayLinkSetCurrentCGDisplay (IntPtr displayLink, int /* CGDirectDisplayID = uint32_t */ displayId);
 		public CVReturn SetCurrentDisplay (int displayId)
 		{
-			return CVDisplayLinkSetCurrentCGDisplay (this.handle, displayId);
+			return CVDisplayLinkSetCurrentCGDisplay (Handle, displayId);
 		}     
 			
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static CVReturn CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext (IntPtr displayLink, IntPtr cglContext, IntPtr cglPixelFormat);
 		public CVReturn SetCurrentDisplay (CGLContext cglContext, CGLPixelFormat cglPixelFormat)
 		{
-			return CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext (this.handle, cglContext.Handle, cglPixelFormat.Handle);
+			return CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext (Handle, cglContext.Handle, cglPixelFormat.Handle);
 		}     
 
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static int /* CGDirectDisplayID = uint32_t */ CVDisplayLinkGetCurrentCGDisplay (IntPtr displayLink);
 		public int GetCurrentDisplay ()
 		{
-			return CVDisplayLinkGetCurrentCGDisplay (this.handle);
+			return CVDisplayLinkGetCurrentCGDisplay (Handle);
 		}
 			
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static CVReturn CVDisplayLinkStart (IntPtr displayLink);
 		public CVReturn Start ()
 		{
-			return CVDisplayLinkStart (this.handle);
+			return CVDisplayLinkStart (Handle);
 		}		     
 			
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static CVReturn CVDisplayLinkStop (IntPtr displayLink);
 		public CVReturn Stop ()
 		{
-			return CVDisplayLinkStop (this.handle);
+			return CVDisplayLinkStop (Handle);
 		}		     
 			
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static CVTime CVDisplayLinkGetNominalOutputVideoRefreshPeriod (IntPtr displayLink);
 		public CVTime NominalOutputVideoRefreshPeriod {
 			get {
-				return CVDisplayLinkGetNominalOutputVideoRefreshPeriod (this.handle);
+				return CVDisplayLinkGetNominalOutputVideoRefreshPeriod (Handle);
 			}
 		}
 
@@ -274,7 +264,7 @@ namespace CoreVideo {
 		extern static CVTime CVDisplayLinkGetOutputVideoLatency (IntPtr displayLink);
 		public CVTime OutputVideoLatency {
 			get {
-				return CVDisplayLinkGetOutputVideoLatency (this.handle);
+				return CVDisplayLinkGetOutputVideoLatency (Handle);
 			}
 		}
 
@@ -282,7 +272,7 @@ namespace CoreVideo {
 		extern static double CVDisplayLinkGetActualOutputVideoRefreshPeriod (IntPtr displayLink);
 		public double ActualOutputVideoRefreshPeriod {
 			get {
-				return CVDisplayLinkGetActualOutputVideoRefreshPeriod (this.handle);
+				return CVDisplayLinkGetActualOutputVideoRefreshPeriod (Handle);
 			}
 		}
 			
@@ -291,7 +281,7 @@ namespace CoreVideo {
 		extern static bool CVDisplayLinkIsRunning (IntPtr displayLink);
 		public bool IsRunning {
 			get {
-				return CVDisplayLinkIsRunning (this.handle);
+				return CVDisplayLinkIsRunning (Handle);
 			}
 		}
 			


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.
* Call 'GetCheckedHandle ()' (which will throw an ObjectDisposedException if
  Handle == IntPtr.Zero) instead of manually checking for IntPtr.Zero and
  throwing ObjectDisposedException.
* Remove the (IntPtr) constructor for .NET