### PR TITLE
[CoreBluetooth] Use new availability attributes and remove API that isn't in Apple's headers from .NET.

### DIFF
--- a/src/CoreBluetooth/CBCompat.cs
+++ b/src/CoreBluetooth/CBCompat.cs
@@ -1,4 +1,4 @@
-#if !XAMCORE_4_0
+#if !NET
 using ObjCRuntime;
 using Foundation;
 using System;
@@ -45,4 +45,4 @@ namespace CoreBluetooth {
 
 #endif
 }
-#endif
+#endif // !NET

--- a/src/CoreBluetooth/CBPeer.cs
+++ b/src/CoreBluetooth/CBPeer.cs
@@ -12,14 +12,12 @@ namespace CoreBluetooth {
 #if !NET
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		[Obsoleted (PlatformName.iOS, 9, 0)]
-#else
-		[UnsupportedOSPlatform ("ios7.0")]
-#endif
 		public virtual CBUUID UUID { 
 			get {
 				return CBUUID.FromCFUUID (_UUID);	
 			}
 		}
+#endif // !NET
 	}
 }
 #endif

--- a/src/CoreBluetooth/CoreBluetooth.cs
+++ b/src/CoreBluetooth/CoreBluetooth.cs
@@ -21,7 +21,7 @@ namespace CoreBluetooth {
 		}
 	}
 
-#if !MONOMAC && !XAMCORE_3_0
+#if !MONOMAC && !NET
 	public partial class CBPeer {
 
 		[Obsolete ("This type is not meant to be created by user code.", true)]
@@ -30,7 +30,7 @@ namespace CoreBluetooth {
 		}
 	}
 #endif
-#if !WATCH && !XAMCORE_4_0
+#if !WATCH && !NET
 	public partial class CBCentralManager {
 
 		public new virtual CBCentralManagerState State {

--- a/src/CoreBluetooth/CoreBluetooth.cs
+++ b/src/CoreBluetooth/CoreBluetooth.cs
@@ -21,7 +21,7 @@ namespace CoreBluetooth {
 		}
 	}
 
-#if !MONOMAC && !NET
+#if !MONOMAC && !XAMCORE_3_0 && !NET
 	public partial class CBPeer {
 
 		[Obsolete ("This type is not meant to be created by user code.", true)]

--- a/src/CoreBluetooth/Enums.cs
+++ b/src/CoreBluetooth/Enums.cs
@@ -65,7 +65,7 @@ namespace CoreBluetooth {
 		Disconnecting,
 	}
 
-#if !XAMCORE_4_0
+#if !NET
 	// NSInteger -> CBPeripheralManager.h
 	[Watch (4,0)]
 	[Native]
@@ -75,7 +75,7 @@ namespace CoreBluetooth {
 		Denied,
 		Authorized,
 	}
-#endif
+#endif // !NET
 
 	// NSUInteger -> CBCharacteristic.h
 	[Watch (4,0)]

--- a/src/CoreBluetooth/GuidWrapper.cs
+++ b/src/CoreBluetooth/GuidWrapper.cs
@@ -30,7 +30,7 @@ namespace CoreBluetooth {
 		{
 			ConnectPeripheral (peripheral, options == null ? null : options.Dictionary);
 		}
-#if !XAMCORE_4_0 && !TVOS && !WATCH
+#if !NET && !TVOS && !WATCH
 		[Obsolete ("Always throws 'NotSupportedException' (not a public API).")]
 		public void RetrievePeripherals (CBUUID [] peripheralUuids)
 			=> throw new NotSupportedException ();

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -318,19 +318,27 @@ namespace CoreBluetooth {
 		[Export ("centralManagerDidUpdateState:")]
 		void UpdatedState (CBCentralManager central);
 
+#if !NET
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_8_4)] // Available in iOS 5.0 through iOS 8.4. Deprecated in iOS 7.0.
+		// Available in iOS 5.0 through iOS 8.4. Deprecated in iOS 7.0.
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Obsoleted (PlatformName.iOS, 8, 4)]
 		[NoMacCatalyst]
 		[Export ("centralManager:didRetrievePeripherals:"), EventArgs ("CBPeripherals")]
 		void RetrievedPeripherals (CBCentralManager central, CBPeripheral [] peripherals);
+#endif
 
+#if !NET
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_8_4)] // Available in iOS 5.0 through iOS 8.4. Deprecated in iOS 7.0.
+		// Available in iOS 5.0 through iOS 8.4. Deprecated in iOS 7.0.
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Obsoleted (PlatformName.iOS, 8, 4)]
 		[NoMacCatalyst]
 		[Export ("centralManager:didRetrieveConnectedPeripherals:"), EventArgs ("CBPeripherals")]
 		void RetrievedConnectedPeripherals (CBCentralManager central, CBPeripheral [] peripherals);
+#endif
 
 		[Export ("centralManager:didDiscoverPeripheral:advertisementData:RSSI:"), EventArgs ("CBDiscoveredPeripheral")]
 		void DiscoveredPeripheral (CBCentralManager central, CBPeripheral peripheral, NSDictionary advertisementData, NSNumber RSSI);
@@ -497,11 +505,14 @@ namespace CoreBluetooth {
 		[NullAllowed]
 		NSNumber RSSI { get;  }
 
+#if !NET
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_9_0)]
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Obsoleted (PlatformName.iOS, 9, 0)]
 		[Export ("isConnected")]
 		bool IsConnected { get;  }
+#endif
 
 		[Export ("services", ArgumentSemantic.Retain)]
 		[NullAllowed]
@@ -588,7 +599,7 @@ namespace CoreBluetooth {
 		void DiscoveredIncludedService  (CBPeripheral peripheral, CBService service, [NullAllowed] NSError error);
 
 		[Export ("peripheral:didDiscoverCharacteristicsForService:error:"), EventArgs ("CBService")]
-#if XAMCORE_4_0
+#if NET
 		void DiscoveredCharacteristics (CBPeripheral peripheral, CBService service, [NullAllowed] NSError error);
 #else
 		void DiscoveredCharacteristic (CBPeripheral peripheral, CBService service, [NullAllowed] NSError error);
@@ -612,12 +623,15 @@ namespace CoreBluetooth {
 		[Export ("peripheral:didWriteValueForDescriptor:error:"), EventArgs ("CBDescriptor")]
 		void WroteDescriptorValue (CBPeripheral peripheral, CBDescriptor descriptor, [NullAllowed] NSError error);
 
+#if !NET
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_8_4)]
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Obsoleted (PlatformName.iOS, 8, 4)]
 		[NoMacCatalyst]
 		[Export ("peripheralDidInvalidateServices:")]
 		void InvalidatedService (CBPeripheral peripheral);	
+#endif // !NET
 
 		[Export ("peripheralDidUpdateName:")]
 		void UpdatedName (CBPeripheral peripheral);
@@ -642,7 +656,7 @@ namespace CoreBluetooth {
 	interface CBService {
 		[Mac (10,9)]
 		[Export ("isPrimary")]
-#if XAMCORE_4_0
+#if NET
 		bool Primary { get; }
 #else
 		bool Primary { get; [NotImplemented ("Not available on 'CBService', only available on 'CBMutableService'.")] set; }
@@ -713,7 +727,7 @@ namespace CoreBluetooth {
 		[Export ("UUIDWithNSUUID:")]
 		CBUUID FromNSUuid (NSUuid theUUID);
 
-#if !XAMCORE_3_0
+#if !XAMCORE_3_0 && !NET
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		[Obsoleted (PlatformName.iOS, 9, 0)]
 		[Field ("CBUUIDGenericAccessProfileString")]
@@ -723,7 +737,7 @@ namespace CoreBluetooth {
 		[Obsoleted (PlatformName.iOS, 9, 0)]
 		[Field ("CBUUIDGenericAttributeProfileString")]
 		NSString GenericAttributeProfileString { get; }
-#endif
+#endif // !XAMCORE_3_0 && !NET
 
 		[Field ("CBUUIDCharacteristicExtendedPropertiesString")]
 		NSString CharacteristicExtendedPropertiesString { get; }
@@ -768,7 +782,7 @@ namespace CoreBluetooth {
 		[Field ("CBUUIDL2CAPPSMCharacteristicString")]
 		NSString L2CapPsmCharacteristicString { get; }
 
-#if !XAMCORE_3_0
+#if !XAMCORE_3_0 && !NET
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		[Obsoleted (PlatformName.iOS, 9, 0)]
 		[Field ("CBUUIDDeviceNameString")]
@@ -798,7 +812,7 @@ namespace CoreBluetooth {
 		[Obsoleted (PlatformName.iOS, 9, 0)]
 		[Field ("CBUUIDServiceChangedString")]
 		NSString ServiceChangedString { get; }
-#endif // !XAMCORE_3_0
+#endif // !XAMCORE_3_0 && !NET
 
 		[iOS (7,1)][Mac (10,10)]
 		[Export ("UUIDString")]
@@ -930,7 +944,7 @@ namespace CoreBluetooth {
 		[iOS (7,0)]
 		NSString RestoredStateAdvertisementDataKey { get; }
 
-#if !MONOMAC || !XAMCORE_4_0
+#if !NET
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'CBManager.Authorization' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'CBManager.Authorization' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'CBManager.Authorization' instead.")]
@@ -938,7 +952,7 @@ namespace CoreBluetooth {
 		[Static]
 		[Export ("authorizationStatus")]
 		CBPeripheralManagerAuthorizationStatus AuthorizationStatus { get; }
-#endif
+#endif // !NET
 	}
 
 	[Watch (4,0)]
@@ -997,13 +1011,16 @@ namespace CoreBluetooth {
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // CBPeer.h: - (instancetype)init NS_UNAVAILABLE;
 	interface CBPeer : NSCopying {
+#if !NET
 		[Internal]
 		[NoTV]
 		[NoWatch]
 		[NoMac]
-		[Availability (Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_9_0)]
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Obsoleted (PlatformName.iOS, 9, 0)]
 		[Export ("UUID")]
 		IntPtr _UUID { get;  }
+#endif
 	
 		[iOS (7, 0)]
 		[Export ("identifier")]

--- a/tests/monotouch-test/CoreBluetooth/CentralManagerTest.cs
+++ b/tests/monotouch-test/CoreBluetooth/CentralManagerTest.cs
@@ -40,7 +40,7 @@ namespace MonoTouchFixtures.CoreBluetooth {
 					PoweredOnEvent.Set ();
 			}
 
-#if !NET
+#if !XAMCORE_3_0 && !NET
 			public override void RetrievedPeripherals (CBCentralManager central, CBPeripheral[] peripherals)
 			{
 			}
@@ -48,7 +48,7 @@ namespace MonoTouchFixtures.CoreBluetooth {
 			public override void RetrievedConnectedPeripherals (CBCentralManager central, CBPeripheral[] peripherals)
 			{
 			}
-#endif // !NET
+#endif // !XAMCORE_3_0 && !NET
 
 			public override void DiscoveredPeripheral (CBCentralManager central, CBPeripheral peripheral, NSDictionary advertisementData, NSNumber RSSI)
 			{
@@ -117,10 +117,10 @@ namespace MonoTouchFixtures.CoreBluetooth {
 				using (var uuid = new NSUuid (heartRateMonitorUUID.ToString (true)))
 					mgr.RetrievePeripheralsWithIdentifiers (uuid);
 			} else {
-#if !NET
+#if !XAMCORE_3_0 && !NET
 				// that API was deprecated in 7.0 and removed from 9.0
 				mgr.RetrievePeripherals (heartRateMonitorUUID);
-#endif // !NET
+#endif // !XAMCORE_3_0 && !NET
 			}
 		}
 	}

--- a/tests/monotouch-test/CoreBluetooth/CentralManagerTest.cs
+++ b/tests/monotouch-test/CoreBluetooth/CentralManagerTest.cs
@@ -32,11 +32,15 @@ namespace MonoTouchFixtures.CoreBluetooth {
 			#region implemented abstract members of MonoTouch.CoreBluetooth.CBCentralManagerDelegate
 			public override void UpdatedState (CBCentralManager central)
 			{
+#if NET
+				if (central.State == CBManagerState.PoweredOn)
+#else
 				if (central.State == CBCentralManagerState.PoweredOn)
+#endif
 					PoweredOnEvent.Set ();
 			}
 
-#if !XAMCORE_3_0
+#if !NET
 			public override void RetrievedPeripherals (CBCentralManager central, CBPeripheral[] peripherals)
 			{
 			}
@@ -44,7 +48,7 @@ namespace MonoTouchFixtures.CoreBluetooth {
 			public override void RetrievedConnectedPeripherals (CBCentralManager central, CBPeripheral[] peripherals)
 			{
 			}
-#endif // !XAMCORE_3_0
+#endif // !NET
 
 			public override void DiscoveredPeripheral (CBCentralManager central, CBPeripheral peripheral, NSDictionary advertisementData, NSNumber RSSI)
 			{
@@ -105,7 +109,6 @@ namespace MonoTouchFixtures.CoreBluetooth {
 			mgr.ScanForPeripherals ((CBUUID[])null, (NSDictionary)null);
 		}
 
-#if !XAMCORE_3_0
 		[Test]
 		public void RetrievePeripherals ()
 		{
@@ -114,11 +117,12 @@ namespace MonoTouchFixtures.CoreBluetooth {
 				using (var uuid = new NSUuid (heartRateMonitorUUID.ToString (true)))
 					mgr.RetrievePeripheralsWithIdentifiers (uuid);
 			} else {
+#if !NET
 				// that API was deprecated in 7.0 and removed from 9.0
 				mgr.RetrievePeripherals (heartRateMonitorUUID);
+#endif // !NET
 			}
 		}
-#endif // !XAMCORE_3_0
 	}
 }
 


### PR DESCRIPTION
* Change all XAMCORE_4_0 defines to NET defines to get the new API version in
  .NET.
* Remove some dead code.
* Change all the old-style [Availability] attributes to new-style [Obsoleted]
  or [Deprecated].
* Adjust tests.