### PR TITLE
[CTFrame] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreText/CTFrame.cs
+++ b/src/CoreText/CTFrame.cs
@@ -25,6 +25,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -76,8 +79,8 @@ namespace CoreText {
 
 		public CTFrameAttributes (NSDictionary dictionary)
 		{
-			if (dictionary == null)
-				throw new ArgumentNullException ("dictionary");
+			if (dictionary is null)
+				throw new ArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
 
@@ -95,41 +98,21 @@ namespace CoreText {
 		}
 	}
 
-	public class CTFrame : INativeObject, IDisposable {
-		internal IntPtr handle;
+	internal static class CTFrameAttributesExtensions {
+		public static IntPtr GetHandle (this CTFrameAttributes self)
+		{
+			if (self is null)
+				return IntPtr.Zero;
+			return self.Dictionary.GetHandle ();
+		}
+	}
 
+	public class CTFrame : NativeObject {
 		internal CTFrame (IntPtr handle, bool owns)
+			: base (handle, owns, verify: true)
 		{
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.ArgumentNull (this, "handle");
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
 		}
 		
-		public IntPtr Handle {
-			get { return handle; }
-		}
-
-		~CTFrame ()
-		{
-			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
-		}
-
 		[DllImport (Constants.CoreTextLibrary)]
 		extern static NSRange CTFrameGetStringRange (IntPtr handle);
 		[DllImport (Constants.CoreTextLibrary)]
@@ -137,30 +120,30 @@ namespace CoreText {
 		
 		public NSRange GetStringRange ()
 		{
-			return CTFrameGetStringRange (handle);
+			return CTFrameGetStringRange (Handle);
 		}
 
 		public NSRange GetVisibleStringRange ()
 		{
-			return CTFrameGetVisibleStringRange (handle);
+			return CTFrameGetVisibleStringRange (Handle);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		extern static IntPtr CTFrameGetPath (IntPtr handle);
 		
-		public CGPath GetPath ()
+		public CGPath? GetPath ()
 		{
-			IntPtr h = CTFrameGetPath (handle);
+			IntPtr h = CTFrameGetPath (Handle);
 			return h == IntPtr.Zero ? null : new CGPath (h, false);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		extern static IntPtr CTFrameGetFrameAttributes (IntPtr handle);
 
-		public CTFrameAttributes GetFrameAttributes ()
+		public CTFrameAttributes? GetFrameAttributes ()
 		{
-			var attrs = (NSDictionary) Runtime.GetNSObject (CTFrameGetFrameAttributes (handle));
-			return attrs == null ? null : new CTFrameAttributes (attrs);
+			var attrs = Runtime.GetNSObject<NSDictionary> (CTFrameGetFrameAttributes (Handle));
+			return attrs is null ? null : new CTFrameAttributes (attrs);
 		}
 		
 		[DllImport (Constants.CoreTextLibrary)]
@@ -168,27 +151,27 @@ namespace CoreText {
 
 		public CTLine [] GetLines ()
 		{
-			var cfArrayRef = CTFrameGetLines (handle);
+			var cfArrayRef = CTFrameGetLines (Handle);
 			if (cfArrayRef == IntPtr.Zero)
-				return new CTLine [0];
+				return Array.Empty<CTLine> ();
 
 			return NSArray.ArrayFromHandleFunc<CTLine> (cfArrayRef, (p) => {
 					// We need to take a ref, since we dispose it later.
 					return new CTLine (p, false);
-				});
+				})!;
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		extern static void CTFrameGetLineOrigins(IntPtr handle, NSRange range, [Out] CGPoint[] origins);
 		public void GetLineOrigins (NSRange range, CGPoint[] origins)
 		{
-			if (origins == null)
-				throw new ArgumentNullException ("origins");
+			if (origins is null)
+				throw new ArgumentNullException (nameof (origins));
 			if (range.Length != 0 && origins.Length < range.Length)
-				throw new ArgumentException ("origins must contain at least range.Length elements.", "origins");
-			else if (origins.Length < CFArray.GetCount (CTFrameGetLines (handle)))
-				throw new ArgumentException ("origins must contain at least GetLines().Length elements.", "origins");
-			CTFrameGetLineOrigins (handle, range, origins);
+				throw new ArgumentException ("origins must contain at least range.Length elements.", nameof (origins));
+			else if (origins.Length < CFArray.GetCount (CTFrameGetLines (Handle)))
+				throw new ArgumentException ("origins must contain at least GetLines().Length elements.", nameof (origins));
+			CTFrameGetLineOrigins (Handle, range, origins);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -196,10 +179,10 @@ namespace CoreText {
 
 		public void Draw (CGContext ctx)
 		{
-			if (ctx == null)
-				throw new ArgumentNullException ("ctx");
+			if (ctx is null)
+				throw new ArgumentNullException (nameof (ctx));
 
-			CTFrameDraw (handle, ctx.Handle);
+			CTFrameDraw (Handle, ctx.Handle);
 		}
 	}
 }


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.
* Use the 'Runtime.GetNSObject<T> (IntPtr, bool)' overload to specify handle
  ownership, to avoid having to call NSObject.DangerousReleaes manually later.
* Use Array.Empty<T> instead of creating an empty array manually.