### PR TITLE
[CI] Do not try to find the minor version until a bug is fixed.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -54,7 +54,7 @@ parameters:
       statusContext: 'VSTS: device tests iOS',
       iOSDeviceDemand: [
         'ios',
-        "Agent.OSVersion -equals '11.6'"
+        "Agent.OSVersion -equals '11.0'" 
       ]
     },
     {
@@ -68,7 +68,7 @@ parameters:
       statusContext: 'VSTS: device tests tvOS',
       iOSDeviceDemand: [
         'tvos',
-        "Agent.OSVersion -equals '11.6'"
+        "Agent.OSVersion -equals '11.0'"
       ]
     }]
 


### PR DESCRIPTION
The agent is not reporting the OS version property and returns only
11.0. This has been fixed in:

https://github.com/microsoft/azure-pipelines-agent/pull/3605

But this was not yet landed.