### PR TITLE
[NaturalLanguage] Remove wrong XAMCORE_4_0 code.

### DIFF
--- a/src/naturallanguage.cs
+++ b/src/naturallanguage.cs
@@ -466,11 +466,7 @@ namespace NaturalLanguage {
 
 		[Export ("vectorForString:")]
 		[return: NullAllowed]
-#if XAMCORE_4_0
-		[return: BindAs (typeof (float[]?))]
-#else
 		[return: BindAs (typeof (float[]))]
-#endif
 		// doc says "array of double" but other API uses float ?!?
 		NSNumber[] GetVector (string @string);
 


### PR DESCRIPTION
Fixes:

> naturallanguage.cs(470,20): error CS8639: The typeof operator cannot be used on a nullable reference type