### PR TITLE
[GLKit] GLKTextureLoaderGrayscaleAsAlpha was available starting in macOS 10.14

### DIFF
--- a/src/glkit.cs
+++ b/src/glkit.cs
@@ -550,9 +550,7 @@ namespace GLKit {
 		[Field ("GLKTextureLoaderOriginBottomLeft")]
 		NSString OriginBottomLeft { get; }
 		
-#if XAMCORE_4_0 // Unavailable in macOS
-		[NoMac]
-#endif
+		[Mac (10,14)]
 		[Field ("GLKTextureLoaderGrayscaleAsAlpha")]
 		NSString GrayscaleAsAlpha { get; }
 


### PR DESCRIPTION
Fixes when building with XAMCORE_4_0:

> GLKit/GLTextureLoader.cs(207,39): error CS0117: 'GLKTextureLoader' does not contain a definition for 'GrayscaleAsAlpha'