### PR TITLE
[ARKit/SoundAnalysis] Fix BindAs attribute for .NET

### DIFF
--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -699,7 +699,9 @@ namespace ARKit {
 
 		[iOS (14,5)]
 		[Export ("captureDeviceType")]
-		[return: BindAs (typeof (AVCaptureDeviceType))]
+#if NET
+		[BindAs (typeof (AVCaptureDeviceType))]
+#endif
 		NSString CaptureDeviceType { get; }
 	}
 

--- a/src/soundanalysis.cs
+++ b/src/soundanalysis.cs
@@ -197,7 +197,11 @@ namespace SoundAnalysis {
 		[Export ("type", ArgumentSemantic.Assign)]
 		SNTimeDurationConstraintType Type { get; }
 
+#if NET
+		[BindAs (typeof (CMTime[]))]
+#else
 		[return: BindAs (typeof (CMTime[]))]
+#endif
 		[Export ("enumeratedDurations", ArgumentSemantic.Strong)]
 		NSValue[] EnumeratedDurations { get; }
 


### PR DESCRIPTION
The [return: ...] syntax doesn't work for properties. The intention was clear
though, so fix the attribute syntax to do the right thing for .NET.