### PR TITLE
[AudioComponent] Enable nullability + a few other code updates

### DIFF
--- a/src/AudioToolbox/MusicTrack.cs
+++ b/src/AudioToolbox/MusicTrack.cs
@@ -249,7 +249,7 @@ namespace AudioToolbox {
 		[DllImport (Constants.AudioToolboxLibrary)]
 		extern static /* OSStatus */ MusicPlayerStatus MusicSequenceDisposeTrack (/* MusicSequence */ IntPtr inSequence, /* MusicTrack */ IntPtr inTrack);
 
-		public static MusicTrack FromSequence (MusicSequence sequence)
+		public static MusicTrack? FromSequence (MusicSequence sequence)
 		{
 			if (sequence is null)
 				throw new ArgumentNullException (nameof (sequence));

--- a/src/AudioUnit/AudioComponent.cs
+++ b/src/AudioUnit/AudioComponent.cs
@@ -27,6 +27,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -75,30 +77,24 @@ namespace AudioUnit
 
 		public ResourceUsageInfo (NSDictionary dic) : base (dic) {}
 
-		public string[] IOKitUserClient { 
+		public string[]? IOKitUserClient {
 			get {
-				var array = GetNativeValue<NSArray> (userClientK);
-				if (array == null )
-					return null;
-				return CFArray.StringArrayFromHandle (array.Handle);
+				return GetStringArrayValue (userClientK);
 			} 
 			set {
-				if (value == null)
+				if (value is null)
 					RemoveValue (userClientK);
 				else
 					SetArrayValue (userClientK, value);
 			}
 		}
 
-		public string[] MachLookUpGlobalName { 
+		public string[]? MachLookUpGlobalName {
 			get {
-				var array = GetNativeValue<NSArray> (globalNameK);
-				if (array == null)
-					return null;
-				return CFArray.StringArrayFromHandle (array.Handle);
+				return GetStringArrayValue (globalNameK);
 			} 
 			set {
-				if (value == null)
+				if (value is null)
 					RemoveValue (globalNameK);	
 				else
 					SetArrayValue (globalNameK, value);
@@ -152,7 +148,7 @@ namespace AudioUnit
 
 		public AudioComponentInfo (NSDictionary dic) : base (dic) {}
 
-		public string Type { 
+		public string? Type {
 			get {
 				return GetStringValue (typeK);
 			} 
@@ -161,7 +157,7 @@ namespace AudioUnit
 			}
 		}
 
-		public string Subtype { 
+		public string? Subtype {
 			get {
 				return GetStringValue (subtypeK);
 			} 
@@ -170,7 +166,7 @@ namespace AudioUnit
 			}
 		}
 
-		public string Manufacturer { 
+		public string? Manufacturer {
 			get {
 				return GetStringValue (manufacturerK);
 			} 
@@ -179,7 +175,7 @@ namespace AudioUnit
 			}
 		}
 
-		public string Name { 
+		public string? Name {
 			get {
 				return GetStringValue (nameK);
 			} 
@@ -197,7 +193,7 @@ namespace AudioUnit
 			}
 		}
 
-		public string FactoryFunction { 
+		public string? FactoryFunction {
 			get {
 				return GetStringValue (factoryFunctionK);
 			} 
@@ -215,7 +211,7 @@ namespace AudioUnit
 			}
 		}
 
-		public ResourceUsageInfo ResourceUsage { 
+		public ResourceUsageInfo? ResourceUsage {
 			get {
 				return GetStrongDictionary<ResourceUsageInfo> (resourceUsageK);
 			} 
@@ -224,15 +220,12 @@ namespace AudioUnit
 			}
 		}
 
-		public string[] Tags { 
+		public string[]? Tags {
 			get {
-				var array = GetNativeValue<NSArray> (tagsK);
-				if (array == null)
-					return null;
-				return CFArray.StringArrayFromHandle (array.Handle);
+				return GetStringArrayValue (tagsK);
 			} 
 			set {
-				if (value == null)
+				if (value is null)
 					RemoveValue (tagsK);	
 				else
 					SetArrayValue (tagsK, value);
@@ -246,11 +239,11 @@ namespace AudioUnit
 
 	public class AudioComponent : INativeObject {
 #if !COREBUILD
-		internal IntPtr handle;
+		IntPtr handle;
 
 		public IntPtr Handle { get { return handle; } }
 
-		internal AudioComponent(IntPtr handle)
+		internal AudioComponent (IntPtr handle)
 		{ 
 			this.handle = handle;
 		}
@@ -260,55 +253,55 @@ namespace AudioUnit
 			return new AudioUnit (this);
 		}
 
-		public static AudioComponent FindNextComponent (AudioComponent cmp, ref AudioComponentDescription cd)
+		public static AudioComponent? FindNextComponent (AudioComponent? cmp, ref AudioComponentDescription cd)
 		{
-			var handle = cmp == null ? IntPtr.Zero : cmp.Handle;
+			var handle = cmp.GetHandle ();
 			handle = AudioComponentFindNext (handle, ref cd);
 			return  (handle != IntPtr.Zero) ? new AudioComponent (handle) : null;
 		}
 
-		public static AudioComponent FindComponent (ref AudioComponentDescription cd)
+		public static AudioComponent? FindComponent (ref AudioComponentDescription cd)
 		{
 			return FindNextComponent (null, ref cd);
 		}
 
-		public static AudioComponent FindComponent (AudioTypeOutput output)
+		public static AudioComponent? FindComponent (AudioTypeOutput output)
 		{
 			var cd = AudioComponentDescription.CreateOutput (output);
 			return FindComponent (ref cd);
 		}
 
-		public static AudioComponent FindComponent (AudioTypeMusicDevice musicDevice)
+		public static AudioComponent? FindComponent (AudioTypeMusicDevice musicDevice)
 		{
 			var cd = AudioComponentDescription.CreateMusicDevice (musicDevice);
 			return FindComponent (ref cd);
 		}
 		
-		public static AudioComponent FindComponent (AudioTypeConverter conveter)
+		public static AudioComponent? FindComponent (AudioTypeConverter conveter)
 		{
 			var cd = AudioComponentDescription.CreateConverter (conveter);
 			return FindComponent (ref cd);
 		}
 		
-		public static AudioComponent FindComponent (AudioTypeEffect effect)
+		public static AudioComponent? FindComponent (AudioTypeEffect effect)
 		{
 			var cd = AudioComponentDescription.CreateEffect (effect);
 			return FindComponent (ref cd);
 		}
 		
-		public static AudioComponent FindComponent (AudioTypeMixer mixer)
+		public static AudioComponent? FindComponent (AudioTypeMixer mixer)
 		{
 			var cd = AudioComponentDescription.CreateMixer (mixer);
 			return FindComponent (ref cd);
 		}
 		
-		public static AudioComponent FindComponent (AudioTypePanner panner)
+		public static AudioComponent? FindComponent (AudioTypePanner panner)
 		{
 			var cd = AudioComponentDescription.CreatePanner (panner);
 			return FindComponent (ref cd);
 		}
 		
-		public static AudioComponent FindComponent (AudioTypeGenerator generator)
+		public static AudioComponent? FindComponent (AudioTypeGenerator generator)
 		{
 			var cd = AudioComponentDescription.CreateGenerator (generator);
 			return FindComponent (ref cd);
@@ -320,10 +313,9 @@ namespace AudioUnit
 		[DllImport(Constants.AudioUnitLibrary, EntryPoint = "AudioComponentCopyName")]
 		static extern int /* OSStatus */ AudioComponentCopyName (IntPtr component, out IntPtr cfstr);
 		
-		public string Name {
+		public string? Name {
 			get {
-				IntPtr r;
-				if (AudioComponentCopyName (handle, out r) == 0)
+				if (AudioComponentCopyName (Handle, out var r) == 0)
 					return CFString.FromHandle (r);
 				return null;
 			}
@@ -334,9 +326,7 @@ namespace AudioUnit
 
 		public AudioComponentDescription? Description {
 			get {
-				AudioComponentDescription desc;
-
-				if (AudioComponentGetDescription (handle, out desc) == 0)
+				if (AudioComponentGetDescription (Handle, out var desc) == 0)
 					return desc;
 
 				return null;
@@ -346,10 +336,9 @@ namespace AudioUnit
 		[DllImport(Constants.AudioUnitLibrary)]
 		static extern int /* OSStatus */ AudioComponentGetVersion (IntPtr component, out int /* UInt32* */ version);
 
-		public Version Version {
+		public Version? Version {
 			get {
-				int ret;
-				if (AudioComponentGetVersion (handle, out ret) == 0)
+				if (AudioComponentGetVersion (Handle, out var ret) == 0)
 					return new Version (ret >> 16, (ret >> 8) & 0xff, ret & 0xff);
 
 				return null;
@@ -377,9 +366,9 @@ namespace AudioUnit
 		[SupportedOSPlatform ("macos11.0")]
 		[SupportedOSPlatform ("maccatalyst14.0")]
 #endif
-		public UIImage CopyIcon ()
+		public UIImage? CopyIcon ()
 		{
-			var ptr = AudioComponentCopyIcon (handle);
+			var ptr = AudioComponentCopyIcon (Handle);
 			return Runtime.GetNSObject<UIImage> (ptr, owns: true);
 		}
 
@@ -403,9 +392,9 @@ namespace AudioUnit
 		[Obsolete ("Starting with ios14.0 use 'CopyIcon' instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif
-		public UIKit.UIImage GetIcon (float desiredPointSize)
+		public UIKit.UIImage? GetIcon (float desiredPointSize)
 		{
-			return new UIKit.UIImage (AudioComponentGetIcon (handle, desiredPointSize));
+			return Runtime.GetNSObject<UIKit.UIImage> (AudioComponentGetIcon (Handle, desiredPointSize));
 		}
 #endif // !__MACCATALYST__
 
@@ -436,7 +425,7 @@ namespace AudioUnit
 #endif
 		public double LastActiveTime {
 			get {
-				return AudioComponentGetLastActiveTime (handle);
+				return AudioComponentGetLastActiveTime (Handle);
 			}
 		}
 #else
@@ -450,9 +439,9 @@ namespace AudioUnit
 #if !NET
 		[Mac (10,11)]
 #endif
-		public AppKit.NSImage GetIcon ()
+		public AppKit.NSImage? GetIcon ()
 		{
-			return new AppKit.NSImage (AudioComponentGetIcon (handle));
+			return Runtime.GetNSObject<AppKit.NSImage> (AudioComponentGetIcon (Handle));
 		}
 #endif
 
@@ -478,14 +467,15 @@ namespace AudioUnit
 #else
 		[SupportedOSPlatform ("ios11.0")]
 #endif
-		public AudioComponentInfo[] ComponentList {
+		public AudioComponentInfo[]? ComponentList {
 			get {
-				using (var cfString = new CFString (Name)) {
-					var cHandle = AudioUnitExtensionCopyComponentList (cfString.Handle);
+				var nameHandle = CFString.CreateNative (Name);
+				try {
+					var cHandle = AudioUnitExtensionCopyComponentList (nameHandle);
 					if (cHandle == IntPtr.Zero)
 						return null;
 					using (var nsArray = Runtime.GetNSObject<NSArray> (cHandle, owns: true)) {
-						if (nsArray == null)
+						if (nsArray is null)
 							return null;
 						// make things easier for developers since we do not know how to have an implicit conversion from NSObject to AudioComponentInfo
 						var dics = NSArray.FromArray <NSDictionary> (nsArray);
@@ -495,18 +485,21 @@ namespace AudioUnit
 						}
 						return result;
 					}
+				} finally {
+					CFString.ReleaseNative (nameHandle);
 				}
 			}
 			set {
-				if (value == null)
+				if (value is null)
 					throw new ArgumentNullException	(nameof	(value));
-				using (var cfString = new CFString (Name)) {
+				var nameHandle = CFString.CreateNative (Name);
+				try {
 					var dics = new NSDictionary [value.Length];
 					for (var i = 0; i < value.Length; i++) {
 						dics [i] = value [i].Dictionary;
 					}
 					using (var array = NSArray.FromNSObjects (dics)) {
-						var result = (AudioConverterError) AudioUnitExtensionSetComponentList (cfString.Handle, array.Handle);
+						var result = (AudioConverterError) AudioUnitExtensionSetComponentList (nameHandle, array.Handle);
 						switch (result) {
 						case AudioConverterError.None:
 							return;
@@ -515,6 +508,8 @@ namespace AudioUnit
 
 						}
 					}
+				} finally {
+					CFString.ReleaseNative (nameHandle);
 				}
 			}
 		}

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -338,7 +338,7 @@ namespace AudioUnit
 			if (component.Handle == IntPtr.Zero)
 				throw new ObjectDisposedException ("component");
 			
-			int err = AudioComponentInstanceNew (component.handle, out handle);
+			int err = AudioComponentInstanceNew (component.Handle, out handle);
 			if (err != 0)
 				throw new AudioUnitException (err);
 			

--- a/src/Foundation/DictionaryContainer.cs
+++ b/src/Foundation/DictionaryContainer.cs
@@ -198,6 +198,15 @@ namespace Foundation {
 			return Runtime.GetINativeObject<T> (Dictionary.LowlevelObjectForKey (key.Handle), false);
 		}
 
+		protected string[]? GetStringArrayValue (NSString key)
+		{
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
+
+			var array = Dictionary.LowlevelObjectForKey (key.Handle);
+			return CFArray.StringArrayFromHandle (array)!;
+		}
+
 		protected NSDictionary? GetNSDictionary (NSString key)
 		{
 			if (key == null)


### PR DESCRIPTION
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.
* Make the 'handle' field private.
* Use the 'Handle' property instead of accessing the private 'handle' field.
* Use CFString.CreateNative/ReleaseNative instead of other means to create
  native strings (the fastest and least memory hungry option).