### PR TITLE
[tools] HomeKit was added to Mac Catalyst in 14.0, so mark it as such.

### DIFF
--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -128,6 +128,10 @@ namespace Introspection {
 #else
 				return TestRuntime.CheckExactXcodeVersion (12, 2, beta: 3);
 #endif
+			case "SpriteKit.SKView":
+				// Causes a crash later. Filed as radar://18440271.
+				// Apple said they won't fix this ('init' isn't a designated initializer)
+				return true;
 			}
 
 #if !NET

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -128,7 +128,7 @@ namespace Introspection {
 #else
 				return TestRuntime.CheckExactXcodeVersion (12, 2, beta: 3);
 #endif
-			case "SpriteKit.SKView":
+			case "SKView":
 				// Causes a crash later. Filed as radar://18440271.
 				// Apple said they won't fix this ('init' isn't a designated initializer)
 				return true;

--- a/tests/introspection/Mac/MacApiCtorInitTest.cs
+++ b/tests/introspection/Mac/MacApiCtorInitTest.cs
@@ -126,15 +126,6 @@ namespace Introspection {
 					return true;
 				break;
 
-#if !XAMCORE_3_0
-			case "SpriteKit.SKView":
-				// Causes a crash later. Filed as radar://18440271.
-				// Apple said they won't fix this ('init' isn't a designated initializer)
-				if (IntPtr.Size == 8)
-					return true;
-				break;
-#endif
-
 			case "MonoMac.AppKit.NSSpeechRecognizer":
 			case "AppKit.NSSpeechRecognizer":
 				// Makes OSX put up "a download is required for speech recognition" dialog.

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -615,10 +615,15 @@ public class Frameworks : Dictionary <string, Framework>
 			catalyst_frameworks.Add ("CoreWlan", "CoreWLAN", 15, 0);
 
 			var min = new Version (13, 0);
+			var v14_0 = new Version (14, 0);
 			var v14_2 = new Version (14, 2);
 			foreach (var f in catalyst_frameworks.Values) {
 				switch (f.Name) {
 				// These frameworks were added to Catalyst after they were added to iOS, so we have to adjust the Versions fields
+				case "HomeKit":
+					f.Version = v14_0;
+					f.VersionAvailableInSimulator = v14_0;
+					break;
 				case "AddressBook":
 				case "ClassKit":
 				case "UserNotificationsUI":


### PR DESCRIPTION
Fixes this launch crash when executing on macOS 10.15:

    dyld: Library not loaded: /System/iOSSupport/System/Library/Frameworks/HomeKit.framework/Versions/A/HomeKit
      Referenced from: /Users/runner/work/1/s/artifacts/mac-test-package/tests/./linker/ios/dont link/dotnet/MacCatalyst/bin/Debug/net6.0-maccatalyst/maccatalyst-x64/dont link.app/Contents/MacOS/dont link
      Reason: image not found