### PR TITLE
[tests] Change TestRuntime.CheckSystemVersion to take a ApplePlatform value instead of a PlatformName enum.

### DIFF
--- a/tests/EmbeddedResources/EmbeddedResources.csproj
+++ b/tests/EmbeddedResources/EmbeddedResources.csproj
@@ -53,6 +53,9 @@
     <Compile Include="..\common\TestRuntime.cs">
       <Link>TestRuntime.cs</Link>
     </Compile>
+    <Compile Include="..\..\tools\common\ApplePlatform.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Welcome.resx">

--- a/tests/EmbeddedResources/dotnet/shared.targets
+++ b/tests/EmbeddedResources/dotnet/shared.targets
@@ -19,6 +19,9 @@
 		<Compile Include="$(RootTestsDirectory)\common\TestRuntime.cs">
 			<Link>TestRuntime.cs</Link>
 		</Compile>
+		<Compile Include="$(RootTestsDirectory)\..\tools\common\ApplePlatform.cs">
+			<Link>ApplePlatform.cs</Link>
+		</Compile>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/bindings-test/dotnet/shared.csproj
+++ b/tests/bindings-test/dotnet/shared.csproj
@@ -50,6 +50,9 @@
     <Compile Include="$(RootTestsDirectory)\common\TestRuntime.cs">
       <Link>TestRuntime.cs</Link>
     </Compile>
+    <Compile Include="$(RootTestsDirectory)\..\tools\common\ApplePlatform.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
     <Compile Include="$(BindingsTestDirectory)\RuntimeTest.cs" />
     <Compile Include="$(BindingsTestDirectory)\CodeBehind.cs" />
     <Compile Include="$(BindingsTestDirectory)\Messaging.cs" />

--- a/tests/bindings-test/iOS/bindings-test.csproj
+++ b/tests/bindings-test/iOS/bindings-test.csproj
@@ -81,6 +81,9 @@
     <Compile Include="..\..\common\TestRuntime.cs">
       <Link>TestRuntime.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tools\common\ApplePlatform.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
     <Compile Include="..\RuntimeTest.cs" />
     <Compile Include="..\CodeBehind.cs" />
     <Compile Include="..\Messaging.cs" />

--- a/tests/bindings-test/macOS/bindings-test.csproj
+++ b/tests/bindings-test/macOS/bindings-test.csproj
@@ -68,6 +68,9 @@
     <Compile Include="..\..\common\TestRuntime.cs">
       <Link>TestRuntime.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tools\common\ApplePlatform.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
     <Compile Include="..\RuntimeTest.cs" />
     <Compile Include="..\CodeBehind.cs" />
     <Compile Include="..\Messaging.cs" />

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -31,6 +31,8 @@ using UIKit;
 #endif
 using ObjCRuntime;
 
+using Xamarin.Utils;
+
 partial class TestRuntime
 {
 
@@ -744,38 +746,40 @@ partial class TestRuntime
 		}
 	}
 
-	public static bool CheckSystemVersion (PlatformName platform, int major, int minor, int build = 0, bool throwIfOtherPlatform = true)
+	public static bool CheckSystemVersion (ApplePlatform platform, int major, int minor, int build = 0, bool throwIfOtherPlatform = true)
 	{
 		switch (platform) {
-		case PlatformName.iOS:
+		case ApplePlatform.iOS:
 			return CheckiOSSystemVersion (major, minor, throwIfOtherPlatform);
-		case PlatformName.MacOSX:
+		case ApplePlatform.MacOSX:
 			return CheckMacSystemVersion (major, minor, build, throwIfOtherPlatform);
-		case PlatformName.TvOS:
+		case ApplePlatform.TVOS:
 			return ChecktvOSSystemVersion (major, minor, throwIfOtherPlatform);
-		case PlatformName.WatchOS:
+		case ApplePlatform.WatchOS:
 			return CheckWatchOSSystemVersion (major, minor, throwIfOtherPlatform);
+		case ApplePlatform.MacCatalyst:
+			return CheckMacCatalystSystemVersion (major, minor, throwIfOtherPlatform);
 		default:
 			throw new Exception ($"Unknown platform: {platform}");
 		}
 	}
 
-	public static void AssertSystemVersion (PlatformName platform, int major, int minor, int build = 0, bool throwIfOtherPlatform = true)
+	public static void AssertSystemVersion (ApplePlatform platform, int major, int minor, int build = 0, bool throwIfOtherPlatform = true)
 	{
 		switch (platform) {
-		case PlatformName.iOS:
+		case ApplePlatform.iOS:
 			AssertiOSSystemVersion (major, minor, throwIfOtherPlatform);
 			break;
-		case PlatformName.MacOSX:
+		case ApplePlatform.MacOSX:
 			AssertMacSystemVersion (major, minor, build, throwIfOtherPlatform);
 			break;
-		case PlatformName.TvOS:
+		case ApplePlatform.TVOS:
 			AsserttvOSSystemVersion (major, minor, throwIfOtherPlatform);
 			break;
-		case PlatformName.WatchOS:
+		case ApplePlatform.WatchOS:
 			AssertWatchOSSystemVersion (major, minor, throwIfOtherPlatform);
 			break;
-		case PlatformName.MacCatalyst:
+		case ApplePlatform.MacCatalyst:
 			AssertMacCatalystSystemVersion (major, minor, build, throwIfOtherPlatform);
 			break;
 		default:

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -34,6 +34,7 @@ using AppKit;
 using UIKit;
 #endif
 using Foundation;
+using Xamarin.Utils;
 
 namespace Introspection
 {
@@ -1001,7 +1002,7 @@ namespace Introspection
 			case Constants.CoreImageLibrary:
 				break;
 			default:
-				if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 11, 0)) {
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 11, 0)) {
 					// on macOS 11.0 the frameworks binary files are not present (cache) but can be loaded
 					if (!Directory.Exists (Path.GetDirectoryName (lib)))
 						return false;

--- a/tests/introspection/Mac/MacApiCtorInitTest.cs
+++ b/tests/introspection/Mac/MacApiCtorInitTest.cs
@@ -15,6 +15,7 @@ using Foundation;
 
 using NUnit.Framework;
 using Xamarin.Tests;
+using Xamarin.Utils;
 
 namespace Introspection {
 
@@ -169,7 +170,7 @@ namespace Introspection {
 				// https://trello.com/c/T6vkA2QF/62-29311598-ikpicturetaker-crashes-randomly-upon-deallocation?menu=filter&filter=corenfc
 				return true;
 			case "Photos.PHProjectChangeRequest":
-				if (TestRuntime.CheckSystemVersion (ObjCRuntime.PlatformName.MacOSX, 10, 15)) {
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 15)) {
 					/*
 	 Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'This method can only be called from inside of -[PHPhotoLibrary performChanges:completionHandler:] or -[PHPhotoLibrary performChangesAndWait:error:]'
 	0   CoreFoundation                      0x00007fff34f29063 __exceptionPreprocess + 250

--- a/tests/introspection/Mac/MacApiSelectorTest.cs
+++ b/tests/introspection/Mac/MacApiSelectorTest.cs
@@ -16,6 +16,7 @@ using ObjCRuntime;
 
 using NUnit.Framework;
 using Xamarin.Tests;
+using Xamarin.Utils;
 
 namespace Introspection {
 	
@@ -696,7 +697,7 @@ namespace Introspection {
 					switch (selectorName) {
 					case "buttonPressed":
 						// It's just gone! https://github.com/xamarin/maccore/issues/1796
-						if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 15))
+						if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 15))
 							return true;
 						break;
 					}
@@ -709,7 +710,7 @@ namespace Introspection {
 					switch (selectorName) {
 					case "isSyncFailureHidden":
 						// It's just gone! https://github.com/xamarin/maccore/issues/1797
-						if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 15))
+						if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 15))
 							return true;
 						break;
 					}

--- a/tests/introspection/iOS/iOSApiPInvokeTest.cs
+++ b/tests/introspection/iOS/iOSApiPInvokeTest.cs
@@ -15,6 +15,7 @@ using Foundation;
 using ObjCRuntime;
 using UIKit;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace Introspection {
 
@@ -74,7 +75,7 @@ namespace Introspection {
 			// 1. is the current SDK target (or a newer one)
 			var sdk = new Version (Constants.SdkVersion);
 #if __WATCHOS__
-			if (!TestRuntime.CheckSystemVersion (PlatformName.WatchOS, sdk.Major, sdk.Minor))
+			if (!TestRuntime.CheckSystemVersion (ApplePlatform.WatchOS, sdk.Major, sdk.Minor))
 				return true;
 #elif __IOS__ || __TVOS__
 			if (!UIDevice.CurrentDevice.CheckSystemVersion (sdk.Major, sdk.Minor))

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -53,6 +53,7 @@ using OpenGLES;
 using WebKit;
 using NUnit.Framework;
 using MonoTests.System.Net.Http;
+using Xamarin.Utils;
 
 
 namespace LinkSdk {
@@ -185,7 +186,7 @@ namespace LinkSdk {
 		// http://bugzilla.xamarin.com/show_bug.cgi?id=980
 		public void Bug980_AddressBook_NRE ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false); // The AddressBook framework was introduced in Mac Catalyst 14.0
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false); // The AddressBook framework was introduced in Mac Catalyst 14.0
 			using (ABPeoplePickerNavigationController picker = new ABPeoplePickerNavigationController ()) {
 				// no NRE should occur
 				if (UIDevice.CurrentDevice.CheckSystemVersion (8, 0))
@@ -206,7 +207,7 @@ namespace LinkSdk {
 					"Please deny access to contacts for this this application (it's important for this test)");
 			}
 #endif // !__MACOS__
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false); // The AddressBook framework was introduced in Mac Catalyst 14.0
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false); // The AddressBook framework was introduced in Mac Catalyst 14.0
 			Assert.IsNotNull (ABPersonAddressKey.City, "ABPersonAddressKey");
 		}
 #endif // HAS_ADDRESSBOOKUI
@@ -928,7 +929,7 @@ namespace LinkSdk {
 #endif
 
 #if __MACOS__
-			var isMac1015 = TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 15);
+			var isMac1015 = TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 15);
 			path = TestFolder (Environment.SpecialFolder.Favorites, supported: isMac1015, exists: isMac1015);
 #elif __MACCATALYST__
 			path = TestFolder (Environment.SpecialFolder.Favorites, exists: true);

--- a/tests/linker/mac/dont link/dont link-mac.csproj
+++ b/tests/linker/mac/dont link/dont link-mac.csproj
@@ -67,6 +67,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Stub.cs" />
+    <Compile Include="..\..\..\..\tools\common\ApplePlatform.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\common\mac\MacMain.cs">
       <Link>MacMain.cs</Link>
     </Compile>

--- a/tests/linker/mac/link all/link all-mac.csproj
+++ b/tests/linker/mac/link all/link all-mac.csproj
@@ -79,6 +79,9 @@
     </Compile>
     <Compile Include="..\..\BaseOptimizeGeneratedCodeTest.cs" />
     <Compile Include="LinkAllTest.cs" />
+    <Compile Include="..\..\..\..\tools\common\ApplePlatform.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\common\PlatformInfo.cs">
       <Link>PlatformInfo.cs</Link>
     </Compile>

--- a/tests/linker/mac/link sdk/link sdk-mac.csproj
+++ b/tests/linker/mac/link sdk/link sdk-mac.csproj
@@ -73,6 +73,9 @@
       <Link>Mac.cs</Link>
     </Compile>
     <Compile Include="LinkSdkTest.cs" />
+    <Compile Include="..\..\..\..\tools\common\ApplePlatform.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\common\PlatformInfo.cs">
       <Link>PlatformInfo.cs</Link>
     </Compile>

--- a/tests/monotouch-test/ARKit/ARAnchorTest.cs
+++ b/tests/monotouch-test/ARKit/ARAnchorTest.cs
@@ -14,6 +14,7 @@ using ARKit;
 using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 using MatrixFloat4x4 = global::OpenTK.NMatrix4;
 
@@ -28,7 +29,7 @@ namespace MonoTouchFixtures.ARKit {
 		{
 			TestRuntime.AssertXcodeVersion (10, 0);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/ARKit/ARConfigurationTest.cs
+++ b/tests/monotouch-test/ARKit/ARConfigurationTest.cs
@@ -6,6 +6,7 @@ using ARKit;
 using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.ARKit {
 
@@ -18,7 +19,7 @@ namespace MonoTouchFixtures.ARKit {
 		{
 			TestRuntime.AssertXcodeVersion (9, 3);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/ARKit/AREnvironmentProbeAnchorTest.cs
+++ b/tests/monotouch-test/ARKit/AREnvironmentProbeAnchorTest.cs
@@ -14,6 +14,7 @@ using ARKit;
 using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 using VectorFloat3 = global::OpenTK.NVector3;
 using MatrixFloat4x4 = global::OpenTK.NMatrix4;
@@ -29,7 +30,7 @@ namespace MonoTouchFixtures.ARKit {
 		{
 			TestRuntime.AssertXcodeVersion (10, 0);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/ARKit/ARFaceGeometryTest.cs
+++ b/tests/monotouch-test/ARKit/ARFaceGeometryTest.cs
@@ -16,6 +16,7 @@ using ARKit;
 using Foundation;
 using NUnit.Framework;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 using VectorFloat2 = global::OpenTK.Vector2;
 using VectorFloat3 = global::OpenTK.NVector3;
@@ -89,7 +90,7 @@ namespace MonoTouchFixtures.ARKit {
 		{
 			TestRuntime.AssertXcodeVersion (9, 0);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/ARKit/ARPlaneGeometryTest.cs
+++ b/tests/monotouch-test/ARKit/ARPlaneGeometryTest.cs
@@ -16,6 +16,7 @@ using ARKit;
 using Foundation;
 using NUnit.Framework;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 using VectorFloat2 = global::OpenTK.Vector2;
 using VectorFloat3 = global::OpenTK.NVector3;
@@ -103,7 +104,7 @@ namespace MonoTouchFixtures.ARKit {
 		{
 			TestRuntime.AssertXcodeVersion (9, 0);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/ARKit/ARPointCloudTest.cs
+++ b/tests/monotouch-test/ARKit/ARPointCloudTest.cs
@@ -17,6 +17,7 @@ using AVFoundation;
 using Foundation;
 using NUnit.Framework;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 using MatrixFloat2x2 = global::OpenTK.NMatrix2;
 using MatrixFloat3x3 = global::OpenTK.NMatrix3;
@@ -78,7 +79,7 @@ namespace MonoTouchFixtures.ARKit {
 		{
 			TestRuntime.AssertXcodeVersion (9, 0);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/ARKit/ARReferenceObjectTest.cs
+++ b/tests/monotouch-test/ARKit/ARReferenceObjectTest.cs
@@ -14,6 +14,7 @@ using ARKit;
 using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 using VectorFloat3 = global::OpenTK.NVector3;
 using MatrixFloat4x4 = global::OpenTK.NMatrix4;
@@ -29,7 +30,7 @@ namespace MonoTouchFixtures.ARKit {
 		{
 			TestRuntime.AssertXcodeVersion (10, 0);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/ARKit/ARSkeleton2DTest.cs
+++ b/tests/monotouch-test/ARKit/ARSkeleton2DTest.cs
@@ -16,6 +16,7 @@ using ARKit;
 using Foundation;
 using NUnit.Framework;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 using Vector2 = global::OpenTK.Vector2;
 
@@ -63,7 +64,7 @@ namespace MonoTouchFixtures.ARKit {
 		{
 			TestRuntime.AssertXcodeVersion (11, 0);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/ARKit/ARSkeleton3DTest.cs
+++ b/tests/monotouch-test/ARKit/ARSkeleton3DTest.cs
@@ -16,6 +16,7 @@ using ARKit;
 using Foundation;
 using NUnit.Framework;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 using Matrix4 = global::OpenTK.NMatrix4;
 
@@ -77,7 +78,7 @@ namespace MonoTouchFixtures.ARKit {
 		{
 			TestRuntime.AssertXcodeVersion (11, 0);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/ARKit/ARSkeletonTest.cs
+++ b/tests/monotouch-test/ARKit/ARSkeletonTest.cs
@@ -7,6 +7,7 @@ using ARKit;
 using Foundation;
 using NUnit.Framework;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace monotouchtest.ARKit {
 	[TestFixture]
@@ -18,7 +19,7 @@ namespace monotouchtest.ARKit {
 		{
 			TestRuntime.AssertXcodeVersion (12, 0);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/AVFoundation/AVAssetImageGeneratorTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVAssetImageGeneratorTest.cs
@@ -18,6 +18,7 @@ using AVFoundation;
 using CoreMedia;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AVFoundation {
 	
@@ -95,7 +96,7 @@ namespace MonoTouchFixtures.AVFoundation {
 		{
 			// This test deadlocks on Mountain Lion (but works on Lion)
 			// https://gist.github.com/rolfbjarne/1190d97af79e554c298f2c133dfd8e87
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			handled = false;
 			mre = new ManualResetEvent (false);

--- a/tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs
@@ -7,6 +7,7 @@ using Foundation;
 using AVFoundation;
 using NUnit.Framework;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AVFoundation {
 
@@ -17,8 +18,8 @@ namespace MonoTouchFixtures.AVFoundation {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/AVFoundation/AVCaptionDimensionTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVCaptionDimensionTest.cs
@@ -4,6 +4,7 @@ using Foundation;
 using AVFoundation;
 using NUnit.Framework;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AVFoundation {
 
@@ -14,7 +15,7 @@ namespace MonoTouchFixtures.AVFoundation {
 		[SetUp]
 		public void SetUp ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 12,0);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 12,0);
 		}
 
 		[TestCase]

--- a/tests/monotouch-test/AVFoundation/AVCaptionPointTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVCaptionPointTest.cs
@@ -4,6 +4,7 @@ using Foundation;
 using AVFoundation;
 using NUnit.Framework;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AVFoundation {
 	
@@ -14,7 +15,7 @@ namespace MonoTouchFixtures.AVFoundation {
 		[SetUp]
 		public void SetUp ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 12,0);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 12,0);
 		}
 		
 		[TestCase]

--- a/tests/monotouch-test/AVFoundation/AVCaptionSizeTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVCaptionSizeTest.cs
@@ -4,6 +4,7 @@ using Foundation;
 using AVFoundation;
 using NUnit.Framework;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AVFoundation {
 	
@@ -14,7 +15,7 @@ namespace MonoTouchFixtures.AVFoundation {
 		[SetUp]
 		public void SetUp ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 12,0);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 12,0);
 		}
 
 		[Test]

--- a/tests/monotouch-test/AVFoundation/CaptureDeviceTest.cs
+++ b/tests/monotouch-test/AVFoundation/CaptureDeviceTest.cs
@@ -3,6 +3,8 @@ using Foundation;
 using AVFoundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
+
 namespace MonoTouchFixtures.AVFoundation {
 
 	[TestFixture]
@@ -32,12 +34,12 @@ namespace MonoTouchFixtures.AVFoundation {
 			Compare (AVMediaType.Timecode, AVMediaTypes.Timecode);
 			Compare (AVMediaType.Video, AVMediaTypes.Video);
 
-			if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 9,0))
+			if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 9,0))
 				Compare (AVMediaType.MetadataObject, AVMediaTypes.MetadataObject);
 
 			// obsoleted in iOS 6, removed in iOS12
 #if !__MACCATALYST__
-			if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 12, 0))
+			if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 12, 0))
 				Assert.Null (AVMediaType.TimedMetadata, "AVMediaTypeTimedMetadata");
 			else
 				Compare (AVMediaType.TimedMetadata, AVMediaTypes.TimedMetadata);

--- a/tests/monotouch-test/AVFoundation/CaptureMetadataOutputTest.cs
+++ b/tests/monotouch-test/AVFoundation/CaptureMetadataOutputTest.cs
@@ -16,6 +16,7 @@ using Foundation;
 using AVFoundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AVFoundation {
 
@@ -34,7 +35,7 @@ namespace MonoTouchFixtures.AVFoundation {
 				Assert.AreEqual (0, obj.WeakAvailableMetadataObjectTypes.Length, "WeakAvailableMetadataObjectTypes#");
 				Assert.IsNotNull (obj.WeakMetadataObjectTypes, "WeakMetadataObjectTypes");
 				Assert.AreEqual (0, obj.WeakMetadataObjectTypes.Length, "WeakMetadataObjectTypes#");
-				if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false))
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false))
 					Assert.AreEqual (new CGRect (0, 0, 1, 1), obj.RectOfInterest, "RectOfInterest");
 
 #if !__MACCATALYST__ // https://github.com/xamarin/maccore/issues/2345
@@ -90,7 +91,7 @@ namespace MonoTouchFixtures.AVFoundation {
 		[Test]
 		public void MetadataObjectTypesTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 
 			if (Runtime.Arch != Arch.DEVICE)
 				Assert.Ignore ("This test only runs on device (requires camera access)");

--- a/tests/monotouch-test/AVFoundation/MetadataObjectTest.cs
+++ b/tests/monotouch-test/AVFoundation/MetadataObjectTest.cs
@@ -14,6 +14,7 @@ using Foundation;
 using AVFoundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AVFoundation {
 
@@ -25,7 +26,7 @@ namespace MonoTouchFixtures.AVFoundation {
 		public void Defaults ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			using (var obj = new AVMetadataFaceObject ()) {
 				Assert.AreEqual ((nint) 0, obj.FaceID, "FaceID");

--- a/tests/monotouch-test/AVFoundation/PlayerItemVideoOutputTest.cs
+++ b/tests/monotouch-test/AVFoundation/PlayerItemVideoOutputTest.cs
@@ -15,6 +15,7 @@ using CoreVideo;
 using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AVFoundation {
 
@@ -25,7 +26,7 @@ namespace MonoTouchFixtures.AVFoundation {
 		[Test]
 		public void Ctor_CVPixelBufferAttributes ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			var attributes = new CVPixelBufferAttributes () {
 				PixelFormatType = CVPixelFormatType.CV32BGRA

--- a/tests/monotouch-test/AVFoundation/SpeechSynthesisVoiceTest.cs
+++ b/tests/monotouch-test/AVFoundation/SpeechSynthesisVoiceTest.cs
@@ -17,6 +17,7 @@ using AppKit;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AVFoundation {
 
@@ -29,10 +30,10 @@ namespace MonoTouchFixtures.AVFoundation {
 		public void SetUp ()
 		{
 #if __WATCHOS__
-			if (!TestRuntime.CheckSystemVersion (PlatformName.WatchOS, 3, 0))
+			if (!TestRuntime.CheckSystemVersion (ApplePlatform.WatchOS, 3, 0))
 				Assert.Inconclusive ("Requires watchOS 3.0+");
 #else
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 #endif
 		}
 

--- a/tests/monotouch-test/AVKit/PlayerViewControllerTest.cs
+++ b/tests/monotouch-test/AVKit/PlayerViewControllerTest.cs
@@ -16,6 +16,7 @@ using UIKit;
 using iAd;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AVKit {
 
@@ -26,7 +27,7 @@ namespace MonoTouchFixtures.AVKit {
 		[Test]
 		public void PreparePrerollAds_New ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 
 			AVPlayerViewController.PrepareForPrerollAds ();
 		}

--- a/tests/monotouch-test/AddressBook/AddressBookTest.cs
+++ b/tests/monotouch-test/AddressBook/AddressBookTest.cs
@@ -15,6 +15,7 @@ using UIKit;
 using AddressBook;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AddressBook {
 	
@@ -28,7 +29,7 @@ namespace MonoTouchFixtures.AddressBook {
 		public void Setup ()
 		{
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]
@@ -37,7 +38,7 @@ namespace MonoTouchFixtures.AddressBook {
 			TestRuntime.CheckAddressBookPermission ();
 			ABAddressBook ab = new ABAddressBook ();
 			var sources = ab.GetAllSources ();
-			int value = Runtime.Arch == Arch.DEVICE || TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false) ? 0 : 1;
+			int value = Runtime.Arch == Arch.DEVICE || TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false) ? 0 : 1;
 			Assert.That (sources.Length, Is.GreaterThanOrEqualTo (value), "GetAllSources");
 		}
 		

--- a/tests/monotouch-test/AddressBook/PersonTest.cs
+++ b/tests/monotouch-test/AddressBook/PersonTest.cs
@@ -15,6 +15,7 @@ using UIKit;
 using AddressBook;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AddressBook {
 	
@@ -26,7 +27,7 @@ namespace MonoTouchFixtures.AddressBook {
 		public void Setup ()
 		{
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/AddressBook/SourceTest.cs
+++ b/tests/monotouch-test/AddressBook/SourceTest.cs
@@ -15,6 +15,7 @@ using UIKit;
 using AddressBook;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AddressBook {
 	
@@ -26,7 +27,7 @@ namespace MonoTouchFixtures.AddressBook {
 		public void Setup ()
 		{
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/AddressBookUI/AddressFormattingTest.cs
+++ b/tests/monotouch-test/AddressBookUI/AddressFormattingTest.cs
@@ -16,6 +16,7 @@ using AddressBookUI;
 using ObjCRuntime;
 using UIKit;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AddressBookUI {
 	
@@ -27,7 +28,7 @@ namespace MonoTouchFixtures.AddressBookUI {
 		public void Setup ()
 		{
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]
@@ -66,7 +67,7 @@ namespace MonoTouchFixtures.AddressBookUI {
 				// iOS 8.2 beta 5 (12D5480a) simulator (Xcode 6.2 beta 5): working
 
 				// we don't check before 8.2 - where both device and simulators works again properly
-				if (!TestRuntime.CheckSystemVersion (PlatformName.iOS, 8, 2))
+				if (!TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 8, 2))
 					return;
 
 				// iOS 11.0 beta 1, 2, 3 and 4 are broken

--- a/tests/monotouch-test/AppKit/NSSearchField.cs
+++ b/tests/monotouch-test/AppKit/NSSearchField.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using AppKit;
 using ObjCRuntime;
 using Foundation;
+using Xamarin.Utils;
 
 namespace Xamarin.Mac.Tests
 {
@@ -14,8 +15,7 @@ namespace Xamarin.Mac.Tests
 		[Test]
 		public void NSSearchFieldShouldSetSearchMenuTemplate ()
 		{
-			if (PlatformHelper.ToMacVersion (PlatformHelper.GetHostApiPlatform ()) < Platform.Mac_10_10)
-				return;
+			TestRuntime.AssertXcodeVersion (6, 1);
 
 			var searchField = new NSSearchField ();
 			var searchMenuTemplate = searchField.SearchMenuTemplate;
@@ -27,8 +27,7 @@ namespace Xamarin.Mac.Tests
 		[Test]
 		public void NSSearchFieldShouldSetSendsWholeSearchString ()
 		{
-			if (PlatformHelper.ToMacVersion (PlatformHelper.GetHostApiPlatform ()) < Platform.Mac_10_10)
-				return;
+			TestRuntime.AssertXcodeVersion (6, 1);
 
 			var searchField = new NSSearchField ();
 			var sendsWholeSearchString = searchField.SendsWholeSearchString;
@@ -40,8 +39,7 @@ namespace Xamarin.Mac.Tests
 		[Test]
 		public void NSSearchFieldShouldSetMaximumRecents ()
 		{
-			if (PlatformHelper.ToMacVersion (PlatformHelper.GetHostApiPlatform ()) < Platform.Mac_10_10)
-				return;
+			TestRuntime.AssertXcodeVersion (6, 1);
 
 			var searchField = new NSSearchField ();
 			var maximumRecents = searchField.MaximumRecents;
@@ -53,8 +51,7 @@ namespace Xamarin.Mac.Tests
 		[Test]
 		public void NSSearchFieldShouldSetSendsSearchStringImmediately ()
 		{
-			if (PlatformHelper.ToMacVersion (PlatformHelper.GetHostApiPlatform ()) < Platform.Mac_10_10)
-				return;
+			TestRuntime.AssertXcodeVersion (6, 1);
 
 			var searchField = new NSSearchField ();
 			var sendsSearchStringImmediately = searchField.SendsSearchStringImmediately;

--- a/tests/monotouch-test/AppKit/NSSlider.cs
+++ b/tests/monotouch-test/AppKit/NSSlider.cs
@@ -5,6 +5,7 @@ using System;
 using AppKit;
 using ObjCRuntime;
 using Foundation;
+using Xamarin.Utils;
 
 namespace Xamarin.Mac.Tests
 {
@@ -15,8 +16,7 @@ namespace Xamarin.Mac.Tests
 		[Test]
 		public void NSSlider_VertialTests()
 		{
-			if (PlatformHelper.ToMacVersion (PlatformHelper.GetHostApiPlatform ()) < Platform.Mac_10_12)
-				return;
+			TestRuntime.AssertXcodeVersion (8, 0);
 
 			NSSlider slider = new NSSlider ();
 			var isVert = slider.IsVertical;

--- a/tests/monotouch-test/AppKit/NSTabViewController.cs
+++ b/tests/monotouch-test/AppKit/NSTabViewController.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using AppKit;
 using ObjCRuntime;
 using Foundation;
+using Xamarin.Utils;
 
 namespace Xamarin.Mac.Tests
 {
@@ -44,7 +45,7 @@ namespace Xamarin.Mac.Tests
 		public void NSTabViewControllerShouldChangeSegmentedControl ()
 		{
 			// This API was removed in 10.11
-			if (PlatformHelper.ToMacVersion (PlatformHelper.GetHostApiPlatform ()) >= Platform.Mac_10_11)
+			if (TestRuntime.CheckXcodeVersion (7, 0))
 				return;
 
 			var segmentedControl = controller.SegmentedControl;

--- a/tests/monotouch-test/AssertsMac.cs
+++ b/tests/monotouch-test/AssertsMac.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 
 using NUnit.Framework;
 using Xamarin.Tests;
+using Xamarin.Utils;
 
 using ObjCRuntime;
 using Foundation;
@@ -14,13 +15,13 @@ namespace Xamarin.Mac.Tests
 	{
 		public static bool IsAtLeastYosemite {
 			get {
-				return PlatformHelper.ToMacVersion (PlatformHelper.GetHostApiPlatform ()) >= Platform.Mac_10_10;
+				return TestRuntime.CheckXcodeVersion (6, 1);
 			}
 		}
 
 		public static bool IsAtLeastElCapitan {
 			get {
-				return PlatformHelper.ToMacVersion (PlatformHelper.GetHostApiPlatform ()) >= Platform.Mac_10_11;
+				return TestRuntime.CheckXcodeVersion (7, 0);
 			}
 		}
 
@@ -32,14 +33,12 @@ namespace Xamarin.Mac.Tests
 
 		public static void EnsureMavericks ()
 		{
-			if (PlatformHelper.ToMacVersion (PlatformHelper.GetHostApiPlatform ()) < Platform.Mac_10_9)
-				Assert.Pass ("This test requires Mavericks. Skipping");
+			TestRuntime.AssertXcodeVersion (6, 0);
 		}
 
 		public static void EnsureMountainLion ()
 		{
-			if (PlatformHelper.ToMacVersion (PlatformHelper.GetHostApiPlatform ()) < Platform.Mac_10_8)
-				Assert.Pass ("This test requires Mountain Lion. Skipping");
+			// We're always running on at least Mountain Lion
 		}
 
 		public static void Ensure64Bit ()

--- a/tests/monotouch-test/AudioToolbox/SoundBankTest.cs
+++ b/tests/monotouch-test/AudioToolbox/SoundBankTest.cs
@@ -14,6 +14,7 @@ using Foundation;
 using AudioToolbox;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AudioToolbox {
 
@@ -26,7 +27,7 @@ namespace MonoTouchFixtures.AudioToolbox {
 		[Test]
 		public void GetName ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			Assert.Throws<ArgumentNullException> (delegate { SoundBank.GetName (null); }, "null");
 
@@ -39,7 +40,7 @@ namespace MonoTouchFixtures.AudioToolbox {
 		[Test]
 		public void GetName_DLS_SimOnly ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 			if (Runtime.Arch == Arch.DEVICE)
 				Assert.Ignore ("Use local file system (need a smaller sample)");
 
@@ -52,8 +53,8 @@ namespace MonoTouchFixtures.AudioToolbox {
 		[Test]
 		public void GetInstrumentInfo ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			Assert.Throws<ArgumentNullException> (delegate { SoundBank.GetInstrumentInfo (null); }, "null");
 
@@ -66,7 +67,7 @@ namespace MonoTouchFixtures.AudioToolbox {
 		[Test]
 		public void GetInstrumentInfo_DLS_SimOnly ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 			if (Runtime.Arch == Arch.DEVICE)
 				Assert.Ignore ("Use local file system (need a smaller sample)");
 

--- a/tests/monotouch-test/AudioToolbox/SystemSoundTest.cs
+++ b/tests/monotouch-test/AudioToolbox/SystemSoundTest.cs
@@ -15,6 +15,7 @@ using Foundation;
 using AudioToolbox;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.AudioToolbox {
 	
@@ -57,7 +58,7 @@ namespace MonoTouchFixtures.AudioToolbox {
 		public void TestCallbackPlaySystem ()
 		{
 			TestRuntime.AssertNotSimulator ();
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 9, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 9, 0, throwIfOtherPlatform: false);
 
 			string path = Path.Combine (NSBundle.MainBundle.ResourcePath, "drum01.mp3");
 
@@ -77,7 +78,7 @@ namespace MonoTouchFixtures.AudioToolbox {
 		public void TestCallbackPlayAlert ()
 		{
 			TestRuntime.AssertNotSimulator ();
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 9, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 9, 0, throwIfOtherPlatform: false);
 
 			string path = Path.Combine (NSBundle.MainBundle.ResourcePath, "drum01.mp3");
 

--- a/tests/monotouch-test/CarPlay/CPMessageListItemTests.cs
+++ b/tests/monotouch-test/CarPlay/CPMessageListItemTests.cs
@@ -14,6 +14,7 @@ using NUnit.Framework;
 using CarPlay;
 using Foundation;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CarPlay {
 
@@ -26,7 +27,7 @@ namespace MonoTouchFixtures.CarPlay {
 		{
 			TestRuntime.AssertXcodeVersion (12, 0);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/CloudKit/CKFetchNotificationChangesOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKFetchNotificationChangesOperationTest.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using Foundation;
 using CloudKit;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CloudKit
 {
@@ -18,7 +19,7 @@ namespace MonoTouchFixtures.CloudKit
 		public void SetUp ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 			op = new CKFetchNotificationChangesOperation (token);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKFetchRecordChangesOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKFetchRecordChangesOperationTest.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using Foundation;
 using CloudKit;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CloudKit
 {
@@ -19,7 +20,7 @@ namespace MonoTouchFixtures.CloudKit
 		public void SetUp ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 			zoneID = new CKRecordZoneID ("foo", "xamarin");
 			op = new CKFetchRecordChangesOperation (zoneID, null);
 		}

--- a/tests/monotouch-test/CloudKit/CKFetchRecordZonesOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKFetchRecordZonesOperationTest.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using Foundation;
 using CloudKit;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CloudKit
 {
@@ -18,7 +19,7 @@ namespace MonoTouchFixtures.CloudKit
 		public void SetUp ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 			op = new CKFetchRecordZonesOperation (zoneIDs);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKFetchRecordsOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKFetchRecordsOperationTest.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using Foundation;
 using CloudKit;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CloudKit
 {
@@ -18,7 +19,7 @@ namespace MonoTouchFixtures.CloudKit
 		public void SetUp ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 			op = new CKFetchRecordsOperation (recordIDs);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKFetchSubscriptionsOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKFetchSubscriptionsOperationTest.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using Foundation;
 using CloudKit;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CloudKit
 {
@@ -19,7 +20,7 @@ namespace MonoTouchFixtures.CloudKit
 		public void SetUp ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 			op = new CKFetchSubscriptionsOperation (ids);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKMarkNotificationsReadOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKMarkNotificationsReadOperationTest.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using Foundation;
 using CloudKit;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CloudKit
 {
@@ -18,7 +19,7 @@ namespace MonoTouchFixtures.CloudKit
 		public void SetUp ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 			op = new CKMarkNotificationsReadOperation (notificationIDs);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKModifyBadgeOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKModifyBadgeOperationTest.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using Foundation;
 using CloudKit;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CloudKit
 {
@@ -17,7 +18,7 @@ namespace MonoTouchFixtures.CloudKit
 		public void SetUp ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 			op = new CKModifyBadgeOperation (3);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKModifyRecordZonesOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKModifyRecordZonesOperationTest.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using Foundation;
 using CloudKit;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CloudKit
 {
@@ -17,7 +18,7 @@ namespace MonoTouchFixtures.CloudKit
 		public void SetUp ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 			op = new CKModifyRecordZonesOperation (null, null);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKModifyRecordsOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKModifyRecordsOperationTest.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using Foundation;
 using CloudKit;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CloudKit
 {
@@ -17,7 +18,7 @@ namespace MonoTouchFixtures.CloudKit
 		public void SetUp ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 			op = new CKModifyRecordsOperation (null, null);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKModifySubscriptionsOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKModifySubscriptionsOperationTest.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using Foundation;
 using CloudKit;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CloudKit
 {
@@ -18,7 +19,7 @@ namespace MonoTouchFixtures.CloudKit
 		public void SetUp ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 			op = new CKModifySubscriptionsOperation (null, null);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKQueryOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKQueryOperationTest.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using Foundation;
 using CloudKit;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CloudKit
 {
@@ -18,7 +19,7 @@ namespace MonoTouchFixtures.CloudKit
 		public void SetUp ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 			q = new CKQuery ("Foo", NSPredicate.FromFormat ("email = '@xamarin'"));
 			op = new CKQueryOperation (q);
 		}

--- a/tests/monotouch-test/CoreAnimation/EmitterBehaviorTest.cs
+++ b/tests/monotouch-test/CoreAnimation/EmitterBehaviorTest.cs
@@ -13,6 +13,7 @@ using Foundation;
 using CoreAnimation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreAnimation {
 
@@ -26,8 +27,8 @@ namespace MonoTouchFixtures.CoreAnimation {
 		[Test]
 		public void AllBehaviorTypes ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			// turns out there's 2 undocumented behaviors: colorOverDistance and valueOverDistance
 			foreach (var type in CAEmitterBehavior.BehaviorTypes) {
@@ -42,8 +43,8 @@ namespace MonoTouchFixtures.CoreAnimation {
 		[Test]
 		public void ColorOverDistance ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			// undocumented - we'll track it over the betas :)
 			using (var eb = CAEmitterBehavior.Create ((NSString) "colorOverDistance")) {
@@ -62,8 +63,8 @@ namespace MonoTouchFixtures.CoreAnimation {
 		[Test]
 		public void ValueOverDistance ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			// undocumented - we'll track it over the betas :)
 			using (var eb = CAEmitterBehavior.Create ((NSString) "valueOverDistance")) {

--- a/tests/monotouch-test/CoreBluetooth/CentralManagerTest.cs
+++ b/tests/monotouch-test/CoreBluetooth/CentralManagerTest.cs
@@ -19,6 +19,7 @@ using ObjCRuntime;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreBluetooth {
 	
@@ -81,7 +82,7 @@ namespace MonoTouchFixtures.CoreBluetooth {
 			//known UUID for a heart monitor, more common, we want to find something and make sure we do not crash
 			heartRateMonitorUUID = CBUUID.FromPartial (0x180D);
 			// Required API is available in macOS 10.8, but it doesn't work (hangs in 10.8-10.9, randomly crashes in 10.10) on the bots.
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 11, throwIfOtherPlatform: false);
 			mgrDelegate = new ManagerDelegate ();
 			mgr = new CBCentralManager (mgrDelegate, new DispatchQueue ("com.xamarin.tests." + TestContext.CurrentContext.Test.Name));
 			if (!mgrDelegate.PoweredOnEvent.WaitOne (TimeSpan.FromSeconds (5)))

--- a/tests/monotouch-test/CoreBluetooth/PeerTest.cs
+++ b/tests/monotouch-test/CoreBluetooth/PeerTest.cs
@@ -13,6 +13,7 @@ using Foundation;
 using CoreBluetooth;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreBluetooth {
 
@@ -22,8 +23,8 @@ namespace MonoTouchFixtures.CoreBluetooth {
 		[Test]
 		public void Constructor ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 13, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 13, throwIfOtherPlatform: false);
 
 			// crash at dispose time in beta 4 (and 5)
 			// the type is undocumented but I think it's should be abstract (not user creatable)

--- a/tests/monotouch-test/CoreBluetooth/UuidTest.cs
+++ b/tests/monotouch-test/CoreBluetooth/UuidTest.cs
@@ -21,6 +21,7 @@ using UIKit;
 #endif
 
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreBluetooth {
 	
@@ -124,7 +125,7 @@ namespace MonoTouchFixtures.CoreBluetooth {
 				Assert.That (u1.GetHashCode (), Is.EqualTo (u2.GetHashCode ()), "GetHashCode-3");
 			}
 #if MONOMAC
-			if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 10)) {
+			if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 10)) {
 				guid = new byte [] { 0xaa, 0xbb, 0xcc, 0xdd };
 				Assert.That (CBUUID.FromBytes (guid),
 					Is.EqualTo (CBUUID.FromBytes (guid)));
@@ -162,7 +163,7 @@ namespace MonoTouchFixtures.CoreBluetooth {
 				Assert.That (u1.GetHashCode (), Is.EqualTo (u2.GetHashCode ()), "GetHashCode-3");
 			}
 #if MONOMAC
-			if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 10)) {
+			if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 10)) {
 				Assert.That (CBUUID.FromBytes (new byte [] { 0xab, 0xcd, 0xef, 0x12 }),
 					Is.EqualTo (MakeFull (0xab, 0xcd, 0xef, 0x12)));
 
@@ -175,7 +176,7 @@ namespace MonoTouchFixtures.CoreBluetooth {
 		[Test]
 		public void Equality_PartialsOfDifferentSizeNotEqual ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 #if MONOMAC
 			Assert.That (CBUUID.FromPartial (0x1234), Is.Not.EqualTo (
 				CBUUID.FromBytes (new byte [] { 0x12, 0x34, 0x56, 0x78 })));

--- a/tests/monotouch-test/CoreData/ManagedObjectContextTest.cs
+++ b/tests/monotouch-test/CoreData/ManagedObjectContextTest.cs
@@ -12,6 +12,7 @@ using Foundation;
 using CoreData;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreData {
 	
@@ -30,7 +31,7 @@ namespace MonoTouchFixtures.CoreData {
 			Assert.That (moc.RegisteredObjects.Count, Is.EqualTo ((nuint) 0), "RegisteredObjects");
 			Assert.False (moc.RetainsRegisteredObjects, "RetainsRegisteredObjects");
 			Assert.That (moc.StalenessInterval, Is.EqualTo (-1), "StalenessInterval");
-			if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 12, throwIfOtherPlatform: false))
+			if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 12, throwIfOtherPlatform: false))
 				Assert.Null (moc.UndoManager, "UndoManager");
 			else
 				Assert.NotNull (moc.UndoManager, "UndoManager");

--- a/tests/monotouch-test/CoreFoundation/DispatchBlockTests.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchBlockTests.cs
@@ -13,6 +13,7 @@ using Foundation;
 using CoreFoundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreFoundation
 {
@@ -24,8 +25,8 @@ namespace MonoTouchFixtures.CoreFoundation
 		[SetUp]
 		public void SetUp ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/CoreFoundation/DispatchGroupTest.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchGroupTest.cs
@@ -13,6 +13,7 @@ using Foundation;
 using CoreFoundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreFoundation {
 	
@@ -49,8 +50,8 @@ namespace MonoTouchFixtures.CoreFoundation {
 		[Test]
 		public void NotifyWithDispatchBlock ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			using (var dg = new DispatchGroup ()) {
 				var called = false;

--- a/tests/monotouch-test/CoreFoundation/DispatchQueueTest.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchQueueTest.cs
@@ -18,6 +18,7 @@ using AppKit;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreFoundation
 {
@@ -86,8 +87,8 @@ namespace MonoTouchFixtures.CoreFoundation
 		[Test]
 		public void DispatchSync ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			using (var queue = new DispatchQueue ("DispatchSync")) {
 				var called = false;
@@ -105,8 +106,8 @@ namespace MonoTouchFixtures.CoreFoundation
 		[Test]
 		public void DispatchBarrierSync ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			using (var queue = new DispatchQueue ("DispatchBarrierSync")) {
 				var called = false;
@@ -124,8 +125,8 @@ namespace MonoTouchFixtures.CoreFoundation
 		[Test]
 		public void DispatchAsync ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			using (var queue = new DispatchQueue ("DispatchAsync")) {
 				var called = false;
@@ -146,8 +147,8 @@ namespace MonoTouchFixtures.CoreFoundation
 		[Test]
 		public void DispatchBarrierAsync ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			using (var queue = new DispatchQueue ("DispatchBarrierAsync")) {
 				var called = false;

--- a/tests/monotouch-test/CoreFoundation/DispatchTests.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchTests.cs
@@ -20,6 +20,7 @@ using UIKit;
 #endif
 using NUnit.Framework;
 using System.Threading;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreFoundation {
 	
@@ -166,12 +167,12 @@ namespace MonoTouchFixtures.CoreFoundation {
 		{
 			var qname = "com.apple.root.default-priority";
 #if __IOS__ 
-			if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 8, 0))
+			if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 8, 0))
 				qname = "com.apple.root.default-qos";
 #elif __WATCHOS__ || __TVOS__
 			qname = "com.apple.root.default-qos";
 #elif __MACOS__
-			if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 10))
+			if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 10))
 				qname = "com.apple.root.default-qos";
 #endif
 			Assert.That (DispatchQueue.DefaultGlobalQueue.Label, Is.EqualTo (qname), "Default");
@@ -231,7 +232,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		[Test]
 		public void GetGlobalQueue_QualityOfService ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			// values changes in OS versions (and even in arch) but we only want to make sure we get a valid string so the prefix is enough
 			Assert.True (DispatchQueue.GetGlobalQueue (DispatchQualityOfService.Default).Label.StartsWith ("com.apple.root."), "Default");

--- a/tests/monotouch-test/CoreFoundation/UrlTest.cs
+++ b/tests/monotouch-test/CoreFoundation/UrlTest.cs
@@ -12,6 +12,7 @@ using Foundation;
 using CoreFoundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreFoundation {
 	
@@ -55,12 +56,12 @@ namespace MonoTouchFixtures.CoreFoundation {
 			using (CFUrl url = CFUrl.FromFile ("/")) {
 				string value = "file://localhost/";
 #if __IOS__
-				if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0))
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 0))
 					value = "file:///";
 #elif __WATCHOS__ || __TVOS__
 				value = "file:///";
 #elif __MACOS__
-				if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 9))
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 9))
 					value = "file:///";
 #endif
 

--- a/tests/monotouch-test/CoreImage/CIKernelTests.cs
+++ b/tests/monotouch-test/CoreImage/CIKernelTests.cs
@@ -15,6 +15,7 @@ using UIKit;
 using PlatformImage = UIKit.UIImage;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreImage
 {
@@ -122,8 +123,8 @@ namespace MonoTouchFixtures.CoreImage
 		[Test]
 		public void CIKernel_BasicTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 11, throwIfOtherPlatform: false);
 
 			Exception ex = null;
 			var t = new Thread (() => {
@@ -174,8 +175,8 @@ namespace MonoTouchFixtures.CoreImage
 		[Test]
 		public void CIKernel_TestFromPrograms ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 11, throwIfOtherPlatform: false);
 
 			CIKernel[] kernels = 
 				CIKernel.FromProgramMultiple (

--- a/tests/monotouch-test/CoreImage/FilterTest.cs
+++ b/tests/monotouch-test/CoreImage/FilterTest.cs
@@ -19,6 +19,7 @@ using CoreText;
 using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreImage {
 
@@ -49,8 +50,8 @@ namespace MonoTouchFixtures.CoreImage {
 		[Test]
 		public void CustomFilterTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 11, throwIfOtherPlatform: false);
 
 			MyFilter filter = new MyFilter ();
 			Assert.NotNull (filter);
@@ -76,8 +77,8 @@ namespace MonoTouchFixtures.CoreImage {
 		[Test]
 		public void ColorSpace ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			using (var f = new CIColorCubeWithColorSpace ()) {
 				Assert.Null (f.ColorSpace, "ColorSpace/default");

--- a/tests/monotouch-test/CoreImage/ImageInitializationOptionsTest.cs
+++ b/tests/monotouch-test/CoreImage/ImageInitializationOptionsTest.cs
@@ -21,6 +21,7 @@ using UIKit;
 #endif
 
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreImage {
 
@@ -49,7 +50,7 @@ namespace MonoTouchFixtures.CoreImage {
 		[Test]
 		public void WithMetadataDefaults ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			var options = new CIImageInitializationOptionsWithMetadata ();
 			Assert.That (options.Dictionary.Count, Is.EqualTo ((nuint) 0), "Count");
@@ -59,7 +60,7 @@ namespace MonoTouchFixtures.CoreImage {
 		[Test]
 		public void WithMetadataProperties ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			var suboptions = new CGImageProperties () {
 				ProfileName = "Xamarin"

--- a/tests/monotouch-test/CoreImage/ImageTest.cs
+++ b/tests/monotouch-test/CoreImage/ImageTest.cs
@@ -22,6 +22,7 @@ using CoreImage;
 using CoreGraphics;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreImage {
 	
@@ -32,14 +33,14 @@ namespace MonoTouchFixtures.CoreImage {
 		[Test]
 		public void EmptyImage ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 			Assert.IsNull (CIImage.EmptyImage.Properties);
 		}
 
 		[Test]
 		public void InitializationWithCustomMetadata ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 			string file = Path.Combine (NSBundle.MainBundle.ResourcePath, "basn3p08.png");
 			using (var dp = new CGDataProvider (file)) {
 				using (var img = CGImage.FromPNG (dp, null, false, CGColorRenderingIntent.Default)) {
@@ -74,15 +75,15 @@ namespace MonoTouchFixtures.CoreImage {
 		[Test]
 		public void AreaHistogram ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			// validate that a null NSDictionary is correct (i.e. uses filter defaults)
 			using (var h = CIImage.EmptyImage.CreateByFiltering ("CIAreaHistogram", null)) {
 				// broken on simulator/64 bits on iOS9 beta 2 - radar 21564256 -> fixed in beta 4
 				var success = true;
 #if __MACOS__
-				if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 11))
+				if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 11))
 					success = false;
 #endif
 				if (success) {

--- a/tests/monotouch-test/CoreLocation/BeaconRegionTest.cs
+++ b/tests/monotouch-test/CoreLocation/BeaconRegionTest.cs
@@ -14,6 +14,7 @@ using UIKit;
 using CoreLocation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreLocation {
 
@@ -24,7 +25,7 @@ namespace MonoTouchFixtures.CoreLocation {
 		[Test]
 		public void Ctor2 ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			using (var uuid = new NSUuid ("E2C56DB5-DFFB-48D2-B060-D0F5A71096E0"))
 			using (var br = new CLBeaconRegion (uuid, "identifier")) {
@@ -43,7 +44,7 @@ namespace MonoTouchFixtures.CoreLocation {
 		[Test]
 		public void Ctor3 ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			using (var uuid = new NSUuid ("E2C56DB5-DFFB-48D2-B060-D0F5A71096E0"))
 			using (var br = new CLBeaconRegion (uuid, 0, "identifier")) {
@@ -61,7 +62,7 @@ namespace MonoTouchFixtures.CoreLocation {
 		[Test]
 		public void Ctor4 ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			using (var uuid = new NSUuid ("E2C56DB5-DFFB-48D2-B060-D0F5A71096E0"))
 			using (var br = new CLBeaconRegion (uuid, 2, 3, "identifier")) {

--- a/tests/monotouch-test/CoreMedia/CMClockOrTimebaseTest.cs
+++ b/tests/monotouch-test/CoreMedia/CMClockOrTimebaseTest.cs
@@ -3,6 +3,7 @@ using Foundation;
 using CoreMedia;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreMedia
 {
@@ -15,7 +16,7 @@ namespace MonoTouchFixtures.CoreMedia
 		[Test]
 		public void RetainReleaseTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			var clock = CMClock.HostTimeClock;
 			var timebase = new CMClockOrTimebase (clock.Handle);

--- a/tests/monotouch-test/CoreMedia/CMClockTest.cs
+++ b/tests/monotouch-test/CoreMedia/CMClockTest.cs
@@ -14,6 +14,7 @@ using CoreMedia;
 using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreMedia {
 	
@@ -39,7 +40,7 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void HostTimeClock ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			using (var clock = CMClock.HostTimeClock) {
 				Assert.That (clock.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");

--- a/tests/monotouch-test/CoreMedia/CMFormatDescriptionTest.cs
+++ b/tests/monotouch-test/CoreMedia/CMFormatDescriptionTest.cs
@@ -18,6 +18,7 @@ using AppKit;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreMedia {
 	
@@ -43,7 +44,7 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void Video ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			CMFormatDescriptionError fde;
 
@@ -81,7 +82,7 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void RefcountTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 			
 			// Bug #27205
 

--- a/tests/monotouch-test/CoreMedia/CMMemoryPoolTest.cs
+++ b/tests/monotouch-test/CoreMedia/CMMemoryPoolTest.cs
@@ -11,6 +11,7 @@ using Foundation;
 using CoreMedia;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreMedia {
 	
@@ -21,7 +22,7 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void Ctor ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			using (var mp = new CMMemoryPool ())
 			{
@@ -35,7 +36,7 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void CtorAgeOutPeriod ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			using (var mp = new CMMemoryPool (TimeSpan.FromSeconds (40)))
 			{

--- a/tests/monotouch-test/CoreMedia/CMTimeTests.cs
+++ b/tests/monotouch-test/CoreMedia/CMTimeTests.cs
@@ -17,6 +17,7 @@ using AppKit;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreMedia {
 	
@@ -101,7 +102,7 @@ namespace MonoTouchFixtures.CoreMedia {
 		public void MultiplyByRatio ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 1);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			var t = new CMTime (1000, 1);
 			t = CMTime.Multiply (t, 20, 10);

--- a/tests/monotouch-test/CoreMedia/CMTimebaseTest.cs
+++ b/tests/monotouch-test/CoreMedia/CMTimebaseTest.cs
@@ -11,6 +11,7 @@ using Foundation;
 using CoreMedia;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreMedia {
 	
@@ -22,7 +23,7 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void DefaultValues ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			var htc = CMClock.HostTimeClock;
 			using (var tb = new CMTimebase (htc)) {
@@ -43,7 +44,7 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void SetAnchorTime ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			using (var tb = new CMTimebase (CMClock.HostTimeClock)) {
 				Assert.AreEqual (CMTimebaseError.None, tb.SetAnchorTime (new CMTime (1000000, 200), new CMTime (-1, -2)));
@@ -55,7 +56,7 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void AddTimer ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			using (var tb = new CMTimebase (CMClock.HostTimeClock)) {
 				var timer = NSTimer.CreateRepeatingTimer (CMTimebase.VeryLongTimeInterval, delegate { });
@@ -71,7 +72,7 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void GetMasterTests ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			using (var tb = new CMTimebase (CMClock.HostTimeClock)) {
 				var masterTB = tb.GetMasterTimebase ();
@@ -92,7 +93,7 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void CopyMasterTests ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			using (var tb = new CMTimebase (CMClock.HostTimeClock)) {
 				var masterTB = tb.CopyMasterTimebase ();

--- a/tests/monotouch-test/CoreMedia/SampleBufferTest.cs
+++ b/tests/monotouch-test/CoreMedia/SampleBufferTest.cs
@@ -15,6 +15,7 @@ using ObjCRuntime;
 using CoreVideo;
 using CoreMedia;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreMedia {
 	
@@ -41,8 +42,8 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void CreateReadyWithPacketDescriptions ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			CMBlockBufferError bbe;
 			using (var bb = CMBlockBuffer.CreateEmpty (0, CMBlockBufferFlags.AlwaysCopyData, out bbe)) {
@@ -61,8 +62,8 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void CreateReady ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			CMBlockBufferError bbe;
 			using (var bb = CMBlockBuffer.CreateEmpty (0, CMBlockBufferFlags.AlwaysCopyData, out bbe)) {
@@ -78,8 +79,8 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void CreateReadyWithImageBuffer_ArrayValidations ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			CMFormatDescriptionError fde;
 			using (var pixelBuffer = new CVPixelBuffer (20, 10, CVPixelFormatType.CV24RGB))
@@ -96,8 +97,8 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void CreateReadyWithImageBuffer ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			CMFormatDescriptionError fde;
 			using (var pixelBuffer = new CVPixelBuffer (20, 10, CVPixelFormatType.CV24RGB))

--- a/tests/monotouch-test/CoreVideo/CVDisplayLinkTest.cs
+++ b/tests/monotouch-test/CoreVideo/CVDisplayLinkTest.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using Foundation;
 using ObjCRuntime;
 using CoreVideo;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreVideo {
 
@@ -16,7 +17,7 @@ namespace MonoTouchFixtures.CoreVideo {
 		[Test]
 		public void CreateFromDisplayIdValidIdTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 12, 0);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 12, 0);
 			Assert.DoesNotThrow (() => {
 				using var displayLink = CVDisplayLink.CreateFromDisplayId ((uint) CGDisplay.MainDisplayID);
 				Assert.NotNull (displayLink, "Not null");
@@ -27,7 +28,7 @@ namespace MonoTouchFixtures.CoreVideo {
 		[Test]
 		public void CreateFromDisplayWrongIdTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 12, 0);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 12, 0);
 			Assert.DoesNotThrow (() => {
 				using var displayLink = CVDisplayLink.CreateFromDisplayId (UInt32.MaxValue);
 				Assert.Null (displayLink, "null");
@@ -37,7 +38,7 @@ namespace MonoTouchFixtures.CoreVideo {
 		[Test]
 		public void CreateFromDisplayIdsTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 12, 0);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 12, 0);
 			// we might not have more than one display, therefore we will use an array 
 			// with a single one, there is nothing in the docs that say that we cannot do that
 			Assert.DoesNotThrow (() => {
@@ -49,7 +50,7 @@ namespace MonoTouchFixtures.CoreVideo {
 		[Test]
 		public void CreateFromOpenGLMaskTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 12, 0);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 12, 0);
 			var openGLMask = CGDisplay.GetOpenGLDisplayMask (CGDisplay.MainDisplayID);
 			Assert.DoesNotThrow (() => {
 				using var displayLink = CVDisplayLink.CreateFromOpenGLMask ((uint) openGLMask);
@@ -77,7 +78,7 @@ namespace MonoTouchFixtures.CoreVideo {
 		[Test]
 		public void GetTypeIdTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 12, 0);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 12, 0);
 			Assert.DoesNotThrow (() => {
 				CVDisplayLink.GetTypeId ();
 			}, "Throws");
@@ -86,7 +87,7 @@ namespace MonoTouchFixtures.CoreVideo {
 		[Test]
 		public void TryTranslateTimeValidTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 12, 0);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 12, 0);
 			var outTime = new CVTimeStamp {
 				Version = 0,
 				Flags = (1L << 0) | (1L << 1), // kCVTimeStampVideoTimeValid | kCVTimeStampHostTimeValid

--- a/tests/monotouch-test/EventKit/AlarmTest.cs
+++ b/tests/monotouch-test/EventKit/AlarmTest.cs
@@ -15,6 +15,7 @@ using CoreGraphics;
 using EventKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.EventKit {
 	
@@ -25,7 +26,7 @@ namespace MonoTouchFixtures.EventKit {
 		[Test]
 		public void NullAllowedTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			using (var alarm = EKAlarm.FromTimeInterval (1234)) {
 				alarm.AbsoluteDate = null;

--- a/tests/monotouch-test/EventKit/CalendarTest.cs
+++ b/tests/monotouch-test/EventKit/CalendarTest.cs
@@ -16,6 +16,7 @@ using CoreGraphics;
 using ObjCRuntime;
 using EventKit;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.EventKit {
 	
@@ -25,7 +26,7 @@ namespace MonoTouchFixtures.EventKit {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 		}
 
 		void RequestPermission ()

--- a/tests/monotouch-test/EventKit/RecurrenceRule.cs
+++ b/tests/monotouch-test/EventKit/RecurrenceRule.cs
@@ -14,6 +14,7 @@ using EventKit;
 using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.EventKit {
 
@@ -24,7 +25,7 @@ namespace MonoTouchFixtures.EventKit {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/EventKit/ReminderTest.cs
+++ b/tests/monotouch-test/EventKit/ReminderTest.cs
@@ -14,6 +14,7 @@ using Foundation;
 using EventKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.EventKit {
 	
@@ -25,7 +26,7 @@ namespace MonoTouchFixtures.EventKit {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 		}
 
 		[Test]
@@ -56,7 +57,7 @@ namespace MonoTouchFixtures.EventKit {
 		[Test]
 		public void Range ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			using (var rem = new EKReminder ()) {
 				// priority is documented to have a range of 0-9 but there's no validation in ObjC

--- a/tests/monotouch-test/ExternalAccessory/AccessoryManagerTest.cs
+++ b/tests/monotouch-test/ExternalAccessory/AccessoryManagerTest.cs
@@ -14,6 +14,7 @@ using Foundation;
 using ExternalAccessory;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.ExternalAccessory {
 
@@ -43,7 +44,7 @@ namespace MonoTouchFixtures.ExternalAccessory {
 		public void ShowBluetoothAccessoryPicker ()
 		{
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 			EAAccessoryManager.SharedAccessoryManager.ShowBluetoothAccessoryPicker (null, null);
 		}
 #endif

--- a/tests/monotouch-test/Foundation/AttributedStringTest.cs
+++ b/tests/monotouch-test/Foundation/AttributedStringTest.cs
@@ -12,6 +12,7 @@ using ObjCRuntime;
 #if !__WATCHOS__
 using CoreText;
 #endif
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Foundation {
 
@@ -84,8 +85,8 @@ namespace MonoTouchFixtures.Foundation {
 		[Test]
 		public void UIKitAttachmentConveniences_New ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 11, throwIfOtherPlatform: false);
 
 			// so we added custom code calling the (old) category helper - but we had to pick a different name
 			using (var ta = new NSTextAttachment (null, null))

--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -2,6 +2,7 @@ using System;
 using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 using RectangleF=CoreGraphics.CGRect;
 using SizeF=CoreGraphics.CGSize;
@@ -90,7 +91,7 @@ namespace MonoTouchFixtures.Foundation {
 				case NSCalendarType.IslamicTabular:
 				case NSCalendarType.IslamicUmmAlQura:
 #if __MACOS__
-					if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 10))
+					if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 10))
 						continue;
 #else
 					if (!TestRuntime.CheckXcodeVersion (6, 0))
@@ -220,7 +221,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void TestAddingByComponents ()
 		{
 			RequiresIos8 ();
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			NSDate now = NSDate.Now;
 			NSDate oneDayFromNow = NSCalendar.CurrentCalendar.DateByAddingUnit (NSCalendarUnit.Day, 1, now, NSCalendarOptions.None);

--- a/tests/monotouch-test/Foundation/EncodingDetectionOptionsTest.cs
+++ b/tests/monotouch-test/Foundation/EncodingDetectionOptionsTest.cs
@@ -10,6 +10,7 @@
 using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Foundation {
 
@@ -21,7 +22,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void SetValueEnumArray ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			var encodings = new NSStringEncoding [] { NSStringEncoding.ISOLatin1, NSStringEncoding.ISOLatin2 };
 			var edo = new EncodingDetectionOptions () {

--- a/tests/monotouch-test/Foundation/FormatterTests.cs
+++ b/tests/monotouch-test/Foundation/FormatterTests.cs
@@ -8,6 +8,7 @@ using AppKit;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Foundation
 {
@@ -21,7 +22,7 @@ namespace MonoTouchFixtures.Foundation
 		void RequiresIos8 ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			if (dateComponentsFormatter == null)
 				dateComponentsFormatter = new NSDateComponentsFormatter ();

--- a/tests/monotouch-test/Foundation/NSDataTest.cs
+++ b/tests/monotouch-test/Foundation/NSDataTest.cs
@@ -19,6 +19,7 @@ using AppKit;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 using MonoTests.System.Net.Http;
 
@@ -32,7 +33,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void ConstructorTest ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			var bytes = Marshal.AllocHGlobal (1);
 			var deallocated = false;
@@ -144,7 +145,7 @@ namespace MonoTouchFixtures.Foundation {
 			}
 #endif
 			// Https seems broken on our macOS 10.9 bot, so skip this test.
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			// we have network issues, try several urls, if one works, be happy, else fail
 			for (var i = 0; i < NetworkResources.RobotsUrls.Length; i++) {
@@ -165,7 +166,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void Base64_Short ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			using (var data = NSData.FromArray (new byte [1] { 42 })) {
 				string s1 = data.GetBase64EncodedString (NSDataBase64EncodingOptions.EndLineWithCarriageReturn);
@@ -186,7 +187,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void Base64_Long ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			byte[] array = new byte [60];
 			using (var data = NSData.FromArray (array)) {
@@ -337,7 +338,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void Base64String ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			using (var d = new NSData ("WGFtYXJpbg==", NSDataBase64DecodingOptions.IgnoreUnknownCharacters)) {
 				Assert.That (d.ToString (), Is.EqualTo ("Xamarin"));
@@ -348,7 +349,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void Base64Data ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			using (var b = NSData.FromString ("WGFtYXJpbg=="))
 			using (var d = new NSData (b, NSDataBase64DecodingOptions.IgnoreUnknownCharacters)) {

--- a/tests/monotouch-test/Foundation/NSDictionaryTest.cs
+++ b/tests/monotouch-test/Foundation/NSDictionaryTest.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 
 using Foundation;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Foundation {
 
@@ -212,7 +213,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void IndexerTest ()
 		{
 			// This test doesn't work on Lion, because Lion returns mutable dictionaries in some places this test asserts that those dictionaries are non-mutable.
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 			IntPtr strkeyptr = IntPtr.Zero;
 			IntPtr strobjptr = IntPtr.Zero;
 			IntPtr objptr;

--- a/tests/monotouch-test/Foundation/NSExpressionTest.cs
+++ b/tests/monotouch-test/Foundation/NSExpressionTest.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 [assembly: Preserve (typeof (NSExpression), AllMembers = true)]
 
@@ -227,7 +228,7 @@ namespace MonoTouchFixtures.Foundation
 		public void AnyKeyPropertiesTest ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			var availableProperties = new List<string> { };
 			using (var expression = NSExpression.FromAnyKey ()) {

--- a/tests/monotouch-test/Foundation/NSLayoutConstraintTest.cs
+++ b/tests/monotouch-test/Foundation/NSLayoutConstraintTest.cs
@@ -11,6 +11,7 @@ using UIKit;
 using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Foundation {
 
@@ -22,7 +23,7 @@ namespace MonoTouchFixtures.Foundation {
 		[Test]
 		public void FromVisualFormat ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			using (var testViewController = new TestViewController ()) {
 				var constraints = NSLayoutConstraint.FromVisualFormat ("V:|[topLayoutGuide]-[firstLabel]-[secondLabel]",

--- a/tests/monotouch-test/Foundation/NSLinguisticAnalysisTest.cs
+++ b/tests/monotouch-test/Foundation/NSLinguisticAnalysisTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace monotouchtest
 {
@@ -39,7 +40,7 @@ namespace monotouchtest
 			testString.EnumerateLinguisticTags (range, NSLinguisticTagScheme.Token, NSLinguisticTaggerOptions.OmitWhitespace, null, Enumerator);
 			var expectedWordCount = 3;
 #if __MACOS__
-			if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 9))
+			if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 9))
 				expectedWordCount = 4;
 #endif
 			Assert.AreEqual (expectedWordCount, words.Count, "Word count: " + string.Join (", ", words));
@@ -73,7 +74,7 @@ namespace monotouchtest
 			var tags = testString.GetLinguisticTags (range, NSLinguisticTagScheme.NameOrLexicalClass, NSLinguisticTaggerOptions.OmitWhitespace, null, out tokenRanges);
 			var expectedWordCount = 3;
 #if __MACOS__
-			if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 9))
+			if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 9))
 				expectedWordCount = 4;
 #endif
 			Assert.AreEqual (expectedWordCount, tags.Length, "Tags Length");

--- a/tests/monotouch-test/Foundation/NSMutableDictionary2Test.cs
+++ b/tests/monotouch-test/Foundation/NSMutableDictionary2Test.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 
 using Foundation;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Foundation {
 
@@ -143,7 +144,7 @@ namespace MonoTouchFixtures.Foundation {
 		{
 			var isMutableCopy = false;
 #if __MACOS__
-			if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 8))
+			if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 8))
 				isMutableCopy = true;
 #endif
 			using (var k = new NSString ("key")) 

--- a/tests/monotouch-test/Foundation/ObjectTest.cs
+++ b/tests/monotouch-test/Foundation/ObjectTest.cs
@@ -25,6 +25,7 @@ using UIKit;
 using PlatformException=Foundation.MonoTouchException;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 using RectangleF=CoreGraphics.CGRect;
 using SizeF=CoreGraphics.CGSize;
@@ -82,7 +83,7 @@ namespace MonoTouchFixtures.Foundation {
 			}
 			var hasSecAccessControl = TestRuntime.CheckXcodeVersion (6, 0);
 #if __MACOS__
-			if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 10))
+			if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 10))
 				hasSecAccessControl = false;
 #endif
 			if (hasSecAccessControl) {

--- a/tests/monotouch-test/Foundation/StringTest.cs
+++ b/tests/monotouch-test/Foundation/StringTest.cs
@@ -23,6 +23,7 @@ using UIStringAttributes = AppKit.NSStringAttributes;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Foundation {
 	
@@ -175,7 +176,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void DrawingExtensions ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 11, throwIfOtherPlatform: false);
 
 			using (var s = new NSString ("foo")) {
 				NSStringDrawingOptions options = NSStringDrawingOptions.OneShot;

--- a/tests/monotouch-test/Foundation/UrlCredentialTest.cs
+++ b/tests/monotouch-test/Foundation/UrlCredentialTest.cs
@@ -19,6 +19,7 @@ using UIKit;
 using NUnit.Framework;
 
 using MonoTouchFixtures.Security;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Foundation {
 
@@ -44,7 +45,7 @@ namespace MonoTouchFixtures.Foundation {
 				Assert.Null (creds.Password, "Password");
 				var expectedPersistence = NSUrlCredentialPersistence.ForSession;
 #if __MACOS__
-				if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 8))
+				if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 8))
 					expectedPersistence = (NSUrlCredentialPersistence) uint.MaxValue;
 #endif
 				Assert.That (creds.Persistence, Is.EqualTo (expectedPersistence), "Persistence");
@@ -63,7 +64,7 @@ namespace MonoTouchFixtures.Foundation {
 				Assert.Null (creds.Password, "Password");
 				var expectedPersistence = NSUrlCredentialPersistence.ForSession;
 #if __MACOS__
-				if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 8))
+				if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 8))
 					expectedPersistence = (NSUrlCredentialPersistence)uint.MaxValue;
 #endif
 				Assert.That (creds.Persistence, Is.EqualTo (expectedPersistence), "Persistence");

--- a/tests/monotouch-test/Foundation/UrlProtocolTest.cs
+++ b/tests/monotouch-test/Foundation/UrlProtocolTest.cs
@@ -21,6 +21,7 @@ using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
 using MonoTests.System.Net.Http;
+using Xamarin.Utils;
 
 
 namespace MonoTouchFixtures.Foundation {
@@ -71,7 +72,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void RegistrarTest ()
 		{
 			// Networking seems broken on our macOS 10.9 bot, so skip this test.
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			Exception ex = null;
 			var done = new ManualResetEvent (false);
@@ -131,7 +132,7 @@ namespace MonoTouchFixtures.Foundation {
 			public override void StartLoading ()
 			{
 #if MONOMAC
-				if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 10)) {
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 10)) {
 					if (State == 3)
 						State++;
 				} else {

--- a/tests/monotouch-test/Foundation/UrlSessionConfigurationTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionConfigurationTest.cs
@@ -17,6 +17,7 @@ using AppKit;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Foundation {
 
@@ -28,7 +29,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void BackgroundSessionConfiguration ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			// https://trello.com/c/F6cyUBFU/70-simple-background-transfer-bo-pang-block-by-an-system-invalidcastexception-in-nsurlsessionconfiguration-backgroundsessionconfigu
 			using (var session = NSUrlSessionConfiguration.BackgroundSessionConfiguration ("id")) {
@@ -40,7 +41,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void Default_Properties ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			var config = NSUrlSessionConfiguration.DefaultSessionConfiguration;
 
@@ -87,7 +88,7 @@ namespace MonoTouchFixtures.Foundation {
 
 			var hasSharedContainerIdentifier = true;
 #if __MACOS__
-			hasSharedContainerIdentifier = TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 10);
+			hasSharedContainerIdentifier = TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 10);
 #else
 			hasSharedContainerIdentifier = TestRuntime.CheckXcodeVersion (6, 0);
 #endif
@@ -117,7 +118,7 @@ namespace MonoTouchFixtures.Foundation {
 
 			var hasProtocolClasses = true;
 #if __MACOS__
-			hasProtocolClasses = TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 10);
+			hasProtocolClasses = TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 10);
 #else
 			hasProtocolClasses = TestRuntime.CheckXcodeVersion (6, 0);
 #endif

--- a/tests/monotouch-test/Foundation/UrlSessionTaskTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTaskTest.cs
@@ -17,6 +17,7 @@ using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
 using MonoTests.System.Net.Http;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Foundation {
 
@@ -28,7 +29,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void Properties ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 			
 			using (var ur = new NSUrlRequest ())
 			using (var task = NSUrlSession.SharedSession.CreateDownloadTask (ur)) {

--- a/tests/monotouch-test/Foundation/UrlSessionTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTest.cs
@@ -19,6 +19,7 @@ using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
 using MonoTests.System.Net.Http;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Foundation {
 
@@ -143,7 +144,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void SharedSession ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 			
 			// in iOS9 those selectors do not respond - but they do work (forwarded to __NSURLSessionLocal type ?)
 			// * delegateQueue, sessionDescription, setSessionDescription:, delegate

--- a/tests/monotouch-test/Foundation/UrlTest.cs
+++ b/tests/monotouch-test/Foundation/UrlTest.cs
@@ -18,6 +18,7 @@ using UIKit;
 #endif
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Foundation {
 	
@@ -28,16 +29,16 @@ namespace MonoTouchFixtures.Foundation {
 		[Test]
 		public void Fields ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 			Assert.That (NSUrl.IsExcludedFromBackupKey.ToString (), Is.EqualTo ("NSURLIsExcludedFromBackupKey"), "IsExcludedFromBackupKey");
 		}
 		
 		[Test]
 		public void IsExcludedFromBackupKey ()
 		{
-			//TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false); // 10.8 fails DoNotBackupMe-1
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false); // 10.10 fails DoNotBackupMe-1
+			//TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false); // 10.8 fails DoNotBackupMe-1
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false); // 10.10 fails DoNotBackupMe-1
 
 			// NOTE: this test was failing with either NullReferenceException or InvalidCastException
 			// when we used CFBoolean as a NSObject (i.e. CFBoolean.TrueObject). The test order execution

--- a/tests/monotouch-test/Foundation/UserDefaultsTest.cs
+++ b/tests/monotouch-test/Foundation/UserDefaultsTest.cs
@@ -16,6 +16,7 @@ using UIKit;
 #endif
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Foundation {
 	
@@ -59,7 +60,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void Ctor_SuiteName ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			// initWithSuiteName:
 			using (var ud = new NSUserDefaults ("suitename", NSUserDefaultsType.SuiteName)) {

--- a/tests/monotouch-test/GLKit/BaseEffectTest.cs
+++ b/tests/monotouch-test/GLKit/BaseEffectTest.cs
@@ -9,6 +9,7 @@ using GLKit;
 using ObjCRuntime;
 using OpenTK;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.GLKit {
 	
@@ -20,7 +21,7 @@ namespace MonoTouchFixtures.GLKit {
 		[Culture ("en")]
 		public void Properties ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			var effect = new GLKBaseEffect ();
 			Assert.That (effect.LightModelAmbientColor.ToString (), Is.EqualTo ("(0.2, 0.2, 0.2, 1)"), "LightModelAmbientColor");

--- a/tests/monotouch-test/GLKit/EffectPropertyFog.cs
+++ b/tests/monotouch-test/GLKit/EffectPropertyFog.cs
@@ -9,6 +9,7 @@ using GLKit;
 using ObjCRuntime;
 using OpenTK;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.GLKit {
 	
@@ -19,7 +20,7 @@ namespace MonoTouchFixtures.GLKit {
 		[Test]
 		public void Properties ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			var fog = new GLKEffectPropertyFog ();
 			Assert.That (fog.Color.ToString (), Is.EqualTo ("(0, 0, 0, 0)"), "Color");

--- a/tests/monotouch-test/GLKit/EffectPropertyLightTest.cs
+++ b/tests/monotouch-test/GLKit/EffectPropertyLightTest.cs
@@ -9,6 +9,7 @@ using GLKit;
 using ObjCRuntime;
 using OpenTK;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.GLKit {
 	
@@ -19,7 +20,7 @@ namespace MonoTouchFixtures.GLKit {
 		[Test]
 		public void Properties ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			var light = new GLKEffectPropertyLight ();
 			Assert.That (light.AmbientColor.ToString (), Is.EqualTo ("(0, 0, 0, 0)"), "AmbientColor");

--- a/tests/monotouch-test/GLKit/EffectPropertyMaterialTest.cs
+++ b/tests/monotouch-test/GLKit/EffectPropertyMaterialTest.cs
@@ -9,6 +9,7 @@ using GLKit;
 using ObjCRuntime;
 using OpenTK;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.GLKit {
 	
@@ -20,7 +21,7 @@ namespace MonoTouchFixtures.GLKit {
 		[Culture ("en")]
 		public void Properties ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			var material = new GLKEffectPropertyMaterial ();
 			Assert.That (material.AmbientColor.ToString (), Is.EqualTo ("(0.2, 0.2, 0.2, 1)"), "AmbientColor");

--- a/tests/monotouch-test/GLKit/EffectPropertyTransformTest.cs
+++ b/tests/monotouch-test/GLKit/EffectPropertyTransformTest.cs
@@ -9,6 +9,7 @@ using GLKit;
 using ObjCRuntime;
 using OpenTK;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.GLKit {
 	
@@ -19,7 +20,7 @@ namespace MonoTouchFixtures.GLKit {
 		[Test]
 		public void Properties ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			var transform = new GLKEffectPropertyTransform ();
 			Assert.That (transform.ModelViewMatrix.ToString (), Is.EqualTo ("(1, 0, 0, 0)\n(0, 1, 0, 0)\n(0, 0, 1, 0)\n(0, 0, 0, 1)"), "ModelViewMatrix");

--- a/tests/monotouch-test/GameKit/LeaderboardTest.cs
+++ b/tests/monotouch-test/GameKit/LeaderboardTest.cs
@@ -19,6 +19,7 @@ using UIKit;
 #endif
 using GameKit;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.GameKit {
 
@@ -28,19 +29,19 @@ namespace MonoTouchFixtures.GameKit {
 
 		void Check (GKLeaderboard lb)
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 #if !__TVOS__
 			Assert.Null (lb.Category, "Category");
 #endif
 #if __MACOS__
-			var hasGroupIdentifier = TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 9);
-			var hasIdentifier = TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 10);
-			var hasRange = TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 10);
+			var hasGroupIdentifier = TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 9);
+			var hasIdentifier = TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 10);
+			var hasRange = TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 10);
 #elif __IOS__
-			var hasGroupIdentifier = TestRuntime.CheckSystemVersion (PlatformName.iOS, 6, 0);
-			var hasIdentifier = TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0);
-			var hasRange = TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0);
+			var hasGroupIdentifier = TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 6, 0);
+			var hasIdentifier = TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 0);
+			var hasRange = TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 0);
 #elif __TVOS__
 			var hasGroupIdentifier = true;
 			var hasIdentifier = true;
@@ -48,7 +49,7 @@ namespace MonoTouchFixtures.GameKit {
 #elif __WATCHOS__
 			var hasGroupIdentifier = true;
 			var hasIdentifier = true;
-			var hasRange = TestRuntime.CheckSystemVersion (PlatformName.WatchOS, 3, 0);
+			var hasRange = TestRuntime.CheckSystemVersion (ApplePlatform.WatchOS, 3, 0);
 #endif
 			if (hasGroupIdentifier) {
 				Assert.Null (lb.GroupIdentifier, "GroupIdentifier");
@@ -71,7 +72,7 @@ namespace MonoTouchFixtures.GameKit {
 		[Test]
 		public void DefaultCtor ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			using (var lb = new GKLeaderboard ()) {
 				Check (lb);
@@ -81,7 +82,7 @@ namespace MonoTouchFixtures.GameKit {
 		[Test]
 		public void PlayersCtor ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			// note: Mavericks does not like (respond to) this selector - but it did work with ML and is documented
 			using (var lb = new GKLeaderboard (new string [0])) {

--- a/tests/monotouch-test/GameKit/LeaderboardViewControllerTest.cs
+++ b/tests/monotouch-test/GameKit/LeaderboardViewControllerTest.cs
@@ -21,6 +21,7 @@ using UIKit;
 #endif
 using GameKit;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.GameKit {
 
@@ -33,9 +34,9 @@ namespace MonoTouchFixtures.GameKit {
 		{
 #if MONOMAC
 			// fails when executed under BigSur - this has been deprecated for a while (even if it remains working elsewhere)
-			if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 11, 0))
+			if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 11, 0))
 				Assert.Inconclusive ("'LeaderboardViewControllerTest' the native 'init' method returned nil.");
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 #endif
 			using (var vc = new GKLeaderboardViewController ()) {
 				Assert.Null (vc.Category, "Category");

--- a/tests/monotouch-test/GameKit/ScoreTest.cs
+++ b/tests/monotouch-test/GameKit/ScoreTest.cs
@@ -21,6 +21,7 @@ using UIKit;
 #endif
 using GameKit;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.GameKit {
 
@@ -44,11 +45,11 @@ namespace MonoTouchFixtures.GameKit {
 
 				// this is a new API in iOS8 (it was private before that) and returned an empty instance like:
 				// "<<GKPlayer: 0x81254e60>(playerID:(null) alias:(null) name:(null) status:(null))>"
-				if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false)) {
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false)) {
 					Assert.Null (s.Player, "Player");
 				}
 
-				if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false)) {
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false)) {
 					Assert.That (s.LeaderboardIdentifier, Is.EqualTo ("category-or-identifier"), "LeaderboardIdentifier");
 				}
 

--- a/tests/monotouch-test/HomeKit/HMMutableSignificantTimeEventTest.cs
+++ b/tests/monotouch-test/HomeKit/HMMutableSignificantTimeEventTest.cs
@@ -16,6 +16,7 @@ using NUnit.Framework;
 using Foundation;
 using HomeKit;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.HomeKit
 {
@@ -28,7 +29,7 @@ namespace MonoTouchFixtures.HomeKit
 		{
 			TestRuntime.AssertXcodeVersion (9, 0);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/HomeKit/HMSignificantTimeEventTest.cs
+++ b/tests/monotouch-test/HomeKit/HMSignificantTimeEventTest.cs
@@ -16,6 +16,7 @@ using NUnit.Framework;
 using Foundation;
 using HomeKit;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.HomeKit
 {
@@ -28,7 +29,7 @@ namespace MonoTouchFixtures.HomeKit
 		{
 			TestRuntime.AssertXcodeVersion (9, 0);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/HttpClient/HttpClientTest.cs
+++ b/tests/monotouch-test/HttpClient/HttpClientTest.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 
 namespace MonoTouchFixtures.HttpClientTests
@@ -93,7 +94,7 @@ namespace MonoTouchFixtures.HttpClientTests
 		[TestCase (typeof (NSUrlSessionHandler), 9)]
 		public void EnsureModifiabilityPostSend (Type handlerType, int macOSMinVersion)
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, macOSMinVersion, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, macOSMinVersion, throwIfOtherPlatform: false);
 
 			var wrapper = HandlerWrapper.GetWrapper (handlerType);
 			using (var client = new HttpClient (wrapper.Handler))

--- a/tests/monotouch-test/MapKit/AnnotationViewTest.cs
+++ b/tests/monotouch-test/MapKit/AnnotationViewTest.cs
@@ -18,6 +18,7 @@ using PlatformImage = UIKit.UIImage;
 using PlatformView = UIKit.UIView;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MapKit {
 	
@@ -56,7 +57,7 @@ namespace MonoTouchFixtures.MapKit {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/MapKit/GeometryTest.cs
+++ b/tests/monotouch-test/MapKit/GeometryTest.cs
@@ -5,6 +5,7 @@ using Foundation;
 using MapKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MapKit {
 	
@@ -15,7 +16,7 @@ namespace MonoTouchFixtures.MapKit {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/MapKit/LocalSearchRequestTest.cs
+++ b/tests/monotouch-test/MapKit/LocalSearchRequestTest.cs
@@ -15,6 +15,7 @@ using CoreLocation;
 using MapKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MapKit {
 	
@@ -25,9 +26,9 @@ namespace MonoTouchFixtures.MapKit {
 		[Test]
 		public void Default ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 6, 1, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 9, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 6, 1, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 9, 2, throwIfOtherPlatform: false);
 
 			using (var lsr = new MKLocalSearchRequest ()) {
 				Assert.Null (lsr.NaturalLanguageQuery, "NaturalLanguageQuery");

--- a/tests/monotouch-test/MapKit/LocalSearchTest.cs
+++ b/tests/monotouch-test/MapKit/LocalSearchTest.cs
@@ -15,6 +15,7 @@ using CoreLocation;
 using MapKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MapKit {
 	
@@ -24,9 +25,9 @@ namespace MonoTouchFixtures.MapKit {
 		[Test]
 		public void EmptyRequest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 6, 1, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 9, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 6, 1, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 9, 2, throwIfOtherPlatform: false);
 
 			using (var lsr = new MKLocalSearchRequest ())
 			using (MKLocalSearch ls = new MKLocalSearch (lsr)) {

--- a/tests/monotouch-test/MapKit/MapRectTest.cs
+++ b/tests/monotouch-test/MapKit/MapRectTest.cs
@@ -7,6 +7,7 @@ using MapKit;
 using CoreGraphics;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MapKit {
 	
@@ -16,7 +17,7 @@ namespace MonoTouchFixtures.MapKit {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 		}
 		
 		[Test]

--- a/tests/monotouch-test/MapKit/MapViewTest.cs
+++ b/tests/monotouch-test/MapKit/MapViewTest.cs
@@ -14,6 +14,7 @@ using UIKit;
 #endif
 using MapKit;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MapKit {
 	
@@ -72,7 +73,7 @@ namespace MonoTouchFixtures.MapKit {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 		}
 		
 		[Test]
@@ -132,7 +133,7 @@ namespace MonoTouchFixtures.MapKit {
 				Assert.Inconclusive ("backing fields are removed when newrefcount is enabled");
 
 #if !MONOMAC
-			if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0)) {
+			if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 0)) {
 				// This test selects annotations on a map view, but according to apple's docs
 				// and a lot of googling this will not necessarily work until the map view is
 				// show. Since we can't relinquish control of the UI thread, we have no option

--- a/tests/monotouch-test/MapKit/OverlayPathRendererTest.cs
+++ b/tests/monotouch-test/MapKit/OverlayPathRendererTest.cs
@@ -15,6 +15,7 @@ using CoreLocation;
 using MapKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MapKit {
 
@@ -24,7 +25,7 @@ namespace MonoTouchFixtures.MapKit {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/MapKit/PinAnnotationViewTest.cs
+++ b/tests/monotouch-test/MapKit/PinAnnotationViewTest.cs
@@ -21,6 +21,7 @@ using AppKit;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MapKit {
 	
@@ -30,7 +31,7 @@ namespace MonoTouchFixtures.MapKit {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 		}
 		
 		[Test]
@@ -41,10 +42,10 @@ namespace MonoTouchFixtures.MapKit {
 				Assert.AreSame (a, av.Annotation, "Annotation");
 
 #if !MONOMAC
-				if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0)) // Crashes with EXC_BAD_ACCESS (SIGABRT) if < iOS 7.0
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 0)) // Crashes with EXC_BAD_ACCESS (SIGABRT) if < iOS 7.0
 					Assert.False (av.AnimatesDrop, "AnimatesDrop");
 
-				if (!TestRuntime.CheckSystemVersion (PlatformName.iOS, 9, 0))
+				if (!TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 9, 0))
 					return;
 #endif
 
@@ -60,7 +61,7 @@ namespace MonoTouchFixtures.MapKit {
 		{
 #if !MONOMAC
 			// Crashes with EXC_BAD_ACCESS (SIGABRT) if < iOS 7.0
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 #endif
 
 			var frame = new CGRect (10, 10, 100, 100);
@@ -74,13 +75,13 @@ namespace MonoTouchFixtures.MapKit {
 				
 				Assert.That (av.PinColor, Is.EqualTo (MKPinAnnotationColor.Red), "PinColor");
 #if MONOMAC
-				if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 12)) {
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 12)) {
 					Assert.That (av.PinTintColor, Is.EqualTo (NSColor.SystemRedColor), "PinTintColor");
 				} else {
 					Assert.Null (av.PinTintColor, "PinTintColor"); // differs from the other init call
 				}
 #else
-				bool not_null = TestRuntime.CheckSystemVersion (PlatformName.iOS, 10, 0);
+				bool not_null = TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 10, 0);
 				if (not_null)
 					Assert.NotNull (av.PinTintColor, "PinTintColor");
 				else

--- a/tests/monotouch-test/MapKit/PolygonTest.cs
+++ b/tests/monotouch-test/MapKit/PolygonTest.cs
@@ -9,6 +9,7 @@ using CoreLocation;
 using MapKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MapKit {
 	
@@ -18,7 +19,7 @@ namespace MonoTouchFixtures.MapKit {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 		}
 		
 		[Test]

--- a/tests/monotouch-test/MapKit/PolylineTest.cs
+++ b/tests/monotouch-test/MapKit/PolylineTest.cs
@@ -9,6 +9,7 @@ using CoreLocation;
 using MapKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MapKit {
 	
@@ -18,7 +19,7 @@ namespace MonoTouchFixtures.MapKit {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 		}
 		
 		[Test]

--- a/tests/monotouch-test/MapKit/ShapeTest.cs
+++ b/tests/monotouch-test/MapKit/ShapeTest.cs
@@ -9,6 +9,7 @@ using CoreLocation;
 using MapKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MapKit {
 	
@@ -18,7 +19,7 @@ namespace MonoTouchFixtures.MapKit {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 		}
 		
 		// used for types that inherits from MKShape

--- a/tests/monotouch-test/MediaAccessibility/AudibleMediaTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/AudibleMediaTest.cs
@@ -14,6 +14,7 @@ using Foundation;
 using MediaAccessibility;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MediaAccessibility {
 
@@ -25,8 +26,8 @@ namespace MonoTouchFixtures.MediaAccessibility {
 		[Test]
 		public void PreferredCharacteristics ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			if (TestRuntime.CheckXcodeVersion (7, 0)) {
 				Assert.NotNull (MAAudibleMedia.GetPreferredCharacteristics ());

--- a/tests/monotouch-test/MediaPlayer/MediaItemTest.cs
+++ b/tests/monotouch-test/MediaPlayer/MediaItemTest.cs
@@ -8,6 +8,7 @@ using Foundation;
 using MediaPlayer;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MediaPlayer {
 
@@ -31,9 +32,9 @@ namespace MonoTouchFixtures.MediaPlayer {
 					Assert.Inconclusive ("This test needs music in the music library on the device.");
 
 				var six_dot_oh = true;
-				var nine_dot_two = TestRuntime.CheckSystemVersion (PlatformName.iOS, 9, 2);
-				var ten_dot_oh = TestRuntime.CheckSystemVersion (PlatformName.iOS, 10, 0);
-				var ten_dot_three = TestRuntime.CheckSystemVersion (PlatformName.iOS, 10, 3);
+				var nine_dot_two = TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 9, 2);
+				var ten_dot_oh = TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 10, 0);
+				var ten_dot_three = TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 10, 3);
 
 				foreach (var i in items) {
 					object dummy;

--- a/tests/monotouch-test/MediaPlayer/MoviePlayerControllerTest.cs
+++ b/tests/monotouch-test/MediaPlayer/MoviePlayerControllerTest.cs
@@ -16,6 +16,7 @@ using UIKit;
 using iAd;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MediaPlayer {
 
@@ -26,10 +27,10 @@ namespace MonoTouchFixtures.MediaPlayer {
 		[Test]
 		public void PreparePrerollAds_New ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0);
 
 			// NSInvalidArgumentException +[MPMoviePlayerController preparePrerollAds]: unrecognized selector sent to class 0x109c46b48
-			if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 10, 0))
+			if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 10, 0))
 				Assert.Ignore ("Broken on iOS 10 beta 3");
 			
 			MPMoviePlayerController.PrepareForPrerollAds ();

--- a/tests/monotouch-test/MediaPlayer/NowPlayingInfoCenterTest.cs
+++ b/tests/monotouch-test/MediaPlayer/NowPlayingInfoCenterTest.cs
@@ -10,6 +10,7 @@ using MediaPlayer;
 using ObjCRuntime;
 using UIKit;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MediaPlayer
 {
@@ -20,10 +21,10 @@ namespace MonoTouchFixtures.MediaPlayer
 	{
 		MPNowPlayingInfo NowPlayingInfo;
 
-		bool v8_0 = TestRuntime.CheckSystemVersion (PlatformName.iOS, 8, 0);
-		bool v9_0 = TestRuntime.CheckSystemVersion (PlatformName.iOS, 9, 0);
-		bool v10_0 = TestRuntime.CheckSystemVersion (PlatformName.iOS, 10, 0);
-		bool v10_3 = TestRuntime.CheckSystemVersion (PlatformName.iOS, 10, 3);
+		bool v8_0 = TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 8, 0);
+		bool v9_0 = TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 9, 0);
+		bool v10_0 = TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 10, 0);
+		bool v10_3 = TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 10, 3);
 
 		[SetUp]
 		public void SetUp ()

--- a/tests/monotouch-test/MediaPlayer/PlayableContentManagerTest.cs
+++ b/tests/monotouch-test/MediaPlayer/PlayableContentManagerTest.cs
@@ -15,6 +15,7 @@ using MediaPlayer;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MediaPlayer {
 
@@ -41,7 +42,7 @@ namespace MonoTouchFixtures.MediaPlayer {
 		[Test]
 		public void Shared ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 1, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 1, throwIfOtherPlatform: false);
 
 			MPPlayableContentManager shared = MPPlayableContentManager.Shared;
 			Assert.Null (shared.DataSource, "DataSource");

--- a/tests/monotouch-test/MediaPlayer/RemoteCommandCenterTest.cs
+++ b/tests/monotouch-test/MediaPlayer/RemoteCommandCenterTest.cs
@@ -17,6 +17,7 @@ using ObjCRuntime;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MediaPlayer {
 
@@ -27,8 +28,8 @@ namespace MonoTouchFixtures.MediaPlayer {
 		[Test]
 		public void Shared ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 1, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 12, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 1, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 12, 2, throwIfOtherPlatform: false);
 
 			MPRemoteCommandCenter shared = MPRemoteCommandCenter.Shared;
 			Assert.NotNull (shared.BookmarkCommand, "BookmarkCommand");
@@ -50,8 +51,8 @@ namespace MonoTouchFixtures.MediaPlayer {
 		[Test]
 		public void Shared_8 ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 12, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 12, 2, throwIfOtherPlatform: false);
 
 			MPRemoteCommandCenter shared = MPRemoteCommandCenter.Shared;
 			Assert.NotNull (shared.ChangeRepeatModeCommand, "ChangeRepeatModeCommand");
@@ -61,8 +62,8 @@ namespace MonoTouchFixtures.MediaPlayer {
 		[Test]
 		public void Shared_9 ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 9, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 12, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 9, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 12, 2, throwIfOtherPlatform: false);
 
 			MPRemoteCommandCenter shared = MPRemoteCommandCenter.Shared;
 			Assert.NotNull (shared.EnableLanguageOptionCommand, "EnableLanguageOptionCommand");

--- a/tests/monotouch-test/MediaPlayer/SkipIntervalCommandTest.cs
+++ b/tests/monotouch-test/MediaPlayer/SkipIntervalCommandTest.cs
@@ -17,6 +17,7 @@ using ObjCRuntime;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MediaPlayer {
 
@@ -32,8 +33,8 @@ namespace MonoTouchFixtures.MediaPlayer {
 				Assert.Ignore ("This test can only be executed once, it modifies global state.");
 			manualBindingDone = true;
 
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 1, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 12, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 1, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 12, 2, throwIfOtherPlatform: false);
 
 			MPSkipIntervalCommand skip = MPRemoteCommandCenter.Shared.SkipBackwardCommand;
 

--- a/tests/monotouch-test/MediaToolbox/AudioProcessingTapTest.cs
+++ b/tests/monotouch-test/MediaToolbox/AudioProcessingTapTest.cs
@@ -16,6 +16,7 @@ using ObjCRuntime;
 using MediaToolbox;
 using AudioToolbox;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MediaToolbox
 {
@@ -29,7 +30,7 @@ namespace MonoTouchFixtures.MediaToolbox
 		[Test]
 		public unsafe void Initialization ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			var cb = new MTAudioProcessingTapCallbacks (
 				delegate(MTAudioProcessingTap tap, nint numberFrames, MTAudioProcessingTapFlags flags, AudioBuffers bufferList, out nint numberFramesOut, out MTAudioProcessingTapFlags flagsOut) {

--- a/tests/monotouch-test/MediaToolbox/ProfessionalVideoWorkflowTest.cs
+++ b/tests/monotouch-test/MediaToolbox/ProfessionalVideoWorkflowTest.cs
@@ -4,6 +4,7 @@ using Foundation;
 using MediaToolbox;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MediaToolbox {
 
@@ -14,7 +15,7 @@ namespace MonoTouchFixtures.MediaToolbox {
 		[Test]
 		public void RegisterFormatReaders ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 			MTProfessionalVideoWorkflow.RegisterFormatReaders ();
 		}
 	}

--- a/tests/monotouch-test/Messages/MSMessageTest.cs
+++ b/tests/monotouch-test/Messages/MSMessageTest.cs
@@ -27,7 +27,7 @@ namespace MonoTouchFixtures.Messages
 		{
 			TestRuntime.AssertXcodeVersion (8, 0);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/Metal/MTLTileRenderPipelineColorAttachmentDescriptorTests.cs
+++ b/tests/monotouch-test/Metal/MTLTileRenderPipelineColorAttachmentDescriptorTests.cs
@@ -7,6 +7,7 @@ using Metal;
 using ObjCRuntime;
 
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Metal {
 
@@ -20,7 +21,7 @@ namespace MonoTouchFixtures.Metal {
 		{
 			TestRuntime.AssertXcodeVersion (9, 0);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 			descriptor = new MTLTileRenderPipelineColorAttachmentDescriptor ();
 		}
 

--- a/tests/monotouch-test/Metal/MTLTileRenderPipelineDescriptor.cs
+++ b/tests/monotouch-test/Metal/MTLTileRenderPipelineDescriptor.cs
@@ -7,6 +7,7 @@ using Metal;
 using ObjCRuntime;
 
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Metal {
 
@@ -20,7 +21,7 @@ namespace MonoTouchFixtures.Metal {
 		{
 			TestRuntime.AssertXcodeVersion (9, 0);
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 			descriptor = new MTLTileRenderPipelineDescriptor ();
 		}
 

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageNormalizedHistogramTests.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageNormalizedHistogramTests.cs
@@ -18,6 +18,7 @@ using MetalPerformanceShaders;
 using ObjCRuntime;
 
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MetalPerformanceShaders {
 	[TestFixture]
@@ -52,7 +53,7 @@ namespace MonoTouchFixtures.MetalPerformanceShaders {
 			catch (Exception ex) {
 				// This test fails on 10.13 bots but not on a local computer with 10.13. Must work on 10.14+.
 				// there is no a good way to tell if MPSImageNormalizedHistogram will work or not...
-				if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 14))
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 14))
 					Assert.Fail (ex.Message);
 				Assert.Inconclusive ("In 10.13 this can fail in some hardware.");
 			}

--- a/tests/monotouch-test/ModelIO/MDLMesh.cs
+++ b/tests/monotouch-test/ModelIO/MDLMesh.cs
@@ -18,6 +18,7 @@ using ModelIO;
 using ObjCRuntime;
 using OpenTK;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.ModelIO {
 
@@ -156,7 +157,7 @@ namespace MonoTouchFixtures.ModelIO {
 			using (var obj = MDLMesh.CreateCylindroid (1, V2, 3, 1, MDLGeometryType.Triangles, true, null)) {
 				Assert.IsNotNull (obj, "obj");
 #if MONOMAC
-				if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 12)) {
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 12)) {
 					Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (0.866025448f, 0.5f, 1f), MinBounds = new Vector3 (-0.866025388f, -0.5f, -0.5f) }, obj.BoundingBox, "BoundingBox");
 				} else {
 					Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (1f, 0.5f, 1f), MinBounds = new Vector3 (-0.866025388f, -0.5f, -0.866025388f) }, obj.BoundingBox, "BoundingBox");

--- a/tests/monotouch-test/MultipeerConnectivity/PeerIDTest.cs
+++ b/tests/monotouch-test/MultipeerConnectivity/PeerIDTest.cs
@@ -14,6 +14,7 @@ using Foundation;
 using MultipeerConnectivity;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MultipeerConnectivity {
 
@@ -25,9 +26,9 @@ namespace MonoTouchFixtures.MultipeerConnectivity {
 		[Test]
 		public void Defaults ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			using (var peer = new MCPeerID ("MyDisplayName")) {
 				Assert.AreEqual ("MyDisplayName", peer.DisplayName, "DisplayName");
@@ -37,9 +38,9 @@ namespace MonoTouchFixtures.MultipeerConnectivity {
 		[Test]
 		public void LocalPeer ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			using (var peer = new MCPeerID ("myself")) {
 				Assert.That (peer.DisplayName, Is.EqualTo ("myself"), "DisplayName");

--- a/tests/monotouch-test/MultipeerConnectivity/SessionTest.cs
+++ b/tests/monotouch-test/MultipeerConnectivity/SessionTest.cs
@@ -20,6 +20,7 @@ using Security;
 using NUnit.Framework;
 
 using MonoTouchFixtures.Security;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.MultipeerConnectivity {
 
@@ -31,17 +32,17 @@ namespace MonoTouchFixtures.MultipeerConnectivity {
 		[Test]
 		public void CtorPeer ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			using (var peer = new MCPeerID ("me"))
 			using (var s = new MCSession (peer)) {
 				Assert.AreSame (s.MyPeerID, peer, "MyPeerID");
 				Assert.Null (s.SecurityIdentity, "SecurityIdentity");
 #if MONOMAC
-				var pref = TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 11) ? MCEncryptionPreference.Required : MCEncryptionPreference.Optional;
+				var pref = TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 11) ? MCEncryptionPreference.Required : MCEncryptionPreference.Optional;
 #else
-				var pref = TestRuntime.CheckSystemVersion (PlatformName.iOS, 9, 0) ? MCEncryptionPreference.Required : MCEncryptionPreference.Optional;
+				var pref = TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 9, 0) ? MCEncryptionPreference.Required : MCEncryptionPreference.Optional;
 #endif
 				Assert.That (s.EncryptionPreference, Is.EqualTo (pref), "EncryptionPreference");
 				Assert.That (s.ConnectedPeers, Is.Empty, "ConnectedPeers");
@@ -51,8 +52,8 @@ namespace MonoTouchFixtures.MultipeerConnectivity {
 		[Test]
 		public void Ctor_OptionalIdentity ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			using (var peer = new MCPeerID ("me"))
 			using (var s = new MCSession (peer, null, MCEncryptionPreference.None)) {
@@ -66,8 +67,8 @@ namespace MonoTouchFixtures.MultipeerConnectivity {
 		[Test]
 		public void Ctor_Identity ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			using (var id = IdentityTest.GetIdentity ())
 			using (var peer = new MCPeerID ("me"))
@@ -83,8 +84,8 @@ namespace MonoTouchFixtures.MultipeerConnectivity {
 		[Test]
 		public void Ctor_Identity_Certificates ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			using (var id = IdentityTest.GetIdentity ())
 			using (var trust = new SecTrust (id.Certificate, SecPolicy.CreateBasicX509Policy ()))

--- a/tests/monotouch-test/NearbyInteraction/NINearbyObjectTest.cs
+++ b/tests/monotouch-test/NearbyInteraction/NINearbyObjectTest.cs
@@ -8,6 +8,7 @@ using ObjCRuntime;
 using NearbyInteraction;
 using NUnit.Framework;
 using OpenTK;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.NearbyInteraction {
 
@@ -18,7 +19,7 @@ namespace MonoTouchFixtures.NearbyInteraction {
 		public void Setup ()
 		{
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/NetworkExtension/OnDemandTest.cs
+++ b/tests/monotouch-test/NetworkExtension/OnDemandTest.cs
@@ -14,6 +14,7 @@ using Foundation;
 using NetworkExtension;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.NetworkExtension {
 
@@ -57,8 +58,8 @@ namespace MonoTouchFixtures.NetworkExtension {
 		[Test]
 		public void OnDemandRuleConnect ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 11, throwIfOtherPlatform: false);
 
 			using (var rule = new NEOnDemandRuleConnect ()) {
 				Assert.That (rule.Action, Is.EqualTo (NEOnDemandRuleAction.Connect), "Action");
@@ -69,8 +70,8 @@ namespace MonoTouchFixtures.NetworkExtension {
 		[Test]
 		public void OnDemandRuleDisconnect ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 11, throwIfOtherPlatform: false);
 
 			using (var rule = new NEOnDemandRuleDisconnect ()) {
 				Assert.That (rule.Action, Is.EqualTo (NEOnDemandRuleAction.Disconnect), "Action");
@@ -81,8 +82,8 @@ namespace MonoTouchFixtures.NetworkExtension {
 		[Test]
 		public void OnDemandRuleIgnore ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 11, throwIfOtherPlatform: false);
 
 			using (var rule = new NEOnDemandRuleIgnore ()) {
 				Assert.That (rule.Action, Is.EqualTo (NEOnDemandRuleAction.Ignore), "Action");
@@ -93,8 +94,8 @@ namespace MonoTouchFixtures.NetworkExtension {
 		[Test]
 		public void NEOnDemandRuleEvaluateConnection ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 11, throwIfOtherPlatform: false);
 
 			using (var rule = new NEOnDemandRuleEvaluateConnection ()) {
 				Assert.That (rule.Action, Is.EqualTo (NEOnDemandRuleAction.EvaluateConnection), "Action");
@@ -113,8 +114,8 @@ namespace MonoTouchFixtures.NetworkExtension {
 		[Test]
 		public void EvaluateConnectionRule_Default ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 11, throwIfOtherPlatform: false);
 
 			using (var rule = new NEEvaluateConnectionRule ()) {
 				Assert.That (rule.Action, Is.EqualTo ((NEEvaluateConnectionRuleAction) 0), "Action");
@@ -127,8 +128,8 @@ namespace MonoTouchFixtures.NetworkExtension {
 		[Test]
 		public void EvaluateConnectionRule ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 11, throwIfOtherPlatform: false);
 
 			using (var rule = new NEEvaluateConnectionRule (new [] { "xamarin.com" }, NEEvaluateConnectionRuleAction.ConnectIfNeeded)) {
 				Assert.That (rule.Action, Is.EqualTo (NEEvaluateConnectionRuleAction.ConnectIfNeeded), "Action");

--- a/tests/monotouch-test/NetworkExtension/VpnManagerTest.cs
+++ b/tests/monotouch-test/NetworkExtension/VpnManagerTest.cs
@@ -14,6 +14,7 @@ using Foundation;
 using NetworkExtension;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.NetworkExtension {
 
@@ -24,8 +25,8 @@ namespace MonoTouchFixtures.NetworkExtension {
 		[Test]
 		public void SharedManager ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 11, throwIfOtherPlatform: false);
 
 			var shared = NEVpnManager.SharedManager;
 			// https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/AddingCapabilities/AddingCapabilities.html#//apple_ref/doc/uid/TP40012582-CH26-SW59
@@ -40,9 +41,9 @@ namespace MonoTouchFixtures.NetworkExtension {
 			Assert.False (shared.Enabled, "Enabled");
 #endif
 #if __IOS__
-			var HasLocalizedDescription = TestRuntime.CheckSystemVersion (PlatformName.iOS, 9, 0);
+			var HasLocalizedDescription = TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 9, 0);
 #elif __MACOS__
-			var HasLocalizedDescription = TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 11);
+			var HasLocalizedDescription = TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 11);
 #endif
 			if (HasLocalizedDescription) {
 #if MONOMAC && !NET
@@ -61,8 +62,8 @@ namespace MonoTouchFixtures.NetworkExtension {
 		[Test]
 		public void Fields ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 11, throwIfOtherPlatform: false);
 
 			Assert.That (NEVpnManager.ErrorDomain.ToString (), Is.EqualTo ("NEVPNErrorDomain"), "ErrorDomain");
 		}

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -47,6 +47,7 @@ using PointF = CoreGraphics.CGPoint;
 using CategoryAttribute = ObjCRuntime.CategoryAttribute;
 
 using XamarinTests.ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.ObjCRuntime {
 
@@ -1440,7 +1441,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void TestNativeObjectArray ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			using (var i1 = new MKPointAnnotation ()) {
 				using (var i2 = new MKPointAnnotation ()) {
@@ -2306,7 +2307,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		public void VoidPtrToINativeObjectArgument ()
 		{
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 
 			using (var obj = new ABPeoplePickerNavigationControllerDelegateImpl ()) {
 				using (var person = new ABPerson ()) {

--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -18,6 +18,7 @@ using UIKit;
 using NUnit.Framework;
 
 using MonoTests.System.Net.Http;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.ObjCRuntime {
 
@@ -106,7 +107,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		public void GetNSObject_Different_Class ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			IntPtr class_ptr = Class.GetHandle ("SKPhysicsBody");
 			var size = new CGSize (3, 2);
@@ -125,7 +126,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		public void GetNSObject_Posing_Class ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			NSUrlSession session = NSUrlSession.SharedSession;
 			using (var request = new NSUrlRequest (new NSUrl (NetworkResources.MicrosoftUrl))) {

--- a/tests/monotouch-test/PassKit/AddPassesViewControllerTest.cs
+++ b/tests/monotouch-test/PassKit/AddPassesViewControllerTest.cs
@@ -15,6 +15,7 @@ using UIKit;
 using PassKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.PassKit {
 	
@@ -41,7 +42,7 @@ namespace MonoTouchFixtures.PassKit {
 		public void InitWithNibNameTest ()
 		{
 			// initWithNibName:bundle: returns nil in iOS 6
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			if (UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Phone)
 				Assert.Inconclusive ("PassKit does not work on iPads");

--- a/tests/monotouch-test/Photos/FetchResultTest.cs
+++ b/tests/monotouch-test/Photos/FetchResultTest.cs
@@ -20,6 +20,7 @@ using CoreGraphics;
 using AssetsLibrary;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Photos {
 
@@ -30,12 +31,12 @@ namespace MonoTouchFixtures.Photos {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 #if HAS_ASSETSLIBRARY
 			if (ALAssetsLibrary.AuthorizationStatus != ALAuthorizationStatus.Authorized)
 				Assert.Inconclusive ("Requires access to the photo library");
 #elif __MACCATALYST__
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 			if (PHPhotoLibrary.GetAuthorizationStatus (PHAccessLevel.ReadWrite) != PHAuthorizationStatus.Authorized)
 				Assert.Inconclusive ("Requires access to the photo library");
 #else

--- a/tests/monotouch-test/PushKit/PushRegistryTest.cs
+++ b/tests/monotouch-test/PushKit/PushRegistryTest.cs
@@ -9,6 +9,7 @@ using PushKit;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.PushKit {
 
@@ -19,9 +20,9 @@ namespace MonoTouchFixtures.PushKit {
 		[Test]
 		public void CtorDispatchQueue ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 
-			if (!TestRuntime.CheckSystemVersion (PlatformName.iOS, 8, 2, throwIfOtherPlatform: false) && IntPtr.Size == 4)
+			if (!TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 8, 2, throwIfOtherPlatform: false) && IntPtr.Size == 4)
 				Assert.Inconclusive ("Requires iOS 8.2 or later in 32-bit mode.");
 
 			using (var dq = new DispatchQueue ("pk-test-queue"))

--- a/tests/monotouch-test/QuickLook/PreviewControllerTest.cs
+++ b/tests/monotouch-test/QuickLook/PreviewControllerTest.cs
@@ -17,6 +17,7 @@ using UIKit;
 using QuickLook;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.QuickLook {
 	
@@ -31,9 +32,9 @@ namespace MonoTouchFixtures.QuickLook {
 				Assert.Null (pc.CurrentPreviewItem, "CurrentPreviewItem");
 				nint index = 0;
 #if !__MACCATALYST__
-				if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 10, 0))
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 10, 0))
 					index = nint.MaxValue;
-				else if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 1))
+				else if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 1))
 					index = -1;
 #endif
 				Assert.That (pc.CurrentPreviewItemIndex, Is.EqualTo (index), "CurrentPreviewItemIndex");

--- a/tests/monotouch-test/SafariServices/ReadingListTest.cs
+++ b/tests/monotouch-test/SafariServices/ReadingListTest.cs
@@ -16,6 +16,7 @@ using SafariServices;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.SafariServices {
 
@@ -29,7 +30,7 @@ namespace MonoTouchFixtures.SafariServices {
 		[Ignore ("This test adds two entries every time it's executed to the global reading list in Safari. For people who use their reading lists this becomes slightly annoying.")]
 		public void DefaultReadingList ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			NSError error;
 			using (var http = new NSUrl ("http://www.xamarin.com"))
@@ -62,7 +63,7 @@ namespace MonoTouchFixtures.SafariServices {
 		[Test]
 		public void SupportsUrl ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			Assert.False (SSReadingList.SupportsUrl (null), "null");
 

--- a/tests/monotouch-test/SceneKit/ActionTest.cs
+++ b/tests/monotouch-test/SceneKit/ActionTest.cs
@@ -7,6 +7,7 @@ using Foundation;
 using SceneKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.SceneKit {
 
@@ -20,7 +21,7 @@ namespace MonoTouchFixtures.SceneKit {
 		public void SetUp ()
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 		}
 
 #if !XAMCORE_4_0

--- a/tests/monotouch-test/SceneKit/NodeTest.cs
+++ b/tests/monotouch-test/SceneKit/NodeTest.cs
@@ -20,6 +20,7 @@ using AppKit;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.SceneKit {
 
@@ -30,8 +31,8 @@ namespace MonoTouchFixtures.SceneKit {
 		[Test]
 		public void AddAnimation ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			using (var a = CAAnimation.CreateAnimation ())
 			using (var n = SCNNode.Create ()) {

--- a/tests/monotouch-test/Security/KeyChainTest.cs
+++ b/tests/monotouch-test/Security/KeyChainTest.cs
@@ -11,6 +11,7 @@ using Foundation;
 using Security;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Security {
 	
@@ -107,7 +108,7 @@ namespace MonoTouchFixtures.Security {
 				SecStatusCode code = SecItemAdd (data.Handle, IntPtr.Zero);
 				var expected = Is.EqualTo (SecStatusCode.DuplicateItem).Or.EqualTo (SecStatusCode.Success);
 #if __MACOS__
-				if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 9))
+				if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 9))
 					expected = Is.EqualTo (SecStatusCode.Param);
 #endif
 				Assert.That (code, expected);

--- a/tests/monotouch-test/Security/KeyTest.cs
+++ b/tests/monotouch-test/Security/KeyTest.cs
@@ -23,6 +23,7 @@ using AppKit;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Security {
 
@@ -41,7 +42,7 @@ namespace MonoTouchFixtures.Security {
 		static X509Certificate2 _c;
 		static X509Certificate2 c {
 			get {
-				TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false); // System.Security.Cryptography.CryptographicException : Input data cannot be coded as a valid certificate.
+				TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false); // System.Security.Cryptography.CryptographicException : Input data cannot be coded as a valid certificate.
 				if (_c == null)
 					_c = new X509Certificate2 (ImportExportTest.farscape_pfx, "farscape");
 				return _c;
@@ -130,7 +131,7 @@ namespace MonoTouchFixtures.Security {
 						Assert.True (public_key.IsAlgorithmSupported (SecKeyOperationType.Encrypt, SecKeyAlgorithm.RsaEncryptionPkcs1), "public/IsAlgorithmSupported/Encrypt");
 
 #if MONOMAC
-						Assert.That (public_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionPkcs1), Is.EqualTo (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 13)), "public/IsAlgorithmSupported/Decrypt");
+						Assert.That (public_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionPkcs1), Is.EqualTo (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 13)), "public/IsAlgorithmSupported/Decrypt");
 
 						using (var pub = public_key.GetPublicKey ()) {
 							// macOS behaviour is not consistent - but the test main goal is to check we get a key
@@ -185,7 +186,7 @@ namespace MonoTouchFixtures.Security {
 					public_key.Dispose ();
 					var expectedResult = SecStatusCode.Success;
 #if __MACOS__
-					if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 8))
+					if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 8))
 						expectedResult = SecStatusCode.InvalidData;
 #endif
 					Assert.That (private_key.Decrypt (SecPadding.PKCS1, cipher, out result), Is.EqualTo (expectedResult), "Decrypt");
@@ -220,9 +221,9 @@ namespace MonoTouchFixtures.Security {
 					var expectedStatus = SecStatusCode.Param;
 
 #if __MACOS__
-					if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 8))
+					if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 8))
 						expectedStatus = SecStatusCode.Success;
-					else if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 12))
+					else if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 12))
 						expectedStatus = SecStatusCode.OutputLengthError;
 #endif
 					Assert.That (rv, Is.EqualTo (expectedStatus), "Encrypt");
@@ -257,7 +258,7 @@ namespace MonoTouchFixtures.Security {
 						Assert.True (public_key.IsAlgorithmSupported (SecKeyOperationType.Encrypt, SecKeyAlgorithm.RsaEncryptionOaepSha1), "public/IsAlgorithmSupported/Encrypt");
 						// I would have expect false
 #if MONOMAC
-						Assert.That (public_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionOaepSha1), Is.EqualTo (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 13)), "public/IsAlgorithmSupported/Decrypt");
+						Assert.That (public_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionOaepSha1), Is.EqualTo (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 13)), "public/IsAlgorithmSupported/Decrypt");
 #else
 						Assert.True (public_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionOaepSha1), "public/IsAlgorithmSupported/Decrypt");
 #endif
@@ -273,7 +274,7 @@ namespace MonoTouchFixtures.Security {
 					Assert.That (private_key.Decrypt (SecPadding.OAEP, cipher, out result), Is.EqualTo (SecStatusCode.Success), "Decrypt");
 					var expectEmpty = false;
 #if __MACOS__
-					if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 12))
+					if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 12))
 						expectEmpty = true;
 #endif
 					if (expectEmpty) {
@@ -327,7 +328,7 @@ namespace MonoTouchFixtures.Security {
 		[Test]
 		public void SignVerifyECSHA1 ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			SecKey private_key;
 			SecKey public_key;

--- a/tests/monotouch-test/Security/PolicyTest.cs
+++ b/tests/monotouch-test/Security/PolicyTest.cs
@@ -20,6 +20,7 @@ using UIKit;
 using Security;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Security {
 	
@@ -109,7 +110,7 @@ namespace MonoTouchFixtures.Security {
 		public void RevocationPolicy ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			using (var policy = SecPolicy.CreateRevocationPolicy (SecRevocation.UseAnyAvailableMethod | SecRevocation.RequirePositiveResponse)) {
 				Assert.That (policy.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
@@ -120,7 +121,7 @@ namespace MonoTouchFixtures.Security {
 					Assert.That (CFGetRetainCount (properties.Handle), Is.EqualTo ((nint) 1), "Properties.RetainCount");
 					var expectedCount = (nuint) 1;
 #if __MACOS__
-					if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 11) && !TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 12))
+					if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 11) && !TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 12))
 						expectedCount = 2;
 #endif
 					Assert.That (properties.Count, Is.EqualTo (expectedCount), "Count");
@@ -142,7 +143,7 @@ namespace MonoTouchFixtures.Security {
 		public void CreateWellKnownPolicies ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			CreatePolicy (SecPolicyIdentifier.AppleX509Basic);
 			CreatePolicy (SecPolicyIdentifier.AppleSSL);
@@ -157,7 +158,7 @@ namespace MonoTouchFixtures.Security {
 			// CreatePolicy (SecPolicyIdentifier.AppleTimeStamping);
 			oid = null;
 #if __MACOS__
-			if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 11) && !TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 12))
+			if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 11) && !TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 12))
 				oid = "3";
 #endif
 			CreatePolicy (SecPolicyIdentifier.AppleRevocation, (NSString) oid);
@@ -167,7 +168,7 @@ namespace MonoTouchFixtures.Security {
 		public void CreateUnknownPolicy ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			using (var oid = new NSString ("1.2.3.4")) {
 				Assert.Throws<ArgumentException> (delegate {

--- a/tests/monotouch-test/Security/SecSharedCredentialTest.cs
+++ b/tests/monotouch-test/Security/SecSharedCredentialTest.cs
@@ -6,6 +6,7 @@ using Foundation;
 using Security;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Security {
 	
@@ -23,7 +24,7 @@ namespace MonoTouchFixtures.Security {
 		public void SetUp ()
 		{
 			// The API here was introduced to Mac Catalyst later than for the other frameworks, so we have this additional check
-			TestRuntime.AssertSystemVersion (PlatformName.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false);
 
 			domainName = "com.xamarin.monotouch-test";
 			account = "twitter";
@@ -55,7 +56,7 @@ namespace MonoTouchFixtures.Security {
 		[Timeout (5000)]
 		public void AddSharedWebCredentialNotNullPassword ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 
 			Action<NSError> handler = (NSError e) =>  {
 				// we do nothing, if we did block the test should be interactive because a dialog is shown.
@@ -69,7 +70,7 @@ namespace MonoTouchFixtures.Security {
 		[Timeout (5000)]
 		public void AddSharedWebCredentialNullPassword ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 
 			password = null;
 			Action<NSError> handler = (NSError e) =>  {
@@ -81,7 +82,7 @@ namespace MonoTouchFixtures.Security {
 		[Test]
 		public void CreateSharedWebCredentialPassword ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 
 			var pwd = SecSharedCredential.CreateSharedWebCredentialPassword ();
 			Assert.IsNotNull (pwd);

--- a/tests/monotouch-test/Security/SecureTransportTest.cs
+++ b/tests/monotouch-test/Security/SecureTransportTest.cs
@@ -20,6 +20,7 @@ using AppKit;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Security {
 
@@ -34,7 +35,7 @@ namespace MonoTouchFixtures.Security {
 		[Test]
 		public void StreamDefaults ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			using (var ssl = new SslContext (SslProtocolSide.Client, SslConnectionType.Stream)) {
 				Assert.That (ssl.BufferedReadSize, Is.EqualTo ((nint) 0), "BufferedReadSize");
@@ -105,10 +106,10 @@ namespace MonoTouchFixtures.Security {
 		[Test]
 		public void DatagramDefaults ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 #if __MACOS__
-			nint dsize = TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 10) ? 1327 : 1387;
+			nint dsize = TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 10) ? 1327 : 1387;
 #else
 			nint dsize = TestRuntime.CheckXcodeVersion (6, 0) ? 1327 : 1387;
 #endif
@@ -144,7 +145,7 @@ namespace MonoTouchFixtures.Security {
 		[Test]
 		public void SslSupportedCiphers ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			int ssl_client_ciphers = -1;
 			using (var client = new SslContext (SslProtocolSide.Client, SslConnectionType.Stream)) {
@@ -183,7 +184,7 @@ namespace MonoTouchFixtures.Security {
 		[Test]
 		public void Tls12 ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			var client = new TcpClient ("google.ca", 443);
 			using (NetworkStream ns = client.GetStream ())

--- a/tests/monotouch-test/Security/TrustTest.cs
+++ b/tests/monotouch-test/Security/TrustTest.cs
@@ -26,6 +26,7 @@ using Security;
 using ObjCRuntime;
 
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.Security {
 	
@@ -76,7 +77,7 @@ namespace MonoTouchFixtures.Security {
 			// the system was able to construct the chain based on the single certificate
 			var expectedTrust = SecTrustResult.RecoverableTrustFailure;
 #if __MACOS__
-			if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 9))
+			if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 9))
 				expectedTrust = SecTrustResult.Unspecified;
 #endif
 			Assert.That (Evaluate (trust, true), Is.EqualTo (expectedTrust), "Evaluate");
@@ -108,7 +109,7 @@ namespace MonoTouchFixtures.Security {
 			}
 
 #if __MACOS__
-			var hasNetworkFetchAllowed = TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 9);
+			var hasNetworkFetchAllowed = TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 9);
 #else
 			var hasNetworkFetchAllowed = TestRuntime.CheckXcodeVersion (5, 0);
 #endif
@@ -148,11 +149,11 @@ namespace MonoTouchFixtures.Security {
 
 					var trust_result = SecTrustResult.Invalid;
 #if __MACOS__
-					if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 13)) {
+					if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 13)) {
 						trust_result = SecTrustResult.RecoverableTrustFailure;
-					} else if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 12)) {
+					} else if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 12)) {
 						trust_result = SecTrustResult.Invalid;
-					} else if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 8)) {
+					} else if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 8)) {
 						trust_result = SecTrustResult.RecoverableTrustFailure;
 					}
 #else
@@ -177,13 +178,13 @@ namespace MonoTouchFixtures.Security {
 				trust.SetVerifyDate (new DateTime (635108745218945450, DateTimeKind.Utc));
 				var expectedTrust = SecTrustResult.RecoverableTrustFailure;
 #if __MACOS__
-				if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 9))
+				if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 9))
 					expectedTrust = SecTrustResult.Unspecified;
 #endif
 				Assert.That (Evaluate (trust, true), Is.EqualTo (expectedTrust), "Evaluate");
 
 #if __MACOS__
-				var hasCreateRevocationPolicy = TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 9);
+				var hasCreateRevocationPolicy = TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 9);
 #else
 				var hasCreateRevocationPolicy = TestRuntime.CheckXcodeVersion (5, 0);
 #endif
@@ -210,13 +211,13 @@ namespace MonoTouchFixtures.Security {
 				// a host name is not meaningful for client certificates
 				var expectedTrust = SecTrustResult.RecoverableTrustFailure;
 #if __MACOS__
-				if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 9))
+				if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 9))
 					expectedTrust = SecTrustResult.Unspecified;
 #endif
 				Assert.That (Evaluate (trust, true), Is.EqualTo (expectedTrust), "Evaluate");
 
 #if __MACOS__
-				var hasGetResult = TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 9);
+				var hasGetResult = TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 9);
 #else
 				var hasGetResult = TestRuntime.CheckXcodeVersion (5, 0);
 #endif
@@ -248,7 +249,7 @@ namespace MonoTouchFixtures.Security {
 
 				var hasOCSPResponse = true;
 #if __MACOS__
-				if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 9))
+				if (!TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 9))
 					hasOCSPResponse = false;
 #else
 				if (!TestRuntime.CheckXcodeVersion (5, 0))
@@ -362,13 +363,13 @@ namespace MonoTouchFixtures.Security {
 				Assert.That (trust.GetCustomAnchorCertificates ().Length, Is.EqualTo (certs.Count), "GetCustomAnchorCertificates");
 
 #if __MACOS__
-				if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 15)) {
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 15)) {
 					trust_result = SecTrustResult.RecoverableTrustFailure;
-				} else if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 13)) {
+				} else if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 13)) {
 					trust_result = SecTrustResult.Unspecified;
-				} else if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 12)) {
+				} else if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 12)) {
 					trust_result = SecTrustResult.Invalid;
-				} else if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 11)) {
+				} else if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 11)) {
 					trust_result = SecTrustResult.RecoverableTrustFailure;
 				} else {
 					trust_result = SecTrustResult.Unspecified;

--- a/tests/monotouch-test/SpriteKit/FieldNodeTest.cs
+++ b/tests/monotouch-test/SpriteKit/FieldNodeTest.cs
@@ -7,6 +7,7 @@ using SpriteKit;
 using ObjCRuntime;
 using OpenTK;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.SpriteKit {
 
@@ -16,8 +17,8 @@ namespace MonoTouchFixtures.SpriteKit {
 		[SetUp]
 		public void VersionCheck ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/SpriteKit/PhysicsWorldTest.cs
+++ b/tests/monotouch-test/SpriteKit/PhysicsWorldTest.cs
@@ -7,6 +7,7 @@ using ObjCRuntime;
 using SpriteKit;
 using OpenTK;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.SpriteKit {
 
@@ -16,8 +17,8 @@ namespace MonoTouchFixtures.SpriteKit {
 		[SetUp]
 		public void VersionCheck ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/SpriteKit/SK3DNodeTest.cs
+++ b/tests/monotouch-test/SpriteKit/SK3DNodeTest.cs
@@ -11,6 +11,7 @@ using ObjCRuntime;
 using SceneKit;
 using OpenTK;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.SpriteKit {
 
@@ -20,8 +21,8 @@ namespace MonoTouchFixtures.SpriteKit {
 		[SetUp]
 		public void VersionCheck ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/SpriteKit/SKShapeNodeTest.cs
+++ b/tests/monotouch-test/SpriteKit/SKShapeNodeTest.cs
@@ -16,6 +16,7 @@ using Foundation;
 using SpriteKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.SpriteKit {
 	[TestFixture]
@@ -25,8 +26,8 @@ namespace MonoTouchFixtures.SpriteKit {
 		[Test]
 		public void FromPointsTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			var pts = new[] {
 				new CGPoint (0, 0),
@@ -40,8 +41,8 @@ namespace MonoTouchFixtures.SpriteKit {
 		[Test]
 		public void FromPointsOffsetTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			var pts = new [] {
 				new CGPoint (0, 0),
@@ -57,8 +58,8 @@ namespace MonoTouchFixtures.SpriteKit {
 		[Test]
 		public void FromSplinePointsTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			var pts = new[] {
 				new CGPoint (0, 0),
@@ -72,8 +73,8 @@ namespace MonoTouchFixtures.SpriteKit {
 		[Test]
 		public void FromSplinePointsOffsetTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
 			var pts = new [] {
 				new CGPoint (0, 0),

--- a/tests/monotouch-test/SpriteKit/SpriteNodeTest.cs
+++ b/tests/monotouch-test/SpriteKit/SpriteNodeTest.cs
@@ -22,6 +22,7 @@ using UIKit;
 #endif
 using SpriteKit;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.SpriteKit {
 
@@ -40,10 +41,10 @@ namespace MonoTouchFixtures.SpriteKit {
 		[SetUp]
 		public void VersionCheck ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 9, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.WatchOS, 3, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 9, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.WatchOS, 3, 0, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/SpriteKit/TextureAtlasTest.cs
+++ b/tests/monotouch-test/SpriteKit/TextureAtlasTest.cs
@@ -14,6 +14,7 @@ using Foundation;
 using SpriteKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.SpriteKit {
 
@@ -29,10 +30,10 @@ namespace MonoTouchFixtures.SpriteKit {
 		[Test]
 		public void Empty ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 9, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.WatchOS, 3, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 9, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.WatchOS, 3, 0, throwIfOtherPlatform: false);
 
 			using (var atlas = new SKTextureAtlas ()) {
 				Assert.That (atlas.TextureNames, Is.Empty, "TextureNames");

--- a/tests/monotouch-test/SpriteKit/TextureTest.cs
+++ b/tests/monotouch-test/SpriteKit/TextureTest.cs
@@ -19,6 +19,7 @@ using UIKit;
 #endif
 using SpriteKit;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.SpriteKit {
 
@@ -34,10 +35,10 @@ namespace MonoTouchFixtures.SpriteKit {
 		[Test]
 		public void Atlas_MissingResource ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 9, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.WatchOS, 3, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 9, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.WatchOS, 3, 0, throwIfOtherPlatform: false);
 
 			using (var atlas = new SKTextureAtlas ()) {
 				// that returns a texture, calling 'MissingResource.png' (128 x 128)
@@ -53,7 +54,7 @@ namespace MonoTouchFixtures.SpriteKit {
 
 #if !MONOMAC
 					// FIXME: bug in iOS9 - it will randomly return 0,0 (but almost always on the first try)
-					if (!TestRuntime.CheckSystemVersion (PlatformName.iOS, 9, 0, throwIfOtherPlatform: false))
+					if (!TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 9, 0, throwIfOtherPlatform: false))
 						Assert.That (texture.Size, Is.EqualTo (new CGSize (128, 128)), "Size");
 #endif
 					

--- a/tests/monotouch-test/StoreKit/ReceiptRefreshRequestTest.cs
+++ b/tests/monotouch-test/StoreKit/ReceiptRefreshRequestTest.cs
@@ -18,6 +18,7 @@ using StoreKit;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.StoreKit {
 
@@ -28,7 +29,7 @@ namespace MonoTouchFixtures.StoreKit {
 		[Test]
 		public void TerminateForInvalidReceipt ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 1, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 1, throwIfOtherPlatform: false);
 			// not yet documented - seems to kill the app on purpose ?!? on both sim and devices
 			//SKReceiptRefreshRequest.TerminateForInvalidReceipt ();
 

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -22,6 +22,7 @@ using System.Security.Authentication;
 using System.Text;
 using Foundation;
 using ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTests.System.Net.Http
 {
@@ -32,7 +33,7 @@ namespace MonoTests.System.Net.Http
 		public MessageHandlerTest ()
 		{
 			// Https seems broken on our macOS 10.9 bot, so skip this test.
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 		}
 
 		void PrintHandlerToTest ()
@@ -60,8 +61,8 @@ namespace MonoTests.System.Net.Http
 		[TestCase (typeof (NSUrlSessionHandler))]
 		public void DnsFailure (Type handlerType)
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			PrintHandlerToTest ();
 
@@ -336,8 +337,8 @@ namespace MonoTests.System.Net.Http
 		public void RedirectionWithAuthorizationHeaders (Type handlerType)
 		{
 
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false); 
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false); 
 
 			bool containsAuthorizarion = false;
 			bool containsHeaders = false;
@@ -385,11 +386,11 @@ namespace MonoTests.System.Net.Http
 		[TestCase (typeof (NSUrlSessionHandler))]
 		public void RejectSslCertificatesServicePointManager (Type handlerType)
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 #if __MACOS__
-			if (handlerType == typeof (NSUrlSessionHandler) && TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 10, 0) && !TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 11, 0))
+			if (handlerType == typeof (NSUrlSessionHandler) && TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 10, 0) && !TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 11, 0))
 				Assert.Ignore ("Fails on macOS 10.10: https://github.com/xamarin/maccore/issues/1645");
 #endif
 
@@ -474,8 +475,8 @@ namespace MonoTests.System.Net.Http
 		[TestCase (typeof (NSUrlSessionHandler))]
 		public void AcceptSslCertificatesServicePointManager (Type handlerType)
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			bool servicePointManagerCbWasExcuted = false;
 			bool done = false;

--- a/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
+++ b/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
@@ -18,6 +18,7 @@ using SystemConfiguration;
 using UIKit;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.SystemConfiguration {
 
@@ -31,7 +32,7 @@ namespace MonoTouchFixtures.SystemConfiguration {
 		{
 			if (Runtime.Arch == Arch.SIMULATOR) {
 				// Fails (NullReferenceException) on iOS6 simulator
-				TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+				TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 			}
 
 #if __TVOS__
@@ -110,7 +111,7 @@ namespace MonoTouchFixtures.SystemConfiguration {
 		[Test]
 		public void MarkPortalOnline ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 
 #if __TVOS__
@@ -133,7 +134,7 @@ namespace MonoTouchFixtures.SystemConfiguration {
 		[Test]
 		public void MarkPortalOffline ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 #if __TVOS__
 			Assert.Throws<NotSupportedException> (() => CaptiveNetwork.MarkPortalOffline ("xamxam"));
@@ -155,7 +156,7 @@ namespace MonoTouchFixtures.SystemConfiguration {
 		[Test]
 		public void SetSupportedSSIDs ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 #if MONOMAC || __MACCATALYST__
 			bool supported = true;

--- a/tests/monotouch-test/UIKit/AccessibilityTest.cs
+++ b/tests/monotouch-test/UIKit/AccessibilityTest.cs
@@ -14,6 +14,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 
@@ -24,7 +25,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void RequestGuidedAccessSession ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			// should not affect execution since it needs to be a "supervised" device (and allowed in MDM)
 			UIAccessibility.RequestGuidedAccessSession (true, delegate (bool didSuccess) {

--- a/tests/monotouch-test/UIKit/ActionSheetTest.cs
+++ b/tests/monotouch-test/UIKit/ActionSheetTest.cs
@@ -10,6 +10,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 	
@@ -25,7 +26,7 @@ namespace MonoTouchFixtures.UIKit {
 			Assert.That (a.DestructiveButtonIndex, Is.EqualTo ((nint) (-1)), "DestructiveButtonIndex");
 			Assert.That (a.FirstOtherButtonIndex, Is.EqualTo ((nint) (-1)), "FirstOtherButtonIndex");
 
-			var style = TestRuntime.CheckSystemVersion (PlatformName.iOS, 8, 0) ? UIActionSheetStyle.Default : UIActionSheetStyle.Automatic;
+			var style = TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 8, 0) ? UIActionSheetStyle.Default : UIActionSheetStyle.Automatic;
 			Assert.That (a.Style, Is.EqualTo (style), "Style");
 
 			Assert.Null (a.Title, "Title");

--- a/tests/monotouch-test/UIKit/AppearanceTest.cs
+++ b/tests/monotouch-test/UIKit/AppearanceTest.cs
@@ -16,6 +16,7 @@ using UIKit;
 using ObjCRuntime;
 
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 
@@ -48,7 +49,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void Appearance ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 
 			using (var traits = new UITraitCollection ()) {
 				nfloat r, g, b, a;
@@ -77,7 +78,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void AppearanceWhenContainedIn ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 
 			using (var traits = new UITraitCollection ()) {
 				nfloat r, g, b, a;
@@ -106,7 +107,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void AppearanceWhenContainedIn_UITraitCollection ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 
 			using (var traits = new UITraitCollection ()) {
 				nfloat r, g, b, a;
@@ -156,7 +157,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void Appearance_UITraitCollection ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 
 			using (var traits = new UITraitCollection ()) {
 				nfloat r, g, b, a;

--- a/tests/monotouch-test/UIKit/ButtonTest.cs
+++ b/tests/monotouch-test/UIKit/ButtonTest.cs
@@ -9,6 +9,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 	
@@ -35,7 +36,7 @@ namespace MonoTouchFixtures.UIKit {
 				b.SetTitleColor (null, UIControlState.Normal);
 				var hasTitleColor = true;
 #if __IOS__
-				if (!TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0))
+				if (!TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 0))
 					hasTitleColor = false;
 #endif
 				if (hasTitleColor)

--- a/tests/monotouch-test/UIKit/CollectionViewControllerTest.cs
+++ b/tests/monotouch-test/UIKit/CollectionViewControllerTest.cs
@@ -7,6 +7,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 
@@ -21,7 +22,7 @@ namespace MonoTouchFixtures.UIKit {
 			// interesting ctor for the linker: a [PostSnippet] directly on the backing field is needed
 			using (var c = new UICollectionViewController (l)) {
 				// that's because Apple did not expose the init* argument as a property until 7.0
-				if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false))
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false))
 					Assert.AreSame (l, c.Layout, "Layout");
 			}
 		}

--- a/tests/monotouch-test/UIKit/CollectionViewTransitionLayoutTest.cs
+++ b/tests/monotouch-test/UIKit/CollectionViewTransitionLayoutTest.cs
@@ -7,6 +7,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 
@@ -17,7 +18,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void Ctor ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			using (var l1 = new UICollectionViewLayout ())
 			using (var l2 = new UICollectionViewLayout ())

--- a/tests/monotouch-test/UIKit/GuidedAccessRestrictionTest.cs
+++ b/tests/monotouch-test/UIKit/GuidedAccessRestrictionTest.cs
@@ -14,6 +14,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 
@@ -24,7 +25,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void GetState ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			Assert.That (UIGuidedAccessRestriction.GetState (null), Is.EqualTo (UIGuidedAccessRestrictionState.Allow), "null");
 		}

--- a/tests/monotouch-test/UIKit/LayoutManagerTest.cs
+++ b/tests/monotouch-test/UIKit/LayoutManagerTest.cs
@@ -14,6 +14,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 
@@ -24,7 +25,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void Defaults ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			using (var lm = new NSLayoutManager ()) {
 				Assert.False (lm.AllowsNonContiguousLayout, "AllowsNonContiguousLayout");
@@ -50,7 +51,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void GetGlyphsTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			using (var txt = new NSTextStorage ()) {
 				var str = "hello world\n\t";

--- a/tests/monotouch-test/UIKit/PopoverControllerTest.cs
+++ b/tests/monotouch-test/UIKit/PopoverControllerTest.cs
@@ -9,6 +9,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 using RectangleF=CoreGraphics.CGRect;
 using SizeF=CoreGraphics.CGSize;
@@ -25,7 +26,7 @@ namespace MonoTouchFixtures.UIKit {
 			if (UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Pad)
 				return;
 
-			bool ios8 = TestRuntime.CheckSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			bool ios8 = TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 			
 			using (var vc = new UIViewController ())
 			using (var pc = new UIPopoverController (vc)) {

--- a/tests/monotouch-test/UIKit/PopoverPresentationControllerTest.cs
+++ b/tests/monotouch-test/UIKit/PopoverPresentationControllerTest.cs
@@ -7,6 +7,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 
@@ -20,7 +21,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void PopoverBackgroundViewType ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 
 			using (var vc = new UIViewController ())
 			using (var pc = new UIPopoverPresentationController (vc, null)) {

--- a/tests/monotouch-test/UIKit/ReferenceLibraryViewControllerTest.cs
+++ b/tests/monotouch-test/UIKit/ReferenceLibraryViewControllerTest.cs
@@ -7,6 +7,7 @@ using Foundation;
 using ObjCRuntime;
 using UIKit;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 	
@@ -21,7 +22,7 @@ namespace MonoTouchFixtures.UIKit {
 
 		public void InitWithTerm ()
 		{
-			if (Runtime.Arch == Arch.DEVICE && TestRuntime.CheckSystemVersion (PlatformName.iOS, 9, 0))
+			if (Runtime.Arch == Arch.DEVICE && TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 9, 0))
 				Assert.Ignore ("crash on iOS9 devices");
 			using (UIReferenceLibraryViewController rlvc = new UIReferenceLibraryViewController ("Mono")) {
 			}

--- a/tests/monotouch-test/UIKit/SimpleTextPrintFormatterTest.cs
+++ b/tests/monotouch-test/UIKit/SimpleTextPrintFormatterTest.cs
@@ -16,6 +16,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 
@@ -33,7 +34,7 @@ namespace MonoTouchFixtures.UIKit {
 					Assert.NotNull (stpf.Color, "Color");
 					Assert.Null (stpf.Font, "Font");
 					Assert.That (stpf.TextAlignment, Is.EqualTo (UITextAlignment.Natural), "TextAlignment");
-				} else if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false)) {
+				} else if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false)) {
 					Assert.Null (stpf.Color, "Color");
 					Assert.Null (stpf.Font, "Font");
 					Assert.That (stpf.TextAlignment, Is.EqualTo (UITextAlignment.Natural), "TextAlignment");
@@ -54,7 +55,7 @@ namespace MonoTouchFixtures.UIKit {
 				if (TestRuntime.CheckXcodeVersion (11, 0)) {
 					Assert.NotNull (stpf.Color, "Color");
 					Assert.That (stpf.TextAlignment, Is.EqualTo (UITextAlignment.Natural), "TextAlignment");
-				} else if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false)) {
+				} else if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false)) {
 					Assert.Null (stpf.Color, "Color");
 					Assert.That (stpf.TextAlignment, Is.EqualTo (UITextAlignment.Natural), "TextAlignment");
 				} else {

--- a/tests/monotouch-test/UIKit/TabBarTest.cs
+++ b/tests/monotouch-test/UIKit/TabBarTest.cs
@@ -10,6 +10,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 	[TestFixture]
@@ -117,7 +118,7 @@ namespace MonoTouchFixtures.UIKit {
 		{
 			using (UITabBar tb = new UITabBar ()) {
 				// TintColor is inherited in iOS7 so it won't be null by default
-				if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false))
+				if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false))
 					Assert.NotNull (tb.TintColor, "1");
 				else
 					Assert.Null (tb.TintColor, "1");
@@ -129,7 +130,7 @@ namespace MonoTouchFixtures.UIKit {
 				if (TestRuntime.IsTVOS) {
 					// we only care that setting `null` gives us back some default OS value
 					Assert.NotNull (tb.TintColor, "3");
-				} else if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false)) {
+				} else if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false)) {
 					Assert.That (tb.TintColor, Is.Not.EqualTo (UIColor.White), "3");
 				} else
 					Assert.Null (tb.TintColor, "3");
@@ -144,7 +145,7 @@ namespace MonoTouchFixtures.UIKit {
 				Assert.Null (tb.SelectedImageTintColor, "1");
 				
 				tb.SelectedImageTintColor = UIColor.Black;
-				if (!TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 1)) {
+				if (!TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 1)) {
 					// before 7.1 the tintColor would have been accepted
 					Assert.NotNull (tb.SelectedImageTintColor, "2");
 			

--- a/tests/monotouch-test/UIKit/TarBarItemTest.cs
+++ b/tests/monotouch-test/UIKit/TarBarItemTest.cs
@@ -16,6 +16,7 @@ using Foundation;
 using ObjCRuntime;
 using UIKit;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 	[TestFixture]
@@ -113,7 +114,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void Ctor_3b_Null ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 				
 			using (UIImage img = new UIImage ()) {
 				using (UITabBarItem tbi1 = new UITabBarItem (null, null, null)) {
@@ -134,7 +135,7 @@ namespace MonoTouchFixtures.UIKit {
 
 					var hasSelectedImage = true;
 #if __IOS__
-					if (!TestRuntime.CheckSystemVersion (PlatformName.iOS, 7,1))
+					if (!TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7,1))
 						hasSelectedImage = false;
 #endif
 					if (hasSelectedImage)
@@ -148,7 +149,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void SelectedImage_7a ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			using (UIImage i1 = new UIImage ())
 			using (UITabBarItem tbi = new UITabBarItem ("title", i1, null)) {
@@ -167,7 +168,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void SelectedImage_7b ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			using (UIImage i1 = new UIImage ())
 			using (UIImage i2 = new UIImage ())

--- a/tests/monotouch-test/UIKit/TextAttachmentTest.cs
+++ b/tests/monotouch-test/UIKit/TextAttachmentTest.cs
@@ -14,6 +14,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 
@@ -24,7 +25,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void CtorNull ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			using (var ta = new NSTextAttachment (null, null)) {
 				Assert.IsTrue (ta.Bounds.IsEmpty, "Bounds");

--- a/tests/monotouch-test/UIKit/TextContainerTest.cs
+++ b/tests/monotouch-test/UIKit/TextContainerTest.cs
@@ -14,6 +14,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 
@@ -24,7 +25,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void Layout ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			using (var tc = new NSTextContainer ()) {
 				Assert.Null (tc.LayoutManager, "LayoutManager");

--- a/tests/monotouch-test/UIKit/TextViewTest.cs
+++ b/tests/monotouch-test/UIKit/TextViewTest.cs
@@ -9,6 +9,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 	
@@ -57,7 +58,7 @@ namespace MonoTouchFixtures.UIKit {
 		// if this fails ping lobrien (or doc team) since it means Apple changed the defaults we documented
 		public void LayoutManager ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			using (UITextView tv = new UITextView ()) {
 				var lm = tv.LayoutManager;

--- a/tests/monotouch-test/UIKit/UIAlertControllerTest.cs
+++ b/tests/monotouch-test/UIKit/UIAlertControllerTest.cs
@@ -16,6 +16,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 	[TestFixture]
@@ -25,7 +26,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void InitWithNibNameTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 			
 			UIAlertController ctrl = new UIAlertController (null, null);
 			Assert.NotNull (ctrl, "UIAlertController ctor(String, NSBundle)");

--- a/tests/monotouch-test/UIKit/UIDocumentTest.cs
+++ b/tests/monotouch-test/UIKit/UIDocumentTest.cs
@@ -18,6 +18,7 @@ using UIKit;
 using ObjCRuntime;
 using MonoTouchException=ObjCRuntime.RuntimeException;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 
@@ -163,7 +164,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void Fields ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 			// just to confirm it's not an NSUrl but an NSString
 			Assert.That (UIDocument.UserActivityDocumentUrlKey.ToString (), Is.EqualTo ("NSUserActivityDocumentURL"), "NSUserActivityDocumentURLKey");
 		}

--- a/tests/monotouch-test/UIKit/UISearchControllerTest.cs
+++ b/tests/monotouch-test/UIKit/UISearchControllerTest.cs
@@ -16,6 +16,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 	[TestFixture]
@@ -25,7 +26,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void InitWithNibNameTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 
 			UISearchController ctrl = new UISearchController (null, null);
 			Assert.NotNull (ctrl, "UISearchController ctor(String, NSBundle)");

--- a/tests/monotouch-test/UIKit/UIStackViewTest.cs
+++ b/tests/monotouch-test/UIKit/UIStackViewTest.cs
@@ -17,6 +17,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 	[TestFixture]
@@ -26,7 +27,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void InitWithFrameTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 9, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 9, 0, throwIfOtherPlatform: false);
 
 			UIStackView stack = new UIStackView (new CGRect (0, 0, 10, 10));
 			Assert.NotNull (stack, "UIStackView ctor(CGRect)");

--- a/tests/monotouch-test/UIKit/VibrancyEffectTest.cs
+++ b/tests/monotouch-test/UIKit/VibrancyEffectTest.cs
@@ -17,6 +17,7 @@ using ObjCRuntime;
 using NotificationCenter;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 
@@ -26,7 +27,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void NotificationCenterVibrancyEffect_New ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
 
 			UIVibrancyEffect.CreateForNotificationCenter ();
 		}

--- a/tests/monotouch-test/UIKit/ViewControllerTest.cs
+++ b/tests/monotouch-test/UIKit/ViewControllerTest.cs
@@ -18,6 +18,7 @@ using ObjCRuntime;
 using iAd;
 #endif
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 	[TestFixture]
@@ -178,7 +179,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void InterstitialAds_New ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 			
 			UIViewController.PrepareForInterstitialAds ();
 		}

--- a/tests/monotouch-test/UIKit/ViewTest.cs
+++ b/tests/monotouch-test/UIKit/ViewTest.cs
@@ -9,6 +9,7 @@ using Foundation;
 using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.UIKit {
 	
@@ -258,7 +259,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void TintColor ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
 			using (var v = new UIView ()) {
 				var tc = v.TintColor;

--- a/tests/monotouch-test/VideoToolbox/VTCompressionSessionTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTCompressionSessionTests.cs
@@ -19,6 +19,7 @@ using AVFoundation;
 using CoreFoundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.VideoToolbox {
 
@@ -29,9 +30,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void CompressionSessionCreateTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 			using (var session = CreateSession ()){
 				Assert.IsNotNull (session, "Session should not be null");
@@ -41,9 +42,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void CompressionSessionSetCompressionPropertiesTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 			using (var session = CreateSession ()){
 
@@ -59,9 +60,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void CompressionSessionSetPropertiesTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 			using (var session = CreateSession ()){
 
@@ -77,9 +78,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void CompressionSessionSetCompressionPropertiesMultiPassStorageTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 			using (var session = CreateSession ())
 			using (var storage = VTMultiPassStorage.Create ()){
@@ -98,9 +99,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void CompressionSessionGetSupportedPropertiesTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 			using (var session = CreateSession ()) {
 				var supportedProps = session.GetSupportedProperties ();
@@ -128,9 +129,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 #endif
 		public void CompressionSessionGetSerializablePropertiesTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 			
 			using (var session = CreateSession ()) {
 				var supportedProps = session.GetSerializableProperties ();

--- a/tests/monotouch-test/VideoToolbox/VTDecompressionSessionTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTDecompressionSessionTests.cs
@@ -19,6 +19,7 @@ using AVFoundation;
 using CoreFoundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.VideoToolbox {
 
@@ -29,9 +30,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void DecompressionSessionCreateTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 			using (var asset = AVAsset.FromUrl (NSBundle.MainBundle.GetUrlForResource ("xamvideotest", "mp4"))) 
 			using (var session = CreateSession (asset)){
@@ -42,9 +43,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void DecompressionSessionSetDecompressionPropertiesTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 			using (var asset = AVAsset.FromUrl (NSBundle.MainBundle.GetUrlForResource ("xamvideotest", "mp4"))) 
 			using (var session = CreateSession (asset)){
@@ -61,9 +62,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void DecompressionSessionSetPropertiesTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 			using (var asset = AVAsset.FromUrl (NSBundle.MainBundle.GetUrlForResource ("xamvideotest", "mp4"))) 
 			using (var session = CreateSession (asset)){
@@ -80,9 +81,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void DecompressionSessionGetSupportedPropertiesTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 8, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 			using (var asset = AVAsset.FromUrl (NSBundle.MainBundle.GetUrlForResource ("xamvideotest", "mp4")))
 			using (var session = CreateSession (asset)) {

--- a/tests/monotouch-test/VideoToolbox/VTFrameSiloTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTFrameSiloTests.cs
@@ -19,6 +19,7 @@ using AVFoundation;
 using CoreFoundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.VideoToolbox {
 
@@ -29,9 +30,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void FrameSiloCreateTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 			using (var silo = VTFrameSilo.Create ()){
 				Assert.IsNotNull (silo, "Silo should not be null");
@@ -41,9 +42,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void SetTimeRangesTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 			using (var silo = VTFrameSilo.Create ()){
 				var result = silo.SetTimeRangesForNextPass (new CMTimeRange [0]);
@@ -54,9 +55,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void ForEachTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 			using (var silo = VTFrameSilo.Create ()){
 

--- a/tests/monotouch-test/VideoToolbox/VTMultiPassStorageTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTMultiPassStorageTests.cs
@@ -19,6 +19,7 @@ using AVFoundation;
 using CoreFoundation;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.VideoToolbox {
 
@@ -29,9 +30,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void MultiPassStorageCreateTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 			using (var storage = VTMultiPassStorage.Create ()){
 				Assert.IsNotNull (storage, "Storage should not be null");
@@ -41,9 +42,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void MultiPassStorageCloseTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 			using (var storage = VTMultiPassStorage.Create ()){
 				var result = storage.Close ();

--- a/tests/monotouch-test/VideoToolbox/VTUtilitiesTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTUtilitiesTests.cs
@@ -29,6 +29,7 @@ using CoreVideo;
 using CoreGraphics;
 using ObjCRuntime;
 using NUnit.Framework;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.VideoToolbox {
 
@@ -42,9 +43,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void ToCGImageTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 9, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 11, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 9, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 11, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 #if MONOMAC
 			var originalImage = new NSImage (NSBundle.MainBundle.PathForResource ("Xam", "png", "CoreImage"));

--- a/tests/monotouch-test/VideoToolbox/VTVideoEncoderListTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTVideoEncoderListTests.cs
@@ -17,6 +17,8 @@ using CoreMedia;
 using ObjCRuntime;
 using NUnit.Framework;
 
+using Xamarin.Utils;
+
 namespace MonoTouchFixtures.VideoToolbox {
 
 	[TestFixture]
@@ -26,9 +28,9 @@ namespace MonoTouchFixtures.VideoToolbox {
 		[Test]
 		public void VideoEncoderListTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 10, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.TvOS, 10, 2, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.TVOS, 10, 2, throwIfOtherPlatform: false);
 
 			var encoders = VTVideoEncoder.GetEncoderList ();
 			Assert.NotNull (encoders, "VTVideoEncoder.GetEncoderList () Should Not be null");

--- a/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
@@ -31,9 +31,6 @@
     <Compile Include="..\..\..\common\mac\MacMain.cs">
       <Link>MacMain.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\tools\common\ApplePlatform.cs">
-      <Link>ApplePlatform.cs</Link>
-    </Compile>
     <Compile Include="..\..\..\..\tools\common\Execution.cs">
       <Link>Execution.cs</Link>
     </Compile>

--- a/tests/monotouch-test/dotnet/shared.csproj
+++ b/tests/monotouch-test/dotnet/shared.csproj
@@ -60,6 +60,9 @@
     <Compile Include="$(RootTestsDirectory)\common\Extensions.cs">
       <Link>Extensions.cs</Link>
     </Compile>
+    <Compile Include="$(RootTestsDirectory)\..\tools\common\ApplePlatform.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/monotouch-test/mono/WeakReferenceTest.cs
+++ b/tests/monotouch-test/mono/WeakReferenceTest.cs
@@ -17,6 +17,7 @@ using ObjCRuntime;
 
 using NUnit.Framework;
 using System.Threading;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures {
 
@@ -32,9 +33,9 @@ namespace MonoTouchFixtures {
 		[SetUp]
 		public void Setup ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.WatchOS, 3, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.WatchOS, 3, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 		}
 
 		[Test]

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -220,6 +220,9 @@
     <Compile Include="..\common\Extensions.cs">
       <Link>Extensions.cs</Link>
     </Compile>
+    <Compile Include="..\..\tools\common\ApplePlatform.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/tests/test-libraries/testgenerator.cs
+++ b/tests/test-libraries/testgenerator.cs
@@ -759,7 +759,7 @@ namespace Bindings.Test
 			w.AppendLine ();
 		}
 		if (v.MinMacOSVersion != null) {
-			w.AppendLine ($"\t\t\tTestRuntime.AssertSystemVersion (PlatformName.MacOSX, {v.MinMacOSVersion.Major}, {v.MinMacOSVersion.Minor}, throwIfOtherPlatform: false);");
+			w.AppendLine ($"\t\t\tTestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, {v.MinMacOSVersion.Major}, {v.MinMacOSVersion.Minor}, throwIfOtherPlatform: false);");
 			w.AppendLine ();
 		}
 	}
@@ -800,6 +800,7 @@ using NUnit.Framework;
 using Bindings.Test;
 
 using XamarinTests.ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.ObjCRuntime {
 
@@ -1428,6 +1429,7 @@ using NUnit.Framework;
 using Bindings.Test;
 
 using XamarinTests.ObjCRuntime;
+using Xamarin.Utils;
 
 namespace MonoTouchFixtures.ObjCRuntime {
 


### PR DESCRIPTION
The PlatformName enum will be removed from .NET soon.