### PR TITLE
[tests] Add the compiler response files from src/ to the .NET test builds.

### DIFF
--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -9,6 +9,7 @@
 		<NativeLibName>ios-fat</NativeLibName>
 		<!-- We need this because we'd otherwise default to the latest OS version we support, and we'll want to execute on earlier versions -->
 		<SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+		<CompilerResponseFile>$(MSBuildThisFileDirectory)\..\..\src\build\dotnet\ios-defines-dotnet.rsp</CompilerResponseFile>
 	</PropertyGroup>
 	<ItemGroup Condition="'$(_PlatformName)' == 'iOS'">
 	</ItemGroup>
@@ -19,6 +20,7 @@
 		<AssetTargetFallback>xamarintvos10;$(AssetTargetFallback)</AssetTargetFallback>
 		<NativeLibName>tvos-fat</NativeLibName>
 		<SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+		<CompilerResponseFile>$(MSBuildThisFileDirectory)\..\..\src\build\dotnet\tvos-defines-dotnet.rsp</CompilerResponseFile>
 	</PropertyGroup>
 	<ItemGroup Condition="$(TargetFramework.EndsWith('-tvos'))">
 	</ItemGroup>
@@ -28,6 +30,7 @@
 		<DefineConstants>$(DefineConstants);MONOMAC</DefineConstants>
 		<NativeLibName>macos-fat</NativeLibName>
 		<SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
+		<CompilerResponseFile>$(MSBuildThisFileDirectory)\..\..\src\build\dotnet\macos-defines-dotnet.rsp</CompilerResponseFile>
 	</PropertyGroup>
 
 	<!-- Logic for Mac Catalyst -->
@@ -35,6 +38,7 @@
 		<AssetTargetFallback>xamarinios10;$(AssetTargetFallback)</AssetTargetFallback>
 		<NativeLibName>maccatalyst-fat</NativeLibName>
 		<SupportedOSPlatformVersion>13.3</SupportedOSPlatformVersion>
+		<CompilerResponseFile>$(MSBuildThisFileDirectory)\..\..\src\build\dotnet\maccatalyst-defines-dotnet.rsp</CompilerResponseFile>
 	</PropertyGroup>
 
 	<!-- Logic for all test suites -->

--- a/tests/monotouch-test/Photos/FetchResultTest.cs
+++ b/tests/monotouch-test/Photos/FetchResultTest.cs
@@ -7,7 +7,7 @@
 // Copyright 2013 Xamarin Inc. All rights reserved.
 //
 
-#if HAS_PHOTOS && !__TVOS__
+#if HAS_PHOTOS && !__TVOS__ && HAS_UIKIT
 
 using System;
 using System.Linq;

--- a/tests/monotouch-test/UIKit/VibrancyEffectTest.cs
+++ b/tests/monotouch-test/UIKit/VibrancyEffectTest.cs
@@ -7,7 +7,7 @@
 // Copyright 2014 Xamarin Inc. All rights reserved.
 //
 
-#if HAS_NOTIFICATIONCENTER
+#if HAS_NOTIFICATIONCENTER && HAS_UIKIT
 
 using System;
 using Foundation;


### PR DESCRIPTION
This means that the HAS_&lt;FRAMEWORK&gt; defines will now work in .NET test code
(as it already does in legacy test code).