### PR TITLE
[CTTextTab] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreText/CTTextTab.cs
+++ b/src/CoreText/CTTextTab.cs
@@ -24,13 +24,15 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
 using ObjCRuntime;
 using Foundation;
 using CoreFoundation;
-using CoreGraphics;
 
 namespace CoreText {
 
@@ -54,8 +56,8 @@ namespace CoreText {
 
 		public CTTextTabOptions (NSDictionary dictionary)
 		{
-			if (dictionary == null)
-				throw new ArgumentNullException ("dictionary");
+			if (dictionary is null)
+				throw new ArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
 
@@ -66,42 +68,21 @@ namespace CoreText {
 			set {Adapter.SetValue (Dictionary, CTTextTabOptionKey.ColumnTerminators, value);}
 		}
 	}
+
+	static class CTTextTabOptionsExtensions {
+		public static IntPtr GetHandle (this CTTextTabOptions? self)
+		{
+			if (self is null)
+				return IntPtr.Zero;
+			return self.Dictionary.GetHandle ();
+		}
+	}
 #endregion
 
-	public class CTTextTab : INativeObject, IDisposable {
-		internal IntPtr handle;
-
+	public class CTTextTab : NativeObject {
 		internal CTTextTab (IntPtr handle, bool owns)
+			: base (handle, owns, verify: true)
 		{
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.ArgumentNull (this, "handle");
-
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
-		}
-		
-		public IntPtr Handle {
-			get {return handle;}
-		}
-
-		~CTTextTab ()
-		{
-			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
 		}
 
 #region Text Tab Creation
@@ -112,13 +93,9 @@ namespace CoreText {
 		{
 		}
 
-		public CTTextTab (CTTextAlignment alignment, double location, CTTextTabOptions options)
+		public CTTextTab (CTTextAlignment alignment, double location, CTTextTabOptions? options)
+			: base (CTTextTabCreate (alignment, location, options.GetHandle ()), true, true)
 		{
-			handle = CTTextTabCreate (alignment, location, 
-					options == null ? IntPtr.Zero : options.Dictionary.Handle);
-
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.Unknown (this);
 		}
 #endregion
 
@@ -126,24 +103,23 @@ namespace CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern CTTextAlignment CTTextTabGetAlignment (IntPtr tab);
 		public CTTextAlignment TextAlignment {
-			get {return CTTextTabGetAlignment (handle);}
+			get { return CTTextTabGetAlignment (Handle); }
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern double CTTextTabGetLocation (IntPtr tab);
 		public double Location {
-			get {return CTTextTabGetLocation (handle);}
+			get { return CTTextTabGetLocation (Handle); }
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTTextTabGetOptions (IntPtr tab);
-		public CTTextTabOptions GetOptions ()
+		public CTTextTabOptions? GetOptions ()
 		{
-			var options = CTTextTabGetOptions (handle);
+			var options = CTTextTabGetOptions (Handle);
 			if (options == IntPtr.Zero)
 				return null;
-			return new CTTextTabOptions (
-					(NSDictionary) Runtime.GetNSObject (options));
+			return new CTTextTabOptions (Runtime.GetNSObject<NSDictionary> (options)!);
 		}
 #endregion
 	}


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.