### PR TITLE
[CGImageMetadataTag] Subclass NativeObject + numerous other code updates

### DIFF
--- a/src/ImageIO/CGImageMetadataTag.cs
+++ b/src/ImageIO/CGImageMetadataTag.cs
@@ -7,6 +7,8 @@
 // Copyright 2013-2014, Xamarin Inc.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -21,7 +23,7 @@ namespace ImageIO {
 #if !NET
 	[iOS (7,0)]
 #endif
-	public class CGImageMetadataTag : INativeObject, IDisposable {
+	public class CGImageMetadataTag : NativeObject {
 
 		// note: CGImageMetadataType is always an int (4 bytes) so it's ok to use in the pinvoke declaration
 		[DllImport (Constants.ImageIOLibrary)]
@@ -29,20 +31,17 @@ namespace ImageIO {
 			/* CFStringRef __nonnull */ IntPtr xmlns, /* CFStringRef __nullable */ IntPtr prefix,
 			/* CFStringRef __nonnull */ IntPtr name, CGImageMetadataType type, /* CFTypeRef __nonnull */ IntPtr value);
 
+#if !NET
 		public CGImageMetadataTag (IntPtr handle)
-			: this (handle, false)
+			: base (handle, false)
 		{
 		}
+#endif
 
 		[Preserve (Conditional=true)]
 		internal CGImageMetadataTag (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (handle == IntPtr.Zero)
-				throw new Exception ("Invalid handle");
-
-			Handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
 		}
 
 		// According to header file the CFType value can be:
@@ -52,50 +51,28 @@ namespace ImageIO {
 		// CFArrayRef	-> NSArray (NSObject)
 		// CFDictionary	-> NSDictionary (NSObject)
 
-		public CGImageMetadataTag (NSString xmlns, NSString prefix, NSString name, CGImageMetadataType type, NSObject value) :
-			this (xmlns, prefix, name, type, value == null ? IntPtr.Zero : value.Handle)
+		public CGImageMetadataTag (NSString xmlns, NSString? prefix, NSString name, CGImageMetadataType type, NSObject? value) :
+			this (xmlns, prefix, name, type, value.GetHandle ())
 		{
 		}
 
 		// CFBoolean support
-		public CGImageMetadataTag (NSString xmlns, NSString prefix, NSString name, CGImageMetadataType type, bool value) :
+		public CGImageMetadataTag (NSString xmlns, NSString? prefix, NSString name, CGImageMetadataType type, bool value) :
 			this (xmlns, prefix, name, type, value ? CFBoolean.TrueHandle : CFBoolean.FalseHandle)
 		{
 		}
 
-		CGImageMetadataTag (NSString xmlns, NSString prefix, NSString name, CGImageMetadataType type, IntPtr value)
+		CGImageMetadataTag (NSString xmlns, NSString? prefix, NSString? name, CGImageMetadataType type, IntPtr value)
 		{
-			if (xmlns == null)
-				throw new ArgumentNullException ("xmlns");
-			if (name == null)
-				throw new ArgumentNullException ("name");
+			if (xmlns is null)
+				throw new ArgumentNullException (nameof (xmlns));
+			if (name is null)
+				throw new ArgumentNullException (nameof (name));
 			// it won't crash - but the instance is invalid (null handle)
 			if (value == IntPtr.Zero)
-				throw new ArgumentNullException ("value");
+				throw new ArgumentNullException (nameof (value));
 
-			var p = (prefix == null) ? IntPtr.Zero : prefix.Handle;
-			Handle = CGImageMetadataTagCreate (xmlns.Handle, p, name.Handle, type, value);
-		}
-
-		public IntPtr Handle { get; internal set; }
-
-		~CGImageMetadataTag ()
-		{
-			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (Handle != IntPtr.Zero){
-				CFObject.CFRelease (Handle);
-				Handle = IntPtr.Zero;
-			}
+			InitializeHandle (CGImageMetadataTagCreate (xmlns.Handle, prefix.GetHandle (), name.Handle, type, value));
 		}
 
 		[DllImport (Constants.ImageIOLibrary, EntryPoint="CGImageMetadataTagGetTypeID")]
@@ -106,10 +83,10 @@ namespace ImageIO {
 		extern static /* CFStringRef __nullable */ IntPtr CGImageMetadataTagCopyNamespace (
 			/* CGImageMetadataTagRef __nonnull */ IntPtr tag);
 
-		public NSString Namespace {
+		public NSString? Namespace {
 			get {
 				var result = CGImageMetadataTagCopyNamespace (Handle);
-				return result == IntPtr.Zero ? null : new NSString (result, true);
+				return Runtime.GetNSObject<NSString> (result, true);
 			}
 		}
 
@@ -117,10 +94,10 @@ namespace ImageIO {
 		extern static /* CFStringRef __nullable */ IntPtr CGImageMetadataTagCopyPrefix (
 			/* CGImageMetadataTagRef __nonnull */ IntPtr tag);
 
-		public NSString Prefix {
+		public NSString? Prefix {
 			get {
 				var result = CGImageMetadataTagCopyPrefix (Handle);
-				return result == IntPtr.Zero ? null : new NSString (result, true);
+				return Runtime.GetNSObject<NSString> (result, true);
 			}
 		}
 
@@ -128,10 +105,10 @@ namespace ImageIO {
 		extern static /* CFStringRef __nullable */ IntPtr CGImageMetadataTagCopyName (
 			/* CGImageMetadataTagRef __nonnull */ IntPtr tag);
 
-		public NSString Name {
+		public NSString? Name {
 			get {
 				var result = CGImageMetadataTagCopyName (Handle);
-				return result == IntPtr.Zero ? null : new NSString (result, true);
+				return Runtime.GetNSObject<NSString> (result, true);
 			}
 		}
 
@@ -140,8 +117,8 @@ namespace ImageIO {
 			/* CGImageMetadataTagRef __nonnull */ IntPtr tag);
 
 		// a boolean is returned as a NSString, i.e. type CGImageMetadataType.String, so NSObject is fine
-		public NSObject Value {
-			get { return Runtime.GetNSObject (CGImageMetadataTagCopyValue (Handle)); }
+		public NSObject? Value {
+			get { return Runtime.GetNSObject<NSObject> (CGImageMetadataTagCopyValue (Handle), true); }
 		}
 
 		// note: CGImageMetadataType is always an int (4 bytes) so it's ok to use in the pinvoke declaration
@@ -156,17 +133,10 @@ namespace ImageIO {
 		extern static /* CFArrayRef __nullable */ IntPtr CGImageMetadataTagCopyQualifiers (
 			/* CGImageMetadataTagRef __nonnull */ IntPtr tag);
 
-		public CGImageMetadataTag[] GetQualifiers ()
+		public CGImageMetadataTag?[]? GetQualifiers ()
 		{
 			IntPtr result = CGImageMetadataTagCopyQualifiers (Handle);
-			if (result == IntPtr.Zero)
-				return null;
-			using (var a = new CFArray (result)) {
-				CGImageMetadataTag[] tags = new CGImageMetadataTag [a.Count];
-				for (int i = 0; i < a.Count; i++)
-					tags [i] = new CGImageMetadataTag (a.GetValue (i), true);
-				return tags;
-			}
+			return CFArray.ArrayFromHandle<CGImageMetadataTag> (result, true);
 		}
 	}
 }

--- a/src/ImageIO/CGImageMetadataTag.cs
+++ b/src/ImageIO/CGImageMetadataTag.cs
@@ -62,7 +62,7 @@ namespace ImageIO {
 		{
 		}
 
-		CGImageMetadataTag (NSString xmlns, NSString? prefix, NSString? name, CGImageMetadataType type, IntPtr value)
+		CGImageMetadataTag (NSString xmlns, NSString? prefix, NSString name, CGImageMetadataType type, IntPtr value)
 		{
 			if (xmlns is null)
 				throw new ArgumentNullException (nameof (xmlns));

--- a/tests/monotouch-test/ImageIO/ImageMetadataTagTest.cs
+++ b/tests/monotouch-test/ImageIO/ImageMetadataTagTest.cs
@@ -128,10 +128,9 @@ namespace MonoTouchFixtures.ImageIO {
 
 			var rc = name.RetainCount;
 			using (var tag = new CGImageMetadataTag (nspace, prefix, name,  CGImageMetadataType.Default, false)) {
-				using (var n = tag.Name) {
-					Assert.That (n.Handle, Is.EqualTo (name.Handle), "same");
-					Assert.That (n.ToString (), Is.EqualTo ("tagName"), "Name");
-				}
+				var n = tag.Name;
+				Assert.That (n.Handle, Is.EqualTo (name.Handle), "same");
+				Assert.That (n.ToString (), Is.EqualTo ("tagName"), "Name");
 				Assert.That (tag.Namespace.ToString (), Is.EqualTo ("http://ns.adobe.com/exif/1.0/"), "Namespace");
 				Assert.That (tag.Prefix.ToString (), Is.EqualTo ("exif"), "Prefix");
 				Assert.That (tag.Type, Is.EqualTo (CGImageMetadataType.String), "Type");


### PR DESCRIPTION
* Subclass NativeObject to reuse object lifetime code.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.
* Use the 'Runtime.GetNSObject<T> (IntPtr, bool)' overload to specify handle
  ownership, to avoid having to call NSObject.DangerousReleaes manually later.
* Remove the (IntPtr) constructor for .NET