### PR TITLE
[CTFrameSetter] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/CoreText/CTFrame.cs
+++ b/src/CoreText/CTFrame.cs
@@ -99,7 +99,7 @@ namespace CoreText {
 	}
 
 	internal static class CTFrameAttributesExtensions {
-		public static IntPtr GetHandle (this CTFrameAttributes self)
+		public static IntPtr GetHandle (this CTFrameAttributes? self)
 		{
 			if (self is null)
 				return IntPtr.Zero;

--- a/src/CoreText/CTFramesetter.cs
+++ b/src/CoreText/CTFramesetter.cs
@@ -24,6 +24,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -35,64 +38,29 @@ using CoreGraphics;
 
 namespace CoreText {
 
-	public class CTFramesetter : INativeObject, IDisposable {
-
-		internal IntPtr handle;
-
+	public class CTFramesetter : NativeObject {
 		internal CTFramesetter (IntPtr handle, bool owns)
+			: base (handle, owns, true)
 		{
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.ArgumentNull (this, "handle");
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
 		}
 		
-		public IntPtr Handle {
-			get {return handle;}
-		}
-
-		~CTFramesetter ()
-		{
-			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
-		}
-
 #region Framesetter Creation
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFramesetterCreateWithAttributedString (IntPtr @string);
 		public CTFramesetter (NSAttributedString value)
+			: base (CTFramesetterCreateWithAttributedString (Runtime.ThrowOnNull (value, nameof (value)).Handle), true, true)
 		{
-			if (value == null)
-				throw ConstructorError.ArgumentNull (this, "value");
-			handle = CTFramesetterCreateWithAttributedString (value.Handle);
-			if (handle == IntPtr.Zero)
-				throw ConstructorError.Unknown (this);
 		}
 #endregion
 
 #region Frame Creation
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFramesetterCreateFrame (IntPtr framesetter, NSRange stringRange, IntPtr path, IntPtr frameAttributes);
-		public CTFrame GetFrame (NSRange stringRange, CGPath path, CTFrameAttributes frameAttributes)
+		public CTFrame? GetFrame (NSRange stringRange, CGPath path, CTFrameAttributes? frameAttributes)
 		{
-			if (path == null)
-				throw new ArgumentNullException ("path");
-			var frame = CTFramesetterCreateFrame (handle, stringRange, path.Handle,
-					frameAttributes == null ? IntPtr.Zero : frameAttributes.Dictionary.Handle);
+			if (path is null)
+				throw new ArgumentNullException (nameof (path));
+			var frame = CTFramesetterCreateFrame (Handle, stringRange, path.Handle, frameAttributes.GetHandle ());
 			if (frame == IntPtr.Zero)
 				return null;
 			return new CTFrame (frame, true);
@@ -100,9 +68,9 @@ namespace CoreText {
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFramesetterGetTypesetter (IntPtr framesetter);
-		public CTTypesetter GetTypesetter ()
+		public CTTypesetter? GetTypesetter ()
 		{
-			var h = CTFramesetterGetTypesetter (handle);
+			var h = CTFramesetterGetTypesetter (Handle);
 
 			if (h == IntPtr.Zero)
 				return null;
@@ -114,11 +82,11 @@ namespace CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern CGSize CTFramesetterSuggestFrameSizeWithConstraints (
 				IntPtr framesetter, NSRange stringRange, IntPtr frameAttributes, CGSize constraints, out NSRange fitRange);
-		public CGSize SuggestFrameSize (NSRange stringRange, CTFrameAttributes frameAttributes, CGSize constraints, out NSRange fitRange)
+		public CGSize SuggestFrameSize (NSRange stringRange, CTFrameAttributes? frameAttributes, CGSize constraints, out NSRange fitRange)
 		{
 			return CTFramesetterSuggestFrameSizeWithConstraints (
-					handle, stringRange,
-					frameAttributes == null ? IntPtr.Zero : frameAttributes.Dictionary.Handle,
+					Handle, stringRange,
+					frameAttributes.GetHandle (),
 					constraints, out fitRange);
 		}
 #endregion
@@ -137,9 +105,9 @@ namespace CoreText {
 		[SupportedOSPlatform ("ios12.0")]
 		[SupportedOSPlatform ("tvos12.0")]
 #endif
-		public static CTFramesetter Create (CTTypesetter typesetter)
+		public static CTFramesetter? Create (CTTypesetter typesetter)
 		{
-			if (typesetter == null)
+			if (typesetter is null)
 				throw new ArgumentNullException (nameof (typesetter));
 
 			var ret = CTFramesetterCreateWithTypesetter (typesetter.Handle);


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.