### PR TITLE
[AppKit] Remove NSEventSubtype from Mac Catalyst.

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -753,6 +753,7 @@ namespace AppKit {
 		ModeSwitch     = 0xF747
 	}
 
+	[NoMacCatalyst]
 #if !NET
 	[Native]
 	public enum NSEventSubtype : ulong {


### PR DESCRIPTION
Fixes this xtro failure:

> !unknown-native-enum! NSEventSubtype bound

Fixes https://github.com/xamarin/maccore/issues/2528.