### PR TITLE
[CGContextPDF] Enable nullability + a few other code updates

### DIFF
--- a/src/CoreGraphics/CGContextPDF.cs
+++ b/src/CoreGraphics/CGContextPDF.cs
@@ -26,6 +26,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -71,13 +73,13 @@ namespace CoreGraphics {
 
 	public partial class CGPDFInfo : CGPDFPageInfo {
 
-		public string Title { get; set; }
-		public string Author { get; set; }
-		public string Subject { get; set; }
-		public string [] Keywords { get; set; }
-		public string Creator { get; set; }
-		public string OwnerPassword { get; set; }
-		public string UserPassword { get; set; }
+		public string? Title { get; set; }
+		public string? Author { get; set; }
+		public string? Subject { get; set; }
+		public string []? Keywords { get; set; }
+		public string? Creator { get; set; }
+		public string? OwnerPassword { get; set; }
+		public string? UserPassword { get; set; }
 		public int? EncryptionKeyLength { get; set; }
 		public bool? AllowsPrinting { get; set; }
 		public bool? AllowsCopying { get; set; }
@@ -104,23 +106,23 @@ namespace CoreGraphics {
 		{
 			var ret = base.ToDictionary ();
 
-			if (Title != null)
+			if (Title is not null)
 				ret.LowlevelSetObject ((NSString) Title, kCGPDFContextTitle);
-			if (Author != null)
+			if (Author is not null)
 				ret.LowlevelSetObject ((NSString) Author, kCGPDFContextAuthor);
-			if (Subject != null)
+			if (Subject is not null)
 				ret.LowlevelSetObject ((NSString) Subject, kCGPDFContextSubject);
-			if (Keywords != null && Keywords.Length > 0){
+			if (Keywords is not null && Keywords.Length > 0){
 				if (Keywords.Length == 1)
 					ret.LowlevelSetObject ((NSString) Keywords [0], kCGPDFContextKeywords);
 				else
 					ret.LowlevelSetObject (NSArray.FromStrings (Keywords), kCGPDFContextKeywords);
 			}
-			if (Creator != null)
+			if (Creator is not null)
 				ret.LowlevelSetObject ((NSString) Creator, kCGPDFContextCreator);
-			if (OwnerPassword != null)
+			if (OwnerPassword is not null)
 				ret.LowlevelSetObject ((NSString) OwnerPassword, kCGPDFContextOwnerPassword);
-			if (UserPassword != null)
+			if (UserPassword is not null)
 				ret.LowlevelSetObject ((NSString) UserPassword, kCGPDFContextUserPassword);
 			if (EncryptionKeyLength.HasValue)
 				ret.LowlevelSetObject (NSNumber.FromInt32 (EncryptionKeyLength.Value), kCGPDFContextEncryptionKeyLength);
@@ -149,18 +151,18 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		unsafe extern static /* CGContextRef */ IntPtr CGPDFContextCreate (/* CGDataConsumerRef */ IntPtr consumer, CGRect *mediaBox, /* CFDictionaryRef */ IntPtr auxiliaryInfo);
 
-		static unsafe IntPtr Create (CGDataConsumer dataConsumer, CGRect *mediaBox, CGPDFInfo info)
+		unsafe static IntPtr Create (CGDataConsumer? dataConsumer, CGRect *mediaBox, CGPDFInfo? info)
 		{
 			using (var dict = info?.ToDictionary ())
 				return CGPDFContextCreate (dataConsumer.GetHandle (), mediaBox, dict.GetHandle ());
 		}
 
-		unsafe CGContextPDF (CGDataConsumer dataConsumer, CGRect *mediaBox, CGPDFInfo info)
+		unsafe CGContextPDF (CGDataConsumer? dataConsumer, CGRect *mediaBox, CGPDFInfo? info)
 			: base (Create (dataConsumer, mediaBox, info), true)
 		{
 		}
 
-		public unsafe CGContextPDF (CGDataConsumer dataConsumer, CGRect mediaBox, CGPDFInfo info) :
+		public unsafe CGContextPDF (CGDataConsumer dataConsumer, CGRect mediaBox, CGPDFInfo? info) :
 			this (dataConsumer, &mediaBox, info)
 		{
 		}
@@ -170,7 +172,7 @@ namespace CoreGraphics {
 		{
 		}
 
-		public unsafe CGContextPDF (CGDataConsumer dataConsumer, CGPDFInfo info) :
+		public unsafe CGContextPDF (CGDataConsumer dataConsumer, CGPDFInfo? info) :
 			this (dataConsumer, null, info)
 		{
 		}
@@ -180,13 +182,13 @@ namespace CoreGraphics {
 		{
 		}
 
-		static unsafe IntPtr Create (NSUrl url, CGRect *mediaBox, CGPDFInfo info)
+		unsafe static IntPtr Create (NSUrl? url, CGRect* mediaBox, CGPDFInfo? info)
 		{
 			using (var dict = info?.ToDictionary ())
 				return CGPDFContextCreateWithURL (url.GetHandle (), mediaBox, dict.GetHandle ());
 		}
 
-		unsafe CGContextPDF (NSUrl url, CGRect *mediaBox, CGPDFInfo info)
+		unsafe CGContextPDF (NSUrl? url, CGRect *mediaBox, CGPDFInfo? info)
 			: base (Create (url, mediaBox, info), true)
 		{
 		}
@@ -201,7 +203,7 @@ namespace CoreGraphics {
 		{
 		}
 
-		public unsafe CGContextPDF (NSUrl url, CGPDFInfo info) :
+		public unsafe CGContextPDF (NSUrl url, CGPDFInfo? info) :
 			this (url, null, info)
 		{
 		}
@@ -227,8 +229,8 @@ namespace CoreGraphics {
 		
 		public void BeginPage (CGPDFPageInfo info)
 		{
-			using (var dict = info == null ? null : info.ToDictionary ())
-				CGPDFContextBeginPage (Handle, dict == null ? IntPtr.Zero : dict.Handle);
+			using (var dict = info?.ToDictionary ())
+				CGPDFContextBeginPage (Handle, dict.GetHandle ());
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -244,7 +246,7 @@ namespace CoreGraphics {
 
 		public void AddDocumentMetadata (NSData data)
 		{
-			if (data == null)
+			if (data is null)
 				return;
 			CGPDFContextAddDocumentMetadata (Handle, data.Handle);
 		}
@@ -254,8 +256,8 @@ namespace CoreGraphics {
 
 		public void SetUrl (NSUrl url, CGRect region)
 		{
-			if (url == null)
-				throw new ArgumentNullException ("url");
+			if (url is null)
+				throw new ArgumentNullException (nameof (url));
 			CGPDFContextSetURLForRect (Handle, url.Handle, region);
 		}
 
@@ -264,11 +266,15 @@ namespace CoreGraphics {
 
 		public void AddDestination (string name, CGPoint point)
 		{
-			if (name == null)
-				throw new ArgumentNullException ("name");
+			if (name is null)
+				throw new ArgumentNullException (nameof (name));
 
-			using (var s = new CFString (name))
-				CGPDFContextAddDestinationAtPoint (Handle, s.Handle, point);
+			var nameHandle = CFString.CreateNative (name);
+			try {
+				CGPDFContextAddDestinationAtPoint (Handle, nameHandle, point);
+			} finally {
+				CFString.ReleaseNative (nameHandle);
+			}
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -276,11 +282,15 @@ namespace CoreGraphics {
 
 		public void SetDestination (string name, CGRect rect)
 		{
-			if (name == null)
-				throw new ArgumentNullException ("name");
+			if (name is null)
+				throw new ArgumentNullException (nameof (name));
 
-			using (var s = new CFString (name))
-				CGPDFContextSetDestinationForRect (Handle, s.Handle, rect);
+			var nameHandle = CFString.CreateNative (name);
+			try {
+				CGPDFContextSetDestinationForRect (Handle, nameHandle, rect);
+			} finally {
+				CFString.ReleaseNative (nameHandle);
+			}
 		}
 
 #if !NET


### PR DESCRIPTION
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use CFString.CreateNative/ReleaseNative instead of other means to create
  native strings (the fastest and least memory hungry option).
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.