### PR TITLE
FromSequence returns a nullable

### DIFF
--- a/src/AudioToolbox/MusicTrack.cs
+++ b/src/AudioToolbox/MusicTrack.cs
@@ -249,7 +249,7 @@ namespace AudioToolbox {
 		[DllImport (Constants.AudioToolboxLibrary)]
 		extern static /* OSStatus */ MusicPlayerStatus MusicSequenceDisposeTrack (/* MusicSequence */ IntPtr inSequence, /* MusicTrack */ IntPtr inTrack);
 
-		public static MusicTrack FromSequence (MusicSequence sequence)
+		public static MusicTrack? FromSequence (MusicSequence sequence)
 		{
 			if (sequence is null)
 				throw new ArgumentNullException (nameof (sequence));


### PR DESCRIPTION
Had trouble compiling today's version of macios. It happens that
FromSequence returns a track created by CreateTrack, and that one
can be null, so I changed the signature of FromSequence to reflect
that fact.