### PR TITLE
[NSZone] Enable nullability + a few other code updates

### DIFF
--- a/src/Foundation/NSZone.cs
+++ b/src/Foundation/NSZone.cs
@@ -1,7 +1,11 @@
 // Copyright 2013 Xamarin Inc. All rights reserved
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
+
+using CoreFoundation;
 using ObjCRuntime;
 
 namespace Foundation {
@@ -17,37 +21,43 @@ namespace Foundation {
 		[DllImport (Constants.FoundationLibrary)]
 		static extern void NSSetZoneName (/* NSZone* */ IntPtr zone, /* NSString* */ IntPtr name);
 
-		internal NSZone ()
-		{
-		}
-
+#if !NET
 		public NSZone (IntPtr handle)
+			: this (handle, false)
 		{
-			this.Handle = handle;
 		}
+#endif
 
 		[Preserve (Conditional = true)]
+#if NET
+		internal NSZone (IntPtr handle, bool owns)
+#else
 		public NSZone (IntPtr handle, bool owns)
-			: this (handle)
+#endif
 		{
 			// NSZone is just an opaque pointer without reference counting, so we ignore the 'owns' parameter.
+			this.Handle = handle;
 		}
 
 		public IntPtr Handle { get; private set; }
 
 #if !COREBUILD
-		public string Name {
+		public string? Name {
 			get {
-				return new NSString (NSZoneName (Handle)).ToString ();
+				return CFString.FromHandle (NSZoneName (Handle));
 			}
 			set {
-				using (var ns = new NSString (value))
-					NSSetZoneName (Handle, ns.Handle);
+				var nsHandle = CFString.CreateNative (value);
+				try {
+					NSSetZoneName (Handle, nsHandle);
+				} finally {
+					CFString.ReleaseNative (nsHandle);
+				}
 			}
 		}
 
 		// note: Copy(NSZone) and MutableCopy(NSZone) with a nil pointer == default
-		public static readonly NSZone Default = new NSZone (NSDefaultMallocZone ());
+		public static readonly NSZone Default = new NSZone (NSDefaultMallocZone (), false);
 #endif
 	}
 }


### PR DESCRIPTION
* Enable nullability and fix code accordingly.
* Use CFString.CreateNative/ReleaseNative instead of other means to create
  native strings (the fastest and least memory hungry option).
* Remove the (IntPtr) constructor for .NET
* Make the (IntPtr, bool) constructor internal for .NET