### PR TITLE
[mtouch/mmp/dotnet-bundler] Rework getting the availability attributes so that it works for .NET as well.

### DIFF
--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -308,12 +308,6 @@ namespace Registrar {
 			}
 		}
 
-		protected override List<AvailabilityBaseAttribute> GetAvailabilityAttributes (Type obj)
-		{
-			// No need to implement this until GetSDKVersion is implemented.
-			return null;
-		}
-
 		protected override Version GetSDKVersion ()
 		{
 			// As far as I can tell we can't figure this out at runtime,

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -1089,7 +1089,7 @@ namespace Registrar {
 		protected abstract ConnectAttribute GetConnectAttribute (TProperty property); // Return null if no attribute is found. Do not consider inherited properties.
 		public abstract ProtocolAttribute GetProtocolAttribute (TType type); // Return null if no attribute is found. Do not consider base types.
 		protected abstract IEnumerable<ProtocolMemberAttribute> GetProtocolMemberAttributes (TType type); // Return null if no attributes found. Do not consider base types.
-		protected abstract List<AvailabilityBaseAttribute> GetAvailabilityAttributes (TType obj); // must only return attributes for the current platform.
+		protected virtual Version GetSdkIntroducedVersion (TType obj, out string message) { message = null; return null; } // returns the sdk version when the type was introduced for the current platform (null if all supported versions)
 		protected abstract Version GetSDKVersion ();
 		protected abstract TType GetProtocolAttributeWrapperType (TType type); // Return null if no attribute is found. Do not consider base types.
 		protected abstract BindAsAttribute GetBindAsAttribute (TMethod method, int parameter_index); // If parameter_index = -1 then get the attribute for the return type. Return null if no attribute is found. Must consider base method.
@@ -1538,62 +1538,54 @@ namespace Registrar {
 
 		void VerifyTypeInSDK (ref List<Exception> exceptions, TType type, ObjCMethod parameterIn = null, ObjCMethod returnTypeOf = null, ObjCProperty propertyTypeOf = null, TType baseTypeOf = null)
 		{
-			var attribs = GetAvailabilityAttributes (type);
-			if (attribs == null || attribs.Count == 0)
+			var sdkVersion = GetSdkIntroducedVersion (type, out var message);
+			if (sdkVersion is null)
 				return;
 
 			Version sdk = GetSDKVersion ();
-			foreach (var attrib in attribs) {
-				// The attributes are already filtered to the current platform.
-				switch (attrib.AvailabilityKind) {
-				case AvailabilityKind.Introduced:
-					if (attrib.Version <= sdk)
-						break;
+			if (sdkVersion <= sdk)
+				return;
 
-					string msg;
-					string zero = GetTypeFullName (type);
-					string one = string.Empty;
-					string two = PlatformName;
-					string three = sdk.ToString ();
-					string four = attrib.Version.ToString ();
-					string five = string.IsNullOrEmpty (attrib.Message) ? "." : ": '" + attrib.Message + "'.";
-					if (baseTypeOf != null) {
-						msg = Errors.MT4162_BaseType;
-						one = GetTypeFullName (baseTypeOf);
-					} else if (parameterIn != null) {
-						msg = Errors.MT4162_Parameter;
-						one = parameterIn.DescriptiveMethodName;
-					} else if (returnTypeOf != null) {
-						msg = Errors.MT4162_ReturnType;
-						one = returnTypeOf.DescriptiveMethodName;
-					} else if (propertyTypeOf != null) {
-						msg = Errors.MT4162_PropertyType;
-						one = propertyTypeOf.FullName;
-					} else {
-						msg = Errors.MT4162_A;
-					}
-
-					msg = string.Format (msg, zero, one, two, three, four, five);
-
-					Exception ex;
-
-					if (baseTypeOf != null) {
-						ex = CreateException (4162, baseTypeOf, msg);
-					} else if (parameterIn != null) {
-						ex = CreateException (4162, parameterIn, msg);
-					} else if (returnTypeOf != null) {
-						ex = CreateException (4162, returnTypeOf, msg);
-					} else if (propertyTypeOf != null) {
-						ex = CreateException (4162, propertyTypeOf, msg);
-					} else {
-						ex = CreateException (4162, msg);
-					}
-
-					AddException (ref exceptions, ex);
-
-					break;
-				}
+			string msg;
+			string zero = GetTypeFullName (type);
+			string one = string.Empty;
+			string two = PlatformName;
+			string three = sdk.ToString ();
+			string four = sdkVersion.ToString ();
+			string five = string.IsNullOrEmpty (message) ? "." : ": '" + message + "'.";
+			if (baseTypeOf != null) {
+				msg = Errors.MT4162_BaseType;
+				one = GetTypeFullName (baseTypeOf);
+			} else if (parameterIn != null) {
+				msg = Errors.MT4162_Parameter;
+				one = parameterIn.DescriptiveMethodName;
+			} else if (returnTypeOf != null) {
+				msg = Errors.MT4162_ReturnType;
+				one = returnTypeOf.DescriptiveMethodName;
+			} else if (propertyTypeOf != null) {
+				msg = Errors.MT4162_PropertyType;
+				one = propertyTypeOf.FullName;
+			} else {
+				msg = Errors.MT4162_A;
 			}
+
+			msg = string.Format (msg, zero, one, two, three, four, five);
+
+			Exception ex;
+
+			if (baseTypeOf != null) {
+				ex = CreateException (4162, baseTypeOf, msg);
+			} else if (parameterIn != null) {
+				ex = CreateException (4162, parameterIn, msg);
+			} else if (returnTypeOf != null) {
+				ex = CreateException (4162, returnTypeOf, msg);
+			} else if (propertyTypeOf != null) {
+				ex = CreateException (4162, propertyTypeOf, msg);
+			} else {
+				ex = CreateException (4162, msg);
+			}
+
+			AddException (ref exceptions, ex);
 		}
 
 		protected static void AddException (ref List<Exception> exceptions, Exception mex)

--- a/tests/common/BundlerTool.cs
+++ b/tests/common/BundlerTool.cs
@@ -337,7 +337,7 @@ namespace Xamarin.Tests
 
 		public abstract void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, IList<string> extraArgs = null, string extraCode = null, string usings = null);
 
-		public static string CompileTestAppExecutable (string targetDirectory, string code = null, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp", string extraCode = null, string usings = null)
+		public static string CreateCode (string code, string usings, string extraCode)
 		{
 			if (code == null)
 				code = "public class TestApp { static void Main () { System.Console.WriteLine (typeof (ObjCRuntime.Runtime).ToString ()); } }";
@@ -345,8 +345,12 @@ namespace Xamarin.Tests
 				code = usings + "\n" + code;
 			if (extraCode != null)
 				code += extraCode;
+			return code;
+		}
 
-			return CompileTestAppCode ("exe", targetDirectory, code, extraArgs, profile, appName);
+		public static string CompileTestAppExecutable (string targetDirectory, string code = null, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp", string extraCode = null, string usings = null)
+		{
+			return CompileTestAppCode ("exe", targetDirectory, CreateCode (code, usings, extraCode), extraArgs, profile, appName);
 		}
 
 		public static string CompileTestAppLibrary (string targetDirectory, string code, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp")

--- a/tests/common/Profile.cs
+++ b/tests/common/Profile.cs
@@ -1,3 +1,5 @@
+using System;
+using Xamarin.Utils;
 
 namespace Xamarin.Tests
 {
@@ -11,5 +13,27 @@ namespace Xamarin.Tests
 		macOSMobile,
 		macOSFull,
 		macOSSystem,
+	}
+
+	public static class ProfileExtensions {
+		public static ApplePlatform AsPlatform (this Profile profile)
+		{
+			switch (profile) {
+			case Profile.iOS:
+				return ApplePlatform.iOS;
+			case Profile.tvOS:
+				return ApplePlatform.TVOS;
+			case Profile.watchOS:
+				return ApplePlatform.WatchOS;
+			case Profile.macOSClassic:
+			case Profile.macOSFull:
+			case Profile.macOSMobile:
+			case Profile.macOSSystem:
+				return ApplePlatform.MacCatalyst;
+			case Profile.None:
+			default:
+				throw new NotImplementedException (profile.ToString ());
+			}
+		}
 	}
 }

--- a/tests/common/Tool.cs
+++ b/tests/common/Tool.cs
@@ -60,6 +60,9 @@ namespace Xamarin.Tests
 			get {
 				return output;
 			}
+			set {
+				output = value;
+			}
 		}
 
 		public int Execute (IList<string> arguments)

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -69,6 +69,9 @@ namespace Xamarin
 		public string AotOtherArguments;
 		public string SymbolList;
 
+		public bool IsDotNet;
+		public string ProjectFile;
+
 #pragma warning restore 649
 
 		public MTouchTool ()
@@ -124,6 +127,12 @@ namespace Xamarin
 		{
 			if (!Action.HasValue)
 				Action = MTouchAction.BuildSim;
+			if (IsDotNet) {
+				var rv = DotNet.Execute ("build", ProjectFile, properties: null, assert_success: false);
+				Output = rv.StandardOutput;
+				ParseMessages ();
+				return rv.ExitCode;
+			}
 			return base.Execute ();
 		}
 
@@ -512,11 +521,54 @@ namespace Xamarin
 			}
 			var app = AppPath ?? Path.Combine (testDir, appName + ".app");
 			Directory.CreateDirectory (app);
-			AppPath = app;
-			RootAssembly = CompileTestAppExecutable (testDir, code, extraArgs, Profile, appName, extraCode, usings);
+			if (IsDotNet) {
+				// This code to create a .NET project from the options in this class is very rudimentary; most options are not honored.
+				// To be fixed when support for more options is needed.
+				var mtouchExtraArgs = new List<string> ();
+				if (Registrar != RegistrarOption.Unspecified)
+					mtouchExtraArgs.Add ($"--registrar:" + Registrar.ToString ().ToLower ());
 
-			if (hasPlist)
-				File.WriteAllText (Path.Combine (app, "Info.plist"), CreatePlist (Profile, appName));
+				string linkMode = string.Empty;
+				if (Linker != LinkerOption.Unspecified) {
+					switch (Linker) {
+					case LinkerOption.DontLink:
+						linkMode = "None";
+						break;
+					case LinkerOption.LinkAll:
+						linkMode = "Full";
+						break;
+					case LinkerOption.LinkSdk:
+						linkMode = "SdkOnly";
+						break;
+					case LinkerOption.LinkPlatform:
+					default:
+						throw new NotImplementedException (Linker.ToString ());
+					}
+					linkMode = "<MtouchLink>" + linkMode + "</MtouchLink>";
+				}
+
+				var csproj = $@"<Project Sdk=""Microsoft.NET.Sdk"">
+	<PropertyGroup>
+		<TargetFramework>{Profile.AsPlatform ().ToFramework ()}</TargetFramework>
+		<OutputType>Exe</OutputType>
+		<MtouchExtraArgs>{string.Join (" ", mtouchExtraArgs)}</MtouchExtraArgs>
+		<ApplicationId>{appName}</ApplicationId>
+		{linkMode}
+	</PropertyGroup>
+</Project>";
+				ProjectFile = Path.Combine (testDir, appName + ".csproj");
+				File.WriteAllText (ProjectFile, csproj);
+				File.WriteAllText (Path.Combine (testDir, appName + ".cs"), CreateCode (code, usings, extraCode));
+				if (hasPlist)
+					File.WriteAllText (Path.Combine (testDir, "Info.plist"), CreatePlist (Profile, appName));
+				Configuration.CopyDotNetSupportingFiles (testDir);
+			} else { 
+				AppPath = app;
+				RootAssembly = CompileTestAppExecutable (testDir, code, extraArgs, Profile, appName, extraCode, usings);
+
+				if (hasPlist)
+					File.WriteAllText (Path.Combine (app, "Info.plist"), CreatePlist (Profile, appName));
+			}
 		}
 
 		public void CreateTemporaryServiceExtension (string code = null, string extraCode = null, IList<string> extraArgs = null, string appName = "testServiceExtension")

--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -842,21 +842,17 @@ public struct FooF { public NSObject Obj; }
 			}
 		}
 
-
 		[Test]
 		[TestCase (Profile.iOS, "iOS", MTouchLinker.DontLink)]
 		[TestCase (Profile.tvOS, "tvOS", MTouchLinker.DontLink)]
 		[TestCase (Profile.iOS, "iOS", MTouchLinker.LinkAll)]
 		//[TestCase (Profile.WatchOS, "watchOS")] // MT0077 interferes
-		public void MT4162 (Profile profile, string name, MTouchLinker linker)
+		public void MT4162_msg (Profile profile, string name, MTouchLinker linker)
 		{
 			var code = @"
 	[Introduced (PlatformName.iOS, 99, 0, 0, PlatformArchitecture.All, ""use Z instead"")]
 	[Introduced (PlatformName.TvOS, 99, 0, 0, PlatformArchitecture.All, ""use Z instead"")]
 	[Introduced (PlatformName.WatchOS, 99, 0, 0, PlatformArchitecture.All, ""use Z instead"")]
-	[Introduced (PlatformName.iOS, 89, 0, 0, PlatformArchitecture.All)]
-	[Introduced (PlatformName.TvOS, 89, 0, 0, PlatformArchitecture.All)]
-	[Introduced (PlatformName.WatchOS, 89, 0, 0, PlatformArchitecture.All)]
 	[Register (IsWrapper = true)]
 	class FutureType : NSObject
 	{
@@ -905,13 +901,140 @@ public struct FooF { public NSObject Obj; }
 				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new [] { "-debug" }, usings: "using System;\nusing Foundation;\nusing ObjCRuntime;\n");
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
 				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a base type of CurrentType) is not available in {name} .* (it was introduced in {name} 99.0.0): 'use Z instead'. Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", custom_pattern_syntax: true);
-				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a base type of CurrentType) is not available in {name} .* (it was introduced in {name} 89.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", custom_pattern_syntax: true);
 				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as the property type of CurrentType.Zap) is not available in {name} .* (it was introduced in {name} 99.0.0): 'use Z instead'. Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", "testApp.cs", custom_pattern_syntax: true);
-				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as the property type of CurrentType.Zap) is not available in {name} .* (it was introduced in {name} 89.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", "testApp.cs", custom_pattern_syntax: true);
 				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a parameter in CurrentType.Foo) is not available in {name} .* (it was introduced in {name} 99.0.0): 'use Z instead'. Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", "testApp.cs", custom_pattern_syntax: true);
-				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a parameter in CurrentType.Foo) is not available in {name} .* (it was introduced in {name} 89.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", "testApp.cs", custom_pattern_syntax: true);
 				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a return type in CurrentType.Bar) is not available in {name} .* (it was introduced in {name} 99.0.0): 'use Z instead'. Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", "testApp.cs", custom_pattern_syntax: true);
-				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a return type in CurrentType.Bar) is not available in {name} .* (it was introduced in {name} 89.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", "testApp.cs", custom_pattern_syntax: true);
+			}
+		}
+
+		[Test]
+		[TestCase (Profile.iOS, "iOS", MTouchLinker.DontLink)]
+		[TestCase (Profile.tvOS, "tvOS", MTouchLinker.DontLink)]
+		[TestCase (Profile.iOS, "iOS", MTouchLinker.LinkAll)]
+		//[TestCase (Profile.WatchOS, "watchOS")] // MT0077 interferes
+		public void MT4162 (Profile profile, string name, MTouchLinker linker)
+		{
+			var code = @"
+	[Introduced (PlatformName.iOS, 99, 0, 0, PlatformArchitecture.All)]
+	[Introduced (PlatformName.TvOS, 99, 0, 0, PlatformArchitecture.All)]
+	[Introduced (PlatformName.WatchOS, 99, 0, 0, PlatformArchitecture.All)]
+	[Register (IsWrapper = true)]
+	class FutureType : NSObject
+	{
+		public FutureType () {}
+	}
+
+	class CurrentType : FutureType
+	{
+		[Export (""foo:"")]
+		public void Foo (FutureType ft)
+		{
+		}
+
+		[Export (""bar"")]
+		public FutureType Bar ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		[Export (""zap"")]
+		public FutureType Zap { get; set; }
+
+		// This is actually working now, but only because we erase the generic argument when converting to ObjC.
+		[Export (""zaps"")]
+		public NSSet<FutureType> Zaps { get; set; }
+	}
+
+	[Protocol (Name = ""FutureProtocol"")]
+	[ProtocolMember (IsRequired = false, IsProperty = true, IsStatic = false, Name = ""FutureProperty"", Selector = ""futureProperty"", PropertyType = typeof (FutureEnum), GetterSelector = ""futureProperty"", SetterSelector = ""setFutureProperty:"", ArgumentSemantic = ArgumentSemantic.UnsafeUnretained)]
+	[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = ""FutureMethod"", Selector = ""futureMethod"", ReturnType = typeof (FutureEnum), ParameterType = new Type [] { typeof (FutureEnum) }, ParameterByRef = new bool [] { false })]
+	public interface IFutureProtocol : INativeObject, IDisposable
+	{
+	}
+
+	[Introduced (PlatformName.iOS, 99, 0, 0, PlatformArchitecture.All)]
+	[Introduced (PlatformName.TvOS, 99, 0, 0, PlatformArchitecture.All)]
+	[Introduced (PlatformName.WatchOS, 99, 0, 0, PlatformArchitecture.All)]
+	public enum FutureEnum {
+	}
+";
+			
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.Profile = profile;
+				mtouch.Linker = linker;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new [] { "-debug" }, usings: "using System;\nusing Foundation;\nusing ObjCRuntime;\n");
+				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
+				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a base type of CurrentType) is not available in {name} .* (it was introduced in {name} 99.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", custom_pattern_syntax: true);
+				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as the property type of CurrentType.Zap) is not available in {name} .* (it was introduced in {name} 99.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", "testApp.cs", custom_pattern_syntax: true);
+				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a parameter in CurrentType.Foo) is not available in {name} .* (it was introduced in {name} 99.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", "testApp.cs", custom_pattern_syntax: true);
+				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a return type in CurrentType.Bar) is not available in {name} .* (it was introduced in {name} 99.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", "testApp.cs", custom_pattern_syntax: true);
+			}
+		}
+
+		[Test]
+		[TestCase (Profile.iOS, "iOS", MTouchLinker.DontLink)]
+		[TestCase (Profile.tvOS, "tvOS", MTouchLinker.DontLink)]
+		[TestCase (Profile.iOS, "iOS", MTouchLinker.LinkAll)]
+		public void MT4162_dotnet (Profile profile, string name, MTouchLinker linker)
+		{
+			var code = @"
+	[SupportedOSPlatform (""ios77.0"")]
+	[SupportedOSPlatform (""tvos77.0"")]
+	[SupportedOSPlatform (""macos77.0"")]
+	[SupportedOSPlatform (""maccatalyst77.0"")]
+	[Register (IsWrapper = true)]
+	class FutureType : NSObject
+	{
+		public FutureType () {}
+	}
+
+	class CurrentType : FutureType
+	{
+		[Export (""foo:"")]
+		public void Foo (FutureType ft)
+		{
+		}
+
+		[Export (""bar"")]
+		public FutureType Bar ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		[Export (""zap"")]
+		public FutureType Zap { get; set; }
+
+		// This is actually working now, but only because we erase the generic argument when converting to ObjC.
+		[Export (""zaps"")]
+		public NSSet<FutureType> Zaps { get; set; }
+	}
+
+	[Protocol (Name = ""FutureProtocol"")]
+	[ProtocolMember (IsRequired = false, IsProperty = true, IsStatic = false, Name = ""FutureProperty"", Selector = ""futureProperty"", PropertyType = typeof (FutureEnum), GetterSelector = ""futureProperty"", SetterSelector = ""setFutureProperty:"", ArgumentSemantic = ArgumentSemantic.UnsafeUnretained)]
+	[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = ""FutureMethod"", Selector = ""futureMethod"", ReturnType = typeof (FutureEnum), ParameterType = new Type [] { typeof (FutureEnum) }, ParameterByRef = new bool [] { false })]
+	public interface IFutureProtocol : INativeObject, IDisposable
+	{
+	}
+
+	[Introduced (PlatformName.iOS, 99, 0, 0, PlatformArchitecture.All)]
+	[Introduced (PlatformName.TvOS, 99, 0, 0, PlatformArchitecture.All)]
+	[Introduced (PlatformName.WatchOS, 99, 0, 0, PlatformArchitecture.All)]
+	public enum FutureEnum {
+	}
+";
+			
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.IsDotNet = true;
+				mtouch.Profile = profile;
+				mtouch.Linker = linker;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new [] { "-debug" }, usings: "using System;\nusing Foundation;\nusing ObjCRuntime;\nusing System.Runtime.Versioning;\n");
+				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
+				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a base type of CurrentType) is not available in {name} .* (it was introduced in {name} 77.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", custom_pattern_syntax: true);
+				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as the property type of CurrentType.Zap) is not available in {name} .* (it was introduced in {name} 77.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", "testApp.cs", custom_pattern_syntax: true);
+				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a parameter in CurrentType.Foo) is not available in {name} .* (it was introduced in {name} 77.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", "testApp.cs", custom_pattern_syntax: true);
+				mtouch.AssertErrorPattern (4162, $"The type 'FutureType' (used as a return type in CurrentType.Bar) is not available in {name} .* (it was introduced in {name} 77.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).", "testApp.cs", custom_pattern_syntax: true);
 			}
 		}
 

--- a/tests/mtouch/mtouchtests.csproj
+++ b/tests/mtouch/mtouchtests.csproj
@@ -88,6 +88,9 @@
       <Link>BinLog.cs</Link>
     </Compile>
     <Compile Include="LocalizationTests.cs" />
+    <Compile Include="..\common\DotNet.cs">
+      <Link>DotNet.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\tools\mtouch\mtouch.csproj">

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -1562,8 +1562,198 @@ namespace Registrar {
 			}
 		}
 
-		void CollectAvailabilityAttributes (IEnumerable<ICustomAttribute> attributes, ref List<AvailabilityBaseAttribute> list)
+#if !NET
+		bool GetLegacyAvailabilityAttribute (ICustomAttribute ca, PlatformName currentPlatform, out Version sdkVersion, out string message)
 		{
+			var caType = ca.AttributeType;
+			AvailabilityKind kind;
+			PlatformName platformName = global::ObjCRuntime.PlatformName.None;
+			PlatformArchitecture architecture = PlatformArchitecture.All;
+			int majorVersion = 0, minorVersion = 0, subminorVersion = 0;
+			bool shorthand = false;
+
+			sdkVersion = null;
+			message = null;
+
+			switch (caType.Name) {
+			case "MacAttribute":
+				shorthand = true;
+				platformName = global::ObjCRuntime.PlatformName.MacOSX;
+				goto case "IntroducedAttribute";
+			case "iOSAttribute":
+				shorthand = true;
+				platformName = global::ObjCRuntime.PlatformName.iOS;
+				goto case "IntroducedAttribute";
+			case "IntroducedAttribute":
+				kind = AvailabilityKind.Introduced;
+				break;
+			default:
+				return false;
+			}
+
+			switch (ca.ConstructorArguments.Count) {
+			case 2:
+				if (!shorthand)
+					throw ErrorHelper.CreateError (4163, Errors.MT4163, caType.Name, ca.ConstructorArguments.Count);
+				majorVersion = (byte) ca.ConstructorArguments [0].Value;
+				minorVersion = (byte) ca.ConstructorArguments [1].Value;
+				break;
+			case 3:
+				if (!shorthand) {
+					platformName = (PlatformName) ca.ConstructorArguments [0].Value;
+					architecture = (PlatformArchitecture) ca.ConstructorArguments [1].Value;
+					message = (string) ca.ConstructorArguments [2].Value;
+				} else {
+					majorVersion = (byte) ca.ConstructorArguments [0].Value;
+					minorVersion = (byte) ca.ConstructorArguments [1].Value;
+					if (ca.ConstructorArguments [2].Type.Name == "Boolean") {
+						var onlyOn64 = (bool) ca.ConstructorArguments [2].Value;
+						architecture = onlyOn64 ? PlatformArchitecture.Arch64 : PlatformArchitecture.All;
+					} else if (ca.ConstructorArguments [2].Type.Name == "Byte") {
+						minorVersion = (byte) ca.ConstructorArguments [2].Value;
+					} else {
+						throw ErrorHelper.CreateError (4163, Errors.MT4163, caType.Name, ca.ConstructorArguments.Count);
+					}
+				}
+				break;
+			case 4:
+				if (!shorthand)
+					throw ErrorHelper.CreateError (4163, Errors.MT4163, caType.Name, ca.ConstructorArguments.Count);
+
+				majorVersion = (byte) ca.ConstructorArguments [0].Value;
+				minorVersion = (byte) ca.ConstructorArguments [1].Value;
+				minorVersion = (byte) ca.ConstructorArguments [2].Value;
+				if (ca.ConstructorArguments [3].Type.Name == "Boolean") {
+					var onlyOn64 = (bool) ca.ConstructorArguments [3].Value;
+					architecture = onlyOn64 ? PlatformArchitecture.Arch64 : PlatformArchitecture.All;
+				} else if (ca.ConstructorArguments [3].Type.Name == "PlatformArchitecture") {
+					architecture = (PlatformArchitecture) (byte) ca.ConstructorArguments [3].Value;
+				} else {
+					throw ErrorHelper.CreateError (4163, Errors.MT4163, caType.Name, ca.ConstructorArguments.Count);
+				}
+				break;
+			case 5:
+				platformName = (PlatformName) ca.ConstructorArguments [0].Value;
+				majorVersion = (int) ca.ConstructorArguments [1].Value;
+				minorVersion = (int) ca.ConstructorArguments [2].Value;
+				architecture = (PlatformArchitecture) ca.ConstructorArguments [3].Value;
+				message = (string) ca.ConstructorArguments [4].Value;
+				break;
+			case 6:
+				platformName = (PlatformName) ca.ConstructorArguments [0].Value;
+				majorVersion = (int) ca.ConstructorArguments [1].Value;
+				minorVersion = (int) ca.ConstructorArguments [2].Value;
+				subminorVersion = (int) ca.ConstructorArguments [3].Value;
+				architecture = (PlatformArchitecture) ca.ConstructorArguments [4].Value;
+				message = (string) ca.ConstructorArguments [5].Value;
+				break;
+			default:
+				throw ErrorHelper.CreateError (4163, Errors.MT4163, caType.Name, ca.ConstructorArguments.Count);
+			}
+
+			if (platformName != currentPlatform)
+				return false;
+
+			sdkVersion = new Version (majorVersion, minorVersion, subminorVersion);
+			switch (kind) {
+			case AvailabilityKind.Introduced:
+				if (shorthand) {
+					sdkVersion = new Version (majorVersion, minorVersion, subminorVersion);
+				} else {
+					switch (ca.ConstructorArguments.Count) {
+					case 5:
+						sdkVersion = new Version (majorVersion, minorVersion);
+						break;
+					case 6:
+						sdkVersion = new Version (majorVersion, minorVersion, subminorVersion);
+						break;
+					default:
+						throw ErrorHelper.CreateError (4163, Errors.MT4163, caType.Name, ca.ConstructorArguments.Count);
+					}
+				}
+				break;
+			default:
+				throw ErrorHelper.CreateError (4163, Errors.MT4163_A, kind);
+			}
+
+			return true;
+		}
+#endif // !NET
+
+#if NET
+		bool GetDotNetAvailabilityAttribute (ICustomAttribute ca, PlatformName currentPlatform, out Version sdkVersion, out string message)
+		{
+			var caType = ca.AttributeType;
+			var platformName = global::ObjCRuntime.PlatformName.None;
+
+			sdkVersion = null;
+			message = null;
+
+			string supportedPlatformAndVersion;
+			switch (ca.ConstructorArguments.Count) {
+			case 1:
+				supportedPlatformAndVersion = (string) ca.ConstructorArguments [0].Value;
+				break;
+			default:
+				throw ErrorHelper.CreateError (4163, Errors.MT4163, caType.Name, ca.ConstructorArguments.Count);
+			}
+
+			if (string.IsNullOrEmpty (supportedPlatformAndVersion))
+				return false;
+
+			var versionIndex = -1;
+			for (var i = 0; i < supportedPlatformAndVersion.Length; i++) {
+				if (supportedPlatformAndVersion [i] >= '0' && supportedPlatformAndVersion [i] <= '9') {
+					versionIndex = i;
+					break;
+				}
+			}
+			string supportedPlatform;
+			string supportedVersion = null;
+
+			if (versionIndex == -1) {
+				supportedPlatform = supportedPlatformAndVersion;
+			} else {
+				supportedPlatform = supportedPlatformAndVersion.Substring (0, versionIndex);
+				supportedVersion = supportedPlatformAndVersion.Substring (versionIndex);
+			}
+
+			supportedPlatform = supportedPlatform.ToLowerInvariant ();
+			switch (supportedPlatform) {
+			case "ios":
+				platformName = global::ObjCRuntime.PlatformName.iOS;
+				break;
+			case "tvos":
+				platformName = global::ObjCRuntime.PlatformName.TvOS;
+				break;
+			case "macos":
+				platformName = global::ObjCRuntime.PlatformName.MacOSX;
+				break;
+			case "maccatalyst":
+				plathuhformName = global::ObjCRuntime.PlatformName.MacCatalyst;
+				break;
+			case "watchos":
+				platformName = global::ObjCRuntime.PlatformName.WatchOS;
+				break;
+			default:
+				return false;
+			}
+
+			if (platformName != currentPlatform)
+				return false;
+
+			if (!Version.TryParse (supportedVersion, out sdkVersion))
+				return false;
+
+			return true;
+		}
+#endif // NET
+
+		bool CollectAvailabilityAttributes (IEnumerable<ICustomAttribute> attributes, out Version sdkVersion, out string message)
+		{
+			sdkVersion = null;
+			message = null;
+
 			PlatformName currentPlatform;
 			switch (App.Platform) {
 			case ApplePlatform.iOS:
@@ -1585,188 +1775,67 @@ namespace Registrar {
 				throw ErrorHelper.CreateError (71, Errors.MX0071, App.Platform, App.ProductName);
 			}
 
-			foreach (var ca in attributes) {
-				var caType = ca.AttributeType;
-				if (caType.Namespace != ObjCRuntime && !string.IsNullOrEmpty (caType.Namespace))
-					continue;
-				
-				AvailabilityKind kind;
-				PlatformName platformName = global::ObjCRuntime.PlatformName.None;
-				PlatformArchitecture architecture = PlatformArchitecture.All;
-				string message = null;
-				int majorVersion = 0, minorVersion = 0, subminorVersion = 0;
-				bool shorthand = false;
+			global::ObjCRuntime.PlatformName [] platforms;
 
-				switch (caType.Name) {
-				case "MacAttribute":
-					shorthand = true;
-					platformName = global::ObjCRuntime.PlatformName.MacOSX;
-					goto case "IntroducedAttribute";
-				case "iOSAttribute":
-					shorthand = true;
-					platformName = global::ObjCRuntime.PlatformName.iOS;
-					goto case "IntroducedAttribute";
-				case "IntroducedAttribute":
-					kind = AvailabilityKind.Introduced;
-					break;
-				case "DeprecatedAttribute":
-					kind = AvailabilityKind.Deprecated;
-					break;
-				case "ObsoletedAttribute":
-					kind = AvailabilityKind.Obsoleted;
-					break;
-				case "UnavailableAttribute":
-					kind = AvailabilityKind.Unavailable;
-					break;
-				default:
-					continue;
-				}
+#if !NET
+			if (currentPlatform == global::ObjCRuntime.PlatformName.MacCatalyst) {
+				// Fall back to any iOS attributes if we can't find something for Mac Catalyst
+				platforms = new global::ObjCRuntime.PlatformName [] {
+					currentPlatform,
+					global::ObjCRuntime.PlatformName.iOS,
+				};
 
-				switch (ca.ConstructorArguments.Count) {
-				case 2:
-					if (!shorthand)
-						throw ErrorHelper.CreateError (4163, Errors.MT4163, caType.Name, ca.ConstructorArguments.Count);
-					majorVersion = (byte) ca.ConstructorArguments [0].Value;
-					minorVersion = (byte) ca.ConstructorArguments [1].Value;
-					break;
-				case 3:
-					if (!shorthand) {
-						platformName = (PlatformName) ca.ConstructorArguments [0].Value;
-						architecture = (PlatformArchitecture) ca.ConstructorArguments [1].Value;
-						message = (string) ca.ConstructorArguments [2].Value;
-					} else {
-						majorVersion = (byte) ca.ConstructorArguments [0].Value;
-						minorVersion = (byte) ca.ConstructorArguments [1].Value;
-						if (ca.ConstructorArguments [2].Type.Name == "Boolean") {
-							var onlyOn64 = (bool) ca.ConstructorArguments [2].Value;
-							architecture = onlyOn64 ? PlatformArchitecture.Arch64 : PlatformArchitecture.All;
-						} else if (ca.ConstructorArguments [2].Type.Name == "Byte") {
-							minorVersion = (byte) ca.ConstructorArguments [2].Value;
-						} else {
-							throw ErrorHelper.CreateError (4163, Errors.MT4163, caType.Name, ca.ConstructorArguments.Count);
-						}
-					}
-					break;
-				case 4:
-					if (!shorthand)
-						throw ErrorHelper.CreateError (4163, Errors.MT4163, caType.Name, ca.ConstructorArguments.Count);
-
-					majorVersion = (byte) ca.ConstructorArguments [0].Value;
-					minorVersion = (byte) ca.ConstructorArguments [1].Value;
-					minorVersion = (byte) ca.ConstructorArguments [2].Value;
-					if (ca.ConstructorArguments [3].Type.Name == "Boolean") {
-						var onlyOn64 = (bool) ca.ConstructorArguments [3].Value;
-						architecture = onlyOn64 ? PlatformArchitecture.Arch64 : PlatformArchitecture.All;
-					} else if (ca.ConstructorArguments [3].Type.Name == "PlatformArchitecture") {
-						architecture = (PlatformArchitecture) (byte) ca.ConstructorArguments [3].Value;
-					} else {
-						throw ErrorHelper.CreateError (4163, Errors.MT4163, caType.Name, ca.ConstructorArguments.Count);
-					}
-					break;
-				case 5:
-					platformName = (PlatformName) ca.ConstructorArguments [0].Value;
-					majorVersion = (int) ca.ConstructorArguments [1].Value;
-					minorVersion = (int) ca.ConstructorArguments [2].Value;
-					architecture = (PlatformArchitecture) ca.ConstructorArguments [3].Value;
-					message = (string) ca.ConstructorArguments [4].Value;
-					break;
-				case 6:
-					platformName = (PlatformName) ca.ConstructorArguments [0].Value;
-					majorVersion = (int) ca.ConstructorArguments [1].Value;
-					minorVersion = (int) ca.ConstructorArguments [2].Value;
-					subminorVersion = (int) ca.ConstructorArguments [3].Value;
-					architecture = (PlatformArchitecture) ca.ConstructorArguments [4].Value;
-					message = (string) ca.ConstructorArguments [5].Value;
-					break;
-				default:
-					throw ErrorHelper.CreateError (4163, Errors.MT4163, caType.Name, ca.ConstructorArguments.Count);
-				}
-
-				if (platformName != currentPlatform)
-					continue;
-
-				AvailabilityBaseAttribute rv;
-				switch (kind) {
-				case AvailabilityKind.Introduced:
-					if (shorthand) {
-						rv = new IntroducedAttribute (platformName, majorVersion, minorVersion, subminorVersion, architecture, message);
-					} else {
-						switch (ca.ConstructorArguments.Count) {
-						case 3:
-							rv = new IntroducedAttribute (platformName, architecture, message);
-							break;
-						case 5:
-							rv = new IntroducedAttribute (platformName, majorVersion, minorVersion, architecture, message);
-							break;
-						case 6:
-							rv = new IntroducedAttribute (platformName, majorVersion, minorVersion, subminorVersion, architecture, message);
-							break;
-						default:
-							throw ErrorHelper.CreateError (4163, Errors.MT4163, caType.Name, ca.ConstructorArguments.Count);
-						}
-					}
-					break;
-				case AvailabilityKind.Deprecated:
-					switch (ca.ConstructorArguments.Count) {
-					case 3:
-						rv = new DeprecatedAttribute (platformName, architecture, message);
-						break;
-					case 5:
-						rv = new DeprecatedAttribute (platformName, majorVersion, minorVersion, architecture, message);
-						break;
-					case 6:
-						rv = new DeprecatedAttribute (platformName, majorVersion, minorVersion, subminorVersion, architecture, message);
-						break;
-					default:
-						throw ErrorHelper.CreateError (4163, Errors.MT4163, caType.Name, ca.ConstructorArguments.Count);
-					}
-					break;
-				case AvailabilityKind.Obsoleted:
-					switch (ca.ConstructorArguments.Count) {
-					case 3:
-						rv = new ObsoletedAttribute (platformName, architecture, message);
-						break;
-					case 5:
-						rv = new ObsoletedAttribute (platformName, majorVersion, minorVersion, architecture, message);
-						break;
-					case 6:
-						rv = new ObsoletedAttribute (platformName, majorVersion, minorVersion, subminorVersion, architecture, message);
-						break;
-					default:
-						throw ErrorHelper.CreateError (4163, Errors.MT4163, caType.Name, ca.ConstructorArguments.Count);
-					}
-					break;
-				case AvailabilityKind.Unavailable:
-					rv = new UnavailableAttribute (platformName, architecture, message);
-					break;
-				default:
-					throw ErrorHelper.CreateError (4163, Errors.MT4163_A, kind);
-				}
-
-				if (list == null)
-					list = new List<AvailabilityBaseAttribute> ();
-				list.Add (rv);
+			} else {
+				platforms = new global::ObjCRuntime.PlatformName [] {
+					currentPlatform,
+				};
 			}
+#else
+			platforms = new global::ObjCRuntime.PlatformName [] {
+				currentPlatform,
+			};
+#endif
+
+			foreach (var platform in platforms) {
+				foreach (var ca in attributes) {
+					var caType = ca.AttributeType;
+#if NET
+					if (!caType.Is ("System.Runtime.Versioning", "SupportedOSPlatformAttribute"))
+						continue;
+					if (GetDotNetAvailabilityAttribute (ca, platform, out sdkVersion, out message))
+						return true;
+#else
+					if (caType.Namespace != ObjCRuntime && !string.IsNullOrEmpty (caType.Namespace))
+						continue;
+					if (GetLegacyAvailabilityAttribute (ca, platform, out sdkVersion, out message))
+						return true;
+#endif
+				}
+			}
+
+			return false;
 		}
 
-		protected override List<AvailabilityBaseAttribute> GetAvailabilityAttributes (TypeReference obj)
+		protected override Version GetSdkIntroducedVersion (TypeReference obj, out string message)
 		{
 			TypeDefinition td = obj.Resolve ();
-			List<AvailabilityBaseAttribute> rv = null;
 
-			if (td == null)
+			message = null;
+
+			if (td is null)
 				return null;
-			
-			if (td.HasCustomAttributes)
-				CollectAvailabilityAttributes (td.CustomAttributes, ref rv);
-			
-			if (AvailabilityAnnotations != null) {
-				object attribObjects;
-				if (AvailabilityAnnotations.TryGetValue (td, out attribObjects))
-					CollectAvailabilityAttributes ((IEnumerable<ICustomAttribute>) attribObjects, ref rv);
+
+			if (td.HasCustomAttributes) {
+				if (CollectAvailabilityAttributes (td.CustomAttributes, out var sdkVersion, out message))
+					return sdkVersion;
 			}
 
-			return rv;
+			if (AvailabilityAnnotations is not null && AvailabilityAnnotations.TryGetValue (td, out var attribObjects)) {
+				if (CollectAvailabilityAttributes ((IEnumerable<ICustomAttribute>) attribObjects, out var sdkVersion, out message))
+					return sdkVersion;
+			}
+
+			return null;
 		}
 
 		protected override Version GetSDKVersion ()

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -1730,7 +1730,7 @@ namespace Registrar {
 				platformName = global::ObjCRuntime.PlatformName.MacOSX;
 				break;
 			case "maccatalyst":
-				plathuhformName = global::ObjCRuntime.PlatformName.MacCatalyst;
+				platformName = global::ObjCRuntime.PlatformName.MacCatalyst;
 				break;
 			case "watchos":
 				platformName = global::ObjCRuntime.PlatformName.WatchOS;

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -1563,9 +1563,28 @@ namespace Registrar {
 		}
 
 #if !NET
-		bool GetLegacyAvailabilityAttribute (ICustomAttribute ca, PlatformName currentPlatform, out Version sdkVersion, out string message)
+		PlatformName AsPlatformName (ApplePlatform platform)
+		{
+			switch (platform) {
+			case ApplePlatform.iOS:
+				return global::ObjCRuntime.PlatformName.iOS;
+			case ApplePlatform.TVOS:
+				return global::ObjCRuntime.PlatformName.TvOS;
+			case ApplePlatform.WatchOS:
+				return global::ObjCRuntime.PlatformName.WatchOS;
+			case ApplePlatform.MacOSX:
+				return global::ObjCRuntime.PlatformName.MacOSX;
+			case ApplePlatform.MacCatalyst:
+				return global::ObjCRuntime.PlatformName.MacCatalyst;
+			default:
+				throw ErrorHelper.CreateError (99, Errors.MX0099, $"unknown platform: {platform}");
+			}
+		}
+
+		bool GetLegacyAvailabilityAttribute (ICustomAttribute ca, ApplePlatform platform, out Version sdkVersion, out string message)
 		{
 			var caType = ca.AttributeType;
+			var currentPlatform = AsPlatformName (platform);
 			AvailabilityKind kind;
 			PlatformName platformName = global::ObjCRuntime.PlatformName.None;
 			PlatformArchitecture architecture = PlatformArchitecture.All;
@@ -1681,10 +1700,10 @@ namespace Registrar {
 #endif // !NET
 
 #if NET
-		bool GetDotNetAvailabilityAttribute (ICustomAttribute ca, PlatformName currentPlatform, out Version sdkVersion, out string message)
+		bool GetDotNetAvailabilityAttribute (ICustomAttribute ca, ApplePlatform currentPlatform, out Version sdkVersion, out string message)
 		{
 			var caType = ca.AttributeType;
-			var platformName = global::ObjCRuntime.PlatformName.None;
+			var platformName = ApplePlatform.None;
 
 			sdkVersion = null;
 			message = null;
@@ -1721,19 +1740,19 @@ namespace Registrar {
 			supportedPlatform = supportedPlatform.ToLowerInvariant ();
 			switch (supportedPlatform) {
 			case "ios":
-				platformName = global::ObjCRuntime.PlatformName.iOS;
+				platformName = ApplePlatform.iOS;
 				break;
 			case "tvos":
-				platformName = global::ObjCRuntime.PlatformName.TvOS;
+				platformName = ApplePlatform.TVOS;
 				break;
 			case "macos":
-				platformName = global::ObjCRuntime.PlatformName.MacOSX;
+				platformName = ApplePlatform.MacOSX;
 				break;
 			case "maccatalyst":
-				platformName = global::ObjCRuntime.PlatformName.MacCatalyst;
+				platformName = ApplePlatform.MacCatalyst;
 				break;
 			case "watchos":
-				platformName = global::ObjCRuntime.PlatformName.WatchOS;
+				platformName = ApplePlatform.WatchOS;
 				break;
 			default:
 				return false;
@@ -1754,44 +1773,44 @@ namespace Registrar {
 			sdkVersion = null;
 			message = null;
 
-			PlatformName currentPlatform;
+			ApplePlatform currentPlatform;
 			switch (App.Platform) {
 			case ApplePlatform.iOS:
-				currentPlatform = global::ObjCRuntime.PlatformName.iOS;
+				currentPlatform = ApplePlatform.iOS;
 				break;
 			case ApplePlatform.TVOS:
-				currentPlatform = global::ObjCRuntime.PlatformName.TvOS;
+				currentPlatform = ApplePlatform.TVOS;
 				break;
 			case ApplePlatform.WatchOS:
-				currentPlatform = global::ObjCRuntime.PlatformName.WatchOS;
+				currentPlatform = ApplePlatform.WatchOS;
 				break;
 			case ApplePlatform.MacOSX:
-				currentPlatform = global::ObjCRuntime.PlatformName.MacOSX;
+				currentPlatform = ApplePlatform.MacOSX;
 				break;
 			case ApplePlatform.MacCatalyst:
-				currentPlatform = global::ObjCRuntime.PlatformName.MacCatalyst;
+				currentPlatform = ApplePlatform.MacCatalyst;
 				break;
 			default:
 				throw ErrorHelper.CreateError (71, Errors.MX0071, App.Platform, App.ProductName);
 			}
 
-			global::ObjCRuntime.PlatformName [] platforms;
+			ApplePlatform [] platforms;
 
 #if !NET
-			if (currentPlatform == global::ObjCRuntime.PlatformName.MacCatalyst) {
+			if (currentPlatform == ApplePlatform.MacCatalyst) {
 				// Fall back to any iOS attributes if we can't find something for Mac Catalyst
-				platforms = new global::ObjCRuntime.PlatformName [] {
+				platforms = new ApplePlatform [] {
 					currentPlatform,
-					global::ObjCRuntime.PlatformName.iOS,
+					ApplePlatform.iOS,
 				};
 
 			} else {
-				platforms = new global::ObjCRuntime.PlatformName [] {
+				platforms = new ApplePlatform [] {
 					currentPlatform,
 				};
 			}
 #else
-			platforms = new global::ObjCRuntime.PlatformName [] {
+			platforms = new ApplePlatform [] {
 				currentPlatform,
 			};
 #endif


### PR DESCRIPTION
* Stop using AvailabilityBaseAttribute, this type will disappear in .NET.
* Handle System.Runtime.Versioning.SupportedOSPlatformAttribute instead of our own availability attributes for .NET.
* Add tests (somewhat hacked together, but they work).