### PR TITLE
[CVMetalTexture] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreVideo/CVMetalTexture.cs
+++ b/src/CoreVideo/CVMetalTexture.cs
@@ -26,37 +26,10 @@ namespace CoreVideo {
 #if !NET
 	[iOS (8,0), Mac (12,0), MacCatalyst (15,0)]
 #endif
-	public class CVMetalTexture : INativeObject, IDisposable {
-
-		internal IntPtr handle;
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-
-		~CVMetalTexture ()
+	public class CVMetalTexture : NativeObject {
+		internal CVMetalTexture (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected
-		virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
-		}
-
-		internal CVMetalTexture (IntPtr handle)
-		{
-			this.handle = handle;
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]
@@ -74,13 +47,13 @@ namespace CoreVideo {
 
 		public IMTLTexture? Texture {
 			get {
-				return Runtime.GetINativeObject<IMTLTexture> (CVMetalTextureGetTexture (handle), owns: false);
+				return Runtime.GetINativeObject<IMTLTexture> (CVMetalTextureGetTexture (Handle), owns: false);
 			}
 		}
 			
 		public bool IsFlipped {
 			get {
-				return CVMetalTextureIsFlipped (handle);
+				return CVMetalTextureIsFlipped (Handle);
 			}
 		}
 
@@ -93,7 +66,7 @@ namespace CoreVideo {
 
 			unsafe {
 				fixed (float *ll = &lowerLeft[0], lr = &lowerRight [0], ur = &upperRight [0], ul = &upperLeft[0]){
-					CVMetalTextureGetCleanTexCoords (handle, (IntPtr) ll, (IntPtr) lr, (IntPtr) ur, (IntPtr) ul);
+					CVMetalTextureGetCleanTexCoords (Handle, (IntPtr) ll, (IntPtr) lr, (IntPtr) ur, (IntPtr) ul);
 				}
 			}
 		}

--- a/src/CoreVideo/CVMetalTextureCache.cs
+++ b/src/CoreVideo/CVMetalTextureCache.cs
@@ -152,7 +152,7 @@ namespace CoreVideo {
 				textureOut:   out texture);
 			if (errorCode != 0)
 				return null;
-			return new CVMetalTexture (texture);
+			return new CVMetalTexture (texture, true);
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Remove the internal (IntPtr) constructor.