### PR TITLE
[CGPDFOperatorTable] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreGraphics/CGPDFOperatorTable.cs
+++ b/src/CoreGraphics/CGPDFOperatorTable.cs
@@ -6,6 +6,8 @@
 //     
 // Copyright 2014 Xamarin Inc. All rights reserved.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -16,7 +18,7 @@ using CoreFoundation;
 namespace CoreGraphics {
 
 	// CGPDFOperatorTable.h
-	public class CGPDFOperatorTable : INativeObject, IDisposable {
+	public class CGPDFOperatorTable : NativeObject {
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGPDFOperatorTableRef */ IntPtr CGPDFOperatorTableCreate ();
@@ -31,50 +33,37 @@ namespace CoreGraphics {
 		delegate void CGPDFOperatorCallback (/* CGPDFScannerRef */ IntPtr scanner, /* void* */ IntPtr info);
 
 		public CGPDFOperatorTable ()
+			: base (CGPDFOperatorTableCreate (), true)
 		{
-			Handle = CGPDFOperatorTableCreate ();
 		}
 
+#if !NET
 		public CGPDFOperatorTable (IntPtr handle)
+			: base (handle, false)
 		{
-			CGPDFOperatorTableRetain (handle);
-			Handle = handle;
 		}
+#endif
 
 		[Preserve (Conditional=true)]
 		internal CGPDFOperatorTable (IntPtr handle, bool owns)
+			 : base (handle, owns)
 		{
-			if (!owns)
-				CGPDFOperatorTableRetain (handle);
-
-			Handle = handle;
 		}
 
-		~CGPDFOperatorTable ()
+		protected override void Retain ()
 		{
-			Dispose (false);
+			CGPDFOperatorTableRetain (GetCheckedHandle ());
 		}
 
-		public void Dispose ()
+		protected override void Release ()
 		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
+			CGPDFOperatorTableRelease (GetCheckedHandle ());
 		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (Handle != IntPtr.Zero) {
-				CGPDFOperatorTableRelease (Handle);
-				Handle = IntPtr.Zero;
-			}
-		}
-
-		public IntPtr Handle { get; private set; }
 
 		// We need this P/Invoke for legacy AOT scenarios (since we have public API taking a 'Action<IntPtr, IntPtr>', and with this particular native function we can't wrap the delegate)
 		// Unfortunately CoreCLR doesn't support generic Action delegates in P/Invokes: https://github.com/dotnet/runtime/issues/32963
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGPDFOperatorTableSetCallback (/* CGPDFOperatorTableRef */ IntPtr table, /* const char */ string name, /* CGPDFOperatorCallback */ Action<IntPtr,IntPtr> callback);
+		extern static void CGPDFOperatorTableSetCallback (/* CGPDFOperatorTableRef */ IntPtr table, /* const char */ string name, /* CGPDFOperatorCallback */ Action<IntPtr,IntPtr>? callback);
 
 #if NET
 		// This signature requires C# 9 (so .NET only).
@@ -88,22 +77,22 @@ namespace CoreGraphics {
 		// This signature can work everywhere, but we can't enforce at compile time that 'callback' is a delegate to a static function (which is required for FullAOT scenarios),
 		// so limit it to non-FullAOT platforms (macOS)
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGPDFOperatorTableSetCallback (/* CGPDFOperatorTableRef */ IntPtr table, /* const char */ string name, /* CGPDFOperatorCallback */ CGPDFOperatorCallback callback);
+		extern static void CGPDFOperatorTableSetCallback (/* CGPDFOperatorTableRef */ IntPtr table, /* const char */ string name, /* CGPDFOperatorCallback */ CGPDFOperatorCallback? callback);
 
 		// this won't work with AOT since the callback must be decorated with [MonoPInvokeCallback]
-		public void SetCallback (string name, Action<CGPDFScanner,object> callback)
+		public void SetCallback (string name, Action<CGPDFScanner?,object?>? callback)
 		{
-			if (name == null)
-				throw new ArgumentNullException ("name");
+			if (name is null)
+				throw new ArgumentNullException (nameof (name));
 
-			if (callback == null)
-				CGPDFOperatorTableSetCallback (Handle, name, (CGPDFOperatorCallback) null);
+			if (callback is null)
+				CGPDFOperatorTableSetCallback (Handle, name, (CGPDFOperatorCallback?) null);
 			else
 				CGPDFOperatorTableSetCallback (Handle, name, new CGPDFOperatorCallback (delegate (IntPtr reserved, IntPtr gchandle) {
 					// we could do 'new CGPDFScanner (reserved, true)' but we would not get `UserInfo` (managed state) back
 					// we could GCHandle `userInfo` but that would (even more) diverge both code bases :(
 					var scanner = GetScannerFromInfo (gchandle);
-					callback (scanner, scanner != null ? scanner.UserInfo : null);
+					callback (scanner, scanner?.UserInfo);
 				}));
 		}
 
@@ -114,10 +103,10 @@ namespace CoreGraphics {
 #if NET && !MONOMAC
 		[Obsolete ("Use the overload that takes a function pointer ('delegate*<IntPtr,IntPtr,void>') instead.")]
 #endif
-		public void SetCallback (string name, Action<IntPtr,IntPtr> callback)
+		public void SetCallback (string name, Action<IntPtr,IntPtr>? callback)
 		{
-			if (name == null)
-				throw new ArgumentNullException ("name");
+			if (name is null)
+				throw new ArgumentNullException (nameof (name));
 
 			CGPDFOperatorTableSetCallback (Handle, name, callback);
 		}
@@ -126,14 +115,14 @@ namespace CoreGraphics {
 		// this signature requires C# 9 and unsafe code
 		public unsafe void SetCallback (string name, delegate* unmanaged<IntPtr, IntPtr, void> callback)
 		{
-			if (name == null)
+			if (name is null)
 				throw new ArgumentNullException (nameof (name));
 
 			CGPDFOperatorTableSetCallback (Handle, name, callback);
 		}
 #endif
 
-		static public CGPDFScanner GetScannerFromInfo (IntPtr gchandle)
+		static public CGPDFScanner? GetScannerFromInfo (IntPtr gchandle)
 		{
 			return GCHandle.FromIntPtr (gchandle).Target as CGPDFScanner;
 		}


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.
* Remove the (IntPtr) constructor for .NET