### PR TITLE
[CGPDFString] Enable nullability + a few other code updates

### DIFF
--- a/src/CoreGraphics/CGPDFString.cs
+++ b/src/CoreGraphics/CGPDFString.cs
@@ -27,6 +27,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -41,14 +43,12 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static IntPtr /*CFStringRef*/ CGPDFStringCopyTextString (IntPtr /*CGPDFStringRef*/ pdfStr);
 
-		static public string ToString (IntPtr pdfString)
+		static public string? ToString (IntPtr pdfString)
 		{
 			if (pdfString == IntPtr.Zero)
 				return null;
 			
-			using (var cfs = new CFString (CGPDFStringCopyTextString (pdfString), true)) {
-				return cfs.ToString ();
-			}
+			return CFString.FromHandle (CGPDFStringCopyTextString (pdfString), true);
 		}
 	}
 }


### PR DESCRIPTION
* Enable nullability and fix code accordingly.
* Use CFString.CreateNative/ReleaseNative instead of other means to create
  native strings (the fastest and least memory hungry option).