### PR TITLE
[CI] Do not set the stage to failure on mac tests fails.

### DIFF
--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -203,7 +203,7 @@ steps:
       Set-GitHubStatus -Status "success" -Description "Tests passed Xamarin.Mac tests on macOS $Env:CONTEXT passed." -Context "$Env:CONTEXT"
       $request = New-GitHubComment -Header "Tests passed on macOS $Env:CONTEXT" -Description "Tests passed" -Message "**All** tests on macOS X $Env:CONTEXT passed." -Emoji ":white_check_mark:"
     }
-    # wwe set the result to 0, the reason is that release pipelines do not like failing tests,
+    # we set the result to 0, the reason is that release pipelines do not like failing tests,
     # yet we do have some  flacky ones, this will allow the release to run. The comment will let use know that we failed
     exit 0  
   displayName: 'Run tests'

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -199,11 +199,13 @@ steps:
           $msg.AppendLine("* $test")
       }
       $request = New-GitHubComment -Header "Tests failed on macOS $Env:CONTEXT" -Description "Tests failed on $Env:CONTEXT." -Message $msg.ToString() -Emoji ":x:"
-      exit 1
     } else {
       Set-GitHubStatus -Status "success" -Description "Tests passed Xamarin.Mac tests on macOS $Env:CONTEXT passed." -Context "$Env:CONTEXT"
       $request = New-GitHubComment -Header "Tests passed on macOS $Env:CONTEXT" -Description "Tests passed" -Message "**All** tests on macOS X $Env:CONTEXT passed." -Emoji ":white_check_mark:"
     }
+    # wwe set the result to 0, the reason is that release pipelines do not like failing tests,
+    # yet we do have some  flacky ones, this will allow the release to run. The comment will let use know that we failed
+    exit 0  
   displayName: 'Run tests'
   env:
     CONTEXT: ${{ parameters.statusContext }}


### PR DESCRIPTION
We want to use release pipelines but they do not like failing tests. In
device tests we set those in the pipeline to green yet we add a comment,
we do the same with the mac tests.