### PR TITLE
[ObjCRuntime] Add a non-deprecated internal system-version checking API and use it everywhere.

### DIFF
--- a/src/AddressBook/ABAddressBook.cs
+++ b/src/AddressBook/ABAddressBook.cs
@@ -86,7 +86,7 @@ namespace AddressBook {
 		{
 #if __MACCATALYST__
 			// avoid TypeLoadException if used before macOS 11.x
-			if (!UIKit.UIDevice.CurrentDevice.CheckSystemVersion (14,0))
+			if (!SystemVersion.CheckiOS (14,0))
 				return;
 #endif
 			// ensure we can init. This is needed before iOS6 (as per doc).

--- a/src/CoreBluetooth/CBManager.cs
+++ b/src/CoreBluetooth/CBManager.cs
@@ -17,9 +17,9 @@ namespace CoreBluetooth {
 			get {
 				// in iOS 13.1 / Watch 6.1 this is a static property, like other [tv|mac]OS
 #if IOS
-				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (13, 1)) {
+				if (SystemVersion.CheckiOS (13, 1)) {
 #elif WATCH
-				if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (6, 1)) {
+				if (SystemVersion.CheckwatchOS (6, 1)) {
 #endif
 					return _SAuthorization;
 				} else {

--- a/src/CoreLocation/CLLocationManager.cs
+++ b/src/CoreLocation/CLLocationManager.cs
@@ -42,7 +42,7 @@ namespace CoreLocation {
 #if IOS
 		public static bool IsMonitoringAvailable (Type t)
 		{
-			if (UIDevice.CurrentDevice.CheckSystemVersion(7,0))
+			if (SystemVersion.CheckiOS (7,0))
 				return IsMonitoringAvailable (new Class (t));
 			return false;
 		}

--- a/src/CoreMedia/CMSync.cs
+++ b/src/CoreMedia/CMSync.cs
@@ -572,20 +572,14 @@ namespace CoreMedia {
 #endif
 
 #if !COREBUILD
-#if MONOMAC // CheckVersion
-		const int GetMethodDeprecatedMajor = 10;
-		const int GetMethodDeprecatedMinor = 11;
-#elif IOS
-		const int GetMethodDeprecatedMajor = 9;
-		const int GetMethodDeprecatedMinor = 0;
-#endif
-
 		bool IsDeprecated ()
 		{
 #if __MACCATALYST__
 			return true;
-#elif IOS || MONOMAC
-			return PlatformHelper.CheckSystemVersion (GetMethodDeprecatedMajor, GetMethodDeprecatedMinor);
+#elif IOS
+			return SystemVersion.CheckiOS (9, 0);
+#elif MONOMAC
+			return SystemVersion.CheckmacOS (10, 11);
 #elif TVOS || WATCH
 			return true;
 #endif

--- a/src/CoreVideo/CVBuffer.cs
+++ b/src/CoreVideo/CVBuffer.cs
@@ -123,9 +123,9 @@ namespace CoreVideo {
 			if (key is null)
 				throw new ArgumentNullException (nameof (key));
 #if IOS || __MACCATALYST__ || TVOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+			if (SystemVersion.CheckiOS (15, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (8, 0))
+			if (SystemVersion.CheckwatchOS (8, 0))
 #endif
 				return Runtime.GetINativeObject<T> (CVBufferCopyAttachment (Handle, key.Handle, out attachmentMode), true);
 			return Runtime.GetINativeObject<T> (CVBufferGetAttachment (Handle, key.Handle, out attachmentMode), false);
@@ -135,7 +135,7 @@ namespace CoreVideo {
 		{
 			if (key is null)
 				throw new ArgumentNullException (nameof (key));
-			if (PlatformHelper.CheckSystemVersion (12, 0))
+			if (SystemVersion.CheckmacOS (12, 0))
 				return Runtime.GetNSObject<NSObject> (CVBufferCopyAttachment (Handle, key.Handle, out attachmentMode), true);
 			else
 				return Runtime.GetNSObject<NSObject> (CVBufferGetAttachment (Handle, key.Handle, out attachmentMode), false);
@@ -171,11 +171,11 @@ namespace CoreVideo {
 		public NSDictionary? GetAttachments (CVAttachmentMode attachmentMode)
 		{
 #if IOS || __MACCATALYST__ || TVOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+			if (SystemVersion.CheckiOS (15, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (8, 0))
+			if (SystemVersion.CheckwatchOS (8, 0))
 #elif MONOMAC
-			if (PlatformHelper.CheckSystemVersion (12, 0))
+			if (SystemVersion.CheckmacOS (12, 0))
 #endif
 				return Runtime.GetINativeObject<NSDictionary> (CVBufferCopyAttachments (Handle, attachmentMode), true);
 			return Runtime.GetNSObject<NSDictionary> (CVBufferGetAttachments (Handle, attachmentMode), false);

--- a/src/Foundation/NSAttributedString.iOS.cs
+++ b/src/Foundation/NSAttributedString.iOS.cs
@@ -58,7 +58,7 @@ namespace Foundation {
 		// use the best selector based on the OS version
 		public NSAttributedString (NSUrl url, NSDictionary options, out NSDictionary resultDocumentAttributes, ref NSError error)
 		{
-			if (UIDevice.CurrentDevice.CheckSystemVersion (9,0))
+			if (SystemVersion.CheckiOS (9,0))
 				Handle = InitWithURL (url, options, out resultDocumentAttributes, ref error);
 			else
 				Handle = InitWithFileURL (url, options, out resultDocumentAttributes, ref error);

--- a/src/GameKit/GKScore.cs
+++ b/src/GameKit/GKScore.cs
@@ -59,7 +59,7 @@ namespace GameKit {
 #if WATCH
 			Handle = InitWithLeaderboardIdentifier (categoryOrIdentifier);
 #else
-			if (UIDevice.CurrentDevice.CheckSystemVersion (7, 0))
+			if (SystemVersion.CheckiOS (7, 0))
 				Handle = InitWithLeaderboardIdentifier (categoryOrIdentifier);
 			else
 				Handle = InitWithCategory (categoryOrIdentifier);

--- a/src/IOSurface/IOSurfacePropertyKey.cs
+++ b/src/IOSurface/IOSurfacePropertyKey.cs
@@ -34,9 +34,9 @@ namespace IOSurface {
 		static bool CheckSystemVersion ()
 		{
 #if MONOMAC
-			return PlatformHelper.CheckSystemVersion (10, 14);
+			return SystemVersion.CheckmacOS (10, 14);
 #elif TVOS || IOS
-			return UIKit.UIDevice.CurrentDevice.CheckSystemVersion (12, 0);
+			return SystemVersion.CheckiOS (12, 0);
 #else
 			#error Unknown platform
 #endif

--- a/src/Intents/INBillTypeResolutionResult.cs
+++ b/src/Intents/INBillTypeResolutionResult.cs
@@ -18,9 +18,9 @@ namespace Intents {
 		public static INBillTypeResolutionResult GetSuccess (INBillType resolvedValue)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #endif
 				return SuccessWithResolvedBillType (resolvedValue);
 			else
@@ -30,9 +30,9 @@ namespace Intents {
 		public static INBillTypeResolutionResult GetConfirmationRequired (INBillType valueToConfirm)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #endif
 				return ConfirmationRequiredWithBillTypeToConfirm (valueToConfirm);
 			else

--- a/src/Intents/INCallRecordTypeResolutionResult.cs
+++ b/src/Intents/INCallRecordTypeResolutionResult.cs
@@ -18,11 +18,11 @@ namespace Intents {
 		public static INCallRecordTypeResolutionResult GetSuccess (INCallRecordType resolvedValue)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #elif MONOMAC
-			if (PlatformHelper.CheckSystemVersion (10, 13))
+			if (SystemVersion.CheckmacOS (10, 13))
 #endif
 				return SuccessWithResolvedCallRecordType (resolvedValue);
 			else
@@ -32,11 +32,11 @@ namespace Intents {
 		public static INCallRecordTypeResolutionResult GetConfirmationRequired (INCallRecordType valueToConfirm)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #elif MONOMAC
-			if (PlatformHelper.CheckSystemVersion (10, 13))
+			if (SystemVersion.CheckmacOS (10, 13))
 #endif
 				return ConfirmationRequiredWithCallRecordTypeToConfirm (valueToConfirm);
 			else

--- a/src/Intents/INCarAirCirculationModeResolutionResult.cs
+++ b/src/Intents/INCarAirCirculationModeResolutionResult.cs
@@ -20,7 +20,7 @@ namespace Intents {
 #if __WATCHOS__
 			throw new PlatformNotSupportedException ("This class is not supported on watchOS");
 #elif __IOS__
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 				return SuccessWithResolvedCarAirCirculationMode (resolvedValue);
 			else
 				return SuccessWithResolvedValue (resolvedValue);
@@ -33,7 +33,7 @@ namespace Intents {
 #if __WATCHOS__
 			throw new PlatformNotSupportedException ("This class is not supported on watchOS");
 #elif __IOS__
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 				return ConfirmationRequiredWithCarAirCirculationModeToConfirm (valueToConfirm);
 			else
 				return ConfirmationRequiredWithValueToConfirm (valueToConfirm);

--- a/src/Intents/INCarAudioSourceResolutionResult.cs
+++ b/src/Intents/INCarAudioSourceResolutionResult.cs
@@ -20,7 +20,7 @@ namespace Intents {
 #if __WATCHOS__
 			throw new PlatformNotSupportedException ("This class is not supported on watchOS");
 #elif __IOS__
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 				return SuccessWithResolvedCarAudioSource (resolvedValue);
 			else
 				return SuccessWithResolvedValue (resolvedValue);
@@ -32,7 +32,7 @@ namespace Intents {
 #if __WATCHOS__
 			throw new PlatformNotSupportedException ("This class is not supported on watchOS");
 #elif __IOS__
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 				return ConfirmationRequiredWithCarAudioSourceToConfirm (valueToConfirm);
 			else
 				return ConfirmationRequiredWithValueToConfirm (valueToConfirm);

--- a/src/Intents/INCarDefrosterResolutionResult.cs
+++ b/src/Intents/INCarDefrosterResolutionResult.cs
@@ -20,7 +20,7 @@ namespace Intents {
 #if __WATCHOS__
 			throw new PlatformNotSupportedException ("This class is not supported on watchOS");
 #elif __IOS__
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 				return SuccessWithResolvedCarDefroster (resolvedValue);
 			else
 				return SuccessWithResolvedValue (resolvedValue);
@@ -32,7 +32,7 @@ namespace Intents {
 #if __WATCHOS__
 			throw new PlatformNotSupportedException ("This class is not supported on watchOS");
 #elif __IOS__
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 				return ConfirmationRequiredWithCarDefrosterToConfirm (valueToConfirm);
 			else
 				return ConfirmationRequiredWithValueToConfirm (valueToConfirm);

--- a/src/Intents/INCarSeatResolutionResult.cs
+++ b/src/Intents/INCarSeatResolutionResult.cs
@@ -19,7 +19,7 @@ namespace Intents {
 #if __WATCHOS__
 			throw new PlatformNotSupportedException ("This class is not supported on watchOS");
 #elif __IOS__
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 				return SuccessWithResolvedCarSeat (resolvedValue);
 			else
 				return SuccessWithResolvedValue (resolvedValue);
@@ -31,7 +31,7 @@ namespace Intents {
 #if __WATCHOS__
 			throw new PlatformNotSupportedException ("This class is not supported on watchOS");
 #elif __IOS__
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 				return ConfirmationRequiredWithCarSeatToConfirm (valueToConfirm);
 			else
 				return ConfirmationRequiredWithValueToConfirm (valueToConfirm);

--- a/src/Intents/INCarSignalOptionsResolutionResult.cs
+++ b/src/Intents/INCarSignalOptionsResolutionResult.cs
@@ -18,9 +18,9 @@ namespace Intents {
 		public static INCarSignalOptionsResolutionResult GetSuccess (INCarSignalOptions resolvedValue)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #endif
 				return SuccessWithResolvedCarSignalOptions (resolvedValue);
 			else
@@ -30,9 +30,9 @@ namespace Intents {
 		public static INCarSignalOptionsResolutionResult GetConfirmationRequired (INCarSignalOptions valueToConfirm)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #endif
 				return ConfirmationRequiredWithCarSignalOptionsToConfirm (valueToConfirm);
 			else

--- a/src/Intents/INMessageAttributeOptionsResolutionResult.cs
+++ b/src/Intents/INMessageAttributeOptionsResolutionResult.cs
@@ -18,11 +18,11 @@ namespace Intents {
 		public static INMessageAttributeOptionsResolutionResult GetSuccess (INMessageAttributeOptions resolvedValue)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #elif MONOMAC
-			if (PlatformHelper.CheckSystemVersion (10, 13))
+			if (SystemVersion.CheckmacOS (10, 13))
 #endif
 				return SuccessWithResolvedMessageAttributeOptions (resolvedValue);
 			else
@@ -32,11 +32,11 @@ namespace Intents {
 		public static INMessageAttributeOptionsResolutionResult GetConfirmationRequired (INMessageAttributeOptions valueToConfirm)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #elif MONOMAC
-			if (PlatformHelper.CheckSystemVersion (10, 13))
+			if (SystemVersion.CheckmacOS (10, 13))
 #endif
 				return ConfirmationRequiredWithMessageAttributeOptionsToConfirm (valueToConfirm);
 			else

--- a/src/Intents/INMessageAttributeResolutionResult.cs
+++ b/src/Intents/INMessageAttributeResolutionResult.cs
@@ -18,11 +18,11 @@ namespace Intents {
 		public static INMessageAttributeResolutionResult GetSuccess (INMessageAttribute resolvedValue)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #elif MONOMAC
-			if (PlatformHelper.CheckSystemVersion (10, 13))
+			if (SystemVersion.CheckmacOS (10, 13))
 #endif
 				return SuccessWithResolvedMessageAttribute (resolvedValue);
 			else
@@ -32,11 +32,11 @@ namespace Intents {
 		public static INMessageAttributeResolutionResult GetConfirmationRequired (INMessageAttribute valueToConfirm)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #elif MONOMAC
-			if (PlatformHelper.CheckSystemVersion (10, 13))
+			if (SystemVersion.CheckmacOS (10, 13))
 #endif
 				return ConfirmationRequiredWithMessageAttributeToConfirm (valueToConfirm);
 			else

--- a/src/Intents/INPaymentStatusResolutionResult.cs
+++ b/src/Intents/INPaymentStatusResolutionResult.cs
@@ -18,9 +18,9 @@ namespace Intents {
 		public static INPaymentStatusResolutionResult GetSuccess (INPaymentStatus resolvedValue)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #endif
 				return SuccessWithResolvedPaymentStatus (resolvedValue);
 			else
@@ -30,9 +30,9 @@ namespace Intents {
 		public static INPaymentStatusResolutionResult GetConfirmationRequired (INPaymentStatus valueToConfirm)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #endif
 				return ConfirmationRequiredWithPaymentStatusToConfirm (valueToConfirm);
 			else

--- a/src/Intents/INRadioTypeResolutionResult.cs
+++ b/src/Intents/INRadioTypeResolutionResult.cs
@@ -20,7 +20,7 @@ namespace Intents {
 #if __WATCHOS__
 			throw new PlatformNotSupportedException ("This class is not supported on watchOS");
 #elif __IOS__
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 				return SuccessWithResolvedRadioType (resolvedValue);
 			else
 				return SuccessWithResolvedValue (resolvedValue);
@@ -32,7 +32,7 @@ namespace Intents {
 #if __WATCHOS__
 			throw new PlatformNotSupportedException ("This class is not supported on watchOS");
 #elif __IOS__
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 				return ConfirmationRequiredWithRadioTypeToConfirm (valueToConfirm);
 			else
 				return ConfirmationRequiredWithValueToConfirm (valueToConfirm);

--- a/src/Intents/INRelativeReferenceResolutionResult.cs
+++ b/src/Intents/INRelativeReferenceResolutionResult.cs
@@ -20,7 +20,7 @@ namespace Intents {
 #if __WATCHOS__
 			throw new PlatformNotSupportedException ("This class is not supported on watchOS");
 #elif __IOS__
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 				return SuccessWithResolvedRelativeReference (resolvedValue);
 			else
 				return SuccessWithResolvedValue (resolvedValue);
@@ -32,7 +32,7 @@ namespace Intents {
 #if __WATCHOS__
 			throw new PlatformNotSupportedException ("This class is not supported on watchOS");
 #elif __IOS__
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 				return ConfirmationRequiredWithRelativeReferenceToConfirm (valueToConfirm);
 			else
 				return ConfirmationRequiredWithValueToConfirm (valueToConfirm);

--- a/src/Intents/INRelativeSettingResolutionResult.cs
+++ b/src/Intents/INRelativeSettingResolutionResult.cs
@@ -20,7 +20,7 @@ namespace Intents {
 #if __WATCHOS__
 			throw new PlatformNotSupportedException ("This class is not supported on watchOS");
 #elif __IOS__
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 				return SuccessWithResolvedRelativeSetting (resolvedValue);
 			else
 				return SuccessWithResolvedValue (resolvedValue);
@@ -32,7 +32,7 @@ namespace Intents {
 #if __WATCHOS__
 			throw new PlatformNotSupportedException ("This class is not supported on watchOS");
 #elif __IOS__
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 				return ConfirmationRequiredWithRelativeSettingToConfirm (valueToConfirm);
 			else
 				return ConfirmationRequiredWithValueToConfirm (valueToConfirm);

--- a/src/Intents/INSaveProfileInCarIntent.cs
+++ b/src/Intents/INSaveProfileInCarIntent.cs
@@ -20,7 +20,7 @@ namespace Intents {
 		public INSaveProfileInCarIntent (NSNumber profileNumber, string profileLabel)
 		{
 			// Apple created this change in 10,2
-			if (UIDevice.CurrentDevice.CheckSystemVersion (10, 2))
+			if (SystemVersion.CheckiOS (10, 2))
 				InitializeHandle (InitWithProfileNumberName (profileNumber, profileLabel));
 			else
 				InitializeHandle (InitWithProfileNumberLabel (profileNumber, profileLabel));

--- a/src/Intents/INSetProfileInCarIntent.cs
+++ b/src/Intents/INSetProfileInCarIntent.cs
@@ -28,7 +28,7 @@ namespace Intents {
 		protected INSetProfileInCarIntent (NSNumber profileNumber, string profileLabel, NSNumber defaultProfile)
 		{
 			// Apple created this change in 10,2
-			if (UIDevice.CurrentDevice.CheckSystemVersion (10, 2))
+			if (SystemVersion.CheckiOS (10, 2))
 				InitializeHandle (InitWithProfileNumberName (profileNumber, profileLabel, defaultProfile));
 			else
 				InitializeHandle (InitWithProfileNumberLabel (profileNumber, profileLabel, defaultProfile));

--- a/src/Intents/INSpeakableString.cs
+++ b/src/Intents/INSpeakableString.cs
@@ -17,11 +17,11 @@ namespace Intents {
 			: base (NSObjectFlag.Empty)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #elif MONOMAC
-			if (PlatformHelper.CheckSystemVersion (10, 13))
+			if (SystemVersion.CheckmacOS (10, 13))
 #endif
 				InitializeHandle (InitWithVocabularyIdentifier (identifier, spokenPhrase, pronunciationHint));
 #if !TVOS

--- a/src/Intents/INWorkoutGoalUnitTypeResolutionResult.cs
+++ b/src/Intents/INWorkoutGoalUnitTypeResolutionResult.cs
@@ -18,9 +18,9 @@ namespace Intents {
 		public static INWorkoutGoalUnitTypeResolutionResult GetSuccess (INWorkoutGoalUnitType resolvedValue)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #endif
 				return SuccessWithResolvedWorkoutGoalUnitType (resolvedValue);
 			else
@@ -30,9 +30,9 @@ namespace Intents {
 		public static INWorkoutGoalUnitTypeResolutionResult GetConfirmationRequired (INWorkoutGoalUnitType valueToConfirm)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #endif
 				return ConfirmationRequiredWithWorkoutGoalUnitTypeToConfirm (valueToConfirm);
 			else

--- a/src/Intents/INWorkoutLocationTypeResolutionResult.cs
+++ b/src/Intents/INWorkoutLocationTypeResolutionResult.cs
@@ -18,9 +18,9 @@ namespace Intents {
 		public static INWorkoutLocationTypeResolutionResult GetSuccess (INWorkoutLocationType resolvedValue)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #endif
 				return SuccessWithResolvedWorkoutLocationType (resolvedValue);
 			else
@@ -30,9 +30,9 @@ namespace Intents {
 		public static INWorkoutLocationTypeResolutionResult GetConfirmationRequired (INWorkoutLocationType valueToConfirm)
 		{
 #if IOS
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+			if (SystemVersion.CheckiOS (11, 0))
 #elif WATCH
-			if (WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+			if (SystemVersion.CheckwatchOS (4, 0))
 #endif
 				return ConfirmationRequiredWithWorkoutLocationTypeToConfirm (valueToConfirm);
 			else

--- a/src/MetricKit/MXMetaData.cs
+++ b/src/MetricKit/MXMetaData.cs
@@ -11,7 +11,7 @@ namespace MetricKit {
 
 		public virtual NSDictionary DictionaryRepresentation {
 			get {
-				if (UIDevice.CurrentDevice.CheckSystemVersion (14,0))
+				if (SystemVersion.CheckiOS (14,0))
 					return _DictionaryRepresentation14;
 				else
 					return _DictionaryRepresentation13;

--- a/src/MetricKit/MXMetric.cs
+++ b/src/MetricKit/MXMetric.cs
@@ -11,7 +11,7 @@ namespace MetricKit {
 
 		public virtual NSDictionary DictionaryRepresentation {
 			get {
-				if (UIDevice.CurrentDevice.CheckSystemVersion (14,0))
+				if (SystemVersion.CheckiOS (14,0))
 					return _DictionaryRepresentation14;
 				else
 					return _DictionaryRepresentation13;

--- a/src/MetricKit/MXMetricPayload.cs
+++ b/src/MetricKit/MXMetricPayload.cs
@@ -11,7 +11,7 @@ namespace MetricKit {
 
 		public virtual NSDictionary DictionaryRepresentation {
 			get {
-				if (UIDevice.CurrentDevice.CheckSystemVersion (14,0))
+				if (SystemVersion.CheckiOS (14,0))
 					return _DictionaryRepresentation14;
 				else
 					return _DictionaryRepresentation13;

--- a/src/ObjCRuntime/PlatformAvailability.cs
+++ b/src/ObjCRuntime/PlatformAvailability.cs
@@ -282,38 +282,6 @@ namespace ObjCRuntime
 
 			return platform;
 		}
-
-#if !COREBUILD && !WATCH
-#if MONOMAC
-		const int sys1 = 1937339185;
-		const int sys2 = 1937339186;
-
-		// Deprecated in OSX 10.8 - but no good alternative is (yet) available
-#if !NET
-		[Deprecated (PlatformName.MacOSX, 10, 8)]
-#else
-		[UnsupportedOSPlatform ("macos10.8")]
-#endif
-		[DllImport ("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-		static extern int Gestalt (int selector, out int result);
-
-		static int osx_major, osx_minor;
-
-		public static bool CheckSystemVersion (int major, int minor)
-		{
-			if (osx_major == 0) {
-				Gestalt (sys1, out osx_major);
-				Gestalt (sys2, out osx_minor);
-			}
-			return osx_major > major || (osx_major == major && osx_minor >= minor);
-		}
-#else
-		public static bool CheckSystemVersion (int major, int minor)
-		{
-			return UIDevice.CurrentDevice.CheckSystemVersion (major, minor);
-		}
-#endif
-#endif
 	}
 
 	[AttributeUsage (AttributeTargets.All, AllowMultiple = true)]

--- a/src/ObjCRuntime/PlatformAvailability.cs
+++ b/src/ObjCRuntime/PlatformAvailability.cs
@@ -282,6 +282,38 @@ namespace ObjCRuntime
 
 			return platform;
 		}
+
+#if !COREBUILD && !WATCH && !NET
+#if MONOMAC
+		const int sys1 = 1937339185;
+		const int sys2 = 1937339186;
+
+		// Deprecated in OSX 10.8 - but no good alternative is (yet) available
+#if !NET
+		[Deprecated (PlatformName.MacOSX, 10, 8)]
+#else
+		[UnsupportedOSPlatform ("macos10.8")]
+#endif
+		[DllImport ("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+		static extern int Gestalt (int selector, out int result);
+
+		static int osx_major, osx_minor;
+
+		public static bool CheckSystemVersion (int major, int minor)
+		{
+			if (osx_major == 0) {
+				Gestalt (sys1, out osx_major);
+				Gestalt (sys2, out osx_minor);
+			}
+			return osx_major > major || (osx_major == major && osx_minor >= minor);
+		}
+#else
+		public static bool CheckSystemVersion (int major, int minor)
+		{
+			return UIDevice.CurrentDevice.CheckSystemVersion (major, minor);
+		}
+#endif
+#endif
 	}
 
 	[AttributeUsage (AttributeTargets.All, AllowMultiple = true)]

--- a/src/ObjCRuntime/SystemVersion.cs
+++ b/src/ObjCRuntime/SystemVersion.cs
@@ -1,0 +1,72 @@
+#nullable enable
+
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+#if !COREBUILD
+namespace ObjCRuntime {
+	internal static class SystemVersion {
+#if __MACOS__
+#if NET
+		// NSProcessInfo.ProcessInfo.OperatingSystemVersion is only available
+		// in macOS 10.10, which means we can only use it in .NET (we support
+		// macOS 10.14+), and not legacy (where we support macOS 10.9+)
+		static NSOperatingSystemVersion? osx_version;
+		internal static bool CheckmacOS (int major, int minor)
+		{
+			if (osx_version is null)
+				osx_version = NSProcessInfo.ProcessInfo.OperatingSystemVersion;
+
+			var osx_major = osx_version.Value.Major;
+			var osx_minor = osx_version.Value.Minor;
+			return osx_major > major || (osx_major == major && osx_minor >= minor);
+		}
+#else
+		const int sys1 = 1937339185;
+		const int sys2 = 1937339186;
+
+		// Deprecated in OSX 10.8 - but no good alternative is (yet) available
+		[Deprecated (PlatformName.MacOSX, 10, 8)]
+		[DllImport ("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+		static extern int Gestalt (int selector, out int result);
+
+		static int osx_major, osx_minor;
+
+		internal static bool CheckmacOS (int major, int minor)
+		{
+			if (osx_major == 0) {
+				Gestalt (sys1, out osx_major);
+				Gestalt (sys2, out osx_minor);
+			}
+			return osx_major > major || (osx_major == major && osx_minor >= minor);
+		}
+#endif // NET
+#elif __IOS__ || __MACCATALYST__ || __TVOS__
+		// These three can be used interchangeably, the OS versions are the same.
+		internal static bool CheckiOS (int major, int minor)
+		{
+			return UIKit.UIDevice.CurrentDevice.CheckSystemVersion (major, minor);
+		}
+
+		internal static bool ChecktvOS (int major, int minor)
+		{
+			return UIKit.UIDevice.CurrentDevice.CheckSystemVersion (major, minor);
+		}
+
+		internal static bool CheckMacCatalyst (int major, int minor)
+		{
+			return UIKit.UIDevice.CurrentDevice.CheckSystemVersion (major, minor);
+		}
+#elif __WATCHOS__
+		internal static bool CheckwatchOS (int major, int minor)
+		{
+			return WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (major, minor);
+		}
+#else
+		#error Unknown platform
+#endif
+	}
+}
+#endif

--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -661,7 +661,7 @@ namespace Security {
 #else
 			// Apple changed/fixed this in iOS7 (not the only change, see comments above)
 			// test suite has a test case that needs to work on both pre-7.0 and post-7.0
-			if ((kind == SecClass.Identity) && !UIDevice.CurrentDevice.CheckSystemVersion (7,0))
+			if ((kind == SecClass.Identity) && !SystemVersion.CheckiOS (7,0))
 				queryDict = new NSMutableDictionary ();
 			else
 				queryDict = NSMutableDictionary.LowlevelFromObjectAndKey (kind, SecClass.SecClassKey);

--- a/src/SpriteKit/SKUniform.cs
+++ b/src/SpriteKit/SKUniform.cs
@@ -33,9 +33,9 @@ namespace SpriteKit {
 		{
 			if (!versionCheck.HasValue) {
 #if MONOMAC
-				versionCheck = PlatformHelper.CheckSystemVersion (10, 12);
+				versionCheck = SystemVersion.CheckmacOS (10, 12);
 #elif TVOS || IOS
-				versionCheck = UIKit.UIDevice.CurrentDevice.CheckSystemVersion (10, 0);
+				versionCheck = SystemVersion.CheckiOS (10, 0);
 #else
 				#error Unknown platform
 #endif

--- a/src/SpriteKit/SKVideoNode.cs
+++ b/src/SpriteKit/SKVideoNode.cs
@@ -20,9 +20,9 @@ namespace SpriteKit {
 		static bool CheckSystemVersion ()
 		{
 #if MONOMAC
-			return PlatformHelper.CheckSystemVersion (10, 10);
+			return SystemVersion.CheckmacOS (10, 10);
 #elif TVOS || IOS
-			return UIKit.UIDevice.CurrentDevice.CheckSystemVersion (8, 0);
+			return SystemVersion.CheckiOS (8, 0);
 #else
 			#error Unknown platform
 #endif

--- a/src/TVMLKit/TVViewElement.cs
+++ b/src/TVMLKit/TVViewElement.cs
@@ -28,19 +28,19 @@ namespace TVMLKit {
 				var value = _UpdateType;
 				switch ((long) value) {
 				case 2:
-					if (UIDevice.CurrentDevice.CheckSystemVersion (12, 0)) {
+					if (SystemVersion.CheckiOS (12, 0)) {
 						return TVElementUpdateType.Styles;
 					} else {
 						return TVElementUpdateType.Children;
 					}
 				case 3:
-					if (UIDevice.CurrentDevice.CheckSystemVersion (12, 0)) {
+					if (SystemVersion.CheckiOS (12, 0)) {
 						return TVElementUpdateType.Children;
 					} else {
 						return TVElementUpdateType.Self;
 					}
 				case 4:
-					if (UIDevice.CurrentDevice.CheckSystemVersion (12, 0)) {
+					if (SystemVersion.CheckiOS (12, 0)) {
 						return TVElementUpdateType.Self;
 					} else {
 						return TVElementUpdateType.Styles;

--- a/src/UIKit/UIDocumentBrowserViewController.cs
+++ b/src/UIKit/UIDocumentBrowserViewController.cs
@@ -36,7 +36,7 @@ namespace UIKit {
 
 		static bool CheckSystemVersion () {
 #if IOS
-			return UIKit.UIDevice.CurrentDevice.CheckSystemVersion (12, 0);
+			return SystemVersion.CheckiOS (12, 0);
 #else
 			#error Unknown platform
 #endif

--- a/src/UIKit/UIScreen.cs
+++ b/src/UIKit/UIScreen.cs
@@ -29,7 +29,7 @@ namespace UIKit {
 
 		public UIImage Capture ()
 		{
-			if (UIDevice.CurrentDevice.CheckSystemVersion (7, 0)) {
+			if (SystemVersion.CheckiOS (7, 0)) {
 				// This is from https://developer.apple.com/library/content/qa/qa1817/_index.html
 				try {
 					var view = UIApplication.SharedApplication.KeyWindow;

--- a/src/WKWebKit/WKCompat.cs
+++ b/src/WKWebKit/WKCompat.cs
@@ -28,9 +28,9 @@ namespace WebKit {
 		[Obsolete ("Use 'CloseAllMediaPresentations (Action completionHandler)' instead.")]
 		public virtual void CloseAllMediaPresentations () {
 #if IOS || __MACCATALYST__
- 				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+				if (SystemVersion.CheckiOS (15, 0))
 #elif MONOMAC
- 				if (PlatformHelper.CheckSystemVersion (12, 0))
+				if (SystemVersion.CheckmacOS (12, 0))
 #endif
 					CloseAllMediaPresentationsAsync ().Wait();
 				else
@@ -45,9 +45,9 @@ namespace WebKit {
  		public virtual void PauseAllMediaPlayback (Action? completionHandler)
 		{
 #if IOS || __MACCATALYST__
- 				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+				if (SystemVersion.CheckiOS (15, 0))
 #elif MONOMAC
- 				if (PlatformHelper.CheckSystemVersion (12, 0))
+				if (SystemVersion.CheckmacOS (12, 0))
 #endif
 					_NewPauseAllMediaPlayback (completionHandler);
 				else
@@ -62,9 +62,9 @@ namespace WebKit {
  		public virtual Task PauseAllMediaPlaybackAsync ()
 		{
 #if IOS || __MACCATALYST__
- 				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+				if (SystemVersion.CheckiOS (15, 0))
 #elif MONOMAC
- 				if (PlatformHelper.CheckSystemVersion (12, 0))
+				if (SystemVersion.CheckmacOS (12, 0))
 #endif
 					return _NewPauseAllMediaPlaybackAsync ();
 				else
@@ -80,9 +80,9 @@ namespace WebKit {
  		public virtual void SuspendAllMediaPlayback (Action? completionHandler)
 		{
 #if IOS || __MACCATALYST__
- 				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+				if (SystemVersion.CheckiOS (15, 0))
 #elif MONOMAC
- 				if (PlatformHelper.CheckSystemVersion (12, 0))
+				if (SystemVersion.CheckmacOS (12, 0))
 #endif
 					SetAllMediaPlaybackSuspended (true, completionHandler);
 				else
@@ -97,9 +97,9 @@ namespace WebKit {
  		public virtual Task SuspendAllMediaPlaybackAsync ()
 		{
 #if IOS || __MACCATALYST__
- 				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+				if (SystemVersion.CheckiOS (15, 0))
 #elif MONOMAC
- 				if (PlatformHelper.CheckSystemVersion (12, 0))
+				if (SystemVersion.CheckmacOS (12, 0))
 #endif
 					return SetAllMediaPlaybackSuspendedAsync (true);
 				else
@@ -115,9 +115,9 @@ namespace WebKit {
  		public virtual void ResumeAllMediaPlayback (Action? completionHandler)
 		{
 #if IOS || __MACCATALYST__
- 				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+				if (SystemVersion.CheckiOS (15, 0))
 #elif MONOMAC
- 				if (PlatformHelper.CheckSystemVersion (12, 0))
+				if (SystemVersion.CheckmacOS (12, 0))
 #endif
 					SetAllMediaPlaybackSuspended (false, completionHandler);
 				else
@@ -132,9 +132,9 @@ namespace WebKit {
  		public virtual Task ResumeAllMediaPlaybackAsync ()
 		{
 #if IOS || __MACCATALYST__
- 				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+				if (SystemVersion.CheckiOS (15, 0))
 #elif MONOMAC
- 				if (PlatformHelper.CheckSystemVersion (12, 0))
+				if (SystemVersion.CheckmacOS (12, 0))
 #endif
 					return SetAllMediaPlaybackSuspendedAsync (false);
 				else

--- a/src/WKWebKit/WKPreferences.cs
+++ b/src/WKWebKit/WKPreferences.cs
@@ -21,9 +21,9 @@ namespace WebKit {
 		public bool TextInteractionEnabled { 
 			get {
 #if IOS || __MACCATALYST__ 
-				if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion (15, 0))
+				if (SystemVersion.CheckiOS (15, 0))
 #elif MONOMAC
-				if (PlatformHelper.CheckSystemVersion (12, 0))
+				if (SystemVersion.CheckmacOS (12, 0))
 #endif
 					return _NewGetTextInteractionEnabled ();
 				else

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1846,6 +1846,7 @@ SHARED_CORE_SOURCES = \
 	ObjCRuntime/Registrar.core.cs \
 	ObjCRuntime/RequiresSuperAttribute.cs \
 	ObjCRuntime/Selector.cs \
+	ObjCRuntime/SystemVersion.cs \
 	ObjCRuntime/ThrowHelper.cs \
 	Simd/MatrixDouble4x4.cs \
 	Simd/MatrixFloat2x2.cs \

--- a/tests/introspection/Mac/MacApiTypoTest.cs
+++ b/tests/introspection/Mac/MacApiTypoTest.cs
@@ -15,9 +15,7 @@ namespace Introspection
 
 		public override void TypoTest ()
 		{
-			var sdk = new Version (Constants.SdkVersion);
-			if (!PlatformHelper.CheckSystemVersion (sdk.Major, sdk.Minor))
-				Assert.Ignore ("Typos only verified using the latest SDK");
+			AssertMatchingOSVersionAndSdkVersion ();
 			checker = new NSSpellChecker ();
 
 			base.TypoTest ();

--- a/tests/monotouch-test/AppKit/NSFont.cs
+++ b/tests/monotouch-test/AppKit/NSFont.cs
@@ -17,8 +17,7 @@ namespace Xamarin.Mac.Tests
 		[Test]
 		public void GetBoundingRect_SmokeTest ()
 		{
-			if (!PlatformHelper.CheckSystemVersion (10, 13))
-				return;
+			TestRuntime.AssertXcodeVersion (9, 0);
 
 			CGFont cgFont = CGFont.CreateWithFontName ("Arial");
 			ushort [] glyphs = new ushort [5];
@@ -37,8 +36,7 @@ namespace Xamarin.Mac.Tests
 		[Test]
 		public void GetBoundingRect_WithEmptyGlyphs ()
 		{
-			if (!PlatformHelper.CheckSystemVersion (10, 13))
-				return;
+			TestRuntime.AssertXcodeVersion (9, 0);
 
 			CGFont cgFont = CGFont.CreateWithFontName ("Arial");
 			ushort [] glyphs = new ushort [] {};

--- a/tests/monotouch-test/MonoMac/CBUUID.cs
+++ b/tests/monotouch-test/MonoMac/CBUUID.cs
@@ -23,13 +23,6 @@ namespace MonoMacFixtures.CoreBluetooth
 	[Preserve (AllMembers = true)]
 	public class CBUUIDTest
 	{
-		[SetUp]
-		public void SetUp ()
-		{
-			if (IntPtr.Size == 4 && PlatformHelper.CheckSystemVersion(10, 13))
-				Assert.Ignore("CCUUID was removed from 32-bit in macOS 10.13");
-		}
-
 		[Test]
 		public void Roundtrip_16bits ()
 		{

--- a/tests/monotouch-test/ObjCRuntime/DelegateAndDataSourceTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/DelegateAndDataSourceTest.cs
@@ -121,10 +121,6 @@ namespace Xamarin.Mac.Tests
 				if (Asserts.IsAtLeastElCapitan && IntPtr.Size == 4)
 					return true;
 				break;
-			case "CBCentralManager":
-				if (IntPtr.Size == 4 && PlatformHelper.CheckSystemVersion(10, 13)) // Removed from 32-bit in macOS 10.13
-					return true;
-				break;
 			case "AVCaptureView":
 				// Deallocating a AVCaptureView makes it trigger a permission dialog, which we don't want, so just skip this type.
 				return true;

--- a/tests/monotouch-test/ObjCRuntime/DelegateAndDataSourceTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/DelegateAndDataSourceTest.cs
@@ -125,7 +125,7 @@ namespace Xamarin.Mac.Tests
 				// Deallocating a AVCaptureView makes it trigger a permission dialog, which we don't want, so just skip this type.
 				return true;
 			case "GKGameCenterViewController": // the native 'init' method returned nil.
-				if (PlatformHelper.CheckSystemVersion (11, 0))
+				if (TestRuntime.CheckXcodeVersion (12, 0))
 					return true;
 				break;
 			case "SKView":


### PR DESCRIPTION
The PlatformHelper class is deprecated, so implement a new version that isn't
deprecated, and which shares a similar API between all platforms - the Check*
methods includes the name of the platform, because that makes it clearer which
version we're talking about from the call site. There's a quirk though:
there's no separate ChecktvOS or CheckMacCatalyst, because the system version
is the same as for iOS, so we can just use 'iOS'.

For macOS we can now use NSProcessInfo.ProcessInfo.OperatingSystemVersion to
determine the OS version, because it's supported in all versions of macOS we
support for .NET.

Fixes issues such as this when building with XAMCORE_4_0:

> CoreMedia/CMSync.cs(590,11): error CS0103: The name 'PlatformHelper' does not exist in the current context