### PR TITLE
[introspection] Fix macOS 10.15 version checks.

### DIFF
--- a/tests/introspection/Mac/MacApiCtorInitTest.cs
+++ b/tests/introspection/Mac/MacApiCtorInitTest.cs
@@ -203,8 +203,6 @@ namespace Introspection {
 			case "MetalPerformanceShaders.MPSPredicate":
 				// Fails on Catalina: Could not initialize an instance of the type 
 				// 'MetalPerformanceShaders.MPSPredicate': the native 'init' method returned nil. 
-				if (Mac.CheckSystemVersion (10, 14))
-					break;
 				if (Mac.CheckSystemVersion (10, 15))
 					return true;
 				break;


### PR DESCRIPTION
The logic seems to want to verify MPSPredicate on maOS 10.14, but not on macOS
10.15+. But checking for macOS 10.14 is always successful on macOS 10.15+,
which means that we can't check for macOS 10.14 before checking macOS 10.15.
So I moved the macOS 10.14 check to after the macOS 10.15 check, but that made
the macOS 10.14 check redundant, because both branches of the condition did
the same thing, so I removed the whole check.

Fixes this introspectionf failure:

    [FAIL] DefaultCtorAllowed :   1 potential errors found in 1387 default ctor validated:
        Default constructor not allowed for MetalPerformanceShaders.MPSPredicate : Could not initialize an instance of the type 'MetalPerformanceShaders.MPSPredicate': the native 'init' method returned nil.