### PR TITLE
[DictionaryContainer] Improve nullability + a few other code improvements.

### DIFF
--- a/src/Foundation/DictionaryContainer.cs
+++ b/src/Foundation/DictionaryContainer.cs
@@ -27,6 +27,7 @@
 //
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 #if !COREBUILD
@@ -60,32 +61,26 @@ namespace Foundation {
 
 		protected T[]? GetArray<T> (NSString key) where T : NSObject
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			var value = CFDictionary.GetValue (Dictionary.Handle, key.Handle);
-			if (value == IntPtr.Zero)
-				return null;
-
 			return NSArray.ArrayFromHandle<T> (value);
 		}
 
 		protected T[]? GetArray<T> (NSString key, Func<IntPtr, T> creator)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			var value = CFDictionary.GetValue (Dictionary.Handle, key.Handle);
-			if (value == IntPtr.Zero)
-				return null;
-
 			return NSArray.ArrayFromHandleFunc<T> (value, creator);
 		}
 
 		protected int? GetInt32Value (NSString key)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			NSObject value;
 			if (!Dictionary.TryGetValue (key, out value))
@@ -96,8 +91,8 @@ namespace Foundation {
 
 		protected uint? GetUInt32Value (NSString key)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			NSObject value;
 			if (!Dictionary.TryGetValue (key, out value))
@@ -108,8 +103,8 @@ namespace Foundation {
 
 		protected nint? GetNIntValue (NSString key)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			NSObject value;
 			if (!Dictionary.TryGetValue (key, out value))
@@ -120,8 +115,8 @@ namespace Foundation {
 
 		protected nuint? GetNUIntValue (NSString key)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			NSObject value;
 			if (!Dictionary.TryGetValue (key, out value))
@@ -132,8 +127,8 @@ namespace Foundation {
 
 		protected long? GetLongValue (NSString key)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			NSObject value;
 			if (!Dictionary.TryGetValue (key, out value))
@@ -144,8 +139,8 @@ namespace Foundation {
 
 		protected uint? GetUIntValue (NSString key)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			NSObject value;
 			if (!Dictionary.TryGetValue (key, out value))
@@ -156,8 +151,8 @@ namespace Foundation {
 
 		protected float? GetFloatValue (NSString key)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			NSObject value;
 			if (!Dictionary.TryGetValue (key, out value))
@@ -168,8 +163,8 @@ namespace Foundation {
 
 		protected double? GetDoubleValue (NSString key)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			NSObject value;
 			if (!Dictionary.TryGetValue (key, out value))
@@ -180,8 +175,8 @@ namespace Foundation {
 
 		protected bool? GetBoolValue (NSString key)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			var value = CFDictionary.GetValue (Dictionary.Handle, key.Handle);
 			if (value == IntPtr.Zero)
@@ -192,8 +187,8 @@ namespace Foundation {
 
 		protected T? GetNativeValue<T> (NSString key) where T : class, INativeObject
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			return Runtime.GetINativeObject<T> (Dictionary.LowlevelObjectForKey (key.Handle), false);
 		}
@@ -209,8 +204,8 @@ namespace Foundation {
 
 		protected NSDictionary? GetNSDictionary (NSString key)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			NSObject value;
 			Dictionary.TryGetValue (key, out value);
@@ -221,8 +216,8 @@ namespace Foundation {
 			where TKey : class, INativeObject
 			where TValue : class, INativeObject
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			NSObject value;
 			Dictionary.TryGetValue (key, out value);
@@ -231,11 +226,11 @@ namespace Foundation {
 
 		protected T? GetStrongDictionary<T> (NSString key) where T : DictionaryContainer
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			var dict = GetNSDictionary (key);
-			if (dict == null)
+			if (dict is null)
 				return null;
 			return (T?) Activator.CreateInstance (typeof(T),
 				new object[] { dict }
@@ -244,8 +239,8 @@ namespace Foundation {
 
 		protected NSString? GetNSStringValue (NSString key)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			NSObject value;
 			Dictionary.TryGetValue (key, out value);
@@ -254,8 +249,8 @@ namespace Foundation {
 
 		protected string? GetStringValue (NSString key)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			NSObject value;
 			if (!Dictionary.TryGetValue (key, out value))
@@ -266,11 +261,14 @@ namespace Foundation {
 
 		protected string? GetStringValue (string key)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
-			using (var str = new CFString (key)) {
-				return CFString.FromHandle (CFDictionary.GetValue (Dictionary.Handle, str.Handle));
+			var keyHandle = CFString.CreateNative (key);
+			try {
+				return CFString.FromHandle (CFDictionary.GetValue (Dictionary.Handle, keyHandle));
+			} finally {
+				CFString.ReleaseNative (keyHandle);
 			}
 		}
 
@@ -315,10 +313,10 @@ namespace Foundation {
 			return value;
 		}
 #endif // !WATCH
-		bool NullCheckAndRemoveKey (NSString key, bool removeEntry)
+		bool NullCheckAndRemoveKey ([NotNullWhen (true)] NSString key, bool removeEntry)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			if (removeEntry)
 				RemoveValue (key);
@@ -328,13 +326,13 @@ namespace Foundation {
 
 		protected void SetArrayValue (NSString key, NSNumber[]? values)
 		{
-			if (NullCheckAndRemoveKey (key, values == null))
+			if (NullCheckAndRemoveKey (key, values is null))
 				Dictionary [key] = NSArray.FromNSObjects (values);
 		}
 
 		protected void SetArrayValue<T> (NSString key, T[]? values)
 		{
-			if (NullCheckAndRemoveKey (key, values == null)) {
+			if (NullCheckAndRemoveKey (key, values is null)) {
 				var nsValues = new NSObject [values!.Length];
 				for (var i = 0; i < values.Length; i++)
 					nsValues [i] = NSObject.FromObject (values [i]);
@@ -344,14 +342,14 @@ namespace Foundation {
 
 		protected void SetArrayValue (NSString key, string[]? values)
 		{
-			if (NullCheckAndRemoveKey (key, values == null))
-				Dictionary [key!] = NSArray.FromStrings (values);
+			if (NullCheckAndRemoveKey (key, values is null))
+				Dictionary [key] = NSArray.FromStrings (values);
 		}
 
 		protected void SetArrayValue (NSString key, INativeObject[]? values)
 		{
-			if (NullCheckAndRemoveKey (key, values == null))
-				CFMutableDictionary.SetValue (Dictionary.Handle, key!.Handle, CFArray.FromNativeObjects (values!).Handle);
+			if (NullCheckAndRemoveKey (key, values is null))
+				CFMutableDictionary.SetValue (Dictionary.Handle, key.Handle, CFArray.FromNativeObjects (values!).Handle);
 		}
 
 		#region Sets CFBoolean value
@@ -359,7 +357,7 @@ namespace Foundation {
 		protected void SetBooleanValue (NSString key, bool? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				CFMutableDictionary.SetValue (Dictionary.Handle, key!.Handle, value!.Value ? CFBoolean.TrueHandle : CFBoolean.FalseHandle);			
+				CFMutableDictionary.SetValue (Dictionary.Handle, key.Handle, value!.Value ? CFBoolean.TrueHandle : CFBoolean.FalseHandle);
 		}
 
 		#endregion
@@ -369,43 +367,43 @@ namespace Foundation {
 		protected void SetNumberValue (NSString key, int? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key!] = new NSNumber (value!.Value);				
+				Dictionary [key] = new NSNumber (value!.Value);				
 		}
 
 		protected void SetNumberValue (NSString key, uint? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key!] = new NSNumber (value!.Value);				
+				Dictionary [key] = new NSNumber (value!.Value);				
 		}
 
 		protected void SetNumberValue (NSString key, nint? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key!] = new NSNumber (value!.Value);	
+				Dictionary [key] = new NSNumber (value!.Value);	
 		}
 
 		protected void SetNumberValue (NSString key, nuint? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key!] = new NSNumber (value!.Value);	
+				Dictionary [key] = new NSNumber (value!.Value);	
 		}
 
 		protected void SetNumberValue (NSString key, long? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key!] = new NSNumber (value!.Value);				
+				Dictionary [key] = new NSNumber (value!.Value);				
 		}
 
 		protected void SetNumberValue (NSString key, float? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key!] = new NSNumber (value!.Value);				
+				Dictionary [key] = new NSNumber (value!.Value);				
 		}
 
 		protected void SetNumberValue (NSString key, double? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key!] = new NSNumber (value!.Value);				
+				Dictionary [key] = new NSNumber (value!.Value);				
 		}
 
 		#endregion
@@ -414,13 +412,13 @@ namespace Foundation {
 
 		protected void SetStringValue (NSString key, string? value)
 		{
-			SetStringValue (key, value == null ? (NSString) null! : new NSString (value));
+			SetStringValue (key, value is null ? (NSString) null! : new NSString (value));
 		}
 
 		protected void SetStringValue (NSString key, NSString? value)
 		{
-			if (NullCheckAndRemoveKey (key, value == null))
-				Dictionary [key!] = value;
+			if (NullCheckAndRemoveKey (key, value is null))
+				Dictionary [key] = value;
 		}
 
 		#endregion
@@ -429,16 +427,16 @@ namespace Foundation {
 
 		protected void SetNativeValue (NSString key, INativeObject? value, bool removeNullValue = true)
 		{
-			if (NullCheckAndRemoveKey (key, removeNullValue && value == null))
-				CFMutableDictionary.SetValue (Dictionary.Handle, key.Handle, value == null ? IntPtr.Zero : value.Handle);
+			if (NullCheckAndRemoveKey (key, removeNullValue && value is null))
+				CFMutableDictionary.SetValue (Dictionary.Handle, key.Handle, value.GetHandle ());
 		}
 
 		#endregion
 
 		protected void RemoveValue (NSString key)
 		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+			if (key is null)
+				throw new ArgumentNullException (nameof (key));
 
 			((NSMutableDictionary) Dictionary).Remove (key);
 		}
@@ -448,26 +446,26 @@ namespace Foundation {
 		protected void SetCGRectValue (NSString key, CGRect? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key!] = value!.Value.ToDictionary ();
+				Dictionary [key] = value!.Value.ToDictionary ();
 		}
 
 		protected void SetCGSizeValue (NSString key, CGSize? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key!] = value!.Value.ToDictionary ();
+				Dictionary [key] = value!.Value.ToDictionary ();
 		}
 
 		protected void SetCGPointValue (NSString key, CGPoint? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key!] = value!.Value.ToDictionary ();
+				Dictionary [key] = value!.Value.ToDictionary ();
 		}
 
 #if !WATCH
 		protected void SetCMTimeValue (NSString key, CMTime? value)
 		{
 			if (NullCheckAndRemoveKey (key, !value.HasValue))
-				Dictionary [key!] = value!.Value.ToDictionary ();
+				Dictionary [key] = value!.Value.ToDictionary ();
 		}
 #endif //!WATCH
 		#endregion
@@ -478,17 +476,17 @@ namespace Foundation {
 	static class DictionaryContainerHelper {
 
 		// helper to avoid the (common pattern)
-		// 	var p = x == null ? IntPtr.Zero : h.Dictionary.Handle;
+		// 	var p = x is null ? IntPtr.Zero : h.Dictionary.Handle;
 		static public IntPtr GetHandle (this DictionaryContainer? self)
 		{
-			return self == null ? IntPtr.Zero : self.Dictionary.Handle;
+			return self is null ? IntPtr.Zero : self.Dictionary.Handle;
 		}
 
 		// helper to avoid the (common pattern)
-		// 	var p = x == null ? null : x.Dictionary;
+		// 	var p = x is null ? null : x.Dictionary;
 		static public NSDictionary? GetDictionary (this DictionaryContainer? self)
 		{
-			return self == null ? null : self.Dictionary;
+			return self is null ? null : self.Dictionary;
 		}
 	}
 #endif


### PR DESCRIPTION
* Add a [NotNullWhen] attribute to the 'key' parameter for the NullCheckAndRemoveKey
  method, which means that if the method returns true, the 'key' parameter wasn't
  null, and thus we can remove numerous ignored null check in call sites ("key!"
  -> "key").
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use CFString.CreateNative/ReleaseNative instead of other means to create native
  strings (the fastest and least memory hungry option).
* Remove unnecessary IntPtr.Zero checks before calling NSArray.ArrayFromHandle.
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get the
  handle instead of checking for null (avoids some code duplication).
* Use 'nameof (parameter)' instead of string constants.