### PR TITLE
[Security/Items] Enable nullability + a few other fixes.

### DIFF
--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -30,6 +30,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Runtime.InteropServices;
@@ -116,9 +119,9 @@ namespace Security {
 
 		public IntPtr Handle { get; internal set; }
 
-		static NSNumber SetLimit (NSMutableDictionary dict, int max)
+		static NSNumber? SetLimit (NSMutableDictionary dict, int max)
 		{
-			NSNumber n = null;
+			NSNumber? n = null;
 			IntPtr val;
 			if (max == -1)
 				val = SecMatchLimit.MatchLimitAll;
@@ -133,10 +136,10 @@ namespace Security {
 			return n;
 		}
 		
-		public static NSData QueryAsData (SecRecord query, bool wantPersistentReference, out SecStatusCode status)
+		public static NSData? QueryAsData (SecRecord query, bool wantPersistentReference, out SecStatusCode status)
 		{
-			if (query == null)
-				throw new ArgumentNullException ("query");
+			if (query is null)
+				throw new ArgumentNullException (nameof (query));
 
 			using (var copy = NSMutableDictionary.FromDictionary (query.queryDict)){
 				SetLimit (copy, 1);
@@ -148,15 +151,15 @@ namespace Security {
 				IntPtr ptr;
 				status = SecItem.SecItemCopyMatching (copy.Handle, out ptr);
 				if (status == SecStatusCode.Success)
-					return new NSData (ptr, false);
+					return Runtime.GetNSObject<NSData> (ptr, false);
 				return null;
 			}
 		}
 
-		public static NSData [] QueryAsData (SecRecord query, bool wantPersistentReference, int max, out SecStatusCode status)
+		public static NSData []? QueryAsData (SecRecord query, bool wantPersistentReference, int max, out SecStatusCode status)
 		{
-			if (query == null)
-				throw new ArgumentNullException ("query");
+			if (query is null)
+				throw new ArgumentNullException (nameof (query));
 
 			using (var copy = NSMutableDictionary.FromDictionary (query.queryDict)){
 				var n = SetLimit (copy, max);
@@ -170,34 +173,30 @@ namespace Security {
 				n = null;
 				if (status == SecStatusCode.Success){
 					if (max == 1)
-						return new NSData [] { new NSData (ptr, false) };
+						return new NSData [] { Runtime.GetNSObject<NSData> (ptr, false)! };
 
-					using var array = new NSArray (ptr);
-					var records = new NSData [array.Count];
-					for (uint i = 0; i < records.Length; i++)
-						records [i] = new NSData (array.ValueAt (i), false);
-					return records;
+					return NSArray.ArrayFromHandle<NSData> (ptr);
 				}
 				return null;
 			}
 		}
 		
-		public static NSData QueryAsData (SecRecord query)
+		public static NSData? QueryAsData (SecRecord query)
 		{
 			SecStatusCode status;
 			return QueryAsData (query, false, out status);
 		}
 
-		public static NSData [] QueryAsData (SecRecord query, int max)
+		public static NSData []? QueryAsData (SecRecord query, int max)
 		{
 			SecStatusCode status;
 			return QueryAsData (query, false, max, out status);
 		}
 		
-		public static SecRecord QueryAsRecord (SecRecord query, out SecStatusCode result)
+		public static SecRecord? QueryAsRecord (SecRecord query, out SecStatusCode result)
 		{
-			if (query == null)
-				throw new ArgumentNullException ("query");
+			if (query is null)
+				throw new ArgumentNullException (nameof (query));
 			
 			using (var copy = NSMutableDictionary.FromDictionary (query.queryDict)){
 				SetLimit (copy, 1);
@@ -211,10 +210,10 @@ namespace Security {
 			}
 		}
 		
-		public static SecRecord [] QueryAsRecord (SecRecord query, int max, out SecStatusCode result)
+		public static SecRecord []? QueryAsRecord (SecRecord query, int max, out SecStatusCode result)
 		{
-			if (query == null)
-				throw new ArgumentNullException ("query");
+			if (query is null)
+				throw new ArgumentNullException (nameof (query));
 			
 			using (var copy = NSMutableDictionary.FromDictionary (query.queryDict)){
 				copy.LowlevelSetObject (CFBoolean.TrueHandle, SecItem.ReturnAttributes);
@@ -224,20 +223,15 @@ namespace Security {
 				IntPtr ptr;
 				result = SecItem.SecItemCopyMatching (copy.Handle, out ptr);
 				n = null;
-				if (result == SecStatusCode.Success){
-					using var array = new NSArray (ptr);
-					var records = new SecRecord [array.Count];
-					for (uint i = 0; i < records.Length; i++)
-						records [i] = new SecRecord (new NSMutableDictionary (array.ValueAt (i), false));
-					return records;
-				}
+				if (result == SecStatusCode.Success)
+					return NSArray.ArrayFromHandleFunc<SecRecord> (ptr, (element) => new SecRecord (Runtime.GetNSObject<NSMutableDictionary> (element, false)!))!;
 				return null;
 			}
 		}
 
-		public static INativeObject[] QueryAsReference (SecRecord query, int max, out SecStatusCode result)
+		public static INativeObject[]? QueryAsReference (SecRecord query, int max, out SecStatusCode result)
 		{
-			if (query == null){
+			if (query is null) {
 				result = SecStatusCode.Param;
 				return null;
 			}
@@ -259,7 +253,7 @@ namespace Security {
 							return new SecIdentity (p, true);
 						else
 							throw new Exception (String.Format ("Unexpected type: 0x{0:x}", cfType));
-					});
+					})!;
 					return array;
 				}
 				return null;
@@ -268,25 +262,25 @@ namespace Security {
 
 		public static SecStatusCode Add (SecRecord record)
 		{
-			if (record == null)
-				throw new ArgumentNullException ("record");
+			if (record is null)
+				throw new ArgumentNullException (nameof (record));
 			return SecItem.SecItemAdd (record.queryDict.Handle, IntPtr.Zero);
 			
 		}
 
 		public static SecStatusCode Remove (SecRecord record)
 		{
-			if (record == null)
-				throw new ArgumentNullException ("record");
+			if (record is null)
+				throw new ArgumentNullException (nameof (record));
 			return SecItem.SecItemDelete (record.queryDict.Handle);
 		}
 		
 		public static SecStatusCode Update (SecRecord query, SecRecord newAttributes)
 		{
-			if (query == null)
-				throw new ArgumentNullException ("record");
-			if (newAttributes == null)
-				throw new ArgumentNullException ("newAttributes");
+			if (query is null)
+				throw new ArgumentNullException (nameof (query));
+			if (newAttributes is null)
+				throw new ArgumentNullException (nameof (newAttributes));
 
 			return SecItem.SecItemUpdate (query.queryDict.Handle, newAttributes.queryDict.Handle);
 
@@ -296,9 +290,9 @@ namespace Security {
 		extern static SecStatusCode SecKeychainAddGenericPassword (
 			IntPtr keychain,
 			int serviceNameLength,
-			byte[] serviceName,
+			byte[]? serviceName,
 			int accountNameLength,
-			byte[] accountName,
+			byte[]? accountName,
 			int passwordLength,
 			byte[] passwordData,
 			IntPtr itemRef);
@@ -307,9 +301,9 @@ namespace Security {
 		extern static SecStatusCode SecKeychainFindGenericPassword (
 			IntPtr keychainOrArray,
 			int serviceNameLength,
-			byte[] serviceName,
+			byte[]? serviceName,
 			int accountNameLength,
-			byte[] accountName,
+			byte[]? accountName,
 			out int passwordLength,
 			out IntPtr passwordData,
 			IntPtr itemRef);
@@ -318,13 +312,13 @@ namespace Security {
 		extern static SecStatusCode SecKeychainAddInternetPassword (
 			IntPtr keychain,
 			int serverNameLength,
-			byte[] serverName,
+			byte[]? serverName,
 			int securityDomainLength,
-			byte[] securityDomain,
+			byte[]? securityDomain,
 			int accountNameLength,
-			byte[] accountName,
+			byte[]? accountName,
 			int pathLength,
-			byte[] path,
+			byte[]? path,
 			short port,
 			IntPtr protocol,
 			IntPtr authenticationType,
@@ -336,13 +330,13 @@ namespace Security {
 		extern static SecStatusCode SecKeychainFindInternetPassword (
 			IntPtr keychain,
 			int serverNameLength,
-			byte[] serverName,
+			byte[]? serverName,
 			int securityDomainLength,
-			byte[] securityDomain,
+			byte[]? securityDomain,
 			int accountNameLength,
-			byte[] accountName,
+			byte[]? accountName,
 			int pathLength,
-			byte[] path,
+			byte[]? path,
 			short port,
 			IntPtr protocol,
 			IntPtr authenticationType,
@@ -359,14 +353,14 @@ namespace Security {
 			byte[] password,
 			SecProtocol protocolType = SecProtocol.Http,
 			short port = 0,
-			string path = null,
+			string? path = null,
 			SecAuthenticationType authenticationType = SecAuthenticationType.Default,
-			string securityDomain = null)
+			string? securityDomain = null)
 		{
-			byte[] serverNameBytes = null;
-			byte[] securityDomainBytes = null;
-			byte[] accountNameBytes = null;
-			byte[] pathBytes = null;
+			byte[]? serverNameBytes = null;
+			byte[]? securityDomainBytes = null;
+			byte[]? accountNameBytes = null;
+			byte[]? pathBytes = null;
 			
 			if (!String.IsNullOrEmpty (serverName))
 				serverNameBytes = System.Text.Encoding.UTF8.GetBytes (serverName);
@@ -394,7 +388,7 @@ namespace Security {
 				SecProtocolKeys.FromSecProtocol (protocolType),
 				KeysAuthenticationType.FromSecAuthenticationType (authenticationType),
 				password?.Length ?? 0,
-				password,
+				password!,
 				IntPtr.Zero);
 		}
 		
@@ -402,19 +396,19 @@ namespace Security {
 		public static SecStatusCode FindInternetPassword(
 			string serverName,
 			string accountName,
-			out byte[] password,
+			out byte[]? password,
 			SecProtocol protocolType = SecProtocol.Http,
 			short port = 0,
-			string path = null,
+			string? path = null,
 			SecAuthenticationType authenticationType = SecAuthenticationType.Default,
-			string securityDomain = null)
+			string? securityDomain = null)
 		{
 			password = null;
 			
-			byte[] serverBytes = null;
-			byte[] securityDomainBytes = null;
-			byte[] accountNameBytes = null;
-			byte[] pathBytes = null;
+			byte[]? serverBytes = null;
+			byte[]? securityDomainBytes = null;
+			byte[]? accountNameBytes = null;
+			byte[]? pathBytes = null;
 
 			IntPtr passwordPtr = IntPtr.Zero;
 			
@@ -465,8 +459,8 @@ namespace Security {
 
 		public static SecStatusCode AddGenericPassword (string serviceName, string accountName, byte[] password)
 		{
-			byte[] serviceNameBytes = null;
-			byte[] accountNameBytes = null;
+			byte[]? serviceNameBytes = null;
+			byte[]? accountNameBytes = null;
 			
 			if (!String.IsNullOrEmpty (serviceName))
 				serviceNameBytes = System.Text.Encoding.UTF8.GetBytes (serviceName);
@@ -481,17 +475,17 @@ namespace Security {
 				accountNameBytes?.Length ?? 0,
 				accountNameBytes,
 				password?.Length ?? 0,
-				password,
+				password!,
 				IntPtr.Zero
 				);
 		}
 
-		public static SecStatusCode FindGenericPassword(string serviceName, string accountName, out byte[] password)
+		public static SecStatusCode FindGenericPassword (string serviceName, string accountName, out byte[]? password)
 		{
 			password = null;
 
-			byte[] serviceNameBytes = null;
-			byte[] accountNameBytes = null;
+			byte[]? serviceNameBytes = null;
+			byte[]? accountNameBytes = null;
 			
 			IntPtr passwordPtr = IntPtr.Zero;
 			
@@ -529,9 +523,9 @@ namespace Security {
 			}
 		}
 #else
-		public static object QueryAsConcreteType (SecRecord query, out SecStatusCode result)
+		public static object? QueryAsConcreteType (SecRecord query, out SecStatusCode result)
 		{
-			if (query == null){
+			if (query is null) {
 				result = SecStatusCode.Param;
 				return null;
 			}
@@ -561,8 +555,8 @@ namespace Security {
 
 		public static void AddIdentity (SecIdentity identity)
 		{
-			if (identity == null)
-				throw new ArgumentNullException ("identity");
+			if (identity is null)
+				throw new ArgumentNullException (nameof (identity));
 			using (var record = new SecRecord ()) {
 				record.SetValueRef (identity);
 
@@ -575,8 +569,8 @@ namespace Security {
 
 		public static void RemoveIdentity (SecIdentity identity)
 		{
-			if (identity == null)
-				throw new ArgumentNullException ("identity");
+			if (identity is null)
+				throw new ArgumentNullException (nameof (identity));
 			using (var record = new SecRecord ()) {
 				record.SetValueRef (identity);
 
@@ -587,18 +581,18 @@ namespace Security {
 			}
 		}
 
-		public static SecIdentity FindIdentity (SecCertificate certificate, bool throwOnError = false)
+		public static SecIdentity? FindIdentity (SecCertificate certificate, bool throwOnError = false)
 		{
-			if (certificate == null)
-				throw new ArgumentNullException ("certificate");
+			if (certificate is null)
+				throw new ArgumentNullException (nameof (certificate));
 			var identity = FindIdentity (cert => SecCertificate.Equals (certificate, cert));
-			if (!throwOnError || identity != null)
+			if (!throwOnError || identity is not null)
 				return identity;
 
 			throw new InvalidOperationException (string.Format ("Could not find SecIdentity for certificate '{0}' in keychain.", certificate.SubjectSummary));
 		}
 
-		static SecIdentity FindIdentity (Predicate<SecCertificate> filter)
+		static SecIdentity? FindIdentity (Predicate<SecCertificate> filter)
 		{
 			/*
 			 * Unfortunately, SecItemCopyMatching() does not allow any search
@@ -610,12 +604,12 @@ namespace Security {
 			using (var record = new SecRecord (SecKind.Identity)) {
 				SecStatusCode status;
 				var result = SecKeyChain.QueryAsReference (record, -1, out status);
-				if (status != SecStatusCode.Success || result == null)
+				if (status != SecStatusCode.Success || result is null)
 					return null;
 
 				for (int i = 0; i < result.Length; i++) {
-					var identity = (SecIdentity)result [i];
-					if (filter (identity.Certificate))
+					var identity = (SecIdentity?)result [i];
+					if (filter (identity?.Certificate!))
 						return identity;
 				}
 			}
@@ -629,14 +623,14 @@ namespace Security {
 		// NSCFDictionary: mutating method sent to immutable object
 		// iOS 6 returns an inmutable NSDictionary handle and when we try to set its values it goes kaboom
 		// By explicitly calling `MutableCopy` we ensure we always have a mutable reference we expect that.
-		NSMutableDictionary _queryDict;
+		NSMutableDictionary? _queryDict;
 		internal NSMutableDictionary queryDict 
 		{ 
 			get {
-				return _queryDict;
+				return _queryDict!;
 			}
 			set {
-				_queryDict = value != null ? (NSMutableDictionary)value.MutableCopy () : null;
+				_queryDict = (NSMutableDictionary) value.MutableCopy ();
 			}
 		}
 
@@ -683,19 +677,19 @@ namespace Security {
 			SetKey (key);
 		}
 
-		public SecCertificate GetCertificate ()
+		public SecCertificate? GetCertificate ()
 		{
 			CheckClass (SecClass.Certificate);
 			return GetValueRef <SecCertificate> ();
 		}
 
-		public SecIdentity GetIdentity ()
+		public SecIdentity? GetIdentity ()
 		{
 			CheckClass (SecClass.Identity);
 			return GetValueRef<SecIdentity> ();
 		}
 
-		public SecKey GetKey ()
+		public SecKey? GetKey ()
 		{
 			CheckClass (SecClass.Key);
 			return GetValueRef<SecKey> ();
@@ -727,12 +721,8 @@ namespace Security {
 
 		protected virtual void Dispose (bool disposing)
 		{
-			if (queryDict != null){
-				if (disposing){
-					queryDict.Dispose ();
-					queryDict = null;
-				}
-			}
+			if (disposing)
+				queryDict?.Dispose ();
 		}
 
 		~SecRecord ()
@@ -745,31 +735,31 @@ namespace Security {
 			return queryDict.LowlevelObjectForKey (key);
 		}
 
-		NSObject FetchObject (IntPtr key)
+		NSObject? FetchObject (IntPtr key)
 		{
 			return Runtime.GetNSObject (Fetch (key));
 		}
 
-		string FetchString (IntPtr key)
+		string? FetchString (IntPtr key)
 		{
-			return (NSString) FetchObject (key);
+			return (NSString?) FetchObject (key);
 		}
 
 		int FetchInt (IntPtr key)
 		{
-			var obj = (NSNumber) FetchObject (key);
-			return obj == null ? -1 : obj.Int32Value;
+			var obj = (NSNumber?) FetchObject (key);
+			return obj is null ? -1 : obj.Int32Value;
 		}
 
 		bool FetchBool (IntPtr key, bool defaultValue)
 		{
-			var obj = (NSNumber) FetchObject (key);
-			return obj == null ? defaultValue : obj.Int32Value != 0;
+			var obj = (NSNumber?) FetchObject (key);
+			return obj is null ? defaultValue : obj.Int32Value != 0;
 		}
 
-		T Fetch<T> (IntPtr key) where T : NSObject
+		T? Fetch<T> (IntPtr key) where T : NSObject
 		{
-			return (T) FetchObject (key);
+			return (T?) FetchObject (key);
 		}
 		
 
@@ -787,11 +777,14 @@ namespace Security {
 		{
 			// FIXME: it's not clear that we should not allow null (i.e. that null should remove entries)
 			// but this is compatible with the exiting behaviour of older XI/XM
-			if (value == null)
+			if (value is null)
 				throw new ArgumentNullException (nameof (value));
-			var ptr = NSString.CreateNative (value);
-			queryDict.LowlevelSetObject (ptr, key);
-			NSString.ReleaseNative (ptr);
+			var ptr = CFString.CreateNative (value);
+			try {
+				queryDict.LowlevelSetObject (ptr, key);
+			} finally {
+				CFString.ReleaseNative (ptr);
+			}
 		}
 		
 		//
@@ -829,12 +822,12 @@ namespace Security {
 #if !NET
 		[iOS (9,0)]
 #endif
-		public string SyncViewHint {
+		public string? SyncViewHint {
 			get {
 				return FetchString (SecAttributeKey.SyncViewHint);
 			}
 			set {
-				SetValue (value, SecAttributeKey.SyncViewHint);
+				SetValue (value!, SecAttributeKey.SyncViewHint);
 			}
 		}
 
@@ -843,56 +836,56 @@ namespace Security {
 #endif
 		public SecTokenID TokenID {
 			get {
-				return SecTokenIDExtensions.GetValue (Fetch<NSString> (SecKeyGenerationAttributeKeys.TokenIDKey.GetHandle ()));
+				return SecTokenIDExtensions.GetValue (Fetch<NSString> (SecKeyGenerationAttributeKeys.TokenIDKey.GetHandle ())!);
 			}
 			set {
 				// choose wisely to avoid NSString -> string -> NSString conversion
-				SetValue ((NSObject) value.GetConstant (), SecKeyGenerationAttributeKeys.TokenIDKey.GetHandle ());
+				SetValue ((NSObject) value.GetConstant ()!, SecKeyGenerationAttributeKeys.TokenIDKey.GetHandle ());
 			}
 		}
 #endif
 
-		public NSDate CreationDate {
+		public NSDate? CreationDate {
 			get {
-				return (NSDate) FetchObject (SecAttributeKey.CreationDate);
+				return (NSDate?) FetchObject (SecAttributeKey.CreationDate);
 			}
 			
 			set {
-				if (value == null)
-					throw new ArgumentNullException ("value");
+				if (value is null)
+					throw new ArgumentNullException (nameof (value));
 				SetValue (value, SecAttributeKey.CreationDate);
 			}
 		}
 
-		public NSDate ModificationDate {
+		public NSDate? ModificationDate {
 			get {
-				return (NSDate) FetchObject (SecAttributeKey.ModificationDate);
+				return (NSDate?) FetchObject (SecAttributeKey.ModificationDate);
 			}
 			
 			set {
-				if (value == null)
-					throw new ArgumentNullException ("value");
+				if (value is null)
+					throw new ArgumentNullException (nameof (value));
 				SetValue (value, SecAttributeKey.ModificationDate);
 			}
 		}
 
-		public string Description {
+		public string? Description {
 			get {
 				return FetchString (SecAttributeKey.Description);
 			}
 
 			set {
-				SetValue (value, SecAttributeKey.Description);
+				SetValue (value!, SecAttributeKey.Description);
 			}
 		}
 
-		public string Comment {
+		public string? Comment {
 			get {
 				return FetchString (SecAttributeKey.Comment);
 			}
 
 			set {
-				SetValue (value, SecAttributeKey.Comment);
+				SetValue (value!, SecAttributeKey.Comment);
 			}
 		}
 
@@ -916,13 +909,13 @@ namespace Security {
 			}
 		}
 
-		public string Label {
+		public string? Label {
 			get {
 				return FetchString (SecAttributeKeys.LabelKey.Handle);
 			}
 
 			set {
-				SetValue (value, SecAttributeKeys.LabelKey.Handle);
+				SetValue (value!, SecAttributeKeys.LabelKey.Handle);
 			}
 		}
 
@@ -946,33 +939,33 @@ namespace Security {
 			}
 		}
 
-		public string Account {
+		public string? Account {
 			get {
 				return FetchString (SecAttributeKey.Account);
 			}
 
 			set {
-				SetValue (value, SecAttributeKey.Account);
+				SetValue (value!, SecAttributeKey.Account);
 			}
 		}
 
-		public string Service {
+		public string? Service {
 			get {
 				return FetchString (SecAttributeKey.Service);
 			}
 
 			set {
-				SetValue (value, SecAttributeKey.Service);
+				SetValue (value!, SecAttributeKey.Service);
 			}
 		}
 
 #if !MONOMAC
-		public string UseOperationPrompt {
+		public string? UseOperationPrompt {
 			get {
 				return FetchString (SecItem.UseOperationPrompt);
 			}
 			set {
-				SetValue (value, SecItem.UseOperationPrompt);
+				SetValue (value!, SecItem.UseOperationPrompt);
 			}
 		}
 
@@ -1002,10 +995,10 @@ namespace Security {
 		public SecAuthenticationUI AuthenticationUI {
 			get {
 				var s = Fetch<NSString> (SecItem.UseAuthenticationUI);
-				return s == null ? SecAuthenticationUI.NotSet : SecAuthenticationUIExtensions.GetValue (s);
+				return s is null ? SecAuthenticationUI.NotSet : SecAuthenticationUIExtensions.GetValue (s);
 			}
 			set {
-				SetValue ((NSObject) value.GetConstant (), SecItem.UseAuthenticationUI);
+				SetValue ((NSObject) value.GetConstant ()!, SecItem.UseAuthenticationUI);
 			}
 		}
 
@@ -1013,12 +1006,12 @@ namespace Security {
 #if !NET
 		[iOS (9, 0), Mac (10, 11)]
 #endif
-		public LocalAuthentication.LAContext AuthenticationContext {
+		public LocalAuthentication.LAContext? AuthenticationContext {
 			get {
 				return Fetch<LocalAuthentication.LAContext> (SecItem.UseAuthenticationContext);
 			}
 			set {
-				if (value == null)
+				if (value is null)
 					throw new ArgumentNullException (nameof (value));
 				SetValue (value.Handle, SecItem.UseAuthenticationContext);
 			}
@@ -1027,48 +1020,48 @@ namespace Security {
 
 		// Must store the _secAccessControl here, since we have no way of inspecting its values if
 		// it is ever returned from a dictionary, so return what we cached.
-		SecAccessControl _secAccessControl;
-		public SecAccessControl AccessControl {
+		SecAccessControl? _secAccessControl;
+		public SecAccessControl? AccessControl {
 			get {
 				return _secAccessControl;
 			}
 			set {
-				if (value == null)
-					throw new ArgumentNullException ("value");
+				if (value is null)
+					throw new ArgumentNullException (nameof (value));
 				_secAccessControl = value;
 				SetValue (value.Handle, SecAttributeKeys.AccessControlKey.Handle);
 			}
 		}
 
-		public NSData Generic {
+		public NSData? Generic {
 			get {
 				return Fetch<NSData> (SecAttributeKey.Generic);
 			}
 
 			set {
-				if (value == null)
-					throw new ArgumentNullException ("value");
+				if (value is null)
+					throw new ArgumentNullException (nameof (value));
 				SetValue (value, SecAttributeKey.Generic);
 			}
 		}
 
-		public string SecurityDomain {
+		public string? SecurityDomain {
 			get {
 				return FetchString (SecAttributeKey.SecurityDomain);
 			}
 
 			set {
-				SetValue (value, SecAttributeKey.SecurityDomain);
+				SetValue (value!, SecAttributeKey.SecurityDomain);
 			}
 		}
 
-		public string Server {
+		public string? Server {
 			get {
 				return FetchString (SecAttributeKey.Server);
 			}
 
 			set {
-				SetValue (value, SecAttributeKey.Server);
+				SetValue (value!, SecAttributeKey.Server);
 			}
 		}
 
@@ -1106,60 +1099,60 @@ namespace Security {
 			}
 		}
 
-		public string Path {
+		public string? Path {
 			get {
 				return FetchString (SecAttributeKey.Path);
 			}
 
 			set {
-				SetValue (value, SecAttributeKey.Path);
+				SetValue (value!, SecAttributeKey.Path);
 			}
 		}
 
 		// read only
-		public string Subject {
+		public string? Subject {
 			get {
 				return FetchString (SecAttributeKey.Subject);
 			}
 		}
 
 		// read only
-		public NSData Issuer {
+		public NSData? Issuer {
 			get {
 				return Fetch<NSData> (SecAttributeKey.Issuer);
 			}
 		}
 
 		// read only
-		public NSData SerialNumber {
+		public NSData? SerialNumber {
 			get {
 				return Fetch<NSData> (SecAttributeKey.SerialNumber);
 			}
 		}
 
 		// read only
-		public NSData SubjectKeyID {
+		public NSData? SubjectKeyID {
 			get {
 				return Fetch<NSData> (SecAttributeKey.SubjectKeyID);
 			}
 		}
 
 		// read only
-		public NSData PublicKeyHash {
+		public NSData? PublicKeyHash {
 			get {
 				return Fetch<NSData> (SecAttributeKey.PublicKeyHash);
 			}
 		}
 
 		// read only
-		public NSNumber CertificateType {
+		public NSNumber? CertificateType {
 			get {
 				return Fetch<NSNumber> (SecAttributeKey.CertificateType);
 			}
 		}
 
 		// read only
-		public NSNumber CertificateEncoding {
+		public NSNumber? CertificateEncoding {
 			get {
 				return Fetch<NSNumber> (SecAttributeKey.CertificateEncoding);
 			}
@@ -1175,19 +1168,19 @@ namespace Security {
 			}
 			set {
 				var k = value.GetConstant ();
-				if (k == null)
-					throw new ArgumentException ("Unknown value");
+				if (k is null)
+					throw new ArgumentException (nameof (value));
 				SetValue ((NSObject) k, SecAttributeKey.KeyClass);
 			}
 		}
 
-		public string ApplicationLabel {
+		public string? ApplicationLabel {
 			get {
 				return FetchString (SecAttributeKey.ApplicationLabel);
 			}
 
 			set {
-				SetValue (value, SecAttributeKey.ApplicationLabel);
+				SetValue (value!, SecAttributeKey.ApplicationLabel);
 			}
 		}
 
@@ -1221,14 +1214,14 @@ namespace Security {
 			}
 		}
 
-		public NSData ApplicationTag {
+		public NSData? ApplicationTag {
 			get {
 				return Fetch<NSData> (SecAttributeKeys.ApplicationTagKey.Handle);
 			}
 			
 			set {
-				if (value == null)
-					throw new ArgumentNullException ("value");
+				if (value is null)
+					throw new ArgumentNullException (nameof (value));
 				SetValue (value, SecAttributeKeys.ApplicationTagKey.Handle);
 			}
 		}
@@ -1244,8 +1237,8 @@ namespace Security {
 			
 			set {
 				var k = value.GetConstant ();
-				if (k == null)
-					throw new ArgumentException ("Unknown value");
+				if (k is null)
+					throw new ArgumentException (nameof (value));
 				SetValue ((NSObject) k, SecKeyGenerationAttributeKeys.KeyTypeKey.Handle);
 			}
 		}
@@ -1340,13 +1333,13 @@ namespace Security {
 			}
 		}
 
-		public string AccessGroup {
+		public string? AccessGroup {
 			get {
 				return FetchString (SecAttributeKey.AccessGroup);
 			}
 
 			set {
-				SetValue (value, SecAttributeKey.AccessGroup);
+				SetValue (value!, SecAttributeKey.AccessGroup);
 			}
 		}
 
@@ -1369,61 +1362,61 @@ namespace Security {
 		// Matches
 		//
 
-		public SecPolicy MatchPolicy {
+		public SecPolicy? MatchPolicy {
 			get {
 				var pol = Fetch (SecItem.MatchPolicy);
-				return (pol == IntPtr.Zero) ? null : new SecPolicy (pol);
+				return (pol == IntPtr.Zero) ? null : new SecPolicy (pol, false);
 			}
 
 			set {
-				if (value == null)
-					throw new ArgumentNullException ("value");
+				if (value is null)
+					throw new ArgumentNullException (nameof (value));
 				SetValue (value.Handle, SecItem.MatchPolicy);
 			}
 		}
 
-		public SecKeyChain[] MatchItemList {
+		public SecKeyChain? []? MatchItemList {
 			get {
 				return NSArray.ArrayFromHandle<SecKeyChain> (Fetch (SecItem.MatchItemList));
 			}
 
 			set {
-				if (value == null)
-					throw new ArgumentNullException ("value");
+				if (value is null)
+					throw new ArgumentNullException (nameof (value));
 				using (var array = NSArray.FromNativeObjects (value))
 					SetValue (array, SecItem.MatchItemList);
 			}
 		}
 
-		public NSData [] MatchIssuers {
+		public NSData? []? MatchIssuers {
 			get {
 				return NSArray.ArrayFromHandle<NSData> (Fetch (SecItem.MatchIssuers));
 			}
 			set {
-				if (value == null)
-					throw new ArgumentNullException ("value");
+				if (value is null)
+					throw new ArgumentNullException (nameof (value));
 				
 				SetValue (NSArray.FromNSObjects (value), SecItem.MatchIssuers);
 			}
 		}
 
-		public string MatchEmailAddressIfPresent {
+		public string? MatchEmailAddressIfPresent {
 			get {
 				return FetchString (SecItem.MatchEmailAddressIfPresent);
 			}
 
 			set {
-				SetValue (value, SecItem.MatchEmailAddressIfPresent);
+				SetValue (value!, SecItem.MatchEmailAddressIfPresent);
 			}
 		}
 
-		public string MatchSubjectContains {
+		public string? MatchSubjectContains {
 			get {
 				return FetchString (SecItem.MatchSubjectContains);
 			}
 
 			set {
-				SetValue (value, SecItem.MatchSubjectContains);
+				SetValue (value!, SecItem.MatchSubjectContains);
 			}
 		}
 
@@ -1447,31 +1440,31 @@ namespace Security {
 			}
 		}
 
-		public NSDate MatchValidOnDate {
+		public NSDate? MatchValidOnDate {
 			get {
-				return (NSDate) (Runtime.GetNSObject (Fetch (SecItem.MatchValidOnDate)));
+				return Runtime.GetNSObject<NSDate> (Fetch (SecItem.MatchValidOnDate));
 			}
 			
 			set {
-				if (value == null)
-					throw new ArgumentNullException ("value");
+				if (value is null)
+					throw new ArgumentNullException (nameof (value));
 				SetValue (value, SecItem.MatchValidOnDate);
 			}
 		}
 
-		public NSData ValueData {
+		public NSData? ValueData {
 			get {
 				return Fetch<NSData> (SecItem.ValueData);
 			}
 
 			set {
-				if (value == null)
-					throw new ArgumentNullException ("value");
+				if (value is null)
+					throw new ArgumentNullException (nameof (value));
 				SetValue (value, SecItem.ValueData);
 			}
 		}
 
-		public T GetValueRef<T> () where T : class, INativeObject
+		public T? GetValueRef<T> () where T : class, INativeObject
 		{
 			return Runtime.GetINativeObject<T> (queryDict.LowlevelObjectForKey (SecItem.ValueRef), false);
 		}
@@ -1479,7 +1472,7 @@ namespace Security {
 		// This can be used to store SecKey, SecCertificate, SecIdentity and SecKeyChainItem (not bound yet, and not availble on iOS)
 		public void SetValueRef (INativeObject value)
 		{
-			SetValue (value == null ? IntPtr.Zero : value.Handle, SecItem.ValueRef);
+			SetValue (value.GetHandle (), SecItem.ValueRef);
 		}
 
 		public void SetCertificate (SecCertificate cert) => SetValueRef (cert);
@@ -1519,7 +1512,7 @@ namespace Security {
 			case SecKind.Identity:
 				return Identity;
 			default:
-				throw new ArgumentException ("secKind");
+				throw new ArgumentException (nameof (secKind));
 			}
 		}
 	}
@@ -1543,7 +1536,7 @@ namespace Security {
 			case SecAccessible.WhenPasscodeSetThisDeviceOnly:
 				return WhenPasscodeSetThisDeviceOnly;
 			default:
-				throw new ArgumentException ("accessible");
+				throw new ArgumentException (nameof (accessible));
 			}
 		}
 			
@@ -1607,7 +1600,7 @@ namespace Security {
 			case SecProtocol.Ircs:return IRCS;
 			case SecProtocol.Pop3s: return POP3S;
 			}
-			throw new ArgumentException ("protocol");
+			throw new ArgumentException (nameof (protocol));
 		}
 
 		public static SecProtocol ToSecProtocol (IntPtr handle)
@@ -1724,7 +1717,7 @@ namespace Security {
 			case SecAuthenticationType.Default:
 				return Default;
 			default:
-				throw new ArgumentException ("type");
+				throw new ArgumentException (nameof (type));
 			}
 		}
 	}
@@ -1755,17 +1748,17 @@ namespace Security {
 
 	public partial class SecKeyParameters : DictionaryContainer {
 		// For caching, as we can't reverse it easily.
-		SecAccessControl _secAccessControl;
+		SecAccessControl? _secAccessControl;
 
 #if !NET
 		[iOS (8, 0), Mac (10, 10)]
 #endif
 		public SecAccessControl AccessControl {
 			get {
-				return _secAccessControl;
+				return _secAccessControl!;
 			}
 			set {
-				if (value == null)
+				if (value is null)
 					throw new ArgumentNullException (nameof (value));
 				_secAccessControl = value;
 				SetNativeValue (SecAttributeKeys.AccessControlKey, value);
@@ -1777,32 +1770,32 @@ namespace Security {
 		public SecKeyType KeyType {
 			get {
 				var type = GetNSStringValue (SecKeyGenerationAttributeKeys.KeyTypeKey);
-				if (type == null)
+				if (type is null)
 					return SecKeyType.Invalid;
 				return SecKeyTypeExtensions.GetValue (type);
 			}
 
 			set {
 				var k = value.GetConstant ();
-				if (k == null)
-					throw new ArgumentException ("Unknown value for KeyType.");
+				if (k is null)
+					throw new ArgumentException (nameof (value));
 				SetStringValue (SecKeyGenerationAttributeKeys.KeyTypeKey, k);
 			}
 		}
 
 		// For caching, as we can't reverse it easily.
-		SecAccessControl _secAccessControl;
+		SecAccessControl? _secAccessControl;
 
 #if !NET
 		[iOS (8, 0), Mac (10, 10)]
 #endif
 		public SecAccessControl AccessControl {
 			get {
-				return _secAccessControl;
+				return _secAccessControl!;
 			}
 
 			set {
-				if (value == null)
+				if (value is null)
 					throw new ArgumentNullException (nameof (value));
 				_secAccessControl = value;
 				SetNativeValue (SecAttributeKeys.AccessControlKey, value);
@@ -1814,7 +1807,7 @@ namespace Security {
 #endif
 		public SecTokenID TokenID {
 			get {
-				return SecTokenIDExtensions.GetValue (GetNSStringValue (SecKeyGenerationAttributeKeys.TokenIDKey));
+				return SecTokenIDExtensions.GetValue (GetNSStringValue (SecKeyGenerationAttributeKeys.TokenIDKey)!);
 			}
 
 			set {


### PR DESCRIPTION
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use CFString.CreateNative/ReleaseNative instead of other means to create
  native strings (the fastest and least memory hungry option).
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.