### PR TITLE
[introspection] Remove a few version checks which are now constant values.

### DIFF
--- a/tests/common/mac/Mac.cs
+++ b/tests/common/mac/Mac.cs
@@ -12,9 +12,6 @@ using System;
 
 namespace Xamarin.Tests {
 	public static class Mac {
-		public static readonly Version Version_10_7 = new Version (10, 7);
-		public static readonly Version Version_10_8 = new Version (10, 8);
-		public static readonly Version Version_10_9 = new Version (10, 9);
 		public static readonly Version Version_10_10 = new Version (10, 10);
 		public static readonly Version Version_10_11 = new Version (10, 11);
 
@@ -22,9 +19,7 @@ namespace Xamarin.Tests {
 
 		public static bool CheckSystemVersion (int major, int minor) => host.Version >= new Version (major, minor);
 		public static bool CheckSystemVersion (int major, int minor, int build) => host.Version >= new Version (major, minor, build);
-		public static bool Is32BitMavericks => host.IsArch32 && IsAtLeast (Version_10_9);
 		public static bool IsYosemiteOrHigher => IsAtLeast (Version_10_10);
-		public static bool IsElCapitanOrHigher => IsAtLeast (Version_10_11);
 		public static bool IsAtLeast (int major, int minor) => IsAtLeast (new Version (major, minor));
 		public static bool IsAtLeast (Version version) => host.IsMac && host.Version >= version;
 	}

--- a/tests/introspection/Mac/MacApiCtorInitTest.cs
+++ b/tests/introspection/Mac/MacApiCtorInitTest.cs
@@ -94,24 +94,6 @@ namespace Introspection {
 			case "MonoMac.AppKit.NSWindow":
 			case "AppKit.NSWindow":
 				return true;
-			case "MonoMac.Foundation.NSUrlSession":
-			case "Foundation.NSUrlSession":
-			case "MonoMac.Foundation.NSUrlSessionTask":
-			case "Foundation.NSUrlSessionTask":
-			case "MonoMac.Foundation.NSUrlSessionDataTask":
-			case "Foundation.NSUrlSessionDataTask":
-			case "MonoMac.Foundation.NSUrlSessionUploadTask":
-			case "Foundation.NSUrlSessionUploadTask":
-			case "MonoMac.Foundation.NSUrlSessionDownloadTask":
-			case "Foundation.NSUrlSessionDownloadTask":
-			case "MonoMac.Foundation.NSUrlSessionConfiguration":
-			case "Foundation.NSUrlSessionConfiguration":
-				// These types were introduced as 64-bit only in Mavericks, and 32+64bits in Yosemite. We can't
-				// express that with our AvailabilityAttribute, we set it as available (for all architectures, since
-				// we can't distinguish them) starting with Mavericks.
-				if (Mac.Is32BitMavericks)
-					return true;
-				break;
 
 			case "GLKit.GLKSkyboxEffect":
 				// Crashes inside libGL.dylib, most likely because something hasn't been initialized yet, because

--- a/tests/introspection/Mac/MacApiFieldTest.cs
+++ b/tests/introspection/Mac/MacApiFieldTest.cs
@@ -61,20 +61,6 @@ namespace Introspection {
 
 		protected override bool Skip (PropertyInfo p)
 		{
-			switch (p.DeclaringType.Name) {
-			case "NSUrlSessionDownloadDelegate":
-				switch (p.Name) {
-				case "TaskResumeDataKey":
-					// This field was introduced as 64-bit only in Mavericks, and 32+64bits in Yosemite. We can't
-					// express that with our AvailabilityAttribute, we set it as available (for all architectures, since
-					// we can't distinguish them) starting with Mavericks.
-					if (Mac.Is32BitMavericks)
-						return true;
-					break;
-				}
-				break;
-			}
-
 			switch (p.Name) {
 			case "CharacteristicValidRangeString":
 				return Mac.CheckSystemVersion (10, 13); // radar 32858911 
@@ -178,11 +164,6 @@ namespace Introspection {
 			// kCLErrorUserInfoAlternateRegionKey also returns null on iOS
 			case "kCLErrorUserInfoAlternateRegionKey":
 				return true;
-			case "NSURLSessionTransferSizeUnknown":
-			case "NSURLSessionDownloadTaskResumeData":
-				if (Mac.Is32BitMavericks)
-					return true;
-				goto default;
 			case "QCCompositionInputRSSArticleDurationKey":
 			case "QCCompositionInputRSSFeedURLKey":
 			case "QCCompositionProtocolRSSVisualizer":


### PR DESCRIPTION
* Mac.Is32BitMavericks is always false (we only run on 64-bit macOS), so remove corresponding code.
* Mac.IsElCapitanOrHigher is never used; remove
* Remove a few unused Mac.Version_* fields.