### PR TITLE
Fix Nullability

### DIFF
--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -126,12 +126,12 @@ namespace CoreGraphics {
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPathEqualToPath (/* CGPathRef */ IntPtr path1, /* CGPathRef */ IntPtr path2);
 
-		public static bool operator == (CGPath path1, CGPath path2)
+		public static bool operator == (CGPath? path1, CGPath? path2)
 		{
 			return Object.Equals (path1, path2);
 		}
 
-		public static bool operator != (CGPath path1, CGPath path2)
+		public static bool operator != (CGPath? path1, CGPath? path2)
 		{
 			return !Object.Equals (path1, path2);
 		}


### PR DESCRIPTION
Fix the issue with:

```
CGPath? path1 = null;
var a = path1 != null;
var b = path1 == null;
```

```
error CS8604: Possible null reference argument for parameter 'path1' in 'bool CGPath.operator !=(CGPath path1, CGPath path2)'.
```