### PR TITLE
[AudioToolbox] AudioConverter.FillComplexBuffer doesn't return a nullable value.

### DIFF
--- a/src/AudioToolbox/AudioConverter.cs
+++ b/src/AudioToolbox/AudioConverter.cs
@@ -503,7 +503,7 @@ namespace AudioToolbox
 			return FillComplexBuffer (ref outputDataPacketSize, outputData, packetDescription, new Tuple<AudioConverter, AudioConverterComplexInputData?> (this, newInputDataHandler));
 		}
 
-		public AudioConverterError? FillComplexBuffer (ref int outputDataPacketSize,
+		public AudioConverterError FillComplexBuffer (ref int outputDataPacketSize,
 			AudioBuffers outputData, AudioStreamPacketDescription[] packetDescription)
 		{
 			if (outputData is null)


### PR DESCRIPTION
Fixes this unintended breaking API change:

```diff
 Type Changed: AudioToolbox.AudioConverter

-public AudioConverterError FillComplexBuffer (ref int outputDataPacketSize, AudioBuffers outputData, AudioStreamPacketDescription[] packetDescription);
+public AudioConverterError? FillComplexBuffer (ref int outputDataPacketSize, AudioBuffers outputData, AudioStreamPacketDescription[] packetDescription);
```