### PR TITLE
[NSData] Enable nullability + a few other code updates

### DIFF
--- a/src/AddressBook/ABPerson.cs
+++ b/src/AddressBook/ABPerson.cs
@@ -1078,7 +1078,7 @@ namespace AddressBook {
 		[DllImport (Constants.AddressBookLibrary)]
 		extern static IntPtr ABPersonCreateVCardRepresentationWithPeople (IntPtr people);
 
-		public static NSData GetVCards (params ABPerson[] people)
+		public static NSData? GetVCards (params ABPerson[] people)
 		{
 			if (people is null)
 				throw new ArgumentNullException (nameof (people));
@@ -1089,7 +1089,7 @@ namespace AddressBook {
 			}
 
 			var ptr = ABPersonCreateVCardRepresentationWithPeople (CFArray.Create (ptrs));
-			return new NSData (ptr, true);
+			return Runtime.GetNSObject<NSData> (ptr, true);
 		}
 
 		[DllImport (Constants.AddressBookLibrary)]

--- a/src/Foundation/NSData.cs
+++ b/src/Foundation/NSData.cs
@@ -26,6 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 //
+
+#nullable enable
+
 using System;
 using ObjCRuntime;
 using System.IO;
@@ -35,15 +38,6 @@ using System.Collections.Generic;
 
 namespace Foundation {
 	public partial class NSData : IEnumerable, IEnumerable<byte> {
-		
-		// some API, like SecItemCopyMatching, returns a retained NSData
-		internal NSData (IntPtr handle, bool owns)
-			: base (handle)
-		{
-			if (!owns)
-				DangerousRelease ();
-		}
-
 		public byte[] ToArray ()
 		{
 			var res = new byte [Length];
@@ -78,8 +72,8 @@ namespace Foundation {
 
 		public static NSData FromArray (byte [] buffer)
 		{
-			if (buffer == null)
-				throw new ArgumentNullException ("buffer");
+			if (buffer is null)
+				throw new ArgumentNullException (nameof (buffer));
 			
 			if (buffer.Length == 0)
 				return FromBytes (IntPtr.Zero, 0);
@@ -91,10 +85,10 @@ namespace Foundation {
 			}
 		}
 
-		public static NSData FromStream (Stream stream)
+		public static NSData? FromStream (Stream stream)
 		{
-			if (stream == null)
-				throw new ArgumentNullException ("stream");
+			if (stream is null)
+				throw new ArgumentNullException (nameof (stream));
 			
 			if (!stream.CanRead)
 				return null;
@@ -131,8 +125,16 @@ namespace Foundation {
 		// Keeps a ref to the source NSData
 		//
 		unsafe class UnmanagedMemoryStreamWithRef : UnmanagedMemoryStream {
-			protected NSData source;
-			
+			NSData? source;
+
+			protected NSData Source {
+				get {
+					if (source is null)
+						throw new ObjectDisposedException (GetType ().FullName);
+					return source;
+				}
+			}
+
 			public UnmanagedMemoryStreamWithRef (NSData source) : base ((byte *)source.Bytes, (long)source.Length)
 			{
 				this.source = source;
@@ -161,10 +163,10 @@ namespace Foundation {
 			{
 				throw new InvalidOperationException ("The underlying NSMutableData changed while we were consuming data");
 			}
-			
+
 			public override int Read ([InAttribute] [OutAttribute] byte[] buffer, int offset, int count)
 			{
-				if (base_address != source.Bytes)
+				if (base_address != Source.Bytes)
 					InvalidOperation ();
 				
 				return base.Read (buffer, offset, count);
@@ -172,7 +174,7 @@ namespace Foundation {
 
 			public override int ReadByte ()
 			{
-				if (base_address != source.Bytes)
+				if (base_address != Source.Bytes)
 					InvalidOperation ();
 
 				return base.ReadByte ();
@@ -180,14 +182,14 @@ namespace Foundation {
 
 			public override void Write (byte[] buffer, int offset, int count)
 			{
-				if (base_address != source.Bytes)
+				if (base_address != Source.Bytes)
 					InvalidOperation ();
 				base.Write (buffer, offset, count);
 			}
 
 			public override void WriteByte (byte value)
 			{
-				if (base_address != source.Bytes)
+				if (base_address != Source.Bytes)
 					InvalidOperation ();
 				base.WriteByte (value);
 			}
@@ -234,37 +236,37 @@ namespace Foundation {
 			}
 		}
 
-		public bool Save (string file, bool auxiliaryFile, out NSError error)
+		public bool Save (string file, bool auxiliaryFile, out NSError? error)
 		{
 			return Save (file, auxiliaryFile ? NSDataWritingOptions.Atomic : (NSDataWritingOptions) 0, out error);
 		}
 
-		public bool Save (string file, NSDataWritingOptions options, out NSError error)
+		public bool Save (string file, NSDataWritingOptions options, out NSError? error)
 		{
 			unsafe {
 				IntPtr val;
 				IntPtr val_addr = (IntPtr) ((IntPtr *) &val);
 
 				bool ret = _Save (file, (nint) (long) options, val_addr);
-				error = (NSError) Runtime.GetNSObject (val);
+				error = Runtime.GetNSObject<NSError> (val);
 				
 				return ret;
 			}
 		}
 
-		public bool Save (NSUrl url, bool auxiliaryFile, out NSError error)
+		public bool Save (NSUrl url, bool auxiliaryFile, out NSError? error)
 		{
 			return Save (url, auxiliaryFile ? NSDataWritingOptions.Atomic : (NSDataWritingOptions) 0, out error);
 		}
 
-		public bool Save (NSUrl url, NSDataWritingOptions options, out NSError error)
+		public bool Save (NSUrl url, NSDataWritingOptions options, out NSError? error)
 		{
 			unsafe {
 				IntPtr val;
 				IntPtr val_addr = (IntPtr) ((IntPtr *) &val);
 
 				bool ret = _Save (url, (nint) (long) options, val_addr);
-				error = (NSError) Runtime.GetNSObject (val);
+				error = Runtime.GetNSObject<NSError> (val);
 
 				return ret;
 			}
@@ -273,7 +275,7 @@ namespace Foundation {
 		public virtual byte this [nint idx] {
 			get {
 				if (idx < 0 || (ulong) idx > Length)
-					throw new ArgumentException ("idx");
+					throw new ArgumentException (nameof (idx));
 				return Marshal.ReadByte (new IntPtr (((long) Bytes) + idx));
 			}
 

--- a/src/Security/Trust.cs
+++ b/src/Security/Trust.cs
@@ -337,9 +337,9 @@ namespace Security {
 #if !NET
 		[Mac (10,9)]
 #endif
-		public NSData GetExceptions ()
+		public NSData? GetExceptions ()
 		{
-			return new NSData (SecTrustCopyExceptions (GetCheckedHandle ()), false); // inverted boolean?
+			return Runtime.GetNSObject<NSData> (SecTrustCopyExceptions (GetCheckedHandle ()), true);
 		}
 
 #if !NET


### PR DESCRIPTION
* Remove the internal (IntPtr, bool) constructor, it has non-standard semantics and it's confusing.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.