### PR TITLE
[mtouch] Fix logic to determine whether we're using Mono.framework on watchOS.

### DIFF
--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -798,13 +798,32 @@ namespace Xamarin.Bundler {
 			if (!enable_msym.HasValue)
 				enable_msym = !EnableDebug && IsDeviceBuild;
 
-			if (!UseMonoFramework.HasValue && DeploymentTarget >= new Version (8, 0)) {
-				if (IsExtension) {
-					UseMonoFramework = true;
-					Driver.Log (2, $"The extension {Name} will automatically link with Mono.framework.");
-				} else if (Extensions.Count > 0) {
-					UseMonoFramework = true;
-					Driver.Log (2, "Automatically linking with Mono.framework because this is an app with extensions");
+			if (!UseMonoFramework.HasValue) {
+				switch (Platform) {
+				case ApplePlatform.iOS:
+				case ApplePlatform.TVOS:
+				case ApplePlatform.MacCatalyst:
+					if (DeploymentTarget >= new Version (8, 0)) {
+						if (IsExtension) {
+							UseMonoFramework = true;
+							Driver.Log (2, $"The extension {Name} will automatically link with Mono.framework.");
+						} else if (Extensions.Count > 0) {
+							UseMonoFramework = true;
+							Driver.Log (2, "Automatically linking with Mono.framework because this is an app with extensions");
+						}
+					}
+					break;
+				case ApplePlatform.WatchOS:
+					if (IsWatchExtension && Extensions.Count > 0) {
+						UseMonoFramework = true;
+						Driver.Log (2, "Automatically linking with Mono.framework because this is a watch app with extensions");
+					} else if (!IsWatchExtension) {
+						UseMonoFramework = true;
+						Driver.Log (2, $"The extension {Name} will automatically link with Mono.framework.");
+					}
+					break;
+				default:
+					throw ErrorHelper.CreateError (71, Errors.MX0071, Platform, ProductName);
 				}
 			}
 


### PR DESCRIPTION
The previous "8.0" sdk version check is incorrect (that's "iOS 8.0", the first
iOS version to add support for user frameworks). However, it started kicking
in for watchOS 8.0, and now suddenly we're trying to build all watchOS
extensions with Mono.framework, which is not what we want.

Instead modify the code to:

* Split by platform, keep the existing behavior for iOS, tvOS and Mac Catalyst
  (since "8.0" is the correct version check for all those platforms).
* Use the Mono framework in watchOS if either of the following are true:
	* In the main watchOS extension if it has nested extensions.
	* In any other extensions (because they'll be nested extensions).

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1430408