### PR TITLE
[AUGraph] Enable nullability + a few other code updates

### DIFF
--- a/src/AudioToolbox/MusicSequence.cs
+++ b/src/AudioToolbox/MusicSequence.cs
@@ -128,7 +128,7 @@ namespace AudioToolbox {
 				if (MusicSequenceGetAUGraph (handle, out h) != MusicPlayerStatus.Success)
 					return null;
 
-				return new AUGraph (h);
+				return new AUGraph (h, false);
 			}
 			set {
 				if (value == null)

--- a/src/AudioUnit/AUGraph.cs
+++ b/src/AudioUnit/AUGraph.cs
@@ -29,6 +29,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Text;
 using System.Collections.Generic;
@@ -73,20 +75,13 @@ namespace AudioUnit
 	{
 		readonly GCHandle gcHandle;
 		IntPtr handle;
+		bool owns;
 
 		[Preserve (Conditional = true)]
 		internal AUGraph (IntPtr handle, bool owns)
 		{
 			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (this.handle);
-
-			gcHandle = GCHandle.Alloc (this);
-		}
-
-		internal AUGraph (IntPtr ptr)
-		{
-			handle = ptr;
+			this.owns = owns;
 			gcHandle = GCHandle.Alloc (this);
 		}
 
@@ -96,55 +91,56 @@ namespace AudioUnit
 			}
 		}
 
-		public AUGraph ()
+
+		static IntPtr Create ()
 		{
-			int err = NewAUGraph (ref handle);
+			int err = NewAUGraph (out var handle);
 			if (err != 0)
 				throw new InvalidOperationException (String.Format ("Cannot create new AUGraph. Error code: {0}", err));
-
-			gcHandle = GCHandle.Alloc (this);
+			return handle;
 		}
 
-		public static AUGraph Create (out int errorCode)
+		public AUGraph ()
+			: this (Create (), true)
 		{
-			IntPtr ret = IntPtr.Zero;
-			errorCode = NewAUGraph (ref ret);
+		}
+
+		public static AUGraph? Create (out int errorCode)
+		{
+			errorCode = NewAUGraph (out var handle);
 
 			if (errorCode != 0)
 				return null;
 
-			return new AUGraph (ret);
+			return new AUGraph (handle, true);
 		}
 
 		public bool IsInitialized {
 			get {
-				bool b;
-				return AUGraphIsInitialized (handle, out b) == AUGraphError.OK && b;
+				return AUGraphIsInitialized (Handle, out var b) == AUGraphError.OK && b;
 			}
 		}
 
 		public bool IsOpen {
 			get {
-				bool b;
-				return AUGraphIsOpen (handle, out b) == AUGraphError.OK && b;
+				return AUGraphIsOpen (Handle, out var b) == AUGraphError.OK && b;
 			}
 		}
 
 		public bool IsRunning {
 			get {
-				bool b;
-				return AUGraphIsRunning (handle, out b) == AUGraphError.OK && b;
+				return AUGraphIsRunning (Handle, out var b) == AUGraphError.OK && b;
 			}
 		}
 
 		public AudioUnitStatus AddRenderNotify (RenderDelegate callback)
 		{
-			if (callback == null)
-				throw new ArgumentException ("Callback can not be null");
+			if (callback is null)
+				throw new ArgumentNullException (nameof (callback));
 
 			AudioUnitStatus error = AudioUnitStatus.OK;
 			if (graphUserCallbacks.Count == 0)
-				error = (AudioUnitStatus)AUGraphAddRenderNotify (handle, renderCallback, GCHandle.ToIntPtr(gcHandle));
+				error = (AudioUnitStatus) AUGraphAddRenderNotify (Handle, renderCallback, GCHandle.ToIntPtr (gcHandle));
 
 			if (error == AudioUnitStatus.OK)
 				graphUserCallbacks.Add (callback);
@@ -153,14 +149,14 @@ namespace AudioUnit
 
 		public AudioUnitStatus RemoveRenderNotify (RenderDelegate callback)
 		{
-			if (callback == null)
-				throw new ArgumentException ("Callback can not be null");
+			if (callback is null)
+				throw new ArgumentNullException (nameof (callback));
 			if (!graphUserCallbacks.Contains (callback))
 				throw new ArgumentException ("Cannot unregister a callback that has not been registered");
 
 			AudioUnitStatus error = AudioUnitStatus.OK;
 			if (graphUserCallbacks.Count == 0)
-				error = (AudioUnitStatus)AUGraphRemoveRenderNotify (handle, renderCallback, GCHandle.ToIntPtr (gcHandle));
+				error = (AudioUnitStatus)AUGraphRemoveRenderNotify (Handle, renderCallback, GCHandle.ToIntPtr (gcHandle));
 
 			graphUserCallbacks.Remove (callback); // Remove from list even if there is an error
 			return error;
@@ -178,8 +174,11 @@ namespace AudioUnit
 		{
 			// getting audiounit instance
 			var handler = GCHandle.FromIntPtr (inRefCon);
-			var inst = (AUGraph)handler.Target;
-			HashSet<RenderDelegate> renderers = inst.graphUserCallbacks;
+			var inst = handler.Target as AUGraph;
+			var renderers = inst?.graphUserCallbacks;
+
+			if (renderers is null)
+				return AudioUnitStatus.InvalidParameter;
 
 			if (renderers.Count != 0) {
 				using (var buffers = new AudioBuffers (_ioData)) {
@@ -194,21 +193,20 @@ namespace AudioUnit
 
 		public void Open ()
 		{ 
-			int err = AUGraphOpen (handle);
+			int err = AUGraphOpen (Handle);
 			if (err != 0)
 				throw new InvalidOperationException (String.Format ("Cannot open AUGraph. Error code: {0}", err));
 		}
 
 		public int TryOpen ()
 		{ 
-			int err = AUGraphOpen (handle);
+			int err = AUGraphOpen (Handle);
 			return err;
 		}
 		
 		public int AddNode (AudioComponentDescription description)
 		{
-			int node;
-			var err = AUGraphAddNode (handle, ref description, out node);
+			var err = AUGraphAddNode (Handle, ref description, out var node);
 			if (err != 0)
 				throw new ArgumentException (String.Format ("Error code: {0}", err));
 			
@@ -217,27 +215,27 @@ namespace AudioUnit
 
 		public AUGraphError RemoveNode (int node)
 		{
-			return AUGraphRemoveNode (handle, node);
+			return AUGraphRemoveNode (Handle, node);
 		}
 
 		public AUGraphError GetCPULoad (out float averageCPULoad)
 		{
-			return AUGraphGetCPULoad (handle, out averageCPULoad);
+			return AUGraphGetCPULoad (Handle, out averageCPULoad);
 		}
 
 		public AUGraphError GetMaxCPULoad (out float maxCPULoad)
 		{
-			return AUGraphGetMaxCPULoad (handle, out maxCPULoad);
+			return AUGraphGetMaxCPULoad (Handle, out maxCPULoad);
 		}
 
 		public AUGraphError GetNode (uint index, out int node)
 		{
-			return AUGraphGetIndNode (handle, index, out node);
+			return AUGraphGetIndNode (Handle, index, out node);
 		}
 
 		public AUGraphError GetNodeCount (out int count)
 		{
-			return AUGraphGetNodeCount (handle, out count);
+			return AUGraphGetNodeCount (Handle, out count);
 		}
 		
 		public AudioUnit GetNodeInfo (int node)
@@ -248,19 +246,15 @@ namespace AudioUnit
 			if (error != AUGraphError.OK)
 				throw new ArgumentException (String.Format ("Error code:{0}", error));
 
-			if (unit == null)
+			if (unit is null)
 				throw new InvalidOperationException ("Can not get object instance");
 
 			return unit;
 		}
 
-		public AudioUnit GetNodeInfo (int node, out AUGraphError error)
+		public AudioUnit? GetNodeInfo (int node, out AUGraphError error)
 		{
-			if (Handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("AUGraph");
-
-			IntPtr ptr;
-			error = AUGraphNodeInfo (handle, node, IntPtr.Zero, out ptr);
+			error = AUGraphNodeInfo (GetCheckedHandle (), node, IntPtr.Zero, out var ptr);
 
 			if (error != AUGraphError.OK || ptr == IntPtr.Zero)
 				return null;
@@ -270,13 +264,9 @@ namespace AudioUnit
 
 		// AudioComponentDescription struct in only correctly fixed for unified
 		// Following current Api behaviour of returning an AudioUnit instead of an error
-		public AudioUnit GetNodeInfo (int node, out AudioComponentDescription cd, out AUGraphError error)
+		public AudioUnit? GetNodeInfo (int node, out AudioComponentDescription cd, out AUGraphError error)
 		{
-			if (Handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("AUGraph");
-
-			IntPtr ptr;
-			error = AUGraphNodeInfo (Handle, node, out cd, out ptr);
+			error = AUGraphNodeInfo (GetCheckedHandle (), node, out cd, out var ptr);
 
 			if (error != AUGraphError.OK || ptr == IntPtr.Zero)
 				return null;
@@ -286,12 +276,12 @@ namespace AudioUnit
 
 		public AUGraphError GetNumberOfInteractions (out uint interactionsCount)
 		{
-			return AUGraphGetNumberOfInteractions (handle, out interactionsCount);
+			return AUGraphGetNumberOfInteractions (Handle, out interactionsCount);
 		}
 
 		public AUGraphError GetNumberOfInteractions (int node, out uint interactionsCount)
 		{
-			return AUGraphCountNodeInteractions (handle, node, out interactionsCount);
+			return AUGraphCountNodeInteractions (Handle, node, out interactionsCount);
 		}
 
 /*
@@ -311,22 +301,22 @@ namespace AudioUnit
 */
 		public AUGraphError ConnnectNodeInput (int sourceNode, uint sourceOutputNumber, int destNode, uint destInputNumber)
 		{
-			return AUGraphConnectNodeInput (handle,
+			return AUGraphConnectNodeInput (Handle,
 							  sourceNode, sourceOutputNumber,                                    
 							  destNode, destInputNumber);
 		}
 
 		public AUGraphError DisconnectNodeInput (int destNode, uint destInputNumber)
 		{
-			return AUGraphDisconnectNodeInput (handle, destNode, destInputNumber);
+			return AUGraphDisconnectNodeInput (Handle, destNode, destInputNumber);
 		}
 
-		Dictionary<uint, RenderDelegate> nodesCallbacks;
+		Dictionary<uint, RenderDelegate>? nodesCallbacks;
 		static readonly CallbackShared CreateRenderCallback = RenderCallbackImpl;
 
 		public AUGraphError SetNodeInputCallback (int destNode, uint destInputNumber, RenderDelegate renderDelegate)
 		{
-			if (nodesCallbacks == null)
+			if (nodesCallbacks is null)
 				nodesCallbacks = new Dictionary<uint, RenderDelegate> ();
 
 			nodesCallbacks [destInputNumber] = renderDelegate;
@@ -334,17 +324,19 @@ namespace AudioUnit
 			var cb = new AURenderCallbackStruct ();
 			cb.Proc = CreateRenderCallback;
 			cb.ProcRefCon = GCHandle.ToIntPtr (gcHandle);
-			return AUGraphSetNodeInputCallback (handle, destNode, destInputNumber, ref cb);
+			return AUGraphSetNodeInputCallback (Handle, destNode, destInputNumber, ref cb);
 		}
 
 		[MonoPInvokeCallback (typeof (CallbackShared))]
 		static AudioUnitStatus RenderCallbackImpl (IntPtr clientData, ref AudioUnitRenderActionFlags actionFlags, ref AudioTimeStamp timeStamp, uint busNumber, uint numberFrames, IntPtr data)
 		{
 			GCHandle gch = GCHandle.FromIntPtr (clientData);
-			var au = (AUGraph) gch.Target;
+			var au = gch.Target as AUGraph;
 
-			RenderDelegate callback;
-			if (!au.nodesCallbacks.TryGetValue (busNumber, out callback))
+			if (au?.nodesCallbacks is null)
+				return AudioUnitStatus.InvalidParameter;
+
+			if (!au.nodesCallbacks.TryGetValue (busNumber, out var callback))
 				return AudioUnitStatus.InvalidParameter;
 
 			using (var buffers = new AudioBuffers (data)) {
@@ -354,28 +346,27 @@ namespace AudioUnit
 
 		public AUGraphError ClearConnections ()
 		{
-			return AUGraphClearConnections (handle);
+			return AUGraphClearConnections (Handle);
 		}
 
 		public AUGraphError Start()
 		{
-			return AUGraphStart (handle);
+			return AUGraphStart (Handle);
 		}
 
 		public AUGraphError Stop()
 		{
-			return AUGraphStop (handle);
+			return AUGraphStop (Handle);
 		}
 		
 		public AUGraphError Initialize()
 		{
-			return AUGraphInitialize (handle);
+			return AUGraphInitialize (Handle);
 		}
 
 		public bool Update ()
 		{
-			bool isUpdated;
-			return AUGraphUpdate (handle, out isUpdated) == AUGraphError.OK && isUpdated;
+			return AUGraphUpdate (Handle, out var isUpdated) == AUGraphError.OK && isUpdated;
 		}
 
 		// Quote from Learning CoreAudio Book:
@@ -383,10 +374,7 @@ namespace AudioUnit
 		// along with the connections between them and the stream format used in each of those connections
 		public void LogAllNodes ()
 		{
-			if (Handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("AUGraph");
-			
-			CAShow (Handle);
+			CAShow (GetCheckedHandle ());
 		}
 
 		public void Dispose()
@@ -397,23 +385,32 @@ namespace AudioUnit
 
 		protected virtual void Dispose (bool disposing)
 		{
-			if (handle != IntPtr.Zero){
-				AUGraphUninitialize (handle);
-				AUGraphClose (handle);
-				DisposeAUGraph (handle);
-				
-				gcHandle.Free();
-				handle = IntPtr.Zero;
+			if (Handle != IntPtr.Zero && owns) {
+				AUGraphUninitialize (Handle);
+				AUGraphClose (Handle);
+				DisposeAUGraph (Handle);
 			}
+
+			if (gcHandle.IsAllocated)
+				gcHandle.Free ();
+
+			handle = IntPtr.Zero;
 		}
 
 		~AUGraph ()
 		{
 			Dispose (false);
 		}
+
+		IntPtr GetCheckedHandle ()
+		{
+			if (handle == IntPtr.Zero)
+				ObjCRuntime.ThrowHelper.ThrowObjectDisposedException (this);
+			return handle;
+		}
 			
 		[DllImport(Constants.AudioToolboxLibrary, EntryPoint = "NewAUGraph")]
-		static extern int /* OSStatus */ NewAUGraph(ref IntPtr outGraph);
+		static extern int /* OSStatus */ NewAUGraph (out IntPtr outGraph);
 
 		[DllImport(Constants.AudioToolboxLibrary, EntryPoint = "AUGraphOpen")]
 		static extern int /* OSStatus */ AUGraphOpen(IntPtr inGraph);


### PR DESCRIPTION
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.
* Use the 'Handle' property instead of accessing the private 'handle' field.
* Fix ownership logic: we can't call CFRetain on this type, but we can keep
  track of whether we own it or not.
* Call 'GetCheckedHandle ()' (which will throw an ObjectDisposedException if
  Handle == IntPtr.Zero) instead of manually checking for IntPtr.Zero and
  throwing ObjectDisposedException.