### PR TITLE
[CTLine] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreText/CTLine.cs
+++ b/src/CoreText/CTLine.cs
@@ -26,6 +26,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -56,62 +59,25 @@ namespace CoreText {
 		IncludeLanguageExtents     = 1 << 5, // iOS8 and Mac 10.11
     }
 	
-	public class CTLine : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CTLine : NativeObject {
 		internal CTLine (IntPtr handle, bool owns)
+			: base (handle, owns, true)
 		{
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.ArgumentNull (this, "handle");
-
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
 		}
 		
-		public IntPtr Handle {
-			get { return handle; }
-		}
-
-		~CTLine ()
-		{
-			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
-		}
-
 #region Line Creation
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTLineCreateWithAttributedString (IntPtr @string);
 		public CTLine (NSAttributedString value)
+			: base (CTLineCreateWithAttributedString (Runtime.ThrowOnNull (value, nameof (value)).Handle), true, true)
 		{
-			if (value == null)
-				throw ConstructorError.ArgumentNull (this, "value");
-
-			handle = CTLineCreateWithAttributedString (value.Handle);
-
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.Unknown (this);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTLineCreateTruncatedLine (IntPtr line, double width, CTLineTruncation truncationType, IntPtr truncationToken);
-		public CTLine GetTruncatedLine (double width, CTLineTruncation truncationType, CTLine truncationToken)
+		public CTLine? GetTruncatedLine (double width, CTLineTruncation truncationType, CTLine? truncationToken)
 		{
-			var h = CTLineCreateTruncatedLine (handle, width, truncationType,
-					truncationToken == null ? IntPtr.Zero : truncationToken.Handle);
+			var h = CTLineCreateTruncatedLine (Handle, width, truncationType, truncationToken.GetHandle ());
 			if (h == IntPtr.Zero)
 				return null;
 			return new CTLine (h, true);
@@ -119,9 +85,9 @@ namespace CoreText {
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTLineCreateJustifiedLine (IntPtr line, nfloat justificationFactor, double justificationWidth);
-		public CTLine GetJustifiedLine (nfloat justificationFactor, double justificationWidth)
+		public CTLine? GetJustifiedLine (nfloat justificationFactor, double justificationWidth)
 		{
-			var h = CTLineCreateJustifiedLine (handle, justificationFactor, justificationWidth);
+			var h = CTLineCreateJustifiedLine (Handle, justificationFactor, justificationWidth);
 			if (h == IntPtr.Zero)
 				return null;
 			return new CTLine (h, true);
@@ -132,41 +98,41 @@ namespace CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern nint CTLineGetGlyphCount (IntPtr line);
 		public nint GlyphCount {
-			get {return CTLineGetGlyphCount (handle);}
+			get { return CTLineGetGlyphCount (Handle); }
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTLineGetGlyphRuns (IntPtr line);
 		public CTRun[] GetGlyphRuns ()
 		{
-			var cfArrayRef = CTLineGetGlyphRuns (handle);
+			var cfArrayRef = CTLineGetGlyphRuns (Handle);
 			if (cfArrayRef == IntPtr.Zero)
-				return new CTRun [0];
+				return Array.Empty<CTRun> ();
 
 			return NSArray.ArrayFromHandle (cfArrayRef, 
-					v => new CTRun (v, false));
+					v => new CTRun (v, false))!;
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern NSRange CTLineGetStringRange (IntPtr line);
 		public NSRange StringRange {
-			get {return CTLineGetStringRange (handle);}
+			get { return CTLineGetStringRange (Handle); }
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern double CTLineGetPenOffsetForFlush (IntPtr line, nfloat flushFactor, double flushWidth);
 		public double GetPenOffsetForFlush (nfloat flushFactor, double flushWidth)
 		{
-			return CTLineGetPenOffsetForFlush (handle, flushFactor, flushWidth);
+			return CTLineGetPenOffsetForFlush (Handle, flushFactor, flushWidth);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern void CTLineDraw (IntPtr line, IntPtr context);
 		public void Draw (CGContext context)
 		{
-			if (context == null)
-				throw new ArgumentNullException ("context");
-			CTLineDraw (handle, context.Handle);
+			if (context is null)
+				throw new ArgumentNullException (nameof (context));
+			CTLineDraw (Handle, context.Handle);
 		}
 #endregion
 
@@ -175,9 +141,9 @@ namespace CoreText {
 		static extern CGRect CTLineGetImageBounds (/* CTLineRef __nonnull */ IntPtr line,
 			/* CGContextRef __nullable */ IntPtr context);
 
-		public CGRect GetImageBounds (CGContext context)
+		public CGRect GetImageBounds (CGContext? context)
 		{
-			return CTLineGetImageBounds (handle, context.GetHandle ());
+			return CTLineGetImageBounds (Handle, context.GetHandle ());
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -185,27 +151,27 @@ namespace CoreText {
 
 		public CGRect GetBounds (CTLineBoundsOptions options)
 		{
-			return CTLineGetBoundsWithOptions (handle, (nuint) (ulong) options);
+			return CTLineGetBoundsWithOptions (Handle, (nuint) (ulong) options);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern double CTLineGetTypographicBounds (IntPtr line, out nfloat ascent, out nfloat descent, out nfloat leading);
 		public double GetTypographicBounds (out nfloat ascent, out nfloat descent, out nfloat leading)
 		{
-			return CTLineGetTypographicBounds (handle, out ascent, out descent, out leading);
+			return CTLineGetTypographicBounds (Handle, out ascent, out descent, out leading);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern double CTLineGetTypographicBounds (IntPtr line, IntPtr ascent, IntPtr descent, IntPtr leading);
 		public double GetTypographicBounds ()
 		{
-			return CTLineGetTypographicBounds (handle, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+			return CTLineGetTypographicBounds (Handle, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern double CTLineGetTrailingWhitespaceWidth (IntPtr line);
 		public double TrailingWhitespaceWidth {
-			get {return CTLineGetTrailingWhitespaceWidth (handle);}
+			get {return CTLineGetTrailingWhitespaceWidth (Handle);}
 		}
 #endregion
 
@@ -214,21 +180,21 @@ namespace CoreText {
 		static extern nint CTLineGetStringIndexForPosition (IntPtr line, CGPoint position);
 		public nint GetStringIndexForPosition (CGPoint position)
 		{
-			return CTLineGetStringIndexForPosition (handle, position);
+			return CTLineGetStringIndexForPosition (Handle, position);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern nfloat CTLineGetOffsetForStringIndex (IntPtr line, nint charIndex, out nfloat secondaryOffset);
 		public nfloat GetOffsetForStringIndex (nint charIndex, out nfloat secondaryOffset)
 		{
-			return CTLineGetOffsetForStringIndex (handle, charIndex, out secondaryOffset);
+			return CTLineGetOffsetForStringIndex (Handle, charIndex, out secondaryOffset);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern nfloat CTLineGetOffsetForStringIndex (IntPtr line, nint charIndex, IntPtr secondaryOffset);
 		public nfloat GetOffsetForStringIndex (nint charIndex)
 		{
-			return CTLineGetOffsetForStringIndex (handle, charIndex, IntPtr.Zero);
+			return CTLineGetOffsetForStringIndex (Handle, charIndex, IntPtr.Zero);
 		}
 
 		public delegate void CaretEdgeEnumerator (double offset, nint charIndex, bool leadingEdge, ref bool stop);
@@ -238,37 +204,32 @@ namespace CoreText {
 		[iOS (9,0)][Mac (10,11)]
 #endif
 		[DllImport (Constants.CoreTextLibrary)]
-		static unsafe extern void CTLineEnumerateCaretOffsets (IntPtr line, BlockLiteral *blockEnumerator);
+		static extern void CTLineEnumerateCaretOffsets (IntPtr line, ref BlockLiteral blockEnumerator);
 
 		static unsafe readonly CaretEdgeEnumeratorProxy static_enumerate = TrampolineEnumerate;
 
 		[MonoPInvokeCallback (typeof (CaretEdgeEnumeratorProxy))]
 		static unsafe void TrampolineEnumerate (IntPtr blockPtr, double offset, nint charIndex, bool leadingEdge, ref bool stop)
 		{
-			var block = (BlockLiteral *) blockPtr;
-                        var del = (CaretEdgeEnumerator) (block->Target);
-                        if (del != null)
-                                del (offset, charIndex, leadingEdge, ref stop);
- 		}
-		
+			var block = (BlockLiteral*) blockPtr;
+			var del = (CaretEdgeEnumerator) (block->Target);
+			if (del is not null)
+				del (offset, charIndex, leadingEdge, ref stop);
+		}
+
 #if !NET
 		[iOS (9,0)][Mac (10,11)]
 #endif
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void EnumerateCaretOffsets (CaretEdgeEnumerator enumerator)
 		{
-			if (enumerator == null)
-				throw new ArgumentNullException ("enumerator");
-                        unsafe {
-                                BlockLiteral *block_ptr_handler;
-                                BlockLiteral block_handler;
-                                block_handler = new BlockLiteral ();
-                                block_ptr_handler = &block_handler;
-                                block_handler.SetupBlockUnsafe (static_enumerate, enumerator);
+			if (enumerator is null)
+				throw new ArgumentNullException (nameof (enumerator));
 
-                                CTLineEnumerateCaretOffsets (handle, block_ptr_handler);
-                                block_ptr_handler->CleanupBlock ();
-                        }
+			var block_handler = new BlockLiteral ();
+			block_handler.SetupBlockUnsafe (static_enumerate, enumerator);
+			CTLineEnumerateCaretOffsets (Handle, ref block_handler);
+			block_handler.CleanupBlock ();
 		}
 #endregion
 	}

--- a/src/CoreText/CTLine.cs
+++ b/src/CoreText/CTLine.cs
@@ -209,10 +209,9 @@ namespace CoreText {
 		static unsafe readonly CaretEdgeEnumeratorProxy static_enumerate = TrampolineEnumerate;
 
 		[MonoPInvokeCallback (typeof (CaretEdgeEnumeratorProxy))]
-		static unsafe void TrampolineEnumerate (IntPtr blockPtr, double offset, nint charIndex, bool leadingEdge, ref bool stop)
+		static void TrampolineEnumerate (IntPtr blockPtr, double offset, nint charIndex, bool leadingEdge, ref bool stop)
 		{
-			var block = (BlockLiteral*) blockPtr;
-			var del = (CaretEdgeEnumerator) (block->Target);
+			var del = BlockLiteral.GetTarget<CaretEdgeEnumerator> (blockPtr);
 			if (del is not null)
 				del (offset, charIndex, leadingEdge, ref stop);
 		}


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.
* Simplify block creation code a bit.
* Use Array.Empty<T> instead of creating an empty array manually.