### PR TITLE
[CGPDFPage] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreGraphics/CGPDFDocument.cs
+++ b/src/CoreGraphics/CGPDFDocument.cs
@@ -139,7 +139,7 @@ namespace CoreGraphics {
 		public CGPDFPage GetPage (nint page)
 		{
 			var h = CGPDFDocumentGetPage (handle, page);
-			return h == IntPtr.Zero ? null : new CGPDFPage (h);
+			return h == IntPtr.Zero ? null : new CGPDFPage (h, false);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]

--- a/src/CoreGraphics/CGPDFPage-2.cs
+++ b/src/CoreGraphics/CGPDFPage-2.cs
@@ -25,10 +25,12 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using ObjCRuntime;
-using Foundation;
 
 namespace CoreGraphics {
 
@@ -44,13 +46,16 @@ namespace CoreGraphics {
 	// CGPDFPage.h
 	public partial class CGPDFPage {
 #if !COREBUILD
+#if !NET
 		public CGPDFPage (IntPtr handle)
+			: base (handle, false)
 		{
-			if (handle == IntPtr.Zero)
-				throw new Exception ("Invalid parameters to CGPDFPage creation");
+		}
+#endif
 
-			CGPDFPageRetain (handle);
-			this.handle = handle;
+		internal CGPDFPage (IntPtr handle, bool owns)
+			: base (handle, owns)
+		{
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -58,7 +63,7 @@ namespace CoreGraphics {
 
 		public CGPDFDocument Document {
 			get {
-				return new CGPDFDocument (CGPDFPageGetDocument (handle));
+				return new CGPDFDocument (CGPDFPageGetDocument (Handle));
 			}
 		}
 
@@ -67,7 +72,7 @@ namespace CoreGraphics {
 
 		public nint PageNumber {
 			get {
-				return CGPDFPageGetPageNumber (handle);
+				return CGPDFPageGetPageNumber (Handle);
  			}
 		}
 		
@@ -76,7 +81,7 @@ namespace CoreGraphics {
 
 		public CGRect GetBoxRect (CGPDFBox box)
 		{
-			return CGPDFPageGetBoxRect (handle, box);
+			return CGPDFPageGetBoxRect (Handle, box);
 		}
 		
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -84,7 +89,7 @@ namespace CoreGraphics {
 
 		public int RotationAngle {
 			get {
-				return CGPDFPageGetRotationAngle (handle);
+				return CGPDFPageGetRotationAngle (Handle);
 			}
 		}
 		
@@ -93,7 +98,7 @@ namespace CoreGraphics {
 
 		public CGAffineTransform GetDrawingTransform (CGPDFBox box, CGRect rect, int rotate, bool preserveAspectRatio)
 		{
-			return CGPDFPageGetDrawingTransform (handle, box, rect, rotate, preserveAspectRatio);
+			return CGPDFPageGetDrawingTransform (Handle, box, rect, rotate, preserveAspectRatio);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -101,7 +106,7 @@ namespace CoreGraphics {
 
 		public CGPDFDictionary Dictionary {
 			get {
-				return new CGPDFDictionary (CGPDFPageGetDictionary (handle));
+				return new CGPDFDictionary (CGPDFPageGetDictionary (Handle));
 			}
 		}
 #endif // !COREBUILD

--- a/src/CoreGraphics/CGPDFPage.cs
+++ b/src/CoreGraphics/CGPDFPage.cs
@@ -25,45 +25,33 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
+using CoreFoundation;
 using ObjCRuntime;
-using Foundation;
 
 namespace CoreGraphics {
 
 	// CGPDFPage.h
-	public partial class CGPDFPage : INativeObject, IDisposable {
-		internal IntPtr handle;
-		
-		~CGPDFPage ()
-		{
-			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-	
+	public partial class CGPDFPage : NativeObject {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGPDFPageRef */ IntPtr CGPDFPageRetain (/* CGPDFPageRef */ IntPtr page);
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGPDFPageRelease (/* CGPDFPageRef */ IntPtr page);
-		
-		protected virtual void Dispose (bool disposing)
+
+		protected override void Retain ()
 		{
-			if (handle != IntPtr.Zero){
-				CGPDFPageRelease (handle);
-				handle = IntPtr.Zero;
-			}
+			CGPDFPageRetain (GetCheckedHandle ());
+		}
+
+		protected override void Release ()
+		{
+			CGPDFPageRelease (GetCheckedHandle ());
 		}
 	}
 }


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.
* Remove the (IntPtr) constructor for .NET