### PR TITLE
[AudioToolbox] Fix nullability issue to fix broken build.

### DIFF
--- a/src/AudioToolbox/MusicTrack.cs
+++ b/src/AudioToolbox/MusicTrack.cs
@@ -249,7 +249,7 @@ namespace AudioToolbox {
 		[DllImport (Constants.AudioToolboxLibrary)]
 		extern static /* OSStatus */ MusicPlayerStatus MusicSequenceDisposeTrack (/* MusicSequence */ IntPtr inSequence, /* MusicTrack */ IntPtr inTrack);
 
-		public static MusicTrack FromSequence (MusicSequence sequence)
+		public static MusicTrack? FromSequence (MusicSequence sequence)
 		{
 			if (sequence is null)
 				throw new ArgumentNullException (nameof (sequence));


### PR DESCRIPTION
Fixes this compile error:

> AudioToolbox/MusicTrack.cs(256,11): error CS8603: Possible null reference return.