### PR TITLE
[src] Introduce DisposableObject and use it.

### DIFF
--- a/src/AudioToolbox/AudioConverter.cs
+++ b/src/AudioToolbox/AudioConverter.cs
@@ -30,6 +30,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
@@ -86,37 +87,20 @@ namespace AudioToolbox
 	public delegate AudioConverterError AudioConverterComplexInputData (ref int numberDataPackets, AudioBuffers data,
 		ref AudioStreamPacketDescription[]? dataPacketDescription);
 
-	public class AudioConverter : IDisposable, INativeObject
+	public class AudioConverter : DisposableObject
 	{
 		delegate AudioConverterError AudioConverterComplexInputDataShared (IntPtr inAudioConverter, ref int ioNumberDataPackets, IntPtr ioData,
 			IntPtr outDataPacketDescription, IntPtr inUserData);
 
-		IntPtr handle;
 		IntPtr packetDescriptions;
 		int packetDescriptionSize;
-		readonly bool owns;
 		static readonly AudioConverterComplexInputDataShared ComplexInputDataShared = FillComplexBufferShared;
 
 		public event AudioConverterComplexInputData? InputData;
 
-		private AudioConverter (IntPtr handle)
-			: this (handle, false)
-		{
-		}
-
 		internal AudioConverter (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			if (handle == IntPtr.Zero)
-				throw new ArgumentException ("address");
-
-			this.handle = handle;
-			this.owns = owns;
-		}
-
-		public IntPtr Handle {
-			get {
-				return handle;
-			}
 		}
 
 		public uint MinimumInputBufferSize {
@@ -445,29 +429,17 @@ namespace AudioToolbox
 			}
 		}
 
-		~AudioConverter ()
+		protected override void Dispose (bool disposing)
 		{
-			Dispose (false);
-		}
+			if (Handle != IntPtr.Zero && Owns)
+				AudioConverterDispose (Handle);
 
-		public void Dispose ()
-		{
-			Dispose (true);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero) {
-				if (owns)
-					AudioConverterDispose (handle);
-
-				handle = IntPtr.Zero;
-			}
 			if (packetDescriptions != IntPtr.Zero) {
 				Marshal.FreeHGlobal (packetDescriptions);
 				packetDescriptions = IntPtr.Zero;
 			}
-			GC.SuppressFinalize (this);
+
+			base.Dispose (disposing);
 		}
 
 		public AudioConverterError ConvertBuffer (byte[] input, byte[] output)

--- a/src/AudioToolbox/MusicTrack.cs
+++ b/src/AudioToolbox/MusicTrack.cs
@@ -204,46 +204,25 @@ namespace AudioToolbox {
 	}
 #endif
 	
-	public class MusicTrack : INativeObject
-#if !COREBUILD
-	, IDisposable
-#endif
+	public class MusicTrack : DisposableObject
 	{
 #if !COREBUILD
 		MusicSequence? sequence;
-		IntPtr handle;
-		bool owns;
 
 		internal MusicTrack (MusicSequence sequence, IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
 			this.sequence = sequence;
-			this.handle = handle;
-			this.owns = owns;
 		}
 
-		~MusicTrack ()
+		protected override void Dispose (bool disposing)
 		{
-			Dispose (false);
-		}
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public IntPtr Handle {
-			get { return handle; }
-		}
-	
-		protected virtual void Dispose (bool disposing)
-		{
-			if (handle != IntPtr.Zero){
-				if (owns && sequence is not null)
-					MusicSequenceDisposeTrack (sequence.Handle, handle);
-				handle = IntPtr.Zero;
+			if (Handle != IntPtr.Zero && Owns) {
+				if (sequence is not null)
+					MusicSequenceDisposeTrack (sequence.Handle, Handle);
 			}
 			sequence = null;
+			base.Dispose (disposing);
 		}
 
 		[DllImport (Constants.AudioToolboxLibrary)]

--- a/src/AudioUnit/AudioComponent.cs
+++ b/src/AudioUnit/AudioComponent.cs
@@ -237,15 +237,11 @@ namespace AudioUnit
 #endif // !COREBUILD
 
 
-	public class AudioComponent : INativeObject {
+	public class AudioComponent : DisposableObject {
 #if !COREBUILD
-		IntPtr handle;
-
-		public IntPtr Handle { get { return handle; } }
-
-		internal AudioComponent (IntPtr handle)
+		internal AudioComponent (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{ 
-			this.handle = handle;
 		}
 			
 		public AudioUnit CreateAudioUnit ()
@@ -257,7 +253,7 @@ namespace AudioUnit
 		{
 			var handle = cmp.GetHandle ();
 			handle = AudioComponentFindNext (handle, ref cd);
-			return  (handle != IntPtr.Zero) ? new AudioComponent (handle) : null;
+			return  (handle != IntPtr.Zero) ? new AudioComponent (handle, false) : null;
 		}
 
 		public static AudioComponent? FindComponent (ref AudioComponentDescription cd)

--- a/src/ObjCRuntime/DisposableObject.cs
+++ b/src/ObjCRuntime/DisposableObject.cs
@@ -1,0 +1,95 @@
+//
+// DisposableObject.cs: A base class for for many native data types without assuming any particular lifecycle.
+
+// Authors:
+//   Rolf Bjarne Kvinge
+//
+// Copyright 2021 Microsoft Corp
+//
+using System;
+using System.Runtime.InteropServices;
+using ObjCRuntime;
+using Foundation;
+
+#nullable enable
+
+namespace ObjCRuntime {
+	//
+	// The DisposableObject class is intended to be a base class for many native data
+	// data types, without assuming any particular lifecycle (might be reference counted,
+	// might not be).
+	//
+	// It provides the common boilerplate for this kind of objects and the Dispose
+	// pattern.
+	//
+	public abstract class DisposableObject : INativeObject, IDisposable {
+		IntPtr handle;
+		readonly bool owns;
+
+		public IntPtr Handle {
+			get => handle;
+			protected set => InitializeHandle (value);
+		}
+
+		protected bool Owns { get; }
+
+		protected DisposableObject ()
+		{
+		}
+
+		protected DisposableObject (IntPtr handle, bool owns)
+			: this (handle, owns, true)
+		{
+		}
+
+		protected DisposableObject (IntPtr handle, bool owns, bool verify)
+		{
+			InitializeHandle (handle, verify);
+			this.owns = owns;
+		}
+
+		~DisposableObject ()
+		{
+			Dispose (false);
+		}
+
+		public void Dispose ()
+		{
+			Dispose (true);
+			GC.SuppressFinalize (this);
+		}
+
+		protected virtual void Dispose (bool disposing)
+		{
+			ClearHandle ();
+		}
+
+		protected void ClearHandle ()
+		{
+			handle = IntPtr.Zero;
+		}
+
+		void InitializeHandle (IntPtr handle, bool verify)
+		{
+#if !COREBUILD
+			if (verify && handle == IntPtr.Zero && Class.ThrowOnInitFailure) {
+				throw new Exception ($"Could not initialize an instance of the type '{GetType ().FullName}': handle is null.\n" +
+				    "It is possible to ignore this condition by setting ObjCRuntime.Class.ThrowOnInitFailure to false.");
+			}
+#endif
+			this.handle = handle;
+		}
+
+		protected virtual void InitializeHandle (IntPtr handle)
+		{
+			InitializeHandle (handle, true);
+		}
+
+		public IntPtr GetCheckedHandle ()
+		{
+			if (handle == IntPtr.Zero)
+				ObjCRuntime.ThrowHelper.ThrowObjectDisposedException (this);
+			return handle;
+		}
+	}
+}

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1836,6 +1836,7 @@ SHARED_CORE_SOURCES = \
 	ObjCRuntime/Blocks.cs \
 	ObjCRuntime/Class.cs \
 	ObjCRuntime/Constants.cs \
+	ObjCRuntime/DisposableObject.cs \
 	ObjCRuntime/INativeObject.cs \
 	ObjCRuntime/LinkWithAttribute.cs \
 	ObjCRuntime/NativeAttribute.cs \


### PR DESCRIPTION
Add a new DisposableObject class, which is a new base class below
NativeObject, to be used for types that aren't reference counted, but still
disposable. NativeObject is now implemented on top of this type, adding
support for reference counting.

Also change several type to use DisposableObject as their base type, which
makes it possible to share a lot more code and delete a good chunk of
duplicated code.