### PR TITLE
[CI] Use a vimage for 10.15 since we do not have actual bots.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -72,7 +72,8 @@ parameters:
     {
       stageName: 'mac_10_15',
       displayName: 'Mac Catalina (10.15)',
-      macPool: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Trusted',
+      macPool: 'macOS-10.15',
+      useImage: true,
       statusContext: 'Mac Catalina (10.15)',
       demands: [
         "Agent.OS -equals Darwin",
@@ -83,6 +84,7 @@ parameters:
       stageName: 'mac_10_14',
       displayName: 'Mac Mojave (10.14)',
       macPool: 'Hosted Mac Internal Mojave',
+      useImage: false,
       statusContext: 'Mac Mojave (10.14)',
       demands: [
         "Agent.OS -equals Darwin",
@@ -92,6 +94,7 @@ parameters:
       stageName: 'mac_10_13',
       displayName: 'Mac High Sierra (10.13)',
       macPool: 'Hosted Mac Internal',
+      useImage: false,
       statusContext: 'Mac High Sierra (10.13)',
       demands: [
         "Agent.OS -equals Darwin",
@@ -101,6 +104,7 @@ parameters:
       stageName: 'mac_11_5_m1',
       displayName: 'M1 - Mac Big Sur (11.5)',
       macPool: 'VSEng-VSMac-Xamarin-Shared',
+      useImage: false,
       statusContext: 'M1 - Mac Big Sur (11.5)',
       demands: [
         "Agent.OS -equals Darwin",
@@ -282,6 +286,7 @@ stages:
           stageName: ${{ config['stageName'] }}
           displayName: ${{ config['displayName'] }}
           macPool: ${{ config['macPool'] }}
+          useImage: ${{ config['useImage'] }}
           statusContext: ${{ config['statusContext'] }}
           keyringPass: $(pass--lab--mac--builder--keychain)
           demands: ${{ config['demands'] }}

--- a/tools/devops/automation/templates/mac/stage.yml
+++ b/tools/devops/automation/templates/mac/stage.yml
@@ -3,6 +3,10 @@ parameters:
 - name: macPool
   type: string
 
+- name: useImage
+  type: boolean
+  default: false
+
 - name: stageName
   type: string
 
@@ -36,8 +40,11 @@ stages:
       clean: all
 
     pool:
-      name: ${{ parameters.macPool }}
-      demands: ${{ parameters.demands }}
+      ${{ if eq(parameters.useImage, false) }}:
+        name: ${{ parameters.macPool }}
+        demands: ${{ parameters.demands }}
+      ${{ else }}:
+        vmImage: ${{ parameters.macPool }}
 
     steps:
     - template: build.yml


### PR DESCRIPTION
We do not have actual bots for 10.15 but we do have an image. So in that case we can state that the pool should be an image. Changes will ensure that the stage will find a device that does have the correct os version.