### PR TITLE
[msbuild/dotnet] Build the Xamarin.PreBuilt.iOS app bundle.

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -42,6 +42,9 @@ $(1)_WINDOWS_NUGET_TARGETS = \
 endef
 $(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),$(eval $(call DefineWindowsTargets,$(platform))))
 
+iOS_WINDOWS_NUGET_TARGETS += \
+	$(DOTNET_DESTDIR)/Microsoft.iOS.Windows.Sdk/tools/msbuild/iOS/Xamarin.PreBuilt.iOS.app.zip \
+
 DIRECTORIES += \
 	$(DOTNET_NUPKG_DIR) \
 	$(DOTNET_PKG_DIR) \
@@ -190,7 +193,7 @@ $(DOTNET_NUPKG_DIR)/%.nupkg: nupkgs/%.nupkg | $(DOTNET_NUPKG_DIR)
 
 ifdef INCLUDE_IOS
 SDK_PACK_IOS_WINDOWS = $(DOTNET_NUPKG_DIR)/$(IOS_WINDOWS_NUGET).Sdk.$(IOS_WINDOWS_NUGET_VERSION_NO_METADATA).nupkg
-SDK_PACKS += $(SDK_PACK_IOS_WINDOWS)
+SDK_PACKS_WINDOWS += $(SDK_PACK_IOS_WINDOWS)
 endif
 
 pack-ios-windows: $(SDK_PACK_IOS_WINDOWS)
@@ -210,7 +213,7 @@ pack-$(shell echo $(1) | tr A-Z a-z): $$(RUNTIME_PACKS_$(1)) $$(REF_PACKS_$(1)) 
 endef
 $(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(eval $(call PacksDefinitions,$(platform))))
 
-TARGETS += $(RUNTIME_PACKS) $(REF_PACKS) $(SDK_PACKS) $(TEMPLATE_PACKS) $(WORKLOAD_PACKS) $(DOTNET_NUPKG_DIR)/vs-workload.props $(DOTNET_NUPKG_DIR)/SignList.xml $(DOTNET_NUPKG_DIR)/SignList.targets
+TARGETS += $(RUNTIME_PACKS) $(REF_PACKS) $(SDK_PACKS) $(TEMPLATE_PACKS) $(WORKLOAD_PACKS) $(DOTNET_NUPKG_DIR)/vs-workload.props $(DOTNET_NUPKG_DIR)/SignList.xml $(DOTNET_NUPKG_DIR)/SignList.targets $(SDK_PACKS_WINDOWS)
 
 define InstallWorkload
 # .NET comes with a workload for us, but we don't want that, we want our own. So delete the workload that comes with .NET.
@@ -280,7 +283,7 @@ $(TMP_PKG_DIR)/Microsoft.$1.Ref.$2.pkg: $(SDK_PACK_$(4)) | $(TMP_PKG_DIR)
 	$$(Q) mv $$@.tmp $$@
 
 # The templates package
-$(TMP_PKG_DIR)/Microsoft.$1.Templates.$2.pkg: $(TEMPLATE_PACK_$(4)) | $(TMP_PKG_DIR)
+$(TMP_PKG_DIR)/Microsoft.$1.Templates.$2.pkg: $(TEMPLATE_PACKS_$(4)) | $(TMP_PKG_DIR)
 	$$(Q) rm -f $$@
 	$$(Q) rm -rf tmpdir/Microsoft.$1.Templates.$2/
 	$$(Q) mkdir -p tmpdir/Microsoft.$1.Templates.$2/usr/local/share/dotnet/template-packs/
@@ -343,7 +346,7 @@ $(TMP_PKG_DIR)/Microsoft.$1.Windows.Bundle.$2.zip: $($(1)_NUGET_TARGETS) $($(1)_
 	$$(Q) mv $$@.tmp $$@
 	$$(Q) echo Created $$@
 
-PACKAGE_TARGETS += $(DOTNET_PKG_DIR)/Microsoft.$1.Windows.Bundle.$2.zip
+WINDOWS_PACKAGE_TARGETS += $(DOTNET_PKG_DIR)/Microsoft.$1.Windows.Bundle.$2.zip
 endef
 $(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),$(eval $(call CreateWindowsBundle,$(platform),$($(platform)_NUGET_VERSION_NO_METADATA),$(shell echo $(platform) | tr A-Z a-z),$(shell echo $(platform) | tr a-z A-Z))))
 
@@ -381,10 +384,10 @@ TARGETS += .stamp-install-workloads
 	fi
 	$(Q) touch $@
 
-TARGETS += $(WORKLOAD_TARGETS)
+TARGETS += $(WORKLOAD_TARGETS) $(WINDOWS_PACKAGE_TARGETS)
 
 msi: $(MSI_TARGETS)
-package: $(PACKAGE_TARGETS) $(MSI_TARGETS)
+package: $(PACKAGE_TARGETS) $(MSI_TARGETS) $(WINDOWS_PACKAGE_TARGETS)
 
 ifdef ENABLE_DOTNET
 all-local:: $(TARGETS)
@@ -403,4 +406,8 @@ clean-local::
 
 .stamp-workaround-for-maccore-issue-2427: global.json $(TOP)/eng/Versions.props $(LOCAL_WORKLOAD_TARGETS)
 	$(Q) $(DOTNET6) restore package/workaround-for-maccore-issue-2427/restore.csproj /bl:package/workaround-for-maccore-issue-2427/restore.binlog $(MSBUILD_VERBOSITY)
+	$(Q) touch $@
+
+$(DOTNET_DESTDIR)/Microsoft.iOS.Windows.Sdk/tools/msbuild/iOS/Xamarin.PreBuilt.iOS.app.zip: .stamp-install-workloads
+	$(Q) $(MAKE) -C $(TOP)/msbuild/Xamarin.HotRestart.PreBuilt all
 	$(Q) touch $@

--- a/dotnet/targets/WorkloadManifest.iOS.template.json
+++ b/dotnet/targets/WorkloadManifest.iOS.template.json
@@ -5,7 +5,7 @@
 			"description": ".NET SDK Workload for building @PLATFORM@ applications.",
 			"packs": [
 				"Microsoft.@PLATFORM@.Sdk",
-				"Microsoft.@PLATFORM@.Windows.Sdk",
+				"microsoft-@PLATFORM@-windows-sdk",
 				"Microsoft.@PLATFORM@.Ref",
 				"Microsoft.@PLATFORM@.Runtime.ios-arm",
 				"Microsoft.@PLATFORM@.Runtime.ios-arm64",
@@ -23,9 +23,14 @@
 			"kind": "sdk",
 			"version": "@VERSION@"
 		},
-		"Microsoft.@PLATFORM@.Windows.Sdk": {
+		"microsoft-@PLATFORM@-windows-sdk": {
 			"kind": "sdk",
-			"version": "@VERSION@"
+			"version": "@VERSION@",
+			"alias-to": {
+				"win-x64": "Microsoft.@PLATFORM@.Windows.Sdk",
+				"win-x86": "Microsoft.@PLATFORM@.Windows.Sdk",
+				"win-arm64": "Microsoft.@PLATFORM@.Windows.Sdk",
+			}
 		},
 		"Microsoft.@PLATFORM@.Ref": {
 			"kind": "framework",

--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -484,7 +484,7 @@ DOTNET_IOS_WINDOWS_OUTPUT_FILES =                                \
 	Xamarin.iOS.Windows.Client.pdb                               \
 	Broker.zip                                                   \
 	Build.zip                                                    \
-	Xamarin.PreBuilt.iOS.app.zip
+
 DOTNET_IOS_WINDOWS_FILES = $(IOS_WINDOWS_TARGETS) $(foreach file,$(DOTNET_IOS_WINDOWS_OUTPUT_FILES),Xamarin.iOS.Tasks.Windows/bin/$(CONFIG)/$(TARGETFRAMEWORK)/$(WINDOWSRUNTIMEIDENTIFIER)/$(file))
 DOTNET_IOS_WINDOWS_MOBILEDEVICE_TOOLS_X86 = $(foreach file,$(IOS_WINDOWS_MOBILEDEVICE_TOOLS),Xamarin.iOS.Tasks.Windows/bin/$(CONFIG)/$(TARGETFRAMEWORK)/$(WINDOWSRUNTIMEIDENTIFIER)/imobiledevice-x86/$(file).*)
 DOTNET_IOS_WINDOWS_MOBILEDEVICE_TOOLS_X64 = $(foreach file,$(IOS_WINDOWS_MOBILEDEVICE_TOOLS),Xamarin.iOS.Tasks.Windows/bin/$(CONFIG)/$(TARGETFRAMEWORK)/$(WINDOWSRUNTIMEIDENTIFIER)/imobiledevice-x64/$(file).*)

--- a/msbuild/Xamarin.HotRestart.PreBuilt/.gitignore
+++ b/msbuild/Xamarin.HotRestart.PreBuilt/.gitignore
@@ -1,0 +1,4 @@
+*.zip
+NuGet.config
+global.json
+

--- a/msbuild/Xamarin.HotRestart.PreBuilt/Makefile
+++ b/msbuild/Xamarin.HotRestart.PreBuilt/Makefile
@@ -1,0 +1,31 @@
+TOP=../..
+
+include $(TOP)/Make.config
+include $(TOP)/mk/rules.mk
+
+APP_DIR=Xamarin.PreBuilt.iOS/bin/Debug/net6.0-ios/ios-arm64/Xamarin.PreBuilt.iOS.app
+
+Xamarin.PreBuilt.iOS.app.zip: .build-stamp
+	$(Q) rm -rf $@
+	$(Q_GEN) cd $(APP_DIR) && zip -9r $(abspath $@) .
+
+NuGet.config: $(TOP)/tests/dotnet/NuGet.config
+	$(Q) $(CP) $< $@
+
+global.json: $(TOP)/tests/dotnet/global.json
+	$(Q) $(CP) $< $@
+
+$(TOP)/tests/dotnet/%:
+	$(Q) $(MAKE) -C $(dir $@) $*
+
+.build-stamp: $(wildcard Xamarin.PreBuilt.iOS/*) Makefile NuGet.config global.json
+	$(Q_GEN) $(DOTNET6) build Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj /bl $(MSBUILD_VERBOSITY)
+	$(Q) touch $@
+
+$(DOTNET_DESTDIR)/$(IOS_WINDOWS_NUGET).Sdk/tools/msbuild/iOS/Xamarin.PreBuilt.iOS.app.zip: Xamarin.PreBuilt.iOS.app.zip
+	$(Q) mkdir -p $(dir $@)
+	$(Q) $(CP) $< $@
+
+all-local:: $(DOTNET_DESTDIR)/$(IOS_WINDOWS_NUGET).Sdk/tools/msbuild/iOS/Xamarin.PreBuilt.iOS.app.zip
+
+install-local:: $(DOTNET_DESTDIR)/$(IOS_WINDOWS_NUGET).Sdk/tools/msbuild/iOS/Xamarin.PreBuilt.iOS.app.zip

--- a/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Info.plist
+++ b/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Info.plist
@@ -20,8 +20,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>Xamarin.PreBuilt</string>
 	<key>CFBundleIdentifier</key>

--- a/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
+++ b/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ProvisioningType>automatic</ProvisioningType>


### PR DESCRIPTION
Build the Xamarin.PreBuilt.iOS app bundle instead of using a prebuilt bundle.

This makes sure that we're always using the latest BCL.

Some accurate build massaging was needed, because:

* To build the prebuilt app we need the iOS workload installed (into our build-local
  .NET installation).
* The iOS workload contains the Microsoft.iOS.Windows.Sdk pack.
* The Microsoft.iOS.Windows.Sdk pack contains the prebuilt app.

Thus we had a circular reference. Fortunately, the Microsoft.iOS.Windows.Sdk pack
is only required on Windows, which means we can break this circular reference by:

* Mark Microsoft.iOS.Windows.Sdk pack as only to be installed on Windows (unfortunately
  it seems we have to list the exact runtime identifiers for the platforms where
  to install the pack, so we can't do something like "win-*", but new variations
  of the "win-*" runtime identifier shouldn't show up all that often).
* Build the prebuilt app on macOS.

This way we don't need the Microsoft.iOS.Windows.Sdk pack when installing the iOS
workload locally.

The .NET build order is now:

* Build general sdk, runtime and ref packs for .NET.
* Build the prebuilt app.
* Build the Microsoft.iOS.Windows.Sdk pack.