### PR TITLE
[dotnet] add %(Platform) to any global @(Using)

### DIFF
--- a/dotnet/targets/Microsoft.MacCatalyst.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.MacCatalyst.Sdk.ImplicitNamespaceImports.props
@@ -23,8 +23,8 @@
 		Ref: https://github.com/dotnet/sdk/issues/19793#issuecomment-900620060
 	-->
 	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'MacCatalyst' And '$(Language)' == 'C#' And ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
-		<Using Include="CoreGraphics" />
-		<Using Include="Foundation" />
-		<Using Include="UIKit" />
+		<Using Include="CoreGraphics" Platform="MacCatalyst" />
+		<Using Include="Foundation" Platform="MacCatalyst" />
+		<Using Include="UIKit" Platform="MacCatalyst" />
 	</ItemGroup>
 </Project>

--- a/dotnet/targets/Microsoft.iOS.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.iOS.Sdk.ImplicitNamespaceImports.props
@@ -23,8 +23,8 @@
 		Ref: https://github.com/dotnet/sdk/issues/19793#issuecomment-900620060
 	-->
 	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'iOS' And '$(Language)' == 'C#' And ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
-		<Using Include="CoreGraphics" />
-		<Using Include="Foundation" />
-		<Using Include="UIKit" />
+		<Using Include="CoreGraphics" Platform="iOS" />
+		<Using Include="Foundation" Platform="iOS" />
+		<Using Include="UIKit" Platform="iOS" />
 	</ItemGroup>
 </Project>

--- a/dotnet/targets/Microsoft.macOS.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.macOS.Sdk.ImplicitNamespaceImports.props
@@ -23,8 +23,8 @@
 		Ref: https://github.com/dotnet/sdk/issues/19793#issuecomment-900620060
 	-->
 	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'macOS' And '$(Language)' == 'C#' And ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
-		<Using Include="AppKit" />
-		<Using Include="CoreGraphics" />
-		<Using Include="Foundation" />
+		<Using Include="AppKit" Platform="macOS" />
+		<Using Include="CoreGraphics" Platform="macOS" />
+		<Using Include="Foundation" Platform="macOS" />
 	</ItemGroup>
 </Project>

--- a/dotnet/targets/Microsoft.tvOS.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.tvOS.Sdk.ImplicitNamespaceImports.props
@@ -23,8 +23,8 @@
 		Ref: https://github.com/dotnet/sdk/issues/19793#issuecomment-900620060
 	-->
 	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'tvOS' And '$(Language)' == 'C#' And ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
-		<Using Include="CoreGraphics" />
-		<Using Include="Foundation" />
-		<Using Include="UIKit" />
+		<Using Include="CoreGraphics" Platform="tvOS" />
+		<Using Include="Foundation" Platform="tvOS" />
+		<Using Include="UIKit" Platform="tvOS" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/3018#pullrequestreview-792369556

In order for the .NET MAUI workload to properly implement implicit
global usings:

1. The .NET MAUI workload will add many `@(Using)` entries that
   conflict with each platform's APIs.

2. We need *something* to identify `@(Using)` is for a specific
   platform, so we can use a new `%(Platform)` metadata for this.

3. Late in .NET MAUI's MSBuild targets, we can do:

```xml
<ItemGroup Condition=" '$(UseMaui)' == 'true' and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
  <Using Remove="@(Using->HasMetadata('Platform'))" />
</ItemGroup>
```

In .NET 7, we might have a nicer design around this, but for now this
is the plan for .NET 6.