### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 14411: Build ID 5419189

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
@@ -1072,14 +1072,14 @@
         </comment>
     </data>
   <data name="W7085" xml:space="preserve">
-        <value>Creating a compressed binding resource package because there are symlinks in the input.</value>
+        <value>Vytváření balíčku prostředků komprimované vazby, protože ve vstupu jsou symbolické odkazy.</value>
     </data>
   <data name="E7086" xml:space="preserve">
-        <value>The value '{0}' is invalid for the Compress property. Valid values: 'true', 'false' or 'auto'.</value>
+        <value>Hodnota {0} není pro vlastnost Compress platná. Platné hodnoty: true, false nebo auto.</value>
         <comment>The following are literal names and should not be translated: Compress, true, false, auto.</comment>
     </data>
   <data name="W7087" xml:space="preserve">
-        <value>Expected a 'manifest' file in the directory {0}.</value>
+        <value>V adresáři {0} byl očekáván soubor manifestu.</value>
         <comment>The following are literal names and should not be translated: manifest</comment>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
@@ -1072,14 +1072,14 @@
         </comment>
     </data>
   <data name="W7085" xml:space="preserve">
-        <value>Creating a compressed binding resource package because there are symlinks in the input.</value>
+        <value>入力にシンボリックリンクが含まれているため、圧縮バインド リソース パッケージを作成しています。</value>
     </data>
   <data name="E7086" xml:space="preserve">
-        <value>The value '{0}' is invalid for the Compress property. Valid values: 'true', 'false' or 'auto'.</value>
+        <value>圧縮プロパティでは、値 '{0}' は無効です。有効な値: 'true'、'false'、'auto'。</value>
         <comment>The following are literal names and should not be translated: Compress, true, false, auto.</comment>
     </data>
   <data name="W7087" xml:space="preserve">
-        <value>Expected a 'manifest' file in the directory {0}.</value>
+        <value>ディレクトリ {0} に 'manifest' ファイルが必要です。</value>
         <comment>The following are literal names and should not be translated: manifest</comment>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
@@ -1072,14 +1072,14 @@
         </comment>
     </data>
   <data name="W7085" xml:space="preserve">
-        <value>Creating a compressed binding resource package because there are symlinks in the input.</value>
+        <value>Tworzenie skompresowanego pakietu zasobów powiązania, ponieważ występują dowiązania symboliczne w danych wejściowych.</value>
     </data>
   <data name="E7086" xml:space="preserve">
-        <value>The value '{0}' is invalid for the Compress property. Valid values: 'true', 'false' or 'auto'.</value>
+        <value>Wartość "{0}" jest nieprawidłowa dla właściwości kompresji. Prawidłowe wartości to "true", "false" lub "auto".</value>
         <comment>The following are literal names and should not be translated: Compress, true, false, auto.</comment>
     </data>
   <data name="W7087" xml:space="preserve">
-        <value>Expected a 'manifest' file in the directory {0}.</value>
+        <value>W katalogu {0} oczekiwano pliku "manifest".</value>
         <comment>The following are literal names and should not be translated: manifest</comment>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
@@ -1072,14 +1072,14 @@
         </comment>
     </data>
   <data name="W7085" xml:space="preserve">
-        <value>Creating a compressed binding resource package because there are symlinks in the input.</value>
+        <value>Girişte sembolik bağlantılar olduğundan sıkıştırılmış bağlama kaynak paketi oluşturuluyor.</value>
     </data>
   <data name="E7086" xml:space="preserve">
-        <value>The value '{0}' is invalid for the Compress property. Valid values: 'true', 'false' or 'auto'.</value>
+        <value>'{0}' değeri Compress özelliği için geçersiz. Geçerli değerler: 'true', 'false' veya 'auto'.</value>
         <comment>The following are literal names and should not be translated: Compress, true, false, auto.</comment>
     </data>
   <data name="W7087" xml:space="preserve">
-        <value>Expected a 'manifest' file in the directory {0}.</value>
+        <value>{0} dizininde bir 'manifest' dosyası bekleniyor.</value>
         <comment>The following are literal names and should not be translated: manifest</comment>
     </data>
 </root>

--- a/tools/mtouch/TranslatedAssemblies/Errors.cs.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.cs.resx
@@ -815,7 +815,7 @@
 		</value>
 	</data>
   <data name="MX1306" xml:space="preserve">
-		<value>Could not decompress the file '{0}'. Please review the build log for more information from the native 'unzip' command.</value>
+		<value>Nepovedlo se dekomprimovat soubor {0}. Zkontrolujte prosím v protokolu o sestavení další informace z nativního příkazu unzip.</value>
 	</data>
   <data name="MM1401" xml:space="preserve">
 		<value>V referencích chybí požadované sestavení Xamarin.Mac.dll.

--- a/tools/mtouch/TranslatedAssemblies/Errors.ja.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.ja.resx
@@ -815,7 +815,7 @@
 		</value>
 	</data>
   <data name="MX1306" xml:space="preserve">
-		<value>Could not decompress the file '{0}'. Please review the build log for more information from the native 'unzip' command.</value>
+		<value>ファイル '{0}' を展開できませんでした。ビルド ログを参照して、ネイティブの 'unzip' コマンドからの詳細情報をご確認ください。</value>
 	</data>
   <data name="MM1401" xml:space="preserve">
 		<value>必要な 'Xamarin.Mac.dll' アセンブリが参照にありません

--- a/tools/mtouch/TranslatedAssemblies/Errors.pl.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.pl.resx
@@ -815,7 +815,7 @@
 		</value>
 	</data>
   <data name="MX1306" xml:space="preserve">
-		<value>Could not decompress the file '{0}'. Please review the build log for more information from the native 'unzip' command.</value>
+		<value>Nie można zdekompresować pliku "{0}". Przejrzyj dziennik kompilacji, aby uzyskać więcej informacji z poziomu polecenia natywnego "unzip".</value>
 	</data>
   <data name="MM1401" xml:space="preserve">
 		<value>W odwołaniach brakuje wymaganego zestawu „Xamarin.Mac.dll”

--- a/tools/mtouch/TranslatedAssemblies/Errors.tr.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.tr.resx
@@ -815,7 +815,7 @@
 		</value>
 	</data>
   <data name="MX1306" xml:space="preserve">
-		<value>Could not decompress the file '{0}'. Please review the build log for more information from the native 'unzip' command.</value>
+		<value>'{0}' dosyası açılamadı. Yerel 'unzip' komutundan daha fazla bilgi için lütfen derleme günlüğünü gözden geçirin.</value>
 	</data>
   <data name="MM1401" xml:space="preserve">
 		<value>Gerekli 'Xamarin.Mac.dll' bütünleştirilmiş kodu başvurularda eksik


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.