### PR TITLE
[iAd] Remove this framework from .NET.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -173,11 +173,11 @@ $(IOS_BUILD_DIR)/native/generated_sources: $(IOS_GENERATOR) $(IOS_APIS) $(IOS_BU
 
 ### .NET ###
 
-$(IOS_DOTNET_BUILD_DIR)/core-ios.dll: $(IOS_CORE_SOURCES) frameworks.sources $(DOTNET_BUILD_DIR)/ios-defines.rsp | $(IOS_DOTNET_BUILD_DIR)
+$(IOS_DOTNET_BUILD_DIR)/core-ios.dll: $(IOS_CORE_SOURCES) frameworks.sources $(DOTNET_BUILD_DIR)/ios-defines-dotnet.rsp | $(IOS_DOTNET_BUILD_DIR)
 	$(Q_DOTNET_GEN) \
 		$(DOTNET6_CSC) $(DOTNET_FLAGS) \
 		$(IOS_CORE_WARNINGS_TO_FIX) \
-		@$(DOTNET_BUILD_DIR)/ios-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/ios-defines-dotnet.rsp \
 		$(IOS_CORE_DEFINES) \
 		$(IOS_CORE_SOURCES) \
 		-out:$@
@@ -212,7 +212,7 @@ $(IOS_DOTNET_BUILD_DIR)/ios.rsp: Makefile Makefile.generator frameworks.sources 
 		-baselib=$(IOS_DOTNET_BUILD_DIR)/core-ios.dll \
 		--target-framework=.NETCoreApp,Version=6.0,Profile=ios \
 		$(IOS_APIS) \
-		@$(DOTNET_BUILD_DIR)/ios-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/ios-defines-dotnet.rsp \
 		> $@
 
 define IOS_TARGETS_template
@@ -237,7 +237,7 @@ $(IOS_DOTNET_BUILD_DIR)/$(1)/Xamarin.iOS%dll $(IOS_DOTNET_BUILD_DIR)/$(1)/Xamari
 		$$(IOS_DEFINES) \
 		$$(IOS_CORE_WARNINGS_TO_FIX) \
 		$$(IOS_CSC_FLAGS_XI) \
-		@$(DOTNET_BUILD_DIR)/ios-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/ios-defines-dotnet.rsp \
 		-res:$(IOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
 		-res:$(IOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml \
 		$$(IOS_SOURCES) @$(IOS_DOTNET_BUILD_DIR)/ios-generated-sources
@@ -585,11 +585,11 @@ $(DOTNET_DESTDIR)/$(MACOS_NUGET).Ref/ref/net6.0/Xamarin.Mac.dll: $(MACOS_DOTNET_
 
 ### .NET ###
 
-$(MACOS_DOTNET_BUILD_DIR)/core-macos.dll: $(MACOS_CORE_SOURCES) frameworks.sources $(DOTNET_BUILD_DIR)/macos-defines.rsp | $(MACOS_DOTNET_BUILD_DIR)
+$(MACOS_DOTNET_BUILD_DIR)/core-macos.dll: $(MACOS_CORE_SOURCES) frameworks.sources $(DOTNET_BUILD_DIR)/macos-defines-dotnet.rsp | $(MACOS_DOTNET_BUILD_DIR)
 	$(Q_DOTNET_GEN) \
 		$(DOTNET6_CSC) $(DOTNET_FLAGS) -out:$@ \
 		$(MAC_CORE_WARNINGS_TO_FIX) \
-		@$(DOTNET_BUILD_DIR)/macos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/macos-defines-dotnet.rsp \
 		$(MAC_CORE_DEFINES) \
 		$(MACOS_CORE_SOURCES) \
 		-out:$@ \
@@ -607,7 +607,7 @@ $(MACOS_DOTNET_BUILD_DIR)/macos.rsp: Makefile Makefile.generator frameworks.sour
 		-baselib:$(MACOS_DOTNET_BUILD_DIR)/core-macos.dll \
 		--target-framework=.NETCoreApp,Version=6.0,Profile=macos \
 		$(MACOS_APIS) \
-		@$(DOTNET_BUILD_DIR)/macos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/macos-defines-dotnet.rsp \
 		> $@
 
 $(MACOS_DOTNET_BUILD_DIR)/64/Xamarin.Mac%dll $(MACOS_DOTNET_BUILD_DIR)/64/Xamarin.Mac%pdb $(MACOS_DOTNET_BUILD_DIR)/ref/Xamarin.Mac%dll: $(MACOS_DOTNET_BUILD_DIR)/macos-generated-sources $(MACOS_SOURCES) $(MAC_CFNETWORK_SOURCES) $(SN_KEY) $(MACOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml $(MACOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml | $(MACOS_DOTNET_BUILD_DIR)/64 $(MACOS_DOTNET_BUILD_DIR)/ref
@@ -621,7 +621,7 @@ $(MACOS_DOTNET_BUILD_DIR)/64/Xamarin.Mac%dll $(MACOS_DOTNET_BUILD_DIR)/64/Xamari
 		$(MAC_CSC_FLAGS_XM) \
 		$(MAC_CFNETWORK_SOURCES) $(MAC_HTTP_SOURCES) $(SHARED_SYSTEM_DRAWING_SOURCES) $(APPLETLS_DEFINES) -D:XAMARIN_MODERN \
 		$(MACOS_SOURCES) \
-		@$(DOTNET_BUILD_DIR)/macos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/macos-defines-dotnet.rsp \
 		-res:$(MACOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
 		-res:$(MACOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml \
 		@$<
@@ -832,11 +832,11 @@ $(BUILD_DIR)/watchos.rsp: Makefile Makefile.generator frameworks.sources
 
 ### .NET ###
 
-$(WATCHOS_DOTNET_BUILD_DIR)/core-watchos.dll: $(WATCHOS_CORE_SOURCES) frameworks.sources $(DOTNET_BUILD_DIR)/watchos-defines.rsp | $(WATCHOS_DOTNET_BUILD_DIR)
+$(WATCHOS_DOTNET_BUILD_DIR)/core-watchos.dll: $(WATCHOS_CORE_SOURCES) frameworks.sources $(DOTNET_BUILD_DIR)/watchos-defines-dotnet.rsp | $(WATCHOS_DOTNET_BUILD_DIR)
 	$(Q_DOTNET_GEN) \
 		$(DOTNET6_CSC) $(DOTNET_FLAGS) \
 		$(WATCHOS_CORE_WARNINGS_TO_FIX) \
-		@$(DOTNET_BUILD_DIR)/watchos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/watchos-defines-dotnet.rsp \
 		$(WATCHOS_CORE_DEFINES) \
 		$(WATCHOS_CORE_SOURCES) \
 		-out:$@ \
@@ -854,7 +854,7 @@ $(WATCHOS_DOTNET_BUILD_DIR)/watchos.rsp: Makefile Makefile.generator frameworks.
 		-baselib=$(WATCHOS_DOTNET_BUILD_DIR)/core-watchos.dll \
 		--target-framework=.NETCoreApp,Version=6.0,Profile=watchos \
 		$(WATCHOS_APIS) \
-		@$(DOTNET_BUILD_DIR)/watchos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/watchos-defines-dotnet.rsp \
 		> $@
 
 $(WATCHOS_DOTNET_BUILD_DIR)/32/Xamarin.WatchOS%dll $(WATCHOS_DOTNET_BUILD_DIR)/32/Xamarin.WatchOS%pdb: $(WATCHOS_DOTNET_BUILD_DIR)/watchos-generated-sources $(WATCHOS_SOURCES) $(PRODUCT_KEY_PATH) $(WATCHOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml | $(WATCHOS_DOTNET_BUILD_DIR)/32 $(WATCHOS_DOTNET_BUILD_DIR)/ref
@@ -867,7 +867,7 @@ $(WATCHOS_DOTNET_BUILD_DIR)/32/Xamarin.WatchOS%dll $(WATCHOS_DOTNET_BUILD_DIR)/3
 		-warnaserror:$(NULLABILITY_WARNINGS) \
 		$(IOS_CSC_FLAGS_XI) \
 		$(WATCHOS_SOURCES) \
-		@$(DOTNET_BUILD_DIR)/watchos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/watchos-defines-dotnet.rsp \
 		-res:$(WATCHOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
 		@$<
 
@@ -882,7 +882,7 @@ $(WATCHOS_DOTNET_BUILD_DIR)/64/Xamarin.WatchOS%dll $(WATCHOS_DOTNET_BUILD_DIR)/6
 		-warnaserror:$(NULLABILITY_WARNINGS) \
 		$(IOS_CSC_FLAGS_XI) \
 		$(WATCHOS_SOURCES) \
-		@$(DOTNET_BUILD_DIR)/watchos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/watchos-defines-dotnet.rsp \
 		-res:$(WATCHOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
 		@$<
 
@@ -1124,11 +1124,11 @@ $(BUILD_DIR)/tvos.rsp: Makefile Makefile.generator frameworks.sources
 
 ### .NET ###
 
-$(TVOS_DOTNET_BUILD_DIR)/core-tvos.dll: $(TVOS_CORE_SOURCES) frameworks.sources Makefile $(DOTNET_BUILD_DIR)/tvos-defines.rsp | $(TVOS_DOTNET_BUILD_DIR)
+$(TVOS_DOTNET_BUILD_DIR)/core-tvos.dll: $(TVOS_CORE_SOURCES) frameworks.sources Makefile $(DOTNET_BUILD_DIR)/tvos-defines-dotnet.rsp | $(TVOS_DOTNET_BUILD_DIR)
 	$(Q_DOTNET_GEN) \
 		$(DOTNET6_CSC) $(DOTNET_FLAGS) \
 		$(TVOS_CORE_WARNINGS_TO_FIX) \
-		@$(DOTNET_BUILD_DIR)/tvos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/tvos-defines-dotnet.rsp \
 		$(TVOS_CORE_DEFINES) \
 		$(TVOS_CORE_SOURCES) \
 		-out:$@ \
@@ -1146,7 +1146,7 @@ $(TVOS_DOTNET_BUILD_DIR)/tvos.rsp: Makefile Makefile.generator frameworks.source
 		-baselib=$(TVOS_DOTNET_BUILD_DIR)/core-tvos.dll \
 		--target-framework=.NETCoreApp,Version=6.0,Profile=tvos \
 		$(TVOS_APIS) \
-		@$(DOTNET_BUILD_DIR)/tvos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/tvos-defines-dotnet.rsp \
 		> $@
 
 $(TVOS_DOTNET_BUILD_DIR)/64/Xamarin.TVOS%dll $(TVOS_DOTNET_BUILD_DIR)/64/Xamarin.TVOS%pdb $(TVOS_DOTNET_BUILD_DIR)/ref/Xamarin.TVOS%dll: $(TVOS_DOTNET_BUILD_DIR)/tvos-generated-sources $(TVOS_SOURCES) $(PRODUCT_KEY_PATH) $(TVOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml $(TVOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml | $(TVOS_DOTNET_BUILD_DIR)/64 $(TVOS_DOTNET_BUILD_DIR)/ref
@@ -1160,7 +1160,7 @@ $(TVOS_DOTNET_BUILD_DIR)/64/Xamarin.TVOS%dll $(TVOS_DOTNET_BUILD_DIR)/64/Xamarin
 		-warnaserror:$(NULLABILITY_WARNINGS) \
 		$(IOS_CSC_FLAGS_XI) \
 		$(TVOS_SOURCES) \
-		@$(DOTNET_BUILD_DIR)/tvos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/tvos-defines-dotnet.rsp \
 		-res:$(TVOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
 		-res:$(TVOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml \
 		@$<
@@ -1336,11 +1336,11 @@ $(BUILD_DIR)/maccatalyst.rsp: Makefile Makefile.generator frameworks.sources
 
 ### .NET ###
 
-$(MACCATALYST_DOTNET_BUILD_DIR)/core-maccatalyst.dll: $(TVOS_CORE_SOURCES) frameworks.sources Makefile $(DOTNET_BUILD_DIR)/maccatalyst-defines.rsp | $(MACCATALYST_DOTNET_BUILD_DIR)
+$(MACCATALYST_DOTNET_BUILD_DIR)/core-maccatalyst.dll: $(TVOS_CORE_SOURCES) frameworks.sources Makefile $(DOTNET_BUILD_DIR)/maccatalyst-defines-dotnet.rsp | $(MACCATALYST_DOTNET_BUILD_DIR)
 	$(Q_DOTNET_GEN) \
 		$(DOTNET6_CSC) $(DOTNET_FLAGS) \
 		$(MACCATALYST_WARNINGS_TO_FIX) \
-		@$(DOTNET_BUILD_DIR)/maccatalyst-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/maccatalyst-defines-dotnet.rsp \
 		$(MACCATALYST_CORE_DEFINES) \
 		$(MACCATALYST_CORE_SOURCES) \
 		-out:$@ \
@@ -1358,7 +1358,7 @@ $(MACCATALYST_DOTNET_BUILD_DIR)/maccatalyst.rsp: Makefile Makefile.generator fra
 		-baselib=$(MACCATALYST_DOTNET_BUILD_DIR)/core-maccatalyst.dll \
 		--target-framework=.NETCoreApp,Version=6.0,Profile=maccatalyst \
 		$(MACCATALYST_APIS) \
-		@$(DOTNET_BUILD_DIR)/maccatalyst-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/maccatalyst-defines-dotnet.rsp \
 		> $@
 
 $(MACCATALYST_DOTNET_BUILD_DIR)/64/Xamarin.MacCatalyst%dll $(MACCATALYST_DOTNET_BUILD_DIR)/64/Xamarin.MacCatalyst%pdb $(MACCATALYST_DOTNET_BUILD_DIR)/ref/Xamarin.MacCatalyst%dll: $(MACCATALYST_DOTNET_BUILD_DIR)/maccatalyst-generated-sources $(MACCATALYST_SOURCES) $(PRODUCT_KEY_PATH) $(MACCATALYST_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml $(MACCATALYST_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml | $(MACCATALYST_DOTNET_BUILD_DIR)/64 $(MACCATALYST_DOTNET_BUILD_DIR)/ref
@@ -1372,7 +1372,7 @@ $(MACCATALYST_DOTNET_BUILD_DIR)/64/Xamarin.MacCatalyst%dll $(MACCATALYST_DOTNET_
 		-warnaserror:$(NULLABILITY_WARNINGS) \
 		$(IOS_CSC_FLAGS_XI) \
 		$(MACCATALYST_SOURCES) \
-		@$(DOTNET_BUILD_DIR)/maccatalyst-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/maccatalyst-defines-dotnet.rsp \
 		-res:$(MACCATALYST_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
 		-res:$(MACCATALYST_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml \
 		@$<

--- a/src/Makefile
+++ b/src/Makefile
@@ -173,11 +173,11 @@ $(IOS_BUILD_DIR)/native/generated_sources: $(IOS_GENERATOR) $(IOS_APIS) $(IOS_BU
 
 ### .NET ###
 
-$(IOS_DOTNET_BUILD_DIR)/core-ios.dll: $(IOS_CORE_SOURCES) frameworks.sources $(BUILD_DIR)/ios-defines.rsp | $(IOS_DOTNET_BUILD_DIR)
+$(IOS_DOTNET_BUILD_DIR)/core-ios.dll: $(IOS_CORE_SOURCES) frameworks.sources $(DOTNET_BUILD_DIR)/ios-defines.rsp | $(IOS_DOTNET_BUILD_DIR)
 	$(Q_DOTNET_GEN) \
 		$(DOTNET6_CSC) $(DOTNET_FLAGS) \
 		$(IOS_CORE_WARNINGS_TO_FIX) \
-		@$(BUILD_DIR)/ios-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/ios-defines.rsp \
 		$(IOS_CORE_DEFINES) \
 		$(IOS_CORE_SOURCES) \
 		-out:$@
@@ -212,7 +212,7 @@ $(IOS_DOTNET_BUILD_DIR)/ios.rsp: Makefile Makefile.generator frameworks.sources 
 		-baselib=$(IOS_DOTNET_BUILD_DIR)/core-ios.dll \
 		--target-framework=.NETCoreApp,Version=6.0,Profile=ios \
 		$(IOS_APIS) \
-		@$(BUILD_DIR)/ios-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/ios-defines.rsp \
 		> $@
 
 define IOS_TARGETS_template
@@ -237,7 +237,7 @@ $(IOS_DOTNET_BUILD_DIR)/$(1)/Xamarin.iOS%dll $(IOS_DOTNET_BUILD_DIR)/$(1)/Xamari
 		$$(IOS_DEFINES) \
 		$$(IOS_CORE_WARNINGS_TO_FIX) \
 		$$(IOS_CSC_FLAGS_XI) \
-		@$(BUILD_DIR)/ios-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/ios-defines.rsp \
 		-res:$(IOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
 		-res:$(IOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml \
 		$$(IOS_SOURCES) @$(IOS_DOTNET_BUILD_DIR)/ios-generated-sources
@@ -585,11 +585,11 @@ $(DOTNET_DESTDIR)/$(MACOS_NUGET).Ref/ref/net6.0/Xamarin.Mac.dll: $(MACOS_DOTNET_
 
 ### .NET ###
 
-$(MACOS_DOTNET_BUILD_DIR)/core-macos.dll: $(MACOS_CORE_SOURCES) frameworks.sources $(BUILD_DIR)/macos-defines.rsp | $(MACOS_DOTNET_BUILD_DIR)
+$(MACOS_DOTNET_BUILD_DIR)/core-macos.dll: $(MACOS_CORE_SOURCES) frameworks.sources $(DOTNET_BUILD_DIR)/macos-defines.rsp | $(MACOS_DOTNET_BUILD_DIR)
 	$(Q_DOTNET_GEN) \
 		$(DOTNET6_CSC) $(DOTNET_FLAGS) -out:$@ \
 		$(MAC_CORE_WARNINGS_TO_FIX) \
-		@$(BUILD_DIR)/macos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/macos-defines.rsp \
 		$(MAC_CORE_DEFINES) \
 		$(MACOS_CORE_SOURCES) \
 		-out:$@ \
@@ -607,7 +607,7 @@ $(MACOS_DOTNET_BUILD_DIR)/macos.rsp: Makefile Makefile.generator frameworks.sour
 		-baselib:$(MACOS_DOTNET_BUILD_DIR)/core-macos.dll \
 		--target-framework=.NETCoreApp,Version=6.0,Profile=macos \
 		$(MACOS_APIS) \
-		@$(BUILD_DIR)/macos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/macos-defines.rsp \
 		> $@
 
 $(MACOS_DOTNET_BUILD_DIR)/64/Xamarin.Mac%dll $(MACOS_DOTNET_BUILD_DIR)/64/Xamarin.Mac%pdb $(MACOS_DOTNET_BUILD_DIR)/ref/Xamarin.Mac%dll: $(MACOS_DOTNET_BUILD_DIR)/macos-generated-sources $(MACOS_SOURCES) $(MAC_CFNETWORK_SOURCES) $(SN_KEY) $(MACOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml $(MACOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml | $(MACOS_DOTNET_BUILD_DIR)/64 $(MACOS_DOTNET_BUILD_DIR)/ref
@@ -621,7 +621,7 @@ $(MACOS_DOTNET_BUILD_DIR)/64/Xamarin.Mac%dll $(MACOS_DOTNET_BUILD_DIR)/64/Xamari
 		$(MAC_CSC_FLAGS_XM) \
 		$(MAC_CFNETWORK_SOURCES) $(MAC_HTTP_SOURCES) $(SHARED_SYSTEM_DRAWING_SOURCES) $(APPLETLS_DEFINES) -D:XAMARIN_MODERN \
 		$(MACOS_SOURCES) \
-		@$(BUILD_DIR)/macos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/macos-defines.rsp \
 		-res:$(MACOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
 		-res:$(MACOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml \
 		@$<
@@ -832,11 +832,11 @@ $(BUILD_DIR)/watchos.rsp: Makefile Makefile.generator frameworks.sources
 
 ### .NET ###
 
-$(WATCHOS_DOTNET_BUILD_DIR)/core-watchos.dll: $(WATCHOS_CORE_SOURCES) frameworks.sources $(BUILD_DIR)/watchos-defines.rsp | $(WATCHOS_DOTNET_BUILD_DIR)
+$(WATCHOS_DOTNET_BUILD_DIR)/core-watchos.dll: $(WATCHOS_CORE_SOURCES) frameworks.sources $(DOTNET_BUILD_DIR)/watchos-defines.rsp | $(WATCHOS_DOTNET_BUILD_DIR)
 	$(Q_DOTNET_GEN) \
 		$(DOTNET6_CSC) $(DOTNET_FLAGS) \
 		$(WATCHOS_CORE_WARNINGS_TO_FIX) \
-		@$(BUILD_DIR)/watchos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/watchos-defines.rsp \
 		$(WATCHOS_CORE_DEFINES) \
 		$(WATCHOS_CORE_SOURCES) \
 		-out:$@ \
@@ -854,7 +854,7 @@ $(WATCHOS_DOTNET_BUILD_DIR)/watchos.rsp: Makefile Makefile.generator frameworks.
 		-baselib=$(WATCHOS_DOTNET_BUILD_DIR)/core-watchos.dll \
 		--target-framework=.NETCoreApp,Version=6.0,Profile=watchos \
 		$(WATCHOS_APIS) \
-		@$(BUILD_DIR)/watchos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/watchos-defines.rsp \
 		> $@
 
 $(WATCHOS_DOTNET_BUILD_DIR)/32/Xamarin.WatchOS%dll $(WATCHOS_DOTNET_BUILD_DIR)/32/Xamarin.WatchOS%pdb: $(WATCHOS_DOTNET_BUILD_DIR)/watchos-generated-sources $(WATCHOS_SOURCES) $(PRODUCT_KEY_PATH) $(WATCHOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml | $(WATCHOS_DOTNET_BUILD_DIR)/32 $(WATCHOS_DOTNET_BUILD_DIR)/ref
@@ -867,7 +867,7 @@ $(WATCHOS_DOTNET_BUILD_DIR)/32/Xamarin.WatchOS%dll $(WATCHOS_DOTNET_BUILD_DIR)/3
 		-warnaserror:$(NULLABILITY_WARNINGS) \
 		$(IOS_CSC_FLAGS_XI) \
 		$(WATCHOS_SOURCES) \
-		@$(BUILD_DIR)/watchos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/watchos-defines.rsp \
 		-res:$(WATCHOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
 		@$<
 
@@ -882,7 +882,7 @@ $(WATCHOS_DOTNET_BUILD_DIR)/64/Xamarin.WatchOS%dll $(WATCHOS_DOTNET_BUILD_DIR)/6
 		-warnaserror:$(NULLABILITY_WARNINGS) \
 		$(IOS_CSC_FLAGS_XI) \
 		$(WATCHOS_SOURCES) \
-		@$(BUILD_DIR)/watchos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/watchos-defines.rsp \
 		-res:$(WATCHOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
 		@$<
 
@@ -1124,11 +1124,11 @@ $(BUILD_DIR)/tvos.rsp: Makefile Makefile.generator frameworks.sources
 
 ### .NET ###
 
-$(TVOS_DOTNET_BUILD_DIR)/core-tvos.dll: $(TVOS_CORE_SOURCES) frameworks.sources Makefile $(BUILD_DIR)/tvos-defines.rsp | $(TVOS_DOTNET_BUILD_DIR)
+$(TVOS_DOTNET_BUILD_DIR)/core-tvos.dll: $(TVOS_CORE_SOURCES) frameworks.sources Makefile $(DOTNET_BUILD_DIR)/tvos-defines.rsp | $(TVOS_DOTNET_BUILD_DIR)
 	$(Q_DOTNET_GEN) \
 		$(DOTNET6_CSC) $(DOTNET_FLAGS) \
 		$(TVOS_CORE_WARNINGS_TO_FIX) \
-		@$(BUILD_DIR)/tvos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/tvos-defines.rsp \
 		$(TVOS_CORE_DEFINES) \
 		$(TVOS_CORE_SOURCES) \
 		-out:$@ \
@@ -1146,7 +1146,7 @@ $(TVOS_DOTNET_BUILD_DIR)/tvos.rsp: Makefile Makefile.generator frameworks.source
 		-baselib=$(TVOS_DOTNET_BUILD_DIR)/core-tvos.dll \
 		--target-framework=.NETCoreApp,Version=6.0,Profile=tvos \
 		$(TVOS_APIS) \
-		@$(BUILD_DIR)/tvos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/tvos-defines.rsp \
 		> $@
 
 $(TVOS_DOTNET_BUILD_DIR)/64/Xamarin.TVOS%dll $(TVOS_DOTNET_BUILD_DIR)/64/Xamarin.TVOS%pdb $(TVOS_DOTNET_BUILD_DIR)/ref/Xamarin.TVOS%dll: $(TVOS_DOTNET_BUILD_DIR)/tvos-generated-sources $(TVOS_SOURCES) $(PRODUCT_KEY_PATH) $(TVOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml $(TVOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml | $(TVOS_DOTNET_BUILD_DIR)/64 $(TVOS_DOTNET_BUILD_DIR)/ref
@@ -1160,7 +1160,7 @@ $(TVOS_DOTNET_BUILD_DIR)/64/Xamarin.TVOS%dll $(TVOS_DOTNET_BUILD_DIR)/64/Xamarin
 		-warnaserror:$(NULLABILITY_WARNINGS) \
 		$(IOS_CSC_FLAGS_XI) \
 		$(TVOS_SOURCES) \
-		@$(BUILD_DIR)/tvos-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/tvos-defines.rsp \
 		-res:$(TVOS_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
 		-res:$(TVOS_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml \
 		@$<
@@ -1336,11 +1336,11 @@ $(BUILD_DIR)/maccatalyst.rsp: Makefile Makefile.generator frameworks.sources
 
 ### .NET ###
 
-$(MACCATALYST_DOTNET_BUILD_DIR)/core-maccatalyst.dll: $(TVOS_CORE_SOURCES) frameworks.sources Makefile $(BUILD_DIR)/maccatalyst-defines.rsp | $(MACCATALYST_DOTNET_BUILD_DIR)
+$(MACCATALYST_DOTNET_BUILD_DIR)/core-maccatalyst.dll: $(TVOS_CORE_SOURCES) frameworks.sources Makefile $(DOTNET_BUILD_DIR)/maccatalyst-defines.rsp | $(MACCATALYST_DOTNET_BUILD_DIR)
 	$(Q_DOTNET_GEN) \
 		$(DOTNET6_CSC) $(DOTNET_FLAGS) \
 		$(MACCATALYST_WARNINGS_TO_FIX) \
-		@$(BUILD_DIR)/maccatalyst-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/maccatalyst-defines.rsp \
 		$(MACCATALYST_CORE_DEFINES) \
 		$(MACCATALYST_CORE_SOURCES) \
 		-out:$@ \
@@ -1358,7 +1358,7 @@ $(MACCATALYST_DOTNET_BUILD_DIR)/maccatalyst.rsp: Makefile Makefile.generator fra
 		-baselib=$(MACCATALYST_DOTNET_BUILD_DIR)/core-maccatalyst.dll \
 		--target-framework=.NETCoreApp,Version=6.0,Profile=maccatalyst \
 		$(MACCATALYST_APIS) \
-		@$(BUILD_DIR)/maccatalyst-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/maccatalyst-defines.rsp \
 		> $@
 
 $(MACCATALYST_DOTNET_BUILD_DIR)/64/Xamarin.MacCatalyst%dll $(MACCATALYST_DOTNET_BUILD_DIR)/64/Xamarin.MacCatalyst%pdb $(MACCATALYST_DOTNET_BUILD_DIR)/ref/Xamarin.MacCatalyst%dll: $(MACCATALYST_DOTNET_BUILD_DIR)/maccatalyst-generated-sources $(MACCATALYST_SOURCES) $(PRODUCT_KEY_PATH) $(MACCATALYST_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml $(MACCATALYST_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml | $(MACCATALYST_DOTNET_BUILD_DIR)/64 $(MACCATALYST_DOTNET_BUILD_DIR)/ref
@@ -1372,7 +1372,7 @@ $(MACCATALYST_DOTNET_BUILD_DIR)/64/Xamarin.MacCatalyst%dll $(MACCATALYST_DOTNET_
 		-warnaserror:$(NULLABILITY_WARNINGS) \
 		$(IOS_CSC_FLAGS_XI) \
 		$(MACCATALYST_SOURCES) \
-		@$(BUILD_DIR)/maccatalyst-defines.rsp \
+		@$(DOTNET_BUILD_DIR)/maccatalyst-defines.rsp \
 		-res:$(MACCATALYST_DOTNET_BUILD_DIR)/ILLink.LinkAttributes.xml \
 		-res:$(MACCATALYST_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml \
 		@$<

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -60,7 +60,7 @@ $(BUILD_DIR)/%-defines.rsp: frameworks.sources Makefile.generator generate-defin
 	$(Q) mv $@.tmp $@
 
 # This rule means: generate a <platform>-defines.rsp for the frameworks in the variable <PLATFORM>_FRAMEWORKS
-$(DOTNET_BUILD_DIR)/%-defines.rsp: frameworks.sources Makefile.generator generate-defines.csharp
+$(DOTNET_BUILD_DIR)/%-defines-dotnet.rsp: frameworks.sources Makefile.generator generate-defines.csharp
 	@mkdir -p $(dir $@)
 	$(Q) ./generate-defines.csharp $@.tmp '$(filter-out $(DOTNET_REMOVED_$(shell echo $* | tr a-z A-Z)_FRAMEWORKS),$($(shell echo $* | tr a-z A-Z)_FRAMEWORKS))'
 	$(Q) mv $@.tmp $@

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -62,7 +62,7 @@ $(BUILD_DIR)/%-defines.rsp: frameworks.sources Makefile.generator generate-defin
 # This rule means: generate a <platform>-defines.rsp for the frameworks in the variable <PLATFORM>_FRAMEWORKS
 $(DOTNET_BUILD_DIR)/%-defines.rsp: frameworks.sources Makefile.generator generate-defines.csharp
 	@mkdir -p $(dir $@)
-	$(Q) ./generate-defines.csharp $@.tmp '$(filter-out $(DOTNET_REMOVED_FRAMEWORKS),$($(shell echo $* | tr a-z A-Z)_FRAMEWORKS))'
+	$(Q) ./generate-defines.csharp $@.tmp '$(filter-out $(DOTNET_REMOVED_$(shell echo $* | tr a-z A-Z)_FRAMEWORKS),$($(shell echo $* | tr a-z A-Z)_FRAMEWORKS))'
 	$(Q) mv $@.tmp $@
 
 $(DOTNET_BUILD_DIR)/Xamarin.Apple.BindingAttributes.dll: generator-attributes.cs Makefile.generator | $(DOTNET_BUILD_DIR)

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -59,6 +59,12 @@ $(BUILD_DIR)/%-defines.rsp: frameworks.sources Makefile.generator generate-defin
 	$(Q) ./generate-defines.csharp $@.tmp '$($(shell echo $* | tr a-z A-Z)_FRAMEWORKS)'
 	$(Q) mv $@.tmp $@
 
+# This rule means: generate a <platform>-defines.rsp for the frameworks in the variable <PLATFORM>_FRAMEWORKS
+$(DOTNET_BUILD_DIR)/%-defines.rsp: frameworks.sources Makefile.generator generate-defines.csharp
+	@mkdir -p $(dir $@)
+	$(Q) ./generate-defines.csharp $@.tmp '$(filter-out $(DOTNET_REMOVED_FRAMEWORKS),$($(shell echo $* | tr a-z A-Z)_FRAMEWORKS))'
+	$(Q) mv $@.tmp $@
+
 $(DOTNET_BUILD_DIR)/Xamarin.Apple.BindingAttributes.dll: generator-attributes.cs Makefile.generator | $(DOTNET_BUILD_DIR)
 	$(Q_DOTNET_BUILD) $(SYSTEM_CSC) $(DOTNET_FLAGS) -out:$@ $<
 

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -25,10 +25,6 @@
 # in either core.dll or the platform assembly, are added to SHARED_[CORE_]SOURCES.
 #
 
-DOTNET_REMOVED_FRAMEWORKS = \
-	iAd \
-	QTKit \
-
 # Accelerate
 
 ACCELERATE_SOURCES = \
@@ -2304,6 +2300,18 @@ MACCATALYST_FRAMEWORKS = \
 	VideoToolbox \
 	Vision \
 	WKWebKit \
+
+# List frameworks that have been removed in .NET
+
+DOTNET_REMOVED_IOS_FRAMEWORKS = \
+	iAd \
+
+DOTNET_REMOVED_MACOS_FRAMEWORKS = \
+	QTKit \
+
+DOTNET_REMOVED_TVOS_FRAMEWORKS = \
+
+DOTNET_REMOVED_MACCATALYST_FRAMEWORKS = \
 
 #
 # Compute the SOURCES variables.

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -25,6 +25,10 @@
 # in either core.dll or the platform assembly, are added to SHARED_[CORE_]SOURCES.
 #
 
+DOTNET_REMOVED_FRAMEWORKS = \
+	iAd \
+	QTKit \
+
 # Accelerate
 
 ACCELERATE_SOURCES = \

--- a/src/iAd/ADCompat.cs
+++ b/src/iAd/ADCompat.cs
@@ -1,4 +1,4 @@
-#if !XAMCORE_4_0
+#if !NET
 
 using System;
 using System.Runtime.InteropServices;
@@ -16,12 +16,8 @@ using UIKit;
 
 namespace iAd {
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Deprecated (PlatformName.iOS, 10, 0, PlatformArchitecture.None, null)]
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public class ADBannerView : UIView {
 
 		public class ADBannerViewAppearance : UIViewAppearance {
@@ -190,11 +186,7 @@ namespace iAd {
 		}
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public class AdErrorEventArgs : EventArgs {
 		public NSError? Error {
 			get { return default (NSError); }
@@ -206,20 +198,12 @@ namespace iAd {
 		}
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Deprecated (PlatformName.iOS, 10, 0, PlatformArchitecture.None, null)]
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public interface IADBannerViewDelegate : INativeObject, IDisposable {
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public static class ADBannerViewDelegate_Extensions {
 
 		public static void AdLoaded (this IADBannerViewDelegate This, ADBannerView banner)
@@ -244,12 +228,8 @@ namespace iAd {
 		}
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Deprecated (PlatformName.iOS, 10, 0, PlatformArchitecture.None, null)]
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public class ADBannerViewDelegate : NSObject, IADBannerViewDelegate, INativeObject, IDisposable {
 
 		public ADBannerViewDelegate ()
@@ -289,61 +269,29 @@ namespace iAd {
 	// some of this API is still provided
 	public partial class ADClient : NSObject {
 
-#if !NET
 		[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#else
-		[UnsupportedOSPlatform ("ios15.0")]
-#if IOS
-		[Obsolete ("Starting with ios15.0 The iAd framework has been removed from iOS.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-#endif
 		public static NSString? ErrorDomain {
 			get { return default (NSString); }
 		}
 
-#if !NET
 		[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#else
-		[UnsupportedOSPlatform ("ios15.0")]
-#if IOS
-		[Obsolete ("Starting with ios15.0 The iAd framework has been removed from iOS.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-#endif
 		public virtual void DetermineAppInstallationAttribution (AttributedToiAdCompletionHandler completionHandler)
 		{
 		}
 
-#if !NET
 		[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#else
-		[UnsupportedOSPlatform ("ios15.0")]
-#if IOS
-		[Obsolete ("Starting with ios15.0 The iAd framework has been removed from iOS.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-#endif
 		public virtual void LookupAdConversionDetails (ADConversionDetails onCompleted)
 		{
 		}
 
-#if !NET
 		[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#else
-		[UnsupportedOSPlatform ("ios15.0")]
-#if IOS
-		[Obsolete ("Starting with ios15.0 The iAd framework has been removed from iOS.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-#endif
 		public virtual Task<ADClientConversionDetailsResult>? LookupAdConversionDetailsAsync()
 		{
 			return default (Task<ADClientConversionDetailsResult>);
 		}
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public class ADClientConversionDetailsResult {
 		public NSDate? AppPurchaseDate {
 			get { return default (NSDate); }
@@ -360,12 +308,8 @@ namespace iAd {
 		}
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Deprecated (PlatformName.iOS, 10, 0, PlatformArchitecture.None, null)]
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public class ADInterstitialAd : NSObject {
 
 		protected internal ADInterstitialAd (IntPtr handle)
@@ -450,11 +394,7 @@ namespace iAd {
 		}
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public class ADErrorEventArgs : EventArgs {
 		public NSError? Error {
 			get { return default (NSError); }
@@ -466,12 +406,8 @@ namespace iAd {
 		}
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Deprecated (PlatformName.iOS, 10, 0, PlatformArchitecture.None, null)]
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public interface IADInterstitialAdDelegate : INativeObject, IDisposable {
 
 		void AdUnloaded (ADInterstitialAd interstitialAd);
@@ -485,23 +421,15 @@ namespace iAd {
 		void ActionFinished (ADInterstitialAd interstitialAd);
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public static class ADInterstitialAdDelegate_Extensions {
 		public static void WillLoad (this IADInterstitialAdDelegate This, ADInterstitialAd interstitialAd)
 		{
 		}
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Deprecated (PlatformName.iOS, 10, 0, PlatformArchitecture.None, null)]
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public abstract class ADInterstitialAdDelegate : NSObject, IADInterstitialAdDelegate, INativeObject, IDisposable {
 
 		protected ADInterstitialAdDelegate ()
@@ -531,12 +459,8 @@ namespace iAd {
 		}
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Deprecated (PlatformName.iOS, 13, 0, PlatformArchitecture.None, null)]
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public class ADInterstitialAdPresentationViewController : UIViewController {
 
 		public unsafe override IntPtr ClassHandle {
@@ -569,12 +493,8 @@ namespace iAd {
 		}
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Deprecated (PlatformName.iOS, 10, 0, PlatformArchitecture.None, null)]
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public static class IAdAdditions {
 
 		public static bool DisplayingBannerAd (this UIViewController This)
@@ -621,17 +541,11 @@ namespace iAd {
 		}
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Deprecated (PlatformName.iOS, 9, 0, PlatformArchitecture.None, "Use 'iAdPreroll_AVPlayerViewController' instead.")]
 	[Obsoleted (PlatformName.iOS, 12, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public static class IAdPreroll {
 
-#if !NET
 		[Introduced (PlatformName.iOS, 8, 0, PlatformArchitecture.All, null)]
-#endif
 		public static void CancelPreroll (this MPMoviePlayerController This)
 		{
 		}
@@ -641,11 +555,7 @@ namespace iAd {
 		}
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public static class iAdPreroll_AVPlayerViewController {
 
 		public static void CancelPreroll (this AVPlayerViewController This)
@@ -657,11 +567,7 @@ namespace iAd {
 		}
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-#else
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public static class ADErrorExtensions {
 
 		public static NSString? GetDomain( this ADError self)
@@ -670,25 +576,17 @@ namespace iAd {
 		}
 	}
 
-#if !NET
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public delegate void ADConversionDetails (NSDate? appPurchaseDate, NSDate? iAdImpressionDate);
 
-#if !NET
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public delegate bool ADPredicate (ADInterstitialAd interstitialAd, bool willLeaveApplication);
 
-#if !NET
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public delegate bool AdAction (ADBannerView banner, bool willLeaveApplication);
 
-#if !NET
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#endif
 	public delegate void AttributedToiAdCompletionHandler (bool attributedToiAd);
 }
 
-#endif // !XAMCORE_4_0
+#endif // !NET

--- a/src/iAd/iAd.cs
+++ b/src/iAd/iAd.cs
@@ -7,6 +7,8 @@
 // Copyright 2011-2014, 2016 Xamarin Inc
 //
 
+#if !NET
+
 using System;
 using ObjCRuntime;
 
@@ -55,10 +57,8 @@ namespace iAd {
 	public enum ADClientError : long {
 		Unknown = 0,
 		TrackingRestrictedOrDenied = 1,
-#if !XAMCORE_4_0
 		[Obsolete ("Use 'TrackingRestrictedOrDenied' instead.")]
 		LimitAdTracking = TrackingRestrictedOrDenied,
-#endif
 		MissingData = 2,
 		CorruptResponse = 3,
 		RequestClientError = 4,
@@ -67,3 +67,5 @@ namespace iAd {
 		UnsupportedPlatform = 7,
 	}
 }
+
+#endif // !NET

--- a/src/iad.cs
+++ b/src/iad.cs
@@ -7,6 +7,7 @@
 // Copyright 2010, Novell, Inc.
 // Copyright 2011-2014 Xamarin Inc. All rights reserved.
 //
+#if !NET
 using ObjCRuntime;
 using Foundation;
 using System;
@@ -36,3 +37,4 @@ namespace iAd {
 		void RequestAttributionDetails (Action<NSDictionary, NSError> completionHandler);
 	}
 }
+#endif // !NET

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -319,7 +319,9 @@ public class Frameworks : Dictionary <string, Framework>
 				{ "CoreMedia", "CoreMedia", 4 },
 				{ "CoreVideo", "CoreVideo", 4 },
 				{ "CoreTelephony", "CoreTelephony", 4 },
+#if !NET
 				{ "iAd", "iAd", 4 },
+#endif
 				{ "QuickLook", "QuickLook", 4 },
 				{ "ImageIO", "ImageIO", 4 },
 				{ "AssetsLibrary", "AssetsLibrary", 4 },
@@ -645,7 +647,9 @@ public class Frameworks : Dictionary <string, Framework>
 				case "EventKitUI":
 				case "HealthKit":
 				case "HealthKitUI":
+#if !NET
 				case "iAd":
+#endif
 				case "IdentityLookupUI":
 				case "Messages":
 				case "MessageUI":

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2223,6 +2223,7 @@ namespace Registrar {
 				header.WriteLine ("#import <CoreImage/CoreImage.h>");
 				header.WriteLine ("#import <CoreImage/CIFilterBuiltins.h>");
 				return;
+#if !NET
 			case "iAd":
 				if (App.SdkVersion.Major >= 13) {
 					// most of the framework has been obliterated from the headers
@@ -2235,6 +2236,7 @@ namespace Registrar {
 					return;
 				}
 				goto default;
+#endif
 			case "ThreadNetwork":
 				h = "<ThreadNetwork/THClient.h>";
 				break;


### PR DESCRIPTION
Also implement a way to use a different response file with HAS_<framework> defines for .NET.

This allows us to have different HAS_<framework> values for the .NET build
(to take into account frameworks that has been removed).