### PR TITLE
[CI test] Test if Tls12 failure is due to outdated OS.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -608,3 +608,5 @@ DOTNET_PLATFORMS_UPPERCASE:=$(shell echo $(DOTNET_PLATFORMS) | tr a-z A-Z)
 
 .SUFFIXES:
 MAKEFLAGS += --no-builtin-rules
+
+# Theory A: OS needs an update.


### PR DESCRIPTION
Run CI on an older branch to check if that also fails - if it does, then it's not a recent regression in our code.

Ref: https://github.com/xamarin/maccore/issues/2525