### PR TITLE
[CGPDFObject] Make CGPDFObject a subclass of CGPDF[Array|Dictionary|Stream] + a few other fixes.

### DIFF
--- a/src/CoreGraphics/CGPDFArray.cs
+++ b/src/CoreGraphics/CGPDFArray.cs
@@ -27,6 +27,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -37,17 +40,18 @@ using CoreFoundation;
 namespace CoreGraphics {
 
 	// CGPDFArray.h
-	public class CGPDFArray : INativeObject {
-		internal IntPtr handle;
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-
-		/* invoked by marshallers */
+	public class CGPDFArray : CGPDFObject {
+		// The lifetime management of CGPDFObject (and CGPDFArray, CGPDFDictionary and CGPDFStream) are tied to
+		// the containing CGPDFDocument, and not possible to handle independently, which is why this class
+		// does not subclass NativeObject (there's no way to retain/release CGPDFObject instances). It's
+		// also why this constructor doesn't have a 'bool owns' parameter: it's always owned by the containing CGPDFDocument.
+#if NET
+		internal CGPDFArray (IntPtr handle)
+#else
 		public CGPDFArray (IntPtr handle)
+#endif
+			: base (handle)
 		{
-			this.handle = handle;
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -55,7 +59,7 @@ namespace CoreGraphics {
 		
 		public nint Count {
 			get {
-				return CGPDFArrayGetCount (handle);
+				return CGPDFArrayGetCount (Handle);
 			}
 		}
 
@@ -67,13 +71,13 @@ namespace CoreGraphics {
 
 		public bool GetBoolean (nint idx, out bool result)
 		{
-			return CGPDFArrayGetBoolean (handle, idx, out result);
+			return CGPDFArrayGetBoolean (Handle, idx, out result);
 		}
 
 #if !XAMCORE_4_0
 		public bool GetBoolean (int idx, out bool result)
 		{
-			return CGPDFArrayGetBoolean (handle, idx, out result);
+			return CGPDFArrayGetBoolean (Handle, idx, out result);
 		}
 #endif
 
@@ -85,13 +89,13 @@ namespace CoreGraphics {
 
 		public bool GetInt (nint idx, out nint result)
 		{
-			return CGPDFArrayGetInteger (handle, idx, out result);
+			return CGPDFArrayGetInteger (Handle, idx, out result);
 		}
 
 #if !XAMCORE_4_0
 		public bool GetInt (int idx, out nint result)
 		{
-			return CGPDFArrayGetInteger (handle, idx, out result);
+			return CGPDFArrayGetInteger (Handle, idx, out result);
 		}
 #endif
 
@@ -103,13 +107,13 @@ namespace CoreGraphics {
 
 		public bool GetFloat (nint idx, out nfloat result)
 		{
-			return CGPDFArrayGetNumber (handle, idx, out result);
+			return CGPDFArrayGetNumber (Handle, idx, out result);
 		}
 
 #if !XAMCORE_4_0
 		public bool GetFloat (int idx, out nfloat result)
 		{
-			return CGPDFArrayGetNumber (handle, idx, out result);
+			return CGPDFArrayGetNumber (Handle, idx, out result);
 		}
 #endif
 
@@ -117,16 +121,16 @@ namespace CoreGraphics {
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFArrayGetName (/* CGPDFArrayRef */ IntPtr array, /* size_t */ nint index, /* const char** */ out IntPtr value);
 
-		public bool GetName (nint idx, out string result)
+		public bool GetName (nint idx, out string? result)
 		{
 			IntPtr res;
-			var r = CGPDFArrayGetName (handle, idx, out res);
+			var r = CGPDFArrayGetName (Handle, idx, out res);
 			result = r ? Marshal.PtrToStringAnsi (res) : null;
 			return r;
 		}
 
 #if !XAMCORE_4_0
-		public bool GetName (int idx, out string result)
+		public bool GetName (int idx, out string? result)
 		{
 			return GetName ((nint) idx, out result);
 		}
@@ -136,16 +140,15 @@ namespace CoreGraphics {
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFArrayGetDictionary (/* CGPDFArrayRef */ IntPtr array, /* size_t */ nint index, /* CGPDFDictionaryRef* */ out IntPtr value);
 
-		public bool GetDictionary (nint idx, out CGPDFDictionary result)
+		public bool GetDictionary (nint idx, out CGPDFDictionary? result)
 		{
-			IntPtr res;
-			var r = CGPDFArrayGetDictionary (handle, idx, out res);
+			var r = CGPDFArrayGetDictionary (Handle, idx, out var res);
 			result = r ? new CGPDFDictionary (res) : null;
 			return r;
 		}
 
 #if !XAMCORE_4_0
-		public bool GetDictionary (int idx, out CGPDFDictionary result)
+		public bool GetDictionary (int idx, out CGPDFDictionary? result)
 		{
 			return GetDictionary ((nint) idx, out result);
 		}
@@ -155,16 +158,15 @@ namespace CoreGraphics {
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFArrayGetStream (/* CGPDFArrayRef */ IntPtr array, /* size_t */ nint index, /* CGPDFStreamRef* */ out IntPtr value);
 
-		public bool GetStream (nint idx, out CGPDFStream result)
+		public bool GetStream (nint idx, out CGPDFStream? result)
 		{
-			IntPtr ptr;
-			var r = CGPDFArrayGetStream (handle, idx, out ptr); 
+			var r = CGPDFArrayGetStream (Handle, idx, out var ptr);
 			result = r ? new CGPDFStream (ptr) : null;
 			return r;
 		}
 
 #if !XAMCORE_4_0
-		public bool GetStream (int idx, out CGPDFStream result)
+		public bool GetStream (int idx, out CGPDFStream? result)
 		{
 			return GetStream ((nint) idx, out result);
 		}
@@ -174,16 +176,15 @@ namespace CoreGraphics {
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFArrayGetArray (/* CGPDFArrayRef */ IntPtr array, /* size_t */ nint index, /* CGPDFArrayRef* */ out IntPtr value);
 
-		public bool GetArray (nint idx, out CGPDFArray array)
+		public bool GetArray (nint idx, out CGPDFArray? array)
 		{
-			IntPtr ptr;
-			var r = CGPDFArrayGetArray (handle, idx, out ptr);
+			var r = CGPDFArrayGetArray (Handle, idx, out var ptr);
 			array = r ? new CGPDFArray (ptr) : null;
 			return r;
 		}
 
 #if !XAMCORE_4_0
-		public bool GetArray (int idx, out CGPDFArray array)
+		public bool GetArray (int idx, out CGPDFArray? array)
 		{
 			return GetArray ((nint) idx, out array);
 		}
@@ -193,16 +194,15 @@ namespace CoreGraphics {
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFArrayGetString (/* CGPDFArrayRef */ IntPtr array, /* size_t */ nint index, /* CGPDFStringRef* */ out IntPtr value);
 
-		public bool GetString (nint idx, out string result)
+		public bool GetString (nint idx, out string? result)
 		{
-			IntPtr res;
-			var r = CGPDFArrayGetString (handle, idx, out res);
+			var r = CGPDFArrayGetString (Handle, idx, out var res);
 			result = r ? CGPDFString.ToString (res) : null;
 			return r;
 		}
 
 #if !XAMCORE_4_0
-		public bool GetString (int idx, out string result)
+		public bool GetString (int idx, out string? result)
 		{
 			return GetString ((nint) idx, out result);
 		}
@@ -214,16 +214,16 @@ namespace CoreGraphics {
 #if !MONOMAC
 		[MonoPInvokeCallback (typeof (ApplyBlockHandlerDelegate))]
 #endif
-		static unsafe bool ApplyBlockHandler (IntPtr block, nint index, IntPtr value, IntPtr info)
+		static bool ApplyBlockHandler (IntPtr block, nint index, IntPtr value, IntPtr info)
 		{
-			var del = (ApplyCallback) ((BlockLiteral *) block)->Target;
-			if (del != null)
+			var del = BlockLiteral.GetTarget<ApplyCallback> (block);
+			if (del is not null)
 				return del (index, CGPDFObject.FromHandle (value), info == IntPtr.Zero ? null : GCHandle.FromIntPtr (info).Target);
 
 			return false;
 		}
 
-		public delegate bool ApplyCallback (nint index, object value, object info);
+		public delegate bool ApplyCallback (nint index, object? value, object? info);
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 #if !NET
@@ -242,19 +242,19 @@ namespace CoreGraphics {
 		[SupportedOSPlatform ("tvos12.0")]
 #endif
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		public bool Apply (ApplyCallback callback, object info = null)
+		public bool Apply (ApplyCallback callback, object? info = null)
 		{
-			if (callback == null)
+			if (callback is null)
 				throw new ArgumentNullException (nameof (callback));
 
 			BlockLiteral block_handler = new BlockLiteral ();
 			block_handler.SetupBlockUnsafe (applyblock_handler, callback);
-			var gc_handle = info == null ? default (GCHandle) : GCHandle.Alloc (info);
+			var gc_handle = info is null ? default (GCHandle) : GCHandle.Alloc (info);
 			try {
-				return CGPDFArrayApplyBlock (handle, ref block_handler, info == null ? IntPtr.Zero : GCHandle.ToIntPtr (gc_handle));
+				return CGPDFArrayApplyBlock (Handle, ref block_handler, info is null ? IntPtr.Zero : GCHandle.ToIntPtr (gc_handle));
 			} finally {
 				block_handler.CleanupBlock ();
-				if (info != null)
+				if (info is not null)
 					gc_handle.Free ();
 			}
 		}

--- a/src/CoreGraphics/CGPDFDictionary.cs
+++ b/src/CoreGraphics/CGPDFDictionary.cs
@@ -27,6 +27,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using Foundation;
@@ -36,17 +39,18 @@ using CoreFoundation;
 namespace CoreGraphics {
 
 	// CGPDFDictionary.h
-	public class CGPDFDictionary : INativeObject {
-		internal IntPtr handle;
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-
-		/* invoked by marshallers */
+	public class CGPDFDictionary : CGPDFObject {
+		// The lifetime management of CGPDFObject (and CGPDFArray, CGPDFDictionary and CGPDFStream) are tied to
+		// the containing CGPDFDocument, and not possible to handle independently, which is why this class
+		// does not subclass NativeObject (there's no way to retain/release CGPDFObject instances). It's
+		// also why this constructor doesn't have a 'bool owns' parameter: it's always owned by the containing CGPDFDocument.
+#if NET
+		internal CGPDFDictionary (IntPtr handle)
+#else
 		public CGPDFDictionary (IntPtr handle)
+#endif
+			: base (handle)
 		{
-			this.handle = handle;
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -54,7 +58,7 @@ namespace CoreGraphics {
 		
 		public int Count {
 			get {
-				return (int) CGPDFDictionaryGetCount (handle);
+				return (int) CGPDFDictionaryGetCount (Handle);
 			}
 		}
 
@@ -66,9 +70,9 @@ namespace CoreGraphics {
 
 		public bool GetBoolean (string key, out bool result)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
-			return CGPDFDictionaryGetBoolean (handle, key, out result);
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
+			return CGPDFDictionaryGetBoolean (Handle, key, out result);
 		}
 
 		// CGPDFInteger -> long int so 32/64 bits -> CGPDFObject.h
@@ -79,9 +83,9 @@ namespace CoreGraphics {
 
 		public bool GetInt (string key, out nint result)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
-			return CGPDFDictionaryGetInteger (handle, key, out result);
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
+			return CGPDFDictionaryGetInteger (Handle, key, out result);
 		}
 
 		// CGPDFReal -> CGFloat -> CGPDFObject.h
@@ -92,21 +96,20 @@ namespace CoreGraphics {
 
 		public bool GetFloat (string key, out nfloat result)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
-			return CGPDFDictionaryGetNumber (handle, key, out result);
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
+			return CGPDFDictionaryGetNumber (Handle, key, out result);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDictionaryGetName (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* const char ** */ out IntPtr value);
 
-		public bool GetName (string key, out string result)
+		public bool GetName (string key, out string? result)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
-			IntPtr res;
-			var r = CGPDFDictionaryGetName (handle, key, out res);
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
+			var r = CGPDFDictionaryGetName (Handle, key, out var res);
 			result = r ? Marshal.PtrToStringAnsi (res) : null;
 			return r;
 		}
@@ -115,12 +118,11 @@ namespace CoreGraphics {
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDictionaryGetDictionary (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFDictionaryRef* */ out IntPtr result);
 
-		public bool GetDictionary (string key, out CGPDFDictionary result)
+		public bool GetDictionary (string key, out CGPDFDictionary? result)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
-			IntPtr res;
-			var r = CGPDFDictionaryGetDictionary (handle, key, out res);
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
+			var r = CGPDFDictionaryGetDictionary (Handle, key, out var res);
 			result = r ? new CGPDFDictionary (res) : null;
 			return r;
 		}
@@ -129,12 +131,11 @@ namespace CoreGraphics {
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDictionaryGetStream (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFStreamRef* */ out IntPtr value);
 
-		public bool GetStream (string key, out CGPDFStream result)
+		public bool GetStream (string key, out CGPDFStream? result)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
-			IntPtr ptr;
-			var r = CGPDFDictionaryGetStream (handle, key, out ptr); 
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
+			var r = CGPDFDictionaryGetStream (Handle, key, out var ptr);
 			result = r ? new CGPDFStream (ptr) : null;
 			return r;
 		}
@@ -143,13 +144,11 @@ namespace CoreGraphics {
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDictionaryGetArray (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFArrayRef* */ out IntPtr value);
 
-		public bool GetArray (string key, out CGPDFArray array)
+		public bool GetArray (string key, out CGPDFArray? array)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
-
-			IntPtr ptr;
-			var r = CGPDFDictionaryGetArray (handle, key, out ptr);
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
+			var r = CGPDFDictionaryGetArray (Handle, key, out var ptr);
 			array = r ? new CGPDFArray (ptr) : null;
 			return r;
 		}
@@ -167,7 +166,7 @@ namespace CoreGraphics {
 		static readonly ApplierFunction applyblock_handler = ApplyBridge;
 #endif // NET
 
-		public delegate void ApplyCallback (string key, object value, object info);
+		public delegate void ApplyCallback (string? key, object? value, object? info);
 
 #if NET
 		[UnmanagedCallersOnly]
@@ -178,15 +177,18 @@ namespace CoreGraphics {
 #endif // NET
 		static void ApplyBridge (IntPtr key, IntPtr pdfObject, IntPtr info)
 		{
-			var data = (Tuple<ApplyCallback, object>) GCHandle.FromIntPtr (info).Target;
-			var callback = data.Item1;
+			var data = GCHandle.FromIntPtr (info).Target as Tuple<ApplyCallback, object?>;
+			if (data is null)
+				return;
 
-			callback (Marshal.PtrToStringUTF8 (key), CGPDFObject.FromHandle (pdfObject), data.Item2);
+			var callback = data.Item1;
+			if (callback is not null)
+				callback (Marshal.PtrToStringUTF8 (key), CGPDFObject.FromHandle (pdfObject), data.Item2);
 		}
 
-		public void Apply (ApplyCallback callback, object info = null)
+		public void Apply (ApplyCallback callback, object? info = null)
 		{
-			var data = new Tuple<ApplyCallback, object> (callback, info);
+			var data = new Tuple<ApplyCallback, object?> (callback, info);
 			var gch = GCHandle.Alloc (data);
 			try {
 #if NET
@@ -210,12 +212,12 @@ namespace CoreGraphics {
 #endif // NET
 		static void ApplyBridge2 (IntPtr key, IntPtr pdfObject, IntPtr info)
 		{
-			var callback = (Action<string,CGPDFObject>) GCHandle.FromIntPtr (info).Target;
-
-			callback (Marshal.PtrToStringUTF8 (key), new CGPDFObject (pdfObject));
+			var callback = GCHandle.FromIntPtr (info).Target as Action<string?, CGPDFObject>;
+			if (callback is not null)
+				callback (Marshal.PtrToStringUTF8 (key), new CGPDFObject (pdfObject));
 		}
 
-		public void Apply (Action<string,CGPDFObject> callback)
+		public void Apply (Action<string?, CGPDFObject> callback)
 		{
 			GCHandle gch = GCHandle.Alloc (callback);
 #if NET
@@ -234,12 +236,11 @@ namespace CoreGraphics {
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool CGPDFDictionaryGetString (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFStringRef* */ out IntPtr value);
 
-		public bool GetString (string key, out string result)
+		public bool GetString (string key, out string? result)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
-			IntPtr res;
-			var r = CGPDFDictionaryGetString (handle, key, out res);
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
+			var r = CGPDFDictionaryGetString (Handle, key, out var res);
 			result = r ? CGPDFString.ToString (res) : null;
 			return r;
 		}

--- a/src/CoreGraphics/CGPDFObject.cs
+++ b/src/CoreGraphics/CGPDFObject.cs
@@ -27,6 +27,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using Foundation;
@@ -37,11 +40,17 @@ namespace CoreGraphics {
 
 	// CGPDFObject.h
 	public class CGPDFObject : INativeObject {
-
 		public IntPtr Handle { get; private set; }
 
-		/* invoked by marshallers */
+		// The lifetime management of CGPDFObject (and CGPDFArray, CGPDFDictionary and CGPDFStream) are tied to
+		// the containing CGPDFDocument, and not possible to handle independently, which is why this class
+		// does not subclass NativeObject (there's no way to retain/release CGPDFObject instances). It's
+		// also why this constructor doesn't have a 'bool owns' parameter: it's always owned by the containing CGPDFDocument.
+#if NET
+		internal CGPDFObject (IntPtr handle)
+#else
 		public CGPDFObject (IntPtr handle)
+#endif
 		{
 			Handle = handle;
 		}
@@ -95,7 +104,7 @@ namespace CoreGraphics {
 			return CGPDFObjectGetValue (Handle, CGPDFObjectType.Real, out value);
 		}
 
-		public bool TryGetValue (out string value)
+		public bool TryGetValue (out string? value)
 		{
 			IntPtr ip;
 			if (CGPDFObjectGetValue (Handle, CGPDFObjectType.String, out ip)) {
@@ -107,7 +116,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public bool TryGetValue (out CGPDFArray value)
+		public bool TryGetValue (out CGPDFArray? value)
 		{
 			IntPtr ip;
 			if (CGPDFObjectGetValue (Handle, CGPDFObjectType.Array, out ip)) {
@@ -119,7 +128,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public bool TryGetValue (out CGPDFDictionary value)
+		public bool TryGetValue (out CGPDFDictionary? value)
 		{
 			IntPtr ip;
 			if (CGPDFObjectGetValue (Handle, CGPDFObjectType.Dictionary, out ip)) {
@@ -131,7 +140,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public bool TryGetValue (out CGPDFStream value)
+		public bool TryGetValue (out CGPDFStream? value)
 		{
 			IntPtr ip;
 			if (CGPDFObjectGetValue (Handle, CGPDFObjectType.Stream, out ip)) {
@@ -143,7 +152,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public bool TryGetName (out string name)
+		public bool TryGetName (out string? name)
 		{
 			IntPtr ip;
 			if (CGPDFObjectGetValue (Handle, CGPDFObjectType.Name, out ip)) {
@@ -155,7 +164,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		internal static object FromHandle (IntPtr handle)
+		internal static object? FromHandle (IntPtr handle)
 		{
 			IntPtr ip;
 

--- a/src/CoreGraphics/CGPDFStream.cs
+++ b/src/CoreGraphics/CGPDFStream.cs
@@ -25,6 +25,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using Foundation;
@@ -41,16 +44,14 @@ namespace CoreGraphics {
 	};
 
 	// CGPDFStream.h
-	public class CGPDFStream : INativeObject {
-		internal IntPtr handle;
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-	
+	public class CGPDFStream : CGPDFObject {
+		// The lifetime management of CGPDFObject (and CGPDFArray, CGPDFDictionary and CGPDFStream) are tied to
+		// the containing CGPDFDocument, and not possible to handle independently, which is why this class
+		// does not subclass NativeObject (there's no way to retain/release CGPDFObject instances). It's
+		// also why this constructor doesn't have a 'bool owns' parameter: it's always owned by the containing CGPDFDocument.
 		internal CGPDFStream (IntPtr handle)
+			: base (handle)
 		{
-			this.handle = handle;
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -58,16 +59,16 @@ namespace CoreGraphics {
 		
 		public CGPDFDictionary Dictionary {
 			get {
-				return new CGPDFDictionary (CGPDFStreamGetDictionary (handle));
+				return new CGPDFDictionary (CGPDFStreamGetDictionary (Handle));
 			}
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CFDataRef */ IntPtr CGPDFStreamCopyData (/* CGPDFStreamRef */ IntPtr stream, /* CGPDFDataFormat* */ out CGPDFDataFormat format);
 
-		public NSData GetData (out CGPDFDataFormat format)
+		public NSData? GetData (out CGPDFDataFormat format)
 		{
-			IntPtr obj = CGPDFStreamCopyData (handle, out format);
+			IntPtr obj = CGPDFStreamCopyData (Handle, out format);
 			return Runtime.GetNSObject<NSData> (obj, true);
 		}
 	}

--- a/tests/monotouch-test/CoreGraphics/PDFArrayTest.cs
+++ b/tests/monotouch-test/CoreGraphics/PDFArrayTest.cs
@@ -19,6 +19,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 	[Preserve (AllMembers = true)]
 	public class PDFArrayTest {
 		
+#if !NET
 		[Test]
 		public void InvalidHandle ()
 		{
@@ -56,5 +57,6 @@ namespace MonoTouchFixtures.CoreGraphics {
 			Assert.False (array.GetString (0, out str), "GetString");
 			Assert.Null (str, "string");
 		}
+#endif // !NET
 	}
 }

--- a/tests/monotouch-test/CoreGraphics/PDFObjectTest.cs
+++ b/tests/monotouch-test/CoreGraphics/PDFObjectTest.cs
@@ -19,6 +19,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 	[Preserve (AllMembers = true)]
 	public class PDFObjectTest {
 
+#if !NET
 		[Test]
 		public void Zero ()
 		{
@@ -44,5 +45,6 @@ namespace MonoTouchFixtures.CoreGraphics {
 
 			Assert.False (po.TryGetName (out s), "name");
 		}
+#endif // !NET
 	}
 }


### PR DESCRIPTION
* Make CGPDFObject a common subclass for the CGPDF[Array|Dictionary|Stream]
  classes, and keep the object lifetime code there.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.
* Make any (IntPtr) constructors internal for .NET
* Simplify block creation code a bit.