### PR TITLE
[SystemSound] Don't implement the INativeObject interface for .NET.

### DIFF
--- a/src/AudioToolbox/SystemSound.cs
+++ b/src/AudioToolbox/SystemSound.cs
@@ -43,7 +43,11 @@ namespace AudioToolbox {
 		Vibrate = 0x00000FFF,
 	}
 
+#if NET
+	public class SystemSound : IDisposable {
+#else
 	public class SystemSound : INativeObject, IDisposable {
+#endif
 #if MONOMAC
 		// TODO:
 #else
@@ -74,12 +78,21 @@ namespace AudioToolbox {
 			Dispose (false);
 		}
 
+#if NET
+		public uint SoundId {
+			get {
+				AssertNotDisposed ();
+				return soundId;
+			}
+		}
+#else
 		public IntPtr Handle {
 			get {
 				AssertNotDisposed ();
 				return (IntPtr) soundId;
 			}
 		}
+#endif
 
 		public bool IsUISound {
 			get {

--- a/tests/monotouch-test/AudioToolbox/SystemSoundTest.cs
+++ b/tests/monotouch-test/AudioToolbox/SystemSoundTest.cs
@@ -99,11 +99,19 @@ namespace MonoTouchFixtures.AudioToolbox {
 			var path = NSBundle.MainBundle.PathForResource ("1", "caf", "AudioToolbox");
 
 			var ss = SystemSound.FromFile (NSUrl.FromFilename (path));
+#if NET
+			Assert.That (ss.SoundId, Is.Not.EqualTo ((uint) 0), "DisposeTest");
+#else
 			Assert.That (ss.Handle, Is.Not.EqualTo (IntPtr.Zero), "DisposeTest");
+#endif
 
 			ss.Dispose ();
 			// Handle prop checks NotDisposed and throws if it is
+#if NET
+			Assert.Throws<ObjectDisposedException> (() => ss.SoundId.ToString (), "DisposeTest");
+#else
 			Assert.Throws<ObjectDisposedException> (() => ss.Handle.ToString (), "DisposeTest");
+#endif
 		}
 	}
 }


### PR DESCRIPTION
The supposed handle for system sounds is an uint, which does not match the
IntPtr handle INativeObject uses, so remove the INativeObject interface from
the SystemSound class.