### PR TITLE
[AppKit/Foundation/UIKit] Use Foundation.NSWritingDirection instead of UIKit.UITextWritingDirection and AppKit.NSWritingDirection for .NET. Fixes #6573.

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1313,11 +1313,9 @@ namespace AppKit {
 		Natural = 4
 	}
 
-#if !XAMCORE_4_0 && MONOMAC
-	// Not hard deprecating now but until XAMCORE_4_0 happens or we can
-	// properly fix all the API using this.
+#if !NET && MONOMAC
+	// Use Foundation.NSWritingDirection in .NET.
 	// see: https://github.com/xamarin/xamarin-macios/issues/6573
-	// [Obsolete ("Use NSWritingDirection in Foundation instead.")]
 	[Flags]
 	[Native]
 	public enum NSWritingDirection : long {
@@ -1327,7 +1325,7 @@ namespace AppKit {
 		[Obsolete ("This API is not available on this platform.")]
 		Override = 2,
 	}
-#endif // !XAMCORE_4_0 && MONOMAC
+#endif // !NET && MONOMAC
 
 	[NoMacCatalyst]
 #if !XAMCORE_4_0

--- a/src/UIKit/UIEnums.cs
+++ b/src/UIKit/UIEnums.cs
@@ -1154,12 +1154,10 @@ namespace UIKit {
 		Forward, Backward, Right, Left, Up, Down
 	}
 	
-#if !XAMCORE_4_0
+#if !NET
 	// NSInteger -> UITextInput.h
-	// Not hard deprecating now but until XAMCORE_4_0 happens or we can
-	// properly fix all the API using this.
+	// Use Foundation.NSWritingDirection in .NET.
 	// see: https://github.com/xamarin/xamarin-macios/issues/6573
-	// [Obsolete ("Use NSWritingDirection in Foundation instead.")]
 	[Native]
 	[NoWatch]
 	public enum UITextWritingDirection : long {

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -95,6 +95,10 @@ using NSTouchBar = Foundation.NSObject;
 using NSToolbar =  Foundation.NSObject;
 #endif
 
+#if !NET
+using NSWritingDirection = UIKit.UITextWritingDirection;
+#endif
+
 using System;
 using System.ComponentModel;
 
@@ -6594,11 +6598,11 @@ namespace UIKit {
 
 		[Abstract]
 		[Export ("baseWritingDirectionForPosition:inDirection:")]
-		UITextWritingDirection GetBaseWritingDirection (UITextPosition forPosition, UITextStorageDirection direction);
+		NSWritingDirection GetBaseWritingDirection (UITextPosition forPosition, UITextStorageDirection direction);
 
 		[Abstract]
 		[Export ("setBaseWritingDirection:forRange:")]
-		void SetBaseWritingDirectionforRange (UITextWritingDirection writingDirection, UITextRange range);
+		void SetBaseWritingDirectionforRange (NSWritingDirection writingDirection, UITextRange range);
 
 		[Abstract]
 		[Export ("firstRectForRange:")]
@@ -6772,7 +6776,7 @@ namespace UIKit {
 		CGRect Rect { get; }
 		
 		[Export ("writingDirection")]
-		UITextWritingDirection WritingDirection { get;  }
+		NSWritingDirection WritingDirection { get;  }
 
 		[Export ("containsStart")]
 		bool ContainsStart { get;  }

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -608,18 +608,23 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void TestNativeEnum ()
 		{
+#if NET
+			var nativeEnumValue = NSWritingDirection.RightToLeft;
+#else
+			var nativeEnumValue = UITextWritingDirection.RightToLeft;
+#endif
 			//public virtual void TestNativeEnum1 (UITextWritingDirection twd)
 			using (var obj = new RegistrarTestClass ()) {
 				if (IntPtr.Size == 4) {
-					Messaging.void_objc_msgSend_int (obj.Handle, Selector.GetHandle ("testNativeEnum1:"), (int) UITextWritingDirection.RightToLeft);
+					Messaging.void_objc_msgSend_int (obj.Handle, Selector.GetHandle ("testNativeEnum1:"), (int) nativeEnumValue);
 				} else {
-					Messaging.void_objc_msgSend_long (obj.Handle, Selector.GetHandle ("testNativeEnum1:"), (long)UITextWritingDirection.RightToLeft);
+					Messaging.void_objc_msgSend_long (obj.Handle, Selector.GetHandle ("testNativeEnum1:"), (long) nativeEnumValue);
 				}
 
 				if (IntPtr.Size == 4) {
-					Messaging.void_objc_msgSend_int_int_long (obj.Handle, Selector.GetHandle ("testNativeEnum1:"), (int) UITextWritingDirection.RightToLeft, 31415, 3141592);
+					Messaging.void_objc_msgSend_int_int_long (obj.Handle, Selector.GetHandle ("testNativeEnum1:"), (int) nativeEnumValue, 31415, 3141592);
 				} else {
-					Messaging.void_objc_msgSend_long_int_long (obj.Handle, Selector.GetHandle ("testNativeEnum1:"), (long) UITextWritingDirection.RightToLeft, 31415, 3141592);
+					Messaging.void_objc_msgSend_long_int_long (obj.Handle, Selector.GetHandle ("testNativeEnum1:"), (long) nativeEnumValue, 31415, 3141592);
 				}
 
 				if (IntPtr.Size == 4) {
@@ -950,10 +955,17 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 #if !__WATCHOS__ && !MONOMAC
 			[Export ("testNativeEnum1:")]
+#if NET
+			public virtual void TestNativeEnum1 (NSWritingDirection twd)
+			{
+				Assert.That (Enum.GetValues (typeof (NSWritingDirection)), Contains.Item (twd), "TestNativeEnum1");
+			}
+#else
 			public virtual void TestNativeEnum1 (UITextWritingDirection twd)
 			{
 				Assert.That (Enum.GetValues (typeof (UITextWritingDirection)), Contains.Item (twd), "TestNativeEnum1");
 			}
+#endif // NET
 
 			public virtual UIPopoverArrowDirection TestNativeEnum2 {
 				[Export ("testNativeEnum2")]
@@ -967,6 +979,15 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 
 
+#if NET
+			[Export ("testNativeEnum3:a:b:")]
+			public virtual void TestNativeEnum1 (NSWritingDirection twd, int a, long b)
+			{
+				Assert.That (Enum.GetValues (typeof (NSWritingDirection)), Contains.Item (twd), "TestNativeEnum3");
+				Assert.AreEqual (31415, a, "TestNativeEnum3 a");
+				Assert.AreEqual (3141592, b, "TestNativeEnum3 b");
+			}
+#else
 			[Export ("testNativeEnum3:a:b:")]
 			public virtual void TestNativeEnum1 (UITextWritingDirection twd, int a, long b)
 			{
@@ -974,6 +995,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				Assert.AreEqual (31415, a, "TestNativeEnum3 a");
 				Assert.AreEqual (3141592, b, "TestNativeEnum3 b");
 			}
+#endif // NET
 #endif // !__WATCHOS__
 
 			[Export ("testCGPoint:out:")]


### PR DESCRIPTION
Fixes this when building with XAMCORE_4_0:

> uikit.cs(6775,3): error CS0246: The type or namespace name 'UITextWritingDirection' could not be found (are you missing a using directive or an assembly reference?)
> uikit.cs(6597,3): error CS0246: The type or namespace name 'UITextWritingDirection' could not be found (are you missing a using directive or an assembly reference?)
> uikit.cs(6601,41): error CS0246: The type or namespace name 'UITextWritingDirection' could not be found (are you missing a using directive or an assembly reference?)

Fixes https://github.com/xamarin/xamarin-macios/issues/6573.