### PR TITLE
[api-diff] Bump to latest stable (xcode13.1 branch) + add support for different reference api urls for legacy iOS and Mac.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -36,7 +36,8 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 
 include $(TOP)/Make.versions
 
-APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/xcode12.5/ab40b131d3e87a96c3414447dcded5fec45bce36/4679032/package/bundle.zip
+APIDIFF_REFERENCES_iOS=https://bosstoragemirror.blob.core.windows.net/wrench/xcode13.1/8fd9e62891f8e4fbaa040cdfbf8b96467060c85c/5371501/package/bundle.zip
+APIDIFF_REFERENCES_Mac=https://bosstoragemirror.blob.core.windows.net/wrench/xcode13.1/8fd9e62891f8e4fbaa040cdfbf8b96467060c85c/5371501/package/bundle.zip
 APIDIFF_REFERENCES_DOTNET_iOS=https://bosstoragemirror.blob.core.windows.net/wrench/main/3c2c3d062daedd66ccd06ecb68192767ddf8e3c4/5315390/package/bundle.zip
 APIDIFF_REFERENCES_DOTNET_tvOS=https://bosstoragemirror.blob.core.windows.net/wrench/main/3c2c3d062daedd66ccd06ecb68192767ddf8e3c4/5315390/package/bundle.zip
 APIDIFF_REFERENCES_DOTNET_macOS=https://bosstoragemirror.blob.core.windows.net/wrench/main/3c2c3d062daedd66ccd06ecb68192767ddf8e3c4/5315390/package/bundle.zip

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ However, we provide links to older Xamarin.iOS and Mac packages for macOS downgr
 
 | Version | Xamarin.iOS       | Xamarin.Mac       |
 |---------|-------------------|-------------------|
+| d16.11 (Xcode 13.1) | [15.2.0.1][30]   | [8.2.0.1][33]    |
+| d16.11 (Xcode 13.0) | [15.0.0.6][29]   | N/A              |
+| d16.10              | [14.20.0.24][31] | [7.14.0.27][32]  |
 | d16.9 (Xcode 12.5)  | [14.16.0.5][27]  | [7.10.0.5][28]   |
 | d16.9               | [14.14.2.5][25]  | [7.8.2.5][26]    |
 | d16.8 (Xcode 12.4)  | [14.10.0.4][23]  | [7.4.0.10][24]   |
@@ -91,3 +94,9 @@ Licensed under the [MIT](https://github.com/xamarin/xamarin-macios/blob/main/LIC
 [26]: https://download.visualstudio.microsoft.com/download/pr/03bd1f2d-5b2a-4b65-8a7b-91da84bd241c/ed062e57143e80070fee1366105a30a6/xamarin.mac-7.8.2.5.pkg
 [27]: https://download.visualstudio.microsoft.com/download/pr/e12e515d-da12-410b-acac-dd564a090b60/d0df6c6cfb219ebc3584bccc30e25bc5/xamarin.ios-14.16.0.5.pkg
 [28]: https://download.visualstudio.microsoft.com/download/pr/e12e515d-da12-410b-acac-dd564a090b60/7537c3cefef02568099b29c1aa7e88a9/xamarin.mac-7.10.0.5.pkg
+[29]: https://download.visualstudio.microsoft.com/download/pr/cddb0c4f-a69c-42a3-bb23-085e48d17af4/a8fb52485eb5e99aeb4edcaf35182231/xamarin.ios-15.0.0.6.pkg
+[30]: https://download.visualstudio.microsoft.com/download/pr/b51d2f25-e4e9-4032-9cfa-152f6e4b01c6/3a74b819968b58792f05efaf11f82c3b/xamarin.ios-15.2.0.1.pkg
+[31]: https://download.visualstudio.microsoft.com/download/pr/4725e1ed-6254-4880-a410-c120d95a814c/70aa4394b2bf0636c8bd2bb9db73d759/xamarin.ios-14.20.0.24.pkg
+[32]: https://download.visualstudio.microsoft.com/download/pr/cddb0c4f-a69c-42a3-bb23-085e48d17af4/ca7547ae1b83548823e23a06d9960f47/xamarin.mac-7.14.0.27.pkg
+[33]: https://download.visualstudio.microsoft.com/download/pr/b51d2f25-e4e9-4032-9cfa-152f6e4b01c6/f5d46401aa91c68fe6b9d2f520116331/xamarin.mac-8.2.0.1.pkg
+

--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -316,60 +316,75 @@ endif # ENABLE_DOTNET
 
 all-local:: $(APIDIFF_DIR)/api-diff.html
 
-# Rules to re-create the reference infos from the current stable 'bundle.zip. assemblies
+# Rules to re-create the reference infos from the current stable 'bundle.zip' assemblies
 
-# split the URL in words based on the path separator, and then chose the 6th word (the hash) in the bundle zip filename
-APIDIFF_HASH ?= $(word 6,$(subst /, ,$(APIDIFF_REFERENCES)))
-BUNDLE_ZIP ?= $(APIDIFF_DIR)/bundle-$(APIDIFF_HASH).zip
-$(BUNDLE_ZIP):
-	# download to a temporary filename so interrupted downloads won't prevent re-downloads.
-	$(Q) if test -f ~/Library/Caches/xamarin-macios/$(notdir $@); then \
-		echo "Found a cached version of $(APIDIFF_REFERENCES)) in ~/Library/Caches/xamarin-macios/$(notdir $@)."; \
-		$(CP) ~/Library/Caches/xamarin-macios/$(notdir $@) $@.tmp; \
-	else \
-		curl -L $(APIDIFF_REFERENCES) > $@.tmp; \
-	fi
-	$(Q) mv $@.tmp $@
+# First download the bundle zips we need. Multiple platforms may (or may not) share the same bundle.zip (with the same url),
+# so account for that and only download each bundle.zip once.
+APIDIFF_URLS=$(APIDIFF_REFERENCES_iOS) $(APIDIFF_REFERENCES_Mac) $(foreach platform,$(DOTNET_PLATFORMS),$(APIDIFF_REFERENCES_DOTNET_$(platform)))
+APIDIFF_UNIQUE_URLS=$(sort $(APIDIFF_URLS))
+APIDIFF_UNIQUE_HASHES=$(foreach url,$(APIDIFF_UNIQUE_URLS),$(word 5,$(subst /, ,$(url))))
 
-UNZIP_STAMP=$(APIDIFF_DIR)/.unzip.$(APIDIFF_HASH).stamp
-UNZIP_DIR=temp/downloads/$(APIDIFF_HASH)
-$(UNZIP_STAMP): $(BUNDLE_ZIP)
-	$(Q) rm -Rf $(UNZIP_DIR)
-	$(Q) mkdir -p $(dir $(UNZIP_DIR))
-	$(Q_GEN) unzip -q -d $(UNZIP_DIR) $(BUNDLE_ZIP)
-	$(Q) touch $@
-
-# the semi-colon at the end means an empty recipe, and is required for make to consider pattern rules
-$(UNZIP_DIR)/%.dll: $(UNZIP_STAMP) ;
-
-# # The dotnet bundles can come from different urls, so unzip them separately.
-# # However, if the hash the urls contain are the same, reuse that hash's zip file
-define DotNetUnzipBundle
-APIDIFF_HASH_DOTNET_$(1) ?= $$(word 6,$$(subst /, ,$$(APIDIFF_REFERENCES_DOTNET_$(1))))
-BUNDLE_ZIP_DOTNET_$(1) ?= $$(APIDIFF_DIR)/bundle-$$(APIDIFF_HASH_DOTNET_$(1)).zip
-$$(BUNDLE_ZIP_DOTNET_$(1)):
-	# download to a temporary filename so interrupted downloads won't prevent re-downloads.
+define DownloadBundle
+BUNDLE_ZIP_$(1)=$(APIDIFF_DIR)/bundle-$(1).zip
+BUNDLE_ZIP_$(1)_URL=$(shell echo $(APIDIFF_UNIQUE_URLS) | tr ' ' '\n' | grep '/$(1)/')
+$$(BUNDLE_ZIP_$(1)):
+	@# download to a temporary filename so interrupted downloads won't prevent re-downloads.
+	@echo "Downloading $$(BUNDLE_ZIP_$(1)_URL)..."
 	$$(Q) if test -f ~/Library/Caches/xamarin-macios/$$(notdir $$@); then \
-		echo "Found a cached version of $$(APIDIFF_REFERENCES_DOTNET_$(1))) in ~/Library/Caches/xamarin-macios/$$(notdir $$@)."; \
+		echo "Found a cached version of $$(notdir $$@) in ~/Library/Caches/xamarin-macios/$$(notdir $$@)."; \
 		$$(CP) ~/Library/Caches/xamarin-macios/$$(notdir $$@) $$@.tmp; \
 	else \
-		curl -L $$(APIDIFF_REFERENCES_DOTNET_$(1)) > $$@.tmp; \
+		curl -f -L $$(if $$(V),-v,-s) "$$(BUNDLE_ZIP_$(1)_URL)" --output $$@.tmp; \
+		if [[ "x$$$$MACIOS_CACHE_DOWNLOADS" != "x" ]]; then \
+			mkdir -p ~/Library/Caches/xamarin-macios/; \
+			$$(CP) $$@.tmp ~/Library/Caches/xamarin-macios/"$$(notdir $$@)"; \
+			echo "Cached the download of $$(notdir $$@) in ~/Library/Caches/xamarin-macios"; \
+		fi; \
 	fi
 	$$(Q) mv $$@.tmp $$@
 
-UNZIP_STAMP_DOTNET_$(1)=$$(APIDIFF_DIR)/.unzip.dotnet-$(1)-$$(APIDIFF_HASH_DOTNET_$(1)).stamp
-UNZIP_DIR_DOTNET_$(1)=temp/downloads/dotnet-$(1)-$$(APIDIFF_HASH_DOTNET_$(1))
-$$(UNZIP_STAMP_DOTNET_$(1)): $$(BUNDLE_ZIP_DOTNET_$(1))
-	$$(Q) rm -Rf $$(UNZIP_DIR_DOTNET_$(1))
-	$$(Q) mkdir -p $$(dir $$(UNZIP_DIR_DOTNET_$(1)))
-	$$(Q_GEN) unzip -q -d $$(UNZIP_DIR_DOTNET_$(1)) $$(BUNDLE_ZIP_DOTNET_$(1))
+BUNDLE_ZIPS+=$$(BUNDLE_ZIP_$(1))
+endef
+$(foreach hash,$(APIDIFF_UNIQUE_HASHES),$(eval $(call DownloadBundle,$(hash))))
+
+download: $(BUNDLE_ZIPS)
+
+# Here we unzip the downloaded bundle.
+define UnzipBundle
+UNZIP_STAMP_$(1)=$(APIDIFF_DIR)/.unzip.$(1).stamp
+UNZIP_DIR_$(1)=temp/downloads/$(1)
+$$(UNZIP_STAMP_$(1)): $$(BUNDLE_ZIP_$(1))
+	$$(Q) rm -Rf "$$(UNZIP_DIR_$(1))"
+	$$(Q) mkdir -p $$(dir $$(UNZIP_DIR_$(1)))
+	$$(Q_GEN) unzip $$(if $$(V),,-q) -d $$(UNZIP_DIR_$(1)) $$<
 	$$(Q) touch $$@
 
-$$(UNZIP_DIR_DOTNET_$(1))/%.dll: $$(UNZIP_STAMP_DOTNET_$(1)) ;
+# the semi-colon at the end means an empty recipe, and is required for make to consider pattern rules
+$$(UNZIP_DIR_$(1))/%.dll: $$(UNZIP_STAMP_$(1)) ;
 
+UNZIP_STAMPS+=$$(UNZIP_STAMP_$(1))
 endef
+$(foreach hash,$(APIDIFF_UNIQUE_HASHES),$(eval $(call UnzipBundle,$(hash))))
 
-$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call DotNetUnzipBundle,$(platform))))
+unzip: $(UNZIP_STAMPS)
+
+# Compute the unzip dir per platform
+APIDIFF_HASH_iOS=$(word 5,$(subst /, ,$(APIDIFF_REFERENCES_iOS)))
+UNZIP_DIR_iOS=$(UNZIP_DIR_$(APIDIFF_HASH_iOS))
+UNZIP_STAMP_iOS=$(UNZIP_STAMP_$(APIDIFF_HASH_iOS))
+APIDIFF_HASH_Mac=$(word 5,$(subst /, ,$(APIDIFF_REFERENCES_Mac)))
+UNZIP_DIR_Mac=$(UNZIP_DIR_$(APIDIFF_HASH_Mac))
+UNZIP_STAMP_Mac=$(UNZIP_STAMP_$(APIDIFF_HASH_Mac))
+
+define DotNetUnzipDirectory
+APIDIFF_HASH_DOTNET_$(1)=$$(word 5,$$(subst /, ,$$(APIDIFF_REFERENCES_DOTNET_$(1))))
+UNZIP_DIR_DOTNET_$(1)=$$(UNZIP_DIR_$$(APIDIFF_HASH_DOTNET_$(1)))
+endef
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call DotNetUnzipDirectory,$(platform))))
+
+# the semi-colon at the end means an empty recipe, and is required for make to consider pattern rules
+$(UNZIP_DIR_Mac)/%.dll: $(UNZIP_STAMP_Mac) ;
+$(UNZIP_DIR_iOS)/%.dll: $(UNZIP_STAMP_iOS) ;
 
 IOS_REFS     = $(foreach file,$(IOS_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/xi/$(file).xml)
 MAC_REFS     = $(foreach file,$(MAC_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/xm/$(file).xml)
@@ -378,7 +393,7 @@ TVOS_REFS    = $(foreach file,$(TVOS_ASSEMBLIES),$(APIDIFF_DIR)/updated-referenc
 MACCATALYST_REFS = $(foreach file,$(MACCATALYST_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/xi/$(file).xml)
 DOTNET_REFS = $(foreach file,$(DOTNET_ASSEMBLIES_MACCATALYST_IOS),$(APIDIFF_DIR)/updated-references/dotnet/$(file).xml)
 
-$(APIDIFF_DIR)/references/xi/%.xml: $(UNZIP_DIR)/%.dll $(MONO_API_INFO)
+$(APIDIFF_DIR)/references/xi/%.xml: $(UNZIP_DIR_iOS)/%.dll $(MONO_API_INFO)
 	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/xi/$*)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $(APIDIFF_DIR)/references/xi/$*.xml
 
@@ -386,7 +401,7 @@ $(APIDIFF_DIR)/updated-references/xi/%.xml: $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/li
 	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/xi/$*)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $(APIDIFF_DIR)/references/xi/$*.xml
 
-$(APIDIFF_DIR)/references/xm/%.xml: $(UNZIP_DIR)/%.dll $(MONO_API_INFO)
+$(APIDIFF_DIR)/references/xm/%.xml: $(UNZIP_DIR_Mac)/%.dll $(MONO_API_INFO)
 	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/xm/$*)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $(APIDIFF_DIR)/references/xm/$*.xml
 
@@ -461,7 +476,7 @@ verify-reference-assemblies-ios: $(APIDIFF_DIR)/temp/native-32/Xamarin.iOS.xml $
 
 clean-local::
 	rm -rf temp references updated-references diff dotnet *.exe* api-diff.html
-	rm -rf *.dll* bundle-*.zip $(UNZIP_STAMP) $(UNZIP_STAMP_DOTNET_iOS) $(UNZIP_STAMP_DOTNET_tvOS) $(UNZIP_STAMP_DOTNET_macOS) $(UNZIP_STAMP_DOTNET_MacCatalyst)
+	rm -rf *.dll* bundle-*.zip $(UNZIP_STAMPS)
 	rm -rf ios-*.md tvos-*.md watchos-*.md macos-*.md dotnet-*.md
 
 DIRS += $(APIDIFF_DIR)/temp $(APIDIFF_DIR)/diff
@@ -587,7 +602,7 @@ ifdef INCLUDE_MACCATALYST
 	@echo "@MonkeyWrench: AddFile: $(CURDIR)/maccat-to-ios.md"
 endif
 endif
-	$(Q) $(MAKE) $(UNZIP_STAMP) $(UNZIP_STAMP_DOTNET_iOS) $(UNZIP_STAMP_DOTNET_tvOS) $(UNZIP_STAMP_DOTNET_macOS) $(UNZIP_STAMP_DOTNET_MacCatalyst)
+	$(Q) $(MAKE) $(UNZIP_STAMPS)
 	$(Q) $(MAKE) all -j8
 	$(Q) $(MAKE) ios-markdown tvos-markdown watchos-markdown macos-markdown maccat-markdown dotnet-markdown dotnet-legacy-markdown dotnet-iOS-MacCatalyst-markdown
 	$(Q) $(CP) api-diff.html index.html


### PR DESCRIPTION
Also fix make logic to only have a single rule per hash, which avoids a few make warnings about duplicate targets.

Update README with new releases.