### PR TITLE
[CoreNFC] Incorporate XAMCORE_4_0 changes into .NET.

### DIFF
--- a/src/corenfc.cs
+++ b/src/corenfc.cs
@@ -12,6 +12,15 @@ using ObjCRuntime;
 using CoreFoundation;
 using Foundation;
 
+#if !NET
+using NFCFeliCaEncryptionId = CoreNFC.EncryptionId;
+using NFCFeliCaPollingRequestCode = CoreNFC.PollingRequestCode;
+using NFCFeliCaPollingTimeSlot = CoreNFC.PollingTimeSlot;
+using NFCIso15693RequestFlag = CoreNFC.RequestFlag;
+using NFCVasErrorCode = CoreNFC.VasErrorCode;
+using NFCVasMode = CoreNFC.VasMode;
+#endif
+
 namespace CoreNFC {
 
 	[iOS (11,0)]
@@ -166,214 +175,214 @@ namespace CoreNFC {
 		void ReadMultipleBlocks (NFCIso15693ReadMultipleBlocksConfiguration readConfiguration, Action<NSData, NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("stayQuietWithCompletionHandler:")]
 		void StayQuiet (Action<NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("readSingleBlockWithRequestFlags:blockNumber:completionHandler:")]
-		void ReadSingleBlock (RequestFlag flags, byte blockNumber, Action<NSData, NSError> completionHandler);
+		void ReadSingleBlock (NFCIso15693RequestFlag flags, byte blockNumber, Action<NSData, NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("writeSingleBlockWithRequestFlags:blockNumber:dataBlock:completionHandler:")]
-		void WriteSingleBlock (RequestFlag flags, byte blockNumber, NSData dataBlock, Action<NSError> completionHandler);
+		void WriteSingleBlock (NFCIso15693RequestFlag flags, byte blockNumber, NSData dataBlock, Action<NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("lockBlockWithRequestFlags:blockNumber:completionHandler:")]
-		void LockBlock (RequestFlag flags, byte blockNumber, Action<NSError> completionHandler);
+		void LockBlock (NFCIso15693RequestFlag flags, byte blockNumber, Action<NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("readMultipleBlocksWithRequestFlags:blockRange:completionHandler:")]
-		void ReadMultipleBlocks (RequestFlag flags, NSRange blockRange, Action<NSData [], NSError> completionHandler);
+		void ReadMultipleBlocks (NFCIso15693RequestFlag flags, NSRange blockRange, Action<NSData [], NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("writeMultipleBlocksWithRequestFlags:blockRange:dataBlocks:completionHandler:")]
-		void WriteMultipleBlocks (RequestFlag flags, NSRange blockRange, NSData[] dataBlocks, Action<NSError> completionHandler);
+		void WriteMultipleBlocks (NFCIso15693RequestFlag flags, NSRange blockRange, NSData[] dataBlocks, Action<NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("selectWithRequestFlags:completionHandler:")]
-		void Select (RequestFlag flags, Action<NSError> completionHandler);
+		void Select (NFCIso15693RequestFlag flags, Action<NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("resetToReadyWithRequestFlags:completionHandler:")]
-		void ResetToReady (RequestFlag flags, Action<NSError> completionHandler);
+		void ResetToReady (NFCIso15693RequestFlag flags, Action<NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("writeAFIWithRequestFlag:afi:completionHandler:")]
-		void WriteAfi (RequestFlag flags, byte afi, Action<NSError> completionHandler);
+		void WriteAfi (NFCIso15693RequestFlag flags, byte afi, Action<NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("lockAFIWithRequestFlag:completionHandler:")]
-		void LockAfi (RequestFlag flags, Action<NSError> completionHandler);
+		void LockAfi (NFCIso15693RequestFlag flags, Action<NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("writeDSFIDWithRequestFlag:dsfid:completionHandler:")]
-		void WriteDsfi (RequestFlag flags, byte dsfid, Action<NSError> completionHandler);
+		void WriteDsfi (NFCIso15693RequestFlag flags, byte dsfid, Action<NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("lockDFSIDWithRequestFlag:completionHandler:")]
-		void LockDfsi (RequestFlag flags, Action<NSError> completionHandler);
+		void LockDfsi (NFCIso15693RequestFlag flags, Action<NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("getSystemInfoWithRequestFlag:completionHandler:")]
-		void GetSystemInfo (RequestFlag flags, NFCGetSystemInfoCompletionHandler completionHandler);
+		void GetSystemInfo (NFCIso15693RequestFlag flags, NFCGetSystemInfoCompletionHandler completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("getMultipleBlockSecurityStatusWithRequestFlag:blockRange:completionHandler:")]
-		void GetMultipleBlockSecurityStatus (RequestFlag flags, NSRange blockRange, Action<NSNumber[], NSError> completionHandler);
+		void GetMultipleBlockSecurityStatus (NFCIso15693RequestFlag flags, NSRange blockRange, Action<NSNumber[], NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("customCommandWithRequestFlag:customCommandCode:customRequestParameters:completionHandler:")]
-		void CustomCommand (RequestFlag flags, nint customCommandCode, NSData customRequestParameters, Action<NSData, NSError> completionHandler);
+		void CustomCommand (NFCIso15693RequestFlag flags, nint customCommandCode, NSData customRequestParameters, Action<NSData, NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("extendedReadSingleBlockWithRequestFlags:blockNumber:completionHandler:")]
-		void ExtendedReadSingleBlock (RequestFlag flags, nint blockNumber, Action<NSData, NSError> completionHandler);
+		void ExtendedReadSingleBlock (NFCIso15693RequestFlag flags, nint blockNumber, Action<NSData, NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("extendedWriteSingleBlockWithRequestFlags:blockNumber:dataBlock:completionHandler:")]
-		void ExtendedWriteSingleBlock (RequestFlag flags, nint blockNumber, NSData dataBlock, Action<NSError> completionHandler);
+		void ExtendedWriteSingleBlock (NFCIso15693RequestFlag flags, nint blockNumber, NSData dataBlock, Action<NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("extendedLockBlockWithRequestFlags:blockNumber:completionHandler:")]
-		void ExtendedLockBlock (RequestFlag flags, nint blockNumber, Action<NSError> completionHandler);
+		void ExtendedLockBlock (NFCIso15693RequestFlag flags, nint blockNumber, Action<NSError> completionHandler);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("extendedReadMultipleBlocksWithRequestFlags:blockRange:completionHandler:")]
-		void ExtendedReadMultipleBlocks (RequestFlag flags, NSRange blockRange, Action<NSData [], NSError> completionHandler);
+		void ExtendedReadMultipleBlocks (NFCIso15693RequestFlag flags, NSRange blockRange, Action<NSData [], NSError> completionHandler);
 
 		[iOS (14, 0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("extendedWriteMultipleBlocksWithRequestFlags:blockRange:dataBlocks:completionHandler:")]
-		void ExtendedWriteMultipleBlocks (RequestFlag flags, NSRange blockRange, NSData[] dataBlocks, Action<NSError> completionHandler);
+		void ExtendedWriteMultipleBlocks (NFCIso15693RequestFlag flags, NSRange blockRange, NSData[] dataBlocks, Action<NSError> completionHandler);
 
 		[iOS (14, 0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("authenticateWithRequestFlags:cryptoSuiteIdentifier:message:completionHandler:")]
-		void Authenticate (RequestFlag flags, nint cryptoSuiteIdentifier, NSData message, NFCIso15693TagResponseCallback completionHandler);
+		void Authenticate (NFCIso15693RequestFlag flags, nint cryptoSuiteIdentifier, NSData message, NFCIso15693TagResponseCallback completionHandler);
 
 		[iOS (14, 0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("keyUpdateWithRequestFlags:keyIdentifier:message:completionHandler:")]
-		void KeyUpdate (RequestFlag flags, nint keyIdentifier, NSData message, NFCIso15693TagResponseCallback completionHandler);
+		void KeyUpdate (NFCIso15693RequestFlag flags, nint keyIdentifier, NSData message, NFCIso15693TagResponseCallback completionHandler);
 
 		[iOS (14, 0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("challengeWithRequestFlags:cryptoSuiteIdentifier:message:completionHandler:")]
-		void Challenge (RequestFlag flags, nint cryptoSuiteIdentifier, NSData message, Action<NSError> completionHandler);
+		void Challenge (NFCIso15693RequestFlag flags, nint cryptoSuiteIdentifier, NSData message, Action<NSError> completionHandler);
 
 		[iOS (14, 0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("readBufferWithRequestFlags:completionHandler:")]
-		void ReadBuffer (RequestFlag flags, NFCIso15693TagResponseCallback completionHandler);
+		void ReadBuffer (NFCIso15693RequestFlag flags, NFCIso15693TagResponseCallback completionHandler);
 
 		[iOS (14, 0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("extendedGetMultipleBlockSecurityStatusWithRequestFlag:blockRange:completionHandler:")]
-		void ExtendedGetMultipleBlockSecurityStatus (RequestFlag flags, NSRange blockRange, NFCIso15693TagGetMultipleBlockSecurityStatusCallback completionHandler);
+		void ExtendedGetMultipleBlockSecurityStatus (NFCIso15693RequestFlag flags, NSRange blockRange, NFCIso15693TagGetMultipleBlockSecurityStatusCallback completionHandler);
 
 		[iOS (14, 0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("extendedFastReadMultipleBlocksWithRequestFlag:blockRange:completionHandler:")]
-		void ExtendedFastReadMultipleBlocks (RequestFlag flags, NSRange blockRange, NFCIso15693TagReadMultipleBlocksCallback completionHandler);
+		void ExtendedFastReadMultipleBlocks (NFCIso15693RequestFlag flags, NSRange blockRange, NFCIso15693TagReadMultipleBlocksCallback completionHandler);
 
 		[iOS (14, 0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("sendRequestWithFlag:commandCode:data:completionHandler:")]
 		void SendRequest (nint flags, nint commandCode, [NullAllowed] NSData data, NFCIso15693TagResponseCallback completionHandler);
 
 		[iOS (14, 0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("getSystemInfoAndUIDWithRequestFlag:completionHandler:")]
-		void GetSystemInfoAndUid (RequestFlag flags, NFCIso15693TagGetSystemInfoAndUidCallback completionHandler);
+		void GetSystemInfoAndUid (NFCIso15693RequestFlag flags, NFCIso15693TagGetSystemInfoAndUidCallback completionHandler);
 
 		[iOS (14, 0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("fastReadMultipleBlocksWithRequestFlag:blockRange:completionHandler:")]
-		void FastReadMultipleBlocks (RequestFlag flags, NSRange blockRange, NFCIso15693TagReadMultipleBlocksCallback completionHandler);
+		void FastReadMultipleBlocks (NFCIso15693RequestFlag flags, NSRange blockRange, NFCIso15693TagReadMultipleBlocksCallback completionHandler);
 
 		[iOS (14, 0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("lockDSFIDWithRequestFlag:completionHandler:")]
-		void LockDsfId (RequestFlag flags, Action<NSError> completionHandler);
+		void LockDsfId (NFCIso15693RequestFlag flags, Action<NSError> completionHandler);
 
 	}
 
@@ -540,7 +549,7 @@ namespace CoreNFC {
 		void InvalidateSession ();
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("invalidateSessionWithErrorMessage:")]
@@ -588,7 +597,7 @@ namespace CoreNFC {
 
 		[iOS (13,0)]
 		[Export ("asNFCISO15693Tag")]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 		[NullAllowed]
 		INFCIso15693Tag AsNFCIso15693Tag { get; }
@@ -599,7 +608,7 @@ namespace CoreNFC {
 
 		[iOS (13,0)]
 		[Export ("asNFCISO7816Tag")]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 		[NullAllowed]
 		INFCIso7816Tag AsNFCIso7816Tag { get; }
@@ -610,7 +619,7 @@ namespace CoreNFC {
 
 		[iOS (13,0)]
 		[Export ("asNFCFeliCaTag")]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 		[NullAllowed]
 		INFCFeliCaTag AsNFCFeliCaTag { get; }
@@ -621,7 +630,7 @@ namespace CoreNFC {
 
 		[iOS (13,0)]
 		[Export ("asNFCMiFareTag")]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 		[NullAllowed]
 		INFCMiFareTag AsNFCMiFareTag { get; }
@@ -654,7 +663,7 @@ namespace CoreNFC {
 
 	[iOS (13,0)]
 	[Native]
-#if XAMCORE_4_0
+#if NET
 	enum NFCFeliCaEncryptionId
 #else
 	[Advice ("The native name of this enum is 'NFCFeliCaEncryptionId'.")]
@@ -693,7 +702,7 @@ namespace CoreNFC {
 
 	[iOS (13,0)]
 	[Native]
-#if XAMCORE_4_0
+#if NET
 	enum NFCFeliCaPollingRequestCode
 #else
 	[Advice ("The native name of this enum is 'NFCFeliCaPollingRequestCode'.")]
@@ -707,7 +716,7 @@ namespace CoreNFC {
 
 	[iOS (13,0)]
 	[Native]
-#if XAMCORE_4_0
+#if NET
 	enum NFCFeliCaPollingTimeSlot
 #else
 	[Advice ("The native name of this enum is 'NFCFeliCaPollingTimeSlot'.")]
@@ -723,7 +732,7 @@ namespace CoreNFC {
 
 	[iOS (13,0)]
 	[Flags]
-#if XAMCORE_4_0
+#if NET
 	enum NFCIso15693RequestFlag
 #else
 	[Advice ("The native name of this enum is 'NFCIso15693RequestFlag'.")]
@@ -754,7 +763,7 @@ namespace CoreNFC {
 
 	[iOS (13,0)]
 	[Native]
-#if XAMCORE_4_0
+#if NET
 	enum NFCVasErrorCode
 #else
 	[Advice ("The native name of this enum is 'NFCVasErrorCode'.")]
@@ -773,7 +782,7 @@ namespace CoreNFC {
 
 	[iOS (13,0)]
 	[Native]
-#if XAMCORE_4_0
+#if NET
 	enum NFCVasMode 
 #else
 	[Advice ("The native name of this enum is 'NFCVasMode'.")]
@@ -818,7 +827,7 @@ namespace CoreNFC {
 	delegate void NFCFeliCaPollingCompletionHandler (NSData pmm, NSData requestData, NSError error);
 	delegate void NFCFeliCaReadWithoutEncryptionCompletionHandler (nint statusFlag1, nint statusFlag2, NSData [] blockData, NSError error);
 	delegate void NFCFeliCaStatus1Status2CompletionHandler (nint statusFlag1, nint statusFlag2, NSError error);
-	delegate void NFCFeliCaRequestServiceV2CompletionHandler (nint statusFlag1, nint statusFlag2, EncryptionId encryptionIdentifier, NSData [] nodeKeyVersionListAes, NSData [] nodeKeyVersionListDes, NSError error);
+	delegate void NFCFeliCaRequestServiceV2CompletionHandler (nint statusFlag1, nint statusFlag2, NFCFeliCaEncryptionId encryptionIdentifier, NSData [] nodeKeyVersionListAes, NSData [] nodeKeyVersionListDes, NSError error);
 	delegate void NFCFeliCaRequestSpecificationVersionCompletionHandler (nint statusFlag1, nint statusFlag2, NSData basicVersion, NSData optionVersion, NSError error);
 
 	[iOS (13,0)]
@@ -835,7 +844,7 @@ namespace CoreNFC {
 
 		[Abstract]
 		[Export ("pollingWithSystemCode:requestCode:timeSlot:completionHandler:")]
-		void Polling (NSData systemCode, PollingRequestCode requestCode, PollingTimeSlot timeSlot, NFCFeliCaPollingCompletionHandler completionHandler);
+		void Polling (NSData systemCode, NFCFeliCaPollingRequestCode requestCode, NFCFeliCaPollingTimeSlot timeSlot, NFCFeliCaPollingCompletionHandler completionHandler);
 
 		[Abstract]
 		[Export ("requestServiceWithNodeCodeList:completionHandler:")]
@@ -977,7 +986,7 @@ namespace CoreNFC {
 		[Export ("tagReaderSessionDidBecomeActive:")]
 		void DidBecomeActive (NFCTagReaderSession session);
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("tagReaderSession:didDetectTags:")]
@@ -1032,7 +1041,7 @@ namespace CoreNFC {
 	interface NFCVasResponse : NSCopying {
 
 		[Export ("status", ArgumentSemantic.Assign)]
-		VasErrorCode Status { get; }
+		NFCVasErrorCode Status { get; }
 
 		[Export ("vasData", ArgumentSemantic.Retain)]
 		NSData VasData { get; }
@@ -1048,10 +1057,10 @@ namespace CoreNFC {
 
 		[Export ("initWithVASMode:passTypeIdentifier:url:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (VasMode mode, string passTypeIdentifier, [NullAllowed] NSUrl url);
+		IntPtr Constructor (NFCVasMode mode, string passTypeIdentifier, [NullAllowed] NSUrl url);
 
 		[Export ("mode", ArgumentSemantic.Assign)]
-		VasMode Mode { get; set; }
+		NFCVasMode Mode { get; set; }
 
 		[Export ("passTypeIdentifier", ArgumentSemantic.Retain)]
 		string PassTypeIdentifier { get; set; }


### PR DESCRIPTION
* Update code to use the correct name for a few enums.
* Change XAMCORE_4_0 ifdefs to be NET ifdefs.

Fixes these errors when building for XAMCORE_4_0/.NET:

> corenfc.cs(821,96): error CS0246: The type or namespace name 'EncryptionId' could not be found (are you missing a using directive or an assembly reference?)
> corenfc.cs(838,36): error CS0246: The type or namespace name 'PollingRequestCode' could not be found (are you missing a using directive or an assembly reference?)
> corenfc.cs(838,68): error CS0246: The type or namespace name 'PollingTimeSlot' could not be found (are you missing a using directive or an assembly reference?)
> corenfc.cs(1035,3): error CS0246: The type or namespace name 'VasErrorCode' could not be found (are you missing a using directive or an assembly reference?)
> corenfc.cs(1051,23): error CS0246: The type or namespace name 'VasMode' could not be found (are you missing a using directive or an assembly reference?)
> corenfc.cs(1054,3): error CS0246: The type or namespace name 'VasMode' could not be found (are you missing a using directive or an assembly reference?)
> corenfc.cs(201,28): error CS0246: The type or namespace name 'RequestFlag' could not be found (are you missing a using directive or an assembly reference?)
> corenfc.cs(180,25): error CS0246: The type or namespace name 'RequestFlag' could not be found (are you missing a using directive or an assembly reference?)
> corenfc.cs(187,26): error CS0246: The type or namespace name 'RequestFlag' could not be found (are you missing a using directive or an assembly reference?)
> corenfc.cs(194,19): error CS0246: The type or namespace name 'RequestFlag' could not be found (are you missing a using directive or an assembly reference?)
> corenfc.cs(208,29): error CS0246: The type or namespace name 'RequestFlag' could not be found (are you missing a using directive or an assembly reference?)
> [...]