### PR TITLE
[devops] Add a 30/60 minute timeout to the steps to install dependencies + run macOS tests.

### DIFF
--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -159,6 +159,7 @@ steps:
     ls -Rla $(Build.SourcesDirectory)/artifacts
     $(Build.SourcesDirectory)/artifacts/mac-test-package/test-dependencies.sh
   displayName: Install dependencies.
+  timeoutInMinutes: 60
   env:
     IGNORE_DOTNET: 1  # Not needed for the tests.
 
@@ -207,6 +208,7 @@ steps:
     # yet we do have some  flacky ones, this will allow the release to run. The comment will let use know that we failed
     exit 0  
   displayName: 'Run tests'
+  timeoutInMinutes: 30
   env:
     CONTEXT: ${{ parameters.statusContext }}
     BUILD_REVISION: $(Build.SourceVersion)


### PR DESCRIPTION
Example: the macOS 10.15 tests here have been going on for 16+ hours after a deadlock: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5431191&view=logs&j=2fda2bbb-61e0-581a-db35-947a0a9403f6&t=e12f7fa3-cd7a-5af6-76e1-5ed4335dbce9 - these timeouts will fail faster. The macOS tests shouldn't even be close to hitting the 30-min timeout any time soon.