### PR TITLE
[CTFontCollection] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreText/CTFontCollection.cs
+++ b/src/CoreText/CTFontCollection.cs
@@ -26,6 +26,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -57,8 +60,8 @@ namespace CoreText {
 
 		public CTFontCollectionOptions (NSDictionary dictionary)
 		{
-			if (dictionary == null)
-				throw new ArgumentNullException ("dictionary");
+			if (dictionary is null)
+				throw new ArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
 
@@ -78,79 +81,47 @@ namespace CoreText {
 		}
 	}
 
-	public class CTFontCollection : INativeObject, IDisposable {
-		internal IntPtr handle;
+	internal static class CTFontCollectionOptionsExtensions {
+		public static IntPtr GetHandle (this CTFontCollectionOptions? @self)
+		{
+			if (@self is null)
+				return IntPtr.Zero;
+			return self.Dictionary.GetHandle ();
+		}
+	}
 
+	public class CTFontCollection : NativeObject {
 		internal CTFontCollection (IntPtr handle, bool owns)
+			: base (handle, owns, verify: true)
 		{
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.ArgumentNull (this, "handle");
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
-		}
-
-		~CTFontCollection ()
-		{
-			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-		
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 #region Collection Creation
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCollectionCreateFromAvailableFonts (IntPtr options);
-		public CTFontCollection (CTFontCollectionOptions options)
+		public CTFontCollection (CTFontCollectionOptions? options)
+			: base (CTFontCollectionCreateFromAvailableFonts (options.GetHandle ()), true, true)
 		{
-			handle = CTFontCollectionCreateFromAvailableFonts (
-					options == null ? IntPtr.Zero : options.Dictionary.Handle);
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.Unknown (this);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCollectionCreateWithFontDescriptors (IntPtr queryDescriptors, IntPtr options);
-		public CTFontCollection (CTFontDescriptor[] queryDescriptors, CTFontCollectionOptions options)
+		static IntPtr Create (CTFontDescriptor []? queryDescriptors, CTFontCollectionOptions? options)
 		{
-			using (var descriptors = queryDescriptors == null
-					? null 
-					: CFArray.FromNativeObjects (queryDescriptors))
-				handle = CTFontCollectionCreateWithFontDescriptors (
-						descriptors == null ? IntPtr.Zero : descriptors.Handle,
-						options == null ? IntPtr.Zero : options.Dictionary.Handle);
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.Unknown (this);
+			using var descriptors = queryDescriptors is null ? null : CFArray.FromNativeObjects (queryDescriptors);
+			return CTFontCollectionCreateWithFontDescriptors (descriptors.GetHandle (), options.GetHandle ());
+		}
+		public CTFontCollection (CTFontDescriptor[]? queryDescriptors, CTFontCollectionOptions? options)
+			: base (Create (queryDescriptors, options), true, true)
+		{
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCollectionCreateCopyWithFontDescriptors (IntPtr original, IntPtr queryDescriptors, IntPtr options);
-		public CTFontCollection WithFontDescriptors (CTFontDescriptor[] queryDescriptors, CTFontCollectionOptions options)
+		public CTFontCollection? WithFontDescriptors (CTFontDescriptor[]? queryDescriptors, CTFontCollectionOptions? options)
 		{
-			IntPtr h;
-			using (var descriptors = queryDescriptors == null 
-					? null 
-					: CFArray.FromNativeObjects (queryDescriptors)) {
-				h = CTFontCollectionCreateCopyWithFontDescriptors (
-						handle,
-						descriptors == null ? IntPtr.Zero : descriptors.Handle,
-						options == null ? IntPtr.Zero : options.Dictionary.Handle);
-			}
+			using var descriptors = queryDescriptors is null ? null : CFArray.FromNativeObjects (queryDescriptors);
+			var	h = CTFontCollectionCreateCopyWithFontDescriptors (Handle, descriptors.GetHandle (), options.GetHandle ());
 			if (h == IntPtr.Zero)
 				return null;
 			return new CTFontCollection (h, true);
@@ -162,13 +133,10 @@ namespace CoreText {
 		static extern IntPtr CTFontCollectionCreateMatchingFontDescriptors (IntPtr collection);
 		public CTFontDescriptor[] GetMatchingFontDescriptors ()
 		{
-			var cfArrayRef = CTFontCollectionCreateMatchingFontDescriptors (handle);
+			var cfArrayRef = CTFontCollectionCreateMatchingFontDescriptors (Handle);
 			if (cfArrayRef == IntPtr.Zero)
 				return Array.Empty <CTFontDescriptor> ();
-			var matches = NSArray.ArrayFromHandle (cfArrayRef,
-					fd => new CTFontDescriptor (fd, false));
-			CFObject.CFRelease (cfArrayRef);
-			return matches;
+			return CFArray.ArrayFromHandleFunc (cfArrayRef, fd => new CTFontDescriptor (fd, false), true)!;
 		}
 
 #if !NET
@@ -186,15 +154,12 @@ namespace CoreText {
 		[SupportedOSPlatform ("ios12.0")]
 		[SupportedOSPlatform ("tvos12.0")]
 #endif
-		public CTFontDescriptor [] GetMatchingFontDescriptors (CTFontCollectionOptions options)
+		public CTFontDescriptor [] GetMatchingFontDescriptors (CTFontCollectionOptions? options)
 		{
-			var cfArrayRef = CTFontCollectionCreateMatchingFontDescriptorsWithOptions (handle, options == null ? IntPtr.Zero : options.Dictionary.Handle);
+			var cfArrayRef = CTFontCollectionCreateMatchingFontDescriptorsWithOptions (Handle, options.GetHandle ());
 			if (cfArrayRef == IntPtr.Zero)
 				return Array.Empty <CTFontDescriptor> ();
-			var matches = NSArray.ArrayFromHandle (cfArrayRef,
-					fd => new CTFontDescriptor (fd, false));
-			CFObject.CFRelease (cfArrayRef);
-			return matches;
+			return CFArray.ArrayFromHandleFunc (cfArrayRef, fd => new CTFontDescriptor (fd, false), true)!;
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -208,26 +173,23 @@ namespace CoreText {
 		{
 			GCHandle c = GCHandle.FromIntPtr (context);
 			var comparer = c.Target as Comparison<CTFontDescriptor>;
-			if (comparer == null)
+			if (comparer is null)
 				return default (CFIndex);
 			var rv = comparer (new CTFontDescriptor (first, false), new CTFontDescriptor (second, false));
 			return (CFIndex) rv;
 		}
 
-		public CTFontDescriptor[] GetMatchingFontDescriptors (Comparison<CTFontDescriptor> comparer)
+		public CTFontDescriptor?[]? GetMatchingFontDescriptors (Comparison<CTFontDescriptor> comparer)
 		{
 			GCHandle comparison = GCHandle.Alloc (comparer);
 			try {
 				var cfArrayRef = CTFontCollectionCreateMatchingFontDescriptorsSortedWithCallback (
-						handle, 
+						Handle,
 						new CTFontCollectionSortDescriptorsCallback (CompareDescriptors),
 						GCHandle.ToIntPtr (comparison));
 				if (cfArrayRef == IntPtr.Zero)
-					return new CTFontDescriptor [0];
-				var matches = NSArray.ArrayFromHandle (cfArrayRef,
-						fd => new CTFontDescriptor (fd, false));
-				CFObject.CFRelease (cfArrayRef);
-				return matches;
+					return Array.Empty<CTFontDescriptor> ();
+				return CFArray.ArrayFromHandleFunc (cfArrayRef, fd => new CTFontDescriptor (fd, false), true)!;
 			}
 			finally {
 				comparison.Free ();


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use CFArray helper methods to create managed array from native CFArrays.
  native strings (the fastest and least memory hungry option).
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.
* Use Array.Empty<T> instead of creating an empty array manually.