### PR TITLE
[AppKit] Fix a few enums for .NET according to current AppKit headers.

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -753,50 +753,57 @@ namespace AppKit {
 		ModeSwitch     = 0xF747
 	}
 
-#if !XAMCORE_4_0 && !__MACCATALYST__
+#if !NET
 	[Native]
 	public enum NSEventSubtype : ulong {
 #else
 	public enum NSEventSubtype : short {
 #endif
+		/* event subtypes for NSEventTypeAppKitDefined events */
 		WindowExposed = 0,
 		ApplicationActivated = 1,
 		ApplicationDeactivated = 2,
-		[Mac (10,10)]
-		Touch = 3,
 		WindowMoved = 4,
 		ScreenChanged = 8,
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("This API is not available on this platform.")]
 		AWT = 16,
 #endif
+		/* event subtypes for NSEventTypeSystemDefined events */
+		/* the value is repeated from above */
+		PowerOff = 1,
+
+		/* event subtypes for mouse events */
+		/* the values are repeated from above */
+		MouseEvent = 0, /* NX_SUBTYPE_DEFAULT */
+		TabletPoint = 1, /* NX_SUBTYPE_TABLET_POINT */
+		TabletProximity = 2, /* NX_SUBTYPE_TABLET_PROXIMITY */
+		Touch = 3, /* NX_SUBTYPE_MOUSE_TOUCH */
 	}
 
+#if !NET
 	[NoMacCatalyst]
-#if !XAMCORE_4_0
 	[Native]
 	public enum NSSystemDefinedEvents : ulong {
-#else
-	public enum NSSystemDefinedEvents : short {
-#endif
+		[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'NSEventSubtype.PowerOff' instead.")]
 		NSPowerOffEventType = 1
 	}
+#endif // !NET
 
+#if !NET
 	[NoMacCatalyst]
-#if !XAMCORE_4_0
 	[Native]
 	public enum NSEventMouseSubtype : ulong {
-#else
-	public enum NSEventMouseSubtype : short {
-#endif
+		[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'NSEventSubtype.MouseEvent' instead.")]
 		Mouse, 
-#if !XAMCORE_4_0
+		[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'NSEventSubtype.TabletPoint' instead.")]
 		TablePoint, 
-#else
-		TabletPoint, 
-#endif
-		TabletProximity, Touch
+		[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'NSEventSubtype.TabletProximity' instead.")]
+		TabletProximity,
+		[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'NSEventSubtype.Touch' instead.")]
+		Touch,
 	}
+#endif // !NET
 	
 #endregion
 


### PR DESCRIPTION
* NSEventSubtype: add missing members, and make the underlying type 'short' for all platforms in .NET.
* NSSystemDefinedEvents, NSEventMouseSubtype: obsolete (and remove from .NET),
  and point to NSEventSubtype.