### PR TITLE
[CG[Mutable]ImageMetadata] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/ImageIO/CGImageMetadata.cs
+++ b/src/ImageIO/CGImageMetadata.cs
@@ -7,6 +7,8 @@
 // Copyright 2013-2014, Xamarin Inc.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -42,19 +44,18 @@ namespace ImageIO {
 #if !NET
 	[iOS (7,0)]
 #endif
-	public partial class CGImageMetadata : INativeObject, IDisposable {
-
+	public partial class CGImageMetadata : NativeObject {
+#if !NET
 		public CGImageMetadata (IntPtr handle)
+			: base (handle, false)
 		{
-			Handle = handle;
 		}
+#endif
 
 		[Preserve (Conditional = true)]
 		internal CGImageMetadata (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			Handle = handle;
-			if (!owns)
-				CFObject.CFRetain (Handle);
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
@@ -62,34 +63,8 @@ namespace ImageIO {
 			/* CFDataRef __nonnull */ IntPtr data);
 
 		public CGImageMetadata (NSData data)
+			: base (CGImageMetadataCreateFromXMPData (Runtime.ThrowOnNull (data, nameof (data)).Handle), true, verify: true)
 		{
-			if (data == null)
-				throw new ArgumentNullException ("data");
-
-			Handle = CGImageMetadataCreateFromXMPData (data.Handle);
-			if (Handle == IntPtr.Zero)
-				throw new ArgumentException ("data");
-		}
-
-		public IntPtr Handle { get; internal set; }
-
-		~CGImageMetadata ()
-		{
-			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (Handle != IntPtr.Zero){
-				CFObject.CFRelease (Handle);
-				Handle = IntPtr.Zero;
-			}
 		}
 
 		[DllImport (Constants.ImageIOLibrary, EntryPoint="CGImageMetadataGetTypeID")]
@@ -101,31 +76,23 @@ namespace ImageIO {
 			/* CGImageMetadataRef __nonnull */ IntPtr metadata, /* CGImageMetadataTagRef __nullable */ IntPtr parent,
 			/* CFStringRef __nonnull*/ IntPtr path);
 
-		public NSString GetStringValue (CGImageMetadata parent, NSString path)
+		public NSString? GetStringValue (CGImageMetadata? parent, NSString path)
 		{
 			// parent may be null
-			if (path == null)
-				throw new ArgumentNullException ("path");
-			IntPtr p = parent == null ? IntPtr.Zero : parent.Handle;
-			IntPtr result = CGImageMetadataCopyStringValueWithPath (Handle, p, path.Handle);
-			return (result == IntPtr.Zero) ? null : new NSString (result);
+			if (path is null)
+				throw new ArgumentNullException (nameof (path));
+			var result = CGImageMetadataCopyStringValueWithPath (Handle, parent.GetHandle (), path.Handle);
+			return Runtime.GetNSObject<NSString> (result, true);
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
 		extern static /* CFArrayRef __nullable */ IntPtr CGImageMetadataCopyTags (
 			/* CGImageMetadataRef __nonnull */ IntPtr metadata);
 
-		public CGImageMetadataTag [] GetTags ()
+		public CGImageMetadataTag []? GetTags ()
 		{
-			IntPtr result = CGImageMetadataCopyTags (Handle);
-			if (result == IntPtr.Zero)
-				return null;
-			using (var a = new CFArray (result)) {
-				CGImageMetadataTag[] tags = new CGImageMetadataTag [a.Count];
-				for (int i = 0; i < a.Count; i++)
-					tags [i] = new CGImageMetadataTag (a.GetValue (i));
-				return tags;
-			}
+			var result = CGImageMetadataCopyTags (Handle);
+			return CFArray.ArrayFromHandleFunc (result, (handle) => new CGImageMetadataTag (handle, false), true);
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
@@ -133,14 +100,13 @@ namespace ImageIO {
 			/* CGImageMetadataRef __nonnull */ IntPtr metadata, /* CGImageMetadataTagRef __nullable */ IntPtr parent,
 			/* CFStringRef __nonnull */ IntPtr path);
 
-		public CGImageMetadataTag GetTag (CGImageMetadata parent, NSString path)
+		public CGImageMetadataTag? GetTag (CGImageMetadata? parent, NSString path)
 		{
 			// parent may be null
-			if (path == null)
-				throw new ArgumentNullException ("path");
-			IntPtr p = parent == null ? IntPtr.Zero : parent.Handle;
-			IntPtr result = CGImageMetadataCopyTagWithPath (Handle, p, path.Handle);
-			return (result == IntPtr.Zero) ? null : new CGImageMetadataTag (result);
+			if (path is null)
+				throw new ArgumentNullException (nameof (path));
+			IntPtr result = CGImageMetadataCopyTagWithPath (Handle, parent.GetHandle (), path.Handle);
+			return (result == IntPtr.Zero) ? null : new CGImageMetadataTag (result, true);
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
@@ -148,27 +114,22 @@ namespace ImageIO {
 			/* CFStringRef __nullable */ IntPtr rootPath, /* CFDictionaryRef __nullable */ IntPtr options,
 			/* __nonnull */ CGImageMetadataTagBlock block);
 
-		public void EnumerateTags (NSString rootPath, CGImageMetadataEnumerateOptions options, CGImageMetadataTagBlock block)
+		public void EnumerateTags (NSString? rootPath, CGImageMetadataEnumerateOptions? options, CGImageMetadataTagBlock block)
 		{
-			IntPtr r = rootPath == null ? IntPtr.Zero : rootPath.Handle;
-			NSDictionary o = null;
-			if (options != null)
-				o = options.ToDictionary ();
-			CGImageMetadataEnumerateTagsUsingBlock (Handle, r, o == null ? IntPtr.Zero : o.Handle, block);
-			if (options != null)
-				o.Dispose ();
+			using var o = options?.ToDictionary ();
+			CGImageMetadataEnumerateTagsUsingBlock (Handle, rootPath.GetHandle (), o.GetHandle (), block);
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
 		extern static /* CFDataRef __nullable */ IntPtr CGImageMetadataCreateXMPData (
 			/* CGImageMetadataRef __nonnull */ IntPtr metadata, /* CFDictionaryRef __nullable */ IntPtr options);
 
-		public NSData CreateXMPData ()
+		public NSData? CreateXMPData ()
 		{
 			// note: there's no options defined for iOS7 (needs to be null)
 			// we'll need to add an overload if this change in the future
 			IntPtr result = CGImageMetadataCreateXMPData (Handle, IntPtr.Zero);
-			return result == IntPtr.Zero ? null : new NSData (result);
+			return Runtime.GetNSObject<NSData> (result, true);
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
@@ -176,14 +137,14 @@ namespace ImageIO {
 			/* CGImageMetadataRef __nonnull */ IntPtr metadata, /* CFStringRef __nonnull */ IntPtr dictionaryName,
 			/* CFStringRef __nonnull */ IntPtr propertyName);
 
-		public CGImageMetadataTag CopyTagMatchingImageProperty (NSString dictionaryName, NSString propertyName)
+		public CGImageMetadataTag? CopyTagMatchingImageProperty (NSString dictionaryName, NSString propertyName)
 		{
-			if (dictionaryName == null)
-				throw new ArgumentNullException ("dictionaryName");
-			if (propertyName == null)
-				throw new ArgumentNullException ("propertyName");
+			if (dictionaryName is null)
+				throw new ArgumentNullException (nameof (dictionaryName));
+			if (propertyName is null)
+				throw new ArgumentNullException (nameof (propertyName));
 			IntPtr result = CGImageMetadataCopyTagMatchingImageProperty (Handle, dictionaryName.Handle, propertyName.Handle);
-			return result == IntPtr.Zero ? null : new CGImageMetadataTag (result);
+			return result == IntPtr.Zero ? null : new CGImageMetadataTag (result, true);
 		}
 	}
 }

--- a/src/ImageIO/CGMutableImageMetadata.cs
+++ b/src/ImageIO/CGMutableImageMetadata.cs
@@ -7,6 +7,8 @@
 // Copyright 2013-2014, Xamarin Inc.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -25,8 +27,8 @@ namespace ImageIO {
 		[DllImport (Constants.ImageIOLibrary)]
 		extern static /* CGMutableImageMetadataRef __nonnull */ IntPtr CGImageMetadataCreateMutable ();
 
-		public CGMutableImageMetadata () : 
-			base (CGImageMetadataCreateMutable ())
+		public CGMutableImageMetadata ()
+			: base (CGImageMetadataCreateMutable (), true)
 		{
 		}
 
@@ -34,11 +36,11 @@ namespace ImageIO {
 		extern static /* CGMutableImageMetadataRef __nullable */ IntPtr CGImageMetadataCreateMutableCopy (
 			/* CGImageMetadataRef __nonnull */ IntPtr metadata);
 
-		public CGMutableImageMetadata (CGImageMetadata metadata) :
-			base (CGImageMetadataCreateMutableCopy (metadata.Handle))
+		public CGMutableImageMetadata (CGImageMetadata metadata)
+			: base (CGImageMetadataCreateMutableCopy (Runtime.ThrowOnNull (metadata, nameof (metadata)).Handle), true)
 		{
-			if (metadata == null)
-				throw new ArgumentNullException ("metadata");
+			if (metadata is null)
+				throw new ArgumentNullException (nameof (metadata));
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
@@ -47,15 +49,14 @@ namespace ImageIO {
 			/* CGMutableImageMetadataRef __nonnull */ IntPtr metadata, /* CFStringRef __nonnull */ IntPtr xmlns,
 			/* CFStringRef __nonnull */ IntPtr prefix, /* CFErrorRef __nullable */ out IntPtr error);
 
-		public bool RegisterNamespace (NSString xmlns, NSString prefix, out NSError error)
+		public bool RegisterNamespace (NSString xmlns, NSString prefix, out NSError? error)
 		{
-			if (xmlns == null)
-				throw new ArgumentNullException ("xmlns");
-			if (prefix == null)
-				throw new ArgumentNullException ("prefix");
-			IntPtr err;
-			bool result = CGImageMetadataRegisterNamespaceForPrefix (Handle, xmlns.Handle, prefix.Handle, out err);
-			error = err == IntPtr.Zero ? null : new NSError (err);
+			if (xmlns is null)
+				throw new ArgumentNullException (nameof (xmlns));
+			if (prefix is null)
+				throw new ArgumentNullException (nameof (prefix));
+			bool result = CGImageMetadataRegisterNamespaceForPrefix (Handle, xmlns.Handle, prefix.Handle, out var err);
+			error = Runtime.GetNSObject<NSError> (err);
 			return result;
 		}
 
@@ -65,14 +66,13 @@ namespace ImageIO {
 			/* CGImageMetadataTagRef __nullable */ IntPtr parent, /* CFStringRef __nonnull */ IntPtr path,
 			/* CGImageMetadataTagRef __nonnull */ IntPtr tag);
 
-		public bool SetTag (CGImageMetadataTag parent, NSString path, CGImageMetadataTag tag)
+		public bool SetTag (CGImageMetadataTag? parent, NSString path, CGImageMetadataTag tag)
 		{
-			IntPtr p = parent == null ? IntPtr.Zero : parent.Handle;
-			if (path == null)
-				throw new ArgumentNullException ("path");
-			if (tag == null)
-				throw new ArgumentNullException ("tag");
-			return CGImageMetadataSetTagWithPath (Handle, p, path.Handle, tag.Handle);
+			if (path is null)
+				throw new ArgumentNullException (nameof (path));
+			if (tag is null)
+				throw new ArgumentNullException (nameof (tag));
+			return CGImageMetadataSetTagWithPath (Handle, parent.GetHandle (), path.Handle, tag.Handle);
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
@@ -81,24 +81,23 @@ namespace ImageIO {
 			/* CGImageMetadataTagRef __nullable */ IntPtr parent, /* CFStringRef __nonnull */ IntPtr path,
 			/* CFTypeRef __nonnull */ IntPtr value);
 
-		public bool SetValue (CGImageMetadataTag parent, NSString path, NSObject value)
+		public bool SetValue (CGImageMetadataTag? parent, NSString path, NSObject value)
 		{
-			if (value == null)
-				throw new ArgumentNullException ("value");
+			if (value is null)
+				throw new ArgumentNullException (nameof (value));
 			return SetValue (parent, path, value.Handle);
 		}
 
-		public bool SetValue (CGImageMetadataTag parent, NSString path, bool value)
+		public bool SetValue (CGImageMetadataTag? parent, NSString path, bool value)
 		{
 			return SetValue (parent, path, value ? CFBoolean.TrueHandle : CFBoolean.FalseHandle);
 		}
 
-		bool SetValue (CGImageMetadataTag parent, NSString path, IntPtr value)
+		bool SetValue (CGImageMetadataTag? parent, NSString path, IntPtr value)
 		{
-			IntPtr p = parent == null ? IntPtr.Zero : parent.Handle;
-			if (path == null)
-				throw new ArgumentNullException ("path");
-			return CGImageMetadataSetValueWithPath (Handle, p, path.Handle, value);
+			if (path is null)
+				throw new ArgumentNullException (nameof (path));
+			return CGImageMetadataSetValueWithPath (Handle, parent.GetHandle (), path.Handle, value);
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
@@ -106,12 +105,11 @@ namespace ImageIO {
 		extern static bool CGImageMetadataRemoveTagWithPath (/* CGMutableImageMetadataRef __nonnull */ IntPtr metadata,
 			/* CGImageMetadataTagRef __nullable */ IntPtr parent, /* CFStringRef __nonnull */ IntPtr path);
 
-		public bool RemoveTag (CGImageMetadataTag parent, NSString path)
+		public bool RemoveTag (CGImageMetadataTag? parent, NSString path)
 		{
-			IntPtr p = parent == null ? IntPtr.Zero : parent.Handle;
-			if (path == null)
-				throw new ArgumentNullException ("path");
-			return CGImageMetadataRemoveTagWithPath (Handle, p, path.Handle);
+			if (path is null)
+				throw new ArgumentNullException (nameof (path));
+			return CGImageMetadataRemoveTagWithPath (Handle, parent.GetHandle (), path.Handle);
 		}
 
 		[DllImport (Constants.ImageIOLibrary)]
@@ -123,8 +121,8 @@ namespace ImageIO {
 
 		public bool SetValueMatchingImageProperty (NSString dictionaryName, NSString propertyName, NSObject value)
 		{
-			if (value == null)
-				throw new ArgumentNullException ("value");
+			if (value is null)
+				throw new ArgumentNullException (nameof (value));
 			return SetValueMatchingImageProperty (dictionaryName, propertyName, value.Handle);
 		}
 
@@ -135,10 +133,10 @@ namespace ImageIO {
 
 		bool SetValueMatchingImageProperty (NSString dictionaryName, NSString propertyName, IntPtr value)
 		{
-			if (dictionaryName == null)
-				throw new ArgumentNullException ("dictionaryName");
-			if (propertyName == null)
-				throw new ArgumentNullException ("propertyName");
+			if (dictionaryName is null)
+				throw new ArgumentNullException (nameof (dictionaryName));
+			if (propertyName is null)
+				throw new ArgumentNullException (nameof (propertyName));
 			return CGImageMetadataSetValueMatchingImageProperty (Handle, dictionaryName.Handle, propertyName.Handle, value);
 		}
 	}


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.
* Use the 'Runtime.GetNSObject<T> (IntPtr, bool)' overload to specify handle
  ownership, to avoid having to call NSObject.DangerousReleaes manually later.
* Remove the (IntPtr) constructor for .NET