### PR TITLE
[Class] Enable nullability + fix a few code updates.

### DIFF
--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -70,11 +70,7 @@ namespace ObjCRuntime {
 			this.handle = GetClassHandle (type);
 		}
 
-#if NET
-		internal Class (IntPtr handle)
-#else
 		public Class (IntPtr handle)
-#endif
 		{
 			this.handle = handle;
 		}

--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -7,6 +7,8 @@
 
 // #define LOG_TYPELOAD
 
+#nullable enable
+
 using System;
 using System.Reflection;
 using System.Collections.Generic;
@@ -24,13 +26,15 @@ namespace ObjCRuntime {
 #endif
 	{
 #if !COREBUILD
+		IntPtr handle;
+
 		public static bool ThrowOnInitFailure = true;
 
 		// We use the last significant bit of the IntPtr to store if this is a custom class or not.
+#pragma warning disable CS8618 // "Non-nullable field must contain a non-null value when exiting constructor." - we ensure these fields are non-null in other ways
 		static Dictionary<Type, IntPtr> type_to_class; // accessed from multiple threads, locking required.
-		static Type[] class_to_type;
-
-		internal IntPtr handle;
+		static Type?[] class_to_type;
+#pragma warning restore CS8618
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		internal unsafe static void Initialize (Runtime.InitializationOptions* options)
@@ -38,10 +42,10 @@ namespace ObjCRuntime {
 			type_to_class = new Dictionary<Type, IntPtr> (Runtime.TypeEqualityComparer);
 
 			var map = options->RegistrationMap;
-			if (map == null)
+			if (map is null)
 				return;
 
-			class_to_type = new Type [map->map_count];
+			class_to_type = new Type? [map->map_count];
 
 			if (!Runtime.DynamicRegistrationSupported)
 				return; // Only the dynamic registrar needs the list of registered assemblies.
@@ -66,21 +70,24 @@ namespace ObjCRuntime {
 			this.handle = GetClassHandle (type);
 		}
 
+#if NET
+		internal Class (IntPtr handle)
+#else
 		public Class (IntPtr handle)
+#endif
 		{
 			this.handle = handle;
 		}
 
 		[Preserve (Conditional = true)]
+#if NET
+		internal Class (IntPtr handle, bool owns)
+#else
 		public Class (IntPtr handle, bool owns)
+#endif
 		{
 			// Class(es) can't be freed, so we ignore the 'owns' parameter.
 			this.handle = handle;
-		}
-
-		internal static Class Construct (IntPtr handle) 
-		{
-			return new Class (handle);
 		}
 
 		public IntPtr Handle {
@@ -88,12 +95,12 @@ namespace ObjCRuntime {
 		}
 
 		public IntPtr SuperClass {
-			get { return class_getSuperclass (handle); }
+			get { return class_getSuperclass (Handle); }
 		}
 
-		public unsafe string Name {
+		public string? Name {
 			get {
-				IntPtr ptr = class_getName (this.handle);
+				var ptr = class_getName (Handle);
 				return Marshal.PtrToStringAuto (ptr);
 			}
 		}
@@ -103,22 +110,22 @@ namespace ObjCRuntime {
 			return objc_getClass (name);
 		}
 
-		public override bool Equals (object right)
+		public override bool Equals (object? right)
 		{
 			return Equals (right as Class);
 		}
 
-		public bool Equals (Class right)
+		public bool Equals (Class? right)
 		{
-			if (right == null)
+			if (right is null)
 				return false;
 
-			return handle == right.handle;
+			return Handle == right.Handle;
 		}
 
 		public override int GetHashCode ()
 		{
-			return handle.GetHashCode ();
+			return Handle.GetHashCode ();
 		}
 
 		// This method is treated as an intrinsic operation by
@@ -186,35 +193,38 @@ namespace ObjCRuntime {
 			return Messaging.IntPtr_objc_msgSend (obj, Selector.GetHandle (Selector.Class));
 		}
 
-		internal static string LookupFullName (IntPtr klass)
+		internal static string? LookupFullName (IntPtr klass)
 		{
-			Type type = Lookup (klass);
-			return type == null ? null : type.FullName;
+			var type = Lookup (klass);
+			return type?.FullName;
 		}
 
-		public static Type Lookup (Class @class)
+		public static Type? Lookup (Class? @class)
 		{
-			return Lookup (@class.Handle, true);
+			if (@class is null)
+				return null;
+
+			return Lookup (@class.Handle, true)!;
 		}
 
 		internal static Type Lookup (IntPtr klass)
 		{
-			return LookupClass (klass, true);
+			return LookupClass (klass, true)!;
 		}
 
-		internal static Type Lookup (IntPtr klass, bool throw_on_error)
+		internal static Type? Lookup (IntPtr klass, bool throw_on_error)
 		{
 			return LookupClass (klass, throw_on_error);
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)] // To inline the Runtime.DynamicRegistrationSupported code if possible.
-		static Type LookupClass (IntPtr klass, bool throw_on_error)
+		static Type? LookupClass (IntPtr klass, bool throw_on_error)
 		{
 			bool is_custom_type;
 			var find_class = klass;
 			do {
 				var tp = FindType (find_class, out is_custom_type);
-				if (tp != null)
+				if (tp is not null)
 					return tp;
 				if (Runtime.DynamicRegistrationSupported)
 					break; // We can't continue looking up the hierarchy if we have the dynamic registrar, because we might be supposed to register this class.
@@ -243,7 +253,7 @@ namespace ObjCRuntime {
 
 			is_custom_type = false;
 
-			if (map == null) {
+			if (map is null) {
 				// Using only the dynamic registrar
 				return IntPtr.Zero;
 			}
@@ -290,7 +300,7 @@ namespace ObjCRuntime {
 			return IntPtr.Zero;
 		}
 
-		unsafe static bool CompareTokenReference (string asm_name, int mod_token, int type_token, uint token_reference)
+		unsafe static bool CompareTokenReference (string? asm_name, int mod_token, int type_token, uint token_reference)
 		{
 			var map = Runtime.options->RegistrationMap;
 			IntPtr assembly_name;
@@ -341,13 +351,13 @@ namespace ObjCRuntime {
 			return -1;
 		}
 
-		internal unsafe static Type FindType (IntPtr @class, out bool is_custom_type)
+		internal unsafe static Type? FindType (IntPtr @class, out bool is_custom_type)
 		{
 			var map = Runtime.options->RegistrationMap;
 
 			is_custom_type = false;
 
-			if (map == null) {
+			if (map is null) {
 #if LOG_TYPELOAD
 				Console.WriteLine ($"FindType (0x{@class:X} = {Marshal.PtrToStringAuto (class_getName (@class))}) => found no map.");
 #endif
@@ -365,8 +375,8 @@ namespace ObjCRuntime {
 
 			is_custom_type = (map->map [mapIndex].flags & Runtime.MTTypeFlags.CustomType) == Runtime.MTTypeFlags.CustomType;
 
-			Type type = class_to_type [mapIndex];
-			if (type != null)
+			var type = class_to_type [mapIndex];
+			if (type is not null)
 				return type;
 
 			// Resolve the map entry we found to a managed type
@@ -382,7 +392,7 @@ namespace ObjCRuntime {
 			return type;
 		}
 
-		internal unsafe static MemberInfo ResolveFullTokenReference (uint token_reference)
+		internal unsafe static MemberInfo? ResolveFullTokenReference (uint token_reference)
 		{
 			// sizeof (MTFullTokenReference) = IntPtr.Size + 4 + 4
 			var entry = Runtime.options->RegistrationMap->full_token_references + (IntPtr.Size + 8) * (int) (token_reference >> 1);
@@ -399,10 +409,10 @@ namespace ObjCRuntime {
 			return ResolveToken (module, token);
 		}
 
-		internal static Type ResolveTypeTokenReference (uint token_reference)
+		internal static Type? ResolveTypeTokenReference (uint token_reference)
 		{
 			var member = ResolveTokenReference (token_reference, 0x02000000 /* TypeDef */);
-			if (member == null)
+			if (member is null)
 				return null;
 			if (member is Type type)
 				return type;
@@ -410,10 +420,10 @@ namespace ObjCRuntime {
 			throw ErrorHelper.CreateError (8022, $"Expected the token reference 0x{token_reference:X} to be a type, but it's a {member.GetType ().Name}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new.");
 		}
 
-		internal static MethodBase ResolveMethodTokenReference (uint token_reference)
+		internal static MethodBase? ResolveMethodTokenReference (uint token_reference)
 		{
 			var member = ResolveTokenReference (token_reference, 0x06000000 /* Method */);
-			if (member == null)
+			if (member is null)
 				return null;
 			if (member is MethodBase method)
 				return method;
@@ -421,7 +431,7 @@ namespace ObjCRuntime {
 			throw ErrorHelper.CreateError (8022, $"Expected the token reference 0x{token_reference:X} to be a method, but it's a {member.GetType ().Name}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new.");
 		}
 
-		unsafe static MemberInfo ResolveTokenReference (uint token_reference, uint implicit_token_type)
+		unsafe static MemberInfo? ResolveTokenReference (uint token_reference, uint implicit_token_type)
 		{
 			var map = Runtime.options->RegistrationMap;
 
@@ -442,7 +452,7 @@ namespace ObjCRuntime {
 			return ResolveToken (module, token | implicit_token_type);
 		}
 
-		static MemberInfo ResolveToken (Module module, uint token)
+		static MemberInfo? ResolveToken (Module module, uint token)
 		{
 			// Finally resolve the token.
 			var token_type = token & 0xFF000000;
@@ -543,7 +553,7 @@ namespace ObjCRuntime {
 		}
 
 		// Look for the specified metadata token in the table of full token references.
-		static unsafe uint GetFullTokenReference (string assembly_name, int module_token, int metadata_token)
+		static unsafe uint GetFullTokenReference (string? assembly_name, int module_token, int metadata_token)
 		{
 			var map = Runtime.options->RegistrationMap;
 			for (int i = 0; i < map->full_token_reference_count; i++) {

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -770,7 +770,7 @@ namespace ObjCRuntime {
 			 * This method is called from generated code from the static registrar.
 			 */
 
-			var iface = Class.ResolveTypeTokenReference (iface_token);
+			var iface = Class.ResolveTypeTokenReference (iface_token)!;
 			var type = Class.ResolveTypeTokenReference (implementation_token);
 			return AllocGCHandle (GetINativeObject (ptr, owns, iface, type));
 		}
@@ -1790,8 +1790,14 @@ namespace ObjCRuntime {
 		// This function will try to compare a native UTF8 string to a managed string without creating a temporary managed string for the native UTF8 string.
 		// Currently this only works if the UTF8 string only contains single-byte characters.
 		// If any multi-byte characters are found, the native utf8 string is converted to a managed string, and then normal managed comparison is done.
-		internal static bool StringEquals (IntPtr utf8, string str)
+		internal static bool StringEquals (IntPtr utf8, string? str)
 		{
+			if (str is null)
+				return utf8 == IntPtr.Zero;
+
+			if (utf8 == IntPtr.Zero)
+				return false;
+
 			// The vast majority of strings we compare fall within the single-byte UTF8 range, so optimize for this
 			unsafe {
 				byte* c = (byte*) utf8;

--- a/src/gameplaykit.cs
+++ b/src/gameplaykit.cs
@@ -279,7 +279,7 @@ namespace GameplayKit {
 		Class GetClassForGenericArgument (nuint index);
 
 		[iOS (10,0), TV (10,0), Mac (10,12)]
-		[Wrap ("Class.Lookup (GetClassForGenericArgument (index))")]
+		[Wrap ("Class.Lookup (GetClassForGenericArgument (index))!")]
 		Type GetTypeForGenericArgument (nuint index);
 	}
 
@@ -627,7 +627,7 @@ namespace GameplayKit {
 		Class GetClassForGenericArgument (nuint index);
 
 		[iOS (10,0), TV (10,0), Mac (10,12)]
-		[Wrap ("Class.Lookup (GetClassForGenericArgument (index))")]
+		[Wrap ("Class.Lookup (GetClassForGenericArgument (index))!")]
 		Type GetTypeForGenericArgument (nuint index);
 	}
 
@@ -699,7 +699,7 @@ namespace GameplayKit {
 		Class GetClassForGenericArgument (nuint index);
 
 		[iOS (10,0), TV (10,0), Mac (10,12)]
-		[Wrap ("Class.Lookup (GetClassForGenericArgument (index))")]
+		[Wrap ("Class.Lookup (GetClassForGenericArgument (index))!")]
 		Type GetTypeForGenericArgument (nuint index);
 	}
 
@@ -764,7 +764,7 @@ namespace GameplayKit {
 		[Export ("classForGenericArgumentAtIndex:")]
 		Class GetClassForGenericArgument (nuint index);
 
-		[Wrap ("Class.Lookup (GetClassForGenericArgument (index))")]
+		[Wrap ("Class.Lookup (GetClassForGenericArgument (index))!")]
 		Type GetTypeForGenericArgument (nuint index);
 	}
 

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -20085,7 +20085,7 @@ namespace UIKit {
 		Class SceneClass { get; set; }
 
 		Type SceneType {
-			[Wrap ("Class.Lookup (SceneClass)")] get;
+			[Wrap ("Class.Lookup (SceneClass)!")] get;
 			[Wrap ("SceneClass = value is null ? null : new Class (value)")] set;
 		}
 
@@ -20094,7 +20094,7 @@ namespace UIKit {
 		Class DelegateClass { get; set; }
 
 		Type DelegateType {
-			[Wrap ("Class.Lookup (DelegateClass)")] get;
+			[Wrap ("Class.Lookup (DelegateClass)!")] get;
 			[Wrap ("DelegateClass = value is null ? null : new Class (value)")] set;
 		}
 


### PR DESCRIPTION
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.
* Make the 'handle' field private.
* Remove the (IntPtr) constructor for .NET
* Make the (IntPtr, bool) constructor internal for .NET
* Remove unused 'Construct' method.