### PR TITLE
[tests] Fix checking for sub-test failures in packaged macOS tests.

### DIFF
--- a/tests/packaged-macos-tests.mk
+++ b/tests/packaged-macos-tests.mk
@@ -159,7 +159,7 @@ endif
 
 build-$(1): .stamp-nuget-restore-mac
 	$$(Q) rm -f ".$$@-failure.stamp"
-	$$(Q) $$(MAKE) -f packaged-macos-tests.mk build-legacy-$(1)                   || cat .$$@-legacy-failure.stamp                     >> ".$$@-failure.stamp"
+	$$(Q) $$(MAKE) -f packaged-macos-tests.mk build-legacy-$(1)                   || echo "build-legacy-$(1) failed"                   >> ".$$@-failure.stamp"
 	$$(Q) $$(MAKE) -f packaged-macos-tests.mk build-mac-dotnet-x64-$(1)           || echo "build-mac-dotnet-x64-$(1) failed"           >> ".$$@-failure.stamp"
 	$$(Q) $$(MAKE) -f packaged-macos-tests.mk build-mac-dotnet-arm64-$(1)         || echo "build-mac-dotnet-arm64-$(1) failed"         >> ".$$@-failure.stamp"
 	$$(Q) $$(MAKE) -f packaged-macos-tests.mk build-maccatalyst-dotnet-x64-$(1)   || echo "build-maccatalyst-dotnet-x64-$(1) failed"   >> ".$$@-failure.stamp"
@@ -168,7 +168,7 @@ build-$(1): .stamp-nuget-restore-mac
 
 exec-$(1):
 	$$(Q) rm -f ".$$@-failure.stamp"
-	$$(Q) $$(MAKE) -f packaged-macos-tests.mk exec-legacy-$(1)                   || cat .$$@-legacy-failure.stamp                    >> ".$$@-failure.stamp"
+	$$(Q) $$(MAKE) -f packaged-macos-tests.mk exec-legacy-$(1)                   || echo "exec-legacy-$(1) failed"                   >> ".$$@-failure.stamp"
 	$$(Q) $$(MAKE) -f packaged-macos-tests.mk exec-mac-dotnet-x64-$(1)           || echo "exec-mac-dotnet-x64-$(1) failed"           >> ".$$@-failure.stamp"
 	$$(Q) $$(MAKE) -f packaged-macos-tests.mk exec-mac-dotnet-arm64-$(1)         || echo "exec-mac-dotnet-arm64-$(1) failed"         >> ".$$@-failure.stamp"
 	$$(Q) $$(MAKE) -f packaged-macos-tests.mk exec-maccatalyst-dotnet-x64-$(1)   || echo "exec-maccatalyst-dotnet-x64-$(1) failed"   >> ".$$@-failure.stamp"


### PR DESCRIPTION
Any failure stamp files are deleted before the failing target exists, so
checking for failure stamp files at a later point won't work.