### PR TITLE
[compare-commits] Ignore *.binlog files when creating a diff of the generated files.

### DIFF
--- a/tools/compare-commits.sh
+++ b/tools/compare-commits.sh
@@ -226,6 +226,7 @@ find "$OUTPUT_DIR/build" "$OUTPUT_DIR/build-new" '(' \
 	-name 'bgen.csproj.*' -or \
 	-name 'bgen.runtimeconfig.dev.json' -or \
 	-name 'PublishOutputs.*.txt' -or \
+	-name '*.binlog' -or \
 	-name '*.cache' \
 	')' -delete
 mkdir -p "$OUTPUT_DIR/generator-diff"


### PR DESCRIPTION
Removes this from the generator diff, which happens on every build:

    diff --git a/build/common/bgen.exe.binlog b/build-new/common/bgen.exe.binlog
    index fc4ecd1fe..3b0503171 100644
    Binary files a/build/common/bgen.exe.binlog and b/build-new/common/bgen.exe.binlog differ