### PR TITLE
[CGBitmapContext] Call the correct base constructor to specify ownership. Fixes #13309.

### DIFF
--- a/src/CoreGraphics/CGBitmapContext.cs
+++ b/src/CoreGraphics/CGBitmapContext.cs
@@ -90,7 +90,7 @@ namespace CoreGraphics {
 		}
 
 		public CGBitmapContext (byte []? data, nint width, nint height, nint bitsPerComponent, nint bytesPerRow, CGColorSpace? colorSpace, CGBitmapFlags bitmapInfo)
-			: base (Create (data, width, height, bitsPerComponent, bytesPerRow, colorSpace, bitmapInfo, out var buffer))
+			: base (Create (data, width, height, bitsPerComponent, bytesPerRow, colorSpace, bitmapInfo, out var buffer), true)
 		{
 			this.buffer = buffer;
 		}


### PR DESCRIPTION
This way we don't leak the CGBitmapContext.

Fixes https://github.com/xamarin/xamarin-macios/issues/13309.